### PR TITLE
[DON'T MERGE][Security Solution][Attacks/Alerts] POC - Option 3: Reusing the Attack Discovery Page

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/common_attributes.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/common_attributes.gen.ts
@@ -286,6 +286,10 @@ export const FindAttackDiscoveryAlertsParams = z.object({
    * When true, return the created Attack discoveries with text replacements applied to the detailsMarkdown, entitySummaryMarkdown, summaryMarkdown, and title fields.
    */
   withReplacements: z.boolean(),
+  /**
+   * global search bar query filter
+   */
+  globalQuery: z.string().optional(),
 });
 
 export type AttackDiscoveryGenerationConfig = z.infer<typeof AttackDiscoveryGenerationConfig>;

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/common_attributes.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/common_attributes.schema.yaml
@@ -179,7 +179,6 @@ components:
           type: string
           description: The reason for a status of failed.
 
-
     CreateAttackDiscoveryAlertsParams:
       type: object
       required:
@@ -295,6 +294,9 @@ components:
         withReplacements:
           description: When true, return the created Attack discoveries with text replacements applied to the detailsMarkdown, entitySummaryMarkdown, summaryMarkdown, and title fields.
           type: boolean
+        globalQuery:
+          description: global search bar query filter
+          type: string
 
     AttackDiscoveryGenerationConfig:
       type: object

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/get/find_attack_discoveries_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/get/find_attack_discoveries_route.gen.ts
@@ -69,6 +69,10 @@ export const AttackDiscoveryFindRequestQuery = z.object({
    */
   shared: BooleanFromString.optional(),
   /**
+   * Elastic global query
+   */
+  global_query: z.string().optional(),
+  /**
    * Field used to sort results. See `AttackDiscoveryFindSortField` for allowed values.
    */
   sort_field: AttackDiscoveryFindSortField.optional().default('@timestamp'),

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/get/find_attack_discoveries_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/attack_discovery/routes/public/get/find_attack_discoveries_route.schema.yaml
@@ -50,7 +50,7 @@ paths:
           required: false
           schema:
             type: string
-          example: "now"
+          example: 'now'
         - name: 'ids'
           description: Filter results to the Attack discoveries with the specified IDs
           in: query
@@ -90,13 +90,20 @@ paths:
           required: false
           schema:
             type: string
-          example: ""
+          example: ''
         - name: 'shared'
           description: Whether to filter by shared visibility. If omitted, both shared and privately visible Attack discoveries are returned. Use `true` to return only shared discoveries, `false` to return only those visible to the current user.
           in: query
           required: false
           schema:
             type: boolean
+        - name: 'global_query'
+          description: Elastic global query
+          in: query
+          required: false
+          schema:
+            type: string
+          example: ''
         - name: 'sort_field'
           description: Field used to sort results. See `AttackDiscoveryFindSortField` for allowed values.
           in: query
@@ -104,7 +111,7 @@ paths:
           schema:
             default: '@timestamp'
             $ref: '#/components/schemas/AttackDiscoveryFindSortField'
-          example: "@timestamp"
+          example: '@timestamp'
         - name: 'sort_order'
           description: Sort order direction `asc` for ascending or `desc` for descending. Defaults to `desc`.
           in: query
@@ -112,14 +119,14 @@ paths:
           schema:
             default: 'desc'
             $ref: '../../../../common_attributes.schema.yaml#/components/schemas/SortOrder'
-          example: "desc"
+          example: 'desc'
         - name: 'start'
           description: Start of the time range for the search. Accepts absolute timestamps (ISO 8601) or relative date math (e.g. "now-7d").
           in: query
           required: false
           schema:
             type: string
-          example: "now-24h"
+          example: 'now-24h'
         - name: 'status'
           description: Filter by alert workflow status. Provide one or more of the allowed workflow states.
           in: query
@@ -132,7 +139,7 @@ paths:
                 - 'acknowledged'
                 - 'closed'
                 - 'open'
-          example: ['open','acknowledged']
+          example: ['open', 'acknowledged']
         - name: 'with_replacements'
           description: When true, return the created Attack discoveries with text replacements applied to the detailsMarkdown, entitySummaryMarkdown, summaryMarkdown, and title fields. Defaults to `true`.
           in: query
@@ -197,11 +204,11 @@ paths:
                   error:
                     type: string
                     description: Error type
-                    example: "Bad Request"
+                    example: 'Bad Request'
                   message:
                     type: string
                     description: Human-readable error message
-                    example: "Invalid request payload."
+                    example: 'Invalid request payload.'
 components:
   schemas:
     AttackDiscoveryFindSortField:

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/index.ts
@@ -21,7 +21,7 @@ import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import { buildEsQuery, type EsQueryConfig } from '@kbn/es-query';
 import type { AIAssistantDataClientParams } from '../../../ai_assistant_data_clients';
 import { AIAssistantDataClient } from '../../../ai_assistant_data_clients';
-import { findDocuments, getQueryFilter } from '../../../ai_assistant_data_clients/find';
+import { findDocuments } from '../../../ai_assistant_data_clients/find';
 import { combineFindAttackDiscoveryFilters } from './combine_find_attack_discovery_filters';
 import { createAttackDiscoveryAlerts } from './create_attack_discovery_alerts';
 import { getAttackDiscoveryGenerations } from './get_attack_discovery_generations';
@@ -302,7 +302,7 @@ export class AttackDiscoveryDataClient extends AIAssistantDataClient {
       uniqueAlertIds,
     } = transformSearchResponseToAlerts({
       logger,
-      response: result1.data,
+      response: result.data,
       includeUniqueAlertIds: includeUniqueAlertIds2,
       enableFieldRendering,
       withReplacements,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/index.ts
@@ -18,9 +18,10 @@ import type { AuthenticatedUser } from '@kbn/core-security-common';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 
+import { buildEsQuery, type EsQueryConfig } from '@kbn/es-query';
 import type { AIAssistantDataClientParams } from '../../../ai_assistant_data_clients';
 import { AIAssistantDataClient } from '../../../ai_assistant_data_clients';
-import { findDocuments } from '../../../ai_assistant_data_clients/find';
+import { findDocuments, getQueryFilter } from '../../../ai_assistant_data_clients/find';
 import { combineFindAttackDiscoveryFilters } from './combine_find_attack_discovery_filters';
 import { createAttackDiscoveryAlerts } from './create_attack_discovery_alerts';
 import { getAttackDiscoveryGenerations } from './get_attack_discovery_generations';
@@ -110,13 +111,162 @@ export class AttackDiscoveryDataClient extends AIAssistantDataClient {
       page = FIRST_PAGE,
       perPage = DEFAULT_PER_PAGE,
       withReplacements = false,
+      globalQuery,
     } = findAttackDiscoveryAlertsParams;
-    const aggs = getFindAttackDiscoveryAlertsAggregation(includeUniqueAlertIds);
+    const includeUniqueAlertIds2 = true;
+    const aggs = getFindAttackDiscoveryAlertsAggregation(includeUniqueAlertIds2);
 
     const index = this.getScheduledAndAdHocIndexPattern();
 
-    const filter = combineFindAttackDiscoveryFilters({
+    const filter1 = combineFindAttackDiscoveryFilters({
       alertIds,
+      connectorNames,
+      end,
+      executionUuid,
+      ids,
+      search,
+      start,
+      status,
+    });
+
+    const combinedFilter1 = getCombinedFilter({
+      authenticatedUser,
+      filter: filter1,
+      shared,
+    });
+    console.log(`[TEST] combinedFilter: ${JSON.stringify(combinedFilter1)}`);
+
+    const result1 = await findDocuments<AttackDiscoveryAlertDocument>({
+      aggs,
+      esClient,
+      filter: combinedFilter1,
+      index,
+      logger,
+      page,
+      perPage,
+      sortField,
+      sortOrder: sortOrder as estypes.SortOrder,
+    });
+
+    const { uniqueAlertIds: uniqueAlertIds1 } = transformSearchResponseToAlerts({
+      logger,
+      response: result1.data,
+      includeUniqueAlertIds: includeUniqueAlertIds2,
+      enableFieldRendering,
+      withReplacements,
+    });
+
+    const asdasdsa = {
+      bool: {
+        filter: {
+          bool: {
+            must: [],
+            filter: [
+              {
+                bool: {
+                  should: [{ term: { 'user.name': { value: 'jwlb3dme23' } } }],
+                  minimum_should_match: 1,
+                },
+              },
+              {
+                range: {
+                  '@timestamp': {
+                    gte: '2025-10-29T23:00:00.000Z',
+                    lte: '2025-10-30T22:59:59.999Z',
+                    format: 'strict_date_optional_time',
+                  },
+                },
+              },
+            ],
+            should: [],
+            must_not: [],
+          },
+        },
+      },
+    };
+
+    const asdasdasdsad = {
+      bool: {
+        filter: {
+          bool: {
+            must: [],
+            filter: [
+              {
+                bool: {
+                  should: [{ match_phrase: { 'user.name': 'jwlb3dme23' } }],
+                  minimum_should_match: 1,
+                },
+              },
+              {
+                range: {
+                  '@timestamp': {
+                    gte: '2025-10-29T23:00:00.000Z',
+                    lte: '2025-10-30T22:59:59.999Z',
+                    format: 'strict_date_optional_time',
+                  },
+                },
+              },
+              {
+                terms: {
+                  _id: [
+                    'b04728ea425d2212554b247080ca8dfc8e5b798362197e77017173c283497782',
+                    '617674934c092513acc43b2632b193950b821740b8b347f24a572ad4d5367418',
+                  ],
+                },
+              },
+            ],
+            should: [],
+            must_not: [],
+          },
+        },
+      },
+    };
+
+    // uniqueAlertIds
+    const convertedGlobalQuery = JSON.parse(globalQuery ?? '{}');
+    convertedGlobalQuery.bool.filter.bool.filter.push({
+      terms: { _id: uniqueAlertIds1 },
+    });
+    // console.log(`[TEST] convertedGlobalQuery: ${JSON.stringify(convertedGlobalQuery)}`);
+
+    const config: EsQueryConfig = {
+      allowLeadingWildcards: true,
+      dateFormatTZ: 'Zulu',
+      ignoreFilterIfFieldNotInIndex: false,
+      queryStringOptions: { analyze_wildcard: true },
+    };
+    const esQuery = buildEsQuery(
+      undefined,
+      [],
+      convertedGlobalQuery.bool.filter.bool.filter,
+      config
+    );
+    // console.log(`[TEST] esQuery: ${JSON.stringify(esQuery)}`);
+
+    const result2 = await esClient.search({
+      index: '.alerts-security.alerts-default',
+      query: esQuery,
+      _source: false,
+      size: 10_000,
+      ignore_unavailable: true,
+    });
+    console.log(`[TEST] alerts.result2: ${JSON.stringify(result2.hits.hits)}`);
+    const filteredAlertIds = result2.hits.hits.map(({ _id }) => _id);
+    console.log(`[TEST] filteredAlertIds: ${JSON.stringify(filteredAlertIds)}`);
+
+    if (!filteredAlertIds.length) {
+      return {
+        connector_names: [],
+        data: [],
+        page: 0,
+        per_page: 0,
+        total: 0,
+        unique_alert_ids_count: 0,
+      };
+    }
+
+    const filter = combineFindAttackDiscoveryFilters({
+      alertIds: filteredAlertIds as string[],
       connectorNames,
       end,
       executionUuid,
@@ -131,6 +281,7 @@ export class AttackDiscoveryDataClient extends AIAssistantDataClient {
       filter,
       shared,
     });
+    console.log(`[TEST] combinedFilter: ${JSON.stringify(combinedFilter)}`);
 
     const result = await findDocuments<AttackDiscoveryAlertDocument>({
       aggs,
@@ -151,8 +302,8 @@ export class AttackDiscoveryDataClient extends AIAssistantDataClient {
       uniqueAlertIds,
     } = transformSearchResponseToAlerts({
       logger,
-      response: result.data,
-      includeUniqueAlertIds,
+      response: result1.data,
+      includeUniqueAlertIds: includeUniqueAlertIds2,
       enableFieldRendering,
       withReplacements,
     });
@@ -164,7 +315,7 @@ export class AttackDiscoveryDataClient extends AIAssistantDataClient {
       per_page: result.perPage,
       total: result.total,
       unique_alert_ids_count: uniqueAlertIdsCount,
-      ...(includeUniqueAlertIds ? { unique_alert_ids: uniqueAlertIds } : {}),
+      ...(includeUniqueAlertIds2 ? { unique_alert_ids: uniqueAlertIds } : {}),
     };
   };
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/get/find_attack_discoveries.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/get/find_attack_discoveries.ts
@@ -113,6 +113,7 @@ export const findAttackDiscoveriesRoute = (
               perPage: query.per_page,
               sortField: query.sort_field,
               sortOrder: query.sort_order,
+              globalQuery: query.global_query,
               withReplacements: query.with_replacements ?? true, // public APIs default to applying replacements in responses as a convenience to non-Kibana clients
             },
             logger,

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/index.tsx
@@ -78,10 +78,10 @@ const AlertsTabComponent: React.FC<Props> = ({ attackDiscovery, replacements }) 
     () => [
       ...globalFilters,
       ...timeRangeFilter,
-      {
-        query: { terms: { _id: originalAlertIds } },
-        meta: {},
-      },
+      // {
+      //   query: { terms: { _id: originalAlertIds } },
+      //   meta: {},
+      // },
     ],
     [globalFilters, originalAlertIds, timeRangeFilter]
   );
@@ -104,8 +104,12 @@ const AlertsTabComponent: React.FC<Props> = ({ attackDiscovery, replacements }) 
 
     try {
       const filter = JSON.parse(combinedQuery?.filterQuery);
+      filter.bool.filter.push({
+        terms: { _id: originalAlertIds },
+      });
       return { bool: { filter } };
-    } catch {
+    } catch (error) {
+      console.error(`[TEST] error: ${JSON.stringify(error)}`);
       return { bool: {} };
     }
   }, [browserFields, dataView, dataViewSpec, filters, globalQuery, uiSettings]);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/history/search_and_filter/index.tsx
@@ -225,7 +225,7 @@ const SearchAndFilterComponent: React.FC<Props> = ({
           />
         </EuiFlexItem>
 
-        <EuiFlexItem
+        {/* <EuiFlexItem
           css={css`
             width: ${DATE_PICKER_WIDTH};
           `}
@@ -242,7 +242,7 @@ const SearchAndFilterComponent: React.FC<Props> = ({
             start={start}
             updateButtonProps={updateButtonProps}
           />
-        </EuiFlexItem>
+        </EuiFlexItem> */}
       </EuiFlexGroup>
 
       {filterByAlertIds.length > 0 && (

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_find_attack_discoveries/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_find_attack_discoveries/index.ts
@@ -43,6 +43,7 @@ interface Props {
   status?: string[];
   sortField?: string;
   sortOrder?: string;
+  globalQuery?: string;
 }
 
 interface UseFindAttackDiscoveries {
@@ -81,6 +82,7 @@ export const useFindAttackDiscoveries = ({
   status,
   sortField = '@timestamp',
   sortOrder = 'desc',
+  globalQuery,
 }: Props): UseFindAttackDiscoveries => {
   const { addError } = useAppToasts();
   const { attackDiscoveryPublicApiEnabled } = useKibanaFeatureFlags();
@@ -116,6 +118,7 @@ export const useFindAttackDiscoveries = ({
         sort_order: sortOrder,
         start,
         status,
+        global_query: globalQuery,
       };
 
       if (attackDiscoveryPublicApiEnabled) {
@@ -143,6 +146,7 @@ export const useFindAttackDiscoveries = ({
       attackDiscoveryPublicApiEnabled,
       connectorNames,
       end,
+      globalQuery,
       http,
       ids,
       includeUniqueAlertIds,


### PR DESCRIPTION
## Summary

Main ticket: https://github.com/elastic/kibana/issues/239258

This is a POC of reusing the Attack discovery page in combination with the KQL search bar ([option 3 in this doc](https://docs.google.com/document/d/1NkFX1hDflNU5jCAtkouGDJsS1KEePMXsHthPIr6XiD4)).

### Key changes

* There are **no detection alerts docs updates**
* A new **KQL search bar on Attack discovery page** which allows user to filter out the attacks and detection alerts. The filters applied to detection alerts and if the attack doesn't have alerts after filters applied it will be filtered out as well.
* Attack discoveries filtering steps
    * Fetch all attack discoveries based on relevant (connector, visibility etc.) currently **selected filters**
    * Collect all detection alerts ids referenced by the filtered attacks
    * Fetch all detection alerts using **global filters** (including KQL bar query) and **alerts ids** from the previous step
    * Fetch all attack discoveries based on relevant (connector, visibility etc.) currently **selected filters** and **alerts ids** from the previous step
* When user opens the alerts tab within the attack, we pass both **referenced alerts ids** and **global filters** to the Alerts table.

### Deployment Credentials

https://p.elstc.co/paste/GtRx9qIp#sZYPHAsYjoKJLBR+XK2KaWfCIke3Wxh2Lhlr1wojhNc

