### PR TITLE
[Discover][Traces] Add data-test-subj for full screen button in TraceWaterfall component

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace_waterfall/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace_waterfall/index.tsx
@@ -83,6 +83,7 @@ export function TraceWaterfall({ traceId, docId, serviceName, dataView }: Props)
             label: fullScreenButtonLabel,
             ariaLabel: fullScreenButtonLabel,
             id: actionId,
+            dataTestSubj: 'unifiedDocViewerObservabilityTracesTraceFullScreenButton',
           },
         ]}
       >


### PR DESCRIPTION
## Summary

This PR adds back `data-test-subj` as `unifiedDocViewerObservabilityTracesTraceFullScreenButton` for the "Expand trace timeline" button.

|Before|After|
|-|-|
|<img width="1563" height="1031" alt="Screenshot 2025-11-04 at 13 10 16" src="https://github.com/user-attachments/assets/bbed867b-84bf-4397-8d50-3fbcb0c26f9a" />|<img width="1920" height="971" alt="Screenshot 2025-11-04 at 13 21 18" src="https://github.com/user-attachments/assets/411ff7f0-f3a9-48d9-b48e-ba6cd5114bdf" />|





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->