### PR TITLE
[FTR] [8.19] Add missing test categories to functional test config

### DIFF
--- a/x-pack/platform/test/security_api_integration/session_cookie.config.ts
+++ b/x-pack/platform/test/security_api_integration/session_cookie.config.ts
@@ -18,6 +18,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     testFiles: [resolve(__dirname, './tests/session_cookie')],
+    testConfigCategory: xPackAPITestsConfig.get('testConfigCategory'),
     services,
     servers: xPackAPITestsConfig.get('servers'),
     esTestCluster: {

--- a/x-pack/solutions/security/test/kubernetes_security/basic/config.ts
+++ b/x-pack/solutions/security/test/kubernetes_security/basic/config.ts
@@ -6,7 +6,6 @@
  */
 
 import { createTestConfig } from '../common/config';
-import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 
 export default createTestConfig({
   license: 'basic',

--- a/x-pack/solutions/security/test/kubernetes_security/basic/config.ts
+++ b/x-pack/solutions/security/test/kubernetes_security/basic/config.ts
@@ -10,7 +10,6 @@ import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 
 export default createTestConfig({
   license: 'basic',
-  testConfigCategory: ScoutTestRunConfigCategory.API_TEST,
   name: 'X-Pack kubernetes_security API integration tests (basic)',
   testFiles: [require.resolve('./tests')],
 });

--- a/x-pack/solutions/security/test/kubernetes_security/basic/config.ts
+++ b/x-pack/solutions/security/test/kubernetes_security/basic/config.ts
@@ -6,9 +6,11 @@
  */
 
 import { createTestConfig } from '../common/config';
+import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 
 export default createTestConfig({
   license: 'basic',
+  testConfigCategory: ScoutTestRunConfigCategory.API_TEST,
   name: 'X-Pack kubernetes_security API integration tests (basic)',
   testFiles: [require.resolve('./tests')],
 });

--- a/x-pack/solutions/security/test/kubernetes_security/common/config.ts
+++ b/x-pack/solutions/security/test/kubernetes_security/common/config.ts
@@ -23,6 +23,7 @@ export function createTestConfig(settings: Settings) {
 
     return {
       testFiles,
+      testConfigCategory: xPackAPITestsConfig.get('testConfigCategory'),
       servers: xPackAPITestsConfig.get('servers'),
       services: xPackAPITestsConfig.get('services'),
       junit: {


### PR DESCRIPTION
We checked our AppEx QA cluster's data and found that some functional test configs were missing a test category (in this case, api-test). This PR adds the missing test category.