### PR TITLE
[9.2] [Detection Engine] Fix infinite-looping bug related to bootstrapping lists resources (#241052)

### DIFF
--- a/x-pack/solutions/security/packages/kbn-securitysolution-list-hooks/src/mocks/response/read_list_index_schema.mock.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-list-hooks/src/mocks/response/read_list_index_schema.mock.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ListItemIndexExistSchema } from '@kbn/securitysolution-io-ts-list-types';
+
+export const getListIndexExistSchemaMock = (
+  overrides: Partial<ListItemIndexExistSchema> = {}
+): ListItemIndexExistSchema => ({
+  list_index: true,
+  list_item_index: true,
+  ...overrides,
+});

--- a/x-pack/solutions/security/packages/kbn-securitysolution-list-hooks/src/use_read_list_index/index.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-list-hooks/src/use_read_list_index/index.test.tsx
@@ -1,0 +1,252 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { waitFor, renderHook } from '@testing-library/react';
+
+import type { SecurityAppError } from '@kbn/securitysolution-t-grid';
+import { httpServiceMock } from '@kbn/core-http-browser-mocks';
+import * as Api from '@kbn/securitysolution-list-api';
+import { getListIndexExistSchemaMock } from '../mocks/response/read_list_index_schema.mock';
+import { useReadListIndex } from '.';
+
+jest.mock('@kbn/securitysolution-list-api');
+
+const customQueryProviderWrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
+  const mockLogger = { error: jest.fn(), log: jest.fn(), warn: jest.fn() };
+  const queryClient = new QueryClient({ logger: mockLogger });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+};
+
+describe('useReadListIndex', () => {
+  let httpMock: ReturnType<typeof httpServiceMock.createStartContract>;
+
+  beforeEach(() => {
+    httpMock = httpServiceMock.createStartContract();
+  });
+
+  describe('when both indices exist', () => {
+    beforeEach(() => {
+      (Api.readListIndex as jest.Mock).mockResolvedValue(getListIndexExistSchemaMock());
+    });
+
+    it('returns a response indicating both indices exist', async () => {
+      const { result } = renderHook(
+        () =>
+          useReadListIndex({
+            http: httpMock,
+            isEnabled: true,
+          }),
+        { wrapper: customQueryProviderWrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            loading: false,
+            result: { list_index: true, list_item_index: true },
+            error: null,
+          })
+        );
+      });
+    });
+  });
+
+  describe('error conditions', () => {
+    let mockOnError: jest.Mock;
+
+    beforeEach(() => {
+      mockOnError = jest.fn();
+    });
+
+    it('does not call onError for an expected 404 response', async () => {
+      const notFoundError: SecurityAppError = {
+        message: 'Error',
+        name: 'Error',
+        body: {
+          message: 'data stream .lists-default does not exist',
+          status_code: 404,
+        },
+      };
+      (Api.readListIndex as jest.Mock).mockRejectedValue(notFoundError);
+
+      const { result } = renderHook(
+        () =>
+          useReadListIndex({
+            http: httpMock,
+            isEnabled: true,
+            onError: mockOnError,
+          }),
+        { wrapper: customQueryProviderWrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            loading: false,
+            error: null,
+          })
+        );
+      });
+
+      expect(mockOnError).not.toHaveBeenCalled();
+    });
+
+    it('returns the appropriate response when neither list index exists', async () => {
+      const neitherFoundError: SecurityAppError = {
+        message: 'Error',
+        name: 'Error',
+        body: {
+          message: 'data stream .lists-default and data stream .items-default does not exist',
+          status_code: 404,
+        },
+      };
+      (Api.readListIndex as jest.Mock).mockRejectedValue(neitherFoundError);
+
+      const { result } = renderHook(
+        () =>
+          useReadListIndex({
+            http: httpMock,
+            isEnabled: true,
+          }),
+        { wrapper: customQueryProviderWrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            loading: false,
+            result: { list_index: false, list_item_index: false },
+            error: null,
+          })
+        );
+      });
+    });
+
+    it('returns the appropriate response when only the lists index exists', async () => {
+      const neitherFoundError: SecurityAppError = {
+        message: 'Error',
+        name: 'Error',
+        body: {
+          message: 'data stream .items-default does not exist',
+          status_code: 404,
+        },
+      };
+      (Api.readListIndex as jest.Mock).mockRejectedValue(neitherFoundError);
+
+      const { result } = renderHook(
+        () =>
+          useReadListIndex({
+            http: httpMock,
+            isEnabled: true,
+          }),
+        { wrapper: customQueryProviderWrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            loading: false,
+            result: { list_index: true, list_item_index: false },
+            error: null,
+          })
+        );
+      });
+    });
+
+    it('returns the appropriate response when only the items index exists', async () => {
+      const neitherFoundError: SecurityAppError = {
+        message: 'Error',
+        name: 'Error',
+        body: {
+          message: 'data stream .lists-default does not exist',
+          status_code: 404,
+        },
+      };
+      (Api.readListIndex as jest.Mock).mockRejectedValue(neitherFoundError);
+
+      const { result } = renderHook(
+        () =>
+          useReadListIndex({
+            http: httpMock,
+            isEnabled: true,
+          }),
+        { wrapper: customQueryProviderWrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            loading: false,
+            result: { list_index: false, list_item_index: true },
+            error: null,
+          })
+        );
+      });
+    });
+
+    it('calls onError with and returns a generic error', async () => {
+      const genericError = new Error('Generic error');
+      (Api.readListIndex as jest.Mock).mockRejectedValue(genericError);
+
+      const { result } = renderHook(
+        () =>
+          useReadListIndex({
+            http: httpMock,
+            isEnabled: true,
+            onError: mockOnError,
+          }),
+        { wrapper: customQueryProviderWrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            loading: false,
+            result: undefined,
+            error: genericError,
+          })
+        );
+      });
+      expect(mockOnError).toHaveBeenCalledWith(genericError);
+    });
+
+    it('calls onError with and returns a 404 error that does not mention an index not being found', async () => {
+      const genericNotFoundError: SecurityAppError = {
+        message: 'Error',
+        name: 'Error',
+        body: {
+          message: 'Not found',
+          status_code: 404,
+        },
+      };
+      (Api.readListIndex as jest.Mock).mockRejectedValue(genericNotFoundError);
+
+      const { result } = renderHook(
+        () =>
+          useReadListIndex({
+            http: httpMock,
+            isEnabled: true,
+            onError: mockOnError,
+          }),
+        { wrapper: customQueryProviderWrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current).toEqual(
+          expect.objectContaining({
+            loading: false,
+            result: undefined,
+            error: genericNotFoundError,
+          })
+        );
+      });
+      expect(mockOnError).toHaveBeenCalledWith(genericNotFoundError);
+    });
+  });
+});

