### PR TITLE
[Docs] Remove reference to non-existing page

### DIFF
--- a/dev_docs/nav-kibana-dev.docnav.json
+++ b/dev_docs/nav-kibana-dev.docnav.json
@@ -246,9 +246,6 @@
         },
         {
           "id": "ktCustomServerlessImage"
-        },
-        {
-          "id": "kibDevTutorialsSolutionNavigation"
         }
       ]
     },
@@ -265,10 +262,6 @@
       "label": "Shared UX",
       "pageId": "kibDevDocsSharedUxOverview",
       "items": [
-        {
-          "label": "Solution Navigation (stateful solution nav and serverless navigation",
-          "id": "kibDevTutorialsSolutionNavigation"
-        },
         {
           "id": "kibDevTutorialFileService",
           "label": "File service"

--- a/dev_docs/shared_ux/shared_ux_landing.mdx
+++ b/dev_docs/shared_ux/shared_ux_landing.mdx
@@ -27,11 +27,6 @@ layout: landing
   sectionTitle="Our Catalog"
   items={[
     {
-      pageId: 'kibDevTutorialsSolutionNavigation',
-      title: 'Serverless Project Navigation',
-      description: 'Learn how to work with the new chrome navigation in serverless projects',
-    },
-    {
       pageId: 'kibDevTutorialFileService',
       title: 'File service',
       description: 'Learn how to add files uploading and downloading to your plugin',


### PR DESCRIPTION
## Summary

It seems like the reference `kibDevTutorialsSolutionNavigation` does not exist and is blocking dev docs from building: `Invalid link to page id kibDevTutorialsSolutionNavigation`