### PR TITLE
[Chrome Grid] Fix `WindowScroller` usages

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processors_tree/components/private_tree.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processors_tree/components/private_tree.tsx
@@ -11,6 +11,7 @@ import { EuiFlexGroup } from '@elastic/eui';
 import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 import List from 'react-virtualized/dist/commonjs/List';
 import WindowScroller from 'react-virtualized/dist/commonjs/WindowScroller';
+import { APP_MAIN_SCROLL_CONTAINER_ID } from '@kbn/core-chrome-layout-constants';
 
 import { DropSpecialLocations } from '../../../constants';
 import type { ProcessorInternal, ProcessorSelector } from '../../../types';
@@ -141,7 +142,10 @@ export const PrivateTree: FunctionComponent<PrivateProps> = ({
   // A list optimized to handle very many items.
   const renderVirtualList = () => {
     return (
-      <WindowScroller ref={windowScrollerRef} scrollElement={window}>
+      <WindowScroller
+        ref={windowScrollerRef}
+        scrollElement={document.getElementById(APP_MAIN_SCROLL_CONTAINER_ID) ?? window}
+      >
         {({ height, registerChild, isScrolling, onChildScroll, scrollTop }: any) => {
           return (
             <AutoSizer disableHeight>

--- a/x-pack/platform/plugins/shared/ingest_pipelines/tsconfig.json
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/tsconfig.json
@@ -42,7 +42,8 @@
     "@kbn/delete-managed-asset-callout",
     "@kbn/shared-ux-utility",
     "@kbn/ingest-pipelines-shared",
-    "@kbn/licensing-types"
+    "@kbn/licensing-types",
+    "@kbn/core-chrome-layout-constants"
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/accordion_waterfall.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/accordion_waterfall.tsx
@@ -20,6 +20,7 @@ import { WindowScroller, AutoSizer } from 'react-virtualized';
 import type { ListChildComponentProps } from 'react-window';
 import { areEqual, VariableSizeList as List } from 'react-window';
 import { css } from '@emotion/react';
+import { APP_MAIN_SCROLL_CONTAINER_ID } from '@kbn/core-chrome-layout-constants';
 import type { IWaterfallGetRelatedErrorsHref } from '../../../../../../../common/waterfall/typings';
 import { asBigNumber } from '../../../../../../../common/utils/formatters';
 import type { Margins } from '../../../../../shared/charts/timeline';
@@ -100,7 +101,12 @@ function Waterfall(props: WaterfallProps) {
   };
 
   return (
-    <WindowScroller onScroll={onScroll} scrollElement={props.scrollElement}>
+    <WindowScroller
+      onScroll={onScroll}
+      scrollElement={
+        props.scrollElement ?? document.getElementById(APP_MAIN_SCROLL_CONTAINER_ID) ?? undefined
+      }
+    >
       {({ registerChild }) => (
         <AutoSizer disableHeight>
           {({ width }) => (

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/index.tsx
@@ -11,6 +11,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { AutoSizer, WindowScroller } from 'react-virtualized';
 import type { ListChildComponentProps } from 'react-window';
 import { VariableSizeList as List, areEqual } from 'react-window';
+import { APP_MAIN_SCROLL_CONTAINER_ID } from '@kbn/core-chrome-layout-constants';
 import type { IWaterfallGetRelatedErrorsHref } from '../../../../common/waterfall/typings';
 import type { TraceItem } from '../../../../common/waterfall/unified_trace_item';
 import { TimelineAxisContainer, VerticalLinesContainer } from '../charts/timeline';
@@ -169,7 +170,12 @@ function TraceTree() {
   );
 
   return (
-    <WindowScroller onScroll={onScroll} scrollElement={scrollElement}>
+    <WindowScroller
+      onScroll={onScroll}
+      scrollElement={
+        scrollElement ?? document.getElementById(APP_MAIN_SCROLL_CONTAINER_ID) ?? undefined
+      }
+    >
       {({ registerChild }) => (
         <AutoSizer disableHeight>
           {({ width }) => (

--- a/x-pack/solutions/observability/plugins/apm/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/apm/tsconfig.json
@@ -146,7 +146,8 @@
     "@kbn/esql-composer",
     "@kbn/discover-shared-plugin",
     "@kbn/core-chrome-browser",
-    "@kbn/react-query"
+    "@kbn/react-query",
+    "@kbn/core-chrome-layout-constants"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/241610 and other usages



Should be tested with both old layout and new layout: 

```
feature_flags.overrides:
  core.chrome.layoutType: 'grid'
```


