### PR TITLE
Fixes Failing test: Task Manager Update By Query Claimer Functional Tests.x-pack/test/task_manager_claimer_update_by_query/test_suites/task_manager/metrics_route·ts - task_manager with update by query task claimer task manager metrics task claim should increment task claim success/total counters

### DIFF
--- a/x-pack/platform/test/task_manager_claimer_update_by_query/test_suites/task_manager/metrics_route.ts
+++ b/x-pack/platform/test/task_manager_claimer_update_by_query/test_suites/task_manager/metrics_route.ts
@@ -46,16 +46,22 @@ export default function ({ getService }: FtrProviderContext) {
     });
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/225112
-  describe.skip('task manager metrics', () => {
+  describe('task manager metrics', () => {
     describe('task claim', () => {
       it('should increment task claim success/total counters', async () => {
+        // reset metrics counter
+        await getMetricsRequest(true);
+
+        const metricsResetTime = Date.now();
+
         // counters are reset every 30 seconds, so wait until the start of a
         // fresh counter cycle to make sure values are incrementing
         const initialMetrics = (
           await getMetrics(
             false,
-            (metrics) => (metrics?.metrics?.task_claim?.value.total || 0) >= 1
+            (metrics) =>
+              !!metrics?.metrics?.task_claim?.timestamp &&
+              new Date(metrics?.metrics?.task_claim?.timestamp).getTime() > metricsResetTime
           )
         ).metrics;
         expect(initialMetrics).not.to.be(null);


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/225112

## Summary

Applies the same fix to the task manager metric test as was applied in this PR: https://github.com/elastic/kibana/pull/196399/files for the mget task claimer version of these tests.

Flaky test runner:
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9722
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9723


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->