### PR TITLE
[Security solution] Fix failing MKI prompt test

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -472,6 +472,7 @@ export const NEW_FEATURES_TOUR_STORAGE_KEYS = {
   TIMELINES: 'securitySolution.security.timelineFlyoutHeader.saveTimelineTour',
   SIEM_MAIN_LANDING_PAGE: 'securitySolution.siemMigrations.setupGuide.v8.18',
   SIEM_RULE_TRANSLATION_PAGE: 'securitySolution.siemMigrations.ruleTranslationGuide.v8.18',
+  DEFAULT_LLM: `elasticAssistant.elasticLLM.costAwarenessTour.assistantHeader.v8.19.default`,
 };
 
 export const RULE_DETAILS_EXECUTION_LOG_TABLE_SHOW_METRIC_COLUMNS_STORAGE_KEY =


### PR DESCRIPTION
## Summary

The prompt test was occasionally failing because the default LLM tour rendered early and covered the system prompt selector.

<img width="1696" height="1072" alt="Screenshot 2025-11-04 at 8 48 27 AM" src="https://github.com/user-attachments/assets/df417bae-25f2-4c3c-81a7-4926db5e8f3a" />

We have code that disables tours for cypress tests. By adding the id for this tour component, we ensure it’s properly included in the list of tours to disable during Cypress runs. This prevents the tour from rendering during automated tests and blocking interactions with UI elements like the system prompt selector, resulting in more stable and consistent test execution.