### PR TITLE
[8.19] [scout] determine test category based on playwright config path (#241361)

### DIFF
--- a/.buildkite/scout_ci_config.yml
+++ b/.buildkite/scout_ci_config.yml
@@ -12,3 +12,4 @@ plugins:
 packages:
   enabled:
   disabled:
+    - kbn-scout # Internal scout tests are run in advance to validate Scout integrity (see .buildkite/scripts/steps/test/scout_test_run_builder.sh)

--- a/.buildkite/scripts/steps/test/scout_test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout_test_run_builder.sh
@@ -12,11 +12,17 @@ node scripts/scout discover-playwright-configs --save
 cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.json
 buildkite-agent artifact upload "scout_playwright_configs.json"
 
-echo '--- Running Scout Integration Tests'
+echo '--- Running Scout API Integration Tests'
 node scripts/scout.js run-tests \
 --serverless=security \
---config src/platform/packages/shared/kbn-scout/test/scout/playwright.config.ts \
+--config src/platform/packages/shared/kbn-scout/test/scout/api/playwright.config.ts \
 --kibana-install-dir "$KIBANA_BUILD_LOCATION"
+
+echo '--- Running Scout EUI Helpers Tests'
+"${KIBANA_DIR:-$(pwd)}/node_modules/.bin/playwright" test \
+  --project local \
+  --grep @svlSecurity \
+  --config src/platform/packages/shared/kbn-scout/test/scout/ui/playwright.config.ts
 
 source .buildkite/scripts/steps/test/scout_upload_report_events.sh
 

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
@@ -93,6 +93,17 @@ export class ScoutPlaywrightReporter implements Reporter {
     };
   }
 
+  private getScoutConfigCategory(configPath: string): ScoutTestRunConfigCategory {
+    const pattern = /scout\/(api|ui)\//;
+    const match = configPath.match(pattern);
+    if (match) {
+      return match[1] === 'api'
+        ? ScoutTestRunConfigCategory.API_TEST
+        : ScoutTestRunConfigCategory.UI_TEST;
+    }
+    return ScoutTestRunConfigCategory.UNKNOWN;
+  }
+
   /**
    * Root path of this reporter's output
    */
@@ -113,7 +124,7 @@ export class ScoutPlaywrightReporter implements Reporter {
     if (config.configFile !== undefined) {
       configInfo = {
         file: this.getScoutFileInfoForPath(path.relative(REPO_ROOT, config.configFile)),
-        category: ScoutTestRunConfigCategory.UI_TEST,
+        category: this.getScoutConfigCategory(config.configFile),
       };
     }
 

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/playwright.config.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/playwright.config.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createPlaywrightConfig } from '../../..';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/playwright.config.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/playwright.config.ts
@@ -9,6 +9,7 @@
 
 import { createPlaywrightConfig } from '../../..';
 
+// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './tests',
 });

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/alerting_rules.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/alerting_rules.spec.ts
@@ -8,8 +8,8 @@
  */
 
 import { randomUUID } from 'crypto';
