### PR TITLE
[SideNav] Improve "More" menu items hover affordability

### DIFF
--- a/src/core/packages/chrome/navigation/src/__tests__/__snapshots__/both_modes.test.tsx.snap
+++ b/src/core/packages/chrome/navigation/src/__tests__/__snapshots__/both_modes.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Both modes should render the side navigation 1`] = `
             />
           </div>
           <div
-            class="euiText emotion-euiText-xs-euiTextAlign-center-verticalStyles-labelStyles"
+            class="euiText emotion-euiText-xs-euiTextAlign-center-textStyles-labelStyles"
           >
             Solution
           </div>
@@ -71,7 +71,7 @@ exports[`Both modes should render the side navigation 1`] = `
                 />
               </div>
               <div
-                class="euiText emotion-euiText-xs-euiTextAlign-center-truncatedStyles-verticalStyles-labelStyles"
+                class="euiText emotion-euiText-xs-euiTextAlign-center-truncatedStyles-textStyles-labelStyles"
               >
                 Dashboards
               </div>
@@ -105,7 +105,7 @@ exports[`Both modes should render the side navigation 1`] = `
                 />
               </div>
               <div
-                class="euiText emotion-euiText-xs-euiTextAlign-center-truncatedStyles-verticalStyles-labelStyles"
+                class="euiText emotion-euiText-xs-euiTextAlign-center-truncatedStyles-textStyles-labelStyles"
               >
                 Discover
               </div>
@@ -140,7 +140,7 @@ exports[`Both modes should render the side navigation 1`] = `
                 />
               </div>
               <div
-                class="euiText emotion-euiText-xs-euiTextAlign-center-truncatedStyles-verticalStyles-labelStyles"
+                class="euiText emotion-euiText-xs-euiTextAlign-center-truncatedStyles-textStyles-labelStyles"
               >
                 Apps
               </div>

--- a/src/core/packages/chrome/navigation/src/__tests__/__snapshots__/expanded_mode.test.tsx.snap
+++ b/src/core/packages/chrome/navigation/src/__tests__/__snapshots__/expanded_mode.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Expanded mode should render the side navigation 1`] = `
             />
           </div>
           <div
-            class="euiText emotion-euiText-xs-euiTextAlign-center-verticalStyles-labelStyles"
+            class="euiText emotion-euiText-xs-euiTextAlign-center-textStyles-labelStyles"
           >
             Solution
           </div>
@@ -71,7 +71,7 @@ exports[`Expanded mode should render the side navigation 1`] = `
                 />
               </div>
               <div
-                class="euiText emotion-euiText-xs-euiTextAlign-center-truncatedStyles-verticalStyles-labelStyles"
+                class="euiText emotion-euiText-xs-euiTextAlign-center-truncatedStyles-textStyles-labelStyles"
               >
                 Dashboards
               </div>
@@ -105,7 +105,7 @@ exports[`Expanded mode should render the side navigation 1`] = `
                 />
               </div>
               <div
-                class="euiText emotion-euiText-xs-euiTextAlign-center-truncatedStyles-verticalStyles-labelStyles"
+                class="euiText emotion-euiText-xs-euiTextAlign-center-truncatedStyles-textStyles-labelStyles"
               >
                 Discover
               </div>
@@ -140,7 +140,7 @@ exports[`Expanded mode should render the side navigation 1`] = `
                 />
               </div>
               <div
-                class="euiText emotion-euiText-xs-euiTextAlign-center-truncatedStyles-verticalStyles-labelStyles"
+                class="euiText emotion-euiText-xs-euiTextAlign-center-truncatedStyles-textStyles-labelStyles"
               >
                 Apps
               </div>

--- a/src/core/packages/chrome/navigation/src/components/menu_item/index.tsx
+++ b/src/core/packages/chrome/navigation/src/components/menu_item/index.tsx
@@ -23,7 +23,6 @@ export interface MenuItemProps extends HTMLAttributes<HTMLAnchorElement | HTMLBu
   iconType: IconType;
   isHighlighted: boolean;
   isCurrent?: boolean;
-  isHorizontal?: boolean;
   isLabelVisible?: boolean;
   isTruncated?: boolean;
 }
@@ -39,7 +38,6 @@ export const MenuItem = forwardRef<HTMLAnchorElement | HTMLButtonElement, MenuIt
       id,
       isCurrent = false,
       isHighlighted,
-      isHorizontal,
       isLabelVisible = true,
       isTruncated = true,
       ...props
