### PR TITLE
[9.1] [FatalReactError] Send additional metrics with Error Telemetry Event to understand transient, non-breaking errors. (#234589)

### DIFF
--- a/src/platform/packages/shared/shared-ux/error_boundary/index.ts
+++ b/src/platform/packages/shared/shared-ux/error_boundary/index.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { KibanaErrorBoundaryProvider } from './src/services/error_boundary_services';
+export { KibanaErrorBoundaryProvider } from './src/services/error_boundary_provider';
 export { KibanaErrorBoundary } from './src/ui/error_boundary';
 export { KibanaSectionErrorBoundary } from './src/ui/section_error_boundary';
 export { ThrowIfError } from './src/ui/throw_if_error';

--- a/src/platform/packages/shared/shared-ux/error_boundary/lib/telemetry_events.ts
+++ b/src/platform/packages/shared/shared-ux/error_boundary/lib/telemetry_events.ts
@@ -32,6 +32,22 @@ export const reactFatalErrorSchema = {
       optional: false as const,
     },
   },
+  component_render_min_duration_ms: {
+    type: 'long' as const,
+    _meta: {
+      description:
+        'Minimum duration in milliseconds that the fatal error component stayed rendered (before unmount). A max value of 10,000 (10s) is enforced to prevent excessive, indefinite or indeterminable durations.',
+      optional: false as const,
+    },
+  },
+  has_transient_navigation: {
+    type: 'boolean' as const,
+    _meta: {
+      description:
+        'Indicates if navigation occurred within the transient window (e.g. first 250ms) after the error occurred. This helps identify transient errors, successfully followed by a navigation, that users may not have seen.',
+      optional: false as const,
+    },
+  },
   error_message: {
     type: 'keyword' as const,
     _meta: {

--- a/src/platform/packages/shared/shared-ux/error_boundary/mocks/index.ts
+++ b/src/platform/packages/shared/shared-ux/error_boundary/mocks/index.ts
@@ -11,3 +11,11 @@ export { BadComponent } from './src/bad_component';
 export { ChunkLoadErrorComponent } from './src/chunk_load_error_component';
 export { getServicesMock } from './src/jest';
 export { KibanaErrorBoundaryStorybookMock } from './src/storybook';
+export { createAnalyticsMock } from './src/analytics_mock';
+export {
+  ControlsBar,
+  Spacer,
+  DocsBlock,
+  StoryActionButton,
+} from './src/error_boundary_story_controls';
+export { createServicesWithAnalyticsMock } from './src/story_services';

--- a/src/platform/packages/shared/shared-ux/error_boundary/mocks/src/analytics_mock.ts
+++ b/src/platform/packages/shared/shared-ux/error_boundary/mocks/src/analytics_mock.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { action } from '@storybook/addon-actions';
+
+export interface TelemetryEvent {
+  type: string;
+  payload: unknown;
+  at: number;
+}
+
+export interface AnalyticsMock {
+  analytics: { reportEvent: (type: string, payload: unknown) => void };
+  getEvents(): TelemetryEvent[];
+  clear(): void;
+  subscribe(cb: (events: TelemetryEvent[]) => void): () => void;
+}
+
+export function createAnalyticsMock(): AnalyticsMock {
+  const events: TelemetryEvent[] = [];
+  const subscribers = new Set<(events: TelemetryEvent[]) => void>();
+  const reportAction = action('Report telemetry event');
+
+  function notify() {
+    subscribers.forEach((cb) => cb([...events]));
+  }
+
+  return {
+    analytics: {
+      reportEvent: (type: string, payload: unknown) => {
+        reportAction(type, payload);
+        events.push({ type, payload, at: Date.now() });
+        notify();
+      },
+    },
+    getEvents: () => [...events],
+    clear: () => {
+      events.splice(0, events.length);
+      notify();
+    },
+    subscribe: (cb) => {
+      subscribers.add(cb);
+      return () => subscribers.delete(cb);
+    },
+  };
+}

--- a/src/platform/packages/shared/shared-ux/error_boundary/mocks/src/bad_component.tsx
+++ b/src/platform/packages/shared/shared-ux/error_boundary/mocks/src/bad_component.tsx
@@ -25,8 +25,8 @@ export const BadComponent = () => {
   };
 
   return (
-    <EuiButton onClick={handleClick} data-test-subj="clickForErrorBtn">
-      Click for error
+    <EuiButton color="danger" onClick={handleClick} data-test-subj="clickForErrorBtn">
+      Throw error
     </EuiButton>
   );
 };

--- a/src/platform/packages/shared/shared-ux/error_boundary/mocks/src/chunk_load_error_component.tsx
+++ b/src/platform/packages/shared/shared-ux/error_boundary/mocks/src/chunk_load_error_component.tsx
@@ -27,8 +27,8 @@ export const ChunkLoadErrorComponent = () => {
   };
 
   return (
-    <EuiButton onClick={handleClick} fill={true} data-test-subj="clickForErrorBtn">
-      Click for error
+    <EuiButton color="danger" onClick={handleClick} fill={true} data-test-subj="clickForErrorBtn">
+      Throw error
     </EuiButton>
   );
 };

--- a/src/platform/packages/shared/shared-ux/error_boundary/mocks/src/error_boundary_story_controls.tsx
+++ b/src/platform/packages/shared/shared-ux/error_boundary/mocks/src/error_boundary_story_controls.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiButton } from '@elastic/eui';
+
+export const Spacer: React.FC = () => <div style={{ height: 12 }} />;
+
+export const ControlsBar: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>{children}</div>
+);
+
+export const DocsBlock: React.FC<{ title: string; children: React.ReactNode }> = ({
+  title,
+  children,
+}) => (
+  <div style={{ marginTop: 12, padding: 12, border: '1px dashed #ccc', borderRadius: 6 }}>
+    <div style={{ fontWeight: 700, marginBottom: 6 }}>{title}</div>
+    <div style={{ lineHeight: 1.5 }}>{children}</div>
+  </div>
+);
+
+export const StoryActionButton: React.FC<{
+  onClick: () => void;
+  children: React.ReactNode;
+  color?:
+    | 'primary'
+    | 'danger'
+    | 'success'
+    | 'warning'
+    | 'text'
+    | 'accent'
+    | 'accentSecondary'
+    | 'neutral'
+    | 'risk'
+    | undefined;
+  fill?: boolean;
+  disabled?: boolean;
+}> = ({ onClick, children, color = 'danger', fill = true, disabled }) => {
+  return (
+    <EuiButton
+      color={color}
+      onClick={onClick}
+      fill={fill}
+      isDisabled={disabled}
+      style={{ margin: 4 }}
+      size="s"
+    >
+      {children}
+    </EuiButton>
+  );
+};

--- a/src/platform/packages/shared/shared-ux/error_boundary/mocks/src/story_services.ts
+++ b/src/platform/packages/shared/shared-ux/error_boundary/mocks/src/story_services.ts
@@ -7,38 +7,25 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { AbstractStorybookMock } from '@kbn/shared-ux-storybook-mock';
 import { action } from '@storybook/addon-actions';
-import { KibanaErrorService } from '../../src/services/error_service';
+import type { AnalyticsMock } from './analytics_mock';
 import { createAnalyticsMock } from './analytics_mock';
 import type { KibanaErrorBoundaryServices } from '../../types';
