### PR TITLE
[ci] skip automated response actions test

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/automated_response_actions.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/automated_response_actions.cy.ts
@@ -20,7 +20,8 @@ import { createEndpointHost } from '../../tasks/create_endpoint_host';
 import { deleteAllLoadedEndpointData } from '../../tasks/delete_all_endpoint_data';
 import { enableAllPolicyProtections } from '../../tasks/endpoint_policy';
 
-describe(
+// FLAKY: https://github.com/elastic/kibana/issues/241197
+describe.skip(
   'Automated Response Actions',
   {
     tags: ['@ess', '@serverless'],


### PR DESCRIPTION
## Summary
This has been failing on main/9.2 - main was skipped earlier, this is skipping 9.2

re: https://github.com/elastic/kibana/issues/241197