### PR TITLE
[Metrics][Discover] Search term not highlight charts title fix

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/index.tsx
@@ -45,6 +45,7 @@ export const Chart = ({
   onFilter,
   onViewDetails,
   requestParams,
+  titleHighlight,
   discoverFetch$,
   size = 'm',
   esqlQuery,
@@ -100,6 +101,7 @@ export const Chart = ({
             onViewDetails={onViewDetails}
             onCopyToDashboard={toggleSaveModalVisible}
             syncCursor={syncCursor}
+            titleHighlight={titleHighlight}
             syncTooltips={syncTooltips}
           />
           {isSaveModalVisible && (

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_experience_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_experience_grid.tsx
@@ -225,6 +225,7 @@ export const MetricsExperienceGrid = ({
             discoverFetch$={discoverFetch$}
             requestParams={requestParams}
             abortController={abortController}
+            searchTerm={searchTerm}
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>


### PR DESCRIPTION
fixes [#241657](https://github.com/elastic/kibana/issues/241657)

## Summary

This PR fixes a regression that removed the charts title highlight based on the search term

![title_highlight_fix](https://github.com/user-attachments/assets/469ecc54-bc65-49a6-8d71-05573073ac18)



### How to test
- Start a local Kibana instance and point it to an oblt cluster - the bug is more likely to occur when the performance is worse
```yml
feature_flags.overrides:
  metricsExperienceEnabled: true
 ```
- Navigate to Discover and Switch to ESQL mode
- Search for a field name and confirm if the lens vis titles are highlighted


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->