### PR TITLE
🌊 Streams: Fix simulation of geo points

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
@@ -166,8 +166,8 @@ export type WithRequired<TObj, TKey extends keyof TObj> = TObj & { [TProp in TKe
  * Input: { "source.geo.location.lat": 41.9, "source.geo.location.lon": 42.0, "other": "value" }
  * Output: { "source.geo.location": { lat: 41.9, lon: 42.0 }, "other": "value" }
  */
-const regroupGeoPointFields = (flattenedDoc: FlattenRecord): Record<string, any> => {
-  const result: Record<string, any> = {};
+const regroupGeoPointFields = (flattenedDoc: FlattenRecord): FlattenRecord => {
+  const result: FlattenRecord = {};
   const processedGeoFields = new Set<string>();
 
   for (const [key, value] of Object.entries(flattenedDoc)) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/processing_simulate.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/processing_simulate.ts
@@ -539,5 +539,105 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         expect(detectedFieldsFailureResponse.body.documents[0].status).to.be('failed');
       });
     });
+
+    describe('Geo point field handling', () => {
+      const CLASSIC_STREAM_NAME = 'logs-geotest-default';
+
+      before(async () => {
+        // Create a sample document with geo point to establish the stream
+        const sampleDoc = {
+          '@timestamp': TEST_TIMESTAMP,
+          message: 'test message',
+          'source.geo.location': {
+            lat: 40.7128,
+            lon: -74.006,
+          },
+        };
+        await indexDocument(esClient, CLASSIC_STREAM_NAME, sampleDoc);
+      });
+
+      after(async () => {
+        await esClient.indices.deleteDataStream({ name: CLASSIC_STREAM_NAME });
+      });
+
+      it('should correctly handle flattened geo point fields in simulation', async () => {
+        const response = await simulateProcessingForStream(apiClient, CLASSIC_STREAM_NAME, {
+          processing: {
+            steps: [
+              {
+                customIdentifier: 'draft',
+                action: 'grok' as const,
+                from: 'message',
+                patterns: ['%{WORD:parsed_field}'],
+                where: { always: {} },
+              },
+            ],
+          },
+          documents: [
+            {
+              '@timestamp': TEST_TIMESTAMP,
+              'source.geo.location.lat': 40.7128,
+              'source.geo.location.lon': -74.006,
+              message: 'test',
+              'other.field': 'value',
+            },
+          ],
+        });
+
+        expect(response.body.documents_metrics.parsed_rate).to.be(1);
+        expect(response.body.documents_metrics.failed_rate).to.be(0);
+
+        const { errors, status, value } = response.body.documents[0];
+        expect(status).to.be('parsed');
+        expect(errors).to.eql([]);
+
+        // Verify simulation succeeded without errors - geo points were regrouped internally
+        // but the response should still show flattened fields
+        expect(value).to.have.property('source.geo.location.lat', 40.7128);
+        expect(value).to.have.property('source.geo.location.lon', -74.006);
+        expect(value).to.have.property('other.field', 'value');
+        expect(value).to.have.property('parsed_field', 'test');
+      });
+
+      it('should handle multiple geo point fields in the same document', async () => {
+        const response = await simulateProcessingForStream(apiClient, CLASSIC_STREAM_NAME, {
+          processing: {
+            steps: [
+              {
+                customIdentifier: 'draft',
+                action: 'grok' as const,
+                from: 'message',
+                patterns: ['%{WORD:parsed_field}'],
+                where: { always: {} },
+              },
+            ],
+          },
+          documents: [
+            {
+              '@timestamp': TEST_TIMESTAMP,
+              'source.geo.location.lat': 40.7128,
+              'source.geo.location.lon': -74.006,
+              'destination.geo.location.lat': 51.5,
+              'destination.geo.location.lon': -0.125,
+              message: 'test',
+            },
+          ],
+        });
+
+        expect(response.body.documents_metrics.parsed_rate).to.be(1);
+        expect(response.body.documents_metrics.failed_rate).to.be(0);
+
+        const { errors, status, value } = response.body.documents[0];
+        expect(status).to.be('parsed');
+        expect(errors).to.eql([]);
+
+        // Verify simulation succeeded - geo points were regrouped internally during processing
+        // but the response still shows them as flattened fields
+        expect(value).to.have.property('source.geo.location.lat', 40.7128);
+        expect(value).to.have.property('source.geo.location.lon', -74.006);
+        expect(value).to.have.property('destination.geo.location.lat', 51.5);
+        expect(value).to.have.property('destination.geo.location.lon', -0.125);
+      });
+    });
   });
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/239876

Note that this doesn't fully resolve the issue, but mitigates it as much as possible (see https://github.com/elastic/streams-program/issues/584 ).

We always fully flatten the sample docs when handling them as part of the simulation. That works well, because field access doesn't care about dotted field names / flattened field names anyway, and we get separate columns etc.

However, there is a problem when dealing with geo point fields in the simulation - the geo point mapper requires the location object with `lat/lon` properties to be a separate object, if we flatten out all objects, that's not the case anymore.

This PR fixes this with minimal changes making sure lat/lon properties are represented by separate objects. Thanks to flexible field access pattern, all operations work the same no matter whether they are flattened or not.

This is just a quickfix, we need to fix it properly to allow geo point support in streams, but it gets rid of the bug for now.

Note that this doesn't allow to map geo point fields through the streams UI, this need to be resolved as part of https://github.com/elastic/streams-program/issues/584 once we have concluded how this should work with the Elasticsearch team.


```
POST logs-geotest-default/_doc
{
  "message": "Hello world",
  "source.geo.location": {
    "lat": 41.999999969266355,
    "lon": 41.99999992735684
  }
}
```

Before
<img width="1142" height="696" alt="Screenshot 2025-11-04 at 13 20 45" src="https://github.com/user-attachments/assets/c6ab5c95-2066-43e2-b876-b826fb469846" />

After
<img width="1152" height="614" alt="Screenshot 2025-11-04 at 13 22 07" src="https://github.com/user-attachments/assets/b65bdd71-f228-4c28-9c61-ac07ff1995f6" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->