### PR TITLE
[Background search] Don't cancel backgrounded searches on search:timeout

### DIFF
--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_abort_controller.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_abort_controller.ts
@@ -75,4 +75,9 @@ export class SearchAbortController {
   public isTimeout() {
     return this.reason === AbortReason.Timeout;
   }
+
+  public clearTimeout() {
+    this.timeoutSub?.unsubscribe();
+    this.timeoutSub = undefined;
+  }
 }

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_abort_controller.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_abort_controller.ts
@@ -75,9 +75,4 @@ export class SearchAbortController {
   public isTimeout() {
     return this.reason === AbortReason.Timeout;
   }
-
-  public clearTimeout() {
-    this.timeoutSub?.unsubscribe();
-    this.timeoutSub = undefined;
-  }
 }

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.test.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.test.ts
@@ -735,33 +735,69 @@ describe('SearchInterceptor', () => {
       expect(mockCoreSetup.http.delete).not.toHaveBeenCalled();
     });
 
-    test('should NOT DELETE a running SAVED async search on async timeout', async () => {
-      sessionService.isCurrentSession.mockReturnValue(true);
-      sessionService.isSaving.mockReturnValue(true);
+    describe('when the search is already backgrounded', () => {
+      test('should NOT DELETE a running SAVED async search on async timeout', async () => {
+        sessionService.isCurrentSession.mockReturnValue(true);
+        sessionService.isSaving.mockReturnValue(true);
 
-      mockCoreSetup.http.post.mockResolvedValue(
-        getMockSearchResponse({
-          isPartial: true,
-          isRunning: true,
-          rawResponse: {},
-          id: '1',
-        })
-      );
+        mockCoreSetup.http.post.mockResolvedValue(
+          getMockSearchResponse({
+            isPartial: true,
+            isRunning: true,
+            rawResponse: {},
+            id: '1',
+          })
+        );
 
-      const response = searchInterceptor.search({}, { pollInterval: 0 });
-      response.subscribe({ next, error });
+        const response = searchInterceptor.search({}, { pollInterval: 0 });
+        response.subscribe({ next, error });
 
-      await timeTravel(10);
+        await timeTravel(10);
 
-      expect(next).toHaveBeenCalled();
-      expect(error).not.toHaveBeenCalled();
-      expect(mockCoreSetup.http.post).toHaveBeenCalled();
-      expect(mockCoreSetup.http.delete).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        expect(mockCoreSetup.http.post).toHaveBeenCalled();
+        expect(mockCoreSetup.http.delete).not.toHaveBeenCalled();
 
-      // Long enough to reach the timeout
-      await timeTravel(2000);
+        // Long enough to reach the timeout
+        await timeTravel(2000);
 
-      expect(mockCoreSetup.http.delete).not.toHaveBeenCalled();
+        expect(mockCoreSetup.http.delete).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the search gets backgrounded during execution', () => {
+      test('should NOT DELETE a running SAVED async search on async timeout', async () => {
+        sessionService.isCurrentSession.mockReturnValue(true);
+        sessionService.isSaving.mockReturnValue(false);
+
+        mockCoreSetup.http.post.mockResolvedValue(
+          getMockSearchResponse({
+            isPartial: true,
+            isRunning: true,
+            rawResponse: {},
+            id: '1',
+          })
+        );
+
+        const response = searchInterceptor.search({}, { pollInterval: 0 });
+        response.subscribe({ next, error });
+
+        // We emit a new state to clear the timeout
+        sessionState$.next(SearchSessionState.BackgroundLoading);
+
+        await timeTravel(10);
+
+        expect(next).toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        expect(mockCoreSetup.http.post).toHaveBeenCalled();
+        expect(mockCoreSetup.http.delete).not.toHaveBeenCalled();
+
+        // Long enough to reach the timeout
+        await timeTravel(2000);
+
+        expect(mockCoreSetup.http.delete).not.toHaveBeenCalled();
+      });
     });
 
     describe('Search session', () => {

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -334,7 +334,7 @@ export class SearchInterceptor {
     let isSavedToBackground =
       this.deps.session.isCurrentSession(sessionId) &&
       (this.deps.session.isSaving() || this.deps.session.isStored());
-    if (isSavedToBackground) searchAbortController.clearTimeout();
+    if (isSavedToBackground) searchAbortController.cleanup();
 
     const savedToBackgroundSub =
       this.deps.session.isCurrentSession(sessionId) &&
@@ -349,7 +349,7 @@ export class SearchInterceptor {
           take(1)
         )
         .subscribe(() => {
-          searchAbortController.clearTimeout();
+          searchAbortController.cleanup();
           isSavedToBackground = true;
         });
 

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -334,6 +334,8 @@ export class SearchInterceptor {
     let isSavedToBackground =
       this.deps.session.isCurrentSession(sessionId) &&
       (this.deps.session.isSaving() || this.deps.session.isStored());
+    if (isSavedToBackground) searchAbortController.clearTimeout();
+
     const savedToBackgroundSub =
       this.deps.session.isCurrentSession(sessionId) &&
       this.deps.session.state$
@@ -347,6 +349,7 @@ export class SearchInterceptor {
           take(1)
         )
         .subscribe(() => {
+          searchAbortController.clearTimeout();
           isSavedToBackground = true;
         });
 
@@ -413,9 +416,7 @@ export class SearchInterceptor {
                 : response
             ),
             tap(async () => {
-              if (!isSavedToBackground) {
-                await sendCancelRequest();
-              }
+              await sendCancelRequest();
               this.handleSearchError(e, request?.params?.body ?? {}, options, true);
             })
           );

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -413,7 +413,9 @@ export class SearchInterceptor {
                 : response
             ),
             tap(async () => {
-              await sendCancelRequest();
+              if (!isSavedToBackground) {
+                await sendCancelRequest();
+              }
               this.handleSearchError(e, request?.params?.body ?? {}, options, true);
             })
           );


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/240513

Before this PR we are cancelling searches after the search:timeout even if they are backgrounded, that shouldn't be the case - with this changes we still cancel the foreground execution, the user will see partial results, but the backgrounded query remains running.

Before

https://github.com/user-attachments/assets/f598f384-4723-4311-88c7-dde44b519543

After

https://github.com/user-attachments/assets/3a04ace3-888b-4e1a-af5c-5d2890fc6285

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.






<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->