### PR TITLE
Use builtin `setTimeout` instead of custom `delay`

### DIFF
--- a/src/core/packages/execution-context/server-internal/src/execution_context_service.test.ts
+++ b/src/core/packages/execution-context/server-internal/src/execution_context_service.test.ts
@@ -7,13 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import { BehaviorSubject } from 'rxjs';
 import { mockCoreContext } from '@kbn/core-base-server-mocks';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import type { InternalExecutionContextSetup } from './execution_context_service';
 import { ExecutionContextService } from './execution_context_service';
-
-const delay = (ms: number = 100) => new Promise((resolve) => setTimeout(resolve, ms));
 
 describe('ExecutionContextService', () => {
   describe('setup', () => {
@@ -35,7 +34,7 @@ describe('ExecutionContextService', () => {
             id: 'id-a',
             description: 'description-a',
           });
-          await delay(500);
+          await timer(500);
           return service.get();
         });
 
@@ -46,7 +45,7 @@ describe('ExecutionContextService', () => {
             id: 'id-b',
             description: 'description-b',
           });
-          await delay(100);
+          await timer(100);
           return service.get();
         });
 
@@ -129,7 +128,7 @@ describe('ExecutionContextService', () => {
             id: 'id-a',
             description: 'description-a',
           });
-          await delay(100);
+          await timer(100);
           return disabledService.get();
         });
 
@@ -147,7 +146,7 @@ describe('ExecutionContextService', () => {
             description: 'description-a',
           },
           async () => {
-            await delay(10);
+            await timer(10);
             return service.get();
           }
         );
@@ -160,7 +159,7 @@ describe('ExecutionContextService', () => {
             description: 'description-b',
           },
           async () => {
-            await delay(50);
+            await timer(50);
             return service.get();
           }
         );
@@ -196,7 +195,7 @@ describe('ExecutionContextService', () => {
             description: 'description-a',
           },
           async () => {
-            await delay(10);
+            await timer(10);
             return service.get();
           }
         );
@@ -213,7 +212,7 @@ describe('ExecutionContextService', () => {
             description: 'description-a',
           },
           async () => {
-            await delay(50);
+            await timer(50);
             return service.get();
           }
         );
@@ -226,7 +225,7 @@ describe('ExecutionContextService', () => {
             description: 'description-b',
           },
           async () => {
-            await delay(10);
+            await timer(10);
             return service.get();
           }
         );
