### PR TITLE
[One Workflow] Accept Custom Workflow IDs on Creation

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/types/v1.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/v1.ts
@@ -207,6 +207,7 @@ export type EsWorkflow = z.infer<typeof EsWorkflowSchema>;
 
 export const CreateWorkflowCommandSchema = z.object({
   yaml: z.string(),
+  id: z.string().optional(),
 });
 
 export const UpdateWorkflowCommandSchema = z.object({

--- a/src/platform/plugins/shared/workflows_management/common/lib/errors/index.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/errors/index.ts
@@ -10,3 +10,4 @@
 export { InvalidYamlSchemaError } from './invalid_yaml_schema';
 export { InvalidYamlSyntaxError } from './invalid_yaml_syntax';
 export { WorkflowValidationError, isWorkflowValidationError } from './workflow_validation_error';
+export { WorkflowConflictError, isWorkflowConflictError } from './workflow_conflict_error';

--- a/src/platform/plugins/shared/workflows_management/common/lib/errors/workflow_conflict_error.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/errors/workflow_conflict_error.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export class WorkflowConflictError extends Error {
+  public readonly statusCode = 409;
+
+  constructor(message: string, public readonly workflowId: string) {
+    super(message);
+    this.name = 'WorkflowConflictError';
+  }
+
+  public toJSON() {
+    return {
+      error: 'Conflict',
+      message: this.message,
+      statusCode: this.statusCode,
+      workflowId: this.workflowId,
+    };
+  }
+}
+
+export function isWorkflowConflictError(error: Error): error is WorkflowConflictError {
+  return error instanceof WorkflowConflictError;
+}

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/route_error_handlers.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/route_error_handlers.ts
@@ -12,6 +12,7 @@ import { WorkflowExecutionNotFoundError } from '@kbn/workflows/common/errors';
 import {
   InvalidYamlSchemaError,
   InvalidYamlSyntaxError,
+  isWorkflowConflictError,
   isWorkflowValidationError,
 } from '../../../common/lib/errors';
 
@@ -27,7 +28,6 @@ export function handleRouteError(
   error: Error,
   options?: { checkNotFound?: boolean }
 ) {
-  // Check for specific error types that need special handling
   if (options?.checkNotFound && error instanceof WorkflowExecutionNotFoundError) {
     return response.notFound();
   }
@@ -46,7 +46,12 @@ export function handleRouteError(
     });
   }
 
-  // Generic error handler
+  if (isWorkflowConflictError(error)) {
+    return response.conflict({
+      body: error.toJSON(),
+    });
+  }
+
   return response.customError({
     statusCode: 500,
     body: {

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/test_utils.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/test_utils.ts
@@ -42,6 +42,7 @@ export const createMockResponse = () => ({
   ok: jest.fn().mockReturnThis(),
   notFound: jest.fn().mockReturnThis(),
   badRequest: jest.fn().mockReturnThis(),
+  conflict: jest.fn().mockReturnThis(),
   customError: jest.fn().mockReturnThis(),
 });
 

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.test.ts
@@ -673,6 +673,147 @@ describe('WorkflowsService', () => {
         })
       );
     });
+
+    it('should create workflow with custom ID when provided', async () => {
+      const mockRequest = {
+        auth: {
+          credentials: {
+            username: 'test-user',
+          },
+        },
+      } as any;
+
+      const customId = 'workflow-12345678-abcd-1234-abcd-123456789abc';
+      const workflowCommand = {
+        yaml: 'name: Custom ID Workflow\nenabled: true\ndefinition:\n  triggers: []',
+        id: customId,
+      };
+
+      mockEsClient.search.mockResolvedValue({
+        hits: {
+          total: { value: 0 },
+          hits: [],
+        },
+      } as any);
+      mockEsClient.index.mockResolvedValue({ _id: customId } as any);
+
+      const result = await service.createWorkflow(workflowCommand, 'default', mockRequest);
+
+      expect(result.id).toBe(customId);
+      expect(result.name).toBe('Custom ID Workflow');
+      expect(mockEsClient.index).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: customId,
+          index: '.workflows-workflows',
+          document: expect.objectContaining({
+            name: 'Custom ID Workflow',
+            enabled: true,
+            createdBy: 'test-user',
+            lastUpdatedBy: 'test-user',
+            spaceId: 'default',
+          }),
+          refresh: 'wait_for',
+          require_alias: true,
+        })
+      );
+    });
+
+    it('should throw WorkflowConflictError when custom ID already exists', async () => {
+      const mockRequest = {
+        auth: {
+          credentials: {
+            username: 'test-user',
+          },
+        },
+      } as any;
+
+      const existingId = 'workflow-12345678-1234-1234-1234-123456789abc';
+      const workflowCommand = {
+        yaml: 'name: Duplicate Workflow\nenabled: true\ndefinition:\n  triggers: []',
+        id: existingId,
+      };
+
+      mockEsClient.search.mockResolvedValue({
+        hits: {
+          total: { value: 1 },
+          hits: [
+            {
+              _id: existingId,
+              _source: {
+                name: 'Existing Workflow',
+                enabled: true,
+                spaceId: 'default',
+                yaml: 'name: Existing Workflow',
+              },
+            },
+          ],
+        },
+      } as any);
+
+      await expect(
+        service.createWorkflow(workflowCommand, 'default', mockRequest)
+      ).rejects.toMatchObject({
+        name: 'WorkflowConflictError',
+        message: `Workflow with id '${existingId}' already exists`,
+        statusCode: 409,
+        workflowId: existingId,
+      });
+
+      expect(mockEsClient.index).not.toHaveBeenCalled();
+    });
+
+    it('should throw WorkflowValidationError for invalid ID format', async () => {
+      const mockRequest = {
+        auth: {
+          credentials: {
+            username: 'test-user',
+          },
+        },
+      } as any;
+
+      const invalidId = 'invalid-id-format';
+      const workflowCommand = {
+        yaml: 'name: Invalid ID Workflow\nenabled: true\ndefinition:\n  triggers: []',
+        id: invalidId,
+      };
+
+      await expect(
+        service.createWorkflow(workflowCommand, 'default', mockRequest)
+      ).rejects.toMatchObject({
+        name: 'WorkflowValidationError',
+        message: `Invalid workflow ID format. Expected format: workflow-{uuid}, received: ${invalidId}`,
+        statusCode: 400,
+      });
+
+      expect(mockEsClient.index).not.toHaveBeenCalled();
+      expect(mockEsClient.search).not.toHaveBeenCalled();
+    });
+
+    it('should throw WorkflowValidationError for ID without workflow prefix', async () => {
+      const mockRequest = {
+        auth: {
+          credentials: {
+            username: 'test-user',
+          },
+        },
+      } as any;
+
+      const invalidId = '12345678-1234-1234-1234-123456789abc';
+      const workflowCommand = {
+        yaml: 'name: Missing Prefix Workflow\nenabled: true\ndefinition:\n  triggers: []',
+        id: invalidId,
+      };
+
+      await expect(
+        service.createWorkflow(workflowCommand, 'default', mockRequest)
+      ).rejects.toMatchObject({
+        name: 'WorkflowValidationError',
+        message: `Invalid workflow ID format. Expected format: workflow-{uuid}, received: ${invalidId}`,
+        statusCode: 400,
+      });
+
+      expect(mockEsClient.index).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateWorkflow', () => {


### PR DESCRIPTION
Implements support for specifying a custom ID when creating workflows, enabling infrastructure-as-code workflows and smooth migrations between clusters.

**Key Changes**:

- Added optional id field to CreateWorkflowCommandSchema
- Validates custom IDs follow workflow-{uuid} format
- Returns 409 Conflict if workflow ID already exists
- Returns 400 Bad Request if ID format is invalid
- Maintains backward compatibility (auto-generates ID if not provided)
