### PR TITLE
[One Workflow] fix: Extra timeout step

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/integration_tests/tests/wait_step.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/integration_tests/tests/wait_step.test.ts
@@ -97,10 +97,10 @@ steps:
         workflowRunFixture.stepExecutionRepositoryMock.stepExecutions.values()
       ).sort((a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime());
 
-      expect(allStepExecutions.length).toBe(4);
-      expect(allStepExecutions[1].stepId).toBe('firstConnectorStep');
-      expect(allStepExecutions[2].stepId).toBe('waitStep');
-      expect(allStepExecutions[3].stepId).toBe('lastConnectorStep');
+      expect(allStepExecutions.length).toBe(3);
+      expect(allStepExecutions[0].stepId).toBe('firstConnectorStep');
+      expect(allStepExecutions[1].stepId).toBe('waitStep');
+      expect(allStepExecutions[2].stepId).toBe('lastConnectorStep');
     });
 
     it('should have correct workflow duration', async () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/integration_tests/tests/workflow_level_timeout.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/integration_tests/tests/workflow_level_timeout.test.ts
@@ -26,22 +26,22 @@ consts:
   items: '["item1", "item2", "item3", "item4"]'
 
 steps:
-  - name: slowInferenceStep1
+  - name: slowInferenceStep1Completed
     type: ${FakeConnectors.slow_1sec_inference.actionTypeId}
     connector-id: ${FakeConnectors.slow_1sec_inference.name}
     with:
         message: 1
-  - name: slowInferenceStep2
+  - name: slowInferenceStep2Completed
     type: ${FakeConnectors.slow_1sec_inference.actionTypeId}
     connector-id: ${FakeConnectors.slow_1sec_inference.name}
     with:
         message: 2
-  - name: slowInferenceStep3
+  - name: slowInferenceStep3Failed
     type: ${FakeConnectors.slow_1sec_inference.actionTypeId}
     connector-id: ${FakeConnectors.slow_1sec_inference.name}
     with:
         message: 3
-  - name: slowInferenceStep4
+  - name: slowInferenceStep4NotStarted
     type: ${FakeConnectors.slow_1sec_inference.actionTypeId}
     connector-id: ${FakeConnectors.slow_1sec_inference.name}
     with:
@@ -52,6 +52,11 @@ steps:
     await workflowRunFixture.runWorkflow({
       workflowYaml,
     });
+  });
+
+  it('should have correct step execution count', async () => {
+    const stepExecutionsCount = workflowRunFixture.stepExecutionRepositoryMock.stepExecutions.size;
+    expect(stepExecutionsCount).toBe(3);
   });
 
   it('should set timeout status for workflow', async () => {
@@ -68,14 +73,38 @@ steps:
       workflowRunFixture.stepExecutionRepositoryMock.stepExecutions.values()
     ).filter(
       (se) =>
-        se.stepId === 'slowInferenceStep' &&
+        se.stepId.endsWith('Completed') &&
         se.stepType === FakeConnectors.slow_1sec_inference.actionTypeId
     );
-
+    expect(slowInferenceStepExecutions.length).toBe(2);
     slowInferenceStepExecutions.forEach((stepExecution) => {
       expect(stepExecution.status).toBe(ExecutionStatus.COMPLETED);
       expect(stepExecution.error).toBeUndefined();
     });
+  });
+
+  it('should have failed status for step exceeding timeout', async () => {
+    const slowInferenceStepExecution = Array.from(
+      workflowRunFixture.stepExecutionRepositoryMock.stepExecutions.values()
+    ).find(
+      (se) =>
+        se.stepId.endsWith('Failed') &&
+        se.stepType === FakeConnectors.slow_1sec_inference.actionTypeId
+    );
+    expect(slowInferenceStepExecution).toBeDefined();
+    expect(slowInferenceStepExecution?.status).toBe(ExecutionStatus.FAILED);
+    expect(slowInferenceStepExecution?.error).toContain('Failed due to workflow timeout');
+  });
+
+  it('should not have started step following failed step', async () => {
+    const slowInferenceStepExecution = Array.from(
+      workflowRunFixture.stepExecutionRepositoryMock.stepExecutions.values()
+    ).find(
+      (se) =>
+        se.stepId.endsWith('NotStarted') &&
+        se.stepType === FakeConnectors.slow_1sec_inference.actionTypeId
+    );
+    expect(slowInferenceStepExecution).toBeUndefined();
   });
 
   it('should invoke connector only 3 times timeout', async () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/nodes_factory.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/nodes_factory.ts
@@ -172,8 +172,7 @@ export class NodesFactory {
           return new EnterWorkflowTimeoutZoneNodeImpl(
             node,
             this.workflowRuntime,
-            this.stepExecutionRuntimeFactory,
-            stepExecutionRuntime
+            this.stepExecutionRuntimeFactory
           );
         }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/nodes_factory.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/nodes_factory.ts
@@ -181,7 +181,7 @@ export class NodesFactory {
         }
       case 'exit-timeout-zone':
         if (isExitWorkflowTimeoutZone(node)) {
-          return new ExitWorkflowTimeoutZoneNodeImpl(stepExecutionRuntime, this.workflowRuntime);
+          return new ExitWorkflowTimeoutZoneNodeImpl(this.workflowRuntime);
         }
 
         if (isExitStepTimeoutZone(node)) {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/enter_workflow_timeout_zone_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/enter_workflow_timeout_zone_node_impl.ts
@@ -18,20 +18,18 @@ export class EnterWorkflowTimeoutZoneNodeImpl implements NodeImplementation, Mon
   constructor(
     private node: EnterTimeoutZoneNode,
     private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager,
-    private stepExecutionRuntimeFactory: StepExecutionRuntimeFactory,
-    private stepExecutionRuntime: StepExecutionRuntime
+    private stepExecutionRuntimeFactory: StepExecutionRuntimeFactory
   ) {}
 
   public async run(): Promise<void> {
-    await this.stepExecutionRuntime.startStep();
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 
   public async monitor(monitoredStepExecutionRuntime: StepExecutionRuntime): Promise<void> {
     const timeoutMs = parseDuration(this.node.timeout);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const stepExecution = this.stepExecutionRuntime.stepExecution!;
-    const whenStepStartedTime = new Date(stepExecution.startedAt).getTime();
+    const whenStepStartedTime = new Date(
+      this.wfExecutionRuntimeManager.getWorkflowExecution().startedAt
+    ).getTime();
     const currentTimeMs = new Date().getTime();
     const currentStepDuration = currentTimeMs - whenStepStartedTime;
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/exit_workflow_timeout_zone_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/exit_workflow_timeout_zone_node_impl.ts
@@ -18,7 +18,6 @@ export class ExitWorkflowTimeoutZoneNodeImpl implements NodeImplementation {
   ) {}
 
   public async run(): Promise<void> {
-    await this.stepExecutionRuntime.finishStep();
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/exit_workflow_timeout_zone_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/exit_workflow_timeout_zone_node_impl.ts
@@ -7,15 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { StepExecutionRuntime } from '../../../workflow_context_manager/step_execution_runtime';
 import type { WorkflowExecutionRuntimeManager } from '../../../workflow_context_manager/workflow_execution_runtime_manager';
 import type { NodeImplementation } from '../../node_implementation';
 
 export class ExitWorkflowTimeoutZoneNodeImpl implements NodeImplementation {
-  constructor(
-    private stepExecutionRuntime: StepExecutionRuntime,
-    private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager
-  ) {}
+  constructor(private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager) {}
 
   public async run(): Promise<void> {
     this.wfExecutionRuntimeManager.navigateToNextNode();

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/tests/enter_workflow_timeout_zone_node_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/tests/enter_workflow_timeout_zone_node_impl.test.ts
@@ -25,7 +25,6 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
   let node: EnterTimeoutZoneNode;
   let wfExecutionRuntimeManagerMock: WorkflowExecutionRuntimeManager;
   let stepExecutionRuntimeFactoryMock: StepExecutionRuntimeFactory;
-  let stepExecutionRuntimeMock: StepExecutionRuntime;
   let impl: EnterWorkflowTimeoutZoneNodeImpl;
 
   const originalDateCtor = global.Date;
@@ -56,16 +55,8 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
       timeout: '60s',
     };
 
-    const mockStepExecution = {
-      startedAt: new Date('2025-09-25T10:14:30.000Z').toISOString(),
-    };
-
-    stepExecutionRuntimeMock = {
-      startStep: jest.fn().mockResolvedValue(undefined),
-      stepExecution: mockStepExecution,
-    } as unknown as StepExecutionRuntime;
-
     wfExecutionRuntimeManagerMock = {
+      getWorkflowExecution: jest.fn(),
       setWorkflowError: jest.fn(),
       navigateToNextNode: jest.fn(),
       markWorkflowTimeouted: jest.fn(),
@@ -78,8 +69,7 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
     impl = new EnterWorkflowTimeoutZoneNodeImpl(
       node,
       wfExecutionRuntimeManagerMock,
-      stepExecutionRuntimeFactoryMock,
-      stepExecutionRuntimeMock
+      stepExecutionRuntimeFactoryMock
     );
 
     mockDateNow = new Date('2025-09-25T10:15:30.000Z');
@@ -87,32 +77,10 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
   });
 
   describe('run method', () => {
-    it('should start step', async () => {
-      await impl.run();
-      expect(stepExecutionRuntimeMock.startStep).toHaveBeenCalledTimes(1);
-      expect(stepExecutionRuntimeMock.startStep).toHaveBeenCalledWith();
-    });
-
     it('should navigate to next node', async () => {
       await impl.run();
       expect(wfExecutionRuntimeManagerMock.navigateToNextNode).toHaveBeenCalledTimes(1);
       expect(wfExecutionRuntimeManagerMock.navigateToNextNode).toHaveBeenCalledWith();
-    });
-
-    it('should execute methods in correct order', async () => {
-      const callOrder: string[] = [];
-
-      stepExecutionRuntimeMock.startStep = jest.fn().mockImplementation(() => {
-        callOrder.push('startStep');
-        return Promise.resolve();
-      });
-      wfExecutionRuntimeManagerMock.navigateToNextNode = jest.fn().mockImplementation(() => {
-        callOrder.push('navigateToNextNode');
-      });
-
-      await impl.run();
-
-      expect(callOrder).toEqual(['startStep', 'navigateToNextNode']);
     });
   });
 
@@ -138,11 +106,9 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
     it('should not abort or fail steps when within timeout limit', async () => {
       const startTime = new Date().getTime() - 30000; // 30 seconds ago (within 60s timeout)
       mockParseDuration.mockReturnValue(60000); // 60 seconds
-
-      // Update the step execution mock for this specific test
-      (stepExecutionRuntimeMock as any).stepExecution = {
+      wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(startTime).toISOString(),
-      };
+      });
 
       await impl.monitor(monitoredStepExecutionRuntimeMock);
 
@@ -154,11 +120,9 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
     it('should abort and fail workflow when timeout exceeded', async () => {
       const startTime = new Date().getTime() - 90000; // 90 seconds ago (exceeds 60s timeout)
       mockParseDuration.mockReturnValue(60000); // 60 seconds
-
-      // Update the step execution mock for this specific test
-      (stepExecutionRuntimeMock as any).stepExecution = {
+      wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(startTime).toISOString(),
-      };
+      });
 
       // Mock empty scope stack (no nested scopes to fail)
       (monitoredStepExecutionRuntimeMock.scopeStack.isEmpty as jest.Mock).mockReturnValue(true);
@@ -174,10 +138,9 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
       const startTime = new Date().getTime() - 90000; // 90 seconds ago (exceeds 60s timeout)
       mockParseDuration.mockReturnValue(60000); // 60 seconds
 
-      // Update the step execution mock for this specific test
-      (stepExecutionRuntimeMock as any).stepExecution = {
+      wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(startTime).toISOString(),
-      };
+      });
 
       // Mock nested scopes to fail
       const scope1 = { nodeId: 'nested-step-1' };
@@ -243,10 +206,9 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
       const startTime = new Date().getTime() - 90000; // 90 seconds ago (exceeds 60s timeout)
       mockParseDuration.mockReturnValue(60000); // 60 seconds
 
-      // Update the step execution mock for this specific test
-      (stepExecutionRuntimeMock as any).stepExecution = {
+      wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(startTime).toISOString(),
-      };
+      });
 
       // Mock empty scope stack (no nested scopes to fail)
       (monitoredStepExecutionRuntimeMock.scopeStack.isEmpty as jest.Mock).mockReturnValue(true);
@@ -260,11 +222,9 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
       node.timeout = '2m'; // 2 minutes
       const startTime = new Date().getTime() - 60000; // 1 minute ago (within 2m limit)
       mockParseDuration.mockReturnValue(120000); // 2 minutes
-
-      // Update the step execution mock for this specific test
-      (stepExecutionRuntimeMock as any).stepExecution = {
+      wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(startTime).toISOString(),
-      };
+      });
 
       await impl.monitor(monitoredStepExecutionRuntimeMock);
 
