### PR TITLE
[9.2] Use KIBANA_SOLUTIONS const (#239563)

### DIFF
--- a/src/platform/packages/private/kbn-repo-packages/modern/package.js
+++ b/src/platform/packages/private/kbn-repo-packages/modern/package.js
@@ -21,6 +21,11 @@ const { readPackageManifest } = require('./parse_package_manifest');
 const normalize = (path) => (Path.sep !== '/' ? path.split('\\').join('/') : path);
 
 /**
+ * @type {import('@kbn/projects-solutions-groups').KibanaSolution[]}
+ */
+const KIBANA_SOLUTIONS = ['search', 'security', 'observability', 'workplace_ai'];
+
+/**
  * Representation of a Package in the Kibana repository
  * @class
  */
@@ -236,10 +241,14 @@ class Package {
       // this conditional branch is the only one that applies in production
       group = this.manifest.group ?? 'common';
       // if the group is 'private-only', enforce it
-      //  BOOKMARK - List of Kibana solutions - FIXME we could use KIBANA_SOLUTIONS array here once we modernize this / get rid of Bazel
-      visibility = ['search', 'security', 'observability', 'chat'].includes(group)
-        ? 'private'
-        : this.manifest.visibility ?? 'shared';
+      // KIBANA_SOLUTIONS - List of Kibana solutions
+      const isSolution = Boolean(KIBANA_SOLUTIONS.find((solution) => solution === group));
+      if (!isSolution && !['platform', 'common'].includes(group)) {
+        throw new Error(
+          `Detected unknown group: ${group}, this module's definition of KIBANA_SOLUTIONS is probably outdated.`
+        );
+      }
+      visibility = isSolution ? 'private' : this.manifest.visibility ?? 'shared';
     }
 
     return { group, visibility };

--- a/src/platform/packages/private/kbn-repo-packages/modern/package.js
+++ b/src/platform/packages/private/kbn-repo-packages/modern/package.js
@@ -23,7 +23,7 @@ const normalize = (path) => (Path.sep !== '/' ? path.split('\\').join('/') : pat
 /**
  * @type {import('@kbn/projects-solutions-groups').KibanaSolution[]}
  */
-const KIBANA_SOLUTIONS = ['search', 'security', 'observability', 'workplace_ai'];
+const KIBANA_SOLUTIONS = ['search', 'security', 'observability', 'chat'];
 
 /**
  * Representation of a Package in the Kibana repository


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Use KIBANA_SOLUTIONS const (#239563)](https://github.com/elastic/kibana/pull/239563)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gerard Soldevila","email":"gerard.soldevila@elastic.co"},"sourceCommit":{"committedDate":"2025-10-28T13:16:24Z","message":"Use KIBANA_SOLUTIONS const (#239563)\n\n## Summary\n\nWe cannot directly import `@kbn/projects-solutions-groups` from\n`@kbn/repo-packages` (as it is a plain Javascript component and we're\nnot compiling any typescript at this stage), but we can enforce types\nthrough annotations, giving us a certain degree of coupling between the\ndefinitions.","sha":"73ec8eb4d7bc407cf984f7b14264dfc831a3b9b7","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:skip","v9.3.0"],"title":"Use KIBANA_SOLUTIONS const","number":239563,"url":"https://github.com/elastic/kibana/pull/239563","mergeCommit":{"message":"Use KIBANA_SOLUTIONS const (#239563)\n\n## Summary\n\nWe cannot directly import `@kbn/projects-solutions-groups` from\n`@kbn/repo-packages` (as it is a plain Javascript component and we're\nnot compiling any typescript at this stage), but we can enforce types\nthrough annotations, giving us a certain degree of coupling between the\ndefinitions.","sha":"73ec8eb4d7bc407cf984f7b14264dfc831a3b9b7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239563","number":239563,"mergeCommit":{"message":"Use KIBANA_SOLUTIONS const (#239563)\n\n## Summary\n\nWe cannot directly import `@kbn/projects-solutions-groups` from\n`@kbn/repo-packages` (as it is a plain Javascript component and we're\nnot compiling any typescript at this stage), but we can enforce types\nthrough annotations, giving us a certain degree of coupling between the\ndefinitions.","sha":"73ec8eb4d7bc407cf984f7b14264dfc831a3b9b7"}}]}] BACKPORT-->