### PR TITLE
[One Discover] Fix filter actions not closing cell popups

### DIFF
--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
@@ -76,6 +76,7 @@ export function CellActionsPopover({
   const makeFilterHandlerByOperator = (operator: '+' | '-') => () => {
     if (onFilter) {
       onFilter(property ?? name, rawValue, operator);
+      closePopover();
     }
   };
 

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/summary_column/summary_column.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/summary_column/summary_column.tsx
@@ -8,7 +8,7 @@
  */
 
 import { DataGridDensity, type DataGridCellValueElementProps } from '@kbn/unified-data-table';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { EuiButtonIcon, EuiCodeBlock, EuiFlexGroup, EuiText, EuiTitle } from '@elastic/eui';
 import { JsonCodeEditor } from '@kbn/unified-doc-viewer-plugin/public';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
@@ -128,6 +128,15 @@ export const SummaryCellPopover = (props: AllSummaryColumnProps) => {
   const { row, dataView, fieldFormats, onFilter, closePopover, share, core, isTracesSummary } =
     props;
 
+  const filterAndClosePopover: AllSummaryColumnProps['onFilter'] = useMemo(() => {
+    if (!onFilter) return undefined;
+
+    return (...params) => {
+      onFilter(...params);
+      closePopover();
+    };
+  }, [onFilter, closePopover]);
+
   const isTraceDoc = isTracesSummary && isTraceDocument(row);
 
   const resourceFields = createResourceFields(
@@ -180,7 +189,7 @@ export const SummaryCellPopover = (props: AllSummaryColumnProps) => {
           <EuiTitle size="xxs">
             <span>{isTraceDoc ? traceLabel : resourceLabel}</span>
           </EuiTitle>
-          <Resource fields={resourceFields} onFilter={onFilter} />
+          <Resource fields={resourceFields} onFilter={filterAndClosePopover} />
         </EuiFlexGroup>
       )}
       <EuiFlexGroup direction="column" gutterSize="s">

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
@@ -982,6 +982,7 @@ const InternalUnifiedDataTable = React.forwardRef<
           onResize,
           sortedColumns,
           disableCellActions,
+          dataGridRef,
         }),
       [
         cellActionsHandling,

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_columns.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_columns.tsx
@@ -7,9 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { MutableRefObject } from 'react';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import type { EuiListGroupItemProps, RenderCellValue } from '@elastic/eui';
+import type { EuiDataGridRefProps, EuiListGroupItemProps, RenderCellValue } from '@elastic/eui';
 import {
   type EuiDataGridColumn,
   type EuiDataGridColumnCellAction,
@@ -122,6 +123,7 @@ function buildEuiGridColumn({
   onResize,
   sortedColumns,
   disableCellActions = false,
+  dataGridRef,
 }: {
   numberOfColumns: number;
   columnName: string;
@@ -147,6 +149,7 @@ function buildEuiGridColumn({
   onResize: UnifiedDataTableProps['onResize'];
   sortedColumns?: EuiDataGridColumnSortingConfig[];
   disableCellActions?: boolean;
+  dataGridRef?: MutableRefObject<EuiDataGridRefProps | null>;
 }) {
   const dataViewField = getDataViewFieldOrCreateFromColumnMeta({
     dataView,
@@ -200,7 +203,8 @@ function buildEuiGridColumn({
             isPlainRecord,
             toastNotifications,
             valueToStringConverter,
-            onFilter
+            onFilter,
+            dataGridRef
           )
         : EMPTY_CELL_ACTIONS;
 
@@ -351,6 +355,7 @@ export function getEuiGridColumns({
   customGridColumnsConfiguration,
   onResize,
   sortedColumns,
+  dataGridRef,
 }: {
   columns: string[];
   columnsCellActions?: EuiDataGridColumnCellAction[][];
@@ -377,6 +382,7 @@ export function getEuiGridColumns({
   customGridColumnsConfiguration?: CustomGridColumnsConfiguration;
   onResize: UnifiedDataTableProps['onResize'];
   sortedColumns?: EuiDataGridColumnSortingConfig[];
+  dataGridRef?: MutableRefObject<EuiDataGridRefProps | null>;
 }) {
   const getColWidth = (column: string) => settings?.columns?.[column]?.width ?? 0;
   const headerRowHeight = deserializeHeaderRowHeight(headerRowHeightLines);
@@ -408,6 +414,7 @@ export function getEuiGridColumns({
       onResize,
       sortedColumns,
       disableCellActions,
+      dataGridRef,
     })
   );
 }

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/default_cell_actions.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/default_cell_actions.tsx
@@ -7,8 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { MutableRefObject } from 'react';
 import React, { useContext } from 'react';
-import type { EuiDataGridColumnCellActionProps } from '@elastic/eui';
+import type { EuiDataGridColumnCellActionProps, EuiDataGridRefProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { DataViewField } from '@kbn/data-views-plugin/public';
 import type { ToastsStart } from '@kbn/core/public';
@@ -23,13 +24,15 @@ function onFilterCell(
   rowIndex: EuiDataGridColumnCellActionProps['rowIndex'],
   columnId: EuiDataGridColumnCellActionProps['columnId'],
   mode: '+' | '-',
-  field: DataViewField
+  field: DataViewField,
+  dataGridRef?: MutableRefObject<EuiDataGridRefProps | null>
 ) {
   const row = context.getRowByIndex(rowIndex);
 
   if (row && field && context.onFilter) {
     const value = row.flattened[columnId];
     context.onFilter(field, value, mode);
+    dataGridRef?.current?.closeCellPopover();
   }
 }
 
@@ -44,10 +47,12 @@ export const FilterInBtn = ({
   cellActionProps: { Component, rowIndex, columnId },
   field,
   isPlainRecord,
+  dataGridRef,
 }: {
   cellActionProps: EuiDataGridColumnCellActionProps;
   field: DataViewField;
   isPlainRecord: boolean | undefined;
+  dataGridRef?: MutableRefObject<EuiDataGridRefProps | null>;
 }) => {
   const context = useContext(UnifiedDataTableContext);
   const filteringDisabled =
@@ -60,7 +65,7 @@ export const FilterInBtn = ({
   return (
     <Component
       onClick={() => {
-        onFilterCell(context, rowIndex, columnId, '+', field);
+        onFilterCell(context, rowIndex, columnId, '+', field, dataGridRef);
       }}
       iconType="plusInCircle"
       aria-label={buttonTitle}
@@ -79,10 +84,12 @@ export const FilterOutBtn = ({
   cellActionProps: { Component, rowIndex, columnId },
   field,
   isPlainRecord,
+  dataGridRef,
 }: {
   cellActionProps: EuiDataGridColumnCellActionProps;
   field: DataViewField;
   isPlainRecord: boolean | undefined;
+  dataGridRef?: MutableRefObject<EuiDataGridRefProps | null>;
 }) => {
   const context = useContext(UnifiedDataTableContext);
   const filteringDisabled =
@@ -95,7 +102,7 @@ export const FilterOutBtn = ({
   return (
     <Component
       onClick={() => {
-        onFilterCell(context, rowIndex, columnId, '-', field);
+        onFilterCell(context, rowIndex, columnId, '-', field, dataGridRef);
       }}
       iconType="minusInCircle"
       aria-label={buttonTitle}
@@ -147,7 +154,8 @@ export function buildCellActions(
   isPlainRecord: boolean | undefined,
   toastNotifications: ToastsStart,
   valueToStringConverter: ValueToStringConverter,
-  onFilter?: DocViewFilterFn
+  onFilter?: DocViewFilterFn,
+  dataGridRef?: MutableRefObject<EuiDataGridRefProps | null>
 ) {
   return [
     ...(onFilter && field.filterable
@@ -157,12 +165,14 @@ export function buildCellActions(
               cellActionProps,
               field,
               isPlainRecord,
+              dataGridRef,
             }),
           (cellActionProps: EuiDataGridColumnCellActionProps) =>
             FilterOutBtn({
               cellActionProps,
               field,
               isPlainRecord,
+              dataGridRef,
             }),
         ]
       : []),


### PR DESCRIPTION
Closes #215293 

## Summary

###  Discover
This PR introduces updates on how we handle cell popover visibility after applying filtering quick actions (filter in/out) for the `UnifiedDataTable` in Discover. 

Up until now, applying filter actions wouldn't close expanded cell popovers. For filter in actions, this provides an inconsistent UX as the popover would sometimes remain open while other times it would close after the filter is applied

https://github.com/user-attachments/assets/237161eb-625e-41ee-adec-f41f28cd9236

For filter out actions, the situation is even worse as the popover will remain open even though the cell it belongs to is no longer in view  (as we just filtered it out!)


https://github.com/user-attachments/assets/d12b566b-d0fd-4180-a289-44d63bb5fb1b

### Contextual Components

This fix must also pay special attention to the observability solution view. In this mode, the summary column is enhanced with, among other things, resource badge components that allow applying filtering actions scoped to the specific resource. When applying these filters the issue is much like before where no cell popovers are closed after applying filtering actions


https://github.com/user-attachments/assets/d47d708b-a87e-4858-8739-2ac6b5402ac4

## Fixes
### Discover
After the fix in this PR, this is how the UX for regular discover works. Notice how the popover is closed right after pressing the quick action button, in both filter in and out cases and without inconsistent behaviour.

https://github.com/user-attachments/assets/43f954de-e38b-4549-ac18-daa1881c1455

### Contextual Components
For contextual components too, notice how both the badge popover and the cell popover itself are closed after applying the quick action

https://github.com/user-attachments/assets/79920b91-7be7-41f4-b769-e0f15aa0ff7a



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->