### PR TITLE
[8.19] [Actions] set max limit on size of emails sent (#239572)

### DIFF
--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -130,6 +130,9 @@ to validate the server.
 The contents of one or more PEM-encoded certificate files in multiline format.
 This configuration can be used for environments where the files cannot be made available.
 
+[[action-config-email-maximum-body-length]] `xpack.actions.email.maximum_body_length`  {ess-icon}::
+The maximum length of an email body in bytes. Values longer than this length will be truncated. The default is 25MB, the maximum is 25MB.
+
 [[action-config-email-domain-allowlist]] `xpack.actions.email.domain_allowlist`  {ess-icon}::
 A list of allowed email domains which can be used with the email connector. When this setting is not used, all email domains are allowed. When this setting is used, if any email is attempted to be sent that (a) includes an addressee with an email domain that is not in the allowlist, or (b) includes a from address domain that is not in the allowlist, it will fail with a message indicating the email is not allowed.
 +

--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -216,6 +216,7 @@ kibana_vars=(
     xpack.actions.allowedHosts
     xpack.actions.customHostSettings
     xpack.actions.email.domain_allowlist
+    xpack.actions.email.maximum_body_length
     xpack.actions.email.services.ses.host
     xpack.actions.email.services.ses.port
     xpack.actions.email.services.enabled

--- a/x-pack/platform/plugins/shared/actions/common/index.ts
+++ b/x-pack/platform/plugins/shared/actions/common/index.ts
@@ -78,3 +78,9 @@ export const ACTIONS_FEATURE_ID = 'actions';
 export const DEFAULT_MICROSOFT_EXCHANGE_URL = 'https://login.microsoftonline.com';
 export const DEFAULT_MICROSOFT_GRAPH_API_URL = 'https://graph.microsoft.com/v1.0';
 export const DEFAULT_MICROSOFT_GRAPH_API_SCOPE = 'https://graph.microsoft.com/.default';
+
+// Default == max, which we will change later when we have more
+// information on email sizes.  Greater than 25MB does seem to cause
+// OOMs, so that seems like a safe limit for now.
+export const MAX_EMAIL_BODY_LENGTH = 25 * 1000 * 1000; // 25MB
+export const DEFAULT_EMAIL_BODY_LENGTH = MAX_EMAIL_BODY_LENGTH;

--- a/x-pack/platform/plugins/shared/actions/server/actions_config.mock.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_config.mock.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_MICROSOFT_EXCHANGE_URL,
   DEFAULT_MICROSOFT_GRAPH_API_SCOPE,
   DEFAULT_MICROSOFT_GRAPH_API_URL,
+  DEFAULT_EMAIL_BODY_LENGTH,
 } from '../common';
 import type { ActionsConfigurationUtilities } from './actions_config';
 
@@ -45,6 +46,7 @@ const createActionsConfigMock = () => {
     }),
     getAwsSesConfig: jest.fn().mockReturnValue(null),
     getEnabledEmailServices: jest.fn().mockReturnValue(['*']),
+    getMaxEmailBodyLength: jest.fn().mockReturnValue(DEFAULT_EMAIL_BODY_LENGTH),
   };
   return mocked;
 };

