### PR TITLE
[Telemetry automated checks] Add 5 retries to the schema download task

### DIFF
--- a/src/platform/packages/private/kbn-telemetry-tools/src/tools/tasks/validate_schema_changes.ts
+++ b/src/platform/packages/private/kbn-telemetry-tools/src/tools/tasks/validate_schema_changes.ts
@@ -47,6 +47,10 @@ export function validateSchemaChanges({ baselineSha, roots, reporter }: TaskCont
           },
           title: `Downloading /${baselineSha}/${path} from Github`,
           enabled: (_) => Boolean(!isPullRequestPipeline || root.configChanged),
+          retry: {
+            delay: 2000,
+            tries: 5,
+          },
         },
         {
           task: async () => {


### PR DESCRIPTION
## Summary

Git repository might fail from time to time when attempting to download telemetry schemas JSON files (e.g. [build](https://buildkite.com/elastic/kibana-on-merge/builds/81018/steps/canvas?jid=019a3acd-b8e5-419a-ba61-2c3ff45ba8d3)).

Adding a few retries to this task will prevent from having to repeat the whole check.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->