### PR TITLE
[Observability Onboarding] Copy update for landing page messages

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.test.tsx
@@ -84,7 +84,7 @@ describe('OnboardingFlowForm', () => {
       renderWithProviders(<OnboardingFlowForm />);
 
       expect(
-        screen.getByText(/Monitor your host and the services running on it, set-up SLO/)
+        screen.getByText(/Track your host and its services by setting up SLOs/)
       ).toBeInTheDocument();
     });
 
@@ -92,7 +92,7 @@ describe('OnboardingFlowForm', () => {
       renderWithProviders(<OnboardingFlowForm />);
 
       expect(
-        screen.getByText(/Observe your Kubernetes cluster.*using logs, metrics, traces/)
+        screen.getByText(/Monitor your Kubernetes cluster and container workloads using logs/)
       ).toBeInTheDocument();
     });
 
@@ -164,7 +164,7 @@ describe('OnboardingFlowForm', () => {
 
       expect(screen.getByText('Cloud')).toBeInTheDocument();
       expect(
-        screen.getByText(/Ingest telemetry data from the Cloud for your applications/)
+        screen.getByText(/Ingest telemetry data from your cloud services to better understand/)
       ).toBeInTheDocument();
     });
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
@@ -67,7 +67,7 @@ export const OnboardingFlowForm: FunctionComponent = () => {
       'xpack.observability_onboarding.onboardingFlowForm.applicationDescription',
       {
         defaultMessage:
-          'Monitor the frontend and backend application that you have developed, set-up synthetic monitors',
+          'Monitor your frontend and backend applications, set up synthetic monitors, and track application performance across your stack',
       }
     ),
     logos: ['opentelemetry', 'java', 'ruby', 'dotnet'],
@@ -83,7 +83,7 @@ export const OnboardingFlowForm: FunctionComponent = () => {
       description: metricsOnboardingEnabled
         ? i18n.translate('xpack.observability_onboarding.onboardingFlowForm.hostDescription', {
             defaultMessage:
-              'Monitor your host and the services running on it, set-up SLO, get alerted, remediate performance issues',
+              'Track your host and its services by setting up SLOs, receiving alerts, and remediating performance issues',
           })
         : i18n.translate(
             'xpack.observability_onboarding.logsEssential.onboardingFlowForm.hostDescription',
@@ -105,7 +105,7 @@ export const OnboardingFlowForm: FunctionComponent = () => {
             'xpack.observability_onboarding.onboardingFlowForm.kubernetesDescription',
             {
               defaultMessage:
-                'Observe your Kubernetes cluster, and your container workloads using logs, metrics, traces and profiling data',
+                'Monitor your Kubernetes cluster and container workloads using logs, metrics, traces, and profiling data',
             }
           )
         : i18n.translate(
@@ -126,7 +126,8 @@ export const OnboardingFlowForm: FunctionComponent = () => {
       description: i18n.translate(
         'xpack.observability_onboarding.onboardingFlowForm.cloudDescription',
         {
-          defaultMessage: 'Ingest telemetry data from the Cloud for your applications and services',
+          defaultMessage:
+            'Ingest telemetry data from your cloud services to better understand application behavior and ensure service availability',
         }
       ),
       logos: ['azure', 'aws', 'gcp'],

--- a/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/README.md
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/README.md
@@ -29,16 +29,13 @@ Some tests are designed to run concurrently (preferred option):
 
 ```bash
 // ESS
-npx playwright test --config x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel_playwright.config.ts
---project=local --grep @ess
+npx playwright test --config x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel.playwright.config.ts --project=local --grep @ess
 
 // Serverless
-npx playwright test --config x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel_playwright.config.ts
---project=local --grep @svlOblt
+npx playwright test --config x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel.playwright.config.ts --project=local --grep @svlOblt
 
 // Serverless Logs-Essentials
-npx playwright test --config x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel_playwright.config.ts
---project=local --grep @svlLogsEssentials
+npx playwright test --config x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel.playwright.config.ts --project=local --grep @svlLogsEssentials
 ```
 
 You can also run tests in UI mode by passing the `--ui` flag to the test command:


### PR DESCRIPTION
Closes #241747 
## Summary

Updates messages in observability onboarding landing page when metrics onboarding is enabled.

<img width="1236" height="772" alt="Screenshot 2025-11-04 at 11 44 03" src="https://github.com/user-attachments/assets/75d9b5a0-e9f0-4e00-ac8d-99c5fdb85775" />



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->