--- a/x-pack/solutions/security/packages/kbn-securitysolution-list-hooks/src/use_read_list_index/index.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-list-hooks/src/use_read_list_index/index.ts
@@ -10,6 +10,11 @@ import { useQuery } from '@tanstack/react-query';
 import type { ApiParams } from '@kbn/securitysolution-list-api';
 import { readListIndex } from '@kbn/securitysolution-list-api';
 import { withOptionalSignal } from '@kbn/securitysolution-hook-utils';
+import {
+  type SecurityAppError,
+  isSecurityAppError,
+  isNotFoundError,
+} from '@kbn/securitysolution-t-grid';
 
 import { READ_INDEX_QUERY_KEY } from '../constants';
 
@@ -31,7 +36,14 @@ export const useReadListIndex = ({
         return null;
       }
 
-      return readListIndexWithOptionalSignal({ http, signal });
+      try {
+        return await readListIndexWithOptionalSignal({ http, signal });
+      } catch (err) {
+        if (isIndexNotCreatedError(err)) {
+          return parseReadIndexResultFrom404Error(err);
+        }
+        return Promise.reject(err);
+      }
     },
     {
       onError,
@@ -46,5 +58,40 @@ export const useReadListIndex = ({
     result: query.data,
     loading: query.isFetching,
     error: query.error,
+  };
+};
+
+const errorMentionsListsIndex = (error: SecurityAppError): boolean =>
+  error.body.message.includes('.lists-');
+const errorMentionsItemsIndex = (error: SecurityAppError): boolean =>
+  error.body.message.includes('.items-');
+
+/**
+ * Determines whether an error response from the `readListIndex`
+ * API call indicates that the index is not yet created.
+ */
+export const isIndexNotCreatedError = (err: unknown): err is SecurityAppError => {
+  return (
+    isSecurityAppError(err) &&
+    isNotFoundError(err) &&
+    (errorMentionsListsIndex(err) || errorMentionsItemsIndex(err))
+  );
+};
+
+/**
+ * Parses the result of a 404 error from the read list index API into an actionable response
+ *
+ * This endpoint returns a 404 if either of the underlying indices do
+ * not exist. By default, this causes the http client to throw an error,
+ * but as this is a valid result from the endpoint, we want to catch that error
+ * and present a result that is actionable to the consumer.
+ * @param error The 404 IndexNotCreated error returned from the read list index API
+ */
+export const parseReadIndexResultFrom404Error = (
+  error: SecurityAppError
+): Awaited<ReturnType<typeof readListIndexWithOptionalSignal>> => {
+  return {
+    list_index: !errorMentionsListsIndex(error),
+    list_item_index: !errorMentionsItemsIndex(error),
   };
 };

--- a/x-pack/solutions/security/packages/kbn-securitysolution-list-hooks/tsconfig.json
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-list-hooks/tsconfig.json
@@ -9,6 +9,7 @@
   },
   "include": [
     "**/*.ts",
+    "**/*.tsx",
   ],
   "kbn_references": [
     "@kbn/securitysolution-hook-utils",
@@ -18,6 +19,7 @@
     "@kbn/securitysolution-utils",
     "@kbn/core-http-browser-mocks",
     "@kbn/core-http-browser",
+    "@kbn/securitysolution-t-grid",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Detection Engine] Fix infinite-looping bug related to bootstrapping lists resources (#241052)](https://github.com/elastic/kibana/pull/241052)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ryland Herrick","email":"ryalnd@gmail.com"},"sourceCommit":{"committedDate":"2025-10-31T17:02:18Z","message":"[Detection Engine] Fix infinite-looping bug related to bootstrapping lists resources (#241052)\n\n# Summary\n\nAddresses #229018.\n\n## Problem Statement\nWhen the users visits the alerting page, we check to see whether the\nlists indices exist, and if not, and they have the appropriate\nprivileges, we try to create it on behalf of the user.\n\nHowever, if the user has enough privileges to _ask_ about the lists\nindices status, but has insufficient privileges to _create_ the lists\nindices, the frontend will enter an infinite loop. With sufficient\nprivileges, this loop is exited when the frontend creates the lists\nindices.\n\n## Explanation\nThe looping is due to a) the fact that the \"read list index\" API\nresponds with a 404 if either of the indices is not present, and b) how\n404s are handled in the frontend. By default, a 404 will cause the http\nclient to throw an error. We use useQuery to cache this query, but\nbecause the request throws an error the request is never cached, and\nthus on the next hook render the cycle renews.\n\n## Solution\nBy manually catching and parsing the 404 API response, we can both a)\nensure proper caching and b) present more information to the consumer of\nthat API. For backwards compatibility reasons, we cannot update the\nsemantics of the API itself.\n\nPractically, since the response to a \"list index not found\" response is\nto call the (generic) \"create list index\" API, this additional\ninformation is not strictly necessary, the additional information could\ne.g. be used to provide a more helpful error message on the client in\nthe future.\n\n## Further Improvements\nIn these cases where the lists indices do not exist, and the user does\nnot have permission to create them, we do not currently inform the user\nof this fact. We could improve the user experience by providing a more\nhelpful error message in this scenario.\n\n\n# How to review\n1. Create a user/role in kibana with _almost_ all of the [necessary\nprivileges to create the list\nindices](https://www.elastic.co/docs/solutions/security/detect-and-alert/detections-requirements#security-detections-requirements-custom-role-privileges),\nsave for the \"manage\" cluster privilege (which is easily overlooked, due\nto its being a single word in a column on that table):\n\n    ```json\n    almost-lists-manager:\n      cluster: []\n      indices:\n        - names:\n            - \".alerts-security.alerts-default\"\n            - \".internal.alerts-security.alerts-default-*\"\n            - \".siem-signals-default\"\n            - \".lists-default\"\n            - \".items-default\"\n          privileges: [\"manage\", \"read\", \"write\", \"view_index_metadata\"]\n          field_security:\n            grant: [\"*\"]\n            except: []\n          allow_restricted_indices: false\n        - names:\n            - \".preview.alerts-security.alerts-default\"\n            - \".internal.preview.alerts-security.alerts-default-*\"\n          privileges: [\"read\"]\n          field_security:\n            grant: [\"*\"]\n            except: []\n          allow_restricted_indices: false\n      applications:\n        - application: \"kibana-.kibana\"\nprivileges: [\"feature_indexPatterns.all\", \"feature_siemV4.all\",\n\"feature_actions.all\", \"feature_savedObjectsManagement.all\"]\n          resources: [\"space:default\"]\n      run_as: []\n      metadata: {}\n      transient_metadata:\n        enabled: true\n      description: \"\"\n    ```\n\n1. Navigate to the alerts page, and confirm that the page loads\nsuccessfully, and does not loop.\n1. (optional) Confirm that navigating to the alerts page on `main`\nreproduces the infinite loop.\n1. (optional) Confirm that adding the \"manage\" cluster privilege results\nin the lists indices being created successfully.\n\n### Checklist\n\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4f008a6cb14bd7f82f72ac2d60be62187f971a33","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:Rule Exceptions","Team:Detection Engine","backport:version","v8.19.0","v9.2.0","v9.3.0"],"title":"[Detection Engine] Fix infinite-looping bug related to bootstrapping lists resources","number":241052,"url":"https://github.com/elastic/kibana/pull/241052","mergeCommit":{"message":"[Detection Engine] Fix infinite-looping bug related to bootstrapping lists resources (#241052)\n\n# Summary\n\nAddresses #229018.\n\n## Problem Statement\nWhen the users visits the alerting page, we check to see whether the\nlists indices exist, and if not, and they have the appropriate\nprivileges, we try to create it on behalf of the user.\n\nHowever, if the user has enough privileges to _ask_ about the lists\nindices status, but has insufficient privileges to _create_ the lists\nindices, the frontend will enter an infinite loop. With sufficient\nprivileges, this loop is exited when the frontend creates the lists\nindices.\n\n## Explanation\nThe looping is due to a) the fact that the \"read list index\" API\nresponds with a 404 if either of the indices is not present, and b) how\n404s are handled in the frontend. By default, a 404 will cause the http\nclient to throw an error. We use useQuery to cache this query, but\nbecause the request throws an error the request is never cached, and\nthus on the next hook render the cycle renews.\n\n## Solution\nBy manually catching and parsing the 404 API response, we can both a)\nensure proper caching and b) present more information to the consumer of\nthat API. For backwards compatibility reasons, we cannot update the\nsemantics of the API itself.\n\nPractically, since the response to a \"list index not found\" response is\nto call the (generic) \"create list index\" API, this additional\ninformation is not strictly necessary, the additional information could\ne.g. be used to provide a more helpful error message on the client in\nthe future.\n\n## Further Improvements\nIn these cases where the lists indices do not exist, and the user does\nnot have permission to create them, we do not currently inform the user\nof this fact. We could improve the user experience by providing a more\nhelpful error message in this scenario.\n\n\n# How to review\n1. Create a user/role in kibana with _almost_ all of the [necessary\nprivileges to create the list\nindices](https://www.elastic.co/docs/solutions/security/detect-and-alert/detections-requirements#security-detections-requirements-custom-role-privileges),\nsave for the \"manage\" cluster privilege (which is easily overlooked, due\nto its being a single word in a column on that table):\n\n    ```json\n    almost-lists-manager:\n      cluster: []\n      indices:\n        - names:\n            - \".alerts-security.alerts-default\"\n            - \".internal.alerts-security.alerts-default-*\"\n            - \".siem-signals-default\"\n            - \".lists-default\"\n            - \".items-default\"\n          privileges: [\"manage\", \"read\", \"write\", \"view_index_metadata\"]\n          field_security:\n            grant: [\"*\"]\n            except: []\n          allow_restricted_indices: false\n        - names:\n            - \".preview.alerts-security.alerts-default\"\n            - \".internal.preview.alerts-security.alerts-default-*\"\n          privileges: [\"read\"]\n          field_security:\n            grant: [\"*\"]\n            except: []\n          allow_restricted_indices: false\n      applications:\n        - application: \"kibana-.kibana\"\nprivileges: [\"feature_indexPatterns.all\", \"feature_siemV4.all\",\n\"feature_actions.all\", \"feature_savedObjectsManagement.all\"]\n          resources: [\"space:default\"]\n      run_as: []\n      metadata: {}\n      transient_metadata:\n        enabled: true\n      description: \"\"\n    ```\n\n1. Navigate to the alerts page, and confirm that the page loads\nsuccessfully, and does not loop.\n1. (optional) Confirm that navigating to the alerts page on `main`\nreproduces the infinite loop.\n1. (optional) Confirm that adding the \"manage\" cluster privilege results\nin the lists indices being created successfully.\n\n### Checklist\n\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4f008a6cb14bd7f82f72ac2d60be62187f971a33"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.2"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241052","number":241052,"mergeCommit":{"message":"[Detection Engine] Fix infinite-looping bug related to bootstrapping lists resources (#241052)\n\n# Summary\n\nAddresses #229018.\n\n## Problem Statement\nWhen the users visits the alerting page, we check to see whether the\nlists indices exist, and if not, and they have the appropriate\nprivileges, we try to create it on behalf of the user.\n\nHowever, if the user has enough privileges to _ask_ about the lists\nindices status, but has insufficient privileges to _create_ the lists\nindices, the frontend will enter an infinite loop. With sufficient\nprivileges, this loop is exited when the frontend creates the lists\nindices.\n\n## Explanation\nThe looping is due to a) the fact that the \"read list index\" API\nresponds with a 404 if either of the indices is not present, and b) how\n404s are handled in the frontend. By default, a 404 will cause the http\nclient to throw an error. We use useQuery to cache this query, but\nbecause the request throws an error the request is never cached, and\nthus on the next hook render the cycle renews.\n\n## Solution\nBy manually catching and parsing the 404 API response, we can both a)\nensure proper caching and b) present more information to the consumer of\nthat API. For backwards compatibility reasons, we cannot update the\nsemantics of the API itself.\n\nPractically, since the response to a \"list index not found\" response is\nto call the (generic) \"create list index\" API, this additional\ninformation is not strictly necessary, the additional information could\ne.g. be used to provide a more helpful error message on the client in\nthe future.\n\n## Further Improvements\nIn these cases where the lists indices do not exist, and the user does\nnot have permission to create them, we do not currently inform the user\nof this fact. We could improve the user experience by providing a more\nhelpful error message in this scenario.\n\n\n# How to review\n1. Create a user/role in kibana with _almost_ all of the [necessary\nprivileges to create the list\nindices](https://www.elastic.co/docs/solutions/security/detect-and-alert/detections-requirements#security-detections-requirements-custom-role-privileges),\nsave for the \"manage\" cluster privilege (which is easily overlooked, due\nto its being a single word in a column on that table):\n\n    ```json\n    almost-lists-manager:\n      cluster: []\n      indices:\n        - names:\n            - \".alerts-security.alerts-default\"\n            - \".internal.alerts-security.alerts-default-*\"\n            - \".siem-signals-default\"\n            - \".lists-default\"\n            - \".items-default\"\n          privileges: [\"manage\", \"read\", \"write\", \"view_index_metadata\"]\n          field_security:\n            grant: [\"*\"]\n            except: []\n          allow_restricted_indices: false\n        - names:\n            - \".preview.alerts-security.alerts-default\"\n            - \".internal.preview.alerts-security.alerts-default-*\"\n          privileges: [\"read\"]\n          field_security:\n            grant: [\"*\"]\n            except: []\n          allow_restricted_indices: false\n      applications:\n        - application: \"kibana-.kibana\"\nprivileges: [\"feature_indexPatterns.all\", \"feature_siemV4.all\",\n\"feature_actions.all\", \"feature_savedObjectsManagement.all\"]\n          resources: [\"space:default\"]\n      run_as: []\n      metadata: {}\n      transient_metadata:\n        enabled: true\n      description: \"\"\n    ```\n\n1. Navigate to the alerts page, and confirm that the page loads\nsuccessfully, and does not loop.\n1. (optional) Confirm that navigating to the alerts page on `main`\nreproduces the infinite loop.\n1. (optional) Confirm that adding the \"manage\" cluster privilege results\nin the lists indices being created successfully.\n\n### Checklist\n\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4f008a6cb14bd7f82f72ac2d60be62187f971a33"}}]}] BACKPORT-->