### PR TITLE
[Security solution] Value report data view filtering fix

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/alert_filtering_metric.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/alert_filtering_metric.test.ts
@@ -8,6 +8,7 @@
 import type { EuiThemeComputed } from '@elastic/eui';
 import { getAlertFilteringMetricLensAttributes } from './alert_filtering_metric';
 import type { ExtraOptions } from '../../types';
+import { getAlertIndexFilter } from './helpers';
 
 interface FormulaColumn {
   params: {
@@ -32,10 +33,12 @@ interface MathColumn {
 describe('getAlertFilteringMetricLensAttributes', () => {
   const defaultEuiTheme = {} as EuiThemeComputed;
   const defaultTotalAlerts = 1000;
+  const defaultSignalIndexName = '.alerts-security.alerts-default';
 
   const defaultArgs = {
     euiTheme: defaultEuiTheme,
     totalAlerts: defaultTotalAlerts,
+    signalIndexName: defaultSignalIndexName,
   };
 
   it('returns lens attributes with correct basic structure, datasource, column, and visualization configurations', () => {
@@ -110,16 +113,18 @@ describe('getAlertFilteringMetricLensAttributes', () => {
     const mockFilters = [
       { meta: { alias: 'test filter', disabled: false, negate: false } },
     ] as ExtraOptions['filters'];
-    expect(getAlertFilteringMetricLensAttributes(defaultArgs).state.filters).toEqual([]);
+    expect(getAlertFilteringMetricLensAttributes(defaultArgs).state.filters).toEqual([
+      getAlertIndexFilter(defaultSignalIndexName),
+    ]);
     expect(
       getAlertFilteringMetricLensAttributes({ ...defaultArgs, extraOptions: {} }).state.filters
-    ).toEqual([]);
+    ).toEqual([getAlertIndexFilter(defaultSignalIndexName)]);
     expect(
       getAlertFilteringMetricLensAttributes({
         ...defaultArgs,
         extraOptions: { filters: mockFilters },
       }).state.filters
-    ).toEqual(mockFilters);
+    ).toEqual([getAlertIndexFilter(defaultSignalIndexName), ...mockFilters]);
     const testCases = [500, 0, 1000000];
     testCases.forEach((totalAlerts) => {
       const testResult = getAlertFilteringMetricLensAttributes({ ...defaultArgs, totalAlerts });
@@ -147,6 +152,43 @@ describe('getAlertFilteringMetricLensAttributes', () => {
     };
     expect(
       getAlertFilteringMetricLensAttributes({ ...defaultArgs, extraOptions }).state.filters
-    ).toEqual(extraOptions.filters);
+    ).toEqual([getAlertIndexFilter(defaultSignalIndexName), ...(extraOptions.filters ?? [])]);
+  });
+
+  it('includes alert index filter in filters array', () => {
+    const result = getAlertFilteringMetricLensAttributes(defaultArgs);
+    const expectedFilter = getAlertIndexFilter(defaultSignalIndexName);
+    expect(result.state.filters).toContainEqual(expectedFilter);
+  });
+
+  it('handles different signal index names correctly', () => {
+    const testCases = [
+      '.alerts-security.alerts-default',
+      '.alerts-security.alerts-custom-space',
+      'custom-alerts-index',
+    ];
+
+    testCases.forEach((signalIndexName) => {
+      const result = getAlertFilteringMetricLensAttributes({
+        ...defaultArgs,
+        signalIndexName,
+      });
+      const expectedFilter = getAlertIndexFilter(signalIndexName);
+      expect(result.state.filters).toContainEqual(expectedFilter);
+    });
+  });
+
+  it('combines alert index filter with extra options filters', () => {
+    const mockFilters = [
+      { meta: { alias: 'extra filter', disabled: false, negate: false } },
+    ] as ExtraOptions['filters'];
+    const result = getAlertFilteringMetricLensAttributes({
+      ...defaultArgs,
+      extraOptions: { filters: mockFilters },
+    });
+
+    expect(result.state.filters).toHaveLength(2);
+    expect(result.state.filters[0]).toEqual(getAlertIndexFilter(defaultSignalIndexName));
+    expect(result.state.filters[1]).toEqual(mockFilters[0]);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/alert_filtering_metric.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/alert_filtering_metric.test.ts
@@ -110,9 +110,9 @@ describe('getAlertFilteringMetricLensAttributes', () => {
         type: 'index-pattern',
       },
     ]);
-    const mockFilters = [
+    const mockFilters: ExtraOptions['filters'] = [
       { meta: { alias: 'test filter', disabled: false, negate: false } },
-    ] as ExtraOptions['filters'];
+    ];
     expect(getAlertFilteringMetricLensAttributes(defaultArgs).state.filters).toEqual([
       getAlertIndexFilter(defaultSignalIndexName),
     ]);
@@ -179,9 +179,9 @@ describe('getAlertFilteringMetricLensAttributes', () => {
   });
 
   it('combines alert index filter with extra options filters', () => {
-    const mockFilters = [
+    const mockFilters: ExtraOptions['filters'] = [
       { meta: { alias: 'extra filter', disabled: false, negate: false } },
-    ] as ExtraOptions['filters'];
+    ];
     const result = getAlertFilteringMetricLensAttributes({
       ...defaultArgs,
       extraOptions: { filters: mockFilters },

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/alert_filtering_metric.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/alert_filtering_metric.ts
@@ -6,6 +6,7 @@
  */
 
 import type { EuiThemeComputed } from '@elastic/eui';
+import { getAlertIndexFilter } from './helpers';
 import type { ExtraOptions, LensAttributes } from '../../types';
 
 export type MyGetLensAttributes = (params: {
@@ -13,11 +14,13 @@ export type MyGetLensAttributes = (params: {
   euiTheme: EuiThemeComputed;
   extraOptions?: ExtraOptions;
   esql?: string;
+  signalIndexName: string;
   totalAlerts: number;
 }) => LensAttributes;
 
 export const getAlertFilteringMetricLensAttributes: MyGetLensAttributes = ({
   extraOptions,
+  signalIndexName,
   totalAlerts,
 }) => {
   return {
@@ -75,7 +78,7 @@ export const getAlertFilteringMetricLensAttributes: MyGetLensAttributes = ({
           },
         },
       },
-      filters: extraOptions?.filters ?? [],
+      filters: [getAlertIndexFilter(signalIndexName), ...(extraOptions?.filters ?? [])],
       internalReferences: [],
       query: { language: 'kuery', query: '_id :*' },
       visualization: {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/cost_savings_metric.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/cost_savings_metric.ts
@@ -6,6 +6,7 @@
  */
 
 import type { EuiThemeComputed } from '@elastic/eui';
+import { getAlertIndexFilter } from './helpers';
 import type { ExtraOptions, LensAttributes } from '../../types';
 
 export type MyGetLensAttributes = (params: {
@@ -16,6 +17,7 @@ export type MyGetLensAttributes = (params: {
   backgroundColor: string;
   minutesPerAlert: number;
   analystHourlyRate: number;
+  signalIndexName: string;
 }) => LensAttributes;
 
 export const getCostSavingsMetricLensAttributes: MyGetLensAttributes = ({
@@ -23,6 +25,7 @@ export const getCostSavingsMetricLensAttributes: MyGetLensAttributes = ({
   backgroundColor,
   extraOptions,
   minutesPerAlert,
+  signalIndexName,
 }) => {
   return {
     description: '',
@@ -97,7 +100,7 @@ export const getCostSavingsMetricLensAttributes: MyGetLensAttributes = ({
           },
         },
       },
-      filters: extraOptions?.filters ?? [],
+      filters: [getAlertIndexFilter(signalIndexName), ...(extraOptions?.filters ?? [])],
       internalReferences: [],
       query: { language: 'kuery', query: '' },
       visualization: {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/cost_savings_trend_area.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/cost_savings_trend_area.ts
@@ -6,6 +6,7 @@
  */
 
 import type { EuiThemeComputed } from '@elastic/eui';
+import { getAlertIndexFilter } from './helpers';
 import type { ExtraOptions, LensAttributes } from '../../types';
 
 const xColumn0 = 'cost_columnX0';
@@ -20,12 +21,14 @@ export type MyGetLensAttributes = (params: {
   esql?: string;
   minutesPerAlert: number;
   analystHourlyRate: number;
+  signalIndexName: string;
 }) => LensAttributes;
 
 export const getCostSavingsTrendAreaLensAttributes: MyGetLensAttributes = ({
   analystHourlyRate,
   extraOptions,
   minutesPerAlert,
+  signalIndexName,
 }) => {
   return {
     description: '',
@@ -128,7 +131,7 @@ export const getCostSavingsTrendAreaLensAttributes: MyGetLensAttributes = ({
           },
         },
       },
-      filters: extraOptions?.filters ?? [],
+      filters: [getAlertIndexFilter(signalIndexName), ...(extraOptions?.filters ?? [])],
       internalReferences: [],
       query: {
         language: 'kuery',

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/helpers.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAlertIndexFilter } from './helpers';
+
+describe('getAlertIndexFilter', () => {
+  const defaultSignalIndexName = '.alerts-security.alerts-default';
+  const defaultIndexPatternId = 'indexpattern-datasource-layer-unifiedHistogram';
+
+  it('returns correct filter structure with default parameters', () => {
+    const result = getAlertIndexFilter(defaultSignalIndexName);
+
+    expect(result).toEqual({
+      meta: {
+        disabled: false,
+        negate: false,
+        alias: null,
+        index: defaultIndexPatternId,
+        key: '_index',
+        field: '_index',
+        params: {
+          query: defaultSignalIndexName,
+        },
+        type: 'phrase',
+      },
+      query: {
+        match_phrase: {
+          _index: defaultSignalIndexName,
+        },
+      },
+      $state: {
+        store: 'appState',
+      },
+    });
+  });
+
+  it('returns correct filter structure with custom indexPatternId', () => {
+    const customIndexPatternId = 'custom-index-pattern-id';
+    const result = getAlertIndexFilter(defaultSignalIndexName, customIndexPatternId);
+
+    expect(result.meta.index).toBe(customIndexPatternId);
+    expect(result.meta.params.query).toBe(defaultSignalIndexName);
+    expect(result.query.match_phrase._index).toBe(defaultSignalIndexName);
+  });
+
+  it('handles different signal index names correctly', () => {
+    const testCases = [
+      '.alerts-security.alerts-default',
+      '.alerts-security.alerts-custom-space',
+      '.alerts-security.alerts-space-123',
+      'custom-alerts-index',
+    ];
+
+    testCases.forEach((signalIndexName) => {
+      const result = getAlertIndexFilter(signalIndexName);
+
+      expect(result.meta.params.query).toBe(signalIndexName);
+      expect(result.query.match_phrase._index).toBe(signalIndexName);
+      expect(result.meta.key).toBe('_index');
+      expect(result.meta.field).toBe('_index');
+    });
+  });
+
+  it('maintains consistent filter properties across different inputs', () => {
+    const result = getAlertIndexFilter(defaultSignalIndexName);
+
+    expect(result.meta.disabled).toBe(false);
+    expect(result.meta.negate).toBe(false);
+    expect(result.meta.alias).toBe(null);
+    expect(result.meta.type).toBe('phrase');
+    expect(result.$state.store).toBe('appState');
+  });
+
+  it('handles empty string signal index name', () => {
+    const result = getAlertIndexFilter('');
+
+    expect(result.meta.params.query).toBe('');
+    expect(result.query.match_phrase._index).toBe('');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/helpers.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const getAlertIndexFilter = (
+  signalIndexName: string,
+  indexPatternId: string = 'indexpattern-datasource-layer-unifiedHistogram'
+) => ({
+  meta: {
+    disabled: false,
+    negate: false,
+    alias: null,
+    index: indexPatternId,
+    key: '_index',
+    field: '_index',
+    params: {
+      query: signalIndexName,
+    },
+    type: 'phrase',
+  },
+  query: {
+    match_phrase: {
+      _index: signalIndexName,
+    },
+  },
+  $state: {
+    store: 'appState',
+  },
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/time_saved_metric.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/time_saved_metric.test.ts
@@ -7,15 +7,18 @@
 
 import { getTimeSavedMetricLensAttributes } from './time_saved_metric';
 import type { EuiThemeComputed } from '@elastic/eui';
+import { getAlertIndexFilter } from './helpers';
 
 describe('getTimeSavedMetricLensAttributes', () => {
   const mockTheme = {} as EuiThemeComputed;
+  const defaultSignalIndexName = '.alerts-security.alerts-default';
   const defaultParams = {
     euiTheme: mockTheme,
     minutesPerAlert: 8,
     extraOptions: undefined,
     stackByField: undefined,
     esql: undefined,
+    signalIndexName: defaultSignalIndexName,
   };
 
   it('includes the correct formula in the count_column', () => {
@@ -36,15 +39,38 @@ describe('getTimeSavedMetricLensAttributes', () => {
       ...defaultParams,
       extraOptions: { filters },
     });
-    expect(result.state.filters).toBe(filters);
+    expect(result.state.filters).toEqual([getAlertIndexFilter(defaultSignalIndexName), ...filters]);
   });
 
-  it('defaults filters to empty array if extraOptions is not provided', () => {
+  it('includes alert index filter even when extraOptions is not provided', () => {
     const result = getTimeSavedMetricLensAttributes({
       ...defaultParams,
       extraOptions: undefined,
     });
-    expect(result.state.filters).toEqual([]);
+    expect(result.state.filters).toEqual([getAlertIndexFilter(defaultSignalIndexName)]);
+  });
+
+  it('includes alert index filter in filters array', () => {
+    const result = getTimeSavedMetricLensAttributes(defaultParams);
+    const expectedFilter = getAlertIndexFilter(defaultSignalIndexName);
+    expect(result.state.filters).toContainEqual(expectedFilter);
+  });
+
+  it('handles different signal index names correctly', () => {
+    const testCases = [
+      '.alerts-security.alerts-default',
+      '.alerts-security.alerts-custom-space',
+      'custom-alerts-index',
+    ];
+
+    testCases.forEach((signalIndexName) => {
+      const result = getTimeSavedMetricLensAttributes({
+        ...defaultParams,
+        signalIndexName,
+      });
+      const expectedFilter = getAlertIndexFilter(signalIndexName);
+      expect(result.state.filters).toContainEqual(expectedFilter);
+    });
   });
 
   it('returns a LensAttributes object with required properties', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/time_saved_metric.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/ai/time_saved_metric.ts
@@ -6,6 +6,7 @@
  */
 
 import type { EuiThemeComputed } from '@elastic/eui';
+import { getAlertIndexFilter } from './helpers';
 import type { ExtraOptions, LensAttributes } from '../../types';
 
 export type MyGetLensAttributes = (params: {
@@ -14,11 +15,13 @@ export type MyGetLensAttributes = (params: {
   extraOptions?: ExtraOptions;
   esql?: string;
   minutesPerAlert: number;
+  signalIndexName: string;
 }) => LensAttributes;
 
 export const getTimeSavedMetricLensAttributes: MyGetLensAttributes = ({
   extraOptions,
   minutesPerAlert,
+  signalIndexName,
 }) => {
   return {
     description: '',
@@ -82,7 +85,7 @@ export const getTimeSavedMetricLensAttributes: MyGetLensAttributes = ({
           },
         },
       },
-      filters: extraOptions?.filters ?? [],
+      filters: [getAlertIndexFilter(signalIndexName), ...(extraOptions?.filters ?? [])],
       internalReferences: [],
       query: { language: 'kuery', query: '_id:*' },
       visualization: {

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.tsx
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { css } from '@emotion/react';
 import { useEuiTheme } from '@elastic/eui';
+import { useSignalIndexWithDefault } from '../../hooks/use_signal_index_with_default';
 import { getExcludeAlertsFilters } from './utils';
+import type { GetLensAttributes } from '../../../common/components/visualization_actions/types';
 import { VisualizationContextMenuActions } from '../../../common/components/visualization_actions/types';
 import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { getAlertFilteringMetricLensAttributes } from '../../../common/components/visualization_actions/lens_attributes/ai/alert_filtering_metric';
@@ -37,6 +39,11 @@ const AlertFilteringMetricComponent: React.FC<Props> = ({
       filters: getExcludeAlertsFilters(attackAlertIds),
     }),
     [attackAlertIds]
+  );
+  const signalIndexName = useSignalIndexWithDefault();
+  const getLensAttributes = useCallback<GetLensAttributes>(
+    (args) => getAlertFilteringMetricLensAttributes({ ...args, signalIndexName, totalAlerts }),
+    [signalIndexName, totalAlerts]
   );
   return (
     <div
@@ -75,9 +82,7 @@ const AlertFilteringMetricComponent: React.FC<Props> = ({
       <VisualizationEmbeddable
         data-test-subj="alert-filtering-metric"
         extraOptions={extraVisualizationOptions}
-        getLensAttributes={(args) =>
-          getAlertFilteringMetricLensAttributes({ ...args, totalAlerts })
-        }
+        getLensAttributes={getLensAttributes}
         timerange={{ from, to }}
         id={`${ID}-area-embeddable`}
         inspectTitle={i18n.FILTERING_RATE}

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings.test.tsx
@@ -66,7 +66,7 @@ describe('CostSavings', () => {
         currentCount: defaultProps.costSavings,
         previousCount: defaultProps.costSavingsCompare,
         stat: '$4,000',
-        statType: 'time saved in hours',
+        statType: 'cost saved in dollars',
         timeRange: '30',
       }),
       {}

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings.tsx
@@ -57,7 +57,7 @@ export const CostSavings: React.FC<Props> = ({
         currentCount={costSavings}
         previousCount={costSavingsCompare}
         stat={formatDollars(costSavingsCompare)}
-        statType={i18n.TIME_SAVED_DESC.toLowerCase()}
+        statType={i18n.COST_SAVED_DESC.toLowerCase()}
         timeRange={timerangeAsDays}
       />
     </EuiPanel>

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_metric.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_metric.test.tsx
@@ -9,10 +9,15 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { CostSavingsMetric } from './cost_savings_metric';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
+import { useSignalIndexWithDefault } from '../../hooks/use_signal_index_with_default';
 
 // Mock VisualizationEmbeddable
 jest.mock('../../../common/components/visualization_actions/visualization_embeddable', () => ({
   VisualizationEmbeddable: jest.fn(() => <div data-test-subj="mock-visualization-embeddable" />),
+}));
+
+jest.mock('../../hooks/use_signal_index_with_default', () => ({
+  useSignalIndexWithDefault: jest.fn(),
 }));
 
 const defaultProps = {
@@ -22,7 +27,16 @@ const defaultProps = {
   analystHourlyRate: 100,
 };
 
+const mockUseSignalIndexWithDefault = useSignalIndexWithDefault as jest.MockedFunction<
+  typeof useSignalIndexWithDefault
+>;
+
 describe('CostSavingsMetric', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSignalIndexWithDefault.mockReturnValue('.alerts-security.alerts-default');
+  });
+
   it('passes correct props to VisualizationEmbeddable', () => {
     render(<CostSavingsMetric {...defaultProps} />);
     expect(VisualizationEmbeddable).toHaveBeenCalledWith(
@@ -36,5 +50,10 @@ describe('CostSavingsMetric', () => {
       }),
       {}
     );
+  });
+
+  it('calls useSignalIndexWithDefault hook', () => {
+    render(<CostSavingsMetric {...defaultProps} />);
+    expect(mockUseSignalIndexWithDefault).toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_metric.tsx
@@ -18,6 +18,7 @@ import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
 import { getCostSavingsMetricLensAttributes } from '../../../common/components/visualization_actions/lens_attributes/ai/cost_savings_metric';
 import { useMetricAnimation } from '../../hooks/use_metric_animation';
+import { useSignalIndexWithDefault } from '../../hooks/use_signal_index_with_default';
 
 interface Props {
   from: string;
@@ -48,7 +49,7 @@ const CostSavingsMetricComponent: React.FC<Props> = ({
     animationDurationMs: 1500,
     selector: '.echMetricText__value',
   });
-
+  const signalIndexName = useSignalIndexWithDefault();
   const timerange = useMemo(() => ({ from, to }), [from, to]);
   const getLensAttributes = useCallback<GetLensAttributes>(
     (args) =>
@@ -57,8 +58,9 @@ const CostSavingsMetricComponent: React.FC<Props> = ({
         backgroundColor: colors.backgroundBaseSuccess,
         minutesPerAlert,
         analystHourlyRate,
+        signalIndexName,
       }),
-    [analystHourlyRate, colors.backgroundBaseSuccess, minutesPerAlert]
+    [analystHourlyRate, colors.backgroundBaseSuccess, minutesPerAlert, signalIndexName]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.test.tsx
@@ -15,6 +15,7 @@ import { useAssistantAvailability } from '../../../assistant/use_assistant_avail
 import { useFindCostSavingsPrompts } from '../../hooks/use_find_cost_savings_prompts';
 import type { StartServices } from '../../../types';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { useSignalIndexWithDefault } from '../../hooks/use_signal_index_with_default';
 
 // Mock dependencies
 jest.mock('../../../common/lib/kibana', () => ({
@@ -42,6 +43,10 @@ jest.mock('../../hooks/use_find_cost_savings_prompts', () => ({
   useFindCostSavingsPrompts: jest.fn(),
 }));
 
+jest.mock('../../hooks/use_signal_index_with_default', () => ({
+  useSignalIndexWithDefault: jest.fn(),
+}));
+
 // Mock VisualizationEmbeddable
 jest.mock('../../../common/components/visualization_actions/visualization_embeddable', () => ({
   VisualizationEmbeddable: jest.fn(() => <div data-test-subj="mock-visualization-embeddable" />),
@@ -52,6 +57,9 @@ const mockLicenseService = licenseService as jest.Mocked<typeof licenseService>;
 const mockUseAssistantAvailability = useAssistantAvailability as jest.Mock;
 const mockUseFindCostSavingsPrompts = useFindCostSavingsPrompts as jest.MockedFunction<
   typeof useFindCostSavingsPrompts
+>;
+const mockUseSignalIndexWithDefault = useSignalIndexWithDefault as jest.MockedFunction<
+  typeof useSignalIndexWithDefault
 >;
 
 const defaultProps = {
@@ -112,6 +120,7 @@ describe('CostSavingsTrend', () => {
       part1: 'Test prompt part 1',
       part2: 'Test prompt part 2',
     });
+    mockUseSignalIndexWithDefault.mockReturnValue('.alerts-security.alerts-default');
   });
 
   it('renders CostSavingsTrend panel', () => {
@@ -135,5 +144,10 @@ describe('CostSavingsTrend', () => {
       }),
       {}
     );
+  });
+
+  it('calls useSignalIndexWithDefault hook', () => {
+    render(<CostSavingsTrend {...defaultProps} />, { wrapper });
+    expect(mockUseSignalIndexWithDefault).toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.tsx
@@ -15,6 +15,7 @@ import {
   useIsWithinMaxBreakpoint,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { useSignalIndexWithDefault } from '../../hooks/use_signal_index_with_default';
 import * as i18n from './translations';
 import type {
   EmbeddableData,
@@ -50,10 +51,16 @@ const CostSavingsTrendComponent: React.FC<Props> = ({
   to,
 }) => {
   const timerange = useMemo(() => ({ from, to }), [from, to]);
+  const signalIndexName = useSignalIndexWithDefault();
   const getLensAttributes = useCallback<GetLensAttributes>(
     (args) =>
-      getCostSavingsTrendAreaLensAttributes({ ...args, minutesPerAlert, analystHourlyRate }),
-    [analystHourlyRate, minutesPerAlert]
+      getCostSavingsTrendAreaLensAttributes({
+        ...args,
+        minutesPerAlert,
+        analystHourlyRate,
+        signalIndexName,
+      }),
+    [analystHourlyRate, minutesPerAlert, signalIndexName]
   );
   const isSmall = useIsWithinMaxBreakpoint('s');
   const {

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useMemo } from 'react';
 
 import { css } from '@emotion/react';
 import { useEuiTheme } from '@elastic/eui';
+import { useSignalIndexWithDefault } from '../../hooks/use_signal_index_with_default';
 import {
   type GetLensAttributes,
   VisualizationContextMenuActions,
@@ -34,9 +35,11 @@ const TimeSavedMetricComponent: React.FC<Props> = ({ from, to, minutesPerAlert }
     euiTheme: { colors },
   } = useEuiTheme();
   const timerange = useMemo(() => ({ from, to }), [from, to]);
+  const signalIndexName = useSignalIndexWithDefault();
+
   const getLensAttributes = useCallback<GetLensAttributes>(
-    (args) => getTimeSavedMetricLensAttributes({ ...args, minutesPerAlert }),
-    [minutesPerAlert]
+    (args) => getTimeSavedMetricLensAttributes({ ...args, minutesPerAlert, signalIndexName }),
+    [minutesPerAlert, signalIndexName]
   );
   return (
     <div

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/translations.ts
@@ -114,6 +114,13 @@ export const TIME_SAVED_DESC = i18n.translate(
   }
 );
 
+export const COST_SAVED_DESC = i18n.translate(
+  'xpack.securitySolution.reports.aiValue.timeSavedTitle',
+  {
+    defaultMessage: 'Cost saved in dollars',
+  }
+);
+
 export const ALERT_PROCESSING_TITLE = i18n.translate(
   'xpack.securitySolution.reports.aiValue.alertProcessingTitle',
   {

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/hooks/use_signal_index_with_default.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/hooks/use_signal_index_with_default.test.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useSignalIndexWithDefault } from './use_signal_index_with_default';
+import { useSignalIndex } from '../../detections/containers/detection_engine/alerts/use_signal_index';
+import { useSpaceId } from '../../common/hooks/use_space_id';
+
+jest.mock('../../detections/containers/detection_engine/alerts/use_signal_index');
+jest.mock('../../common/hooks/use_space_id');
+
+const mockUseSignalIndex = useSignalIndex as jest.MockedFunction<typeof useSignalIndex>;
+const mockUseSpaceId = useSpaceId as jest.MockedFunction<typeof useSpaceId>;
+
+describe('useSignalIndexWithDefault', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns signalIndexName when provided by useSignalIndex', () => {
+    const mockSignalIndexName = '.alerts-security.alerts-custom';
+    mockUseSignalIndex.mockReturnValue({
+      loading: false,
+      signalIndexExists: true,
+      signalIndexName: mockSignalIndexName,
+      signalIndexMappingOutdated: false,
+      createDeSignalIndex: null,
+    });
+    mockUseSpaceId.mockReturnValue('default');
+
+    const { result } = renderHook(() => useSignalIndexWithDefault());
+
+    expect(result.current).toBe(mockSignalIndexName);
+  });
+
+  it('returns default index name when signalIndexName is null', () => {
+    mockUseSignalIndex.mockReturnValue({
+      loading: false,
+      signalIndexExists: false,
+      signalIndexName: null,
+      signalIndexMappingOutdated: null,
+      createDeSignalIndex: null,
+    });
+    mockUseSpaceId.mockReturnValue('custom-space');
+
+    const { result } = renderHook(() => useSignalIndexWithDefault());
+
+    expect(result.current).toBe('.alerts-security.alerts-custom-space');
+  });
+
+  it('returns default index name when signalIndexName is undefined', () => {
+    mockUseSignalIndex.mockReturnValue({
+      loading: false,
+      signalIndexExists: false,
+      signalIndexName: undefined as any,
+      signalIndexMappingOutdated: null,
+      createDeSignalIndex: null,
+    });
+    mockUseSpaceId.mockReturnValue('default');
+
+    const { result } = renderHook(() => useSignalIndexWithDefault());
+
+    expect(result.current).toBe('.alerts-security.alerts-default');
+  });
+
+  it('uses correct space ID in default index name', () => {
+    const testCases = [
+      { spaceId: 'default', expected: '.alerts-security.alerts-default' },
+      { spaceId: 'custom-space', expected: '.alerts-security.alerts-custom-space' },
+      { spaceId: 'space-123', expected: '.alerts-security.alerts-space-123' },
+    ];
+
+    testCases.forEach(({ spaceId, expected }) => {
+      mockUseSignalIndex.mockReturnValue({
+        loading: false,
+        signalIndexExists: false,
+        signalIndexName: null,
+        signalIndexMappingOutdated: null,
+        createDeSignalIndex: null,
+      });
+      mockUseSpaceId.mockReturnValue(spaceId);
+
+      const { result } = renderHook(() => useSignalIndexWithDefault());
+
+      expect(result.current).toBe(expected);
+    });
+  });
+
+  it('memoizes result when dependencies do not change', () => {
+    const mockSignalIndexName = '.alerts-security.alerts-test';
+    mockUseSignalIndex.mockReturnValue({
+      loading: false,
+      signalIndexExists: true,
+      signalIndexName: mockSignalIndexName,
+      signalIndexMappingOutdated: false,
+      createDeSignalIndex: null,
+    });
+    mockUseSpaceId.mockReturnValue('default');
+
+    const { result, rerender } = renderHook(() => useSignalIndexWithDefault());
+    const firstResult = result.current;
+
+    rerender();
+    expect(result.current).toBe(firstResult);
+  });
+
+  it('recalculates when signalIndexName changes', () => {
+    mockUseSpaceId.mockReturnValue('default');
+
+    mockUseSignalIndex.mockReturnValue({
+      loading: false,
+      signalIndexExists: true,
+      signalIndexName: '.alerts-security.alerts-first',
+      signalIndexMappingOutdated: false,
+      createDeSignalIndex: null,
+    });
+
+    const { result, rerender } = renderHook(() => useSignalIndexWithDefault());
+    expect(result.current).toBe('.alerts-security.alerts-first');
+
+    mockUseSignalIndex.mockReturnValue({
+      loading: false,
+      signalIndexExists: true,
+      signalIndexName: '.alerts-security.alerts-second',
+      signalIndexMappingOutdated: false,
+      createDeSignalIndex: null,
+    });
+
+    rerender();
+    expect(result.current).toBe('.alerts-security.alerts-second');
+  });
+
+  it('recalculates when spaceId changes', () => {
+    mockUseSignalIndex.mockReturnValue({
+      loading: false,
+      signalIndexExists: false,
+      signalIndexName: null,
+      signalIndexMappingOutdated: null,
+      createDeSignalIndex: null,
+    });
+
+    mockUseSpaceId.mockReturnValue('first-space');
+    const { result, rerender } = renderHook(() => useSignalIndexWithDefault());
+    expect(result.current).toBe('.alerts-security.alerts-first-space');
+
+    mockUseSpaceId.mockReturnValue('second-space');
+    rerender();
+    expect(result.current).toBe('.alerts-security.alerts-second-space');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/hooks/use_signal_index_with_default.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/hooks/use_signal_index_with_default.test.tsx
@@ -52,21 +52,6 @@ describe('useSignalIndexWithDefault', () => {
     expect(result.current).toBe('.alerts-security.alerts-custom-space');
   });
 
-  it('returns default index name when signalIndexName is undefined', () => {
-    mockUseSignalIndex.mockReturnValue({
-      loading: false,
-      signalIndexExists: false,
-      signalIndexName: undefined as any,
-      signalIndexMappingOutdated: null,
-      createDeSignalIndex: null,
-    });
-    mockUseSpaceId.mockReturnValue('default');
-
-    const { result } = renderHook(() => useSignalIndexWithDefault());
-
-    expect(result.current).toBe('.alerts-security.alerts-default');
-  });
-
   it('uses correct space ID in default index name', () => {
     const testCases = [
       { spaceId: 'default', expected: '.alerts-security.alerts-default' },

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/hooks/use_signal_index_with_default.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/hooks/use_signal_index_with_default.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { useSignalIndex } from '../../detections/containers/detection_engine/alerts/use_signal_index';
+import { useSpaceId } from '../../common/hooks/use_space_id';
+
+export const useSignalIndexWithDefault = () => {
+  const { signalIndexName } = useSignalIndex();
+  const spaceId = useSpaceId();
+  const alertsIndex = useMemo(() => {
+    return signalIndexName ?? `.alerts-security.alerts-${spaceId}`;
+  }, [signalIndexName, spaceId]);
+  return alertsIndex;
+};


### PR DESCRIPTION
### Summary

I incorrectly believed that adding the `scopeId={SourcererScopeName.detections}` property to the `VisualizationEmbeddable` component would filter the queries on the value report page to search only the alerts index. However, `useDataView(SourcererScopeName.detections)` actually returns the full security solution data view. In order to only search the signals index, I added signal index filtering to all the AI value report lens visualizations. I also introduce a hook to provide a default signal index name, as `useSignalIndex()` can return `{ signalIndexName: null }`.

### Steps to reproduce

1. Be in serverless complete with `admin` or `soc_manager` role. Have alerts data and attack discoveries. Have additional non-alert events (I used `yarn start generate-logs` with `security-documents-generator`).
2. Navigate to value reports

Before fix: 
The cost savings metric did not match the cost savings in the description. Additionally, time saved, alert filtering rate, and cost savings trend were incorrect.
<img width="1353" height="815" alt="Screenshot 2025-11-03 at 8 56 45 AM" src="https://github.com/user-attachments/assets/48fadc71-f91e-48f1-ba65-9fa78146f30d" />

After fix:
The cost savings metric matches the cost savings in the description. Time saved, alert filtering rate, and cost savings trend are now accurate.
<img width="1360" height="819" alt="Screenshot 2025-11-03 at 11 09 30 AM" src="https://github.com/user-attachments/assets/a4d64318-d109-4943-9f1a-79be0cd16d20" />


### Changes
- **New helper function** (`helpers.ts`): `getAlertIndexFilter` creates index filters for lens attributes
- **Updated lens attributes functions**: Added `signalIndexName` parameter and integrated `getAlertIndexFilter` in:
  - `alert_filtering_metric.ts`
  - `cost_savings_metric.ts`
  - `time_saved_metric.ts`
  - `cost_savings_trend_area.ts`
- **New hook** (`use_signal_index_with_default.tsx`): Returns signal index name with fallback to `.alerts-security.alerts-{spaceId}`
- **Updated React components**: Components now use `useSignalIndexWithDefault` to get alerts index name
- **Fixed translation**: Updated `statType` value to be correct