--- a/x-pack/platform/plugins/shared/actions/server/actions_config.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_config.test.ts
@@ -12,6 +12,8 @@ import {
   DEFAULT_MICROSOFT_EXCHANGE_URL,
   DEFAULT_MICROSOFT_GRAPH_API_SCOPE,
   DEFAULT_MICROSOFT_GRAPH_API_URL,
+  MAX_EMAIL_BODY_LENGTH,
+  DEFAULT_EMAIL_BODY_LENGTH,
 } from '../common';
 import {
   getActionsConfigurationUtilities,
@@ -538,6 +540,52 @@ describe('validateEmailAddresses()', () => {
     expect(message).toMatchInlineSnapshot(
       `"not valid emails: invalid-email-address, (garbage); not allowed emails: bob@elastic.co, jim@elastic.co, hal@bad.com, lou@notgood.org"`
     );
+  });
+});
+
+describe('getMaxEmailBodyLength() ', () => {
+  function getAcu(maxEmailBodyLength?: number) {
+    const actionsConfig =
+      maxEmailBodyLength == null
+        ? defaultActionsConfig
+        : {
+            ...defaultActionsConfig,
+            email: {
+              maximum_body_length: maxEmailBodyLength,
+            },
+          };
+
+    return getActionsConfigurationUtilities(actionsConfig);
+  }
+
+  test('default value is as expected', async () => {
+    const acu = getAcu();
+    const actual = acu.getMaxEmailBodyLength();
+    expect(actual).toBe(DEFAULT_EMAIL_BODY_LENGTH);
+  });
+
+  test('value coerced to minimum of range if below', async () => {
+    const acu = getAcu(-100);
+    const actual = acu.getMaxEmailBodyLength();
+    expect(actual).toBe(0);
+  });
+
+  test('value of 0 accepted', async () => {
+    const acu = getAcu(0);
+    const actual = acu.getMaxEmailBodyLength();
+    expect(actual).toBe(0);
+  });
+
+  test('value within range is passed through', async () => {
+    const acu = getAcu(100);
+    const actual = acu.getMaxEmailBodyLength();
+    expect(actual).toBe(100);
+  });
+
+  test('value coerced to maximum of range if above', async () => {
+    const acu = getAcu(MAX_EMAIL_BODY_LENGTH + 100);
+    const actual = acu.getMaxEmailBodyLength();
+    expect(actual).toBe(MAX_EMAIL_BODY_LENGTH);
   });
 });
 

--- a/x-pack/platform/plugins/shared/actions/server/actions_config.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_config.ts
@@ -18,7 +18,12 @@ import { ActionTypeDisabledError } from './lib';
 import type { AwsSesConfig, ProxySettings, ResponseSettings, SSLSettings } from './types';
 import { getSSLSettingsFromConfig } from './lib/get_node_ssl_options';
 import type { ValidateEmailAddressesOptions } from '../common';
-import { validateEmailAddresses, invalidEmailsAsMessage } from '../common';
+import {
+  validateEmailAddresses,
+  invalidEmailsAsMessage,
+  DEFAULT_EMAIL_BODY_LENGTH,
+  MAX_EMAIL_BODY_LENGTH,
+} from '../common';
 export { AllowedHosts, EnabledActionTypes } from './config';
 
 enum AllowListingField {
@@ -64,6 +69,7 @@ export interface ActionsConfigurationUtilities {
   };
   getAwsSesConfig: () => AwsSesConfig;
   getEnabledEmailServices: () => string[];
+  getMaxEmailBodyLength: () => number;
 }
 
 function allowListErrorMessage(field: AllowListingField, value: string) {
@@ -265,6 +271,11 @@ export function getActionsConfigurationUtilities(
       }
 
       return ['*'];
+    },
+    getMaxEmailBodyLength() {
+      const configuredLength = config.email?.maximum_body_length ?? DEFAULT_EMAIL_BODY_LENGTH;
+      const nonNegativeLength = Math.max(0, configuredLength);
+      return Math.min(nonNegativeLength, MAX_EMAIL_BODY_LENGTH);
     },
   };
 }

--- a/x-pack/platform/plugins/shared/actions/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/config.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { MAX_EMAIL_BODY_LENGTH } from '../common';
 import type { ActionsConfig } from './config';
 import { configSchema, getValidatedConfig } from './config';
 import type { Logger } from '@kbn/core/server';