@@ -258,7 +257,7 @@ describe('ExecutionContextService', () => {
             description: 'description-a',
           },
           async () => {
-            await delay(10);
+            await timer(10);
             return service.withContext(
               {
                 type: 'type-b',
@@ -301,7 +300,7 @@ describe('ExecutionContextService', () => {
             description: 'description-b',
           },
           async () => {
-            await delay(10);
+            await timer(10);
             return service.get();
           }
         );
@@ -331,7 +330,7 @@ describe('ExecutionContextService', () => {
             description: 'description-a',
           },
           async () => {
-            await delay(10);
+            await timer(10);
             throw error;
           }
         );
@@ -372,7 +371,7 @@ describe('ExecutionContextService', () => {
             description: 'description-b',
           },
           async () => {
-            await delay(10);
+            await timer(10);
             return service.get();
           }
         );
@@ -468,7 +467,7 @@ describe('ExecutionContextService', () => {
             id: 'id-a',
             description: 'description-a',
           });
-          await delay(100);
+          await timer(100);
           return service.get();
         });
       }

--- a/src/core/packages/http/browser-internal/src/fetch.test.ts
+++ b/src/core/packages/http/browser-internal/src/fetch.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import fetchMock from 'fetch-mock';
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -17,10 +18,6 @@ import type { HttpResponse, HttpFetchOptionsWithPath } from '@kbn/core-http-brow
 import { Fetch } from './fetch';
 import { BasePath } from './base_path';
 import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
-
-function delay<T>(duration: number) {
-  return new Promise<T>((r) => setTimeout(r, duration));
-}
 
 const BASE_PATH = 'http://localhost/myBase';
 
@@ -624,7 +621,7 @@ describe('Fetch', () => {
       });
 
       fetchInstance.fetch('/my/path').then(unusedSpy, unusedSpy);
-      await delay(1000);
+      await timer(1000);
 
       expect(unusedSpy).toHaveBeenCalledTimes(0);
       expect(usedSpy).toHaveBeenCalledTimes(1);
@@ -645,7 +642,7 @@ describe('Fetch', () => {
       fetchInstance.intercept({ request: usedSpy, response: unusedSpy });
 
       fetchInstance.fetch('/my/path').then(unusedSpy, unusedSpy);
-      await delay(1000);
+      await timer(1000);
 
       expect(fetchMock.called()).toBe(true);
       expect(usedSpy).toHaveBeenCalledTimes(3);
@@ -665,7 +662,7 @@ describe('Fetch', () => {
       fetchInstance.intercept({ response: unusedSpy, responseError: unusedSpy });
 
       fetchInstance.post('/my/path').then(unusedSpy, unusedSpy);
-      await delay(1000);
+      await timer(1000);
 
       expect(fetchMock.called()).toBe(true);
       expect(unusedSpy).toHaveBeenCalledTimes(0);
@@ -840,7 +837,7 @@ describe('Fetch', () => {
       });
 
       fetchInstance.fetch('/my/path');
-      await delay(500);
+      await timer(500);
 
       expect(unusedSpy).toHaveBeenCalledTimes(0);
     });

--- a/src/core/packages/saved-objects/migration-server-internal/src/common/utils/delay.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/common/utils/delay.ts
@@ -20,7 +20,8 @@ export const createDelayFn =
   <F extends (...args: any) => any>(fn: F): (() => ReturnType<F>) => {
     return () => {
       return state.retryDelay > 0
-        ? new Promise((resolve) => setTimeout(resolve, state.retryDelay)).then(fn)
+        ? // we need to use the standard setTimeout here, this way we can alter its behavior with jest.useFakeTimers()
+          new Promise((resolve) => setTimeout(resolve, state.retryDelay)).then(fn)
         : fn();
     };
   };

--- a/src/core/packages/saved-objects/migration-server-internal/src/zdt/actions/wait_for_delay.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/zdt/actions/wait_for_delay.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import * as Either from 'fp-ts/Either';
 import type * as TaskEither from 'fp-ts/TaskEither';
 
@@ -18,7 +19,7 @@ export const waitForDelay = ({
   delayInSec,
 }: WaitForDelayParams): TaskEither.TaskEither<never, 'wait_succeeded'> => {
   return () => {
-    return delay(delayInSec)
+    return timer(delayInSec * 1000)
       .then(() => Either.right('wait_succeeded' as const))
       .catch((err) => {
         // will never happen
@@ -26,6 +27,3 @@ export const waitForDelay = ({
       });
   };
 };
-
-const delay = (delayInSec: number) =>
-  new Promise<void>((resolve) => setTimeout(resolve, delayInSec * 1000));

--- a/src/core/packages/saved-objects/migration-server-internal/src/zdt/actions/wait_for_delay.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/zdt/actions/wait_for_delay.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { setTimeout as timer } from 'timers/promises';
 import * as Either from 'fp-ts/Either';
 import type * as TaskEither from 'fp-ts/TaskEither';
 
@@ -19,7 +18,8 @@ export const waitForDelay = ({
   delayInSec,
 }: WaitForDelayParams): TaskEither.TaskEither<never, 'wait_succeeded'> => {
   return () => {
-    return timer(delayInSec * 1000)
+    // we need to use the standard setTimeout here, this way we can alter its behavior with jest.useFakeTimers()
+    return new Promise((resolve) => setTimeout(resolve, delayInSec * 1000))
       .then(() => Either.right('wait_succeeded' as const))
       .catch((err) => {
         // will never happen

--- a/src/core/packages/status/server-internal/src/log_core_services_status.test.ts
+++ b/src/core/packages/status/server-internal/src/log_core_services_status.test.ts
@@ -15,7 +15,7 @@ import type { ServiceStatus } from '@kbn/core-status-common';
 import { type CoreStatus, ServiceStatusLevels } from '@kbn/core-status-common';
 import { logCoreStatusChanges } from './log_core_services_status';
 
-const delay = async (millis: number = 10) => await jest.advanceTimersByTimeAsync(millis);
+const jestDelay = async (millis: number = 10) => await jest.advanceTimersByTimeAsync(millis);
 
 describe('logCoreStatusChanges', () => {
   const serviceUnavailable: ServiceStatus = {
@@ -59,7 +59,7 @@ describe('logCoreStatusChanges', () => {
     core$.next({ elasticsearch: serviceAvailable, savedObjects: serviceAvailable });
     core$.next({ elasticsearch: serviceAvailable, savedObjects: serviceAvailable });
 
-    await delay();
+    await jestDelay();
 
     expect(l.get).toBeCalledTimes(3);
     expect(l.get).nthCalledWith(1, 'elasticsearch');
@@ -85,7 +85,7 @@ describe('logCoreStatusChanges', () => {
     core$.next({ elasticsearch: serviceAvailable, savedObjects: serviceAvailable });
     core$.next({ elasticsearch: serviceAvailable, savedObjects: serviceAvailable });
 
-    await delay();
+    await jestDelay();
 
     expect(l.get).toBeCalledTimes(2);
     expect(l.get).nthCalledWith(1, 'elasticsearch');
@@ -133,7 +133,7 @@ describe('logCoreStatusChanges', () => {
     core$.next({ savedObjects: serviceAvailable, elasticsearch: serviceAvailable });
 
     // give the 'bufferTime' operator enough time to emit and log
-    await delay(1_000);
+    await jestDelay(1_000);
 
     expect(l.get).toBeCalledWith('elasticsearch');
     expect(l.get).toBeCalledWith('savedObjects');
@@ -224,7 +224,7 @@ describe('logCoreStatusChanges', () => {
     });
 
     // give the 'bufferTime' operator enough time to emit and log
-    await delay(1_000);
+    await jestDelay(1_000);
 
     // emit a last message (some time after)
     core$.next({

--- a/src/core/packages/status/server-internal/src/log_overall_status.test.ts
+++ b/src/core/packages/status/server-internal/src/log_overall_status.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import { Subject } from 'rxjs';
 import type { Logger } from '@kbn/logging';
 import type { ILoggingSystem } from '@kbn/core-logging-server-internal';
@@ -14,9 +15,6 @@ import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import type { ServiceStatus } from '@kbn/core-status-common';
 import { ServiceStatusLevels } from '@kbn/core-status-common';
 import { logOverallStatusChanges } from './log_overall_status';
-
-const delay = async (millis: number = 10) =>
-  await new Promise((resolve) => setTimeout(resolve, millis));
 
 describe('logOverallStatusChanges', () => {
   let overall$: Subject<ServiceStatus>;
@@ -46,7 +44,7 @@ describe('logOverallStatusChanges', () => {
 
     overall$.next({ level: ServiceStatusLevels.unavailable, summary: 'Initializing . . .' });
 
-    await delay();
+    await timer(10);
 
     expect(l.get).not.toBeCalled();
     expect(l.info).not.toBeCalled();
@@ -66,7 +64,7 @@ describe('logOverallStatusChanges', () => {
     overall$.next({ level: ServiceStatusLevels.degraded, summary: 'Waiting for ES indices' });
     overall$.next({ level: ServiceStatusLevels.available, summary: 'Ready!' });
 
-    await delay();
+    await timer(10);
 
     expect(l.get).not.toBeCalled();
     expect(l.error).toBeCalledTimes(1);
@@ -94,7 +92,7 @@ describe('logOverallStatusChanges', () => {
     overall$.next({ level: ServiceStatusLevels.degraded, summary: 'Waiting (attempt #4)' });
     overall$.next({ level: ServiceStatusLevels.available, summary: 'Ready!' });
 
-    await delay();
+    await timer(10);
 
     expect(l.get).not.toBeCalled();
     expect(l.error).toBeCalledTimes(1);
@@ -123,7 +121,7 @@ describe('logOverallStatusChanges', () => {
     overall$.next({ level: ServiceStatusLevels.degraded, summary: 'Waiting (attempt #4)' });
     overall$.next({ level: ServiceStatusLevels.available, summary: 'Ready!' });
 
-    await delay();
+    await timer(10);
 
     expect(l.get).not.toBeCalled();
     expect(l.error).toBeCalledTimes(1);

--- a/src/core/packages/status/server-internal/src/log_plugins_status.test.ts
+++ b/src/core/packages/status/server-internal/src/log_plugins_status.test.ts
@@ -15,7 +15,7 @@ import { ServiceStatusLevels } from '@kbn/core-status-common';
 import { logPluginsStatusChanges } from './log_plugins_status';
 import type { PluginStatus } from './types';
 
-const delay = async (millis: number = 10) => await jest.advanceTimersByTimeAsync(millis);
+const jestDelay = async (millis: number = 10) => await jest.advanceTimersByTimeAsync(millis);
 
 describe('logPluginsStatusChanges', () => {
   const reportedUnavailable: PluginStatus = {
@@ -71,7 +71,7 @@ describe('logPluginsStatusChanges', () => {
     plugins$.next({ A: reportedAvailable, B: reportedAvailable, C: inferredAvailable });
     plugins$.next({ A: reportedAvailable, B: reportedAvailable, C: inferredAvailable });
 
-    await delay();
+    await jestDelay();
     expect(l.get).toBeCalledTimes(3);
     expect(l.get).nthCalledWith(1, 'A');
     expect(l.get).nthCalledWith(2, 'B');
@@ -96,7 +96,7 @@ describe('logPluginsStatusChanges', () => {
     plugins$.next({ A: reportedAvailable, B: reportedAvailable, C: inferredAvailable });
     plugins$.next({ A: reportedAvailable, B: reportedAvailable, C: inferredAvailable });
 
-    await delay();
+    await jestDelay();
 
     expect(l.get).toBeCalledTimes(2);
     expect(l.get).nthCalledWith(1, 'A');
@@ -144,7 +144,7 @@ describe('logPluginsStatusChanges', () => {
     plugins$.next({ A: reportedAvailable, B: reportedAvailable });
 
     // give the 'bufferTime' operator enough time to emit and log
-    await delay(1_000);
+    await jestDelay(1_000);
 
     expect(l.get).toBeCalledWith('A');
     expect(l.get).toBeCalledWith('B');
@@ -188,7 +188,7 @@ describe('logPluginsStatusChanges', () => {
     plugins$.next({ A: { ...reportedUnavailable, summary: `attempt #${++attempt}` } });
 
     // give the 'bufferTime' operator enough time to emit and log
-    await delay(1_000);
+    await jestDelay(1_000);
 
     // emit a last message (some time after)
     plugins$.next({ A: { ...reportedAvailable, summary: `attempt #${++attempt}` } });

--- a/src/core/packages/status/server-internal/src/plugins_status.test.ts
+++ b/src/core/packages/status/server-internal/src/plugins_status.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import type { PluginName } from '@kbn/core-base-common';
 import { PluginsStatusService } from './plugins_status';
 import type { Observable } from 'rxjs';
@@ -394,8 +395,6 @@ describe('PluginStatusService', () => {
   });
 
   describe('getDependenciesStatus$', () => {
-    const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
     it('only includes dependencies of specified plugin', async () => {
       const service = new PluginsStatusService({
         core$: coreAllAvailable$,
@@ -454,7 +453,7 @@ describe('PluginStatusService', () => {
       expect(statusUpdates).toStrictEqual([]);
 
       // Waiting for the debounce timeout should cut a new update
-      await delay(25);
+      await timer(25);
       subscription.unsubscribe();
 
       expect(statusUpdates).toStrictEqual([{ a: { ...available, reported: true } }]);
@@ -489,9 +488,9 @@ describe('PluginStatusService', () => {
       pluginA$.next(available);
       pluginA$.next(degraded);
       // Waiting for the debounce timeout should cut a new update
-      await delay(25);
+      await timer(25);
       pluginA$.next(available);
-      await delay(25);
+      await timer(25);
       subscription.unsubscribe();
 
       expect(statusUpdates).toMatchInlineSnapshot(`

--- a/src/core/packages/status/server-internal/src/status_service.test.ts
+++ b/src/core/packages/status/server-internal/src/status_service.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import { of, BehaviorSubject, firstValueFrom, Observable } from 'rxjs';
 
 import { type ServiceStatus, ServiceStatusLevels, type CoreStatus } from '@kbn/core-status-common';
@@ -50,8 +51,6 @@ describe('StatusService', () => {
     logPluginsStatusChangesMock.mockReset();
     logOverallStatusChangesMock.mockReset();
   });
-
-  const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
   const available: ServiceStatus<any> = {
     level: ServiceStatusLevels.available,
@@ -313,20 +312,20 @@ describe('StatusService', () => {
 
         // Wait for timers to ensure that duplicate events are still filtered out regardless of debouncing.
         elasticsearch$.next(available);
-        await delay(100);
+        await timer(100);
         elasticsearch$.next(available);
-        await delay(100);
+        await timer(100);
         elasticsearch$.next({
           level: ServiceStatusLevels.available,
           summary: `Wow another summary`,
         });
-        await delay(100);
+        await timer(100);
         savedObjects$.next(degraded);
-        await delay(100);
+        await timer(100);
         savedObjects$.next(available);
-        await delay(100);
+        await timer(100);
         savedObjects$.next(available);
-        await delay(100);
+        await timer(100);
         subscription.unsubscribe();
 
         expect(statusUpdates).toMatchInlineSnapshot(`
@@ -376,9 +375,9 @@ describe('StatusService', () => {
         savedObjects$.next(available);
         savedObjects$.next(degraded);
         // Waiting for the debounce timeout should cut a new update
-        await delay(100);
+        await timer(100);
         savedObjects$.next(available);
-        await delay(100);
+        await timer(100);
         subscription.unsubscribe();
 
         expect(statusUpdates).toMatchInlineSnapshot(`
@@ -488,20 +487,20 @@ describe('StatusService', () => {
 
         // Wait for timers to ensure that duplicate events are still filtered out regardless of debouncing.
         elasticsearch$.next(available);
-        await delay(100);
+        await timer(100);
         elasticsearch$.next(available);
-        await delay(100);
+        await timer(100);
         elasticsearch$.next({
           level: ServiceStatusLevels.available,
           summary: `Wow another summary`,
         });
-        await delay(100);
+        await timer(100);
         savedObjects$.next(degraded);
-        await delay(100);
+        await timer(100);
         savedObjects$.next(available);
-        await delay(100);
+        await timer(100);
         savedObjects$.next(available);
-        await delay(100);
+        await timer(100);
         subscription.unsubscribe();
 
         expect(statusUpdates).toMatchInlineSnapshot(`
@@ -551,9 +550,9 @@ describe('StatusService', () => {
         savedObjects$.next(available);
         savedObjects$.next(degraded);
         // Waiting for the debounce timeout should cut a new update
-        await delay(100);
+        await timer(100);
         savedObjects$.next(available);
-        await delay(100);
+        await timer(100);
         subscription.unsubscribe();
 
         expect(statusUpdates).toMatchInlineSnapshot(`

--- a/src/core/server/integration_tests/execution_context/tracing.test.ts
+++ b/src/core/server/integration_tests/execution_context/tracing.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import { ExecutionContextContainer } from '@kbn/core-execution-context-browser-internal';
 import type { createRoot } from '@kbn/core-test-helpers-kbn-server';
 import {
@@ -17,8 +18,6 @@ import {
 } from '@kbn/core-test-helpers-kbn-server';
 
 import type { RequestHandlerContext } from '../..';
-
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const parentContext = {
   type: 'test-type',
@@ -341,7 +340,7 @@ describe('trace', () => {
         },
         async (context, req, res) => {
           executionContext.set(parentContext);
-          await delay(100);
+          await timer(100);
           return res.ok({ body: executionContext.get() });
         }
       );
@@ -365,7 +364,7 @@ describe('trace', () => {
         },
         async (context, req, res) => {
           executionContext.set({ ...parentContext, id: String(id++) });
-          await delay(100);
+          await timer(100);
           return res.ok({ body: executionContext.get() });
         }
       );
@@ -392,7 +391,7 @@ describe('trace', () => {
         },
         async (context, req, res) => {
           executionContext.set({ ...parentContext, id: String(id) });
-          await delay(id-- * 100);
+          await timer(id-- * 100);
           return res.ok({ body: executionContext.get() });
         }
       );
@@ -427,7 +426,7 @@ describe('trace', () => {
         },
         async (context, req, res) => {
           executionContext.set(parentContext);
-          await delay(id-- * 100);
+          await timer(id-- * 100);
           const esClient = (await context.core).elasticsearch.client;
           const { headers } = await esClient.asCurrentUser.ping({}, { meta: true });
           return res.ok({ body: headers || {} });
@@ -775,9 +774,9 @@ describe('trace', () => {
           },
           async (context, req, res) => {
             return executionContext.withContext(parentContext, async () => {
-              await delay(100);
+              await timer(100);
               return executionContext.withContext(nestedContext, async () => {
-                await delay(100);
+                await timer(100);
                 return res.ok({ body: executionContext.get() });
               });
             });

--- a/src/core/server/integration_tests/http/cookie_session_storage.test.ts
+++ b/src/core/server/integration_tests/http/cookie_session_storage.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import { parse as parseCookie } from 'tough-cookie';
 import supertest from 'supertest';
 import { duration as momentDuration } from 'moment';
@@ -87,7 +88,7 @@ const userData = { id: '42' };
 const sessionDurationMs = 1000;
 const path = '/';
 const sessVal = () => ({ value: userData, expires: Date.now() + sessionDurationMs, path });
-const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
 const cookieOptions = {
   name: 'sid',
   encryptionKey: 'something_at_least_32_characters',
@@ -258,7 +259,7 @@ describe('Cookie based SessionStorage', () => {
       const cookies = response.get('set-cookie')!;
       expect(cookies).toBeDefined();
 
-      await delay(sessionDurationMs);
+      await timer(sessionDurationMs);
 
       const sessionCookie = retrieveSessionCookie(cookies[0]);
       const response2 = await supertest(innerServer.listener)

--- a/src/core/server/integration_tests/http/request.test.ts
+++ b/src/core/server/integration_tests/http/request.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 jest.mock('uuid', () => ({
   v4: jest.fn().mockReturnValue('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'),
 }));
@@ -40,7 +41,6 @@ afterEach(async () => {
   await server.stop();
 });
 
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 describe('KibanaRequest', () => {
   describe('auth', () => {
     describe('isAuthenticated', () => {
@@ -222,7 +222,7 @@ describe('KibanaRequest', () => {
               });
 
               // prevents the server to respond
-              await delay(30000);
+              await timer(30_000);
               return res.ok({ body: 'ok' });
             }
           );
@@ -261,7 +261,7 @@ describe('KibanaRequest', () => {
               });
 
               // prevents the server to respond
-              await delay(30000);
+              await timer(30_000);
               return res.ok({ body: 'ok' });
             }
           );
@@ -418,7 +418,7 @@ describe('KibanaRequest', () => {
               });
 
               expect(nextSpy).not.toHaveBeenCalled();
-              await delay(30000);
+              await timer(30_000);
               return res.ok({ body: 'ok' });
             }
           );
@@ -456,7 +456,7 @@ describe('KibanaRequest', () => {
               });
 
               expect(nextSpy).not.toHaveBeenCalled();
-              await delay(30000);
+              await timer(30_000);
               return res.ok({ body: 'ok' });
             }
           );

--- a/src/core/server/integration_tests/logging/logging.test.ts
+++ b/src/core/server/integration_tests/logging/logging.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import type { LoggerContextConfigInput } from '@kbn/core-logging-server';
 import { createRoot as createkbnTestServerRoot } from '@kbn/core-test-helpers-kbn-server';
 import type { InternalCoreSetup } from '@kbn/core-lifecycle-server-internal';
@@ -138,8 +139,6 @@ describe('logging service', () => {
       ],
     };
 
-    const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
     let root: ReturnType<typeof createRoot>;
     let setup: InternalCoreSetup;
     let mockConsoleLog: jest.SpyInstance;
@@ -147,7 +146,7 @@ describe('logging service', () => {
     const setContextConfig = async (enable: boolean) => {
       loggingConfig$.next(enable ? CUSTOM_LOGGING_CONFIG : {});
       // need to wait for config to reload. nextTick is enough, using delay just to be sure
-      await delay(10);
+      await timer(10);
     };
 
     beforeAll(async () => {

--- a/src/core/server/integration_tests/logging/rolling_file_appender.test.ts
+++ b/src/core/server/integration_tests/logging/rolling_file_appender.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import { join } from 'path';
 import { rm, mkdtemp, readFile, readdir } from 'fs/promises';
 import moment from 'moment-timezone';
@@ -14,8 +15,7 @@ import { getNextRollingTime } from '@kbn/core-logging-server-internal';
 import { createRoot as createkbnTestServerRoot } from '@kbn/core-test-helpers-kbn-server';
 
 const flushDelay = 2000;
-const delay = (waitInMs: number) => new Promise((resolve) => setTimeout(resolve, waitInMs));
-const flush = async () => delay(flushDelay);
+const flush = async () => timer(flushDelay);
 
 function createRoot(appenderConfig: any) {
   return createkbnTestServerRoot({
@@ -241,7 +241,7 @@ describe('RollingFileAppender', () => {
       logger.info(message(3));
       logger.info(message(4));
 
-      await delay(2500);
+      await timer(2500);
 
       // roll - 'kibana-1.log'
       logger.info(message(5));
@@ -288,7 +288,7 @@ describe('RollingFileAppender', () => {
       const waitForNextRollingTime = () => {
         const now = Date.now();
         const nextRolling = getNextRollingTime(now, moment.duration(1, 'second'), true);
-        return delay(nextRolling - now + 1);
+        return timer(nextRolling - now + 1);
       };
 
       // wait for a rolling time boundary to minimize the risk to have logs emitted in different intervals

--- a/src/core/server/integration_tests/metrics/server_collector.test.ts
+++ b/src/core/server/integration_tests/metrics/server_collector.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { take, filter } from 'rxjs';
 import supertest from 'supertest';
@@ -16,7 +17,6 @@ import type { HttpService } from '@kbn/core-http-server-internal';
 import { contextServiceMock } from '@kbn/core-http-context-server-mocks';
 import { executionContextServiceMock } from '@kbn/core-execution-context-server-mocks';
 import { ServerMetricsCollector } from '@kbn/core-metrics-collectors-server-internal';
-import { setTimeout as setTimeoutPromise } from 'timers/promises';
 import { createInternalHttpService } from '../utilities';
 
 describe('ServerMetricsCollector', () => {
@@ -25,7 +25,6 @@ describe('ServerMetricsCollector', () => {
   let hapiServer: HapiServer;
   let router: IRouter;
 
-  const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
   const sendGet = (path: string) => supertest(hapiServer.listener).get(path);
 
   beforeEach(async () => {
@@ -170,14 +169,14 @@ describe('ServerMetricsCollector', () => {
     router.get(
       { path: '/500-ms', validate: false, security: { authz: { requiredPrivileges: ['foo'] } } },
       async (ctx, req, res) => {
-        await delay(500);
+        await timer(500);
         return res.ok({ body: '' });
       }
     );
     router.get(
       { path: '/250-ms', validate: false, security: { authz: { requiredPrivileges: ['foo'] } } },
       async (ctx, req, res) => {
-        await delay(250);
+        await timer(250);
         return res.ok({ body: '' });
       }
     );
@@ -239,7 +238,7 @@ describe('ServerMetricsCollector', () => {
     await Promise.all([res1, res2]);
     // Give the event-loop one more cycle to allow concurrent connections to be
     // up to date before collecting
-    await setTimeoutPromise(0);
+    await timer(0);
     metrics = await collector.collect();
     expect(metrics.concurrent_connections).toEqual(0);
   });
@@ -307,7 +306,7 @@ describe('ServerMetricsCollector', () => {
       router.get(
         { path: '/500-ms', validate: false, security: { authz: { requiredPrivileges: ['foo'] } } },
         async (ctx, req, res) => {
-          await delay(500);
+          await timer(500);
           return res.ok({ body: '' });
         }
       );

--- a/src/core/server/integration_tests/saved_objects/migrations/group1/v2_migration.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group1/v2_migration.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import { join } from 'path';
 import { omit } from 'lodash';
 import JSON5 from 'json5';
@@ -34,7 +35,6 @@ import {
   getReindexingMigratorTestKit,
   getUpToDateMigratorTestKit,
 } from '@kbn/migrator-test-kit/fixtures';
-import { delay } from '../test_utils';
 import { expectDocumentsMigratedToHighestVersion } from '@kbn/migrator-test-kit/expect';
 
 const logFilePath = join(__dirname, 'v2_migration.log');
@@ -49,7 +49,7 @@ describe('v2 migration', () => {
   afterAll(async () => {
     if (esServer) {
       await esServer.stop();
-      await delay(5); // give it a few seconds... cause we always do ¯\_(ツ)_/¯
+      await timer(5_000); // give it a few seconds... cause we always do ¯\_(ツ)_/¯
     }
   });
 

--- a/src/core/server/integration_tests/saved_objects/migrations/group2/multiple_kb_nodes.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/multiple_kb_nodes.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import { join } from 'path';
 import { omit, sortBy } from 'lodash';
 import type { TestElasticsearchUtils } from '@kbn/core-test-helpers-kbn-server';
@@ -27,7 +28,7 @@ import {
   BASELINE_TEST_ARCHIVE_LARGE,
 } from '../kibana_migrator_archive_utils';
 import { getRelocatingMigratorTestKit, kibanaSplitIndex } from '@kbn/migrator-test-kit/fixtures';
-import { delay, parseLogFile } from '../test_utils';
+import { parseLogFile } from '../test_utils';
 import '../jest_matchers';
 import { expectDocumentsMigratedToHighestVersion } from '@kbn/migrator-test-kit/expect';
 
@@ -83,7 +84,7 @@ describe('multiple Kibana nodes performing a reindexing migration', () => {
 
   afterEach(async () => {
     await esServer?.stop();
-    await delay(5); // give it a few seconds... cause we always do ¯\_(ツ)_/¯
+    await timer(5_000); // give it a few seconds... cause we always do ¯\_(ツ)_/¯
   });
 
   async function checkBeforeState() {
@@ -277,7 +278,7 @@ async function startWithDelay<T>(runnables: Array<Job<T>>, delayInSec: number) {
     );
     if (i < runnables.length - 2) {
       // We wait between instances, but not after the last one
-      await delay(delayInSec);
+      await timer(delayInSec * 1000);
     }
   }
   const results = await Promise.all(promises);

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/fail_on_rollback.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/fail_on_rollback.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import type { TestElasticsearchUtils } from '@kbn/core-test-helpers-kbn-server';
 import {
   startElasticsearch,
@@ -16,7 +17,6 @@ import {
   currentVersion,
 } from '@kbn/migrator-test-kit';
 import '../jest_matchers';
-import { delay } from '../test_utils';
 import { getUpToDateMigratorTestKit } from '@kbn/migrator-test-kit/fixtures';
 import { BASELINE_TEST_ARCHIVE_SMALL } from '../kibana_migrator_archive_utils';
 
@@ -50,6 +50,6 @@ describe('when rolling back to an older version', () => {
 
   afterAll(async () => {
     await esServer?.stop();
-    await delay(2);
+    await timer(2_000);
   });
 });

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/read_batch_size.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/read_batch_size.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import { join } from 'path';
 import type { Root } from '@kbn/core-root-server-internal';
 import {
@@ -14,7 +15,6 @@ import {
   type TestElasticsearchUtils,
 } from '@kbn/core-test-helpers-kbn-server';
 import { clearLog, readLog, startElasticsearch } from '@kbn/migrator-test-kit';
-import { delay } from '../test_utils';
 import { getFips } from 'crypto';
 import { BASELINE_TEST_ARCHIVE_SMALL } from '../kibana_migrator_archive_utils';
 
@@ -37,7 +37,7 @@ describe.skip('migration v2 - read batch size', () => {
   afterEach(async () => {
     await root?.shutdown();
     await esServer?.stop();
-    await delay(5); // give it a few seconds... cause we always do ¯\_(ツ)_/¯
+    await timer(5_000); // give it a few seconds... cause we always do ¯\_(ツ)_/¯
   });
 
   if (getFips() === 0) {

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/split_failed_to_clone.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/split_failed_to_clone.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { join } from 'path';
+import { setTimeout as timer } from 'timers/promises';
 import type { TestElasticsearchUtils } from '@kbn/core-test-helpers-kbn-server';
 import type { CloneIndexParams } from '@kbn/core-saved-objects-migration-server-internal/src/actions';
 
@@ -21,14 +22,15 @@ import {
 } from '@kbn/migrator-test-kit';
 import { BASELINE_TEST_ARCHIVE_SMALL } from '../kibana_migrator_archive_utils';
 import { getRelocatingMigratorTestKit, kibanaSplitIndex } from '@kbn/migrator-test-kit/fixtures';
-import { delay } from '../test_utils';
 import '../jest_matchers';
 
 // mock clone_index from src/core/packages/saved-objects
 jest.mock('@kbn/core-saved-objects-migration-server-internal/src/actions/clone_index', () => {
+  const { setTimeout: actualTimer } = jest.requireActual('timers/promises');
   const realModule = jest.requireActual(
     '@kbn/core-saved-objects-migration-server-internal/src/actions/clone_index'
   );
+
   return {
     ...realModule,
     cloneIndex: (params: CloneIndexParams) => async () => {
@@ -36,7 +38,7 @@ jest.mock('@kbn/core-saved-objects-migration-server-internal/src/actions/clone_i
       // .kibana_migrator so that .kibana_migrator can completely finish the migration before we
       // fail
       if (!params.target.includes('tasks') && !params.target.includes('new'))
-        await new Promise((resolve) => setTimeout(resolve, 2000));
+        await actualTimer(2_000);
       return realModule.cloneIndex(params)();
     },
   };
@@ -55,7 +57,7 @@ describe('when splitting .kibana into multiple indices and one clone fails', () 
 
   afterAll(async () => {
     await esServer?.stop();
-    await delay(2);
+    await timer(2_000);
   });
 
   it('after resolving the problem and retrying the migration completes successfully', async () => {

--- a/src/core/server/integration_tests/saved_objects/migrations/group5/pickup_updated_types_only.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group5/pickup_updated_types_only.test.ts
@@ -8,6 +8,7 @@
  */
 
 import Path from 'path';
+import { setTimeout as timer } from 'timers/promises';
 import type { TestElasticsearchUtils } from '@kbn/core-test-helpers-kbn-server';
 import { clearLog, defaultKibanaIndex, startElasticsearch } from '@kbn/migrator-test-kit';
 
@@ -18,7 +19,7 @@ import {
   getReindexingMigratorTestKit,
 } from '@kbn/migrator-test-kit/fixtures';
 import '../jest_matchers';
-import { delay, parseLogFile } from '../test_utils';
+import { parseLogFile } from '../test_utils';
 
 export const logFilePath = Path.join(__dirname, 'pickup_updated_types_only.test.log');
 
@@ -88,6 +89,6 @@ describe('pickupUpdatedMappings', () => {
 
   afterAll(async () => {
     await esServer?.stop();
-    await delay(2);
+    await timer(2_000);
   });
 });

--- a/src/core/server/integration_tests/saved_objects/migrations/group6/single_migrator_failures.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group6/single_migrator_failures.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { join } from 'path';
+import { setTimeout as timer } from 'timers/promises';
 import type { TestElasticsearchUtils } from '@kbn/core-test-helpers-kbn-server';
 import {
   clearLog,
@@ -16,7 +17,6 @@ import {
   defaultKibanaIndex,
   defaultKibanaTaskIndex,
 } from '@kbn/migrator-test-kit';
-import { delay } from '../test_utils';
 import '../jest_matchers';
 import { getElasticsearchClientWrapperFactory } from '@kbn/migrator-test-kit';
 import { BASELINE_TEST_ARCHIVE_SMALL } from '../kibana_migrator_archive_utils';
@@ -225,7 +225,7 @@ describe('split .kibana index into multiple system indices', () => {
       ).toEqual(true);
 
       await esServer?.stop();
-      await delay(2);
+      await timer(2_000);
     });
   });
 });

--- a/src/core/server/integration_tests/saved_objects/migrations/kibana_migrator_archive_utils.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/kibana_migrator_archive_utils.ts
@@ -13,6 +13,7 @@ import { join } from 'path';
 import fs from 'fs/promises';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { setTimeout as timer } from 'timers/promises';
 const execPromise = promisify(exec);
 
 import type { SavedObjectsBulkCreateObject } from '@kbn/core-saved-objects-api-server';
@@ -23,7 +24,6 @@ import {
   startElasticsearch,
 } from '@kbn/migrator-test-kit';
 import { baselineTypes, getBaselineDocuments } from '@kbn/migrator-test-kit/fixtures';
-import { delay } from './test_utils';
 
 export const BASELINE_ELASTICSEARCH_VERSION = '9.3.0';
 export const BASELINE_DOCUMENTS_PER_TYPE_SMALL = 200;
@@ -90,16 +90,16 @@ export const createBaselineArchive = async ({
   }
 
   // wait a bit more to make sure everything's persisted to disk
-  await delay(30);
+  await timer(30_000);
 
   await compressBaselineArchive(basePath, dataArchive);
   console.log(`Archive created in: ${(Date.now() - startTime) / 1000} seconds`, dataArchive);
 
   // leave command line enough time to finish creating + closing ZIP file
-  await delay(30);
+  await timer(30_000);
 
   await esServer.stop();
-  await delay(10);
+  await timer(10_000);
   await fs.rm(basePath, { recursive: true, force: true });
 };
 

--- a/src/core/server/integration_tests/saved_objects/migrations/test_utils.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/test_utils.ts
@@ -33,9 +33,6 @@ export const getMigrationDocLink = () => {
   return docLinks.kibanaUpgradeSavedObjects;
 };
 
-export const delay = (seconds: number) =>
-  new Promise((resolve) => setTimeout(resolve, seconds * 1000));
-
 export const createType = (parts: Partial<SavedObjectsType>): SavedObjectsType => ({
   name: 'test-type',
   hidden: false,

--- a/src/core/test-helpers/model-versions/src/test_bed/test_bed.ts
+++ b/src/core/test-helpers/model-versions/src/test_bed/test_bed.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { setTimeout as timer } from 'timers/promises';
 import type { TestElasticsearchUtils } from '@kbn/core-test-helpers-kbn-server';
 import { startElasticsearch } from './elasticsearch';
 import { prepareModelVersionTestKit } from './test_kit';
@@ -76,7 +77,7 @@ export const createModelVersionTestBed = (): ModelVersionTestBed => {
       throw new Error('Elasticsearch not started');
     }
     await elasticsearch.stop();
-    await delay(10);
+    await timer(10_000);
     elasticsearch = undefined;
   };
 
@@ -86,5 +87,3 @@ export const createModelVersionTestBed = (): ModelVersionTestBed => {
     prepareTestKit: prepareModelVersionTestKit,
   };
 };
-
-const delay = (seconds: number) => new Promise((resolve) => setTimeout(resolve, seconds * 1000));


### PR DESCRIPTION
## Summary

Removes in-home  `delay` function definitions and uses the builtin Node one.
This PR only replaces occurrences in `src/core`, but follow-up PRs should be created to replace it across the whole codebase.