### PR TITLE
Fix 403 on read benchmark rules API for read only user

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/benchmark_rules/get_states/v1.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/routes/benchmark_rules/get_states/v1.ts
@@ -40,8 +40,17 @@ export const getCspBenchmarkRulesStatesHandler = async (
   } catch (err) {
     const error = transformError(err);
     if (error.statusCode === 404) {
-      const newCspSettings = await createCspSettingObject(encryptedSoClient);
-      return newCspSettings.attributes.rules;
+      try {
+        const newCspSettings = await createCspSettingObject(encryptedSoClient);
+        return newCspSettings.attributes.rules;
+      } catch (createErr) {
+        const createError = transformError(createErr);
+        // If user doesn't have permission to create settings (read-only user), return empty rules
+        if (createError.statusCode === 403) {
+          return {};
+        }
+        throw createErr;
+      }
     }
 
     throw new Error(

--- a/x-pack/solutions/security/test/cloud_security_posture_api/routes/benchmarks.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_api/routes/benchmarks.ts
@@ -243,8 +243,7 @@ export default function (providerContext: FtrProviderContext) {
         expect(benchmarksResult.statusCode).to.equal(403);
       });
 
-      // Blocked by https://github.com/elastic/kibana/issues/188059
-      it.skip('Calling Benchmark API as User with read access to Security', async () => {
+      it('Calling Benchmark API as User with read access to Security', async () => {
         const benchmark = 'cis_aws';
         const benchmarkRules = await getCspBenchmarkRules(benchmark);
 

--- a/x-pack/solutions/security/test/cloud_security_posture_api/routes/csp_benchmark_rules_get_states.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_api/routes/csp_benchmark_rules_get_states.ts
@@ -157,14 +157,14 @@ export default function (providerContext: FtrProviderContext) {
 
       expectExpect(body).toEqual({});
     });
-    // Blocked by https://github.com/elastic/kibana/issues/188059
-    it.skip('GET rules states API with user with read access', async () => {
+
+    it('GET rules states API with user with read access', async () => {
       const { status } = await supertestWithoutAuth
         .get(`/internal/cloud_security_posture/rules/_get_states?tags=CIS`)
         .set(ELASTIC_HTTP_VERSION_HEADER, '1')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .set('kbn-xsrf', 'xxxx')
-        .auth('role_security_read_user', cspSecurity.getPasswordForUser('role_security_read_use'));
+        .auth('role_security_read_user', cspSecurity.getPasswordForUser('role_security_read_user'));
       expect(status).to.be(200);
     });
 

--- a/x-pack/solutions/security/test/cloud_security_posture_api/routes/helper/user_roles_utilites.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_api/routes/helper/user_roles_utilites.ts
@@ -9,6 +9,7 @@ import {
   CDR_LATEST_NATIVE_VULNERABILITIES_INDEX_PATTERN,
   FINDINGS_INDEX_PATTERN,
   CDR_LATEST_NATIVE_MISCONFIGURATIONS_INDEX_ALIAS,
+  DEPRECATED_CDR_LATEST_NATIVE_MISCONFIGURATIONS_INDEX_PATTERN,
 } from '@kbn/cloud-security-posture-common';
 import {
   BENCHMARK_SCORE_INDEX_PATTERN,
@@ -23,7 +24,10 @@ const alertsSecurityUserIndices = [
     privileges: ['read'],
   },
   {
-    names: [CDR_LATEST_NATIVE_MISCONFIGURATIONS_INDEX_ALIAS],
+    names: [
+      CDR_LATEST_NATIVE_MISCONFIGURATIONS_INDEX_ALIAS,
+      DEPRECATED_CDR_LATEST_NATIVE_MISCONFIGURATIONS_INDEX_PATTERN,
+    ],
     privileges: ['read'],
   },
   {
@@ -46,7 +50,10 @@ const securityUserIndinces = [
     privileges: ['read'],
   },
   {
-    names: [CDR_LATEST_NATIVE_MISCONFIGURATIONS_INDEX_ALIAS],
+    names: [
+      CDR_LATEST_NATIVE_MISCONFIGURATIONS_INDEX_ALIAS,
+      DEPRECATED_CDR_LATEST_NATIVE_MISCONFIGURATIONS_INDEX_PATTERN,
+    ],
     privileges: ['read'],
   },
   {


### PR DESCRIPTION
## Summary

`get_status` on benchmark rules api returns 403 for a read-only user because under the hood it tries to create a SO if it hasn't been created yet. Ideally we shouldn't place non-read operations under getSmth api, but as the issue really mostly affecting our test I'm keeping the fix simple (return empty response if SO doesn't exist yet) 

As a result unskipping two API ftrs

Fixes: 
- https://github.com/elastic/kibana/issues/188059

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