@@ -62,11 +60,12 @@ export const MenuItem = forwardRef<HTMLAnchorElement | HTMLButtonElement, MenuIt
       position: relative;
       overflow: hidden;
       align-items: center;
-      justify-content: ${isHorizontal ? 'initial' : 'center'};
+      justify-content: center;
       display: flex;
-      flex-direction: ${isHorizontal ? 'row' : 'column'};
+      flex-direction: column;
       // 3px is from Figma; there is no token
-      gap: ${isHorizontal ? euiTheme.size.s : '3px'};
+      gap: 3px;
+      // eslint-disable-next-line @elastic/eui/no-css-color
       color: var(--menu-item-text-color);
       // Focus affordance with border on the iconWrapper instead
       outline: none !important;
@@ -81,8 +80,6 @@ export const MenuItem = forwardRef<HTMLAnchorElement | HTMLButtonElement, MenuIt
         border-radius: ${euiTheme.border.radius.medium};
         background-color: ${isHighlighted
           ? euiTheme.components.buttons.backgroundPrimary
-          : isHorizontal
-          ? euiTheme.colors.backgroundBaseSubdued
           : euiTheme.components.buttons.backgroundText};
         z-index: 1;
       }
@@ -132,18 +129,14 @@ export const MenuItem = forwardRef<HTMLAnchorElement | HTMLButtonElement, MenuIt
             -webkit-line-clamp: 2;
           `);
 
-    const verticalStyles = css`
+    const textStyles = css`
       ${euiFontSize(euiThemeContext, 'xxs', { unit: 'px' }).fontSize};
       font-weight: ${euiTheme.font.weight.semiBold};
     `;
 
