### PR TITLE
updates hashing algorithms to be fips140-3 compliant

### DIFF
--- a/src/core/packages/apps/server-internal/src/bundle_routes/dynamic_asset_response.test.ts
+++ b/src/core/packages/apps/server-internal/src/bundle_routes/dynamic_asset_response.test.ts
@@ -82,7 +82,7 @@ describe('headers', () => {
     expect(result.options.headers).toEqual({
       'cache-control': 'must-revalidate',
       'content-type': 'application/javascript; charset=utf-8',
-      etag: expect.stringMatching(/^[a-f0-9]{40}-\/public/i),
+      etag: expect.stringMatching(/^[a-f0-9]{64}-\/public/i),
     });
   });
 });

--- a/src/core/packages/apps/server-internal/src/bundle_routes/utils.ts
+++ b/src/core/packages/apps/server-internal/src/bundle_routes/utils.ts
@@ -14,7 +14,7 @@ import * as Rx from 'rxjs';
 import { map, takeUntil } from 'rxjs';
 
 export const generateFileHash = (fd: number): Promise<string> => {
-  const hash = createHash('sha1'); // eslint-disable-line @kbn/eslint/no_unsafe_hash
+  const hash = createHash('sha256');
   const read = createReadStream(null as any, {
     fd,
     start: 0,

--- a/src/core/packages/rendering/server-internal/src/bootstrap/bootstrap_renderer.ts
+++ b/src/core/packages/rendering/server-internal/src/bootstrap/bootstrap_renderer.ts
@@ -113,7 +113,7 @@ export const bootstrapRendererFactory: BootstrapRendererFactory = ({
       publicPathMap,
     });
 
-    const hash = createHash('sha1'); // eslint-disable-line @kbn/eslint/no_unsafe_hash
+    const hash = createHash('sha256');
     hash.update(body);
     const etag = hash.digest('hex');
 


### PR DESCRIPTION
## Summary

A recent CodeQL scan revealed two locations ([A](https://github.com/elastic/kibana/security/code-scanning/611) and [B](https://github.com/elastic/kibana/security/code-scanning/610)) where weak hashing algorithms are used.

These alerts were initially classified as a false positive, but was later found that while sha1 is currently approved for FIPS 140-2, it won't be approved under FIPS 140-3.

## Implementation
This PR updates uses of the weak SHA1 algorithm with the stronger, standard SHA256 algorithm in the two locations identified by the CodeQL scan.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks
One thing to consider is that SHA256 is potentially not a drop-in replacement for SHA1. That is because, for the same inputs, these two algorithms produce different hashes, with different lengths. However, these hashes are meant to be generated for etags, which are ephemeral cache identifiers. This will simply cause a one-time cache bust as the etags will change due to the change in algorithm.




<!--ONMERGE {"backportTargets":["8.19","9.3"]} ONMERGE-->