### PR TITLE
[9.2] [Context Security]  Fix Agent-Based Failing to produce data  (#241390)

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/constants.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/constants.ts
@@ -8,6 +8,7 @@ export const TEMPLATE_URL_ACCOUNT_TYPE_ENV_VAR = 'ACCOUNT_TYPE';
 export const TEMPLATE_URL_ELASTIC_RESOURCE_ID_ENV_VAR = 'RESOURCE_ID';
 export const CLOUD_FORMATION_TEMPLATE_URL_CLOUD_CONNECTORS =
   'cloud_formation_cloud_connectors_template';
+export const ARM_TEMPLATE_URL_CLOUD_CONNECTORS = 'arm_template_cloud_connectors_url';
 
 export const AWS_SINGLE_ACCOUNT = 'single-account';
 export const AWS_ORGANIZATION_ACCOUNT = 'organization-account';

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_setup.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_setup.tsx
@@ -151,7 +151,9 @@ const CloudIntegrationSetup = memo<CloudIntegrationSetupProps>(
         <ProviderSelector
           selectedProvider={selectedProvider}
           setSelectedProvider={(provider) => {
-            const showCloudConnectors = isCloudConnectorsEnabledForProvider(provider);
+            const showCloudConnectors =
+              isCloudConnectorsEnabledForProvider(provider) &&
+              setupTechnology === SetupTechnology.AGENTLESS;
             setEnabledPolicyInput(provider, showCloudConnectors);
           }}
           disabled={isEditPage}
@@ -247,19 +249,26 @@ const CloudIntegrationSetup = memo<CloudIntegrationSetupProps>(
               useDescribedFormGroup={false}
               onSetupTechnologyChange={(value) => {
                 updateSetupTechnology(value);
-                const showCloudConnectors = isCloudConnectorsEnabledForProvider(selectedProvider);
+                const showCloudConnectors =
+                  isCloudConnectorsEnabledForProvider(selectedProvider) &&
+                  value === SetupTechnology.AGENTLESS;
                 updatePolicy({
-                  updatedPolicy: updatePolicyWithInputs(
-                    newPolicy,
-                    config.providers[selectedProvider].type,
-                    getDefaultCloudCredentialsType(
-                      value === SetupTechnology.AGENTLESS,
-                      selectedProvider,
-                      packageInfo,
-                      showCloudConnectors,
-                      templateName
-                    )
-                  ),
+                  updatedPolicy: {
+                    ...updatePolicyWithInputs(
+                      newPolicy,
+                      config.providers[selectedProvider].type,
+                      getDefaultCloudCredentialsType(
+                        value === SetupTechnology.AGENTLESS,
+                        selectedProvider,
+                        packageInfo,
+                        showCloudConnectors,
+                        templateName
+                      )
+                    ),
+                    supports_cloud_connector:
+                      showCloudConnectors && value === SetupTechnology.AGENTLESS,
+                    cloud_connector_id: undefined,
+                  },
                 });
               }}
             />

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_setup.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_setup.tsx
@@ -265,8 +265,7 @@ const CloudIntegrationSetup = memo<CloudIntegrationSetupProps>(
                         templateName
                       )
                     ),
-                    supports_cloud_connector:
-                      showCloudConnectors && value === SetupTechnology.AGENTLESS,
+                    supports_cloud_connector: showCloudConnectors,
                     cloud_connector_id: undefined,
                   },
                 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.test.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.test.ts
@@ -13,10 +13,15 @@ import {
   getCloudShellDefaultValue,
   findVariableDef,
   getDefaultAwsCredentialsType,
-  getDefaultAzureCredentialsType,
+  getDefaultAwsCredentialConfig,
+  getDefaultAzureCredentialsConfig,
   getDefaultGcpHiddenVars,
 } from './utils';
 import { getMockPolicyAWS, getPackageInfoMock, TEMPLATE_NAME } from './test/mock';
+import {
+  CLOUD_FORMATION_TEMPLATE_URL_CLOUD_CONNECTORS,
+  ARM_TEMPLATE_URL_CLOUD_CONNECTORS,
+} from './cloud_connector/constants';
 
 describe('getPosturePolicy', () => {
   for (const [name, getPolicy, expectedVars] of [
@@ -211,7 +216,12 @@ describe('getDefaultAwsCredentialsType', () => {
       ],
     } as PackageInfo;
 
-    const result = getDefaultAwsCredentialsType({} as PackageInfo, false, setupTechnology);
+    const result = getDefaultAwsCredentialsType(
+      {} as PackageInfo,
+      false,
+      TEMPLATE_NAME,
+      setupTechnology
+    );
 
     expect(result).toBe('assume_role');
   });
@@ -222,9 +232,151 @@ describe('getDefaultAwsCredentialsType', () => {
     const result = getDefaultAwsCredentialsType(packageInfo, false, TEMPLATE_NAME, setupTechnology);
     expect(result).toBe('cloud_formation');
   });
+
+  it('should return "cloud_connectors" for agentless, when cloud connectors template is available and showCloudConnectors is true', () => {
+    const setupTechnology = SetupTechnology.AGENTLESS;
+    packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: CLOUD_FORMATION_TEMPLATE_URL_CLOUD_CONNECTORS,
+                  default: 'http://example.com/cloud_formation_cloud_connectors_template',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+
+    const result = getDefaultAwsCredentialsType(packageInfo, true, TEMPLATE_NAME, setupTechnology);
+
+    expect(result).toBe('cloud_connectors');
+  });
 });
 
-describe('getDefaultAzureCredentialsType', () => {
+describe('getDefaultAwsCredentialsConfig', () => {
+  it('should return "cloud_connectors" for agentless, when cloud connectors template is available and showCloudConnectors is true', () => {
+    const packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: CLOUD_FORMATION_TEMPLATE_URL_CLOUD_CONNECTORS,
+                  default: 'http://example.com/cloud_formation_cloud_connectors_template',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+    const result = getDefaultAwsCredentialConfig({
+      packageInfo,
+      templateName: TEMPLATE_NAME,
+      isAgentless: true,
+      showCloudConnectors: true,
+    });
+
+    expect(result['aws.credentials.type'].value).toBe('cloud_connectors');
+    expect(result['aws.supports_cloud_connectors'].value).toBe(true);
+  });
+
+  it('should return "cloud_formation" for agent-based, when cloud formation template is available', () => {
+    const packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: 'cloud_formation_template',
+                  default: 'http://example.com/cloud_formation_template',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+    const result = getDefaultAwsCredentialConfig({
+      packageInfo,
+      templateName: TEMPLATE_NAME,
+      isAgentless: false,
+      showCloudConnectors: false,
+    });
+
+    expect(result['aws.credentials.type'].value).toBe('cloud_formation');
+    expect(result['aws.supports_cloud_connectors'].value).toBe(false);
+  });
+
+  it('should return "assume_role" for agent-based, when cloud formation template is not available', () => {
+    const packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: 'cloud_shell',
+                  default: 'http://example.com/cloud_shell',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+    const result = getDefaultAwsCredentialConfig({
+      packageInfo,
+      templateName: TEMPLATE_NAME,
+      isAgentless: false,
+      showCloudConnectors: false,
+    });
+
+    expect(result['aws.credentials.type'].value).toBe('assume_role');
+    expect(result['aws.supports_cloud_connectors'].value).toBe(false);
+  });
+
+  it('should return "cloud_formation" for agent-based even with showCloudConnectors true, when cloud formation template is available', () => {
+    const packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: 'cloud_formation_template',
+                  default: 'http://example.com/cloud_formation_template',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+    const result = getDefaultAwsCredentialConfig({
+      packageInfo,
+      templateName: TEMPLATE_NAME,
+      isAgentless: false,
+      showCloudConnectors: true,
+    });
+
+    expect(result['aws.credentials.type'].value).toBe('cloud_formation');
+    expect(result['aws.supports_cloud_connectors'].value).toBe(true);
+  });
+});
+describe('getDefaultAzureCredentialsConfig', () => {
   let packageInfo: PackageInfo;
 
   beforeEach(() => {
@@ -248,31 +400,18 @@ describe('getDefaultAzureCredentialsType', () => {
   });
 
   it('should return "service_principal_with_client_secret" for agentless', () => {
-    const setupTechnology = SetupTechnology.AGENTLESS;
-    const result = getDefaultAzureCredentialsType(
-      packageInfo,
-      TEMPLATE_NAME,
-      setupTechnology,
-      false
-    );
+    const result = getDefaultAzureCredentialsConfig(packageInfo, TEMPLATE_NAME, true, false);
 
     expect(result['azure.credentials.type'].value).toBe('service_principal_with_client_secret');
   });
 
   it('should return "arm_template" for agent-based, when arm_template is available', () => {
-    const setupTechnology = SetupTechnology.AGENT_BASED;
-    const result = getDefaultAzureCredentialsType(
-      packageInfo,
-      TEMPLATE_NAME,
-      setupTechnology,
-      false
-    );
+    const result = getDefaultAzureCredentialsConfig(packageInfo, TEMPLATE_NAME, false, false);
 
     expect(result['azure.credentials.type'].value).toBe('arm_template');
   });
 
   it('should return "managed_identity" for agent-based, when arm_template is not available', () => {
-    const setupTechnology = SetupTechnology.AGENT_BASED;
     packageInfo = {
       policy_templates: [
         {
@@ -290,15 +429,59 @@ describe('getDefaultAzureCredentialsType', () => {
         },
       ],
     } as PackageInfo;
-
-    const result = getDefaultAzureCredentialsType(
-      packageInfo,
-      TEMPLATE_NAME,
-      setupTechnology,
-      false
-    );
+    const result = getDefaultAzureCredentialsConfig(packageInfo, TEMPLATE_NAME, false, false);
 
     expect(result['azure.credentials.type'].value).toBe('managed_identity');
+  });
+
+  it('should return "cloud_connectors" for agentless, when cloud connectors template is available and showCloudConnectors is true', () => {
+    packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: ARM_TEMPLATE_URL_CLOUD_CONNECTORS,
+                  default: 'http://example.com/arm_template_cloud_connectors_url',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+
+    const result = getDefaultAzureCredentialsConfig(packageInfo, TEMPLATE_NAME, true, true);
+
+    expect(result['azure.credentials.type'].value).toBe('cloud_connectors');
+    expect(result['azure.supports_cloud_connectors'].value).toBe(true);
+  });
+
+  it('should return "arm_template" for agent-based even with showCloudConnectors true, when arm_template is available', () => {
+    packageInfo = {
+      policy_templates: [
+        {
+          name: TEMPLATE_NAME,
+          inputs: [
+            {
+              vars: [
+                {
+                  name: 'arm_template_url',
+                  default: 'http://example.com/arm_template_url',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as PackageInfo;
+
+    const result = getDefaultAzureCredentialsConfig(packageInfo, TEMPLATE_NAME, false, true);
+
+    expect(result['azure.credentials.type'].value).toBe('arm_template');
+    expect(result['azure.supports_cloud_connectors'].value).toBe(true);
   });
 });
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/utils.ts
@@ -170,7 +170,7 @@ export const getCloudFormationDefaultValue = (
   return cloudFormationTemplate;
 };
 
-const getDefaultAwsCredentialConfig = ({
+export const getDefaultAwsCredentialConfig = ({
   isAgentless,
   showCloudConnectors,
   packageInfo,
@@ -202,12 +202,10 @@ const getDefaultAwsCredentialConfig = ({
       value: credentialsType,
       type: 'text',
     },
-    ...(showCloudConnectors && {
-      'aws.supports_cloud_connectors': {
-        value: showCloudConnectors,
-        type: 'bool',
-      },
-    }),
+    'aws.supports_cloud_connectors': {
+      value: showCloudConnectors,
+      type: 'bool',
+    },
   };
 
   return config;
@@ -243,14 +241,12 @@ export const getDefaultCloudCredentialsType = (
         type: 'text',
       },
     },
-    azure: {
-      'azure.credentials.type': {
-        value: isAgentless
-          ? AZURE_CREDENTIALS_TYPE.SERVICE_PRINCIPAL_WITH_CLIENT_SECRET
-          : AZURE_CREDENTIALS_TYPE.ARM_TEMPLATE,
-        type: 'text',
-      },
-    },
+    azure: getDefaultAzureCredentialsConfig(
+      packageInfo,
+      templateName,
+      isAgentless,
+      showCloudConnectors
+    ),
   };
 
   return credentialsTypes[provider];
@@ -376,10 +372,10 @@ export const getInputHiddenVars = (
         templateName,
       });
     case AZURE_PROVIDER:
-      return getDefaultAzureCredentialsType(
+      return getDefaultAzureCredentialsConfig(
         packageInfo,
         templateName,
-        setupTechnology,
+        setupTechnology === SetupTechnology.AGENTLESS,
         showCloudConnectors
       );
     case GCP_PROVIDER:
@@ -433,10 +429,10 @@ export const getArmTemplateUrlFromPackage = (
   return armTemplateUrl;
 };
 
-export const getDefaultAzureCredentialsType = (
+export const getDefaultAzureCredentialsConfig = (
   packageInfo: PackageInfo,
   templateName: string,
-  setupTechnology: SetupTechnology,
+  isAgentless: boolean,
   showCloudConnectors: boolean
 ): {
   [key: string]: {
@@ -444,7 +440,6 @@ export const getDefaultAzureCredentialsType = (
     type: 'text' | 'bool';
   };
 } => {
-  const isAgentless = setupTechnology === SetupTechnology.AGENTLESS;
   const hasArmTemplateUrl = !!getArmTemplateUrlFromPackage(packageInfo, templateName);
 
   let credentialType: AzureCredentialsType = AZURE_CREDENTIALS_TYPE.MANAGED_IDENTITY;
@@ -467,12 +462,10 @@ export const getDefaultAzureCredentialsType = (
       value: credentialType,
       type: 'text',
     },
-    ...(showCloudConnectors && {
-      'azure.supports_cloud_connectors': {
-        value: showCloudConnectors,
-        type: 'bool',
-      },
-    }),
+    'azure.supports_cloud_connectors': {
+      value: showCloudConnectors,
+      type: 'bool',
+    },
   };
 
   return config;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Context Security]  Fix Agent-Based Failing to produce data  (#241390)](https://github.com/elastic/kibana/pull/241390)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Lola","email":"omolola.akinleye@elastic.co"},"sourceCommit":{"committedDate":"2025-10-31T02:03:53Z","message":"[Context Security]  Fix Agent-Based Failing to produce data  (#241390)\n\n## Summary\nIn `9.2.0` AWS ECH environment, we introduce a regression when enabled\nthe Advanced Settings by default `EnabledCloudConnector:true` and if the\nuser switches from `Agentless` to `Agentbased`. This results in CSPM and\nAsset Inventory unable to ingest data.\n\n**Root Cause:**\n1. **Enabled by default in Cloud Connector**\n<img width=\"720\" height=\"244\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1cab451b-c568-4a89-b61f-8c88fd0f01b3\"\n/>\n\n2. Selecting `Agent-based` updates Package policy api contract still\npersists `aws.supports_cloud_connectors`\n\n```\nstreams\": {\n        \"cloud_security_posture.findings\": {\n          \"enabled\": true,\n          \"vars\": {\n            \"aws.credentials.type\": \"cloud_connectors\",\n            \"aws.account_type\": \"single-account\",\n            \"aws.supports_cloud_connectors\": true\n          }\n        }\n      }\n```\n\n3. This results in cloudbeat error logs and CSPM/Asset Inventory fails\nto produce Findings and Asset data\n\n**Solution Fix**\n1. Change the default setting` showCloudConnectors` to include\n`isAgentless` flag\n ```const showCloudConnectors =\nisCloudConnectorsEnabledForProvider(selectedProvider) &&\n                  value === SetupTechnology.AGENTLESS;\n  ```\n                  \n2. Update `aws.supports_cloud_connectors: showCloudConnectors` ||\n`azure.supports_cloud_connectors: showCloudConnectors`\n  \n\nhttps://github.com/user-attachments/assets/25d54857-cf52-43f0-85e5-291f50c037a0","sha":"59beb79a1bbc8b85225594a6c75b7359b9f758dc","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:breaking","Team:Cloud Security","ci:project-deploy-security","backport:version","v9.3.0","v9.2.1"],"title":"[Context Security]  Fix Agent-Based Failing to produce data ","number":241390,"url":"https://github.com/elastic/kibana/pull/241390","mergeCommit":{"message":"[Context Security]  Fix Agent-Based Failing to produce data  (#241390)\n\n## Summary\nIn `9.2.0` AWS ECH environment, we introduce a regression when enabled\nthe Advanced Settings by default `EnabledCloudConnector:true` and if the\nuser switches from `Agentless` to `Agentbased`. This results in CSPM and\nAsset Inventory unable to ingest data.\n\n**Root Cause:**\n1. **Enabled by default in Cloud Connector**\n<img width=\"720\" height=\"244\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1cab451b-c568-4a89-b61f-8c88fd0f01b3\"\n/>\n\n2. Selecting `Agent-based` updates Package policy api contract still\npersists `aws.supports_cloud_connectors`\n\n```\nstreams\": {\n        \"cloud_security_posture.findings\": {\n          \"enabled\": true,\n          \"vars\": {\n            \"aws.credentials.type\": \"cloud_connectors\",\n            \"aws.account_type\": \"single-account\",\n            \"aws.supports_cloud_connectors\": true\n          }\n        }\n      }\n```\n\n3. This results in cloudbeat error logs and CSPM/Asset Inventory fails\nto produce Findings and Asset data\n\n**Solution Fix**\n1. Change the default setting` showCloudConnectors` to include\n`isAgentless` flag\n ```const showCloudConnectors =\nisCloudConnectorsEnabledForProvider(selectedProvider) &&\n                  value === SetupTechnology.AGENTLESS;\n  ```\n                  \n2. Update `aws.supports_cloud_connectors: showCloudConnectors` ||\n`azure.supports_cloud_connectors: showCloudConnectors`\n  \n\nhttps://github.com/user-attachments/assets/25d54857-cf52-43f0-85e5-291f50c037a0","sha":"59beb79a1bbc8b85225594a6c75b7359b9f758dc"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241390","number":241390,"mergeCommit":{"message":"[Context Security]  Fix Agent-Based Failing to produce data  (#241390)\n\n## Summary\nIn `9.2.0` AWS ECH environment, we introduce a regression when enabled\nthe Advanced Settings by default `EnabledCloudConnector:true` and if the\nuser switches from `Agentless` to `Agentbased`. This results in CSPM and\nAsset Inventory unable to ingest data.\n\n**Root Cause:**\n1. **Enabled by default in Cloud Connector**\n<img width=\"720\" height=\"244\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1cab451b-c568-4a89-b61f-8c88fd0f01b3\"\n/>\n\n2. Selecting `Agent-based` updates Package policy api contract still\npersists `aws.supports_cloud_connectors`\n\n```\nstreams\": {\n        \"cloud_security_posture.findings\": {\n          \"enabled\": true,\n          \"vars\": {\n            \"aws.credentials.type\": \"cloud_connectors\",\n            \"aws.account_type\": \"single-account\",\n            \"aws.supports_cloud_connectors\": true\n          }\n        }\n      }\n```\n\n3. This results in cloudbeat error logs and CSPM/Asset Inventory fails\nto produce Findings and Asset data\n\n**Solution Fix**\n1. Change the default setting` showCloudConnectors` to include\n`isAgentless` flag\n ```const showCloudConnectors =\nisCloudConnectorsEnabledForProvider(selectedProvider) &&\n                  value === SetupTechnology.AGENTLESS;\n  ```\n                  \n2. Update `aws.supports_cloud_connectors: showCloudConnectors` ||\n`azure.supports_cloud_connectors: showCloudConnectors`\n  \n\nhttps://github.com/user-attachments/assets/25d54857-cf52-43f0-85e5-291f50c037a0","sha":"59beb79a1bbc8b85225594a6c75b7359b9f758dc"}},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->