+import { KibanaErrorService } from '../../src/services/error_service';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Params {}
+export function createServicesWithAnalyticsMock(): {
+  services: KibanaErrorBoundaryServices;
+  mock: AnalyticsMock;
+} {
+  const onClickRefresh = action('Reload window');
+  const mock = createAnalyticsMock();
+  const analytics = mock.analytics;
 
-export class KibanaErrorBoundaryStorybookMock extends AbstractStorybookMock<
-  {},
-  KibanaErrorBoundaryServices
-> {
-  propArguments = {};
-
-  serviceArguments = {};
-
-  dependencies = [];
-
-  getServices(params: Params = {}): KibanaErrorBoundaryServices {
-    const onClickRefresh = action('Reload window');
-    const mock = createAnalyticsMock();
-    const analytics = mock.analytics;
-
-    return {
-      ...params,
+  return {
+    services: {
       onClickRefresh,
       errorService: new KibanaErrorService({ analytics }),
-    };
-  }
-
-  getProps(params: Params) {
-    return params;
-  }
+    },
+    mock,
+  };
 }

--- a/src/platform/packages/shared/shared-ux/error_boundary/src/services/error_boundary_provider.tsx
+++ b/src/platform/packages/shared/shared-ux/error_boundary/src/services/error_boundary_provider.tsx
@@ -34,9 +34,11 @@ export const KibanaErrorBoundaryProvider: FC<
 > = ({ children, analytics }) => {
   const parentContext = useContext(Context);
   const value: KibanaErrorBoundaryServices = useMemo(() => {
-    // FIXME: analytics dep is optional - know when not to overwrite
     if (parentContext) {
-      return parentContext;
+      // Only use the parent context if it has the same analytics service
+      if (parentContext.errorService.getAnalyticsReference() === analytics) {
+        return parentContext;
+      }
     }
 
     return {

--- a/src/platform/packages/shared/shared-ux/error_boundary/src/services/error_service.test.ts
+++ b/src/platform/packages/shared/shared-ux/error_boundary/src/services/error_service.test.ts
@@ -7,42 +7,48 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { KibanaErrorService } from './error_service';
+import {
+  KibanaErrorService,
+  TRANSIENT_NAVIGATION_WINDOW_MS,
+  DEFAULT_MAX_ERROR_DURATION_MS,
+} from './error_service';
 
 describe('KibanaErrorBoundary Error Service', () => {
-  beforeEach(() => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
   const mockDeps = {
     analytics: { reportEvent: jest.fn() },
   };
   const service = new KibanaErrorService(mockDeps);
 
-  it('construction', () => {
-    expect(service).toHaveProperty('registerError');
-  });
+  describe('Service components', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
 
-  it('decorates fatal error object', () => {
-    const testFatal = new Error('This is an unrecognized and fatal error');
-    const serviceError = service.registerError(testFatal, { componentStack: '' });
+    it('construction', () => {
+      expect(service).toHaveProperty('enqueueError');
+      expect(service).toHaveProperty('commitError');
+    });
 
-    expect(serviceError.isFatal).toBe(true);
-  });
+    it('decorates fatal error object', () => {
+      const testFatal = new Error('This is an unrecognized and fatal error');
+      const enqueued = service.enqueueError(testFatal, { componentStack: '' });
 
-  it('decorates recoverable error object', () => {
-    const testRecoverable = new Error('Could not load chunk blah blah');
-    testRecoverable.name = 'ChunkLoadError';
-    const serviceError = service.registerError(testRecoverable, { componentStack: '' });
+      expect(enqueued.isFatal).toBe(true);
+    });
 
-    expect(serviceError.isFatal).toBe(false);
-  });
+    it('decorates recoverable error object', () => {
+      const testRecoverable = new Error('Could not load chunk blah blah');
+      testRecoverable.name = 'ChunkLoadError';
+      const enqueued = service.enqueueError(testRecoverable, { componentStack: '' });
 
-  it('derives component name', () => {
-    const testFatal = new Error('This is an unrecognized and fatal error');
+      expect(enqueued.isFatal).toBe(false);
+    });
 
-    const errorInfo = {
-      componentStack: `
+    it('derives component name', () => {
+      const testFatal = new Error('This is an unrecognized and fatal error');
+
+      const errorInfo = {
+        componentStack: `
     at BadComponent (http://localhost:9001/main.iframe.bundle.js:11616:73)
     at ErrorBoundaryInternal (http://localhost:9001/main.iframe.bundle.js:12232:81)
     at KibanaErrorBoundary (http://localhost:9001/main.iframe.bundle.js:12295:116)
@@ -51,18 +57,18 @@ describe('KibanaErrorBoundary Error Service', () => {
     at http://localhost:9001/kbn-ui-shared-deps-npm.dll.js:164499:73
     at section
     at http://localhost:9001/kbn-ui-shared-deps-npm.dll.js`,
-    };
+      };
 
-    const serviceError = service.registerError(testFatal, errorInfo);
+      const enqueued = service.enqueueError(testFatal, errorInfo);
 
-    expect(serviceError.name).toBe('BadComponent');
-  });
+      expect(enqueued.name).toBe('BadComponent');
+    });
 
-  it('passes the common helper utility when deriving component name', () => {
-    const testFatal = new Error('This is an mind-bendingly fatal error');
+    it('passes the common helper utility when deriving component name', () => {
+      const testFatal = new Error('This is an mind-bendingly fatal error');
 
-    const errorInfo = {
-      componentStack: `
+      const errorInfo = {
+        componentStack: `
     at ThrowIfError (http://localhost:9001/main.iframe.bundle.js:11616:73)
     at BadComponent (http://localhost:9001/main.iframe.bundle.js:11616:73)
     at ErrorBoundaryInternal (http://localhost:9001/main.iframe.bundle.js:12232:81)
@@ -72,57 +78,353 @@ describe('KibanaErrorBoundary Error Service', () => {
     at http://localhost:9001/kbn-ui-shared-deps-npm.dll.js:164499:73
     at section
     at http://localhost:9001/kbn-ui-shared-deps-npm.dll.js`,
-    };
+      };
 
-    const serviceError = service.registerError(testFatal, errorInfo);
+      const enqueued = service.enqueueError(testFatal, errorInfo);
 
-    // should not be "ThrowIfError"
-    expect(serviceError.name).toBe('BadComponent');
-  });
+      // should not be "ThrowIfError"
+      expect(enqueued.name).toBe('BadComponent');
+    });
 
-  it('captures the error event for telemetry', () => {
-    jest.resetAllMocks();
-    const testFatal = new Error('This is an outrageous and fatal error');
+    it('captures the error event for telemetry', () => {
+      jest.resetAllMocks();
+      jest.useFakeTimers();
 
-    const errorInfo = {
-      componentStack: `
+      const testFatal = new Error('This is an outrageous and fatal error');
+
+      const errorInfo = {
+        componentStack: `
     at OutrageousMaker (http://localhost:9001/main.iframe.bundle.js:11616:73)
     `,
-    };
+      };
 
-    service.registerError(testFatal, errorInfo);
+      const enqueued = service.enqueueError(testFatal, errorInfo);
 
-    expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
-    expect(mockDeps.analytics.reportEvent.mock.calls[0][0]).toBe('fatal-error-react');
-    expect(mockDeps.analytics.reportEvent.mock.calls[0][1]).toMatchObject({
-      component_name: 'OutrageousMaker',
-      error_message: 'Error: This is an outrageous and fatal error',
+      // Fast-forward time by the monitoring navigation window to ensure error can be committed
+      jest.advanceTimersByTime(TRANSIENT_NAVIGATION_WINDOW_MS);
+
+      // Commit after transient navigation window
+      service.commitError(enqueued.id);
+
+      expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      expect(mockDeps.analytics.reportEvent.mock.calls[0][0]).toBe('fatal-error-react');
+      expect(mockDeps.analytics.reportEvent.mock.calls[0][1]).toMatchObject({
+        component_name: 'OutrageousMaker',
+        error_message: 'Error: This is an outrageous and fatal error',
+        has_transient_navigation: false,
+      });
+
+      jest.useRealTimers();
+    });
+
+    it('captures component stack trace and error stack trace for telemetry', () => {
+      jest.resetAllMocks();
+      jest.useFakeTimers();
+
+      const testFatal = new Error('This is an outrageous and fatal error');
+
+      const errorInfo = {
+        componentStack: `
+    at OutrageousMaker (http://localhost:9001/main.iframe.bundle.js:11616:73)
+    `,
+      };
+
+      const enqueued = service.enqueueError(testFatal, errorInfo);
+
+      // Fast-forward time by the monitoring navigation window to ensure error can be committed
+      jest.advanceTimersByTime(TRANSIENT_NAVIGATION_WINDOW_MS);
+
+      // Commit after transient navigation window
+      service.commitError(enqueued.id);
+
+      expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      expect(mockDeps.analytics.reportEvent.mock.calls[0][0]).toBe('fatal-error-react');
+      expect(
+        String(mockDeps.analytics.reportEvent.mock.calls[0][1].component_stack).includes(
+          'at OutrageousMaker'
+        )
+      ).toBe(true);
+      expect(
+        String(mockDeps.analytics.reportEvent.mock.calls[0][1].error_stack).startsWith(
+          'Error: This is an outrageous and fatal error'
+        )
+      ).toBe(true);
+
+      jest.useRealTimers();
     });
   });
 
-  it('captures component stack trace and error stack trace for telemetry', () => {
-    jest.resetAllMocks();
-    const testFatal = new Error('This is an outrageous and fatal error');
+  describe('enqueueError and commitError flow', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+      jest.useFakeTimers();
+    });
 
-    const errorInfo = {
-      componentStack: `
-    at OutrageousMaker (http://localhost:9001/main.iframe.bundle.js:11616:73)
-    `,
-    };
+    afterEach(() => {
+      jest.useRealTimers();
+    });
 
-    service.registerError(testFatal, errorInfo);
+    it('does not report non-fatal errors', () => {
+      const testNonFatal = new Error('Non-fatal ChunkLoadError');
+      testNonFatal.name = 'ChunkLoadError';
 
-    expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
-    expect(mockDeps.analytics.reportEvent.mock.calls[0][0]).toBe('fatal-error-react');
-    expect(
-      String(mockDeps.analytics.reportEvent.mock.calls[0][1].component_stack).includes(
-        'at OutrageousMaker'
-      )
-    ).toBe(true);
-    expect(
-      String(mockDeps.analytics.reportEvent.mock.calls[0][1].error_stack).startsWith(
-        'Error: This is an outrageous and fatal error'
-      )
-    ).toBe(true);
+      // Use enqueueError directly to test the flow
+      service.enqueueError(testNonFatal, { componentStack: '' });
+
+      // Advance timers to ensure all potential reporting timeouts would fire
+      jest.advanceTimersByTime(DEFAULT_MAX_ERROR_DURATION_MS + 1000);
+
+      // Reporting should not happen for non-fatal errors
+      expect(mockDeps.analytics.reportEvent).not.toHaveBeenCalled();
+    });
+
+    it('correctly waits for TRANSIENT_NAVIGATION_WINDOW_MS even when external commit happens earlier', () => {
+      const testError = new Error('Test error for early commit');
+
+      // First, enqueue the error
+      const enqueuedError = service.enqueueError(testError, {
+        componentStack: 'at EarlyCommitComponent',
+      });
+
+      // Simulate an external commit request at 150ms
+      jest.advanceTimersByTime(150);
+      service.commitError(enqueuedError.id);
+
+      // At this point, the error should not be reported yet since we need to wait for the transient window so that navigation can be checked
+      expect(mockDeps.analytics.reportEvent).not.toHaveBeenCalled();
+
+      // Now advance to the full TRANSIENT_NAVIGATION_WINDOW_MS
+      jest.advanceTimersByTime(TRANSIENT_NAVIGATION_WINDOW_MS - 150);
+
+      // Now the error should be reported
+      expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+
+      // Check that the duration is around 150ms (when commit was called) not 250ms (when it was reported)
+      const reportedDuration =
+        mockDeps.analytics.reportEvent.mock.calls[0][1].component_render_min_duration_ms;
+      expect(reportedDuration).toBeGreaterThanOrEqual(145); // Allow small timing variance
+      expect(reportedDuration).toBeLessThanOrEqual(155);
+    });
+
+    it('auto-commits after DEFAULT_MAX_ERROR_DURATION_MS if commitError is never called', () => {
+      const testError = new Error('Test error for auto commit');
+
+      // Enqueue the error but never explicitly call commitError
+      service.enqueueError(testError, {
+        componentStack: `
+    at AutoCommitComponent (http://localhost:9001/main.iframe.bundle.js:11616:73)
+    at ErrorBoundaryInternal (http://localhost:9001/main.iframe.bundle.js:12232:81)`,
+      });
+
+      // After TRANSIENT_NAVIGATION_WINDOW_MS, it will check navigation but not report yet
+      jest.advanceTimersByTime(TRANSIENT_NAVIGATION_WINDOW_MS);
+      expect(mockDeps.analytics.reportEvent).not.toHaveBeenCalled();
+
+      // After the full DEFAULT_MAX_ERROR_DURATION_MS, it should auto-commit
+      jest.advanceTimersByTime(DEFAULT_MAX_ERROR_DURATION_MS - TRANSIENT_NAVIGATION_WINDOW_MS);
+
+      // Now the error should be reported
+      expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      expect(mockDeps.analytics.reportEvent.mock.calls[0][1].component_name).toBe(
+        'AutoCommitComponent'
+      );
+
+      // The duration should be approximately DEFAULT_MAX_ERROR_DURATION_MS
+      const reportedDuration =
+        mockDeps.analytics.reportEvent.mock.calls[0][1].component_render_min_duration_ms;
+      expect(reportedDuration).toBeGreaterThanOrEqual(DEFAULT_MAX_ERROR_DURATION_MS - 10); // Allow timing variance
+      expect(reportedDuration).toBeLessThanOrEqual(DEFAULT_MAX_ERROR_DURATION_MS + 10);
+    });
+
+    it('correctly reports has_transient_navigation when navigation occurs within window', () => {
+      // Mock getCurrentPathname to return different values on subsequent calls
+      const originalGetCurrentPathname = (service as any).getCurrentPathname;
+      const mockGetCurrentPathname = jest.fn();
+
+      // First call: initial pathname
+      // Second call: simulated navigation path
+      mockGetCurrentPathname
+        .mockReturnValueOnce('/initial-path')
+        .mockReturnValueOnce('/navigated-path');
+
+      (service as any).getCurrentPathname = mockGetCurrentPathname;
+
+      const testError = new Error('Test error for navigation detection');
+
+      // Enqueue the error
+      const enqueuedError = service.enqueueError(testError, {
+        componentStack: 'at NavigationComponent',
+      });
+
+      // Fast-forward to just when transient navigation check happens
+      jest.advanceTimersByTime(TRANSIENT_NAVIGATION_WINDOW_MS);
+
+      // External commit to trigger reporting
+      service.commitError(enqueuedError.id);
+
+      // Check if navigation was correctly detected
+      expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      expect(mockDeps.analytics.reportEvent.mock.calls[0][1].has_transient_navigation).toBe(true);
+
+      // Restore original function
+      (service as any).getCurrentPathname = originalGetCurrentPathname;
+    });
+
+    it('does not report has_transient_navigation when navigation occurs after window', () => {
+      // Mock getCurrentPathname to return different values on subsequent calls
+      const originalGetCurrentPathname = (service as any).getCurrentPathname;
+      const mockGetCurrentPathname = jest.fn();
+
+      // First two calls return same path (during transient window check)
+      // Third call would be after the window when we're committing
+      mockGetCurrentPathname
+        .mockReturnValueOnce('/initial-path')
+        .mockReturnValueOnce('/initial-path')
+        .mockReturnValueOnce('/navigated-later-path');
+
+      (service as any).getCurrentPathname = mockGetCurrentPathname;
+
+      const testError = new Error('Test error for late navigation');
+
+      // Enqueue the error
+      const enqueuedError = service.enqueueError(testError, {
+        componentStack: 'at LateNavigationComponent',
+      });
+
+      // Fast-forward to just when transient navigation check happens
+      jest.advanceTimersByTime(TRANSIENT_NAVIGATION_WINDOW_MS);
+
+      // At this point navigation hasn't happened yet during the window
+
+      // Fast-forward more time to simulate later navigation
+      jest.advanceTimersByTime(500);
+
+      // External commit to trigger reporting
+      service.commitError(enqueuedError.id);
+
+      // Check that has_transient_navigation is false because navigation happened after the window
+      expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      expect(mockDeps.analytics.reportEvent.mock.calls[0][1].has_transient_navigation).toBe(false);
+
+      // Restore original function
+      (service as any).getCurrentPathname = originalGetCurrentPathname;
+    });
+  });
+
+  describe('race conditions', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('handles invalid error IDs gracefully', () => {
+      // Try to commit a non-existent error
+      const result = service.commitError('non-existent-error-id');
+
+      // Should return null and not throw
+      expect(result).toBeNull();
+      expect(mockDeps.analytics.reportEvent).not.toHaveBeenCalled();
+    });
+
+    it('handles multiple errors simultaneously without interference', () => {
+      // Enqueue two separate errors
+      const error1 = new Error('First test error');
+      const error2 = new Error('Second test error');
+
+      const enqueuedError1 = service.enqueueError(error1, {
+        componentStack: `
+    at FirstComponent (http://localhost:9001/main.iframe.bundle.js:11616:73)`,
+      });
+
+      const enqueuedError2 = service.enqueueError(error2, {
+        componentStack: `
+    at SecondComponent (http://localhost:9001/main.iframe.bundle.js:11616:73)`,
+      });
+
+      // Advance time to check transient navigation
+      jest.advanceTimersByTime(TRANSIENT_NAVIGATION_WINDOW_MS);
+
+      // Commit first error
+      service.commitError(enqueuedError1.id);
+
+      // First error should be reported
+      expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      expect(mockDeps.analytics.reportEvent.mock.calls[0][1].component_name).toBe('FirstComponent');
+
+      jest.clearAllMocks();
+
+      // Commit second error
+      service.commitError(enqueuedError2.id);
+
+      // Second error should be reported separately
+      expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+      expect(mockDeps.analytics.reportEvent.mock.calls[0][1].component_name).toBe(
+        'SecondComponent'
+      );
+    });
+
+    it('prevents re-reporting of already reported errors', () => {
+      const testError = new Error('Test for re-reporting');
+
+      const enqueuedError = service.enqueueError(testError, {
+        componentStack: `
+    at ReportComponent (http://localhost:9001/main.iframe.bundle.js:11616:73)`,
+      });
+
+      // Advance time to check transient navigation
+      jest.advanceTimersByTime(TRANSIENT_NAVIGATION_WINDOW_MS);
+
+      // Commit error first time
+      service.commitError(enqueuedError.id);
+      expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+
+      jest.clearAllMocks();
+
+      // Try to commit the same error again
+      const result = service.commitError(enqueuedError.id);
+
+      // Should return null because error was already reported
+      expect(result).toBeNull();
+      expect(mockDeps.analytics.reportEvent).not.toHaveBeenCalled();
+    });
+
+    it('correctly handles early user action without navigation', () => {
+      // This scenario: Error occurs, user sees it briefly (<250ms) and clicks "refresh"
+      // No navigation occurs but error should be reported with correct duration
+
+      const testError = new Error('Test early user action');
+
+      // Enqueue error
+      const enqueuedError = service.enqueueError(testError, {
+        componentStack: `
+    at EarlyActionComponent (http://localhost:9001/main.iframe.bundle.js:11616:73)`,
+      });
+
+      // User takes action at 100ms (clicks refresh/retry/etc)
+      jest.advanceTimersByTime(100);
+      service.commitError(enqueuedError.id);
+
+      // Transient check hasn't run yet (happens at 250ms)
+      expect(mockDeps.analytics.reportEvent).not.toHaveBeenCalled();
+
+      // Advance to transient check
+      jest.advanceTimersByTime(TRANSIENT_NAVIGATION_WINDOW_MS - 100);
+
+      // Now the error should be reported
+      expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+
+      // The duration should be 100ms (when user took action)
+      const reportedDuration =
+        mockDeps.analytics.reportEvent.mock.calls[0][1].component_render_min_duration_ms;
+      expect(reportedDuration).toBeGreaterThanOrEqual(95);
+      expect(reportedDuration).toBeLessThanOrEqual(105);
+
+      // Transient navigation should be false (no navigation occurred)
+      expect(mockDeps.analytics.reportEvent.mock.calls[0][1].has_transient_navigation).toBe(false);
+    });
   });
 });

--- a/src/platform/packages/shared/shared-ux/error_boundary/src/services/error_service.ts
+++ b/src/platform/packages/shared/shared-ux/error_boundary/src/services/error_service.ts
@@ -12,7 +12,14 @@ import { REACT_FATAL_ERROR_EVENT_TYPE } from '../../lib/telemetry_events';
 import { KibanaErrorBoundaryProviderDeps } from '../../types';
 import { ThrowIfError } from '../ui/throw_if_error';
 
-const MATCH_CHUNK_LOADERROR = /ChunkLoadError/;
+const MATCH_CHUNK_LOAD_ERROR = /ChunkLoadError/;
+
+// Maximum duration to track for error component rendering
+export const DEFAULT_MAX_ERROR_DURATION_MS = 10 * 1000; // 10 seconds
+
+// Time window to capture transient navigation after an error
+// Navigation within this window suggests the error was transient and may not have been seen by users
+export const TRANSIENT_NAVIGATION_WINDOW_MS = 250;
 
 interface ErrorServiceError {
   error: Error;
@@ -25,6 +32,21 @@ interface Deps {
   analytics?: KibanaErrorBoundaryProviderDeps['analytics'];
 }
 
+// To keep track of errors that are enqueued for later reporting
+interface EnqueuedError extends ErrorServiceError {
+  id: string;
+  isReported: boolean;
+
+  initialPathname: string;
+  hasTransientNavigation: boolean;
+  transientNavigationDetermined: boolean;
+
+  enqueuedAt: number; // Timestamp when error was enqueued
+  committedAt?: number; // Track when commit was requested (externally or auto)
+
+  timeoutId?: ReturnType<typeof setTimeout>;
+}
+
 /**
  * Kibana Error Boundary Services: Error Service
  * Each Error Boundary tracks an instance of this class
@@ -32,6 +54,7 @@ interface Deps {
  */
 export class KibanaErrorService {
   private analytics?: Deps['analytics'];
+  private enqueuedErrors: Map<string, EnqueuedError> = new Map();
 
   constructor(deps: Deps) {
     this.analytics = deps.analytics;
@@ -42,7 +65,7 @@ export class KibanaErrorService {
    * or treated with "danger" coloring and include a detailed error message.
    */
   private getIsFatal(error: Error) {
-    const isChunkLoadError = MATCH_CHUNK_LOADERROR.test(error.name);
+    const isChunkLoadError = MATCH_CHUNK_LOAD_ERROR.test(error.name);
     return !isChunkLoadError; // "ChunkLoadError" is recoverable by refreshing the page
   }
 
@@ -56,7 +79,7 @@ export class KibanaErrorService {
 
     if (stackLines) {
       let i = 0;
-      while (i < stackLines.length - 1) {
+      while (i < stackLines.length) {
         // scan the stack trace text
         if (stackLines[i].match(errorIndicator)) {
           // extract the name of the bad component
@@ -73,31 +96,136 @@ export class KibanaErrorService {
     return errorComponentName;
   }
 
+  private getCurrentPathname(): string {
+    return typeof window !== 'undefined' ? window.location.pathname : '';
+  }
+
+  public getAnalyticsReference() {
+    return this.analytics;
+  }
+
   /**
-   * Creates a decorated error object
+   * Enqueues an error to be reported later with timing and navigation information
+   * @param error The error that was thrown
+   * @param errorInfo React error info containing component stack
+   * @returns An ID for the enqueued error that can be used to commit it later
    */
-  public registerError(error: Error, errorInfo?: React.ErrorInfo): ErrorServiceError {
+  public enqueueError(error: Error, errorInfo?: React.ErrorInfo): EnqueuedError {
     const isFatal = this.getIsFatal(error);
-    const name = this.getErrorComponentName(errorInfo);
+    const id = `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+
+    // Create the enqueued error object
+    const enqueuedError: EnqueuedError = {
+      id,
+      error,
+      errorInfo,
+      isFatal,
+      name: this.getErrorComponentName(errorInfo),
+      isReported: false,
+      hasTransientNavigation: false,
+      transientNavigationDetermined: false,
+      initialPathname: this.getCurrentPathname(),
+      enqueuedAt: Date.now(), // Set the enqueued timestamp
+    };
+
+    this.enqueuedErrors.set(id, enqueuedError);
+
+    // Set up single timer for transient navigation check
+    if (isFatal) {
+      enqueuedError.timeoutId = setTimeout(() => {
+        this.handleTransientNavigationCheck(id);
+      }, TRANSIENT_NAVIGATION_WINDOW_MS);
+    }
+
+    return enqueuedError;
+  }
+
+  /**
+   * Handles the transient navigation check after TRANSIENT_NAVIGATION_WINDOW_MS
+   * @private
+   */
+  private handleTransientNavigationCheck(errorId: string): void {
+    const enqueuedError = this.enqueuedErrors.get(errorId);
+    if (!enqueuedError || enqueuedError.isReported) {
+      return;
+    }
+
+    // Check for transient navigation
+    const currentPathname = this.getCurrentPathname();
+
+    enqueuedError.hasTransientNavigation = enqueuedError.initialPathname !== currentPathname;
+    enqueuedError.transientNavigationDetermined = true;
+
+    // If external commit was already requested, commit immediately
+    if (enqueuedError.committedAt) {
+      this.reportError(enqueuedError);
+    } else {
+      // Otherwise, set up timer for the remaining duration until max timeout
+      const remainingTime = DEFAULT_MAX_ERROR_DURATION_MS - TRANSIENT_NAVIGATION_WINDOW_MS;
+      enqueuedError.timeoutId = setTimeout(() => {
+        this.reportError(enqueuedError);
+      }, remainingTime);
+    }
+  }
+
+  /**
+   * Commits an error, ensuring transient navigation has been determined
+   * @param errorId The ID of the enqueued error
+   * @returns The error object or null if not found or already committed
+   */
+  public commitError(errorId: string): ErrorServiceError | null {
+    const enqueuedError = this.enqueuedErrors.get(errorId);
+
+    if (!enqueuedError || enqueuedError.isReported) {
+      return null;
+    }
+
+    // Mark the commit timestamp
+    enqueuedError.committedAt = enqueuedError.committedAt ?? Date.now();
+
+    // If transient navigation hasn't been determined yet, just mark the request and return null
+    // The handleTransientNavigationCheck will call reportError when ready
+    if (!enqueuedError.transientNavigationDetermined) {
+      return null;
+    }
+
+    // Transient navigation is already determined, commit immediately
+    return this.reportError(enqueuedError);
+  }
+
+  /**
+   * Actually reports the error telemetry
+   * @private
+   */
+  private reportError(enqueuedError: EnqueuedError): ErrorServiceError {
+    if (enqueuedError.isReported) {
+      return {
+        error: enqueuedError.error,
+        errorInfo: enqueuedError.errorInfo,
+        isFatal: enqueuedError.isFatal,
+        name: enqueuedError.name,
+      };
+    }
+
+    // Mark the error as reported
+    enqueuedError.isReported = true;
+
+    if (enqueuedError.timeoutId) {
+      // Mark the error as committed
+      enqueuedError.timeoutId = undefined;
+    }
 
     try {
-      if (isFatal && this.analytics) {
-        let componentStack = '';
-        let errorStack = '';
-
-        if (errorInfo && errorInfo.componentStack) {
-          componentStack = errorInfo.componentStack;
-        }
-
-        if (error instanceof Error && typeof error.stack === 'string') {
-          errorStack = error.stack;
-        }
-
+      if (enqueuedError.isFatal && this.analytics) {
         this.analytics.reportEvent(REACT_FATAL_ERROR_EVENT_TYPE, {
-          component_name: name,
-          component_stack: componentStack,
-          error_message: error.toString(),
-          error_stack: errorStack,
+          component_name: enqueuedError.name,
+          component_stack: enqueuedError.errorInfo?.componentStack || '',
+          error_message: enqueuedError.error.toString(),
+          error_stack:
+            typeof enqueuedError.error.stack === 'string' ? enqueuedError.error.stack : '',
+          component_render_min_duration_ms:
+            (enqueuedError.committedAt ?? Date.now()) - enqueuedError.enqueuedAt,
+          has_transient_navigation: enqueuedError.hasTransientNavigation,
         });
       }
     } catch (e) {
@@ -106,10 +234,10 @@ export class KibanaErrorService {
     }
 
     return {
-      error,
-      errorInfo,
-      isFatal,
-      name,
+      error: enqueuedError.error,
+      errorInfo: enqueuedError.errorInfo,
+      isFatal: enqueuedError.isFatal,
+      name: enqueuedError.name,
     };
   }
 }

--- a/src/platform/packages/shared/shared-ux/error_boundary/src/services/index.ts
+++ b/src/platform/packages/shared/shared-ux/error_boundary/src/services/index.ts
@@ -7,4 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { useErrorBoundary } from './error_boundary_services';
+export { useErrorBoundary } from './error_boundary_provider';

--- a/src/platform/packages/shared/shared-ux/error_boundary/src/ui/base_error_boundary.tsx
+++ b/src/platform/packages/shared/shared-ux/error_boundary/src/ui/base_error_boundary.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { KibanaErrorBoundaryServices } from '../../types';
+
+export interface BaseErrorBoundaryProps {
+  services: KibanaErrorBoundaryServices;
+}
+
+export interface BaseErrorBoundaryState {
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+  componentName: string | null;
+  isFatal: boolean | null;
+  errorId?: string;
+}
+
+/**
+ * Base error boundary component for error handling
+ * Subclasses must implement their own componentDidCatch and error reporting
+ */
+export abstract class BaseErrorBoundary<
+  P extends BaseErrorBoundaryProps,
+  S extends BaseErrorBoundaryState
+> extends React.Component<P, S> {
+  private beforeUnloadHandler = () => {
+    const errorId = this.state.errorId;
+    if (errorId) {
+      this.props.services.errorService.commitError(errorId);
+    }
+  };
+
+  componentDidMount() {
+    if (typeof window !== 'undefined') {
+      // Listen for page unload events (refresh, tab close, navigation away)
+      window.addEventListener('beforeunload', this.beforeUnloadHandler);
+    }
+  }
+
+  /**
+   * Clean up event listeners when component unmounts
+   */
+  componentWillUnmount() {
+    // Remove beforeunload event listener
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('beforeunload', this.beforeUnloadHandler);
+    }
+
+    // Commit the error when cleaning up
+    const errorId = this.state.errorId;
+    if (errorId) {
+      this.props.services.errorService.commitError(errorId);
+    }
+  }
+
+  /**
+   * Render method must be implemented by extending classes
+   */
+  abstract render(): React.ReactNode;
+}

--- a/src/platform/packages/shared/shared-ux/error_boundary/src/ui/error_boundary.fatal.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/error_boundary/src/ui/error_boundary.fatal.stories.tsx
@@ -7,24 +7,40 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { StoryFn, Meta } from '@storybook/react';
-import React from 'react';
-
-import { EuiFormFieldset } from '@elastic/eui';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  EuiFormFieldset,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiTitle,
+  EuiText,
+  EuiIconTip,
+} from '@elastic/eui';
+import { action } from '@storybook/addon-actions';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Template } from '../../mocks/src/storybook_template';
-import { BadComponent, KibanaErrorBoundaryStorybookMock } from '../../mocks';
-import { KibanaErrorBoundaryDepsProvider } from '../services/error_boundary_services';
-import { KibanaErrorBoundary } from './error_boundary';
-import { KibanaSectionErrorBoundary } from './section_error_boundary';
+import {
+  BadComponent,
+  createServicesWithAnalyticsMock,
+  Spacer,
+  DocsBlock,
+  StoryActionButton,
+} from '../../mocks';
 
 import mdx from '../../README.mdx';
-
-const storybookMock = new KibanaErrorBoundaryStorybookMock();
+import { KibanaErrorBoundaryDepsProvider } from '../services/error_boundary_provider';
+import {
+  DEFAULT_MAX_ERROR_DURATION_MS,
+  TRANSIENT_NAVIGATION_WINDOW_MS,
+} from '../services/error_service';
+import { KibanaErrorBoundary } from './error_boundary';
+import { KibanaSectionErrorBoundary } from './section_error_boundary';
 
 export default {
   title: 'Errors/Fatal Errors',
   description:
-    'This is the Kibana Error Boundary. Use this to put a boundary around React components that may throw errors when rendering. It will intercept the error and determine if it is fatal or recoverable.',
+    'This is the Kibana Error Boundary. Use this to put a boundary around React components that may throw errors when rendering. It will intercept the error and determine if it is fatal or recoverable.\n\nIn these stories we demonstrate the new telemetry fields: `component_render_min_duration_ms` and `has_transient_navigation`. You can observe reported telemetry in Storybook\'s Actions tab ("Report telemetry event").',
   parameters: {
     docs: {
       page: mdx,
@@ -33,7 +49,7 @@ export default {
 } as Meta;
 
 export const ErrorInCallout: StoryFn = () => {
-  const services = storybookMock.getServices();
+  const { services } = createServicesWithAnalyticsMock();
 
   return (
     <Template>
@@ -47,7 +63,7 @@ export const ErrorInCallout: StoryFn = () => {
 };
 
 export const SectionErrorInCallout: StoryFn = () => {
-  const services = storybookMock.getServices();
+  const { services } = createServicesWithAnalyticsMock();
 
   return (
     <Template>
@@ -62,6 +78,409 @@ export const SectionErrorInCallout: StoryFn = () => {
             <BadComponent />
           </KibanaSectionErrorBoundary>
         </EuiFormFieldset>
+      </KibanaErrorBoundaryDepsProvider>
+    </Template>
+  );
+};
+
+export const TransientError: StoryFn = () => {
+  const { services } = createServicesWithAnalyticsMock();
+
+  // Start with boundary NOT mounted so the embedded "Throw error" button is not visible outside cards
+  const [showBoundary, setShowBoundary] = useState(false);
+  const startRef = useRef<number>(0);
+  const navTimeoutRef = useRef<number | null>(null);
+  const unmountTimeoutRef = useRef<number | null>(null);
+  const logUnmount = useMemo(() => action('Unmounted error boundary'), []);
+
+  useEffect(() => {
+    return () => {
+      if (navTimeoutRef.current) window.clearTimeout(navTimeoutRef.current);
+      if (unmountTimeoutRef.current) window.clearTimeout(unmountTimeoutRef.current);
+    };
+  }, []);
+
+  const clearTimers = useCallback(() => {
+    if (navTimeoutRef.current) window.clearTimeout(navTimeoutRef.current);
+    if (unmountTimeoutRef.current) window.clearTimeout(unmountTimeoutRef.current);
+    navTimeoutRef.current = null;
+    unmountTimeoutRef.current = null;
+  }, []);
+
+  const clickErrorButton = useCallback(() => {
+    const btn = document.querySelector(
+      '[data-test-subj="clickForErrorBtn"]'
+    ) as HTMLButtonElement | null;
+    if (btn) {
+      btn.click();
+      return true;
+    }
+    return false;
+  }, []);
+
+  const scheduleNavigation = useCallback((delayMs: number) => {
+    if (navTimeoutRef.current) window.clearTimeout(navTimeoutRef.current);
+    navTimeoutRef.current = window.setTimeout(() => {
+      const newPath = `/storybook-nav-${Date.now()}`;
+      window.history.pushState({}, '', newPath);
+      setShowBoundary((v) => v);
+    }, delayMs);
+  }, []);
+
+  const scheduleUnmount = useCallback(
+    (delayMs: number) => {
+      if (unmountTimeoutRef.current) window.clearTimeout(unmountTimeoutRef.current);
+      const plannedAt = Date.now();
+      unmountTimeoutRef.current = window.setTimeout(() => {
+        setShowBoundary(false);
+        const startAt = startRef.current || plannedAt;
+        const elapsed = Date.now() - startAt;
+        logUnmount({ plannedDelayMs: delayMs, elapsedMs: elapsed });
+        // Remount to allow repeated runs
+        window.setTimeout(() => setShowBoundary(true), 0);
+      }, delayMs);
+    },
+    [logUnmount]
+  );
+
+  const runScenario = useCallback(
+    ({
+      unmountDelayMs,
+      withNav,
+      navAfterWindow,
+    }: {
+      unmountDelayMs: number;
+      withNav?: boolean;
+      // if true, schedule nav after TRANSIENT_NAVIGATION_WINDOW_MS, else schedule close to unmount
+      navAfterWindow?: boolean;
+    }) => {
+      // Do not clear any telemetry storage here; events are visible in Storybook Actions
+      clearTimers();
+      if (!showBoundary) setShowBoundary(true);
+      startRef.current = Date.now();
+      window.setTimeout(() => {
+        clickErrorButton();
+        if (withNav) {
+          let navDelay = Math.max(0, unmountDelayMs - 20);
+          if (navAfterWindow) {
+            navDelay = Math.min(
+              Math.max(TRANSIENT_NAVIGATION_WINDOW_MS + 10, 0),
+              Math.max(0, unmountDelayMs - 20)
+            );
+          }
+          scheduleNavigation(navDelay);
+        }
+        scheduleUnmount(unmountDelayMs);
+      }, 0);
+    },
+    [showBoundary, clearTimers, clickErrorButton, scheduleNavigation, scheduleUnmount]
+  );
+
+  // Manual flows
+  const [manualMode, setManualMode] = useState<'none' | 'plain' | 'nav'>('none');
+
+  const startManual = useCallback(
+    (mode: 'plain' | 'nav') => {
+      // Do not clear any telemetry storage here; events are visible in Storybook Actions
+      clearTimers();
+      if (!showBoundary) setShowBoundary(true);
+      startRef.current = Date.now();
+      setManualMode(mode);
+      window.setTimeout(() => {
+        clickErrorButton();
+      }, 0);
+    },
+    [clearTimers, showBoundary, clickErrorButton]
+  );
+
+  const manualUnmount = useCallback(() => {
+    if (manualMode === 'nav') {
+      // Navigate just before unmount
+      scheduleNavigation(0);
+      window.setTimeout(() => {
+        setShowBoundary(false);
+        const elapsed = Date.now() - startRef.current;
+        logUnmount({ plannedDelayMs: 'manual+nav', elapsedMs: elapsed });
+        window.setTimeout(() => setShowBoundary(true), 0);
+        setManualMode('none');
+      }, 20);
+    } else if (manualMode === 'plain') {
+      setShowBoundary(false);
+      const elapsed = Date.now() - startRef.current;
+      logUnmount({ plannedDelayMs: 'manual', elapsedMs: elapsed });
+      window.setTimeout(() => setShowBoundary(true), 0);
+      setManualMode('none');
+    }
+  }, [manualMode, scheduleNavigation, logUnmount]);
+
+  return (
+    <Template>
+      <KibanaErrorBoundaryDepsProvider {...services}>
+        <DocsBlock title="Background">
+          <div>
+            Here a &quot;Transient Error&quot; is as an error that self-resolves quickly, often
+            following a navigation, where user may not even visually notice the error.
+            <br />
+            <br />
+            When an unrecoverable error is thrown, Error Boundary waits for at least{' '}
+            <code>TRANSIENT_NAVIGATION_WINDOW_MS</code> ({TRANSIENT_NAVIGATION_WINDOW_MS}ms) to
+            capture any transient navigation. It then reports telemetry including{' '}
+            <code>has_transient_navigation</code> and <code>component_render_min_duration_ms</code>.
+            If no user interaction occurs, the error auto-commits after{' '}
+            <code>DEFAULT_MAX_ERROR_DURATION_MS</code> ({DEFAULT_MAX_ERROR_DURATION_MS}ms).
+          </div>
+          <ul style={{ listStyleType: 'circle', paddingLeft: '1.5em' }}>
+            <li>
+              <strong>
+                <code>component_render_min_duration_ms</code>
+              </strong>
+              : records how long the error component stayed rendered. Helpful to identify
+              short-lived momentary errors that users may not have seen.
+            </li>
+            <li>
+              <strong>
+                <code>has_transient_navigation</code>
+              </strong>
+              : true if a navigation occurred within the first{' '}
+              <code>TRANSIENT_NAVIGATION_WINDOW_MS</code> after error occurred. Helps identify
+              transient errors followed possibly by a successful navigation.
+            </li>
+          </ul>
+        </DocsBlock>
+
+        <DocsBlock title="Behavior">
+          <div>
+            Use the scenarios below to simulate short-lived vs longer errors and with/without
+            navigation inside the transient window. Each scenario mounts a boundary, throws, and
+            then unmounts per its plan so you can observe timings and navigation classification.
+            <br />
+            <br />
+            <b>Note</b> reported events can be observed in Storybook&apos;s <strong>Actions</strong>{' '}
+            tab (watch the log entry &quot;Report telemetry event&quot;).
+          </div>
+        </DocsBlock>
+
+        <Spacer />
+
+        <EuiFlexGroup gutterSize="m" wrap>
+          <EuiFlexItem grow={1} style={{ minWidth: 280 }}>
+            <EuiPanel>
+              <EuiTitle size="xs">
+                <h3>100ms</h3>
+              </EuiTitle>
+              <EuiText size="s">
+                <p>
+                  Auto unmount after 100ms. No navigation. Expected: has_transient_navigation =
+                  false.
+                </p>
+              </EuiText>
+              <StoryActionButton onClick={() => runScenario({ unmountDelayMs: 100 })}>
+                Run 100ms
+              </StoryActionButton>
+              <span style={{ marginLeft: 8 }}>
+                ?
+                <EuiIconTip
+                  content={
+                    <span>
+                      <strong>Telemetry expectation</strong>:<br />
+                      <code>component_render_min_duration_ms</code> ≈ <strong>100ms</strong>
+                      (actual render time until unmount). Reporting may still wait for the
+                      <code> TRANSIENT_NAVIGATION_WINDOW_MS</code>, but this metric reflects the
+                      component’s own lifetime. <code>has_transient_navigation</code> ={' '}
+                      <strong>false</strong> (no navigation occurred).
+                    </span>
+                  }
+                  position="right"
+                  type="questionInCircle"
+                />
+              </span>
+            </EuiPanel>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={1} style={{ minWidth: 280 }}>
+            <EuiPanel>
+              <EuiTitle size="xs">
+                <h3>With Nav 100ms</h3>
+              </EuiTitle>
+              <EuiText size="s">
+                <p>
+                  Navigate just before unmount (within 100ms). Expected: has_transient_navigation =
+                  true.
+                </p>
+              </EuiText>
+              <StoryActionButton
+                onClick={() => runScenario({ unmountDelayMs: 100, withNav: true })}
+              >
+                Run 100ms + Nav
+              </StoryActionButton>
+              <span style={{ marginLeft: 8 }}>
+                ?
+                <EuiIconTip
+                  content={
+                    <span>
+                      <strong>Telemetry expectation</strong>:<br />
+                      <code>component_render_min_duration_ms</code> ≈ <strong>100ms</strong>
+                      (actual render time until unmount). A navigation occurs within the transient
+                      window, so <code>has_transient_navigation</code> = <strong>true</strong>.
+                    </span>
+                  }
+                  position="right"
+                  type="questionInCircle"
+                />
+              </span>
+            </EuiPanel>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={1} style={{ minWidth: 280 }}>
+            <EuiPanel>
+              <EuiTitle size="xs">
+                <h3>400ms</h3>
+              </EuiTitle>
+              <EuiText size="s">
+                <p>
+                  Auto unmount after 400ms. No navigation. Expected: has_transient_navigation =
+                  false.
+                </p>
+              </EuiText>
+              <StoryActionButton onClick={() => runScenario({ unmountDelayMs: 400 })}>
+                Run 400ms
+              </StoryActionButton>
+              <span style={{ marginLeft: 8 }}>
+                ?
+                <EuiIconTip
+                  content={
+                    <span>
+                      <strong>Telemetry expectation</strong>:<br />
+                      <code>component_render_min_duration_ms</code> ≈ <strong>400ms</strong>
+                      (actual render time). No navigation takes place, so{' '}
+                      <code>has_transient_navigation</code> = <strong>false</strong>.
+                    </span>
+                  }
+                  position="right"
+                  type="questionInCircle"
+                />
+              </span>
+            </EuiPanel>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={1} style={{ minWidth: 280 }}>
+            <EuiPanel>
+              <EuiTitle size="xs">
+                <h3>With Nav 400ms</h3>
+              </EuiTitle>
+              <EuiText size="s">
+                <p>
+                  Navigate after <code>TRANSIENT_NAVIGATION_WINDOW_MS</code> and before unmount.
+                  Expected: has_transient_navigation = false.
+                </p>
+              </EuiText>
+              <StoryActionButton
+                onClick={() =>
+                  runScenario({ unmountDelayMs: 400, withNav: true, navAfterWindow: true })
+                }
+              >
+                Run 400ms + Nav (after window)
+              </StoryActionButton>
+              <span style={{ marginLeft: 8 }}>
+                ?
+                <EuiIconTip
+                  content={
+                    <span>
+                      <strong>Telemetry expectation</strong>:<br />
+                      <code>component_render_min_duration_ms</code> ≈ <strong>400ms</strong>
+                      (actual render time). Navigation occurs <em>after</em> the transient window,
+                      so <code>has_transient_navigation</code> = <strong>false</strong>.
+                    </span>
+                  }
+                  position="right"
+                  type="questionInCircle"
+                />
+              </span>
+            </EuiPanel>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={1} style={{ minWidth: 280 }}>
+            <EuiPanel>
+              <EuiTitle size="xs">
+                <h3>Manual</h3>
+              </EuiTitle>
+              <EuiText size="s">
+                <p>Throw and manually unmount when ready. No navigation.</p>
+              </EuiText>
+              {manualMode !== 'plain' ? (
+                <StoryActionButton onClick={() => startManual('plain')}>
+                  Throw (manual)
+                </StoryActionButton>
+              ) : (
+                <StoryActionButton color="primary" onClick={manualUnmount}>
+                  Unmount now
+                </StoryActionButton>
+              )}
+              <span style={{ marginLeft: 8 }}>
+                ?
+                <EuiIconTip
+                  content={
+                    <span>
+                      <strong>Telemetry expectation</strong>:<br />
+                      <code>component_render_min_duration_ms</code> equals the time until you click{' '}
+                      <em>Unmount now</em> (the component’s actual render duration). Unless you
+                      navigate, <code>has_transient_navigation</code> will be <strong>false</strong>
+                      . Reporting may still wait out the transient window, but the duration reflects
+                      the component’s lifetime.
+                    </span>
+                  }
+                  position="right"
+                  type="questionInCircle"
+                />
+              </span>
+            </EuiPanel>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={1} style={{ minWidth: 280 }}>
+            <EuiPanel>
+              <EuiTitle size="xs">
+                <h3>Manual Nav</h3>
+              </EuiTitle>
+              <EuiText size="s">
+                <p>Throw and unmount with a navigation just before unmounting.</p>
+              </EuiText>
+              {manualMode !== 'nav' ? (
+                <StoryActionButton onClick={() => startManual('nav')}>
+                  Throw (manual + nav)
+                </StoryActionButton>
+              ) : (
+                <StoryActionButton color="primary" onClick={manualUnmount}>
+                  Unmount with Nav
+                </StoryActionButton>
+              )}
+              <span style={{ marginLeft: 8 }}>
+                ?
+                <EuiIconTip
+                  content={
+                    <span>
+                      <strong>Telemetry expectation</strong>:<br />
+                      The duration equals the time until you unmount. If you click
+                      <em> Unmount with Nav</em> quickly after throwing, the navigation occurs
+                      within <code>TRANSIENT_NAVIGATION_WINDOW_MS</code> and{' '}
+                      <code>has_transient_navigation</code> will be <strong>true</strong>. Waiting
+                      longer makes it <strong>false</strong>.
+                    </span>
+                  }
+                  position="right"
+                  type="questionInCircle"
+                />
+              </span>
+            </EuiPanel>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <Spacer />
+
+        {showBoundary && (
+          <KibanaErrorBoundary>
+            <BadComponent />
+          </KibanaErrorBoundary>
+        )}
       </KibanaErrorBoundaryDepsProvider>
     </Template>
   );

--- a/src/platform/packages/shared/shared-ux/error_boundary/src/ui/error_boundary.recoverable.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/error_boundary/src/ui/error_boundary.recoverable.stories.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import { EuiFormFieldset } from '@elastic/eui';
 import { Template } from '../../mocks/src/storybook_template';
 import { ChunkLoadErrorComponent, KibanaErrorBoundaryStorybookMock } from '../../mocks';
-import { KibanaErrorBoundaryDepsProvider } from '../services/error_boundary_services';
+import { KibanaErrorBoundaryDepsProvider } from '../services/error_boundary_provider';
 import { KibanaErrorBoundary } from './error_boundary';
 import { KibanaSectionErrorBoundary } from './section_error_boundary';
 

--- a/src/platform/packages/shared/shared-ux/error_boundary/src/ui/error_boundary.test.tsx
+++ b/src/platform/packages/shared/shared-ux/error_boundary/src/ui/error_boundary.test.tsx
@@ -8,13 +8,18 @@
  */
 
 import { render } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
-import React, { FC, PropsWithChildren } from 'react';
+import userEvent from '@testing-library/user-event';
+import type { FC, PropsWithChildren } from 'react';
+import React from 'react';
 import { apm } from '@elastic/apm-rum';
+import {
+  DEFAULT_MAX_ERROR_DURATION_MS,
+  TRANSIENT_NAVIGATION_WINDOW_MS,
+} from '../services/error_service';
 
 import { BadComponent, ChunkLoadErrorComponent, getServicesMock } from '../../mocks';
-import { KibanaErrorBoundaryServices } from '../../types';
-import { KibanaErrorBoundaryDepsProvider } from '../services/error_boundary_services';
+import type { KibanaErrorBoundaryServices } from '../../types';
+import { KibanaErrorBoundaryDepsProvider } from '../services/error_boundary_provider';
 import { KibanaErrorService } from '../services/error_service';
 import { KibanaErrorBoundary } from './error_boundary';
 import { errorMessageStrings as strings } from './message_strings';
@@ -23,10 +28,22 @@ jest.mock('@elastic/apm-rum');
 
 describe('<KibanaErrorBoundary>', () => {
   let services: KibanaErrorBoundaryServices;
+  let user: ReturnType<typeof userEvent.setup>;
   beforeEach(() => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
+    // Use fake timers for all tests so userEvent can drive microtasks deterministically.
+    jest.useFakeTimers();
     services = getServicesMock();
     (apm.captureError as jest.Mock).mockClear();
+    user = userEvent.setup({
+      advanceTimers: async (ms) => {
+        await jest.advanceTimersByTimeAsync(ms);
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   const Template: FC<PropsWithChildren<unknown>> = ({ children }) => {
@@ -51,12 +68,12 @@ describe('<KibanaErrorBoundary>', () => {
         <ChunkLoadErrorComponent />
       </Template>
     );
-    await userEvent.click(await findByTestId('clickForErrorBtn'));
+    await user.click(await findByTestId('clickForErrorBtn'));
 
     expect(await findByText(strings.page.callout.recoverable.title())).toBeVisible();
     expect(await findByText(strings.page.callout.recoverable.pageReloadButton())).toBeVisible();
 
-    await userEvent.click(await findByTestId('errorBoundaryRecoverablePromptReloadBtn'));
+    await user.click(await findByTestId('errorBoundaryRecoverablePromptReloadBtn'));
 
     expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
@@ -69,14 +86,14 @@ describe('<KibanaErrorBoundary>', () => {
         <BadComponent />
       </Template>
     );
-    await userEvent.click(await findByTestId('clickForErrorBtn'));
+    await user.click(await findByTestId('clickForErrorBtn'));
 
     expect(await findByText(strings.page.callout.fatal.title())).toBeVisible();
     expect(await findByText(strings.page.callout.fatal.body())).toBeVisible();
     expect(await findByText(strings.page.callout.fatal.showDetailsButton())).toBeVisible();
     expect(await findByText(strings.page.callout.fatal.pageReloadButton())).toBeVisible();
 
-    await userEvent.click(await findByTestId('errorBoundaryFatalPromptReloadBtn'));
+    await user.click(await findByTestId('errorBoundaryFatalPromptReloadBtn'));
 
     expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
@@ -92,8 +109,12 @@ describe('<KibanaErrorBoundary>', () => {
         <BadComponent />
       </Template>
     );
-    await userEvent.click(await findByTestId('clickForErrorBtn'));
+    await user.click(await findByTestId('clickForErrorBtn'));
 
+    // Advance all timers to force auto-report (transient window + remaining duration)
+    await jest.advanceTimersByTimeAsync(DEFAULT_MAX_ERROR_DURATION_MS);
+
+    expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
     expect(mockDeps.analytics.reportEvent.mock.calls[0][0]).toBe('fatal-error-react');
     expect(mockDeps.analytics.reportEvent.mock.calls[0][1]).toMatchObject({
       component_name: 'BadComponent',
@@ -112,7 +133,10 @@ describe('<KibanaErrorBoundary>', () => {
         <BadComponent />
       </Template>
     );
-    await userEvent.click(await findByTestId('clickForErrorBtn'));
+
+    await user.click(await findByTestId('clickForErrorBtn'));
+
+    await jest.advanceTimersByTimeAsync(DEFAULT_MAX_ERROR_DURATION_MS);
 
     expect(
       mockDeps.analytics.reportEvent.mock.calls[0][1].component_stack.includes('at BadComponent')
@@ -130,12 +154,73 @@ describe('<KibanaErrorBoundary>', () => {
         <BadComponent />
       </Template>
     );
-    await userEvent.click(await findByTestId('clickForErrorBtn'));
+    await user.click(await findByTestId('clickForErrorBtn'));
 
     expect(apm.captureError).toHaveBeenCalledTimes(1);
     expect(apm.captureError).toHaveBeenCalledWith(
       new Error('This is an error to show the test user!'),
       { labels: { error_type: 'PageFatalReactError' } }
     );
+  });
+
+  it('reports after transient window when unmounts early', async () => {
+    const mockDeps = { analytics: { reportEvent: jest.fn() } };
+    services.errorService = new KibanaErrorService(mockDeps);
+    const { findByTestId, unmount } = render(
+      <Template>
+        <BadComponent />
+      </Template>
+    );
+
+    await user.click(await findByTestId('clickForErrorBtn'));
+
+    // Unmount early (simulate navigation or teardown before max duration)
+    unmount();
+
+    // Should not have reported yet (still in transient window)
+    expect(mockDeps.analytics.reportEvent).not.toHaveBeenCalled();
+
+    // Advance only the transient navigation window, not the full default max
+    await jest.advanceTimersByTimeAsync(TRANSIENT_NAVIGATION_WINDOW_MS);
+
+    // Should have reported exactly once
+    expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+    const payload = mockDeps.analytics.reportEvent.mock.calls[0][1];
+
+    // Duration should reflect early commit (less than full default window, and <= transient window)
+    expect(payload.component_render_min_duration_ms).toBeLessThanOrEqual(
+      TRANSIENT_NAVIGATION_WINDOW_MS
+    );
+    expect(payload.component_name).toBe('BadComponent');
+    expect(payload.error_message).toBe('Error: This is an error to show the test user!');
+  });
+
+  it('reports after max duration if not unmounted early', async () => {
+    const mockDeps = { analytics: { reportEvent: jest.fn() } };
+    services.errorService = new KibanaErrorService(mockDeps);
+    const { findByTestId } = render(
+      <Template>
+        <BadComponent />
+      </Template>
+    );
+
+    await user.click(await findByTestId('clickForErrorBtn'));
+
+    // Should not have reported yet (still in transient window)
+    expect(mockDeps.analytics.reportEvent).not.toHaveBeenCalled();
+
+    // Advance until the max duration has fully elapsed
+    await jest.advanceTimersByTimeAsync(DEFAULT_MAX_ERROR_DURATION_MS);
+
+    // Should have reported exactly once
+    expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+    const payload = mockDeps.analytics.reportEvent.mock.calls[0][1];
+
+    // Duration should reflect the max wait time
+    expect(payload.component_render_min_duration_ms).toBeGreaterThanOrEqual(
+      DEFAULT_MAX_ERROR_DURATION_MS
+    );
+    expect(payload.component_name).toBe('BadComponent');
+    expect(payload.error_message).toBe('Error: This is an error to show the test user!');
   });
 });

--- a/src/platform/packages/shared/shared-ux/error_boundary/src/ui/error_boundary.tsx
+++ b/src/platform/packages/shared/shared-ux/error_boundary/src/ui/error_boundary.tsx
@@ -11,26 +11,19 @@ import { apm } from '@elastic/apm-rum';
 import React from 'react';
 
 import { getErrorBoundaryLabels } from '../../lib';
-import type { KibanaErrorBoundaryServices } from '../../types';
 import { useErrorBoundary } from '../services';
 import { FatalPrompt, RecoverablePrompt } from './message_components';
+import {
+  BaseErrorBoundary,
+  type BaseErrorBoundaryState,
+  type BaseErrorBoundaryProps,
+} from './base_error_boundary';
 
-interface ErrorBoundaryState {
-  error: null | Error;
-  errorInfo: null | Partial<React.ErrorInfo>;
-  componentName: null | string;
-  isFatal: null | boolean;
-}
-
-interface ServiceContext {
-  services: KibanaErrorBoundaryServices;
-}
-
-class ErrorBoundaryInternal extends React.Component<
-  React.PropsWithChildren<ServiceContext>,
-  ErrorBoundaryState
+class ErrorBoundaryInternal extends BaseErrorBoundary<
+  React.PropsWithChildren<BaseErrorBoundaryProps>,
+  BaseErrorBoundaryState
 > {
-  constructor(props: React.PropsWithChildren<ServiceContext>) {
+  constructor(props: React.PropsWithChildren<BaseErrorBoundaryProps>) {
     super(props);
     this.state = {
       error: null,
@@ -47,9 +40,16 @@ class ErrorBoundaryInternal extends React.Component<
     console.error('Error caught by Kibana React Error Boundary'); // eslint-disable-line no-console
     console.error(error); // eslint-disable-line no-console
 
-    const { name, isFatal } = this.props.services.errorService.registerError(error, errorInfo);
-    this.setState(() => {
-      return { error, errorInfo, componentName: name, isFatal };
+    // Enqueue the error instead of registering it immediately
+    const enqueuedError = this.props.services.errorService.enqueueError(error, errorInfo);
+    const { id: errorId, isFatal, name } = enqueuedError;
+
+    this.setState({
+      error,
+      errorInfo,
+      componentName: name,
+      isFatal,
+      errorId,
     });
   }
 

--- a/src/platform/packages/shared/shared-ux/error_boundary/src/ui/section_error_boundary.test.tsx
+++ b/src/platform/packages/shared/shared-ux/error_boundary/src/ui/section_error_boundary.test.tsx
@@ -9,12 +9,17 @@
 
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React, { FC, PropsWithChildren } from 'react';
+import type { FC, PropsWithChildren } from 'react';
+import React from 'react';
 import { apm } from '@elastic/apm-rum';
+import {
+  DEFAULT_MAX_ERROR_DURATION_MS,
+  TRANSIENT_NAVIGATION_WINDOW_MS,
+} from '../services/error_service';
 
 import { BadComponent, ChunkLoadErrorComponent, getServicesMock } from '../../mocks';
-import { KibanaErrorBoundaryServices } from '../../types';
-import { KibanaErrorBoundaryDepsProvider } from '../services/error_boundary_services';
+import type { KibanaErrorBoundaryServices } from '../../types';
+import { KibanaErrorBoundaryDepsProvider } from '../services/error_boundary_provider';
 import { KibanaErrorService } from '../services/error_service';
 import { KibanaSectionErrorBoundary } from './section_error_boundary';
 import { errorMessageStrings as strings } from './message_strings';
@@ -23,10 +28,21 @@ jest.mock('@elastic/apm-rum');
 
 describe('<KibanaSectionErrorBoundary>', () => {
   let services: KibanaErrorBoundaryServices;
+  let user: ReturnType<typeof userEvent.setup>;
   beforeEach(() => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.useFakeTimers();
     services = getServicesMock();
     (apm.captureError as jest.Mock).mockClear();
+    user = userEvent.setup({
+      advanceTimers: async (ms) => {
+        await jest.advanceTimersByTimeAsync(ms);
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   const Template: FC<PropsWithChildren<unknown>> = ({ children }) => {
@@ -53,13 +69,13 @@ describe('<KibanaSectionErrorBoundary>', () => {
         <ChunkLoadErrorComponent />
       </Template>
     );
-    await userEvent.click(getByTestId('clickForErrorBtn'));
+    await user.click(getByTestId('clickForErrorBtn'));
 
     expect(getByText(strings.section.callout.recoverable.title('test section name'))).toBeVisible();
     expect(getByText(strings.section.callout.recoverable.body('test section name'))).toBeVisible();
     expect(getByText(strings.section.callout.recoverable.pageReloadButton())).toBeVisible();
 
-    await userEvent.click(getByTestId('sectionErrorBoundaryRecoverBtn'));
+    await user.click(getByTestId('sectionErrorBoundaryRecoverBtn'));
 
     expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
@@ -70,7 +86,7 @@ describe('<KibanaSectionErrorBoundary>', () => {
         <BadComponent />
       </Template>
     );
-    await userEvent.click(getByTestId('clickForErrorBtn'));
+    await user.click(getByTestId('clickForErrorBtn'));
 
     expect(getByText(strings.section.callout.fatal.title('test section name'))).toBeVisible();
     expect(getByText(strings.section.callout.fatal.body('test section name'))).toBeVisible();
@@ -88,7 +104,10 @@ describe('<KibanaSectionErrorBoundary>', () => {
         <BadComponent />
       </Template>
     );
-    await userEvent.click(await findByTestId('clickForErrorBtn'));
+    await user.click(await findByTestId('clickForErrorBtn'));
+
+    // Wait until `DEFAULT_MAX_ERROR_DURATION_MS` for auto commit/reporting
+    await jest.advanceTimersByTimeAsync(DEFAULT_MAX_ERROR_DURATION_MS);
 
     expect(mockDeps.analytics.reportEvent.mock.calls[0][0]).toBe('fatal-error-react');
     expect(mockDeps.analytics.reportEvent.mock.calls[0][1]).toMatchObject({
@@ -108,7 +127,10 @@ describe('<KibanaSectionErrorBoundary>', () => {
         <BadComponent />
       </Template>
     );
-    await userEvent.click(await findByTestId('clickForErrorBtn'));
+    await user.click(await findByTestId('clickForErrorBtn'));
+
+    // Wait until `DEFAULT_MAX_ERROR_DURATION_MS` for auto commit/reporting
+    await jest.advanceTimersByTimeAsync(DEFAULT_MAX_ERROR_DURATION_MS);
 
     expect(
       mockDeps.analytics.reportEvent.mock.calls[0][1].component_stack.includes('at BadComponent')
@@ -126,12 +148,73 @@ describe('<KibanaSectionErrorBoundary>', () => {
         <BadComponent />
       </Template>
     );
-    await userEvent.click(await findByTestId('clickForErrorBtn'));
+    await user.click(await findByTestId('clickForErrorBtn'));
 
     expect(apm.captureError).toHaveBeenCalledTimes(1);
     expect(apm.captureError).toHaveBeenCalledWith(
       new Error('This is an error to show the test user!'),
       { labels: { error_type: 'SectionFatalReactError' } }
     );
+  });
+
+  it('reports after transient window when unmounts early', async () => {
+    const mockDeps = { analytics: { reportEvent: jest.fn() } };
+    services.errorService = new KibanaErrorService(mockDeps);
+    const { findByTestId, unmount } = render(
+      <Template>
+        <BadComponent />
+      </Template>
+    );
+
+    await user.click(await findByTestId('clickForErrorBtn'));
+
+    // Unmount early (simulate navigation or teardown before max duration)
+    unmount();
+
+    // Should not have reported yet (still in transient window)
+    expect(mockDeps.analytics.reportEvent).not.toHaveBeenCalled();
+
+    // Advance only the transient navigation window, not the full default max
+    await jest.advanceTimersByTimeAsync(TRANSIENT_NAVIGATION_WINDOW_MS);
+
+    // Should have reported exactly once
+    expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+    const payload = mockDeps.analytics.reportEvent.mock.calls[0][1];
+
+    // Duration should reflect early commit (less than full default window, and <= transient window)
+    expect(payload.component_render_min_duration_ms).toBeLessThanOrEqual(
+      TRANSIENT_NAVIGATION_WINDOW_MS
+    );
+    expect(payload.component_name).toBe('BadComponent');
+    expect(payload.error_message).toBe('Error: This is an error to show the test user!');
+  });
+
+  it('reports after max duration if not unmounted early', async () => {
+    const mockDeps = { analytics: { reportEvent: jest.fn() } };
+    services.errorService = new KibanaErrorService(mockDeps);
+    const { findByTestId } = render(
+      <Template>
+        <BadComponent />
+      </Template>
+    );
+
+    await user.click(await findByTestId('clickForErrorBtn'));
+
+    // Should not have reported yet (still in transient window)
+    expect(mockDeps.analytics.reportEvent).not.toHaveBeenCalled();
+
+    // Advance until the max duration has fully elapsed
+    await jest.advanceTimersByTimeAsync(DEFAULT_MAX_ERROR_DURATION_MS);
+
+    // Should have reported exactly once
+    expect(mockDeps.analytics.reportEvent).toHaveBeenCalledTimes(1);
+    const payload = mockDeps.analytics.reportEvent.mock.calls[0][1];
+
+    // Duration should reflect the max wait time
+    expect(payload.component_render_min_duration_ms).toBeGreaterThanOrEqual(
+      DEFAULT_MAX_ERROR_DURATION_MS
+    );
+    expect(payload.component_name).toBe('BadComponent');
+    expect(payload.error_message).toBe('Error: This is an error to show the test user!');
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[FatalReactError] Send additional metrics with Error Telemetry Event to understand transient, non-breaking errors. (#234589)](https://github.com/elastic/kibana/pull/234589)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Abdul Wahab Zahid","email":"awahab07@yahoo.com"},"sourceCommit":{"committedDate":"2025-10-30T11:35:42Z","message":"[FatalReactError] Send additional metrics with Error Telemetry Event to understand transient, non-breaking errors. (#234589)\n\n## Summary\n\nThis PR improves the React error boundary telemetry in Shared UX to\ncorrectly classify and measure short-lived (“transient”) errors.\n\n## Problem\n\nHistorically, we could not reliably distinguish between:\n\n* A momentary Error Boundary that appears briefly and then disappears, a\nprobable false positive due to immediate user navigation or recovery.\n* A “seen” error UI that remained on screen long enough to be considered\na user-visible failure (validly Fatal).\n\nThis made it difficult to detect transient errors that users likely did\nnot see, and possibly should not be reported as Fatal errors to\ntelemetry (or alerted for).\n\n### What this PR does\n\nAdds two telemetry fields to `REACT_FATAL_ERROR_EVENT_TYPE`:\n\n* `component_render_min_duration_ms`: Minimum time the error boundary UI\ncomponent remained mounted.\n    -  Helps identify truly momentary/transient error experiences\n* `has_transient_navigation`: A boolean that is `true` only if a\nnavigation occurred within the first `TRANSIENT_NAVIGATION_WINDOW_MS`\n(e.g. 250ms) after the error appeared.\n- Enables analysis of transient errors that coincide with user or\nprogrammatic navigation (e.g., route change after an error render)\n\n#### Refactored Error Reporting Logic\n\nTo accurately capture `has_transient_navigation`, an error is not\nreported immediately. Instead, it is first enqueued and held for a brief\ntime window (default 250ms) to determine if a transient navigation has\noccurred. The error report is only committed after this window elapses,\nensuring `has_transient_navigation` has been correctly determined. A\ncommit is triggered as a result of any user action which unmounts the\nerror boundary (provided `TRANSIENT_NAVIGATION_WINDOW_MS` has elapsed\notherwise it'll wait), or automatically after 10 seconds.\n\nThis waiting period for classification does not affect\n`component_render_min_duration_ms`, which accurately measures the\ncomponent's actual on-screen render time.\n\n- `TRANSIENT_NAVIGATION_WINDOW_MS` (default 250ms) define the nav\nsettlement window.\n- `DEFAULT_MAX_ERROR_DURATION_MS` (default 10s) max time the error is\nheld from reporting to determine `component_render_min_duration_ms`. So\n`component_render_min_duration_ms` maxes out at 10s.\n\n#### Example Payload\n\n```json\n{\n  \"component_name\": \"KibanaSectionErrorBoundary\",\n  \"component_stack\": \"...\",\n  \"error_message\": \"Error: ...\",\n  \"error_stack\": \"...\",\n  \"component_render_min_duration_ms\": 103,\n  \"has_transient_navigation\": true\n}\n```\n\n## How to Test / Reproduce\n\nSince it's hard to reproduce such transient errors in Dev env, two\nreproducible error scenarios have been simulated in the commit\n`564007eb91704558a67e3474cdb116c0418a908a`. You can check out that\ncommit and reproduce the scenarios.\n\n**Tip** to see the reported Fatal Error payload, you can add a log point\nin\nhttp://localhost:5601/entry:core/node_modules/@elastic/ebt/client/src/analytics_client/analytics_client.js\nat L46 with content `'reporting event', eventType, eventData`:\n\n<img width=\"600\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/9fb56722-4c2b-418e-8690-80c7e05a35d9\"\n/>\n\n\n\n### A) Logs app router issue\n\n(was fixed by\n[elastic/kibana#194580](https://github.com/elastic/kibana/pull/194580/files#diff-65b7459bd6dcaafd801e69ddd217d7e977391ef8398526de737132b919c23c52))\n\nAfter checking out [the\ncommit](https://github.com/elastic/kibana/pull/234589/commits/564007eb91704558a67e3474cdb116c0418a908a),\nvisit `http://localhost:5601/<proxy>/app/logs`\n\n\nhttps://github.com/user-attachments/assets/e885e945-4ba9-499e-aeb2-afc9482e31e0\n\n\n\n### B) Demo transient scenarios (in Kibana)\n\nAfter checking out the same\n[commit](https://github.com/elastic/kibana/pull/234589/commits/564007eb91704558a67e3474cdb116c0418a908a),\nvisit Observability Onboarding page\n`http://localhost:5601/<proxy>/app/observabilityOnboarding` as shown in\nthe following video:\n\n\n\nhttps://github.com/user-attachments/assets/85897472-af10-46b9-8792-ee5fadf40426\n\n\n\n### C) Storybook\n\nA comprehensive story with docs/comments has been added for an\nelaborated reproduction of the scenarios.\n\nRun via `yarn run storybook shared_ux`, visit `localhost:9001` and\nconsult the following videos:\n\n\n\nhttps://github.com/user-attachments/assets/2615863b-9055-4618-a679-5468d75f7725\n\n\n\nhttps://github.com/user-attachments/assets/bb82817f-52fd-48eb-ae8d-86400373c20c\n\n\n\n### D) Reproducing the known error in prod scenario\n\nMost number of transient errors in prod were reported by the scenario\ndemonstrated in the following video where user's nav attempts in quick\nsuccession would raise this error.\n\n\nhttps://github.com/user-attachments/assets/670c6912-c706-4a32-967a-fbc870e92923\n\nAs show above, it was reproducible before, but after\n[this](https://github.com/elastic/kibana/pull/220313) fix, it should be\nquite hard to reproduce. The metrics added in this PR will make it\neasier to identify such errors if they are still being reported, and\ncould possibly be filtered out based on the values of those metrics.\n\nTo reproduce this in Storybook, use the following story which allows to\nperform a navigation in close succession to the error boundary\nrendering:\n\n\nhttps://github.com/user-attachments/assets/c5d1a82a-19f4-477b-a969-d756ff57c7c3\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b411ebaed424bad51113b8737193daf36d8e8459","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.2.0","v9.1.5","v9.3.0","v9.2.1"],"title":"[FatalReactError] Send additional metrics with Error Telemetry Event to understand transient, non-breaking errors.","number":234589,"url":"https://github.com/elastic/kibana/pull/234589","mergeCommit":{"message":"[FatalReactError] Send additional metrics with Error Telemetry Event to understand transient, non-breaking errors. (#234589)\n\n## Summary\n\nThis PR improves the React error boundary telemetry in Shared UX to\ncorrectly classify and measure short-lived (“transient”) errors.\n\n## Problem\n\nHistorically, we could not reliably distinguish between:\n\n* A momentary Error Boundary that appears briefly and then disappears, a\nprobable false positive due to immediate user navigation or recovery.\n* A “seen” error UI that remained on screen long enough to be considered\na user-visible failure (validly Fatal).\n\nThis made it difficult to detect transient errors that users likely did\nnot see, and possibly should not be reported as Fatal errors to\ntelemetry (or alerted for).\n\n### What this PR does\n\nAdds two telemetry fields to `REACT_FATAL_ERROR_EVENT_TYPE`:\n\n* `component_render_min_duration_ms`: Minimum time the error boundary UI\ncomponent remained mounted.\n    -  Helps identify truly momentary/transient error experiences\n* `has_transient_navigation`: A boolean that is `true` only if a\nnavigation occurred within the first `TRANSIENT_NAVIGATION_WINDOW_MS`\n(e.g. 250ms) after the error appeared.\n- Enables analysis of transient errors that coincide with user or\nprogrammatic navigation (e.g., route change after an error render)\n\n#### Refactored Error Reporting Logic\n\nTo accurately capture `has_transient_navigation`, an error is not\nreported immediately. Instead, it is first enqueued and held for a brief\ntime window (default 250ms) to determine if a transient navigation has\noccurred. The error report is only committed after this window elapses,\nensuring `has_transient_navigation` has been correctly determined. A\ncommit is triggered as a result of any user action which unmounts the\nerror boundary (provided `TRANSIENT_NAVIGATION_WINDOW_MS` has elapsed\notherwise it'll wait), or automatically after 10 seconds.\n\nThis waiting period for classification does not affect\n`component_render_min_duration_ms`, which accurately measures the\ncomponent's actual on-screen render time.\n\n- `TRANSIENT_NAVIGATION_WINDOW_MS` (default 250ms) define the nav\nsettlement window.\n- `DEFAULT_MAX_ERROR_DURATION_MS` (default 10s) max time the error is\nheld from reporting to determine `component_render_min_duration_ms`. So\n`component_render_min_duration_ms` maxes out at 10s.\n\n#### Example Payload\n\n```json\n{\n  \"component_name\": \"KibanaSectionErrorBoundary\",\n  \"component_stack\": \"...\",\n  \"error_message\": \"Error: ...\",\n  \"error_stack\": \"...\",\n  \"component_render_min_duration_ms\": 103,\n  \"has_transient_navigation\": true\n}\n```\n\n## How to Test / Reproduce\n\nSince it's hard to reproduce such transient errors in Dev env, two\nreproducible error scenarios have been simulated in the commit\n`564007eb91704558a67e3474cdb116c0418a908a`. You can check out that\ncommit and reproduce the scenarios.\n\n**Tip** to see the reported Fatal Error payload, you can add a log point\nin\nhttp://localhost:5601/entry:core/node_modules/@elastic/ebt/client/src/analytics_client/analytics_client.js\nat L46 with content `'reporting event', eventType, eventData`:\n\n<img width=\"600\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/9fb56722-4c2b-418e-8690-80c7e05a35d9\"\n/>\n\n\n\n### A) Logs app router issue\n\n(was fixed by\n[elastic/kibana#194580](https://github.com/elastic/kibana/pull/194580/files#diff-65b7459bd6dcaafd801e69ddd217d7e977391ef8398526de737132b919c23c52))\n\nAfter checking out [the\ncommit](https://github.com/elastic/kibana/pull/234589/commits/564007eb91704558a67e3474cdb116c0418a908a),\nvisit `http://localhost:5601/<proxy>/app/logs`\n\n\nhttps://github.com/user-attachments/assets/e885e945-4ba9-499e-aeb2-afc9482e31e0\n\n\n\n### B) Demo transient scenarios (in Kibana)\n\nAfter checking out the same\n[commit](https://github.com/elastic/kibana/pull/234589/commits/564007eb91704558a67e3474cdb116c0418a908a),\nvisit Observability Onboarding page\n`http://localhost:5601/<proxy>/app/observabilityOnboarding` as shown in\nthe following video:\n\n\n\nhttps://github.com/user-attachments/assets/85897472-af10-46b9-8792-ee5fadf40426\n\n\n\n### C) Storybook\n\nA comprehensive story with docs/comments has been added for an\nelaborated reproduction of the scenarios.\n\nRun via `yarn run storybook shared_ux`, visit `localhost:9001` and\nconsult the following videos:\n\n\n\nhttps://github.com/user-attachments/assets/2615863b-9055-4618-a679-5468d75f7725\n\n\n\nhttps://github.com/user-attachments/assets/bb82817f-52fd-48eb-ae8d-86400373c20c\n\n\n\n### D) Reproducing the known error in prod scenario\n\nMost number of transient errors in prod were reported by the scenario\ndemonstrated in the following video where user's nav attempts in quick\nsuccession would raise this error.\n\n\nhttps://github.com/user-attachments/assets/670c6912-c706-4a32-967a-fbc870e92923\n\nAs show above, it was reproducible before, but after\n[this](https://github.com/elastic/kibana/pull/220313) fix, it should be\nquite hard to reproduce. The metrics added in this PR will make it\neasier to identify such errors if they are still being reported, and\ncould possibly be filtered out based on the values of those metrics.\n\nTo reproduce this in Storybook, use the following story which allows to\nperform a navigation in close succession to the error boundary\nrendering:\n\n\nhttps://github.com/user-attachments/assets/c5d1a82a-19f4-477b-a969-d756ff57c7c3\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b411ebaed424bad51113b8737193daf36d8e8459"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/241267","number":241267,"state":"MERGED","mergeCommit":{"sha":"2c17eea9e5e13e12635c347b36934e754c39a3eb","message":"[9.2] [FatalReactError] Send additional metrics with Error Telemetry Event to understand transient, non-breaking errors. (#234589) (#241267)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[FatalReactError] Send additional metrics with Error Telemetry Event\nto understand transient, non-breaking errors.\n(#234589)](https://github.com/elastic/kibana/pull/234589)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Abdul Wahab Zahid <awahab07@yahoo.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"branch":"9.1","label":"v9.1.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/234589","number":234589,"mergeCommit":{"message":"[FatalReactError] Send additional metrics with Error Telemetry Event to understand transient, non-breaking errors. (#234589)\n\n## Summary\n\nThis PR improves the React error boundary telemetry in Shared UX to\ncorrectly classify and measure short-lived (“transient”) errors.\n\n## Problem\n\nHistorically, we could not reliably distinguish between:\n\n* A momentary Error Boundary that appears briefly and then disappears, a\nprobable false positive due to immediate user navigation or recovery.\n* A “seen” error UI that remained on screen long enough to be considered\na user-visible failure (validly Fatal).\n\nThis made it difficult to detect transient errors that users likely did\nnot see, and possibly should not be reported as Fatal errors to\ntelemetry (or alerted for).\n\n### What this PR does\n\nAdds two telemetry fields to `REACT_FATAL_ERROR_EVENT_TYPE`:\n\n* `component_render_min_duration_ms`: Minimum time the error boundary UI\ncomponent remained mounted.\n    -  Helps identify truly momentary/transient error experiences\n* `has_transient_navigation`: A boolean that is `true` only if a\nnavigation occurred within the first `TRANSIENT_NAVIGATION_WINDOW_MS`\n(e.g. 250ms) after the error appeared.\n- Enables analysis of transient errors that coincide with user or\nprogrammatic navigation (e.g., route change after an error render)\n\n#### Refactored Error Reporting Logic\n\nTo accurately capture `has_transient_navigation`, an error is not\nreported immediately. Instead, it is first enqueued and held for a brief\ntime window (default 250ms) to determine if a transient navigation has\noccurred. The error report is only committed after this window elapses,\nensuring `has_transient_navigation` has been correctly determined. A\ncommit is triggered as a result of any user action which unmounts the\nerror boundary (provided `TRANSIENT_NAVIGATION_WINDOW_MS` has elapsed\notherwise it'll wait), or automatically after 10 seconds.\n\nThis waiting period for classification does not affect\n`component_render_min_duration_ms`, which accurately measures the\ncomponent's actual on-screen render time.\n\n- `TRANSIENT_NAVIGATION_WINDOW_MS` (default 250ms) define the nav\nsettlement window.\n- `DEFAULT_MAX_ERROR_DURATION_MS` (default 10s) max time the error is\nheld from reporting to determine `component_render_min_duration_ms`. So\n`component_render_min_duration_ms` maxes out at 10s.\n\n#### Example Payload\n\n```json\n{\n  \"component_name\": \"KibanaSectionErrorBoundary\",\n  \"component_stack\": \"...\",\n  \"error_message\": \"Error: ...\",\n  \"error_stack\": \"...\",\n  \"component_render_min_duration_ms\": 103,\n  \"has_transient_navigation\": true\n}\n```\n\n## How to Test / Reproduce\n\nSince it's hard to reproduce such transient errors in Dev env, two\nreproducible error scenarios have been simulated in the commit\n`564007eb91704558a67e3474cdb116c0418a908a`. You can check out that\ncommit and reproduce the scenarios.\n\n**Tip** to see the reported Fatal Error payload, you can add a log point\nin\nhttp://localhost:5601/entry:core/node_modules/@elastic/ebt/client/src/analytics_client/analytics_client.js\nat L46 with content `'reporting event', eventType, eventData`:\n\n<img width=\"600\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/9fb56722-4c2b-418e-8690-80c7e05a35d9\"\n/>\n\n\n\n### A) Logs app router issue\n\n(was fixed by\n[elastic/kibana#194580](https://github.com/elastic/kibana/pull/194580/files#diff-65b7459bd6dcaafd801e69ddd217d7e977391ef8398526de737132b919c23c52))\n\nAfter checking out [the\ncommit](https://github.com/elastic/kibana/pull/234589/commits/564007eb91704558a67e3474cdb116c0418a908a),\nvisit `http://localhost:5601/<proxy>/app/logs`\n\n\nhttps://github.com/user-attachments/assets/e885e945-4ba9-499e-aeb2-afc9482e31e0\n\n\n\n### B) Demo transient scenarios (in Kibana)\n\nAfter checking out the same\n[commit](https://github.com/elastic/kibana/pull/234589/commits/564007eb91704558a67e3474cdb116c0418a908a),\nvisit Observability Onboarding page\n`http://localhost:5601/<proxy>/app/observabilityOnboarding` as shown in\nthe following video:\n\n\n\nhttps://github.com/user-attachments/assets/85897472-af10-46b9-8792-ee5fadf40426\n\n\n\n### C) Storybook\n\nA comprehensive story with docs/comments has been added for an\nelaborated reproduction of the scenarios.\n\nRun via `yarn run storybook shared_ux`, visit `localhost:9001` and\nconsult the following videos:\n\n\n\nhttps://github.com/user-attachments/assets/2615863b-9055-4618-a679-5468d75f7725\n\n\n\nhttps://github.com/user-attachments/assets/bb82817f-52fd-48eb-ae8d-86400373c20c\n\n\n\n### D) Reproducing the known error in prod scenario\n\nMost number of transient errors in prod were reported by the scenario\ndemonstrated in the following video where user's nav attempts in quick\nsuccession would raise this error.\n\n\nhttps://github.com/user-attachments/assets/670c6912-c706-4a32-967a-fbc870e92923\n\nAs show above, it was reproducible before, but after\n[this](https://github.com/elastic/kibana/pull/220313) fix, it should be\nquite hard to reproduce. The metrics added in this PR will make it\neasier to identify such errors if they are still being reported, and\ncould possibly be filtered out based on the values of those metrics.\n\nTo reproduce this in Storybook, use the following story which allows to\nperform a navigation in close succession to the error boundary\nrendering:\n\n\nhttps://github.com/user-attachments/assets/c5d1a82a-19f4-477b-a969-d756ff57c7c3\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b411ebaed424bad51113b8737193daf36d8e8459"}}]}] BACKPORT-->