### PR TITLE
[9.2] [Metrics][Discover] Reset pagination state when filters change (#241621)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/hooks/use_metrics_grid_state.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/hooks/use_metrics_grid_state.ts
@@ -34,6 +34,7 @@ export const useMetricsGridState = () => {
   const onDimensionsChange = useCallback(
     (nextDimensions: string[]) => {
       dispatch(setDimensions(nextDimensions));
+      dispatch(setCurrentPage(0));
       const filteredValues =
         nextDimensions.length === 0
           ? []
@@ -44,11 +45,15 @@ export const useMetricsGridState = () => {
   );
 
   const onValuesChange = useCallback(
-    (values: string[]) => dispatch(setValueFilters(values)),
+    (values: string[]) => {
+      dispatch(setCurrentPage(0));
+      dispatch(setValueFilters(values));
+    },
     [dispatch]
   );
 
   const onClearAllDimensions = useCallback(() => {
+    dispatch(setCurrentPage(0));
     dispatch(setDimensions([]));
     dispatch(setValueFilters([]));
   }, [dispatch]);
@@ -58,11 +63,13 @@ export const useMetricsGridState = () => {
   const onPageChange = useCallback((page: number) => dispatch(setCurrentPage(page)), [dispatch]);
 
   const onClearSearchTerm = useCallback(() => {
+    dispatch(setCurrentPage(0));
     dispatch(setSearchTerm(''));
   }, [dispatch]);
 
   const onSearchTermChange = useCallback(
     (term: string) => {
+      dispatch(setCurrentPage(0));
       dispatch(setSearchTerm(term));
     },
     [dispatch]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Metrics][Discover] Reset pagination state when filters change (#241621)](https://github.com/elastic/kibana/pull/241621)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-11-04T13:55:41Z","message":"[Metrics][Discover] Reset pagination state when filters change (#241621)\n\nfixes https://github.com/elastic/kibana/issues/241441\n\n## Summary\n\nThis PR ensures that the pagination's current page state is reset when\nany of the filters in the grid change.\n\n**Reset when Dimensions dropdown changes**\n\n![rest_when_dim_change](https://github.com/user-attachments/assets/d746491f-60fc-486f-a59c-f89880dba0c2)\n\n**Reset when Values dropdown changes**\n\n![rest_when_values_change](https://github.com/user-attachments/assets/7ebc8643-b66d-45aa-951c-e438b966bcb1)\n\n**Reset when Search changes**\n\n![rest_when_search_change](https://github.com/user-attachments/assets/96c82e1f-a34f-475c-8efc-80aaa1efc65d)\n\n## How to test\n- Start a local Kibana instance and point it to an oblt cluster - the\nbug is more likely to occur when the performance is worse\n```yml\nfeature_flags.overrides:\n  metricsExperienceEnabled: true\n ```\n- Navigate to Discover and Switch to ESQL mode\n- Navigate to the last page of the grid and play with Dimensions and Values dropdowns, and Search input\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b10e9827e446547db0befe1b4b5e77ce3bcf7a1d","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.2.0","v9.3.0"],"title":"[Metrics][Discover] Reset pagination state when filters change","number":241621,"url":"https://github.com/elastic/kibana/pull/241621","mergeCommit":{"message":"[Metrics][Discover] Reset pagination state when filters change (#241621)\n\nfixes https://github.com/elastic/kibana/issues/241441\n\n## Summary\n\nThis PR ensures that the pagination's current page state is reset when\nany of the filters in the grid change.\n\n**Reset when Dimensions dropdown changes**\n\n![rest_when_dim_change](https://github.com/user-attachments/assets/d746491f-60fc-486f-a59c-f89880dba0c2)\n\n**Reset when Values dropdown changes**\n\n![rest_when_values_change](https://github.com/user-attachments/assets/7ebc8643-b66d-45aa-951c-e438b966bcb1)\n\n**Reset when Search changes**\n\n![rest_when_search_change](https://github.com/user-attachments/assets/96c82e1f-a34f-475c-8efc-80aaa1efc65d)\n\n## How to test\n- Start a local Kibana instance and point it to an oblt cluster - the\nbug is more likely to occur when the performance is worse\n```yml\nfeature_flags.overrides:\n  metricsExperienceEnabled: true\n ```\n- Navigate to Discover and Switch to ESQL mode\n- Navigate to the last page of the grid and play with Dimensions and Values dropdowns, and Search input\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b10e9827e446547db0befe1b4b5e77ce3bcf7a1d"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241621","number":241621,"mergeCommit":{"message":"[Metrics][Discover] Reset pagination state when filters change (#241621)\n\nfixes https://github.com/elastic/kibana/issues/241441\n\n## Summary\n\nThis PR ensures that the pagination's current page state is reset when\nany of the filters in the grid change.\n\n**Reset when Dimensions dropdown changes**\n\n![rest_when_dim_change](https://github.com/user-attachments/assets/d746491f-60fc-486f-a59c-f89880dba0c2)\n\n**Reset when Values dropdown changes**\n\n![rest_when_values_change](https://github.com/user-attachments/assets/7ebc8643-b66d-45aa-951c-e438b966bcb1)\n\n**Reset when Search changes**\n\n![rest_when_search_change](https://github.com/user-attachments/assets/96c82e1f-a34f-475c-8efc-80aaa1efc65d)\n\n## How to test\n- Start a local Kibana instance and point it to an oblt cluster - the\nbug is more likely to occur when the performance is worse\n```yml\nfeature_flags.overrides:\n  metricsExperienceEnabled: true\n ```\n- Navigate to Discover and Switch to ESQL mode\n- Navigate to the last page of the grid and play with Dimensions and Values dropdowns, and Search input\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b10e9827e446547db0befe1b4b5e77ce3bcf7a1d"}}]}] BACKPORT-->