### PR TITLE
[Metrics][Discover] Fix the "Values" dropdown visualizing incorrectly on smaller screens

### DIFF
--- a/src/dev/storybook/aliases.ts
+++ b/src/dev/storybook/aliases.ts
@@ -67,6 +67,7 @@ export const storybookAliases = {
   triggers_actions_ui: 'x-pack/platform/plugins/shared/triggers_actions_ui/.storybook',
   ui_actions_enhanced: 'src/platform/plugins/shared/ui_actions_enhanced/.storybook',
   unified_doc_viewer: 'src/platform/plugins/shared/unified_doc_viewer/.storybook',
+  unified_metrics_grid: 'src/platform/packages/shared/kbn-unified-metrics-grid/.storybook',
   unified_search: 'src/platform/plugins/shared/unified_search/.storybook',
   unified_tabs: 'src/platform/packages/shared/kbn-unified-tabs/.storybook',
   upgrade_assistant: 'x-pack/platform/packages/private/upgrade-assistant/public/.storybook',

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/.storybook/main.js
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/.storybook/main.js
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+module.exports = require('@kbn/storybook').defaultConfig;

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/values_selector.stories.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/values_selector.stories.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import type { MetricsExperienceClient } from '@kbn/metrics-experience-plugin/public';
+import { ValuesSelector } from './values_selector';
+import { MetricsExperienceClientProvider } from '../../context/metrics_experience_client_provider';
+import { FIELD_VALUE_SEPARATOR } from '../../common/constants';
+
+export default {
+  title: 'kbn-unified-metrics-grid/ValuesSelector',
+  component: ValuesSelector,
+};
+
+const defaultTimeRange = {
+  from: 'now-15m',
+  to: 'now',
+};
+
+// Create a QueryClient instance for React Query
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+// Mock client for Storybook
+const mockClient: MetricsExperienceClient = {
+  getDimensions: async () => ({
+    values: [
+      { field: 'host.name', value: 'server-01' },
+      { field: 'host.name', value: 'server-02' },
+      { field: 'host.name', value: 'server-03' },
+      { field: 'service.name', value: 'api-service' },
+      { field: 'service.name', value: 'web-service' },
+      { field: 'service.name', value: 'database-service' },
+    ],
+  }),
+  getFields: async () => ({ fields: [], total: 0, page: 1 }),
+} as MetricsExperienceClient;
+
+// Wrapper component with all required providers
+const StoryWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <IntlProvider locale="en">
+    <QueryClientProvider client={queryClient}>
+      <MetricsExperienceClientProvider value={{ client: mockClient }}>
+        {children}
+      </MetricsExperienceClientProvider>
+    </QueryClientProvider>
+  </IntlProvider>
+);
+
+export const Default = () => {
+  const [selectedValues, setSelectedValues] = useState<string[]>([]);
+
+  return (
+    <StoryWrapper>
+      <ValuesSelector
+        selectedDimensions={['host.name', 'service.name']}
+        selectedValues={selectedValues}
+        indices={['metrics-*']}
+        timeRange={defaultTimeRange}
+        onChange={setSelectedValues}
+        onClear={() => setSelectedValues([])}
+      />
+    </StoryWrapper>
+  );
+};
+
+export const WithSelectedValues = () => {
+  const [selectedValues, setSelectedValues] = useState<string[]>([
+    `host.name${FIELD_VALUE_SEPARATOR}server-01`,
+    `service.name${FIELD_VALUE_SEPARATOR}api-service`,
+  ]);
+
+  return (
+    <StoryWrapper>
+      <ValuesSelector
+        selectedDimensions={['host.name', 'service.name']}
+        selectedValues={selectedValues}
+        indices={['metrics-*']}
+        timeRange={defaultTimeRange}
+        onChange={setSelectedValues}
+        onClear={() => setSelectedValues([])}
+      />
+    </StoryWrapper>
+  );
+};
+
+export const Disabled = () => {
+  const [selectedValues, setSelectedValues] = useState<string[]>([]);
+
+  return (
+    <StoryWrapper>
+      <ValuesSelector
+        selectedDimensions={['host.name']}
+        selectedValues={selectedValues}
+        indices={['metrics-*']}
+        disabled={true}
+        timeRange={defaultTimeRange}
+        onChange={setSelectedValues}
+        onClear={() => setSelectedValues([])}
+      />
+    </StoryWrapper>
+  );
+};
+
+export const NoDimensionsLoadingState = () => {
+  const [selectedValues, setSelectedValues] = useState<string[]>([]);
+
+  return (
+    <StoryWrapper>
+      <ValuesSelector
+        selectedDimensions={[]}
+        selectedValues={selectedValues}
+        indices={['metrics-*']}
+        timeRange={defaultTimeRange}
+        onChange={setSelectedValues}
+        onClear={() => setSelectedValues([])}
+      />
+    </StoryWrapper>
+  );
+};

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/values_selector.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/values_selector.tsx
@@ -29,7 +29,7 @@ import {
   METRICS_VALUES_SELECTOR_DATA_TEST_SUBJ,
 } from '../../common/constants';
 
-interface ValuesFilterProps {
+export interface ValuesFilterProps {
   selectedDimensions: string[];
   selectedValues: string[];
   indices?: string[];

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/values_selector.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/values_selector.tsx
@@ -104,7 +104,7 @@ export const ValuesSelector = ({
     const count = selectedValues.length;
 
     return (
-      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
         <EuiFlexItem grow={false}>
           {count > 0 ? (
             <FormattedMessage


### PR DESCRIPTION
## Summary

Closes #239348

This PR addresses "Values" dropdown visualizing incorrectly on smaller screens. 

### How to test
- Run `yarn storybook unified_metrics_grid`
- Select `ValuesSelector` and `With selected values`.

Before:
<img width="991" height="964" alt="Screenshot 2025-11-04 at 14 08 30" src="https://github.com/user-attachments/assets/4b7e4121-f3b0-4159-bb74-63949e702301" />

After:
<img width="993" height="968" alt="Screenshot 2025-11-04 at 14 09 08" src="https://github.com/user-attachments/assets/4346493f-aca2-400a-81ec-993f2a4fba18" />




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->