@@ -278,53 +238,38 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
       // Test seconds
       node.timeout = '30s';
       mockParseDuration.mockReturnValue(30000);
-      (stepExecutionRuntimeMock as any).stepExecution = {
+      wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(recentStartTime).toISOString(),
-      };
+      });
       await impl.monitor(monitoredStepExecutionRuntimeMock);
       expect(parseDuration).toHaveBeenCalledWith('30s');
 
       // Test minutes
       node.timeout = '5m';
       mockParseDuration.mockReturnValue(300000);
-      (stepExecutionRuntimeMock as any).stepExecution = {
+      wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(recentStartTime).toISOString(),
-      };
+      });
       await impl.monitor(monitoredStepExecutionRuntimeMock);
       expect(parseDuration).toHaveBeenCalledWith('5m');
 
       // Test hours
       node.timeout = '1h';
       mockParseDuration.mockReturnValue(3600000);
-      (stepExecutionRuntimeMock as any).stepExecution = {
+      wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(recentStartTime).toISOString(),
-      };
+      });
       await impl.monitor(monitoredStepExecutionRuntimeMock);
       expect(parseDuration).toHaveBeenCalledWith('1h');
-    });
-
-    it('should use correct step execution from step execution runtime', async () => {
-      const startTime = new Date().getTime() - 30000;
-
-      // Update the step execution mock for this specific test
-      (stepExecutionRuntimeMock as any).stepExecution = {
-        startedAt: new Date(startTime).toISOString(),
-      };
-
-      await impl.monitor(monitoredStepExecutionRuntimeMock);
-
-      // The implementation uses stepExecutionRuntime.stepExecution directly
-      expect(stepExecutionRuntimeMock.stepExecution).toBeDefined();
     });
 
     it('should use correct time calculations', async () => {
       const startTime = mockDateNow.getTime() - 90000; // 90 seconds ago (exceeds 60s timeout)
       mockParseDuration.mockReturnValue(60000); // 60 seconds
 
-      // Update the step execution mock for this specific test
-      (stepExecutionRuntimeMock as any).stepExecution = {
+      wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(startTime).toISOString(),
-      };
+      });
 
       (monitoredStepExecutionRuntimeMock.scopeStack.isEmpty as jest.Mock).mockReturnValue(true);
 
