### PR TITLE
[FTR] [9.1] Add missing test categories to functional test config

### DIFF
--- a/x-pack/platform/test/security_api_integration/session_cookie.config.ts
+++ b/x-pack/platform/test/security_api_integration/session_cookie.config.ts
@@ -18,6 +18,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     testFiles: [resolve(__dirname, './tests/session_cookie')],
+    testConfigCategory: xPackAPITestsConfig.get('testConfigCategory'),
     services,
     servers: xPackAPITestsConfig.get('servers'),
     esTestCluster: {

--- a/x-pack/platform/test/security_api_integration/session_shard_missing.config.ts
+++ b/x-pack/platform/test/security_api_integration/session_shard_missing.config.ts
@@ -23,6 +23,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     testFiles: [resolve(__dirname, './tests/session_shard_missing')],
+    testConfigCategory: xPackAPITestsConfig.get('testConfigCategory'),
     services,
     servers: xPackAPITestsConfig.get('servers'),
     esTestCluster: {

--- a/x-pack/platform/test/upgrade_assistant_integration/config.ts
+++ b/x-pack/platform/test/upgrade_assistant_integration/config.ts
@@ -30,6 +30,7 @@ export default async function ({ readConfigFile, log }: FtrConfigProviderContext
 
   return {
     testFiles: [require.resolve('./upgrade_assistant')],
+    testConfigCategory: xPackApiTestsConfig.get('testConfigCategory'),
     servers: xPackApiTestsConfig.get('servers'),
     services: {
       ...commonFunctionalServices,


### PR DESCRIPTION
We checked our AppEx QA cluster's data and found that some functional test configs were missing a test category (in this case, api-test). This PR adds the missing test category.