### PR TITLE
[9.1] [Index Management] Branch data streams api tests lifecycle validation (#241105)

### DIFF
--- a/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_common.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_common.ts
@@ -7,9 +7,14 @@
 
 import expect from '@kbn/expect';
 
+<<<<<<< HEAD:x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams.ts
 import { DataStream } from '@kbn/index-management-plugin/common';
 import { FtrProviderContext } from '../../ftr_provider_context';
 import { InternalRequestHeader, RoleCredentials } from '../../../shared/services';
+=======
+import type { FtrProviderContext } from '../../../ftr_provider_context';
+import type { InternalRequestHeader, RoleCredentials } from '../../../../shared/services';
+>>>>>>> f8984ec6420 ([Index Management] Branch data streams api tests lifecycle validation (#241105)):x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_common.ts
 
 const API_BASE_PATH = '/api/index_management';
 
@@ -23,9 +28,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const es = getService('es');
 
-  describe('Data streams', function () {
-    // see details: https://github.com/elastic/kibana/issues/187372
-    this.tags(['failsOnMKI']);
+  describe('Data streams common', function () {
     before(async () => {
       roleAuthc = await svlUserManager.createM2mApiKeyWithRoleScope('admin');
       internalReqHeader = svlCommonApi.getInternalRequestHeader();
@@ -33,12 +36,14 @@ export default function ({ getService }: FtrProviderContext) {
     after(async () => {
       await svlUserManager.invalidateM2mApiKeyWithRoleScope(roleAuthc);
     });
+
     describe('Get', () => {
       const testDataStreamName = 'test-data-stream';
 
       before(async () => await svlDatastreamsHelpers.createDataStream(testDataStreamName));
       after(async () => await svlDatastreamsHelpers.deleteDataStream(testDataStreamName));
 
+<<<<<<< HEAD:x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams.ts
       it('returns an array of data streams', async () => {
         const { body: dataStreams, status } = await supertestWithoutAuth
           .get(`${API_BASE_PATH}/data_streams`)
@@ -132,6 +137,8 @@ export default function ({ getService }: FtrProviderContext) {
         });
       });
 
+=======
+>>>>>>> f8984ec6420 ([Index Management] Branch data streams api tests lifecycle validation (#241105)):x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_common.ts
       describe('index mode of logs-*-* data streams', () => {
         const logsdbDataStreamName = 'logs-test-ds';
 

--- a/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_common.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_common.ts
@@ -7,14 +7,8 @@
 
 import expect from '@kbn/expect';
 
-<<<<<<< HEAD:x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams.ts
-import { DataStream } from '@kbn/index-management-plugin/common';
-import { FtrProviderContext } from '../../ftr_provider_context';
-import { InternalRequestHeader, RoleCredentials } from '../../../shared/services';
-=======
 import type { FtrProviderContext } from '../../../ftr_provider_context';
 import type { InternalRequestHeader, RoleCredentials } from '../../../../shared/services';
->>>>>>> f8984ec6420 ([Index Management] Branch data streams api tests lifecycle validation (#241105)):x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_common.ts
 
 const API_BASE_PATH = '/api/index_management';
 
@@ -43,102 +37,6 @@ export default function ({ getService }: FtrProviderContext) {
       before(async () => await svlDatastreamsHelpers.createDataStream(testDataStreamName));
       after(async () => await svlDatastreamsHelpers.deleteDataStream(testDataStreamName));
 
-<<<<<<< HEAD:x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams.ts
-      it('returns an array of data streams', async () => {
-        const { body: dataStreams, status } = await supertestWithoutAuth
-          .get(`${API_BASE_PATH}/data_streams`)
-          .set(internalReqHeader)
-          .set(roleAuthc.apiKeyHeader);
-
-        svlCommonApi.assertResponseStatusCode(200, status, dataStreams);
-
-        expect(dataStreams).to.be.an('array');
-
-        // returned array can contain automatically created data streams
-        const testDataStream = dataStreams.find(
-          (dataStream: DataStream) => dataStream.name === testDataStreamName
-        );
-
-        expect(testDataStream).to.be.ok();
-
-        // ES determines these values so we'll just echo them back.
-        const { name: indexName, uuid } = testDataStream!.indices[0];
-
-        expect(testDataStream).to.eql({
-          name: testDataStreamName,
-          lifecycle: {
-            enabled: true,
-          },
-          privileges: {
-            delete_index: true,
-            manage_data_stream_lifecycle: true,
-            read_failure_store: true,
-          },
-          timeStampField: { name: '@timestamp' },
-          indices: [
-            {
-              name: indexName,
-              uuid,
-              preferILM: true,
-              managedBy: 'Data stream lifecycle',
-            },
-          ],
-          nextGenerationManagedBy: 'Data stream lifecycle',
-          generation: 1,
-          health: 'green',
-          indexTemplateName: testDataStreamName,
-          hidden: false,
-          failureStoreEnabled: false,
-          indexMode: 'standard',
-        });
-      });
-
-      it('returns a single data stream by ID', async () => {
-        const { body: dataStream, status } = await supertestWithoutAuth
-          .get(`${API_BASE_PATH}/data_streams/${testDataStreamName}`)
-          .set(internalReqHeader)
-          .set(roleAuthc.apiKeyHeader);
-
-        svlCommonApi.assertResponseStatusCode(200, status, dataStream);
-
-        // ES determines these values so we'll just echo them back.
-        const { name: indexName, uuid } = dataStream.indices[0];
-        const { storageSize, storageSizeBytes, ...dataStreamWithoutStorageSize } = dataStream;
-
-        expect(dataStreamWithoutStorageSize).to.eql({
-          name: testDataStreamName,
-          privileges: {
-            delete_index: true,
-            manage_data_stream_lifecycle: true,
-            read_failure_store: true,
-          },
-          timeStampField: { name: '@timestamp' },
-          indices: [
-            {
-              name: indexName,
-              managedBy: 'Data stream lifecycle',
-              preferILM: true,
-              uuid,
-            },
-          ],
-          generation: 1,
-          health: 'green',
-          indexTemplateName: testDataStreamName,
-          nextGenerationManagedBy: 'Data stream lifecycle',
-          hidden: false,
-          lifecycle: {
-            enabled: true,
-          },
-          meteringDocsCount: 0,
-          meteringStorageSize: '0b',
-          meteringStorageSizeBytes: 0,
-          failureStoreEnabled: false,
-          indexMode: 'standard',
-        });
-      });
-
-=======
->>>>>>> f8984ec6420 ([Index Management] Branch data streams api tests lifecycle validation (#241105)):x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_common.ts
       describe('index mode of logs-*-* data streams', () => {
         const logsdbDataStreamName = 'logs-test-ds';
 

--- a/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_mki.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_mki.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+
+import type { DataStream } from '@kbn/index-management-plugin/common';
+import getopts from 'getopts';
+import type { ServerlessProjectType } from '@kbn/es';
+import type { FtrProviderContext } from '../../../ftr_provider_context';
+import type { InternalRequestHeader, RoleCredentials } from '../../../../shared/services';
+
+const API_BASE_PATH = '/api/index_management';
+
+export default function ({ getService }: FtrProviderContext) {
+  const svlCommonApi = getService('svlCommonApi');
+  const svlUserManager = getService('svlUserManager');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+  let roleAuthc: RoleCredentials;
+  let internalReqHeader: InternalRequestHeader;
+  const config = getService('config');
+  const svlDatastreamsHelpers = getService('svlDatastreamsHelpers');
+
+  const options = getopts(config.get('kbnTestServer.serverArgs'));
+  const projectType = options.serverless as ServerlessProjectType;
+
+  describe('Data streams MKI', function () {
+    this.tags(['skipSvlWorkplaceAI', 'skipSvlOblt', 'skipSvlSearch', 'skipSvlSec']);
+
+    const testDataStreamName = 'test-data-stream';
+    before(async () => {
+      roleAuthc = await svlUserManager.createM2mApiKeyWithRoleScope('admin');
+      internalReqHeader = svlCommonApi.getInternalRequestHeader();
+      await svlDatastreamsHelpers.createDataStream(testDataStreamName);
+    });
+    after(async () => {
+      await svlUserManager.invalidateM2mApiKeyWithRoleScope(roleAuthc);
+      await svlDatastreamsHelpers.deleteDataStream(testDataStreamName);
+    });
+    it('returns an array of data streams', async () => {
+      const { body: dataStreams, status } = await supertestWithoutAuth
+        .get(`${API_BASE_PATH}/data_streams`)
+        .set(internalReqHeader)
+        .set(roleAuthc.apiKeyHeader);
+
+      svlCommonApi.assertResponseStatusCode(200, status, dataStreams);
+
+      expect(dataStreams).to.be.an('array');
+
+      // returned array can contain automatically created data streams
+      const testDataStream = dataStreams.find(
+        (dataStream: DataStream) => dataStream.name === testDataStreamName
+      );
+
+      expect(testDataStream).to.be.ok();
+
+      // ES determines these values so we'll just echo them back.
+      const { name: indexName, uuid } = testDataStream!.indices[0];
+
+      // Security MKI enforces a default project-level retention. Since we don't have a way of determining the project type, we'll just check for both cases.
+      if (projectType === 'security') {
+        expect(testDataStream).to.eql({
+          name: testDataStreamName,
+          lifecycle: {
+            enabled: true,
+            effective_retention: '396d',
+            globalMaxRetention: '396d',
+            retention_determined_by: 'default_global_retention',
+          },
+          privileges: {
+            delete_index: true,
+            manage_data_stream_lifecycle: true,
+            read_failure_store: true,
+          },
+          timeStampField: { name: '@timestamp' },
+          indices: [
+            {
+              name: indexName,
+              uuid,
+              preferILM: true,
+              managedBy: 'Data stream lifecycle',
+            },
+          ],
+          nextGenerationManagedBy: 'Data stream lifecycle',
+          generation: 1,
+          health: 'green',
+          indexTemplateName: testDataStreamName,
+          hidden: false,
+          failureStoreEnabled: false,
+          indexMode: 'standard',
+          failureStoreRetention: {
+            defaultRetentionPeriod: '30d',
+          },
+        });
+      } else {
+        expect(testDataStream).to.eql({
+          name: testDataStreamName,
+          lifecycle: {
+            enabled: true,
+          },
+          privileges: {
+            delete_index: true,
+            manage_data_stream_lifecycle: true,
+            read_failure_store: true,
+          },
+          timeStampField: { name: '@timestamp' },
+          indices: [
+            {
+              name: indexName,
+              uuid,
+              preferILM: true,
+              managedBy: 'Data stream lifecycle',
+            },
+          ],
+          nextGenerationManagedBy: 'Data stream lifecycle',
+          generation: 1,
+          health: 'green',
+          indexTemplateName: testDataStreamName,
+          hidden: false,
+          failureStoreEnabled: false,
+          indexMode: 'standard',
+          failureStoreRetention: {
+            defaultRetentionPeriod: '30d',
+          },
+        });
+      }
+    });
+
+    it('returns a single data stream by ID', async () => {
+      const { body: dataStream, status } = await supertestWithoutAuth
+        .get(`${API_BASE_PATH}/data_streams/${testDataStreamName}`)
+        .set(internalReqHeader)
+        .set(roleAuthc.apiKeyHeader);
+
+      svlCommonApi.assertResponseStatusCode(200, status, dataStream);
+
+      // ES determines these values so we'll just echo them back.
+      const { name: indexName, uuid } = dataStream.indices[0];
+      const { storageSize, storageSizeBytes, ...dataStreamWithoutStorageSize } = dataStream;
+
+      // Security MKI enforces a default project-level retention. Since we don't have a way of determining the project type, we'll just check for both cases.
+      if (projectType === 'security') {
+        expect(dataStreamWithoutStorageSize).to.eql({
+          name: testDataStreamName,
+          privileges: {
+            delete_index: true,
+            manage_data_stream_lifecycle: true,
+            read_failure_store: true,
+          },
+          timeStampField: { name: '@timestamp' },
+          indices: [
+            {
+              name: indexName,
+              managedBy: 'Data stream lifecycle',
+              preferILM: true,
+              uuid,
+            },
+          ],
+          generation: 1,
+          health: 'green',
+          indexTemplateName: testDataStreamName,
+          nextGenerationManagedBy: 'Data stream lifecycle',
+          hidden: false,
+          lifecycle: {
+            enabled: true,
+            effective_retention: '396d',
+            globalMaxRetention: '396d',
+            retention_determined_by: 'default_global_retention',
+          },
+          meteringDocsCount: 0,
+          meteringStorageSize: '0b',
+          meteringStorageSizeBytes: 0,
+          failureStoreEnabled: false,
+          indexMode: 'standard',
+          failureStoreRetention: {
+            defaultRetentionPeriod: '30d',
+          },
+        });
+      } else {
+        expect(dataStreamWithoutStorageSize).to.eql({
+          name: testDataStreamName,
+          privileges: {
+            delete_index: true,
+            manage_data_stream_lifecycle: true,
+            read_failure_store: true,
+          },
+          timeStampField: { name: '@timestamp' },
+          indices: [
+            {
+              name: indexName,
+              managedBy: 'Data stream lifecycle',
+              preferILM: true,
+              uuid,
+            },
+          ],
+          generation: 1,
+          health: 'green',
+          indexTemplateName: testDataStreamName,
+          nextGenerationManagedBy: 'Data stream lifecycle',
+          hidden: false,
+          lifecycle: {
+            enabled: true,
+          },
+          meteringDocsCount: 0,
+          meteringStorageSize: '0b',
+          meteringStorageSizeBytes: 0,
+          failureStoreEnabled: false,
+          indexMode: 'standard',
+          failureStoreRetention: {
+            defaultRetentionPeriod: '30d',
+          },
+        });
+      }
+    });
+  });
+}

--- a/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_mki.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_mki.ts
@@ -91,9 +91,6 @@ export default function ({ getService }: FtrProviderContext) {
           hidden: false,
           failureStoreEnabled: false,
           indexMode: 'standard',
-          failureStoreRetention: {
-            defaultRetentionPeriod: '30d',
-          },
         });
       } else {
         expect(testDataStream).to.eql({
@@ -122,9 +119,6 @@ export default function ({ getService }: FtrProviderContext) {
           hidden: false,
           failureStoreEnabled: false,
           indexMode: 'standard',
-          failureStoreRetention: {
-            defaultRetentionPeriod: '30d',
-          },
         });
       }
     });
@@ -175,9 +169,6 @@ export default function ({ getService }: FtrProviderContext) {
           meteringStorageSizeBytes: 0,
           failureStoreEnabled: false,
           indexMode: 'standard',
-          failureStoreRetention: {
-            defaultRetentionPeriod: '30d',
-          },
         });
       } else {
         expect(dataStreamWithoutStorageSize).to.eql({
@@ -209,9 +200,6 @@ export default function ({ getService }: FtrProviderContext) {
           meteringStorageSizeBytes: 0,
           failureStoreEnabled: false,
           indexMode: 'standard',
-          failureStoreRetention: {
-            defaultRetentionPeriod: '30d',
-          },
         });
       }
     });

--- a/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_serverless.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_serverless.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+
+import type { DataStream } from '@kbn/index-management-plugin/common';
+import type { FtrProviderContext } from '../../../ftr_provider_context';
+import type { InternalRequestHeader, RoleCredentials } from '../../../../shared/services';
+
+const API_BASE_PATH = '/api/index_management';
+
+export default function ({ getService }: FtrProviderContext) {
+  const svlCommonApi = getService('svlCommonApi');
+  const svlUserManager = getService('svlUserManager');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+  let roleAuthc: RoleCredentials;
+  let internalReqHeader: InternalRequestHeader;
+  const svlDatastreamsHelpers = getService('svlDatastreamsHelpers');
+
+  describe('Data streams serverless', function () {
+    this.tags(['skipMKI']);
+
+    const testDataStreamName = 'test-data-stream';
+    before(async () => {
+      roleAuthc = await svlUserManager.createM2mApiKeyWithRoleScope('admin');
+      internalReqHeader = svlCommonApi.getInternalRequestHeader();
+      await svlDatastreamsHelpers.createDataStream(testDataStreamName);
+    });
+    after(async () => {
+      await svlUserManager.invalidateM2mApiKeyWithRoleScope(roleAuthc);
+      await svlDatastreamsHelpers.deleteDataStream(testDataStreamName);
+    });
+    it('returns an array of data streams', async () => {
+      const { body: dataStreams, status } = await supertestWithoutAuth
+        .get(`${API_BASE_PATH}/data_streams`)
+        .set(internalReqHeader)
+        .set(roleAuthc.apiKeyHeader);
+
+      svlCommonApi.assertResponseStatusCode(200, status, dataStreams);
+
+      expect(dataStreams).to.be.an('array');
+
+      // returned array can contain automatically created data streams
+      const testDataStream = dataStreams.find(
+        (dataStream: DataStream) => dataStream.name === testDataStreamName
+      );
+
+      expect(testDataStream).to.be.ok();
+
+      // ES determines these values so we'll just echo them back.
+      const { name: indexName, uuid } = testDataStream!.indices[0];
+
+      expect(testDataStream).to.eql({
+        name: testDataStreamName,
+        lifecycle: {
+          enabled: true,
+        },
+        privileges: {
+          delete_index: true,
+          manage_data_stream_lifecycle: true,
+          read_failure_store: true,
+        },
+        timeStampField: { name: '@timestamp' },
+        indices: [
+          {
+            name: indexName,
+            uuid,
+            preferILM: true,
+            managedBy: 'Data stream lifecycle',
+          },
+        ],
+        nextGenerationManagedBy: 'Data stream lifecycle',
+        generation: 1,
+        health: 'green',
+        indexTemplateName: testDataStreamName,
+        hidden: false,
+        failureStoreEnabled: false,
+        indexMode: 'standard',
+        failureStoreRetention: {
+          defaultRetentionPeriod: '30d',
+        },
+      });
+    });
+
+    it('returns a single data stream by ID', async () => {
+      const { body: dataStream, status } = await supertestWithoutAuth
+        .get(`${API_BASE_PATH}/data_streams/${testDataStreamName}`)
+        .set(internalReqHeader)
+        .set(roleAuthc.apiKeyHeader);
+
+      svlCommonApi.assertResponseStatusCode(200, status, dataStream);
+
+      // ES determines these values so we'll just echo them back.
+      const { name: indexName, uuid } = dataStream.indices[0];
+      const { storageSize, storageSizeBytes, ...dataStreamWithoutStorageSize } = dataStream;
+
+      expect(dataStreamWithoutStorageSize).to.eql({
+        name: testDataStreamName,
+        privileges: {
+          delete_index: true,
+          manage_data_stream_lifecycle: true,
+          read_failure_store: true,
+        },
+        timeStampField: { name: '@timestamp' },
+        indices: [
+          {
+            name: indexName,
+            managedBy: 'Data stream lifecycle',
+            preferILM: true,
+            uuid,
+          },
+        ],
+        generation: 1,
+        health: 'green',
+        indexTemplateName: testDataStreamName,
+        nextGenerationManagedBy: 'Data stream lifecycle',
+        hidden: false,
+        lifecycle: {
+          enabled: true,
+        },
+        meteringDocsCount: 0,
+        meteringStorageSize: '0b',
+        meteringStorageSizeBytes: 0,
+        failureStoreEnabled: false,
+        indexMode: 'standard',
+        failureStoreRetention: {
+          defaultRetentionPeriod: '30d',
+        },
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_serverless.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/ds_serverless.ts
@@ -80,9 +80,6 @@ export default function ({ getService }: FtrProviderContext) {
         hidden: false,
         failureStoreEnabled: false,
         indexMode: 'standard',
-        failureStoreRetention: {
-          defaultRetentionPeriod: '30d',
-        },
       });
     });
 
@@ -127,9 +124,6 @@ export default function ({ getService }: FtrProviderContext) {
         meteringStorageSizeBytes: 0,
         failureStoreEnabled: false,
         indexMode: 'standard',
-        failureStoreRetention: {
-          defaultRetentionPeriod: '30d',
-        },
       });
     });
   });

--- a/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/index.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/index_management/datastreams/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('Data streams', function () {
+    loadTestFile(require.resolve('./ds_common'));
+    loadTestFile(require.resolve('./ds_mki'));
+    loadTestFile(require.resolve('./ds_serverless'));
+  });
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Index Management] Branch data streams api tests lifecycle validation (#241105)](https://github.com/elastic/kibana/pull/241105)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sonia Sanz Vivas","email":"sonia.sanzvivas@elastic.co"},"sourceCommit":{"committedDate":"2025-11-03T14:06:26Z","message":"[Index Management] Branch data streams api tests lifecycle validation (#241105)\n\nFixes https://github.com/elastic/kibana/issues/187372\n\n## Summary\nThe Data Stream serverless tests were failing in MKI for Security\nbecause Security MKI enforces a default project-level retention. This PR\nsplits the ds test into three files: one for common tests, one for\nserverless tests (`skipMKI`) and one for MKI (`['skipSvlWorkplaceAI',\n'skipSvlOblt', 'skipSvlSearch', 'skipSvlSec']`). In MKI, the tests\nassert is different if the project is Security or not.\n\nTestes locally in MKI Security and Observability.\n\nFlaky tes runner:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9657","sha":"f8984ec6420af9b5f82efc9630708f4d10a73aeb","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Index Management","Team:Kibana Management","release_note:skip","backport:all-open","v9.3.0"],"title":"[Index Management] Branch data streams api tests lifecycle validation","number":241105,"url":"https://github.com/elastic/kibana/pull/241105","mergeCommit":{"message":"[Index Management] Branch data streams api tests lifecycle validation (#241105)\n\nFixes https://github.com/elastic/kibana/issues/187372\n\n## Summary\nThe Data Stream serverless tests were failing in MKI for Security\nbecause Security MKI enforces a default project-level retention. This PR\nsplits the ds test into three files: one for common tests, one for\nserverless tests (`skipMKI`) and one for MKI (`['skipSvlWorkplaceAI',\n'skipSvlOblt', 'skipSvlSearch', 'skipSvlSec']`). In MKI, the tests\nassert is different if the project is Security or not.\n\nTestes locally in MKI Security and Observability.\n\nFlaky tes runner:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9657","sha":"f8984ec6420af9b5f82efc9630708f4d10a73aeb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241105","number":241105,"mergeCommit":{"message":"[Index Management] Branch data streams api tests lifecycle validation (#241105)\n\nFixes https://github.com/elastic/kibana/issues/187372\n\n## Summary\nThe Data Stream serverless tests were failing in MKI for Security\nbecause Security MKI enforces a default project-level retention. This PR\nsplits the ds test into three files: one for common tests, one for\nserverless tests (`skipMKI`) and one for MKI (`['skipSvlWorkplaceAI',\n'skipSvlOblt', 'skipSvlSearch', 'skipSvlSec']`). In MKI, the tests\nassert is different if the project is Security or not.\n\nTestes locally in MKI Security and Observability.\n\nFlaky tes runner:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9657","sha":"f8984ec6420af9b5f82efc9630708f4d10a73aeb"}}]}] BACKPORT-->