@@ -256,6 +257,74 @@ describe('config validation', () => {
     config.email = { domain_allowlist: ['a.com', 'b.c.com', 'd.e.f.com'] };
     result = configSchema.validate(config);
     expect(result.email?.domain_allowlist).toEqual(['a.com', 'b.c.com', 'd.e.f.com']);
+  });
+
+  describe('email.maximum_body_length', () => {
+    // note, this just tests the current behavior, but if we change so the
+    // default was ALWAYS the defined default, it's fine to change it.
+    test('validates that the value is undefined with no email parent', () => {
+      const validatedConfig = configSchema.validate({});
+      expect(validatedConfig.email?.maximum_body_length).toBe(undefined);
+    });
+
+    test('validates with value 0', () => {
+      const validatedConfig = configSchema.validate({
+        email: {
+          maximum_body_length: 0,
+        },
+      });
+      expect(validatedConfig.email?.maximum_body_length).toBe(0);
+    });
+
+    test('validates valid value set', () => {
+      const validatedConfig = configSchema.validate({
+        email: {
+          maximum_body_length: 42,
+        },
+      });
+      expect(validatedConfig.email?.maximum_body_length).toBe(42);
+    });
+
+    test('throws error on negative value', () => {
+      const config = {
+        email: {
+          maximum_body_length: -42,
+        },
+      };
+
+      expect(() => configSchema.validate(config)).toThrowErrorMatchingInlineSnapshot(
+        `"[email.maximum_body_length]: Value must be equal to or greater than [0]."`
+      );
+    });
+
+    test('logs warning when value is greater than max', () => {
+      const config = {
+        email: {
+          maximum_body_length: MAX_EMAIL_BODY_LENGTH + 1,
+        },
+      };
+      const validatedConfig = getValidatedConfig(mockLogger, configSchema.validate(config));
+
+      // value is still > max here, fixed in actionConfigUtils getMaxEmailBodyLength()
+      expect(validatedConfig.email?.maximum_body_length).toBe(MAX_EMAIL_BODY_LENGTH + 1);
+      expect(mockLogger.warn.mock.calls[0][0]).toBe(
+        'The configuration xpack.actions.email.maximum_body_length value 25000001 is larger than the maximum setting of 25000000 and the maximum value will be used instead'
+      );
+    });
+
+    test('logs warning on zero value', () => {
+      const config = {
+        email: {
+          maximum_body_length: 0,
+        },
+      };
+      const validatedConfig = getValidatedConfig(mockLogger, configSchema.validate(config));
+
+      expect(validatedConfig.email?.maximum_body_length).toBe(0);
+      expect(mockLogger.warn.mock.calls[0][0]).toBe(
+        'The configuration xpack.actions.email.maximum_body_length is set to 0 and will result in sending empty emails'
+      );
+    });
   });
 
   test('validates xpack.actions.webhook', () => {

--- a/x-pack/platform/plugins/shared/actions/server/config.ts
+++ b/x-pack/platform/plugins/shared/actions/server/config.ts
@@ -12,6 +12,8 @@ import {
   DEFAULT_MICROSOFT_EXCHANGE_URL,
   DEFAULT_MICROSOFT_GRAPH_API_SCOPE,
   DEFAULT_MICROSOFT_GRAPH_API_URL,
+  DEFAULT_EMAIL_BODY_LENGTH,
+  MAX_EMAIL_BODY_LENGTH,
 } from '../common';
 
 export enum AllowedHosts {
@@ -136,6 +138,9 @@ export const configSchema = schema.object({
     schema.object(
       {
         domain_allowlist: schema.maybe(schema.arrayOf(schema.string())),
+        maximum_body_length: schema.maybe(
+          schema.number({ min: 0, defaultValue: DEFAULT_EMAIL_BODY_LENGTH })
+        ),
         services: schema.maybe(
           schema.object(
             {
@@ -237,6 +242,21 @@ export function getValidatedConfig(logger: Logger, originalConfig: ActionsConfig
     const tmp: Record<string, unknown> = originalConfig;
     delete tmp.proxyOnlyHosts;
     return tmp as ActionsConfig;
+  }
+
+  if (originalConfig.email && originalConfig.email.maximum_body_length != null) {
+    const emailMaximumBodyLength = originalConfig.email.maximum_body_length;
+    if (emailMaximumBodyLength === 0) {
+      logger.warn(
+        `The configuration xpack.actions.email.maximum_body_length is set to 0 and will result in sending empty emails`
+      );
+    }
+
+    if (emailMaximumBodyLength > MAX_EMAIL_BODY_LENGTH) {
+      logger.warn(
+        `The configuration xpack.actions.email.maximum_body_length value ${emailMaximumBodyLength} is larger than the maximum setting of ${MAX_EMAIL_BODY_LENGTH} and the maximum value will be used instead`
+      );
+    }
   }
 
   return originalConfig;

--- a/x-pack/platform/test/alerting_api_integration/common/config.ts
+++ b/x-pack/platform/test/alerting_api_integration/common/config.ts
@@ -39,6 +39,7 @@ interface CreateTestConfigOptions {
   disabledRuleTypes?: string[];
   enabledRuleTypes?: string[];
   maxAlerts?: number;
+  emailMaximumBodyLength?: number;
 }
 
 // test.not-enabled is specifically not enabled
@@ -309,6 +310,11 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
         ? []
         : [`--xpack.alerting.enabledRuleTypes=${JSON.stringify(options.enabledRuleTypes)}`];
 
+    const emailMaximumBodyLengthSetting =
+      options.emailMaximumBodyLength == null
+        ? []
+        : [`--xpack.actions.email.maximum_body_length=${options.emailMaximumBodyLength}`];
+
     return {
       testConfigCategory: ScoutTestRunConfigCategory.API_TEST,
       testFiles: testFiles ? testFiles : [require.resolve(`../${name}/tests/`)],
@@ -361,6 +367,7 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
           ...maxScheduledPerMinuteSettings,
           ...disabledRuleTypesSetting,
           ...enabledRuleTypesSetting,
+          ...emailMaximumBodyLengthSetting,
           '--xpack.eventLog.logEntries=true',
           '--xpack.task_manager.ephemeral_tasks.enabled=false',
           `--xpack.task_manager.unsafe.exclude_task_types=${JSON.stringify([

--- a/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/server/routes.ts
+++ b/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/server/routes.ts
@@ -637,6 +637,55 @@ export function defineRoutes(
 
   router.post(
     {
+      path: '/api/alerts_fixture/{id}/_execute_connector_as_notification',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+        body: schema.object({
+          params: schema.recordOf(schema.string(), schema.any()),
+        }),
+      },
+    },
+    async (
+      context: RequestHandlerContext,
+      req: KibanaRequest<any, any, any, any>,
+      res: KibanaResponseFactory
+    ): Promise<IKibanaResponse<any>> => {
+      const [_, { actions }] = await core.getStartServices();
+
+      const actionsClient = await actions.getActionsClientWithRequest(req);
+
+      try {
+        return res.ok({
+          body: await actionsClient.execute({
+            actionId: req.params.id,
+            params: req.body.params,
+            source: {
+              type: ActionExecutionSourceType.NOTIFICATION,
+              source: null,
+            },
+            relatedSavedObjects: [],
+          }),
+        });
+      } catch (err) {
+        if (err.isBoom && err.output.statusCode === 403) {
+          return res.forbidden({ body: err });
+        }
+
+        throw err;
+      }
+    }
+  );
+
+  router.post(
+    {
       path: '/_test/report_gap',
       validate: {
         body: schema.object({

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config.ts
@@ -7,6 +7,8 @@
 
 import { createTestConfig } from '../../common/config';
 
+export const EmailMaximumBodyLength = 10000;
+
 export default createTestConfig('security_and_spaces', {
   disabledPlugins: [],
   license: 'trial',
@@ -20,4 +22,5 @@ export default createTestConfig('security_and_spaces', {
     'crowdstrikeConnectorOn',
     'microsoftDefenderEndpointOn',
   ],
+  emailMaximumBodyLength: EmailMaximumBodyLength,
 });

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner.ts
@@ -6,6 +6,7 @@
  */
 
 import { createTestConfig } from '../../common/config';
+import { EmailMaximumBodyLength } from './config';
 
 export default createTestConfig('security_and_spaces', {
   disabledPlugins: [],
@@ -20,4 +21,5 @@ export default createTestConfig('security_and_spaces', {
     'crowdstrikeConnectorOn',
     'microsoftDefenderEndpointOn',
   ],
+  emailMaximumBodyLength: EmailMaximumBodyLength,
 });

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/email.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/email.ts
@@ -14,6 +14,7 @@ import {
 import type { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
 import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
+import { EmailMaximumBodyLength } from '../../../config';
 
 export default function emailTest({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
@@ -601,6 +602,58 @@ export default function emailTest({ getService }: FtrProviderContext) {
           },
         })
         .expect(200);
+    });
+
+    it('should trim large message parameters', async () => {
+      const longLength = EmailMaximumBodyLength * 2;
+      const longString = ''.padEnd(longLength, 'x');
+      await supertest
+        .post(`/api/actions/connector/${createdActionId}/_execute`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          params: {
+            to: ['kibana-action-test@elastic.co'],
+            subject: 'email-subject',
+            message: longString,
+          },
+        })
+        .expect(200)
+        .then(async (resp: any) => {
+          const { text, html } = resp.body.data.message;
+          expect(text.length).lessThan(longLength);
+          expect(html.length).lessThan(longLength);
+          const startMessageRegExpText =
+            /^Your message's length of 20000 exceeded the 10000 bytes limit that is set for the connector/;
+          const startMessageRegExpHtml =
+            /^<p>Your message's length of 20000 exceeded the 10000 bytes limit that is set for the connector/;
+          expect(text).match(startMessageRegExpText);
+          expect(html).match(startMessageRegExpHtml);
+        });
+    });
+
+    it('should trim large messageHTML parameters', async () => {
+      const longLength = EmailMaximumBodyLength * 2;
+      const longString = ''.padEnd(longLength, 'x');
+      await supertest
+        .post(`/api/alerts_fixture/${createdActionId}/_execute_connector_as_notification`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          params: {
+            to: ['kibana-action-test@elastic.co'],
+            subject: 'email-subject',
+            message: 'hallo',
+            messageHTML: longString,
+          },
+        })
+        .expect(200)
+        .then(async (resp: any) => {
+          const { text, html } = resp.body.data.message;
+          expect(text).to.match(/^hallo/);
+          expect(`${html}`.length).to.be.lessThan(longLength);
+          const startMessageRegExpHtml =
+            /^Your message's length of 20000 exceeded the 10000 bytes limit that is set for the connector /;
+          expect(html).to.match(startMessageRegExpHtml);
+        });
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Actions] set max limit on size of emails sent (#239572)](https://github.com/elastic/kibana/pull/239572)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2025-10-31T13:25:59Z","message":"[Actions] set max limit on size of emails sent (#239572)\n\nresolves https://github.com/elastic/kibana/issues/235127\n\n## Summary\n\n## ToDo\n\n- [ ] issue to update cloud for new config setting\n- [ ] issue to lower default value based on existing usage\n- [ ] issue to surface error in rule execution UX\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"21e34eabc452db0269eb48a0dcfc471f8d2e96a5","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Actions","Team:ResponseOps","backport missing","Feature:Actions/ConnectorTypes","backport:all-open","v9.3.0"],"title":"[Actions] set max limit on size of emails sent","number":239572,"url":"https://github.com/elastic/kibana/pull/239572","mergeCommit":{"message":"[Actions] set max limit on size of emails sent (#239572)\n\nresolves https://github.com/elastic/kibana/issues/235127\n\n## Summary\n\n## ToDo\n\n- [ ] issue to update cloud for new config setting\n- [ ] issue to lower default value based on existing usage\n- [ ] issue to surface error in rule execution UX\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"21e34eabc452db0269eb48a0dcfc471f8d2e96a5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239572","number":239572,"mergeCommit":{"message":"[Actions] set max limit on size of emails sent (#239572)\n\nresolves https://github.com/elastic/kibana/issues/235127\n\n## Summary\n\n## ToDo\n\n- [ ] issue to update cloud for new config setting\n- [ ] issue to lower default value based on existing usage\n- [ ] issue to surface error in rule execution UX\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"21e34eabc452db0269eb48a0dcfc471f8d2e96a5"}},{"url":"https://github.com/elastic/kibana/pull/241460","number":241460,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/241766","number":241766,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->