### PR TITLE
[One Workflow] Added Kibana URL and execution-specific URL to the workflow context

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/schema.ts
@@ -474,6 +474,7 @@ export const WorkflowExecutionContextSchema = z.object({
   id: z.string(),
   isTestRun: z.boolean(),
   startedAt: z.date(),
+  url: z.string(),
 });
 export type WorkflowExecutionContext = z.infer<typeof WorkflowExecutionContextSchema>;
 
@@ -525,6 +526,7 @@ export const WorkflowContextSchema = z.object({
   event: EventSchema.optional(),
   execution: WorkflowExecutionContextSchema,
   workflow: WorkflowDataContextSchema,
+  kibanaUrl: z.string(),
   inputs: z
     .record(
       z.union([

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/kibana_action_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/kibana_action_step.ts
@@ -15,6 +15,7 @@ import { buildKibanaRequestFromAction } from '@kbn/workflows';
 import type { z } from '@kbn/zod';
 import type { BaseStep, RunStepResult } from './node_implementation';
 import { BaseAtomicNodeImplementation } from './node_implementation';
+import { getKibanaUrl } from '../utils';
 import type { StepExecutionRuntime } from '../workflow_context_manager/step_execution_runtime';
 import type { WorkflowExecutionRuntimeManager } from '../workflow_context_manager/workflow_execution_runtime_manager';
 import type { IWorkflowEventLogger } from '../workflow_event_logger/workflow_event_logger';
@@ -103,29 +104,9 @@ export class KibanaActionStepImpl extends BaseAtomicNodeImplementation<KibanaAct
   }
 
   private getKibanaUrl(): string {
-    // Get Kibana URL from server.publicBaseUrl config if available
     const coreStart = this.stepExecutionRuntime.contextManager.getCoreStart();
-    if (coreStart?.http?.basePath?.publicBaseUrl) {
-      return coreStart.http.basePath.publicBaseUrl;
-    }
-    // Get Kibana URL from cloud.kibanaUrl config if available
     const { cloudSetup } = this.stepExecutionRuntime.contextManager.getDependencies();
-    if (cloudSetup?.kibanaUrl) {
-      return cloudSetup.kibanaUrl;
-    }
-
-    // Fallback to local network binding
-    const http = coreStart?.http;
-    if (http) {
-      const { protocol, hostname, port } = http.getServerInfo();
-      return `${protocol}://${hostname}:${port}${http.basePath
-        // Prepending on '' removes the serverBasePath
-        .prepend('/')
-        .slice(0, -1)}`;
-    }
-
-    // Fallback to localhost for development
-    return 'http://localhost:5601';
+    return getKibanaUrl(coreStart, cloudSetup);
   }
 
   private getAuthHeaders(): Record<string, string> {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/utils/get_kibana_url.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/utils/get_kibana_url.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CloudSetup } from '@kbn/cloud-plugin/server';
+import type { CoreStart } from '@kbn/core/server';
+import { buildWorkflowExecutionUrl, getKibanaUrl } from './get_kibana_url';
+
+describe('getKibanaUrl', () => {
+  it('returns publicBaseUrl when available', () => {
+    const coreStart = {
+      http: {
+        basePath: {
+          publicBaseUrl: 'https://kibana.example.com',
+        },
+      },
+    } as CoreStart;
+
+    expect(getKibanaUrl(coreStart)).toBe('https://kibana.example.com');
+  });
+
+  it('returns cloud kibanaUrl when publicBaseUrl is not available', () => {
+    const coreStart = {
+      http: {
+        basePath: {},
+      },
+    } as CoreStart;
+    const cloudSetup = {
+      kibanaUrl: 'https://cloud.kibana.example.com',
+    } as CloudSetup;
+
+    expect(getKibanaUrl(coreStart, cloudSetup)).toBe('https://cloud.kibana.example.com');
+  });
+
+  it('builds URL from server info when neither publicBaseUrl nor cloud URL is available', () => {
+    const coreStart = {
+      http: {
+        basePath: {
+          prepend: jest.fn((path: string) => `/base-path${path}`),
+        },
+        getServerInfo: jest.fn(() => ({
+          protocol: 'https',
+          hostname: 'localhost',
+          port: 5601,
+        })),
+      },
+    } as unknown as CoreStart;
+
+    expect(getKibanaUrl(coreStart)).toBe('https://localhost:5601/base-path');
+  });
+
+  it('returns localhost fallback when no core start is provided', () => {
+    expect(getKibanaUrl()).toBe('http://localhost:5601');
+  });
+});
+
+describe('buildWorkflowExecutionUrl', () => {
+  it('builds URL for default space', () => {
+    const url = buildWorkflowExecutionUrl(
+      'https://kibana.example.com',
+      'default',
+      'workflow-123',
+      'execution-456'
+    );
+
+    expect(url).toBe(
+      'https://kibana.example.com/app/workflows/workflow-workflow-123?executionId=execution-456&tab=executions'
+    );
+  });
+
+  it('builds URL for non-default space', () => {
+    const url = buildWorkflowExecutionUrl(
+      'https://kibana.example.com',
+      'my-space',
+      'workflow-123',
+      'execution-456'
+    );
+
+    expect(url).toBe(
+      'https://kibana.example.com/s/my-space/app/workflows/workflow-workflow-123?executionId=execution-456&tab=executions'
+    );
+  });
+
+  it('builds URL with stepExecutionId', () => {
+    const url = buildWorkflowExecutionUrl(
+      'https://kibana.example.com',
+      'default',
+      'workflow-123',
+      'execution-456',
+      'step-789'
+    );
+
+    expect(url).toBe(
+      'https://kibana.example.com/app/workflows/workflow-workflow-123?executionId=execution-456&tab=executions&stepExecutionId=step-789'
+    );
+  });
+
+  it('builds URL matching user example format', () => {
+    const url = buildWorkflowExecutionUrl(
+      'http://localhost:5601/fbi',
+      'default',
+      '8e737e4c-e9cf-422a-b690-0acb9368b050',
+      '050a6b75-59ef-4137-9708-e1c8a9a30e4c',
+      '99ce063eca45a6e84646538924fd2a989a6085a1fdf874c553deeae46d6ce13c'
+    );
+
+    expect(url).toBe(
+      'http://localhost:5601/fbi/app/workflows/workflow-8e737e4c-e9cf-422a-b690-0acb9368b050?executionId=050a6b75-59ef-4137-9708-e1c8a9a30e4c&tab=executions&stepExecutionId=99ce063eca45a6e84646538924fd2a989a6085a1fdf874c553deeae46d6ce13c'
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/utils/get_kibana_url.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/utils/get_kibana_url.test.ts
@@ -69,7 +69,7 @@ describe('buildWorkflowExecutionUrl', () => {
     );
 
     expect(url).toBe(
-      'https://kibana.example.com/app/workflows/workflow-workflow-123?executionId=execution-456&tab=executions'
+      'https://kibana.example.com/app/workflows/workflow-123?executionId=execution-456&tab=executions'
     );
   });
 
@@ -82,7 +82,7 @@ describe('buildWorkflowExecutionUrl', () => {
     );
 
     expect(url).toBe(
-      'https://kibana.example.com/s/my-space/app/workflows/workflow-workflow-123?executionId=execution-456&tab=executions'
+      'https://kibana.example.com/s/my-space/app/workflows/workflow-123?executionId=execution-456&tab=executions'
     );
   });
 
@@ -96,7 +96,7 @@ describe('buildWorkflowExecutionUrl', () => {
     );
 
     expect(url).toBe(
-      'https://kibana.example.com/app/workflows/workflow-workflow-123?executionId=execution-456&tab=executions&stepExecutionId=step-789'
+      'https://kibana.example.com/app/workflows/workflow-123?executionId=execution-456&tab=executions&stepExecutionId=step-789'
     );
   });
 
@@ -110,7 +110,7 @@ describe('buildWorkflowExecutionUrl', () => {
     );
 
     expect(url).toBe(
-      'http://localhost:5601/fbi/app/workflows/workflow-8e737e4c-e9cf-422a-b690-0acb9368b050?executionId=050a6b75-59ef-4137-9708-e1c8a9a30e4c&tab=executions&stepExecutionId=99ce063eca45a6e84646538924fd2a989a6085a1fdf874c553deeae46d6ce13c'
+      'http://localhost:5601/fbi/app/workflows/8e737e4c-e9cf-422a-b690-0acb9368b050?executionId=050a6b75-59ef-4137-9708-e1c8a9a30e4c&tab=executions&stepExecutionId=99ce063eca45a6e84646538924fd2a989a6085a1fdf874c553deeae46d6ce13c'
     );
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/utils/get_kibana_url.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/utils/get_kibana_url.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CloudSetup } from '@kbn/cloud-plugin/server';
+import type { CoreStart } from '@kbn/core/server';
+
+export function getKibanaUrl(coreStart?: CoreStart, cloudSetup?: CloudSetup): string {
+  if (coreStart?.http?.basePath?.publicBaseUrl) {
+    return coreStart.http.basePath.publicBaseUrl;
+  }
+
+  if (cloudSetup?.kibanaUrl) {
+    return cloudSetup.kibanaUrl;
+  }
+
+  const http = coreStart?.http;
+  if (http) {
+    const { protocol, hostname, port } = http.getServerInfo();
+    return `${protocol}://${hostname}:${port}${http.basePath.prepend('/').slice(0, -1)}`;
+  }
+
+  return 'http://localhost:5601';
+}
+
+export function buildWorkflowExecutionUrl(
+  kibanaUrl: string,
+  spaceId: string,
+  workflowId: string,
+  executionId: string,
+  stepExecutionId?: string
+): string {
+  const spacePrefix = spaceId === 'default' ? '' : `/s/${spaceId}`;
+  const baseUrl = `${kibanaUrl}${spacePrefix}/app/workflows/${workflowId}`;
+  const params = new URLSearchParams({
+    executionId,
+    tab: 'executions',
+  });
+
+  if (stepExecutionId) {
+    params.set('stepExecutionId', stepExecutionId);
+  }
+
+  return `${baseUrl}?${params.toString()}`;
+}

--- a/src/platform/plugins/shared/workflows_execution_engine/server/utils/index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/utils/index.ts
@@ -10,3 +10,4 @@
 export { parseDuration } from './parse-duration/parse-duration';
 export { buildStepExecutionId } from './build_step_execution_id/build_step_execution_id';
 export { stringifyStackFrames } from './stringify_stack_frames';
+export { getKibanaUrl, buildWorkflowExecutionUrl } from './get_kibana_url';

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/workflow_context_manager.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/workflow_context_manager.test.ts
@@ -32,6 +32,21 @@ jest.mock('../../utils', () => ({
   buildStepExecutionId: jest.fn().mockImplementation((executionId, stepId, path) => {
     return `${stepId}_generated`;
   }),
+  getKibanaUrl: jest.fn().mockReturnValue('http://localhost:5601'),
+  buildWorkflowExecutionUrl: jest
+    .fn()
+    .mockImplementation((kibanaUrl, spaceId, workflowId, executionId, stepExecutionId) => {
+      const spacePrefix = spaceId === 'default' ? '' : `/s/${spaceId}`;
+      const baseUrl = `${kibanaUrl}${spacePrefix}/app/workflows/workflow-${workflowId}`;
+      const params = new URLSearchParams({
+        executionId,
+        tab: 'executions',
+      });
+      if (stepExecutionId) {
+        params.set('stepExecutionId', stepExecutionId);
+      }
+      return `${baseUrl}?${params.toString()}`;
+    }),
 }));
 
 describe('WorkflowContextManager', () => {
@@ -817,6 +832,7 @@ describe('WorkflowContextManager', () => {
             id: 'exec-123',
             isTestRun: false,
             startedAt: new Date('2023-01-01T00:00:00.000Z'),
+            url: 'http://localhost:5601/s/space-789/app/workflows/workflow-workflow-456?executionId=exec-123&tab=executions',
           },
           workflow: {
             id: 'workflow-456',
@@ -824,6 +840,7 @@ describe('WorkflowContextManager', () => {
             enabled: true,
             spaceId: 'space-789',
           },
+          kibanaUrl: 'http://localhost:5601',
           consts: {
             API_URL: 'https://api.example.com',
             TIMEOUT: 5000,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/workflow_context_manager.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/workflow_context_manager.test.ts
@@ -37,7 +37,7 @@ jest.mock('../../utils', () => ({
     .fn()
     .mockImplementation((kibanaUrl, spaceId, workflowId, executionId, stepExecutionId) => {
       const spacePrefix = spaceId === 'default' ? '' : `/s/${spaceId}`;
-      const baseUrl = `${kibanaUrl}${spacePrefix}/app/workflows/workflow-${workflowId}`;
+      const baseUrl = `${kibanaUrl}${spacePrefix}/app/workflows/${workflowId}`;
       const params = new URLSearchParams({
         executionId,
         tab: 'executions',
@@ -832,7 +832,7 @@ describe('WorkflowContextManager', () => {
             id: 'exec-123',
             isTestRun: false,
             startedAt: new Date('2023-01-01T00:00:00.000Z'),
-            url: 'http://localhost:5601/s/space-789/app/workflows/workflow-workflow-456?executionId=exec-123&tab=executions',
+            url: 'http://localhost:5601/s/space-789/app/workflows/workflow-456?executionId=exec-123&tab=executions',
           },
           workflow: {
             id: 'workflow-456',

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
@@ -17,7 +17,7 @@ import type { WorkflowExecutionState } from './workflow_execution_state';
 import { WorkflowScopeStack } from './workflow_scope_stack';
 import type { RunStepResult } from '../step/node_implementation';
 import type { WorkflowTemplatingEngine } from '../templating_engine';
-import { buildStepExecutionId } from '../utils';
+import { buildStepExecutionId, buildWorkflowExecutionUrl, getKibanaUrl } from '../utils';
 
 export interface ContextManagerInit {
   // New properties for logging
@@ -190,12 +190,20 @@ export class WorkflowContextManager {
 
   private buildWorkflowContext(): WorkflowContext {
     const workflowExecution = this.workflowExecutionState.getWorkflowExecution();
+    const kibanaUrl = getKibanaUrl(this.coreStart, this.dependencies.cloudSetup);
+    const executionUrl = buildWorkflowExecutionUrl(
+      kibanaUrl,
+      workflowExecution.spaceId,
+      workflowExecution.workflowId,
+      workflowExecution.id
+    );
 
     return {
       execution: {
         id: workflowExecution.id,
         isTestRun: !!workflowExecution.isTestRun,
         startedAt: new Date(workflowExecution.startedAt),
+        url: executionUrl,
       },
       workflow: {
         id: workflowExecution.workflowId,
@@ -203,6 +211,7 @@ export class WorkflowContextManager {
         enabled: workflowExecution.workflowDefinition.enabled,
         spaceId: workflowExecution.spaceId,
       },
+      kibanaUrl,
       consts: workflowExecution.workflowDefinition.consts || {},
       event: workflowExecution.context?.event,
       inputs: workflowExecution.context?.inputs,


### PR DESCRIPTION
Added Kibana URL and execution-specific URL to the workflow context, making it easy for workflow steps to generate links back to the Kibana UI (e.g., for notifications or external integrations).

**New Context Fields**:

- kibanaUrl - The base Kibana URL (e.g., http://localhost:5601)
- execution.url - Direct link to the specific workflow execution (e.g., http://localhost:5601/s/space-name/app/workflows/workflow-id?executionId=exec-id&tab=executions)