### PR TITLE
[Synthetics] Only update relevant space monitors where global params changes happens !!

### DIFF
--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -60,6 +60,7 @@ export default function ({ getService }: FtrProviderContext) {
         'SLO:ORPHAN_SUMMARIES-CLEANUP-TASK',
         'SampleDataIngest:InstallSampleData',
         'Synthetics:Clean-Up-Package-Policies',
+        'Synthetics:Sync-Global-Params-Private-Locations',
         'Synthetics:Sync-Private-Location-Monitors',
         'UPTIME:SyntheticsService:Sync-Saved-Monitor-Objects',
         'actions:.bedrock',

--- a/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
@@ -16,6 +16,7 @@ import type {
 import { SavedObjectsClient } from '@kbn/core/server';
 import { mappingFromFieldMap } from '@kbn/alerting-plugin/common';
 import { Dataset } from '@kbn/rule-registry-plugin/server';
+import { SyncGlobalParamsPrivateLocationsTask } from './tasks/sync_global_params_task';
 import type {
   SyntheticsPluginsSetupDependencies,
   SyntheticsPluginsStartDependencies,
@@ -44,6 +45,7 @@ export class Plugin implements PluginType {
   private syntheticsMonitorClient?: SyntheticsMonitorClient;
   private readonly telemetryEventsSender: TelemetryEventsSender;
   private syncPrivateLocationMonitorsTask?: SyncPrivateLocationMonitorsTask;
+  private syncGlobalParamsTask?: SyncGlobalParamsPrivateLocationsTask;
 
   constructor(private readonly initContext: PluginInitializerContext<UptimeConfig>) {
     this.logger = initContext.logger.get();
@@ -101,6 +103,13 @@ export class Plugin implements PluginType {
     );
     this.syncPrivateLocationMonitorsTask.registerTaskDefinition(plugins.taskManager);
 
+    this.syncGlobalParamsTask = new SyncGlobalParamsPrivateLocationsTask(
+      this.server,
+      plugins.taskManager,
+      this.syntheticsMonitorClient
+    );
+
+    this.syncGlobalParamsTask.registerTaskDefinition(plugins.taskManager);
     plugins.embeddable.registerTransforms(SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE, {
       transformOutInjectsReferences: true,
       transformIn: getTransformIn(plugins.embeddable.transformEnhancementsIn),

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/edit_param.ts
@@ -10,12 +10,12 @@ import { schema } from '@kbn/config-schema';
 import type { SavedObject } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { isEmpty } from 'lodash';
-import { runSynPrivateLocationMonitorsTaskSoon } from '../../../tasks/sync_private_locations_monitors_task';
 import { validateRouteSpaceName } from '../../common';
 import type { SyntheticsRestApiRouteFactory } from '../../types';
 import type { SyntheticsParamRequest, SyntheticsParams } from '../../../../common/runtime_types';
 import { syntheticsParamType } from '../../../../common/types/saved_objects';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { asyncGlobalParamsPropagation } from '../../../tasks/sync_global_params_task';
 
 const RequestParamsSchema = schema.object({
   id: schema.string(),
@@ -86,8 +86,9 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
         newParam
       )) as SavedObject<SyntheticsParams>;
 
-      await runSynPrivateLocationMonitorsTaskSoon({
+      await asyncGlobalParamsPropagation({
         server,
+        paramsSpacesToSync: existingParam.namespaces || [spaceId],
       });
 
       return { id: responseId, key, tags, description, namespaces, value };

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/sync_global_params.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/sync_global_params.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SyncPrivateLocationMonitorsTask } from '../../../tasks/sync_private_locations_monitors_task';
+import { asyncGlobalParamsPropagation } from '../../../tasks/sync_global_params_task';
 import { SYNTHETICS_API_URLS } from '../../../../common/constants';
 import { getPrivateLocations } from '../../../synthetics_service/get_private_locations';
 import type { SyntheticsRestApiRouteFactory } from '../../types';
@@ -21,16 +21,15 @@ export const syncParamsSyntheticsParamsRoute: SyntheticsRestApiRouteFactory = ()
     },
   },
   writeAccess: true,
-  handler: async ({ syntheticsMonitorClient, server }): Promise<any> => {
+  handler: async ({ syntheticsMonitorClient, server, spaceId }): Promise<any> => {
     const soClient = server.coreStart.savedObjects.createInternalRepository();
 
     const allPrivateLocations = await getPrivateLocations(soClient);
 
-    const syncTask = new SyncPrivateLocationMonitorsTask(server, syntheticsMonitorClient);
     if (allPrivateLocations.length > 0) {
-      await syncTask.syncGlobalParams({
-        allPrivateLocations,
-        soClient,
+      await asyncGlobalParamsPropagation({
+        server,
+        paramsSpacesToSync: [spaceId],
       });
     }
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/clean_up_duplicate_policies.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/clean_up_duplicate_policies.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { syntheticsMonitorSOTypes } from '../../common/types/saved_objects';
+import type { EncryptedSyntheticsMonitorAttributes } from '../../common/runtime_types';
+import { SyntheticsPrivateLocation } from '../synthetics_service/private_location/synthetics_private_location';
+import { getFilterForTestNowRun } from '../synthetics_service/private_location/clean_up_task';
+import type { SyncTaskState } from './sync_private_locations_monitors_task';
+import type { SyntheticsServerSetup } from '../types';
+
+export async function cleanUpDuplicatedPackagePolicies(
+  serverSetup: SyntheticsServerSetup,
+  soClient: SavedObjectsClientContract,
+  taskState: SyncTaskState
+) {
+  let performCleanupSync = false;
+  const { fleet } = serverSetup.pluginsStart;
+  const { logger } = serverSetup;
+
+  const debugLog = (msg: string) => {
+    logger.debug(`[PrivateLocationCleanUpTask] ${msg}`);
+  };
+
+  if (taskState.hasAlreadyDoneCleanup) {
+    debugLog('Skipping cleanup of duplicated package policies as it has already been done once');
+    return { performCleanupSync };
+  } else if (taskState.maxCleanUpRetries <= 0) {
+    debugLog('Skipping cleanup of duplicated package policies as max retries have been reached');
+    taskState.hasAlreadyDoneCleanup = true;
+    taskState.maxCleanUpRetries = 3;
+    return { performCleanupSync };
+  }
+  debugLog('Starting cleanup of duplicated package policies');
+
+  try {
+    const esClient = serverSetup.coreStart?.elasticsearch?.client.asInternalUser;
+
+    const finder = soClient.createPointInTimeFinder<EncryptedSyntheticsMonitorAttributes>({
+      type: syntheticsMonitorSOTypes,
+      fields: ['id', 'name', 'locations', 'origin'],
+      namespaces: ['*'],
+    });
+
+    const privateLocationAPI = new SyntheticsPrivateLocation(serverSetup);
+
+    const expectedPackagePolicies = new Set<string>();
+    for await (const result of finder.find()) {
+      result.saved_objects.forEach((monitor) => {
+        monitor.attributes.locations?.forEach((location) => {
+          const spaceId = monitor.namespaces?.[0];
+          if (!location.isServiceManaged && spaceId) {
+            const policyId = privateLocationAPI.getPolicyId(
+              {
+                origin: monitor.attributes.origin,
+                id: monitor.id,
+              },
+              location.id,
+              spaceId
+            );
+            expectedPackagePolicies.add(policyId);
+          }
+        });
+      });
+    }
+
+    finder.close().catch(() => {});
+
+    const packagePoliciesKuery = getFilterForTestNowRun(true);
+
+    const policiesIterator = await fleet.packagePolicyService.fetchAllItemIds(soClient, {
+      kuery: packagePoliciesKuery,
+      spaceIds: ['*'],
+      perPage: 100,
+    });
+    const packagePoliciesToDelete: string[] = [];
+
+    for await (const packagePoliciesIds of policiesIterator) {
+      for (const packagePolicyId of packagePoliciesIds) {
+        if (!expectedPackagePolicies.has(packagePolicyId)) {
+          packagePoliciesToDelete.push(packagePolicyId);
+        }
+        // remove it from the set to mark it as found
+        expectedPackagePolicies.delete(packagePolicyId);
+      }
+    }
+
+    // if we have any to delete or any expected that were not found we need to perform a sync
+    performCleanupSync = packagePoliciesToDelete.length > 0 || expectedPackagePolicies.size > 0;
+
+    if (packagePoliciesToDelete.length > 0) {
+      logger.info(
+        ` [PrivateLocationCleanUpTask] Found ${
+          packagePoliciesToDelete.length
+        } duplicate package policies to delete: ${packagePoliciesToDelete.join(', ')}`
+      );
+      await fleet.packagePolicyService.delete(soClient, esClient, packagePoliciesToDelete, {
+        force: true,
+        spaceIds: ['*'],
+      });
+    }
+    taskState.hasAlreadyDoneCleanup = true;
+    taskState.maxCleanUpRetries = 3;
+    return { performCleanupSync };
+  } catch (e) {
+    taskState.maxCleanUpRetries -= 1;
+    if (taskState.maxCleanUpRetries <= 0) {
+      debugLog('Skipping cleanup of duplicated package policies as max retries have been reached');
+      taskState.hasAlreadyDoneCleanup = true;
+      taskState.maxCleanUpRetries = 3;
+    }
+    logger.error(
+      '[SyncPrivateLocationMonitorsTask] Error cleaning up duplicated package policies',
+      { error: e }
+    );
+    return { performCleanupSync };
+  }
+}

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  SavedObjectsClientContract,
+  SavedObjectsFindResult,
+} from '@kbn/core-saved-objects-api-server';
+import type { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
+import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
+import { normalizeSecrets } from '../synthetics_service/utils';
+import type { PrivateLocationAttributes } from '../runtime_types/private_locations';
+import type {
+  HeartbeatConfig,
+  MonitorFields,
+  SyntheticsMonitorWithSecretsAttributes,
+} from '../../common/runtime_types';
+import { MonitorConfigRepository } from '../services/monitor_config_repository';
+import type { SyntheticsMonitorClient } from '../synthetics_service/synthetics_monitor/synthetics_monitor_client';
+import type { SyntheticsServerSetup } from '../types';
+import {
+  formatHeartbeatRequest,
+  mixParamsWithGlobalParams,
+} from '../synthetics_service/formatters/public_formatters/format_configs';
+
+export class DeployPrivateLocationMonitors {
+  constructor(
+    public serverSetup: SyntheticsServerSetup,
+    public syntheticsMonitorClient: SyntheticsMonitorClient
+  ) {}
+
+  async syncPackagePolicies({
+    allPrivateLocations,
+    encryptedSavedObjects,
+    soClient,
+    spaceIdToSync,
+  }: {
+    spaceIdToSync?: string;
+    soClient: SavedObjectsClientContract;
+    allPrivateLocations: PrivateLocationAttributes[];
+    encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
+  }) {
+    if (allPrivateLocations.length === 0) {
+      this.debugLog('No private locations found, skipping sync of private location monitors');
+      return;
+    }
+
+    const { privateLocationAPI } = this.syntheticsMonitorClient;
+
+    const { configsBySpaces, paramsBySpace, monitorSpaceIds, maintenanceWindows } =
+      await this.getAllMonitorConfigs({
+        encryptedSavedObjects,
+        soClient,
+        spaceId: spaceIdToSync,
+      });
+
+    return this.serverSetup.fleet.runWithCache(async () => {
+      this.debugLog(
+        `Starting sync of private location monitors for spaces: ${Array.from(monitorSpaceIds).join(
+          ', '
+        )}`
+      );
+      for (const spaceId of monitorSpaceIds) {
+        const privateConfigs: Array<{
+          config: HeartbeatConfig;
+          globalParams: Record<string, string>;
+        }> = [];
+        const monitors = configsBySpaces[spaceId];
+        this.debugLog(`Processing spaceId: ${spaceId}, monitors count: ${monitors?.length ?? 0}`);
+        if (!monitors) {
+          continue;
+        }
+        for (const monitor of monitors) {
+          const { privateLocations } = this.parseLocations(monitor);
+
+          if (privateLocations.length > 0) {
+            privateConfigs.push({ config: monitor, globalParams: paramsBySpace[spaceId] });
+          }
+        }
+        if (privateConfigs.length > 0) {
+          this.debugLog(
+            `Syncing private configs for spaceId: ${spaceId}, privateConfigs count: ${privateConfigs.length}`
+          );
+
+          await privateLocationAPI.editMonitors(
+            privateConfigs,
+            allPrivateLocations,
+            spaceId,
+            maintenanceWindows
+          );
+        } else {
+          this.debugLog(`No privateConfigs to sync for spaceId: ${spaceId}`);
+        }
+      }
+    });
+  }
+
+  async getAllMonitorConfigs({
+    soClient,
+    encryptedSavedObjects,
+    spaceId = ALL_SPACES_ID,
+  }: {
+    soClient: SavedObjectsClientContract;
+    encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
+    spaceId?: string;
+  }) {
+    const { syntheticsService } = this.syntheticsMonitorClient;
+    const paramsBySpacePromise = syntheticsService.getSyntheticsParams({ spaceId });
+    const maintenanceWindowsPromise = syntheticsService.getMaintenanceWindows();
+    const monitorConfigRepository = new MonitorConfigRepository(
+      soClient,
+      encryptedSavedObjects.getClient()
+    );
+
+    const monitorsPromise = monitorConfigRepository.findDecryptedMonitors({
+      spaceId,
+    });
+
+    const [paramsBySpace, monitors, maintenanceWindows] = await Promise.all([
+      paramsBySpacePromise,
+      monitorsPromise,
+      maintenanceWindowsPromise,
+    ]);
+
+    return {
+      ...this.mixParamsWithMonitors(monitors, paramsBySpace),
+      paramsBySpace,
+      maintenanceWindows,
+    };
+  }
+
+  parseLocations(config: HeartbeatConfig) {
+    const { locations } = config;
+
+    const privateLocations = locations.filter((loc) => !loc.isServiceManaged);
+    const publicLocations = locations.filter((loc) => loc.isServiceManaged);
+
+    return { privateLocations, publicLocations };
+  }
+
+  mixParamsWithMonitors(
+    monitors: Array<SavedObjectsFindResult<SyntheticsMonitorWithSecretsAttributes>>,
+    paramsBySpace: Record<string, Record<string, string>>
+  ) {
+    const configsBySpaces: Record<string, HeartbeatConfig[]> = {};
+    const monitorSpaceIds = new Set<string>();
+
+    for (const monitor of monitors) {
+      const spaceId = monitor.namespaces?.[0];
+      if (!spaceId) {
+        continue;
+      }
+      monitorSpaceIds.add(spaceId);
+      const normalizedMonitor = normalizeSecrets(monitor).attributes as MonitorFields;
+      const { str: paramsString } = mixParamsWithGlobalParams(
+        paramsBySpace[spaceId],
+        normalizedMonitor
+      );
+
+      if (!configsBySpaces[spaceId]) {
+        configsBySpaces[spaceId] = [];
+      }
+
+      configsBySpaces[spaceId].push(
+        formatHeartbeatRequest(
+          {
+            spaceId,
+            monitor: normalizedMonitor,
+            configId: monitor.id,
+          },
+          paramsString
+        )
+      );
+    }
+
+    return { configsBySpaces, monitorSpaceIds };
+  }
+
+  debugLog = (message: string) => {
+    this.serverSetup.logger.debug(`[SyncPrivateLocationMonitorsTask] ${message}`);
+  };
+}

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
@@ -180,6 +180,6 @@ export class DeployPrivateLocationMonitors {
   }
 
   debugLog = (message: string) => {
-    this.serverSetup.logger.debug(`[SyncPrivateLocationMonitorsTask] ${message}`);
+    this.serverSetup.logger.debug(`[DeployPrivateLocationMonitors] ${message}`);
   };
 }

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { asyncGlobalParamsPropagation } from './sync_global_params_task';
+import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
+
+describe('asyncGlobalParamsPropagation', () => {
+  const FIXED_NOW = 1_000_000;
+
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('schedules a task for each provided space', async () => {
+    const ensureScheduled = jest.fn().mockResolvedValue(undefined);
+    const server = { pluginsStart: { taskManager: { ensureScheduled } } } as any;
+    const spaces = ['space-a', 'space-b'];
+
+    await asyncGlobalParamsPropagation({ server, paramsSpacesToSync: spaces });
+
+    expect(ensureScheduled).toHaveBeenCalledTimes(spaces.length);
+
+    const expectedRunAt = new Date(FIXED_NOW + 3 * 1000).getTime();
+    const calls = ensureScheduled.mock.calls.map((c) => c[0]);
+
+    for (let i = 0; i < spaces.length; i++) {
+      const scheduled = calls[i];
+      expect(scheduled.taskType).toBe('Synthetics:Sync-Global-Params-Private-Locations');
+      expect(scheduled.params).toEqual({});
+      expect(scheduled.state).toEqual({ paramsSpaceToSync: spaces[i] });
+      expect(scheduled.id).toMatch(/^Synthetics:Sync-Global-Params-Private-Locations:/);
+      expect(scheduled.runAt).toBeInstanceOf(Date);
+      // small allowance for Date object creation
+      expect(Math.abs(scheduled.runAt.getTime() - expectedRunAt)).toBeLessThan(50);
+    }
+  });
+
+  test('when ALL_SPACES_ID present only schedules for ALL_SPACES_ID', async () => {
+    const ensureScheduled = jest.fn().mockResolvedValue(undefined);
+    const server = { pluginsStart: { taskManager: { ensureScheduled } } } as any;
+    const spaces = [ALL_SPACES_ID, 'other-space'];
+
+    await asyncGlobalParamsPropagation({ server, paramsSpacesToSync: spaces });
+
+    expect(ensureScheduled).toHaveBeenCalledTimes(1);
+    const scheduled = ensureScheduled.mock.calls[0][0];
+    expect(scheduled.state).toEqual({ paramsSpaceToSync: ALL_SPACES_ID });
+    expect(scheduled.taskType).toBe('Synthetics:Sync-Global-Params-Private-Locations');
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.ts
@@ -79,7 +79,7 @@ export class SyncGlobalParamsPrivateLocationsTask {
       const soClient = savedObjects.createInternalRepository();
 
       const allPrivateLocations = await getPrivateLocations(soClient, ALL_SPACES_ID);
-      if (allPrivateLocations.length > 0) {
+      if (allPrivateLocations.length > 0 && paramsSpaceToSync) {
         await this.deployPackagePolicies.syncPackagePolicies({
           allPrivateLocations,
           soClient,
@@ -92,14 +92,11 @@ export class SyncGlobalParamsPrivateLocationsTask {
       logger.error(`Sync of global params failed: ${error.message}`);
       return {
         error,
-        state: { paramsSpaceToSync, syncAllSpaces: false },
+        state: {},
       };
     }
     return {
-      state: {
-        paramsSpacesToSync: [],
-        syncAllSpaces: false,
-      },
+      state: {},
     };
   }
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TaskManagerSetupContract } from '@kbn/task-manager-plugin/server/plugin';
+import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
+import type {
+  ConcreteTaskInstance,
+  IntervalSchedule,
+  RruleSchedule,
+} from '@kbn/task-manager-plugin/server';
+import { v4 as uuidv4 } from 'uuid';
+
+import { DeployPrivateLocationMonitors } from './deploy_private_location_monitors';
+import type { SyntheticsMonitorClient } from '../synthetics_service/synthetics_monitor/synthetics_monitor_client';
+import { getPrivateLocations } from '../synthetics_service/get_private_locations';
+import type { SyntheticsServerSetup } from '../types';
+
+const TASK_TYPE = 'Synthetics:Sync-Global-Params-Private-Locations';
+
+interface TaskState extends Record<string, unknown> {
+  paramsSpaceToSync?: string;
+  syncAllSpaces: boolean;
+}
+
+export type CustomTaskInstance = Omit<ConcreteTaskInstance, 'state'> & {
+  state: Partial<TaskState>;
+};
+
+export class SyncGlobalParamsPrivateLocationsTask {
+  public deployPackagePolicies: DeployPrivateLocationMonitors;
+  constructor(
+    public serverSetup: SyntheticsServerSetup,
+    public taskManager: TaskManagerSetupContract,
+    public syntheticsMonitorClient: SyntheticsMonitorClient
+  ) {
+    this.deployPackagePolicies = new DeployPrivateLocationMonitors(
+      serverSetup,
+      syntheticsMonitorClient
+    );
+  }
+
+  registerTaskDefinition(taskManager: TaskManagerSetupContract) {
+    taskManager.registerTaskDefinitions({
+      [TASK_TYPE]: {
+        title: 'Synthetics Sync Global Params Task',
+        description:
+          'This task is executed so that we can sync private location monitors for example when global params are updated',
+        timeout: '10m',
+        maxAttempts: 1,
+        createTaskRunner: ({ taskInstance }) => {
+          return {
+            run: async () => {
+              return this.runTask({ taskInstance });
+            },
+          };
+        },
+      },
+    });
+  }
+
+  public async runTask({
+    taskInstance,
+  }: {
+    taskInstance: CustomTaskInstance;
+  }): Promise<{ state: TaskState; error?: Error; schedule?: IntervalSchedule | RruleSchedule }> {
+    const {
+      coreStart: { savedObjects },
+      encryptedSavedObjects,
+      logger,
+    } = this.serverSetup;
+
+    const paramsSpaceToSync = taskInstance.state.paramsSpaceToSync;
+
+    try {
+      this.debugLog(`current task state is ${JSON.stringify(taskInstance.state)}`);
+      const soClient = savedObjects.createInternalRepository();
+
+      const allPrivateLocations = await getPrivateLocations(soClient, ALL_SPACES_ID);
+      if (allPrivateLocations.length > 0) {
+        if (paramsSpaceToSync) {
+          await this.deployPackagePolicies.syncPackagePolicies({
+            allPrivateLocations,
+            soClient,
+            encryptedSavedObjects,
+            spaceIdToSync: paramsSpaceToSync,
+          });
+          this.debugLog(`Sync of global params succeeded for space  ${paramsSpaceToSync}`);
+        } else if (taskInstance.state.syncAllSpaces) {
+          await this.deployPackagePolicies.syncPackagePolicies({
+            allPrivateLocations,
+            soClient,
+            encryptedSavedObjects,
+            spaceIdToSync: paramsSpaceToSync,
+          });
+          this.debugLog(`Sync of global params succeeded for all spaces`);
+        }
+      }
+    } catch (error) {
+      logger.error(`Sync of global params failed: ${error.message}`);
+      return {
+        error,
+        state: { paramsSpaceToSync, syncAllSpaces: false },
+      };
+    }
+    return {
+      state: {
+        paramsSpacesToSync: [],
+        syncAllSpaces: false,
+      },
+    };
+  }
+
+  debugLog = (message: string) => {
+    this.serverSetup.logger.debug(`[SyncGlobalParamsPrivateLocationsTask] ${message}`);
+  };
+}
+
+export const asyncGlobalParamsPropagation = async ({
+  server,
+  paramsSpacesToSync,
+}: {
+  server: SyntheticsServerSetup;
+  paramsSpacesToSync: string[];
+}) => {
+  const {
+    pluginsStart: { taskManager },
+  } = server;
+  if (paramsSpacesToSync.includes(ALL_SPACES_ID)) {
+    await taskManager.ensureScheduled({
+      id: `${TASK_TYPE}:${uuidv4()}`,
+      params: {},
+      taskType: TASK_TYPE,
+      runAt: new Date(Date.now() + 3 * 1000),
+      state: { syncAllSpaces: true } as TaskState,
+    });
+  } else {
+    for (const spaceId of paramsSpacesToSync) {
+      await taskManager.ensureScheduled({
+        id: `${TASK_TYPE}:${uuidv4()}`,
+        params: {},
+        taskType: TASK_TYPE,
+        runAt: new Date(Date.now() + 3 * 1000),
+        state: { paramsSpaceToSync: spaceId, syncAllSpaces: false } as TaskState,
+      });
+    }
+  }
+};

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.ts
@@ -115,23 +115,19 @@ export const asyncGlobalParamsPropagation = async ({
   const {
     pluginsStart: { taskManager },
   } = server;
-  if (paramsSpacesToSync.includes(ALL_SPACES_ID)) {
-    await taskManager.ensureScheduled({
-      id: `${TASK_TYPE}:${uuidv4()}`,
-      params: {},
-      taskType: TASK_TYPE,
-      runAt: new Date(Date.now() + 3 * 1000),
-      state: { paramsSpaceToSync: ALL_SPACES_ID } as TaskState,
-    });
-  } else {
-    for (const spaceId of paramsSpacesToSync) {
+  const spacesToUpdate = paramsSpacesToSync.includes(ALL_SPACES_ID)
+    ? [ALL_SPACES_ID]
+    : paramsSpacesToSync;
+
+  await Promise.all(
+    spacesToUpdate.map(async (spaceId) => {
       await taskManager.ensureScheduled({
         id: `${TASK_TYPE}:${uuidv4()}`,
         params: {},
         taskType: TASK_TYPE,
         runAt: new Date(Date.now() + 3 * 1000),
-        state: { paramsSpaceToSync: spaceId } as TaskState,
+        state: { paramsSpaceToSync: spaceId },
       });
-    }
-  }
+    })
+  );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
@@ -128,8 +128,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
   describe('runTask', () => {
     it('should skip sync if no data has changed', async () => {
       const taskInstance = getMockTaskInstance();
-      jest.spyOn(task, 'hasAnyDataChanged').mockResolvedValue({
-        hasDataChanged: false,
+      jest.spyOn(task, 'hasMWsChanged').mockResolvedValue({
+        hasMWsChanged: false,
       });
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
         {
@@ -142,7 +142,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
 
       const result = await task.runTask({ taskInstance });
 
-      expect(task.hasAnyDataChanged).toHaveBeenCalled();
+      expect(task.hasMWsChanged).toHaveBeenCalled();
       expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining('No data has changed since last run')
       );
@@ -152,7 +152,6 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         disableAutoSync: false,
         hasAlreadyDoneCleanup: false,
         lastStartedAt: expect.anything(),
-        lastTotalParams: 1,
         lastTotalMWs: 1,
         maxCleanUpRetries: 2,
       });
@@ -160,8 +159,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
 
     it('should run sync if data has changed', async () => {
       const taskInstance = getMockTaskInstance();
-      jest.spyOn(task, 'hasAnyDataChanged').mockResolvedValue({
-        hasDataChanged: true,
+      jest.spyOn(task, 'hasMWsChanged').mockResolvedValue({
+        hasMWsChanged: true,
       });
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
         {
@@ -171,12 +170,12 @@ describe('SyncPrivateLocationMonitorsTask', () => {
           agentPolicyId: 'policy-1',
         },
       ]);
-      jest.spyOn(task, 'syncGlobalParams').mockResolvedValue(undefined);
+      jest.spyOn(task.deployPackagePolicies, 'syncPackagePolicies').mockResolvedValue(undefined);
 
       const result = await task.runTask({ taskInstance });
       expect(mockLogger.debug).toHaveBeenNthCalledWith(
         2,
-        '[SyncPrivateLocationMonitorsTask] Starting cleanup of duplicated package policies'
+        '[PrivateLocationCleanUpTask] Starting cleanup of duplicated package policies'
       );
 
       expect(mockLogger.debug).toHaveBeenNthCalledWith(
@@ -187,11 +186,10 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         4,
         '[SyncPrivateLocationMonitorsTask] Sync of private location monitors succeeded'
       );
-      expect(task.syncGlobalParams).toHaveBeenCalled();
+      expect(task.deployPackagePolicies.syncPackagePolicies).toHaveBeenCalled();
       expect(result.error).toBeUndefined();
       expect(result.state).toEqual({
         disableAutoSync: false,
-        lastTotalParams: 1,
         lastTotalMWs: 1,
         maxCleanUpRetries: 2,
         hasAlreadyDoneCleanup: false,
@@ -201,16 +199,16 @@ describe('SyncPrivateLocationMonitorsTask', () => {
 
     it('should not sync if data changed but no private locations exist', async () => {
       const taskInstance = getMockTaskInstance();
-      jest.spyOn(task, 'hasAnyDataChanged').mockResolvedValue({
-        hasDataChanged: true,
+      jest.spyOn(task, 'hasMWsChanged').mockResolvedValue({
+        hasMWsChanged: true,
       });
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([]);
-      jest.spyOn(task, 'syncGlobalParams');
+      jest.spyOn(task.deployPackagePolicies, 'syncPackagePolicies');
 
       await task.runTask({ taskInstance });
 
       expect(getPrivateLocationsModule.getPrivateLocations).toHaveBeenCalled();
-      expect(task.syncGlobalParams).not.toHaveBeenCalled();
+      expect(task.deployPackagePolicies.syncPackagePolicies).not.toHaveBeenCalled();
       expect(mockLogger.debug).toHaveBeenLastCalledWith(
         '[SyncPrivateLocationMonitorsTask] Sync of private location monitors succeeded'
       );
@@ -219,7 +217,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
     it('should handle errors during the run', async () => {
       const taskInstance = getMockTaskInstance();
       const error = new Error('Sync failed');
-      jest.spyOn(task, 'hasAnyDataChanged').mockRejectedValue(error);
+      jest.spyOn(task, 'hasMWsChanged').mockRejectedValue(error);
 
       const result = await task.runTask({ taskInstance });
 
@@ -230,7 +228,6 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(result.state).toEqual({
         disableAutoSync: false,
         lastStartedAt: expect.anything(),
-        lastTotalParams: 1,
         lastTotalMWs: 1,
         hasAlreadyDoneCleanup: false,
         maxCleanUpRetries: 2,
@@ -244,8 +241,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         ...getMockTaskInstance({ lastStartedAt: initialLastStartedAt }),
         startedAt,
       };
-      jest.spyOn(task, 'hasAnyDataChanged').mockResolvedValue({
-        hasDataChanged: false,
+      jest.spyOn(task, 'hasMWsChanged').mockResolvedValue({
+        hasMWsChanged: false,
       });
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
         {
@@ -263,98 +260,34 @@ describe('SyncPrivateLocationMonitorsTask', () => {
   });
 
   describe('hasAnyDataChanged', () => {
-    it('should return true if params changed', async () => {
-      jest
-        .spyOn(task, 'hasAnyParamChanged')
-        .mockResolvedValue({ hasParamsChanges: true, totalParams: 2 } as any);
-      jest
-        .spyOn(task, 'hasMWsChanged')
-        .mockResolvedValue({ hasMWsChanged: false, totalMWs: 1 } as any);
-      const taskState = { lastTotalParams: 1, lastTotalMWs: 1 };
-
-      const res = await task.hasAnyDataChanged({
-        taskState: taskState as any,
-        soClient: mockSoClient as any,
-        lastStartedAt: new Date().toISOString(),
-      });
-
-      expect(res.hasDataChanged).toBe(true);
-      expect(taskState.lastTotalParams).toBe(2);
-      expect(taskState.lastTotalMWs).toBe(1);
-    });
-
     it('should return true if maintenance windows changed', async () => {
-      jest
-        .spyOn(task, 'hasAnyParamChanged')
-        .mockResolvedValue({ hasParamsChanges: false, totalParams: 1 } as any);
       jest
         .spyOn(task, 'hasMWsChanged')
         .mockResolvedValue({ hasMWsChanged: true, totalMWs: 2 } as any);
 
-      const res = await task.hasAnyDataChanged({
-        taskState: { lastTotalParams: 1, lastTotalMWs: 1 } as any,
+      const res = await task.hasMWsChanged({
+        taskState: { lastTotalMWs: 1 } as any,
         soClient: mockSoClient as any,
         lastStartedAt: new Date().toISOString(),
       });
 
-      expect(res.hasDataChanged).toBe(true);
+      expect(res.hasMWsChanged).toBe(true);
     });
 
     it('should return false if nothing changed', async () => {
-      jest
-        .spyOn(task, 'hasAnyParamChanged')
-        .mockResolvedValue({ hasParamsChanges: false, totalParams: 1 } as any);
       jest
         .spyOn(task, 'hasMWsChanged')
         .mockResolvedValue({ hasMWsChanged: false, totalMWs: 1 } as any);
 
       const taskState = { lastTotalParams: 1, lastTotalMWs: 1 };
 
-      const res = await task.hasAnyDataChanged({
+      const res = await task.hasMWsChanged({
         taskState: taskState as any,
         soClient: mockSoClient as any,
         lastStartedAt: new Date().toISOString(),
       });
 
-      expect(res.hasDataChanged).toBe(false);
-    });
-  });
-
-  describe('hasAnyParamChanged', () => {
-    it('returns true if updated params are found', async () => {
-      mockSoClient.find
-        .mockResolvedValueOnce({ total: 1 } as any) // updated
-        .mockResolvedValueOnce({ total: 10 } as any); // total
-      const { hasParamsChanges } = await task.hasAnyParamChanged({
-        soClient: mockSoClient as any,
-        lastStartedAt: '...',
-        lastTotalParams: 10,
-      });
-      expect(hasParamsChanges).toBe(true);
-    });
-
-    it('returns true if total number of params changed', async () => {
-      mockSoClient.find
-        .mockResolvedValueOnce({ total: 0 } as any) // updated
-        .mockResolvedValueOnce({ total: 11 } as any); // total
-      const { hasParamsChanges } = await task.hasAnyParamChanged({
-        soClient: mockSoClient as any,
-        lastStartedAt: '...',
-        lastTotalParams: 10,
-      });
-      expect(hasParamsChanges).toBe(true);
-    });
-
-    it('returns false if no changes are detected', async () => {
-      mockSoClient.find
-        .mockResolvedValueOnce({ total: 0 } as any) // updated
-        .mockResolvedValueOnce({ total: 10 } as any); // total
-      const { hasParamsChanges } = await task.hasAnyParamChanged({
-        soClient: mockSoClient as any,
-        lastStartedAt: '...',
-        lastTotalParams: 10,
-      });
-      expect(hasParamsChanges).toBe(false);
+      expect(res.hasMWsChanged).toBe(false);
     });
   });
 
@@ -366,7 +299,9 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const { hasMWsChanged } = await task.hasMWsChanged({
         soClient: mockSoClient as any,
         lastStartedAt: '...',
-        lastTotalMWs: 5,
+        taskState: {
+          lastTotalMWs: 5,
+        } as any,
       });
       expect(hasMWsChanged).toBe(true);
     });
@@ -378,7 +313,9 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const { hasMWsChanged } = await task.hasMWsChanged({
         soClient: mockSoClient as any,
         lastStartedAt: '...',
-        lastTotalMWs: 5,
+        taskState: {
+          lastTotalMWs: 5,
+        } as any,
       });
       expect(hasMWsChanged).toBe(true);
     });
@@ -390,7 +327,9 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const { hasMWsChanged } = await task.hasMWsChanged({
         soClient: mockSoClient as any,
         lastStartedAt: '...',
-        lastTotalMWs: 5,
+        taskState: {
+          lastTotalMWs: 5,
+        } as any,
       });
       expect(hasMWsChanged).toBe(false);
     });
@@ -401,11 +340,11 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const mockAllPrivateLocations = [{ id: 'pl-1', name: 'Private Location 1' }];
 
       // Mocking the return of getAllMonitorConfigs
-      jest.spyOn(task, 'getAllMonitorConfigs').mockResolvedValue({
+      jest.spyOn(task.deployPackagePolicies, 'getAllMonitorConfigs').mockResolvedValue({
         configsBySpaces: {
           space1: [{ id: 'm1', locations: [{ name: 'pl-1', isServiceManaged: false }] }],
         },
-        spaceIds: new Set(['space1']),
+        monitorSpaceIds: new Set(['space1']),
         paramsBySpace: { space1: { global: 'param' } },
         maintenanceWindows: [],
       } as any);
@@ -414,12 +353,14 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         .spyOn(task, 'parseLocations')
         .mockReturnValue({ privateLocations: ['pl-1'], publicLocations: [] } as any);
 
-      await task.syncGlobalParams({
+      await task.deployPackagePolicies.syncPackagePolicies({
         allPrivateLocations: mockAllPrivateLocations as any,
         soClient: mockSoClient as any,
+        spaceIdToSync: 'space1',
+        encryptedSavedObjects: mockEncryptedSoClient as any,
       });
 
-      expect(task.getAllMonitorConfigs).toHaveBeenCalled();
+      expect(task.deployPackagePolicies.getAllMonitorConfigs).toHaveBeenCalled();
       expect(mockSyntheticsMonitorClient.privateLocationAPI.editMonitors).toHaveBeenCalledWith(
         expect.any(Array),
         mockAllPrivateLocations,
@@ -429,7 +370,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
     });
 
     it('should not call editMonitors if no monitors are on private locations', async () => {
-      jest.spyOn(task, 'getAllMonitorConfigs').mockResolvedValue({
+      jest.spyOn(task.deployPackagePolicies, 'getAllMonitorConfigs').mockResolvedValue({
         configsBySpaces: {
           space1: [{ id: 'm1', locations: [] }],
         },
@@ -443,9 +384,11 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         .spyOn(task, 'parseLocations')
         .mockReturnValue({ privateLocations: [], publicLocations: [] } as any);
 
-      await task.syncGlobalParams({
+      await task.deployPackagePolicies.syncPackagePolicies({
         allPrivateLocations: [],
         soClient: mockSoClient as any,
+        encryptedSavedObjects: mockEncryptedSoClient as any,
+        spaceIdToSync: 'space1',
       });
 
       expect(mockSyntheticsMonitorClient.privateLocationAPI.editMonitors).not.toHaveBeenCalled();
@@ -559,7 +502,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, state as any);
       expect(result.performCleanupSync).toBe(false);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as it has already been done once'
+        '[PrivateLocationCleanUpTask] Skipping cleanup of duplicated package policies as it has already been done once'
       );
     });
 
@@ -570,7 +513,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(state.hasAlreadyDoneCleanup).toBe(true);
       expect(state.maxCleanUpRetries).toBe(3);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as max retries have been reached'
+        '[PrivateLocationCleanUpTask] Skipping cleanup of duplicated package policies as max retries have been reached'
       );
     });
 
@@ -586,7 +529,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(state.hasAlreadyDoneCleanup).toBe(true);
       expect(state.maxCleanUpRetries).toBe(3);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as max retries have been reached'
+        '[PrivateLocationCleanUpTask] Skipping cleanup of duplicated package policies as max retries have been reached'
       );
     });
   });

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
@@ -6,11 +6,7 @@
  */
 
 import type { TaskManagerSetupContract } from '@kbn/task-manager-plugin/server/plugin';
-import type {
-  SavedObjectsClientContract,
-  SavedObjectsFindResult,
-} from '@kbn/core-saved-objects-api-server';
-import type { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
 import type {
   ConcreteTaskInstance,
@@ -20,33 +16,19 @@ import type {
 import moment from 'moment';
 import { MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE } from '@kbn/maintenance-windows-plugin/common';
 import pRetry from 'p-retry';
-import { getFilterForTestNowRun } from '../synthetics_service/private_location/clean_up_task';
-import { syntheticsMonitorSOTypes, syntheticsParamType } from '../../common/types/saved_objects';
-import { normalizeSecrets } from '../synthetics_service/utils';
-import type { PrivateLocationAttributes } from '../runtime_types/private_locations';
-import type {
-  EncryptedSyntheticsMonitorAttributes,
-  HeartbeatConfig,
-  MonitorFields,
-  SyntheticsMonitorWithSecretsAttributes,
-} from '../../common/runtime_types';
-import { MonitorConfigRepository } from '../services/monitor_config_repository';
+import { DeployPrivateLocationMonitors } from './deploy_private_location_monitors';
+import { cleanUpDuplicatedPackagePolicies } from './clean_up_duplicate_policies';
+import type { HeartbeatConfig } from '../../common/runtime_types';
 import type { SyntheticsMonitorClient } from '../synthetics_service/synthetics_monitor/synthetics_monitor_client';
 import { getPrivateLocations } from '../synthetics_service/get_private_locations';
 import type { SyntheticsServerSetup } from '../types';
-import {
-  formatHeartbeatRequest,
-  mixParamsWithGlobalParams,
-} from '../synthetics_service/formatters/public_formatters/format_configs';
-import { SyntheticsPrivateLocation } from '../synthetics_service/private_location/synthetics_private_location';
 
 const TASK_TYPE = 'Synthetics:Sync-Private-Location-Monitors';
 export const PRIVATE_LOCATIONS_SYNC_TASK_ID = `${TASK_TYPE}-single-instance`;
 const TASK_SCHEDULE = '60m';
 
-interface TaskState extends Record<string, unknown> {
+export interface SyncTaskState extends Record<string, unknown> {
   lastStartedAt: string;
-  lastTotalParams: number;
   lastTotalMWs: number;
   hasAlreadyDoneCleanup: boolean;
   maxCleanUpRetries: number;
@@ -54,14 +36,20 @@ interface TaskState extends Record<string, unknown> {
 }
 
 export type CustomTaskInstance = Omit<ConcreteTaskInstance, 'state'> & {
-  state: Partial<TaskState>;
+  state: Partial<SyncTaskState>;
 };
 
 export class SyncPrivateLocationMonitorsTask {
+  public deployPackagePolicies: DeployPrivateLocationMonitors;
   constructor(
     public serverSetup: SyntheticsServerSetup,
     public syntheticsMonitorClient: SyntheticsMonitorClient
-  ) {}
+  ) {
+    this.deployPackagePolicies = new DeployPrivateLocationMonitors(
+      serverSetup,
+      syntheticsMonitorClient
+    );
+  }
 
   registerTaskDefinition(taskManager: TaskManagerSetupContract) {
     taskManager.registerTaskDefinitions({
@@ -82,11 +70,11 @@ export class SyncPrivateLocationMonitorsTask {
     });
   }
 
-  public async runTask({
-    taskInstance,
-  }: {
-    taskInstance: CustomTaskInstance;
-  }): Promise<{ state: TaskState; error?: Error; schedule?: IntervalSchedule | RruleSchedule }> {
+  public async runTask({ taskInstance }: { taskInstance: CustomTaskInstance }): Promise<{
+    state: SyncTaskState;
+    error?: Error;
+    schedule?: IntervalSchedule | RruleSchedule;
+  }> {
     this.debugLog(
       `Syncing private location monitors, current task state is ${JSON.stringify(
         taskInstance.state
@@ -96,6 +84,7 @@ export class SyncPrivateLocationMonitorsTask {
     const {
       coreStart: { savedObjects },
       logger,
+      pluginsStart: { encryptedSavedObjects },
     } = this.serverSetup;
 
     let lastStartedAt = taskInstance.state.lastStartedAt;
@@ -117,16 +106,16 @@ export class SyncPrivateLocationMonitorsTask {
       );
 
       const allPrivateLocations = await getPrivateLocations(soClient, ALL_SPACES_ID);
-      const { hasDataChanged } = await this.hasAnyDataChanged({
+      const { hasMWsChanged } = await this.hasMWsChanged({
         soClient,
         taskState,
         lastStartedAt,
       });
 
       // Only perform syncGlobalParams if:
-      // - hasDataChanged and disableAutoSync is false
+      // - hasMWsChanged and disableAutoSync is false
       // - OR performCleanupSync is true (from cleanup), regardless of disableAutoSync
-      const dataChangeSync = hasDataChanged && !taskState.disableAutoSync;
+      const dataChangeSync = hasMWsChanged && !taskState.disableAutoSync;
       if (dataChangeSync || performCleanupSync) {
         if (dataChangeSync) {
           this.debugLog(`Syncing private location monitors because data has changed`);
@@ -135,9 +124,10 @@ export class SyncPrivateLocationMonitorsTask {
         }
 
         if (allPrivateLocations.length > 0) {
-          await this.syncGlobalParams({
+          await this.deployPackagePolicies.syncPackagePolicies({
             allPrivateLocations,
             soClient,
+            encryptedSavedObjects,
           });
         } else {
           this.debugLog(`No private locations found, skipping sync`);
@@ -170,12 +160,11 @@ export class SyncPrivateLocationMonitorsTask {
     };
   }
 
-  getNewTaskState({ taskInstance }: { taskInstance: CustomTaskInstance }): TaskState {
+  getNewTaskState({ taskInstance }: { taskInstance: CustomTaskInstance }): SyncTaskState {
     const startedAt = taskInstance.startedAt || new Date();
 
     return {
       lastStartedAt: startedAt.toISOString(),
-      lastTotalParams: taskInstance.state.lastTotalParams || 0,
       lastTotalMWs: taskInstance.state.lastTotalMWs || 0,
       hasAlreadyDoneCleanup: taskInstance.state.hasAlreadyDoneCleanup || false,
       maxCleanUpRetries: taskInstance.state.maxCleanUpRetries || 3,
@@ -200,117 +189,6 @@ export class SyncPrivateLocationMonitorsTask {
     this.debugLog(`Sync private location monitors task scheduled successfully`);
   };
 
-  hasAnyDataChanged = async ({
-    taskState,
-    soClient,
-    lastStartedAt,
-  }: {
-    taskState: TaskState;
-    soClient: SavedObjectsClientContract;
-    lastStartedAt: string;
-  }) => {
-    const { lastTotalParams, lastTotalMWs } = taskState;
-
-    const { totalParams, hasParamsChanges } = await this.hasAnyParamChanged({
-      soClient,
-      lastStartedAt,
-      lastTotalParams,
-    });
-    const { totalMWs, hasMWsChanged } = await this.hasMWsChanged({
-      soClient,
-      lastStartedAt,
-      lastTotalMWs,
-    });
-    taskState.lastTotalParams = totalParams;
-    taskState.lastTotalMWs = totalMWs;
-
-    const hasDataChanged = hasMWsChanged || hasParamsChanges;
-    return { hasDataChanged };
-  };
-
-  async syncGlobalParams({
-    allPrivateLocations,
-    soClient,
-  }: {
-    soClient: SavedObjectsClientContract;
-    allPrivateLocations: PrivateLocationAttributes[];
-  }) {
-    const { privateLocationAPI } = this.syntheticsMonitorClient;
-
-    const { configsBySpaces, paramsBySpace, spaceIds, maintenanceWindows } =
-      await this.getAllMonitorConfigs({
-        encryptedSavedObjects: this.serverSetup.encryptedSavedObjects,
-        soClient,
-      });
-
-    return this.serverSetup.fleet.runWithCache(async () => {
-      for (const spaceId of spaceIds) {
-        const privateConfigs: Array<{
-          config: HeartbeatConfig;
-          globalParams: Record<string, string>;
-        }> = [];
-        const monitors = configsBySpaces[spaceId];
-        this.debugLog(`Processing spaceId: ${spaceId}, monitors count: ${monitors?.length ?? 0}`);
-        if (!monitors) {
-          continue;
-        }
-        for (const monitor of monitors) {
-          const { privateLocations } = this.parseLocations(monitor);
-
-          if (privateLocations.length > 0) {
-            privateConfigs.push({ config: monitor, globalParams: paramsBySpace[spaceId] });
-          }
-        }
-        if (privateConfigs.length > 0) {
-          this.debugLog(
-            `Syncing private configs for spaceId: ${spaceId}, privateConfigs count: ${privateConfigs.length}`
-          );
-
-          await privateLocationAPI.editMonitors(
-            privateConfigs,
-            allPrivateLocations,
-            spaceId,
-            maintenanceWindows
-          );
-        } else {
-          this.debugLog(`No privateConfigs to sync for spaceId: ${spaceId}`);
-        }
-      }
-    });
-  }
-
-  async getAllMonitorConfigs({
-    soClient,
-    encryptedSavedObjects,
-  }: {
-    soClient: SavedObjectsClientContract;
-    encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
-  }) {
-    const { syntheticsService } = this.syntheticsMonitorClient;
-    const paramsBySpacePromise = syntheticsService.getSyntheticsParams({ spaceId: ALL_SPACES_ID });
-    const maintenanceWindowsPromise = syntheticsService.getMaintenanceWindows();
-    const monitorConfigRepository = new MonitorConfigRepository(
-      soClient,
-      encryptedSavedObjects.getClient()
-    );
-
-    const monitorsPromise = monitorConfigRepository.findDecryptedMonitors({
-      spaceId: ALL_SPACES_ID,
-    });
-
-    const [paramsBySpace, monitors, maintenanceWindows] = await Promise.all([
-      paramsBySpacePromise,
-      monitorsPromise,
-      maintenanceWindowsPromise,
-    ]);
-
-    return {
-      ...this.mixParamsWithMonitors(monitors, paramsBySpace),
-      paramsBySpace,
-      maintenanceWindows,
-    };
-  }
-
   parseLocations(config: HeartbeatConfig) {
     const { locations } = config;
 
@@ -320,94 +198,17 @@ export class SyncPrivateLocationMonitorsTask {
     return { privateLocations, publicLocations };
   }
 
-  mixParamsWithMonitors(
-    monitors: Array<SavedObjectsFindResult<SyntheticsMonitorWithSecretsAttributes>>,
-    paramsBySpace: Record<string, Record<string, string>>
-  ) {
-    const configsBySpaces: Record<string, HeartbeatConfig[]> = {};
-    const spaceIds = new Set<string>();
-
-    for (const monitor of monitors) {
-      const spaceId = monitor.namespaces?.[0];
-      if (!spaceId) {
-        continue;
-      }
-      spaceIds.add(spaceId);
-      const normalizedMonitor = normalizeSecrets(monitor).attributes as MonitorFields;
-      const { str: paramsString } = mixParamsWithGlobalParams(
-        paramsBySpace[spaceId],
-        normalizedMonitor
-      );
-
-      if (!configsBySpaces[spaceId]) {
-        configsBySpaces[spaceId] = [];
-      }
-
-      configsBySpaces[spaceId].push(
-        formatHeartbeatRequest(
-          {
-            spaceId,
-            monitor: normalizedMonitor,
-            configId: monitor.id,
-          },
-          paramsString
-        )
-      );
-    }
-
-    return { configsBySpaces, spaceIds };
-  }
-
-  async hasAnyParamChanged({
-    soClient,
-    lastStartedAt,
-    lastTotalParams,
-  }: {
-    soClient: SavedObjectsClientContract;
-    lastStartedAt: string;
-    lastTotalParams: number;
-  }) {
-    const { logger } = this.serverSetup;
-    const [editedParams, totalParams] = await Promise.all([
-      soClient.find({
-        type: syntheticsParamType,
-        perPage: 0,
-        namespaces: [ALL_SPACES_ID],
-        filter: `synthetics-param.updated_at > "${lastStartedAt}"`,
-        fields: [],
-      }),
-      soClient.find({
-        type: syntheticsParamType,
-        perPage: 0,
-        namespaces: [ALL_SPACES_ID],
-        fields: [],
-      }),
-    ]);
-    logger.debug(
-      `Found ${editedParams.total} params updated and ${totalParams.total} total params`
-    );
-    const updatedParams = editedParams.total;
-    const noOfParams = totalParams.total;
-
-    const hasParamsChanges = updatedParams > 0 || noOfParams !== lastTotalParams;
-
-    return {
-      hasParamsChanges,
-      updatedParams: editedParams.total,
-      totalParams: noOfParams,
-    };
-  }
-
   async hasMWsChanged({
     soClient,
     lastStartedAt,
-    lastTotalMWs,
+    taskState,
   }: {
     soClient: SavedObjectsClientContract;
     lastStartedAt: string;
-    lastTotalMWs: number;
+    taskState: SyncTaskState;
   }) {
     const { logger } = this.serverSetup;
+    const { lastTotalMWs } = taskState;
 
     const [editedMWs, totalMWs] = await Promise.all([
       soClient.find({
@@ -432,125 +233,23 @@ export class SyncPrivateLocationMonitorsTask {
 
     const hasMWsChanged = updatedMWs > 0 || noOfMWs !== lastTotalMWs;
 
+    taskState.lastTotalMWs = noOfMWs;
+
     return {
       hasMWsChanged,
-      updatedMWs,
-      totalMWs: noOfMWs,
     };
+  }
+
+  async cleanUpDuplicatedPackagePolicies(
+    soClient: SavedObjectsClientContract,
+    taskState: SyncTaskState
+  ) {
+    return await cleanUpDuplicatedPackagePolicies(this.serverSetup, soClient, taskState);
   }
 
   debugLog = (message: string) => {
     this.serverSetup.logger.debug(`[SyncPrivateLocationMonitorsTask] ${message}`);
   };
-
-  async cleanUpDuplicatedPackagePolicies(
-    soClient: SavedObjectsClientContract,
-    taskState: TaskState
-  ) {
-    let performCleanupSync = false;
-
-    if (taskState.hasAlreadyDoneCleanup) {
-      this.debugLog(
-        'Skipping cleanup of duplicated package policies as it has already been done once'
-      );
-      return { performCleanupSync };
-    } else if (taskState.maxCleanUpRetries <= 0) {
-      this.debugLog(
-        'Skipping cleanup of duplicated package policies as max retries have been reached'
-      );
-      taskState.hasAlreadyDoneCleanup = true;
-      taskState.maxCleanUpRetries = 3;
-      return { performCleanupSync };
-    }
-    this.debugLog('Starting cleanup of duplicated package policies');
-    const { fleet } = this.serverSetup.pluginsStart;
-    const { logger } = this.serverSetup;
-
-    try {
-      const esClient = this.serverSetup.coreStart?.elasticsearch?.client.asInternalUser;
-
-      const finder = soClient.createPointInTimeFinder<EncryptedSyntheticsMonitorAttributes>({
-        type: syntheticsMonitorSOTypes,
-        fields: ['id', 'name', 'locations', 'origin'],
-        namespaces: ['*'],
-      });
-
-      const privateLocationAPI = new SyntheticsPrivateLocation(this.serverSetup);
-
-      const expectedPackagePolicies = new Set<string>();
-      for await (const result of finder.find()) {
-        result.saved_objects.forEach((monitor) => {
-          monitor.attributes.locations?.forEach((location) => {
-            const spaceId = monitor.namespaces?.[0];
-            if (!location.isServiceManaged && spaceId) {
-              const policyId = privateLocationAPI.getPolicyId(
-                {
-                  origin: monitor.attributes.origin,
-                  id: monitor.id,
-                },
-                location.id,
-                spaceId
-              );
-              expectedPackagePolicies.add(policyId);
-            }
-          });
-        });
-      }
-
-      finder.close().catch(() => {});
-
-      const packagePoliciesKuery = getFilterForTestNowRun(true);
-
-      const policiesIterator = await fleet.packagePolicyService.fetchAllItemIds(soClient, {
-        kuery: packagePoliciesKuery,
-        spaceIds: ['*'],
-        perPage: 100,
-      });
-      const packagePoliciesToDelete: string[] = [];
-
-      for await (const packagePoliciesIds of policiesIterator) {
-        for (const packagePolicyId of packagePoliciesIds) {
-          if (!expectedPackagePolicies.has(packagePolicyId)) {
-            packagePoliciesToDelete.push(packagePolicyId);
-          }
-          // remove it from the set to mark it as found
-          expectedPackagePolicies.delete(packagePolicyId);
-        }
-      }
-
-      // if we have any to delete or any expected that were not found we need to perform a sync
-      performCleanupSync = packagePoliciesToDelete.length > 0 || expectedPackagePolicies.size > 0;
-
-      if (packagePoliciesToDelete.length > 0) {
-        logger.info(
-          ` [PrivateLocationCleanUpTask] Found ${
-            packagePoliciesToDelete.length
-          } duplicate package policies to delete: ${packagePoliciesToDelete.join(', ')}`
-        );
-        await fleet.packagePolicyService.delete(soClient, esClient, packagePoliciesToDelete, {
-          force: true,
-          spaceIds: ['*'],
-        });
-      }
-      taskState.hasAlreadyDoneCleanup = true;
-      taskState.maxCleanUpRetries = 3;
-      return { performCleanupSync };
-    } catch (e) {
-      taskState.maxCleanUpRetries -= 1;
-      if (taskState.maxCleanUpRetries <= 0) {
-        this.debugLog(
-          'Skipping cleanup of duplicated package policies as max retries have been reached'
-        );
-        taskState.hasAlreadyDoneCleanup = true;
-        taskState.maxCleanUpRetries = 3;
-      }
-      logger.error(
-        '[SyncPrivateLocationMonitorsTask] Error cleaning up duplicated package policies',
-        { error: e }
-      );
-      return { performCleanupSync };
-    }
-  }
 }
 
 export const runSynPrivateLocationMonitorsTaskSoon = async ({


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/241433
Fixes https://github.com/elastic/kibana/issues/241432

Only update the monitors in which params changes have been made, this is done via a one time task which gets triggered when some changes to global params to happens.

When some modification to params happens, we get `spaces` and pass that to the async task `paramsSpacesToSync`, this is a no-recurring task, which only runs once. The task uses the `paramsSpacesToSync` value from state and propagate global params values to monitors.

Global params triggers from the existing recurring task have been removed.


When params are updated, we call following API, since we aren't providing schedule, this will create one time instance of the task. paramsSpacesToSync is spaceIds of the params.

```

  await taskManager.ensureScheduled({
    id: `${TASK_TYPE}:${uuidv4()}`,
    params: {},
    taskType: TASK_TYPE,
    runAt: new Date(Date.now() + 3 * 1000),
    state: { paramsSpacesToSync },
  });
```


### Testing
Try adding/editing/deleting params in any space and it should task debug logs state, to enable logs

```
logging.loggers:
  - name: plugins.synthetics
    level: debug
    appenders: [console]
```
`paramsSpacesToSync` value will get logged as debug log via

`      this.debugLog(`current task state is ${JSON.stringify(taskInstance.state)}`);
`


Also following log will indicate correctly logged spaces of monitors

```
      this.debugLog(
        `Starting sync of private location monitors for spaces: ${Array.from(monitorSpaceIds).join(
          ', '
        )}`
      );
```

### Code changes
A new file deploy_private_location_monitors.ts has been added with `DeployPrivateLocationMonitors` which will handle updating package policies in relevant spaces 

A new task file has been added with task Synthetics:Sync-Global-Params-Private-Locations

<!--ONMERGE {"backportTargets":["8.19","9.2"]} ONMERGE-->