-    const horizontalStyles = css`
-      font-weight: ${isHighlighted ? euiTheme.font.weight.semiBold : euiTheme.font.weight.regular};
-    `;
-
     const labelStyles = css`
       ${truncatedStyles}
-      ${isHorizontal ? horizontalStyles : verticalStyles}
+      ${textStyles}
       overflow: hidden;
       max-width: 100%;
       padding: 0 ${euiTheme.size.s};
@@ -157,7 +150,7 @@ export const MenuItem = forwardRef<HTMLAnchorElement | HTMLButtonElement, MenuIt
           </Suspense>
         </div>
         {isLabelVisible ? (
-          <EuiText size={isHorizontal ? 's' : 'xs'} textAlign="center" css={labelStyles}>
+          <EuiText size="xs" textAlign="center" css={labelStyles}>
             {children}
           </EuiText>
         ) : (

--- a/src/core/packages/chrome/navigation/src/components/navigation.tsx
+++ b/src/core/packages/chrome/navigation/src/components/navigation.tsx
@@ -204,7 +204,6 @@ export const Navigation = ({
                           <NestedSecondaryMenu.PrimaryMenuItem
                             key={item.id}
                             isHighlighted={item.id === visuallyActivePageId}
-                            isCollapsed={isCollapsed}
                             hasSubmenu={hasSubmenu}
                             onClick={() => {
                               onItemClick?.(item);

--- a/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/primary_menu_item.tsx
+++ b/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/primary_menu_item.tsx
@@ -12,16 +12,15 @@ import React, { useCallback } from 'react';
 import { css } from '@emotion/react';
 import { EuiIcon, useEuiTheme } from '@elastic/eui';
 
-import { SideNav } from '../side_nav';
 import { useNestedMenu } from './use_nested_menu';
+import { SecondaryMenu } from '../secondary_menu';
 
 export interface PrimaryMenuItemProps
-  extends Omit<ComponentProps<typeof SideNav.PrimaryMenuItem>, 'children' | 'isHighlighted'> {
+  extends Omit<ComponentProps<typeof SecondaryMenu.Item>, 'children' | 'isHighlighted'> {
   children: ReactNode;
   hasSubmenu?: boolean;
   isHighlighted?: boolean;
   isCurrent?: boolean;
-  isCollapsed: boolean;
   onClick?: () => void;
 }
 
@@ -61,17 +60,17 @@ export const PrimaryMenuItem: FC<PrimaryMenuItemProps> = ({
 
   return (
     <div css={wrapperStyle}>
-      <SideNav.PrimaryMenuItem
+      <SecondaryMenu.Item
         id={id}
         isHighlighted={isHighlighted}
         isCurrent={isCurrent}
         onClick={handleClick}
+        hasSubmenu={hasSubmenu}
         {...props}
-        as={hasSubmenu ? 'button' : 'a'}
       >
         {children}
-        {hasSubmenu && <EuiIcon color="text" css={arrowStyle} type="arrowRight" size="m" />}
-      </SideNav.PrimaryMenuItem>
+        {hasSubmenu && <EuiIcon color="textDisabled" css={arrowStyle} type="arrowRight" size="m" />}
+      </SecondaryMenu.Item>
     </div>
   );
 };

--- a/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/primary_menu_item.tsx
+++ b/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/primary_menu_item.tsx
@@ -63,7 +63,6 @@ export const PrimaryMenuItem: FC<PrimaryMenuItemProps> = ({
     <div css={wrapperStyle}>
       <SideNav.PrimaryMenuItem
         id={id}
-        isHorizontal
         isHighlighted={isHighlighted}
         isCurrent={isCurrent}
         onClick={handleClick}

--- a/src/core/packages/chrome/navigation/src/components/secondary_menu/item.tsx
+++ b/src/core/packages/chrome/navigation/src/components/secondary_menu/item.tsx
@@ -18,12 +18,13 @@ import type { SecondaryMenuItem } from '../../../types';
 import { BetaBadge } from '../beta_badge';
 import { useHighContrastModeStyles } from '../../hooks/use_high_contrast_mode_styles';
 
-export interface SecondaryMenuItemProps extends SecondaryMenuItem {
+export interface SecondaryMenuItemProps extends Omit<SecondaryMenuItem, 'href'> {
   children: ReactNode;
-  href: string;
+  hasSubmenu?: boolean;
+  href?: string;
   iconType?: IconType;
-  isHighlighted: boolean;
   isCurrent?: boolean;
+  isHighlighted: boolean;
   key: string;
   onClick?: () => void;
   testSubjPrefix?: string;
@@ -36,11 +37,13 @@ export interface SecondaryMenuItemProps extends SecondaryMenuItem {
 export const SecondaryMenuItemComponent = ({
   badgeType,
   children,
+  hasSubmenu,
+  href,
   iconType,
   id,
-  isHighlighted,
   isCurrent,
   isExternal,
+  isHighlighted,
   testSubjPrefix = 'secondaryMenuItem',
   ...props
 }: SecondaryMenuItemProps): JSX.Element => {
@@ -69,7 +72,7 @@ export const SecondaryMenuItemComponent = ({
     }
 
     svg:not(.euiBetaBadge__icon) {
-      color: ${euiTheme.colors.textDisabled};
+      color: ${iconSide === 'right' ? euiTheme.colors.textDisabled : 'inherit'};
     }
 
     --high-contrast-hover-indicator-color: ${isHighlighted
@@ -100,6 +103,7 @@ export const SecondaryMenuItemComponent = ({
           data-highlighted="true"
           data-test-subj={`${testSubjPrefix}-${id}`}
           fullWidth
+          href={hasSubmenu ? undefined : href}
           size="s"
           textProps={false}
           {...iconProps}
@@ -110,10 +114,11 @@ export const SecondaryMenuItemComponent = ({
       ) : (
         <EuiButtonEmpty
           aria-current={isCurrent ? 'page' : undefined}
-          css={buttonStyles}
           color="text"
+          css={buttonStyles}
           data-highlighted="false"
           data-test-subj={`${testSubjPrefix}-${id}`}
+          href={hasSubmenu ? undefined : href}
           size="s"
           textProps={false}
           {...iconProps}

--- a/src/core/packages/chrome/navigation/src/components/secondary_menu/item.tsx
+++ b/src/core/packages/chrome/navigation/src/components/secondary_menu/item.tsx
@@ -99,6 +99,7 @@ export const SecondaryMenuItemComponent = ({
       {isHighlighted ? (
         <EuiButton
           aria-current={isCurrent ? 'page' : undefined}
+          id={id}
           css={buttonStyles}
           data-highlighted="true"
           data-test-subj={`${testSubjPrefix}-${id}`}
@@ -114,6 +115,7 @@ export const SecondaryMenuItemComponent = ({
       ) : (
         <EuiButtonEmpty
           aria-current={isCurrent ? 'page' : undefined}
+          id={id}
           color="text"
           css={buttonStyles}
           data-highlighted="false"

--- a/src/core/packages/chrome/navigation/src/components/side_nav/primary_menu_item.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/primary_menu_item.tsx
@@ -28,7 +28,6 @@ export interface SideNavPrimaryMenuItemProps extends MenuItem {
   isHighlighted: boolean;
   isCurrent?: boolean;
   isCollapsed: boolean;
-  isHorizontal?: boolean;
   onClick?: () => void;
 }
 
@@ -43,7 +42,6 @@ export const SideNavPrimaryMenuItem = forwardRef<HTMLAnchorElement, SideNavPrima
       isHighlighted,
       isCurrent,
       isCollapsed,
-      isHorizontal,
       badgeType,
       ...props
     },
@@ -64,33 +62,31 @@ export const SideNavPrimaryMenuItem = forwardRef<HTMLAnchorElement, SideNavPrima
       gap: ${euiTheme.size.xs};
     `;
 
