### PR TITLE
[Fleet] Show warnings on sync integrations UI when referencing other entities

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -46452,6 +46452,21 @@
                           },
                           "type": {
                             "type": "string"
+                          },
+                          "warning": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "title"
+                            ],
+                            "type": "object"
                           }
                         },
                         "required": [
@@ -46650,6 +46665,21 @@
                           },
                           "type": {
                             "type": "string"
+                          },
+                          "warning": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "title"
+                            ],
+                            "type": "object"
                           }
                         },
                         "required": [

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/remote_synced_integrations.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/remote_synced_integrations.ts
@@ -34,6 +34,10 @@ export interface RemoteSyncedIntegrationsStatus extends RemoteSyncedIntegrations
 export interface RemoteSyncedCustomAssetsStatus extends BaseCustomAssetsData {
   sync_status: SyncStatus;
   error?: string;
+  warning?: {
+    title: string;
+    message?: string;
+  };
 }
 
 export interface RemoteSyncedCustomAssetsRecord {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/outputs_table/integration_status.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/outputs_table/integration_status.tsx
@@ -259,7 +259,7 @@ export const IntegrationStatus: React.FunctionComponent<{
                 id={`${customAsset.type}:${customAsset.name}`}
                 key={`${customAsset.type}:${customAsset.name}`}
                 arrowDisplay={customAsset.error ? 'left' : 'none'}
-                isDisabled={!customAsset.error}
+                isDisabled={!customAsset.error && !customAsset.warning}
                 buttonContent={
                   <EuiFlexGroup alignItems="baseline" gutterSize="xs">
                     <EuiFlexItem grow={false}>
@@ -284,10 +284,18 @@ export const IntegrationStatus: React.FunctionComponent<{
                   ) : (
                     <EuiIcon
                       size="m"
-                      color={customAsset.sync_status === SyncStatus.FAILED ? 'danger' : 'success'}
+                      color={
+                        customAsset.sync_status === SyncStatus.FAILED
+                          ? 'danger'
+                          : customAsset.sync_status === SyncStatus.WARNING
+                          ? 'warning'
+                          : 'success'
+                      }
                       type={
                         customAsset.sync_status === SyncStatus.FAILED
                           ? 'errorFilled'
+                          : customAsset.sync_status === SyncStatus.WARNING
+                          ? 'warning'
                           : 'checkInCircleFilled'
                       }
                     />
@@ -295,27 +303,63 @@ export const IntegrationStatus: React.FunctionComponent<{
                 }
                 paddingSize="none"
               >
-                {customAsset.error && (
-                  <>
-                    <EuiSpacer size="s" />
-                    <EuiCallOut
-                      announceOnMount={false}
-                      title={
-                        <FormattedMessage
-                          id="xpack.fleet.integrationSyncStatus.errorTitle"
-                          defaultMessage="Error"
-                        />
-                      }
-                      color="danger"
-                      iconType="error"
-                      size="s"
-                      data-test-subj="integrationSyncAssetErrorCallout"
-                    >
-                      <EuiText size="s">{customAsset.error}</EuiText>
-                    </EuiCallOut>
-                    <EuiSpacer size="s" />
-                  </>
-                )}
+                <>
+                  {customAsset.error && (
+                    <>
+                      <EuiSpacer size="s" />
+                      <EuiCallOut
+                        announceOnMount={false}
+                        title={
+                          <FormattedMessage
+                            id="xpack.fleet.integrationSyncStatus.errorTitle"
+                            defaultMessage="Error"
+                          />
+                        }
+                        color="danger"
+                        iconType="error"
+                        size="s"
+                        data-test-subj="integrationSyncAssetErrorCallout"
+                      >
+                        <EuiText size="s">{customAsset.error}</EuiText>
+                      </EuiCallOut>
+                      <EuiSpacer size="s" />
+                    </>
+                  )}
+                  {customAsset.sync_status === SyncStatus.WARNING && customAsset.warning && (
+                    <>
+                      <EuiSpacer size="s" />
+                      <EuiCallOut
+                        announceOnMount
+                        title={
+                          <FormattedMessage
+                            id="xpack.fleet.integrationSyncStatus.customAssetWarningTitle"
+                            defaultMessage="{Warning}"
+                            values={{
+                              Warning: customAsset.warning.title,
+                            }}
+                          />
+                        }
+                        color="warning"
+                        iconType="warning"
+                        size="s"
+                        data-test-subj="customAssetWarningCallout"
+                      >
+                        {customAsset.warning.message && (
+                          <EuiText size="s">
+                            <FormattedMessage
+                              id="xpack.fleet.integrationSyncStatus.customAssetWarningContent"
+                              defaultMessage="{customAssetWarning}"
+                              values={{
+                                customAssetWarning: customAsset.warning.message,
+                              }}
+                            />
+                          </EuiText>
+                        )}
+                      </EuiCallOut>
+                      <EuiSpacer size="s" />
+                    </>
+                  )}
+                </>
               </EuiAccordion>
             );
           })}

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/compare_synced_integrations.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/compare_synced_integrations.test.ts
@@ -1025,6 +1025,7 @@ describe('fetchAndCompareSyncedIntegrations', () => {
               },
             },
           ],