-import { apiTest, expect } from '../../../../src/playwright';
-import { createAlertRuleParams } from '../../fixtures/constants';
+import { apiTest, expect } from '../../../../../src/playwright';
+import { createAlertRuleParams } from '../../../fixtures/constants';
 
 apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, () => {
   let ruleId: string;

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/cases.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/cases.spec.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { apiTest, expect } from '../../../../src/playwright';
-import { createCasePayload } from '../../fixtures/constants';
+import { apiTest, expect } from '../../../../../src/playwright';
+import { createCasePayload } from '../../../fixtures/constants';
 
 apiTest.describe('Cases Helpers', { tag: ['@svlSecurity', '@ess'] }, () => {
   let caseId: string;

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/fleet.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/fleet.spec.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { apiTest, expect } from '../../../../src/playwright';
+import { apiTest, expect } from '../../../../../src/playwright';
 
 apiTest.describe('Fleet Integration Management', { tag: ['@svlSecurity', '@ess'] }, () => {
   let integrationName: string;

--- a/src/platform/packages/shared/kbn-scout/test/scout/ui/playwright.config.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/ui/playwright.config.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { createPlaywrightConfig } from '../..';
+import { createPlaywrightConfig } from '../../..';
 
 // eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({

--- a/src/platform/packages/shared/kbn-scout/test/scout/ui/tests/eui_wrappers/check_box.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/ui/tests/eui_wrappers/check_box.spec.ts
@@ -11,8 +11,6 @@ import { test, expect } from '../../../../../src/playwright';
 import { EuiCheckBoxWrapper } from '../../../../../src/playwright/eui_components';
 import { navigateToEuiTestPage } from '../../../fixtures/eui_helpers';
 
-/* eslint-disable playwright/prefer-web-first-assertions */
-
 // TODO: 'toBeChecked' is not available in playwright version we are using. Remove after Playwright upgrade
 
 test.describe('EUI testing wrapper: EuiCheckBox', { tag: ['@svlSecurity', '@ess'] }, () => {

--- a/src/platform/packages/shared/kbn-scout/test/scout/ui/tests/eui_wrappers/check_box.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/ui/tests/eui_wrappers/check_box.spec.ts
@@ -7,9 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { test, expect } from '../../../../src/playwright';
-import { EuiCheckBoxWrapper } from '../../../../src/playwright/eui_components';
-import { navigateToEuiTestPage } from '../../fixtures/eui_helpers';
+import { test, expect } from '../../../../../src/playwright';
+import { EuiCheckBoxWrapper } from '../../../../../src/playwright/eui_components';
+import { navigateToEuiTestPage } from '../../../fixtures/eui_helpers';
+
+/* eslint-disable playwright/prefer-web-first-assertions */
+
+// TODO: 'toBeChecked' is not available in playwright version we are using. Remove after Playwright upgrade
 
 test.describe('EUI testing wrapper: EuiCheckBox', { tag: ['@svlSecurity', '@ess'] }, () => {
   test(`checkbox`, async ({ page, log }) => {

--- a/src/platform/packages/shared/kbn-scout/test/scout/ui/tests/eui_wrappers/combo_box.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/ui/tests/eui_wrappers/combo_box.spec.ts
@@ -7,9 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { test, expect } from '../../../../src/playwright';
-import { EuiComboBoxWrapper } from '../../../../src/playwright/eui_components';
-import { navigateToEuiTestPage } from '../../fixtures/eui_helpers';
+import { test, expect } from '../../../../../src/playwright';
+import { EuiComboBoxWrapper } from '../../../../../src/playwright/eui_components';
+import { navigateToEuiTestPage } from '../../../fixtures/eui_helpers';
 
 test.describe('EUI testing wrapper: EuiComboBox', { tag: ['@svlSecurity', '@ess'] }, () => {
   test(`with multiple selections (pills)`, async ({ page, log }) => {

--- a/src/platform/packages/shared/kbn-scout/test/scout/ui/tests/eui_wrappers/data_grid.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/ui/tests/eui_wrappers/data_grid.spec.ts
@@ -7,9 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { test, expect } from '../../../../src/playwright';
-import { EuiDataGridWrapper } from '../../../../src/playwright/eui_components';
-import { navigateToEuiTestPage } from '../../fixtures/eui_helpers';
+import { test, expect } from '../../../../../src/playwright';
+import { EuiDataGridWrapper } from '../../../../../src/playwright/eui_components';
+import { navigateToEuiTestPage } from '../../../fixtures/eui_helpers';
 
 test.describe('EUI testing wrapper: EuiDataGrid', { tag: ['@svlSecurity', '@ess'] }, () => {
   test(`data grid, run`, async ({ page, log }) => {

--- a/src/platform/packages/shared/kbn-scout/test/scout/ui/tests/eui_wrappers/selectable.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/ui/tests/eui_wrappers/selectable.spec.ts
@@ -7,9 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { test, expect } from '../../../../src/playwright';
-import { EuiSelectableWrapper } from '../../../../src/playwright/eui_components';
-import { navigateToEuiTestPage } from '../../fixtures/eui_helpers';
+import { test, expect } from '../../../../../src/playwright';
+import { EuiSelectableWrapper } from '../../../../../src/playwright/eui_components';
+import { navigateToEuiTestPage } from '../../../fixtures/eui_helpers';
 
 test.describe('EUI testing wrapper: EuiSelectable', { tag: ['@svlSecurity', '@ess'] }, () => {
   test(`selectable with search field`, async ({ page, log }) => {

--- a/src/platform/packages/shared/kbn-scout/test/scout/ui/tests/eui_wrappers/toast.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/ui/tests/eui_wrappers/toast.spec.ts
@@ -7,9 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { test, expect } from '../../../../src/playwright';
-import { EuiToastWrapper } from '../../../../src/playwright/eui_components';
-import { navigateToEuiTestPage } from '../../fixtures/eui_helpers';
+import { test, expect } from '../../../../../src/playwright';
+import { EuiToastWrapper } from '../../../../../src/playwright/eui_components';
+import { navigateToEuiTestPage } from '../../../fixtures/eui_helpers';
 
 test.describe('EUI testing wrapper: EuiToast', { tag: ['@svlSecurity', '@ess'] }, () => {
   test(`toast`, async ({ page, log }) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[scout] determine test category based on playwright config path (#241361)](https://github.com/elastic/kibana/pull/241361)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-11-03T11:03:22Z","message":"[scout] determine test category based on playwright config path (#241361)\n\n## Summary\n\ncloses https://github.com/elastic/appex-qa-team/issues/511 and should\nfix Scout reporter for API tests.","sha":"ef9b621f2c1c9e72d6fd7951b0866f0ee63f8bdd","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","test:scout","v9.3.0","v8.19.7","v9.2.1"],"title":"[scout] determine test category based on playwright config path","number":241361,"url":"https://github.com/elastic/kibana/pull/241361","mergeCommit":{"message":"[scout] determine test category based on playwright config path (#241361)\n\n## Summary\n\ncloses https://github.com/elastic/appex-qa-team/issues/511 and should\nfix Scout reporter for API tests.","sha":"ef9b621f2c1c9e72d6fd7951b0866f0ee63f8bdd"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241361","number":241361,"mergeCommit":{"message":"[scout] determine test category based on playwright config path (#241361)\n\n## Summary\n\ncloses https://github.com/elastic/appex-qa-team/issues/511 and should\nfix Scout reporter for API tests.","sha":"ef9b621f2c1c9e72d6fd7951b0866f0ee63f8bdd"}},{"branch":"8.19","label":"v8.19.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/241595","number":241595,"state":"MERGED","mergeCommit":{"sha":"e5441a5bda6e27cb99a58ca4fafda1fa4af4ab7f","message":"[9.2] [scout] determine test category based on playwright config path (#241361) (#241595)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[scout] determine test category based on playwright config path\n(#241361)](https://github.com/elastic/kibana/pull/241361)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}}]}] BACKPORT-->