@@ -337,10 +282,9 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
     it('should return resolved Promise in all cases', async () => {
       const startTime = new Date().getTime() - 30000;
 
-      // Update the step execution mock for this specific test
-      (stepExecutionRuntimeMock as any).stepExecution = {
+      wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(startTime).toISOString(),
-      };
+      });
 
       const result = await impl.monitor(monitoredStepExecutionRuntimeMock);
       expect(result).toBeUndefined(); // Promise<void> resolves to undefined
@@ -350,10 +294,9 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
       const startTime = new Date().getTime() - 60000; // exactly 60 seconds ago
       mockParseDuration.mockReturnValue(60000); // exactly 60 seconds timeout
 
-      // Update the step execution mock for this specific test
-      (stepExecutionRuntimeMock as any).stepExecution = {
+      wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(startTime).toISOString(),
-      };
+      });
 
       await impl.monitor(monitoredStepExecutionRuntimeMock);
 
@@ -365,10 +308,9 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
       const startTime = new Date().getTime() - 60001; // 60001ms ago (just over 60s timeout)
       mockParseDuration.mockReturnValue(60000); // 60 seconds
 
-      // Update the step execution mock for this specific test
-      (stepExecutionRuntimeMock as any).stepExecution = {
+      wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(startTime).toISOString(),
-      };
+      });
 
       (monitoredStepExecutionRuntimeMock.scopeStack.isEmpty as jest.Mock).mockReturnValue(true);
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/tests/exit_workflow_timeout_zone_node_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/tests/exit_workflow_timeout_zone_node_impl.test.ts
@@ -7,28 +7,19 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { StepExecutionRuntime } from '../../../../workflow_context_manager/step_execution_runtime';
 import type { WorkflowExecutionRuntimeManager } from '../../../../workflow_context_manager/workflow_execution_runtime_manager';
 import { ExitWorkflowTimeoutZoneNodeImpl } from '../exit_workflow_timeout_zone_node_impl';
 
 describe('ExitWorkflowTimeoutZoneNodeImpl', () => {
-  let stepExecutionRuntimeMock: StepExecutionRuntime;
   let wfExecutionRuntimeManagerMock: WorkflowExecutionRuntimeManager;
   let impl: ExitWorkflowTimeoutZoneNodeImpl;
 
   beforeEach(() => {
-    stepExecutionRuntimeMock = {
-      finishStep: jest.fn().mockResolvedValue(undefined),
-    } as unknown as StepExecutionRuntime;
-
     wfExecutionRuntimeManagerMock = {
       navigateToNextNode: jest.fn(),
     } as unknown as WorkflowExecutionRuntimeManager;
 
-    impl = new ExitWorkflowTimeoutZoneNodeImpl(
-      stepExecutionRuntimeMock,
-      wfExecutionRuntimeManagerMock
-    );
+    impl = new ExitWorkflowTimeoutZoneNodeImpl(wfExecutionRuntimeManagerMock);
   });
 
   it('should navigate to next node', async () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/tests/exit_workflow_timeout_zone_node_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/tests/exit_workflow_timeout_zone_node_impl.test.ts
@@ -31,31 +31,9 @@ describe('ExitWorkflowTimeoutZoneNodeImpl', () => {
     );
   });
 
-  it('should finish step', async () => {
-    await impl.run();
-    expect(stepExecutionRuntimeMock.finishStep).toHaveBeenCalledTimes(1);
-    expect(stepExecutionRuntimeMock.finishStep).toHaveBeenCalledWith();
-  });
-
   it('should navigate to next node', async () => {
     await impl.run();
     expect(wfExecutionRuntimeManagerMock.navigateToNextNode).toHaveBeenCalledTimes(1);
     expect(wfExecutionRuntimeManagerMock.navigateToNextNode).toHaveBeenCalledWith();
-  });
-
-  it('should execute methods in correct order', async () => {
-    const callOrder: string[] = [];
-
-    stepExecutionRuntimeMock.finishStep = jest.fn().mockImplementation(() => {
-      callOrder.push('finishStep');
-      return Promise.resolve();
-    });
-    wfExecutionRuntimeManagerMock.navigateToNextNode = jest.fn().mockImplementation(() => {
-      callOrder.push('navigateToNextNode');
-    });
-
-    await impl.run();
-
-    expect(callOrder).toEqual(['finishStep', 'navigateToNextNode']);
   });
 });


### PR DESCRIPTION
## Summary

Closes: https://github.com/elastic/security-team/issues/14543

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