+          created_date_millis: 1762258252589,
         },
       });
       (getPipelineMock as jest.MockedFunction<any>).mockResolvedValueOnce({

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/compare_synced_integrations.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/compare_synced_integrations.test.ts
@@ -1691,6 +1691,120 @@ describe('fetchAndCompareSyncedIntegrations', () => {
         },
       });
     });
+
+    it('should return warning status if component template has ILM policy', async () => {
+      (getComponentTemplateMock as jest.MockedFunction<any>).mockResolvedValue({
+        component_templates: [
+          {
+            name: 'logs-system.auth@custom',
+            component_template: {
+              template: {
+                mappings: {
+                  dynamic_templates: [],
+                },
+                settings: {
+                  index: {
+                    lifecycle: {
+                      name: 'test_ilm_policy',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+
+      esClientMock = {
+        search: jest.fn().mockResolvedValue({
+          hits: {
+            hits: [
+              {
+                _source: {
+                  integrations: [
+                    {
+                      package_name: 'system',
+                      package_version: '1.67.3',
+                      updated_at: '2025-03-20T14:18:40.076Z',
+                      install_status: 'installed',
+                    },
+                  ],
+                  custom_assets: {
+                    'component_template:logs-system.auth@custom': {
+                      type: 'component_template',
+                      name: 'logs-system.auth@custom',
+                      package_name: 'system',
+                      package_version: '1.67.3',
+                      is_deleted: false,
+                      template: {
+                        mappings: {
+                          dynamic_templates: [],
+                        },
+                        settings: {
+                          index: {
+                            lifecycle: {
+                              name: 'test_ilm_policy',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        }),
+      };
+      (getPackageSavedObjects as jest.MockedFunction<any>).mockReturnValue({
+        page: 1,
+        per_page: 10000,
+        total: 1,
+        saved_objects: [
+          {
+            type: 'epm-packages',
+            id: 'system',
+            attributes: {
+              version: '1.67.3',
+              install_status: 'installed',
+            },
+            updated_at: '2025-03-26T14:06:27.611Z',
+          },
+        ],
+      });
+
+      const res = await fetchAndCompareSyncedIntegrations(
+        esClientMock,
+        soClientMock,
+        'fleet-synced-integrations-ccr-*',
+        mockedLogger
+      );
+
+      expect(res).toEqual({
+        integrations: [
+          {
+            package_name: 'system',
+            package_version: '1.67.3',
+            install_status: { main: 'installed', remote: 'installed' },
+            sync_status: 'completed',
+            updated_at: expect.any(String),
+          },
+        ],
+        custom_assets: {
+          'component_template:logs-system.auth@custom': {
+            name: 'logs-system.auth@custom',
+            package_name: 'system',
+            package_version: '1.67.3',
+            sync_status: 'warning',
+            type: 'component_template',
+            warning: {
+              title: `Component template references ILM policy`,
+              message: `logs-system.auth@custom references "test_ilm_policy" that might not exist on the remote cluster. Please create it manually.`,
+            },
+          },
+        },
+      });
+    });
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/compare_synced_integrations.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/compare_synced_integrations.ts
@@ -496,6 +496,16 @@ const compareCustomAssets = ({
         sync_status: SyncStatus.SYNCHRONIZING,
       };
     } else if (isEqual(installedCompTemplate, ccrCustomAsset?.template)) {
+      if (ccrCustomAsset?.template.settings?.index?.lifecycle?.name) {
+        return {
+          ...result,
+          sync_status: SyncStatus.WARNING,
+          warning: {
+            title: `Component template references ILM policy`,
+            message: `${ccrCustomAsset.name} references "${ccrCustomAsset?.template.settings?.index?.lifecycle?.name}" that might not exist on the remote cluster. Please create it manually.`,
+          },
+        };
+      }
       return {
         ...result,
         sync_status: SyncStatus.COMPLETED,

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/compare_synced_integrations.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/compare_synced_integrations.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { isEqual } from 'lodash';
+import { isEqual, omit } from 'lodash';
 
 import type {
   ElasticsearchClient,
@@ -392,6 +392,21 @@ const compareCustomAssets = ({
 
   if (ccrCustomAsset.type === 'ingest_pipeline') {
     const installedPipeline = ingestPipelines?.[ccrCustomAsset.name];
+
+    const installedPipelineWithoutTimestamps = omit(installedPipeline, [
+      'created_date',
+      'created_date_millis',
+      'modified_date',
+      'modified_date_millis',
+    ]);
+
+    const ccrCustomPipelineWithoutTimestamps = omit(ccrCustomAsset?.pipeline, [
+      'created_date',
+      'created_date_millis',
+      'modified_date',
+      'modified_date_millis',
+    ]);
+
     if (!installedPipeline) {
       if (ccrCustomAsset.is_deleted === true) {
         return {
@@ -441,7 +456,7 @@ const compareCustomAssets = ({
         ...result,
         sync_status: SyncStatus.SYNCHRONIZING,
       };
-    } else if (isEqual(installedPipeline, ccrCustomAsset?.pipeline)) {
+    } else if (isEqual(installedPipelineWithoutTimestamps, ccrCustomPipelineWithoutTimestamps)) {
       return {
         ...result,
         sync_status: SyncStatus.COMPLETED,

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.test.ts
@@ -890,6 +890,51 @@ describe('custom assets', () => {
       expect(esClientMock.ingest.putPipeline).not.toHaveBeenCalled();
     });
 
+    it('should not update ingest pipeline if not changed except timestamps', async () => {
+      esClientMock = {
+        ingest: {
+          getPipeline: jest.fn().mockResolvedValue({
+            'logs-system.auth@custom': {
+              processors: [
+                {
+                  user_agent: {
+                    field: 'user_agent',
+                  },
+                },
+              ],
+              created_date_millis: 1762258252589,
+            },
+          }),
+          putPipeline: jest.fn().mockResolvedValue({}),
+        },
+      };
+
+      await installCustomAsset(
+        {
+          is_deleted: false,
+          name: 'logs-system.auth@custom',
+          package_name: 'system',
+          package_version: '0.1.0',
+          pipeline: {
+            processors: [
+              {
+                user_agent: {
+                  field: 'user_agent',
+                },
+              },
+            ],
+            created_date_millis: 1762258252588,
+          },
+          type: 'ingest_pipeline',
+        },
+        esClientMock,
+        new AbortController(),
+        { debug: jest.fn() } as any
+      );
+
+      expect(esClientMock.ingest.putPipeline).not.toHaveBeenCalled();
+    });
+
     it('should not create ingest pipeline if has enrich processor', async () => {
       esClientMock = {
         ingest: {

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.test.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { FleetError } from '../../errors';
 import { packagePolicyService } from '../../services';
 
 import {
@@ -974,8 +975,8 @@ describe('custom assets', () => {
           { debug: jest.fn() } as any
         )
       ).rejects.toThrowError(
-        new Error(
-          `Not supported to sync ingest pipelines referencing enrich policies. Please sync manually.`
+        new FleetError(
+          `Syncing ingest pipelines that reference enrich policies is not supported. Please sync manually.`
         )
       );
 

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.test.ts
@@ -929,7 +929,9 @@ describe('custom assets', () => {
           { debug: jest.fn() } as any
         )
       ).rejects.toThrowError(
-        new Error(`Not supported to sync ingest pipelines referencing enrich policies`)
+        new Error(
+          `Not supported to sync ingest pipelines referencing enrich policies. Please sync manually.`
+        )
       );
 
       expect(esClientMock.ingest.putPipeline).not.toHaveBeenCalled();

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.test.ts
@@ -889,5 +889,50 @@ describe('custom assets', () => {
 
       expect(esClientMock.ingest.putPipeline).not.toHaveBeenCalled();
     });
+
+    it('should not create ingest pipeline if has enrich processor', async () => {
+      esClientMock = {
+        ingest: {
+          getPipeline: jest.fn().mockResolvedValue({}),
+          putPipeline: jest.fn().mockResolvedValue({}),
+        },
+      };
+
+      await expect(
+        installCustomAsset(
+          {
+            is_deleted: false,
+            name: 'logs-system.auth@custom',
+            package_name: 'system',
+            package_version: '0.1.0',
+            pipeline: {
+              processors: [
+                {
+                  enrich: {
+                    field: 'test_field',
+                    policy_name: 'test_enrich_policy',
+                    target_field: 'target',
+                  },
+                },
+              ],
+              version: 1,
+              description: 'description pipeline',
+              created_date: '2024-01-01T12:00:00.000Z',
+              created_date_millis: 1704110400000,
+              modified_date: '2025-01-01T12:00:00.000Z',
+              modified_date_millis: 1735732800000,
+            },
+            type: 'ingest_pipeline',
+          },
+          esClientMock,
+          new AbortController(),
+          { debug: jest.fn() } as any
+        )
+      ).rejects.toThrowError(
+        new Error(`Not supported to sync ingest pipelines referencing enrich policies`)
+      );
+
+      expect(esClientMock.ingest.putPipeline).not.toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
@@ -7,7 +7,7 @@
 
 import type { ElasticsearchClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
 
-import { isEqual } from 'lodash';
+import { isEqual, omit } from 'lodash';
 import type {
   ClusterGetComponentTemplateResponse,
   IngestGetPipelineResponse,
@@ -17,8 +17,6 @@ import { retryTransientEsErrors } from '../../services/epm/elasticsearch/retry';
 
 import { packagePolicyService } from '../../services';
 import { SO_SEARCH_LIMIT } from '../../constants';
-
-import type { IngestPipelineWithDateFields } from '../../../common/types';
 
 import type { CustomAssetsData, IntegrationsData, SyncIntegrationsData } from './model';
 
@@ -288,11 +286,27 @@ async function updateIngestPipeline(
     }
   }
 
+  // Remove system-managed properties (dates) that cannot be set during create/update of ingest pipelines
+  const customAssetPipelineWithoutTimestamps = omit(customAsset.pipeline, [
+    'created_date',
+    'created_date_millis',
+    'modified_date',
+    'modified_date_millis',
+  ]);
+
+  const existingPipelineWithoutTimestamps = omit(existingPipeline, [
+    'created_date',
+    'created_date_millis',
+    'modified_date',
+    'modified_date_millis',
+  ]);
+
   let shouldUpdatePipeline = false;
   if (existingPipeline) {
     shouldUpdatePipeline =
       (existingPipeline.version && existingPipeline.version < customAsset.pipeline.version) ||
-      (!existingPipeline.version && !isEqual(existingPipeline, customAsset.pipeline));
+      (!existingPipeline.version &&
+        !isEqual(existingPipelineWithoutTimestamps, customAssetPipelineWithoutTimestamps));
   } else {
     shouldUpdatePipeline = true;
   }
@@ -306,20 +320,12 @@ async function updateIngestPipeline(
   if (shouldUpdatePipeline) {
     logger.debug(`Updating ingest pipeline: ${customAsset.name}`);
 
-    // Remove system-managed properties (dates) that cannot be set during create/update of ingest pipelines
-    const {
-      created_date: createdDate,
-      created_date_millis: createdDateMillis,
-      modified_date: modifiedDate,
-      modified_date_millis: modifiedDateMillis,
-      ...updatedIngestPipeline
-    } = customAsset.pipeline as IngestPipelineWithDateFields;
     return retryTransientEsErrors(
       () =>
         esClient.ingest.putPipeline(
           {
             id: customAsset.name,
-            ...updatedIngestPipeline,
+            ...customAssetPipelineWithoutTimestamps,
           },
           {
             signal: abortController.signal,

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
@@ -18,6 +18,8 @@ import { retryTransientEsErrors } from '../../services/epm/elasticsearch/retry';
 import { packagePolicyService } from '../../services';
 import { SO_SEARCH_LIMIT } from '../../constants';
 
+import { FleetError } from '../../errors';
+
 import type { CustomAssetsData, IntegrationsData, SyncIntegrationsData } from './model';
 
 const DELETED_ASSET_TTL = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -312,8 +314,8 @@ async function updateIngestPipeline(
   }
 
   if (shouldUpdatePipeline && customAsset.pipeline.processors.some((p: any) => p.enrich)) {
-    throw new Error(
-      `Not supported to sync ingest pipelines referencing enrich policies. Please sync manually.`
+    throw new FleetError(
+      `Syncing ingest pipelines that reference enrich policies is not supported. Please sync manually.`
     );
   }
 

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
@@ -297,8 +297,10 @@ async function updateIngestPipeline(
     shouldUpdatePipeline = true;
   }
 
-  if (shouldUpdatePipeline && customAsset.pipeline.processors.some((p) => p.enrich)) {
-    throw new Error(`Not supported to sync ingest pipelines referencing enrich policies`);
+  if (shouldUpdatePipeline && customAsset.pipeline.processors.some((p: any) => p.enrich)) {
+    throw new Error(
+      `Not supported to sync ingest pipelines referencing enrich policies. Please sync manually.`
+    );
   }
 
   if (shouldUpdatePipeline) {

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/sync_integrations/custom_assets.ts
@@ -297,6 +297,10 @@ async function updateIngestPipeline(
     shouldUpdatePipeline = true;
   }
 
+  if (shouldUpdatePipeline && customAsset.pipeline.processors.some((p) => p.enrich)) {
+    throw new Error(`Not supported to sync ingest pipelines referencing enrich policies`);
+  }
+
   if (shouldUpdatePipeline) {
     logger.debug(`Updating ingest pipeline: ${customAsset.name}`);
 

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/synced_integrations.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/synced_integrations.ts
@@ -49,6 +49,12 @@ export const CustomAssetsDataSchema = schema.object({
   ]),
   error: schema.maybe(schema.string()),
   is_deleted: schema.maybe(schema.boolean()),
+  warning: schema.maybe(
+    schema.object({
+      title: schema.string(),
+      message: schema.maybe(schema.string()),
+    })
+  ),
 });
 
 export const GetRemoteSyncedIntegrationsStatusResponseSchema = schema.object({


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/234392


Show specific error message when custom ingest pipeline references an enrich policy:

<img width="1552" height="417" alt="image" src="https://github.com/user-attachments/assets/ee7bd48d-c108-4b43-b51f-994a0e5edb8d" />
<img width="716" height="324" alt="image" src="https://github.com/user-attachments/assets/acc6e15a-2f22-45e8-9b3f-bc7ba6275278" />
<img width="599" height="252" alt="image" src="https://github.com/user-attachments/assets/e7a6598e-4aa5-42a2-9a0d-4153ace8086c" />

Show warning when custom component template references an ILM policy:

```
PUT _component_template/logs-system.auth@custom
{
  "template": {
    "mappings": {
            "dynamic_templates": []
          },
    "settings": {
      "lifecycle": {
        "name": "test_ilm_policy2"
      }
    }
  }
}
```

<img width="594" height="827" alt="image" src="https://github.com/user-attachments/assets/bb9c2d62-f12a-4150-a751-268221eb20d1" />

To verify locally, start 2 clusters and set up sync between them, following this guide: https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/remote_clusters_ccr.md


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->