+    const badgeLabel =
+      badgeType === 'beta'
+        ? i18n.translate('core.ui.chrome.sideNavigation.betaTooltipLabel', {
+            defaultMessage: 'Beta',
+          })
+        : badgeType === 'techPreview'
+        ? i18n.translate('core.ui.chrome.sideNavigation.techPreviewTooltipLabel', {
+            defaultMessage: 'Tech preview',
+          })
+        : undefined;
+
     const getLabelWithBeta = (label: ReactNode) => (
       <div css={betaContentStyles}>
         <span>{label}</span>
-        {badgeType && <BetaBadge type={badgeType} isInverted={!isHorizontal} />}
+        {badgeType && <BetaBadge type={badgeType} isInverted />}
       </div>
     );
 
     const getTooltipContent = () => {
-      if (isHorizontal || hasContent) return null;
+      if (hasContent) return null;
       if (isCollapsed) return badgeType ? getLabelWithBeta(children) : children;
-      if (!isCollapsed && badgeType)
-        return getLabelWithBeta(
-          badgeType === 'beta'
-            ? i18n.translate('core.ui.chrome.sideNavigation.betaTooltipLabel', {
-                defaultMessage: 'Beta',
-              })
-            : badgeType === 'techPreview'
-            ? i18n.translate('core.ui.chrome.sideNavigation.techPreviewTooltipLabel', {
-                defaultMessage: 'Tech preview',
-              })
-            : children
-        );
+      if (!isCollapsed && badgeType) return getLabelWithBeta(badgeLabel ? badgeLabel : children);
 
       return null;
     };
-
-    const menuItemContent = isHorizontal && badgeType ? getLabelWithBeta(children) : children;
 
     const menuItem = (
       <MenuItemComponent
@@ -100,12 +96,11 @@ export const SideNavPrimaryMenuItem = forwardRef<HTMLAnchorElement, SideNavPrima
         id={id}
         isCurrent={isCurrent}
         isHighlighted={isHighlighted}
-        isHorizontal={isHorizontal}
-        isLabelVisible={isHorizontal ? true : !isCollapsed}
+        isLabelVisible={!isCollapsed}
         ref={ref}
         {...props}
       >
-        {menuItemContent}
+        {children}
       </MenuItemComponent>
     );
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana-team/issues/2195

### Context

We received feedback that the "More" primary menu items are of poor affordability:

https://github.com/user-attachments/assets/423289a7-6046-40c3-af53-6c9026504ea3

Only the `EuiButtonIcon` changes on hover. We decided remove this variant and used the regular `SecondaryMenuItem` instead (`EuiButtonEmpty`).

<img width="750" height="164" alt="Screenshot 2025-11-04 at 16 10 53" src="https://github.com/user-attachments/assets/d50de019-1e1a-4ad5-83b8-202bfe502bde" />

### Screenshots

| Before | After |
|-------|-------|
| <img width="368" height="223" alt="Screenshot 2025-11-04 at 16 18 37" src="https://github.com/user-attachments/assets/8beb9170-b8ab-4507-9363-7bb775a1b662" /> | <img width="357" height="235" alt="Screenshot 2025-11-04 at 15 51 34" src="https://github.com/user-attachments/assets/064640dd-4795-4b02-8825-246e7b7e9621" /> |

### Checklist

- [ ] verify that all [beta badges](https://www.figma.com/design/SDtdvdzPcaDZRRXMV02gSW/Solution-Side-Navigation--9.2-?node-id=6216-53843&t=PuqILHGmYoh7BSpY-0) display as expected
- [ ] verify that all [tech preview badges](https://www.figma.com/design/SDtdvdzPcaDZRRXMV02gSW/Solution-Side-Navigation--9.2-?node-id=6216-53843&t=PuqILHGmYoh7BSpY-0) display as expected
- [ ] verify that all **primary menu items** and **secondary menu items** are links, except:
    - [ ] "More" primary menu items that have a submenu are a button and don't navigate
    - [ ] "More" menu toggle itself is a button and doesn't navigate
- [ ] verify that icon colors are as expected (on the left, they're of `text` color, on the right - `popout`, `arrowRight` are of `textDisabled` color)