### PR TITLE
[9.1] [APM] Fix APM flaky test cleanup logic (#241310)

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/services/derived_annotations.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/services/derived_annotations.spec.ts
@@ -134,9 +134,12 @@ export default function annotationApiTests({ getService }: DeploymentAgnosticFtr
       });
 
       after(async () => {
-        await es.indices.delete({
-          index: indexName,
-        });
+        const indexExists = await es.indices.exists({ index: indexName });
+        if (indexExists) {
+          await es.indices.delete({
+            index: indexName,
+          });
+        }
         await samlAuth.invalidateM2mApiKeyWithRoleScope(roleAuthc);
       });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[APM] Fix APM flaky test cleanup logic (#241310)](https://github.com/elastic/kibana/pull/241310)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-10-30T18:56:19Z","message":"[APM] Fix APM flaky test cleanup logic (#241310)\n\nCloses #234664\n\n## Summary\n\nThis PR fixes a flaky APM test cleanup `after` issue. The test was\nfailing because the after hook was trying to delete the Elasticsearch\nindex apm-8.0.0-transaction without first checking if it exists. This\ncaused an `index_not_found_exception` when the index didn't exist. The\ntest setup in the before hook properly checks if the index exists before\ndeleting it ([lines\n35-40](https://github.com/elastic/kibana/compare/main...jennypavlova:kibana:fix-flaky-apm-test-after?expand=1#diff-88902b6ae54830e04bb08653dfda680e427fd98f5d5ae8e5eff6d6dbad455e2cL35-L40)),\nbut the cleanup in the after hook ([line\n137](https://github.com/elastic/kibana/compare/main...jennypavlova:kibana:fix-flaky-apm-test-after?expand=1#diff-88902b6ae54830e04bb08653dfda680e427fd98f5d5ae8e5eff6d6dbad455e2cL137))\nwas missing this same safety check.","sha":"8b85ef36f35258ad1b6b3f8160ec9ff6f4c3cf74","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:obs-ux-infra_services","backport:version","v9.1.0","v9.0.2","v9.0.3","v9.2.0","v9.3.0"],"title":"[APM] Fix APM flaky test cleanup logic","number":241310,"url":"https://github.com/elastic/kibana/pull/241310","mergeCommit":{"message":"[APM] Fix APM flaky test cleanup logic (#241310)\n\nCloses #234664\n\n## Summary\n\nThis PR fixes a flaky APM test cleanup `after` issue. The test was\nfailing because the after hook was trying to delete the Elasticsearch\nindex apm-8.0.0-transaction without first checking if it exists. This\ncaused an `index_not_found_exception` when the index didn't exist. The\ntest setup in the before hook properly checks if the index exists before\ndeleting it ([lines\n35-40](https://github.com/elastic/kibana/compare/main...jennypavlova:kibana:fix-flaky-apm-test-after?expand=1#diff-88902b6ae54830e04bb08653dfda680e427fd98f5d5ae8e5eff6d6dbad455e2cL35-L40)),\nbut the cleanup in the after hook ([line\n137](https://github.com/elastic/kibana/compare/main...jennypavlova:kibana:fix-flaky-apm-test-after?expand=1#diff-88902b6ae54830e04bb08653dfda680e427fd98f5d5ae8e5eff6d6dbad455e2cL137))\nwas missing this same safety check.","sha":"8b85ef36f35258ad1b6b3f8160ec9ff6f4c3cf74"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.2"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/241362","number":241362,"state":"OPEN"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241310","number":241310,"mergeCommit":{"message":"[APM] Fix APM flaky test cleanup logic (#241310)\n\nCloses #234664\n\n## Summary\n\nThis PR fixes a flaky APM test cleanup `after` issue. The test was\nfailing because the after hook was trying to delete the Elasticsearch\nindex apm-8.0.0-transaction without first checking if it exists. This\ncaused an `index_not_found_exception` when the index didn't exist. The\ntest setup in the before hook properly checks if the index exists before\ndeleting it ([lines\n35-40](https://github.com/elastic/kibana/compare/main...jennypavlova:kibana:fix-flaky-apm-test-after?expand=1#diff-88902b6ae54830e04bb08653dfda680e427fd98f5d5ae8e5eff6d6dbad455e2cL35-L40)),\nbut the cleanup in the after hook ([line\n137](https://github.com/elastic/kibana/compare/main...jennypavlova:kibana:fix-flaky-apm-test-after?expand=1#diff-88902b6ae54830e04bb08653dfda680e427fd98f5d5ae8e5eff6d6dbad455e2cL137))\nwas missing this same safety check.","sha":"8b85ef36f35258ad1b6b3f8160ec9ff6f4c3cf74"}}]}] BACKPORT-->