### PR TITLE
[ES|QL] Cleanup the utils

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -28,7 +28,6 @@ export {
   hasStartEndParams,
   getNamedParams,
   prettifyQuery,
-  isQueryWrappedByPipes,
   retrieveMetadataColumns,
   getQueryColumnsFromESQLQuery,
   isESQLColumnSortable,

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -17,7 +17,6 @@ export {
   hasTransformationalCommand,
   getTimeFieldFromESQLQuery,
   prettifyQuery,
-  isQueryWrappedByPipes,
   retrieveMetadataColumns,
   getQueryColumnsFromESQLQuery,
   mapVariableToColumn,

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { BasicPrettyPrinter, EsqlQuery, parse, mutate } from '@kbn/esql-ast';
+import { BasicPrettyPrinter, EsqlQuery, Parser, mutate } from '@kbn/esql-ast';
 import type { BinaryExpressionComparisonOperator } from '@kbn/esql-ast/src/types';
 import { sanitazeESQLInput } from './sanitaze_input';
 
@@ -142,7 +142,7 @@ export function appendWhereClauseToESQLQuery(
 }
 
 export const appendStatsByToQuery = (queryString: string, column: string) => {
-  const { root } = parse(queryString);
+  const { root } = Parser.parse(queryString);
   const lastCommand = root.commands[root.commands.length - 1];
   if (lastCommand.name === 'stats') {
     const statsCommand = lastCommand;

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_esql_with_safe_limit.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_esql_with_safe_limit.ts
@@ -7,17 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { parse } from '@kbn/esql-ast';
+import { Parser } from '@kbn/esql-ast';
 
 export function getESQLWithSafeLimit(esql: string, limit: number): string {
-  const { ast } = parse(esql);
-  const sourceCommand = ast.find(({ name }) => ['from', 'ts'].includes(name));
+  const { root } = Parser.parse(esql);
+  const sourceCommand = root.commands.find(({ name }) => ['from', 'ts'].includes(name));
   if (!sourceCommand) {
     return esql;
   }
 
   let sortCommandIndex = -1;
-  const sortCommand = ast.find(({ name }, index) => {
+  const sortCommand = root.commands.find(({ name }, index) => {
     sortCommandIndex = index;
     return name === 'sort';
   });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_cannot_be_sampled.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_cannot_be_sampled.ts
@@ -8,7 +8,7 @@
  */
 import type { AggregateQuery, Query } from '@kbn/es-query';
 import { Walker } from '@kbn/esql-ast';
-import { parse } from '@kbn/esql-ast';
+import { Parser } from '@kbn/esql-ast';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 
 /**
@@ -22,7 +22,7 @@ export const queryContainsFunction = (
   functions: string[]
 ): boolean => {
   if (query && isOfAggregateQueryType(query)) {
-    const { root } = parse(query.esql);
+    const { root } = Parser.parse(query.esql);
     return functions.some(
       (f) =>
         Walker.hasFunction(root, f) ||

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -7,6 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
+import type { monaco } from '@kbn/monaco';
+import type { ESQLColumn } from '@kbn/esql-ast';
+import { Parser, walk } from '@kbn/esql-ast';
 import { ESQLVariableType, type ESQLControlVariable } from '@kbn/esql-types';
 import {
   getIndexPatternFromESQLQuery,
@@ -16,7 +19,6 @@ import {
   hasTransformationalCommand,
   getTimeFieldFromESQLQuery,
   prettifyQuery,
-  isQueryWrappedByPipes,
   retrieveMetadataColumns,
   getQueryColumnsFromESQLQuery,
   mapVariableToColumn,
@@ -31,9 +33,7 @@ import {
   hasLimitBeforeAggregate,
   missingSortBeforeLimit,
 } from './query_parsing_helpers';
-import type { monaco } from '@kbn/monaco';
-import type { ESQLColumn } from '@kbn/esql-ast';
-import { parse, walk } from '@kbn/esql-ast';
+
 describe('esql query helpers', () => {
   describe('getIndexPatternFromESQLQuery', () => {
     it('should return the index pattern string from esql queries', () => {
@@ -292,23 +292,6 @@ describe('esql query helpers', () => {
     it('should return the query with FROM command if TS command is found', function () {
       const query = convertTimeseriesCommandToFrom('TS index1 | KEEP field1, field2 | SORT field1');
       expect(query).toEqual('FROM index1 | KEEP field1, field2 | SORT field1');
-    });
-  });
-
-  describe('isQueryWrappedByPipes', function () {
-    it('should return false if the query is not wrapped', function () {
-      const flag = isQueryWrappedByPipes('FROM index1 | KEEP field1, field2 | SORT field1');
-      expect(flag).toBeFalsy();
-    });
-
-    it('should return true if the query is wrapped', function () {
-      const flag = isQueryWrappedByPipes('FROM index1 /n| KEEP field1, field2 /n| SORT field1');
-      expect(flag).toBeTruthy();
-    });
-
-    it('should return true if the query is wrapped and prettified', function () {
-      const flag = isQueryWrappedByPipes('FROM index1 /n  | KEEP field1, field2 /n  | SORT field1');
-      expect(flag).toBeTruthy();
     });
   });
 
@@ -975,7 +958,7 @@ describe('esql query helpers', () => {
   describe('getArgsFromRenameFunction', () => {
     it('should return the args from an = rename function', () => {
       const esql = 'FROM index | RENAME renamed = original';
-      const { root } = parse(esql);
+      const { root } = Parser.parse(esql);
       let renameFunction;
       walk(root, {
         visitFunction: (node) => (renameFunction = node),
@@ -989,7 +972,7 @@ describe('esql query helpers', () => {
 
     it('should return the args from an AS rename function', () => {
       const esql = 'FROM index | RENAME original AS renamed';
-      const { root } = parse(esql);
+      const { root } = Parser.parse(esql);
       let renameFunction;
       walk(root, {
         visitFunction: (node) => (renameFunction = node),

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import {
-  parse,
   Walker,
   walk,
   Parser,
@@ -36,8 +35,8 @@ const DEFAULT_ESQL_LIMIT = 1000;
 
 // retrieves the index pattern from the aggregate query for ES|QL using ast parsing
 export function getIndexPatternFromESQLQuery(esql?: string) {
-  const { ast } = parse(esql);
-  const sourceCommand = ast.find(({ name }) => ['from', 'ts'].includes(name));
+  const { root } = Parser.parse(esql || '');
+  const sourceCommand = root.commands.find(({ name }) => ['from', 'ts'].includes(name));
   const args = (sourceCommand?.args ?? []) as ESQLSource[];
   const indices = args.filter((arg) => arg.sourceType === 'index');
   return indices?.map((index) => index.name).join(',');
@@ -143,14 +142,14 @@ export function hasTransformationalCommand(esql?: string) {
 }
 
 export function getLimitFromESQLQuery(esql: string): number {
-  const { ast } = parse(esql);
-  const limitCommands = ast.filter(({ name }) => name === 'limit');
+  const { root } = Parser.parse(esql || '');
+  const limitCommands = root.commands.filter(({ name }) => name === 'limit');
   if (!limitCommands || !limitCommands.length) {
     return DEFAULT_ESQL_LIMIT;
   }
   const limits: number[] = [];
 
-  walk(ast, {
+  walk(root.commands, {
     visitLiteral: (node) => {
       if (!isNaN(Number(node.value))) {
         limits.push(Number(node.value));
@@ -205,14 +204,14 @@ export function convertTimeseriesCommandToFrom(esql?: string): string {
  * @returns string
  */
 export const getTimeFieldFromESQLQuery = (esql: string) => {
-  const { ast } = parse(esql);
+  const { root } = Parser.parse(esql);
   const functions: ESQLFunction[] = [];
 
-  walk(ast, {
+  walk(root.commands, {
     visitFunction: (node) => functions.push(node),
   });
 
-  const params = Walker.params(ast);
+  const params = Walker.params(root);
   const timeNamedParam = params.find(
     (param) => param.value === '_tstart' || param.value === '_tend'
   );
@@ -253,10 +252,10 @@ export const getTimeFieldFromESQLQuery = (esql: string) => {
 };
 
 export const getKqlSearchQueries = (esql: string) => {
-  const { ast } = parse(esql);
+  const { root } = Parser.parse(esql);
   const functions: ESQLFunction[] = [];
 
-  walk(ast, {
+  walk(root.commands, {
     visitFunction: (node) => functions.push(node),
   });
 
@@ -272,23 +271,16 @@ export const getKqlSearchQueries = (esql: string) => {
     .filter((query) => query !== '');
 };
 
-export const isQueryWrappedByPipes = (query: string): boolean => {
-  const { ast } = parse(query);
-  const numberOfCommands = ast.length;
-  const pipesWithNewLine = query.split('\n  |');
-  return numberOfCommands === pipesWithNewLine?.length;
-};
-
 export const prettifyQuery = (src: string): string => {
   const { root } = Parser.parse(src, { withFormatting: true });
   return WrappingPrettyPrinter.print(root, { multiline: true });
 };
 
 export const retrieveMetadataColumns = (esql: string): string[] => {
-  const { ast } = parse(esql);
+  const { root } = Parser.parse(esql);
   const options: ESQLCommandOption[] = [];
 
-  walk(ast, {
+  walk(root, {
     visitCommandOption: (node) => options.push(node),
   });
   const metadataOptions = options.find(({ name }) => name === 'metadata');
@@ -296,7 +288,7 @@ export const retrieveMetadataColumns = (esql: string): string[] => {
 };
 
 export const getQueryColumnsFromESQLQuery = (esql: string): string[] => {
-  const { root } = parse(esql);
+  const { root } = Parser.parse(esql);
   const columns: ESQLColumn[] = [];
 
   walk(root, {
@@ -307,7 +299,7 @@ export const getQueryColumnsFromESQLQuery = (esql: string): string[] => {
 };
 
 export const getESQLQueryVariables = (esql: string): string[] => {
-  const { root } = parse(esql);
+  const { root } = Parser.parse(esql);
   const usedVariablesInQuery = Walker.params(root);
   return usedVariablesInQuery.map((v) => v.text.replace(/^\?+/, ''));
 };
@@ -426,7 +418,7 @@ export const getValuesFromQueryField = (queryString: string, cursorPosition?: mo
   }
 
   const validQuery = `${queryInCursorPosition} ""`;
-  const { root } = parse(validQuery);
+  const { root } = Parser.parse(validQuery);
   const lastCommand = root.commands[root.commands.length - 1];
   const columns: ESQLColumn[] = [];
 
@@ -475,7 +467,7 @@ export const fixESQLQueryWithVariables = (
 };
 
 export const getCategorizeColumns = (esql: string): string[] => {
-  const { root } = parse(esql);
+  const { root } = Parser.parse(esql);
   const statsCommand = root.commands.find(({ name }) => name === 'stats');
   if (!statsCommand) {
     return [];
@@ -558,7 +550,7 @@ export const getArgsFromRenameFunction = (
  * @param esql: string - The ESQL query string
  */
 export const getCategorizeField = (esql: string): string[] => {
-  const { root } = parse(esql);
+  const { root } = Parser.parse(esql);
   const columns: string[] = [];
   const functions = Walker.matchAll(root.commands, {
     type: 'function',

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.test.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.test.tsx
@@ -38,7 +38,6 @@ jest.mock('@kbn/esql-utils', () => {
     }),
     getIndexPatternFromESQLQuery: jest.fn().mockReturnValue('index1'),
     getLimitFromESQLQuery: jest.fn().mockReturnValue(1000),
-    isQueryWrappedByPipes: jest.fn().mockReturnValue(false),
     getValuesFromQueryField: jest.fn().mockReturnValue('field'),
     getESQLQueryColumnsRaw: jest.fn().mockResolvedValue([{ name: 'column1' }, { name: 'column2' }]),
   };


### PR DESCRIPTION
## Summary

Cleanups the esql-utils:

- Removed deprecated parse function
- Removed isQueryWrappedByPipes as it is not used anymore

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



