### PR TITLE
[9.1] [Actions] set max limit on size of emails sent (#239572)

### DIFF
--- a/docs/reference/cloud/elastic-cloud-kibana-settings.md
+++ b/docs/reference/cloud/elastic-cloud-kibana-settings.md
@@ -54,6 +54,15 @@ If you want to allow anonymous authentication in Kibana, these settings are supp
 
 You can configure the following X-Pack settings from the Kibana **User Settings** editor.
 
+### Version 8.19.7+, 9.1.7+, 9.2.1+,9.3+ [ec_version_8_19_7_9_1_7_9_2_1_9_3]
+- {applies_to}`stack: ga 9.3.0`
+- {applies_to}`stack: ga 9.2.1`
+- {applies_to}`stack: ga 9.1.7`
+- {applies_to}`stack: ga 8.19.7`
+
+`xpack.actions.email.maximum_body_length`
+:    The maximum length of an email body in bytes.  Values longer than this length will be truncated.  The default is 25MB, the maximum is 25MB.
+
 ### Version 9.1+ [ec_version_9_1]
 ```{applies_to}
 stack: ga 9.1

--- a/docs/reference/configuration-reference/alerting-settings.md
+++ b/docs/reference/configuration-reference/alerting-settings.md
@@ -151,6 +151,9 @@ $$$action-config-email-domain-allowlist$$$
 
     Only "to", "cc", or "bcc" email addresses that match the listed patterns will be accepted. For example, "admin-network@company.org" or "sales-north@example.com".
 
+`xpack.actions.email.maximum_body_length` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}") {applies_to}`stack: ga 9.3.0` {applies_to}`stack: ga 9.2.1` {applies_to}`stack: ga 9.1.7` {applies_to}`stack: ga 8.19.7`
+:    The maximum length of an email body in bytes.  Values longer than this length will be truncated.  The default is 25MB, the maximum is 25MB.
+
 `xpack.actions.email.services.ses.host` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}") {applies_to}`stack: ga 9.1`
 :    The SMTP endpoint for an Amazon Simple Email Service (SES) service provider that can be used by email connectors.
 

--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -212,6 +212,7 @@ kibana_vars=(
     xpack.actions.allowedHosts
     xpack.actions.customHostSettings
     xpack.actions.email.domain_allowlist
+    xpack.actions.email.maximum_body_length
     xpack.actions.email.services.ses.host
     xpack.actions.email.services.ses.port
     xpack.actions.email.services.enabled

--- a/x-pack/platform/plugins/shared/actions/common/index.ts
+++ b/x-pack/platform/plugins/shared/actions/common/index.ts
@@ -78,3 +78,9 @@ export const ACTIONS_FEATURE_ID = 'actions';
 export const DEFAULT_MICROSOFT_EXCHANGE_URL = 'https://login.microsoftonline.com';
 export const DEFAULT_MICROSOFT_GRAPH_API_URL = 'https://graph.microsoft.com/v1.0';
 export const DEFAULT_MICROSOFT_GRAPH_API_SCOPE = 'https://graph.microsoft.com/.default';
+
+// Default == max, which we will change later when we have more
+// information on email sizes.  Greater than 25MB does seem to cause
+// OOMs, so that seems like a safe limit for now.
+export const MAX_EMAIL_BODY_LENGTH = 25 * 1000 * 1000; // 25MB
+export const DEFAULT_EMAIL_BODY_LENGTH = MAX_EMAIL_BODY_LENGTH;

--- a/x-pack/platform/plugins/shared/actions/server/actions_config.mock.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_config.mock.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_MICROSOFT_EXCHANGE_URL,
   DEFAULT_MICROSOFT_GRAPH_API_SCOPE,
   DEFAULT_MICROSOFT_GRAPH_API_URL,
+  DEFAULT_EMAIL_BODY_LENGTH,
 } from '../common';
 import type { ActionsConfigurationUtilities } from './actions_config';
 
@@ -45,6 +46,7 @@ const createActionsConfigMock = () => {
     }),
     getAwsSesConfig: jest.fn().mockReturnValue(null),
     getEnabledEmailServices: jest.fn().mockReturnValue(['*']),
+    getMaxEmailBodyLength: jest.fn().mockReturnValue(DEFAULT_EMAIL_BODY_LENGTH),
   };
   return mocked;
 };

--- a/x-pack/platform/plugins/shared/actions/server/actions_config.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_config.test.ts
@@ -12,6 +12,8 @@ import {
   DEFAULT_MICROSOFT_EXCHANGE_URL,
   DEFAULT_MICROSOFT_GRAPH_API_SCOPE,
   DEFAULT_MICROSOFT_GRAPH_API_URL,
+  MAX_EMAIL_BODY_LENGTH,
+  DEFAULT_EMAIL_BODY_LENGTH,
 } from '../common';
 import {
   getActionsConfigurationUtilities,
@@ -517,6 +519,52 @@ describe('validateEmailAddresses()', () => {
     expect(message).toMatchInlineSnapshot(
       `"not valid emails: invalid-email-address, (garbage); not allowed emails: bob@elastic.co, jim@elastic.co, hal@bad.com, lou@notgood.org"`
     );
+  });
+});
+
+describe('getMaxEmailBodyLength() ', () => {
+  function getAcu(maxEmailBodyLength?: number) {
+    const actionsConfig =
+      maxEmailBodyLength == null
+        ? defaultActionsConfig
+        : {
+            ...defaultActionsConfig,
+            email: {
+              maximum_body_length: maxEmailBodyLength,
+            },
+          };
+
+    return getActionsConfigurationUtilities(actionsConfig);
+  }
+
+  test('default value is as expected', async () => {
+    const acu = getAcu();
+    const actual = acu.getMaxEmailBodyLength();
+    expect(actual).toBe(DEFAULT_EMAIL_BODY_LENGTH);
+  });
+
+  test('value coerced to minimum of range if below', async () => {
+    const acu = getAcu(-100);
+    const actual = acu.getMaxEmailBodyLength();
+    expect(actual).toBe(0);
+  });
+
+  test('value of 0 accepted', async () => {
+    const acu = getAcu(0);
+    const actual = acu.getMaxEmailBodyLength();
+    expect(actual).toBe(0);
+  });
+
+  test('value within range is passed through', async () => {
+    const acu = getAcu(100);
+    const actual = acu.getMaxEmailBodyLength();
+    expect(actual).toBe(100);
+  });
+
+  test('value coerced to maximum of range if above', async () => {
+    const acu = getAcu(MAX_EMAIL_BODY_LENGTH + 100);
+    const actual = acu.getMaxEmailBodyLength();
+    expect(actual).toBe(MAX_EMAIL_BODY_LENGTH);
   });
 });
 

--- a/x-pack/platform/plugins/shared/actions/server/actions_config.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_config.ts
@@ -18,7 +18,12 @@ import { ActionTypeDisabledError } from './lib';
 import type { AwsSesConfig, ProxySettings, ResponseSettings, SSLSettings } from './types';
 import { getSSLSettingsFromConfig } from './lib/get_node_ssl_options';
 import type { ValidateEmailAddressesOptions } from '../common';
-import { validateEmailAddresses, invalidEmailsAsMessage } from '../common';
+import {
+  validateEmailAddresses,
+  invalidEmailsAsMessage,
+  DEFAULT_EMAIL_BODY_LENGTH,
+  MAX_EMAIL_BODY_LENGTH,
+} from '../common';
 export { AllowedHosts, EnabledActionTypes } from './config';
 
 enum AllowListingField {
@@ -64,6 +69,7 @@ export interface ActionsConfigurationUtilities {
   };
   getAwsSesConfig: () => AwsSesConfig;
   getEnabledEmailServices: () => string[];
+  getMaxEmailBodyLength: () => number;
 }
 
 function allowListErrorMessage(field: AllowListingField, value: string) {
@@ -261,6 +267,11 @@ export function getActionsConfigurationUtilities(
       }
 
       return ['*'];
+    },
+    getMaxEmailBodyLength() {
+      const configuredLength = config.email?.maximum_body_length ?? DEFAULT_EMAIL_BODY_LENGTH;
+      const nonNegativeLength = Math.max(0, configuredLength);
+      return Math.min(nonNegativeLength, MAX_EMAIL_BODY_LENGTH);
     },
   };
 }

--- a/x-pack/platform/plugins/shared/actions/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/config.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { MAX_EMAIL_BODY_LENGTH } from '../common';
 import type { ActionsConfig } from './config';
 import { configSchema, getValidatedConfig } from './config';
 import type { Logger } from '@kbn/core/server';
@@ -248,6 +249,74 @@ describe('config validation', () => {
     config.email = { domain_allowlist: ['a.com', 'b.c.com', 'd.e.f.com'] };
     result = configSchema.validate(config);
     expect(result.email?.domain_allowlist).toEqual(['a.com', 'b.c.com', 'd.e.f.com']);
+  });
+
+  describe('email.maximum_body_length', () => {
+    // note, this just tests the current behavior, but if we change so the
+    // default was ALWAYS the defined default, it's fine to change it.
+    test('validates that the value is undefined with no email parent', () => {
+      const validatedConfig = configSchema.validate({});
+      expect(validatedConfig.email?.maximum_body_length).toBe(undefined);
+    });
+
+    test('validates with value 0', () => {
+      const validatedConfig = configSchema.validate({
+        email: {
+          maximum_body_length: 0,
+        },
+      });
+      expect(validatedConfig.email?.maximum_body_length).toBe(0);
+    });
+
+    test('validates valid value set', () => {
+      const validatedConfig = configSchema.validate({
+        email: {
+          maximum_body_length: 42,
+        },
+      });
+      expect(validatedConfig.email?.maximum_body_length).toBe(42);
+    });
+
+    test('throws error on negative value', () => {
+      const config = {
+        email: {
+          maximum_body_length: -42,
+        },
+      };
+
+      expect(() => configSchema.validate(config)).toThrowErrorMatchingInlineSnapshot(
+        `"[email.maximum_body_length]: Value must be equal to or greater than [0]."`
+      );
+    });
+
+    test('logs warning when value is greater than max', () => {
+      const config = {
+        email: {
+          maximum_body_length: MAX_EMAIL_BODY_LENGTH + 1,
+        },
+      };
+      const validatedConfig = getValidatedConfig(mockLogger, configSchema.validate(config));
+
+      // value is still > max here, fixed in actionConfigUtils getMaxEmailBodyLength()
+      expect(validatedConfig.email?.maximum_body_length).toBe(MAX_EMAIL_BODY_LENGTH + 1);
+      expect(mockLogger.warn.mock.calls[0][0]).toBe(
+        'The configuration xpack.actions.email.maximum_body_length value 25000001 is larger than the maximum setting of 25000000 and the maximum value will be used instead'
+      );
+    });
+
+    test('logs warning on zero value', () => {
+      const config = {
+        email: {
+          maximum_body_length: 0,
+        },
+      };
+      const validatedConfig = getValidatedConfig(mockLogger, configSchema.validate(config));
+
+      expect(validatedConfig.email?.maximum_body_length).toBe(0);
+      expect(mockLogger.warn.mock.calls[0][0]).toBe(
+        'The configuration xpack.actions.email.maximum_body_length is set to 0 and will result in sending empty emails'
+      );
+    });
   });
 
   test('validates xpack.actions.webhook', () => {

--- a/x-pack/platform/plugins/shared/actions/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/config.test.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { MAX_EMAIL_BODY_LENGTH } from '../common';
 import type { ActionsConfig } from './config';
 import { configSchema, getValidatedConfig } from './config';
 import type { Logger } from '@kbn/core/server';

--- a/x-pack/platform/plugins/shared/actions/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/config.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { MAX_EMAIL_BODY_LENGTH } from '../common';
 import type { ActionsConfig } from './config';
 import { configSchema, getValidatedConfig } from './config';
 import type { Logger } from '@kbn/core/server';

--- a/x-pack/platform/test/alerting_api_integration/common/config.ts
+++ b/x-pack/platform/test/alerting_api_integration/common/config.ts
@@ -39,6 +39,7 @@ interface CreateTestConfigOptions {
   disabledRuleTypes?: string[];
   enabledRuleTypes?: string[];
   maxAlerts?: number;
+  emailMaximumBodyLength?: number;
 }
 
 // test.not-enabled is specifically not enabled
@@ -307,6 +308,11 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
         ? []
         : [`--xpack.alerting.enabledRuleTypes=${JSON.stringify(options.enabledRuleTypes)}`];
 
+    const emailMaximumBodyLengthSetting =
+      options.emailMaximumBodyLength == null
+        ? []
+        : [`--xpack.actions.email.maximum_body_length=${options.emailMaximumBodyLength}`];
+
     return {
       testConfigCategory: ScoutTestRunConfigCategory.API_TEST,
       testFiles: testFiles ? testFiles : [require.resolve(`../${name}/tests/`)],
@@ -358,6 +364,7 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
           ...maxScheduledPerMinuteSettings,
           ...disabledRuleTypesSetting,
           ...enabledRuleTypesSetting,
+          ...emailMaximumBodyLengthSetting,
           '--xpack.eventLog.logEntries=true',
           `--xpack.task_manager.unsafe.exclude_task_types=${JSON.stringify([
             'actions:test.excluded',

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config.ts
@@ -7,6 +7,8 @@
 
 import { createTestConfig } from '../../common/config';
 
+export const EmailMaximumBodyLength = 10000;
+
 export default createTestConfig('security_and_spaces', {
   disabledPlugins: [],
   license: 'trial',
@@ -20,4 +22,5 @@ export default createTestConfig('security_and_spaces', {
     'crowdstrikeConnectorOn',
     'microsoftDefenderEndpointOn',
   ],
+  emailMaximumBodyLength: EmailMaximumBodyLength,
 });

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner.ts
@@ -6,6 +6,7 @@
  */
 
 import { createTestConfig } from '../../common/config';
+import { EmailMaximumBodyLength } from './config';
 
 export default createTestConfig('security_and_spaces', {
   disabledPlugins: [],
@@ -20,4 +21,5 @@ export default createTestConfig('security_and_spaces', {
     'crowdstrikeConnectorOn',
     'microsoftDefenderEndpointOn',
   ],
+  emailMaximumBodyLength: EmailMaximumBodyLength,
 });

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/email.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/email.ts
@@ -14,6 +14,7 @@ import {
 import type { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
 import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
+import { EmailMaximumBodyLength } from '../../../config';
 
 export default function emailTest({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
@@ -601,6 +602,58 @@ export default function emailTest({ getService }: FtrProviderContext) {
           },
         })
         .expect(200);
+    });
+
+    it('should trim large message parameters', async () => {
+      const longLength = EmailMaximumBodyLength * 2;
+      const longString = ''.padEnd(longLength, 'x');
+      await supertest
+        .post(`/api/actions/connector/${createdActionId}/_execute`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          params: {
+            to: ['kibana-action-test@elastic.co'],
+            subject: 'email-subject',
+            message: longString,
+          },
+        })
+        .expect(200)
+        .then(async (resp: any) => {
+          const { text, html } = resp.body.data.message;
+          expect(text.length).lessThan(longLength);
+          expect(html.length).lessThan(longLength);
+          const startMessageRegExpText =
+            /^Your message's length of 20000 exceeded the 10000 bytes limit that is set for the connector/;
+          const startMessageRegExpHtml =
+            /^<p>Your message's length of 20000 exceeded the 10000 bytes limit that is set for the connector/;
+          expect(text).match(startMessageRegExpText);
+          expect(html).match(startMessageRegExpHtml);
+        });
+    });
+
+    it('should trim large messageHTML parameters', async () => {
+      const longLength = EmailMaximumBodyLength * 2;
+      const longString = ''.padEnd(longLength, 'x');
+      await supertest
+        .post(`/api/alerts_fixture/${createdActionId}/_execute_connector_as_notification`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          params: {
+            to: ['kibana-action-test@elastic.co'],
+            subject: 'email-subject',
+            message: 'hallo',
+            messageHTML: longString,
+          },
+        })
+        .expect(200)
+        .then(async (resp: any) => {
+          const { text, html } = resp.body.data.message;
+          expect(text).to.match(/^hallo/);
+          expect(`${html}`.length).to.be.lessThan(longLength);
+          const startMessageRegExpHtml =
+            /^Your message's length of 20000 exceeded the 10000 bytes limit that is set for the connector /;
+          expect(html).to.match(startMessageRegExpHtml);
+        });
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Actions] set max limit on size of emails sent (#239572)](https://github.com/elastic/kibana/pull/239572)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2025-10-31T13:25:59Z","message":"[Actions] set max limit on size of emails sent (#239572)\n\nresolves https://github.com/elastic/kibana/issues/235127\n\n## Summary\n\n## ToDo\n\n- [ ] issue to update cloud for new config setting\n- [ ] issue to lower default value based on existing usage\n- [ ] issue to surface error in rule execution UX\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"21e34eabc452db0269eb48a0dcfc471f8d2e96a5","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Actions","Team:ResponseOps","backport missing","Feature:Actions/ConnectorTypes","backport:all-open","v9.3.0"],"title":"[Actions] set max limit on size of emails sent","number":239572,"url":"https://github.com/elastic/kibana/pull/239572","mergeCommit":{"message":"[Actions] set max limit on size of emails sent (#239572)\n\nresolves https://github.com/elastic/kibana/issues/235127\n\n## Summary\n\n## ToDo\n\n- [ ] issue to update cloud for new config setting\n- [ ] issue to lower default value based on existing usage\n- [ ] issue to surface error in rule execution UX\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"21e34eabc452db0269eb48a0dcfc471f8d2e96a5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239572","number":239572,"mergeCommit":{"message":"[Actions] set max limit on size of emails sent (#239572)\n\nresolves https://github.com/elastic/kibana/issues/235127\n\n## Summary\n\n## ToDo\n\n- [ ] issue to update cloud for new config setting\n- [ ] issue to lower default value based on existing usage\n- [ ] issue to surface error in rule execution UX\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"21e34eabc452db0269eb48a0dcfc471f8d2e96a5"}},{"url":"https://github.com/elastic/kibana/pull/241460","number":241460,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->