### PR TITLE
[8.19][Console] Unskip ESQL suggestions test

### DIFF
--- a/src/platform/test/functional/apps/console/_autocomplete.ts
+++ b/src/platform/test/functional/apps/console/_autocomplete.ts
@@ -421,8 +421,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.console.clearEditorText();
       });
 
-      // Failing in CI: https://github.com/elastic/kibana/issues/229438
-      it.skip('autocompletes ESQL inside triple quotes query', async () => {
+      it('autocompletes ESQL inside triple quotes query', async () => {
         await PageObjects.console.enterText(`POST _query\n`);
         await PageObjects.console.enterText(`{\n\t"query": """`);
         await PageObjects.console.sleepForDebouncePeriod();

--- a/src/platform/test/functional/page_objects/console_page.ts
+++ b/src/platform/test/functional/page_objects/console_page.ts
@@ -122,10 +122,16 @@ export class ConsolePageObject extends FtrService {
 
   public async getAllAutocompleteSuggestions() {
     const suggestionsWidget = await this.find.byClassName('suggest-widget');
+
+    await this.retry.waitFor(
+      'verify suggestions widget to be displayed',
+      async () => await suggestionsWidget.isDisplayed()
+    );
+
     const suggestions = await suggestionsWidget.findAllByClassName('monaco-list-row');
     const labels = await Promise.all(
       suggestions.map(async (suggestion) => {
-        const label = await suggestion.findByClassName('label-name');
+        const label = await suggestion.findByClassName('monaco-highlighted-label');
         return label.getVisibleText();
       })
     );


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/229438

## Summary

This PR fixes the tests for ESQL suggestions in Console in 8.19 branch.

Flaky test runner build: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9744

