### PR TITLE
[9.1] [Maps] Fix flaky test in maps geo file – remove exact assertion on approximate document count (#241426)

### DIFF
--- a/x-pack/platform/test/functional/apps/maps/group4/file_upload/geojson.js
+++ b/x-pack/platform/test/functional/apps/maps/group4/file_upload/geojson.js
@@ -54,6 +54,7 @@ export default function ({ getPageObjects, getService }) {
     });
 
     it('should add as document layer', async () => {
+      await maps.setView(0, 0, 1); //  set stable viewport to prevent flakiness caused by MVT tiles loading different data at varying zoom levels
       await geoFileUpload.addFileAsDocumentLayer();
       await maps.waitForLayersToLoad();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Maps] Fix flaky test in maps geo file – remove exact assertion on approximate document count (#241426)](https://github.com/elastic/kibana/pull/241426)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ola Pawlus","email":"98127445+olapawlus@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-11-03T15:17:31Z","message":"[Maps] Fix flaky test in maps geo file – remove exact assertion on approximate document count (#241426)\n\nResolves #234490\nThe link to Flaky Test Runner:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9709\n\n### Summary\nThis PR fixes a flaky test in the maps geo file upload suite.\nThe test was asserting an exact document count (Found ~281 documents),\nbut due to MVT tile rendering, the number of documents may vary slightly\ndepending on the zoom level.\n\n### Details\nIn some runs, the count fluctuated between ~280 and ~281, causing the\ntest to fail intermittently.\n\n### Reasoning\nThe failing test screenshot showed a slightly different zoom level\ncompared to the local FTR environment.\nTo stabilize the test, I explicitly set the zoom level at the beginning\nof the test to ensure consistent MVT data loading.","sha":"7943c3e3f3e145a94c985d5aca1a08ee51360610","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","loe:small","technical debt","failed-test","release_note:skip","impact:critical","backport:version","v9.2.0","v9.3.0","v8.19.7","v9.1.7","v9.2.1"],"title":"[Maps] Fix flaky test in maps geo file – remove exact assertion on approximate document count","number":241426,"url":"https://github.com/elastic/kibana/pull/241426","mergeCommit":{"message":"[Maps] Fix flaky test in maps geo file – remove exact assertion on approximate document count (#241426)\n\nResolves #234490\nThe link to Flaky Test Runner:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9709\n\n### Summary\nThis PR fixes a flaky test in the maps geo file upload suite.\nThe test was asserting an exact document count (Found ~281 documents),\nbut due to MVT tile rendering, the number of documents may vary slightly\ndepending on the zoom level.\n\n### Details\nIn some runs, the count fluctuated between ~280 and ~281, causing the\ntest to fail intermittently.\n\n### Reasoning\nThe failing test screenshot showed a slightly different zoom level\ncompared to the local FTR environment.\nTo stabilize the test, I explicitly set the zoom level at the beginning\nof the test to ensure consistent MVT data loading.","sha":"7943c3e3f3e145a94c985d5aca1a08ee51360610"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/241649","number":241649,"state":"MERGED","mergeCommit":{"sha":"96243bb98eb73b007cfc01fff78c3b8ecf48250e","message":"[9.2] [Maps] Fix flaky test in maps geo file – remove exact assertion on approximate document count (#241426) (#241649)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Maps] Fix flaky test in maps geo file – remove exact assertion on\napproximate document count\n(#241426)](https://github.com/elastic/kibana/pull/241426)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ola Pawlus <98127445+olapawlus@users.noreply.github.com>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241426","number":241426,"mergeCommit":{"message":"[Maps] Fix flaky test in maps geo file – remove exact assertion on approximate document count (#241426)\n\nResolves #234490\nThe link to Flaky Test Runner:\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9709\n\n### Summary\nThis PR fixes a flaky test in the maps geo file upload suite.\nThe test was asserting an exact document count (Found ~281 documents),\nbut due to MVT tile rendering, the number of documents may vary slightly\ndepending on the zoom level.\n\n### Details\nIn some runs, the count fluctuated between ~280 and ~281, causing the\ntest to fail intermittently.\n\n### Reasoning\nThe failing test screenshot showed a slightly different zoom level\ncompared to the local FTR environment.\nTo stabilize the test, I explicitly set the zoom level at the beginning\nof the test to ensure consistent MVT data loading.","sha":"7943c3e3f3e145a94c985d5aca1a08ee51360610"}},{"branch":"8.19","label":"v8.19.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->