### PR TITLE
[9.2] Fix enforcement of unique policy name of policies across spaces (#239631)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -349,14 +349,10 @@ export const createAgentPolicyHandler: FleetRequestHandler<
   const monitoringEnabled = request.body.monitoring_enabled;
   const logger = appContextService.getLogger().get('httpCreateAgentPolicyHandler');
 
-  const {
-    has_fleet_server: hasFleetServer,
-    force,
-    space_ids: spaceIds,
-    ...newPolicy
-  } = request.body;
+  const { has_fleet_server: hasFleetServer, force, ...newPolicy } = request.body;
   const spaceId = fleetContext.spaceId;
   const authorizationHeader = HTTPAuthorizationHeader.parseFromRequest(request, user?.username);
+  const { space_ids: spaceIds } = request.body;
 
   logger.debug(`Creating agent policy [${newPolicy.name}]`);
 
@@ -399,9 +395,11 @@ export const createAgentPolicyHandler: FleetRequestHandler<
       (spaceIds.length > 1 || (spaceIds.length === 0 && spaceIds[0]) !== spaceId)
     ) {
       await updateAgentPolicySpaces({
-        agentPolicyId: agentPolicy.id,
+        agentPolicy: {
+          ...agentPolicy,
+          space_ids: spaceIds,
+        },
         currentSpaceId: spaceId,
-        newSpaceIds: spaceIds,
         authorizedSpaces,
         options: { force },
       });
@@ -541,8 +539,9 @@ export const updateAgentPolicyHandler: FleetRequestHandler<
   const fleetContext = await context.fleet;
   const esClient = coreContext.elasticsearch.client.asInternalUser;
   const user = appContextService.getSecurityCore().authc.getCurrentUser(request) || undefined;
-  const { force, bumpRevision, space_ids: spaceIds, ...data } = request.body;
+  const { force, bumpRevision, ...data } = request.body;
 
+  const spaceIds = data.space_ids;
   let spaceId = fleetContext.spaceId;
 
   logger.debug(`updating policy [${request.params.agentPolicyId}] in space [${spaceId}]`);
@@ -559,11 +558,10 @@ export const updateAgentPolicyHandler: FleetRequestHandler<
         spaceIds
       );
       await updateAgentPolicySpaces({
-        agentPolicyId: request.params.agentPolicyId,
+        agentPolicy: { ...data, id: request.params.agentPolicyId },
         currentSpaceId: spaceId,
-        newSpaceIds: spaceIds,
         authorizedSpaces,
-        options: { force, validateUniqueName: true },
+        options: { force },
       });
 
       spaceId = spaceIds[0];

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
@@ -13,7 +13,7 @@ import type { SavedObjectError } from '@kbn/core-saved-objects-common';
 
 import { createSavedObjectClientMock } from '../mocks';
 
-import { LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../../common/constants';
+import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../../common/constants';
 
 import {
   PackagePolicyRestrictionRelatedError,
@@ -27,10 +27,7 @@ import type {
   NewAgentPolicy,
   PreconfiguredAgentPolicy,
 } from '../types';
-import {
-  LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
-  AGENT_POLICY_SAVED_OBJECT_TYPE,
-} from '../constants';
+import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '../constants';
 
 import { AGENT_POLICY_INDEX, SO_SEARCH_LIMIT } from '../../common';
 
@@ -56,7 +53,7 @@ jest.mock('./spaces/helpers');
 function getSavedObjectMock(agentPolicyAttributes: any) {
   const mock = createSavedObjectClientMock();
   const mockPolicy = {
-    type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+    type: AGENT_POLICY_SAVED_OBJECT_TYPE,
     references: [],
     attributes: agentPolicyAttributes as AgentPolicy,
   };
@@ -78,7 +75,7 @@ function getSavedObjectMock(agentPolicyAttributes: any) {
   });
   mock.find.mockImplementation(async (options) => {
     switch (options.type) {
-      case LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE:
+      case AGENT_POLICY_SAVED_OBJECT_TYPE:
         return {
           saved_objects: [
             {
@@ -91,7 +88,7 @@ function getSavedObjectMock(agentPolicyAttributes: any) {
           page: 1,
           per_page: 1,
         };
-      case LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE:
+      case PACKAGE_POLICY_SAVED_OBJECT_TYPE:
         return {
           saved_objects: [],
           total: 0,
@@ -172,10 +169,10 @@ describe('Agent policy', () => {
     mockedLogger = loggerMock.create();
     mockedAppContextService.getLogger.mockReturnValue(mockedLogger);
     mockedAppContextService.getExperimentalFeatures.mockReturnValue({} as any);
-    jest.mocked(isSpaceAwarenessEnabled).mockResolvedValue(false);
+    jest.mocked(isSpaceAwarenessEnabled).mockResolvedValue(true);
     jest
       .mocked(getPackagePolicySavedObjectType)
-      .mockResolvedValue(LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE);
+      .mockResolvedValue(PACKAGE_POLICY_SAVED_OBJECT_TYPE);
   });
 
   afterEach(() => {
@@ -186,7 +183,7 @@ describe('Agent policy', () => {
     it('is_managed present and false by default', async () => {
       const soClient = getAgentPolicyCreateMock();
       // ignore unrelated unique name constraint
-      agentPolicyService.requireUniqueName = async () => {};
+      jest.spyOn(agentPolicyService, 'requireUniqueName').mockResolvedValue(undefined);
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
       await expect(
@@ -202,7 +199,7 @@ describe('Agent policy', () => {
 
     it('should set is_managed property, if given', async () => {
       // ignore unrelated unique name constraint
-      agentPolicyService.requireUniqueName = async () => {};
+      jest.spyOn(agentPolicyService, 'requireUniqueName').mockResolvedValue(undefined);
       const soClient = getAgentPolicyCreateMock();
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
       await expect(
@@ -230,7 +227,7 @@ describe('Agent policy', () => {
 
       soClient.create.mockResolvedValueOnce({
         id: 'test-agent-policy',
-        type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+        type: AGENT_POLICY_SAVED_OBJECT_TYPE,
         attributes: {
           name: 'test',
         },
@@ -253,7 +250,7 @@ describe('Agent policy', () => {
         action: 'create',
         name: 'test',
         id: 'test-agent-policy',
-        savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+        savedObjectType: AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
     });
 
@@ -683,7 +680,7 @@ describe('Agent policy', () => {
               name: 'Test',
             },
             references: [],
-            type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
           },
         ],
       });
@@ -694,7 +691,7 @@ describe('Agent policy', () => {
         action: 'get',
         id: 'test-agent-policy',
         name: 'Test',
-        savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+        savedObjectType: AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
     });
   });
@@ -711,7 +708,7 @@ describe('Agent policy', () => {
               name: 'Test 1',
             },
             references: [],
-            type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
           },
           {
             id: 'test-agent-policy-2',
@@ -719,7 +716,7 @@ describe('Agent policy', () => {
               name: 'Test 2',
             },
             references: [],
-            type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
           },
         ],
       });
@@ -730,14 +727,14 @@ describe('Agent policy', () => {
         action: 'get',
         id: 'test-agent-policy-1',
         name: 'Test 1',
-        savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+        savedObjectType: AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenNthCalledWith(2, {
         action: 'get',
         id: 'test-agent-policy-2',
         name: 'Test 2',
-        savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+        savedObjectType: AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
     });
   });
@@ -755,7 +752,7 @@ describe('Agent policy', () => {
               name: 'Test 1',
             },
             references: [],
-            type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
             score: 0,
           },
           {
@@ -764,7 +761,7 @@ describe('Agent policy', () => {
               name: 'Test 2',
             },
             references: [],
-            type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
             score: 0,
           },
         ],
@@ -782,14 +779,14 @@ describe('Agent policy', () => {
         action: 'find',
         id: 'test-agent-policy-1',
         name: 'Test 1',
-        savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+        savedObjectType: AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenNthCalledWith(2, {
         action: 'find',
         id: 'test-agent-policy-2',
         name: 'Test 2',
-        savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+        savedObjectType: AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
     });
   });
@@ -854,7 +851,7 @@ describe('Agent policy', () => {
         action: 'delete',
         id: 'mocked',
         name: 'Test',
-        savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+        savedObjectType: AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
     });
 
@@ -960,7 +957,7 @@ describe('Agent policy', () => {
             }),
             id: 'agent-policy-id',
             namespace: undefined,
-            type: 'ingest-agent-policies',
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
             version: undefined,
           }),
         ],
@@ -1155,7 +1152,7 @@ describe('Agent policy', () => {
   describe('update', () => {
     it('should update is_managed property, if given', async () => {
       // ignore unrelated unique name constraint
-      agentPolicyService.requireUniqueName = async () => {};
+      jest.spyOn(agentPolicyService, 'requireUniqueName').mockResolvedValue(undefined);
       const soClient = createSavedObjectClientMock();
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
@@ -1225,7 +1222,7 @@ describe('Agent policy', () => {
             },
             references: [],
             id: 'test-agent-policy',
-            type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
           },
         ],
       });
@@ -1240,7 +1237,7 @@ describe('Agent policy', () => {
         action: 'update',
         name: 'Test',
         id: 'test-agent-policy',
-        savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+        savedObjectType: AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
     });
 
@@ -1489,10 +1486,10 @@ describe('Agent policy', () => {
     });
 
     it('should link shared package policies', async () => {
-      agentPolicyService.requireUniqueName = async () => {};
+      jest.spyOn(agentPolicyService, 'requireUniqueName').mockResolvedValue(undefined);
       soClient = createSavedObjectClientMock();
       const mockPolicy = {
-        type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+        type: AGENT_POLICY_SAVED_OBJECT_TYPE,
         references: [],
         attributes: { revision: 1, package_policies: ['package-1'] } as any,
       };
@@ -1723,7 +1720,7 @@ describe('Agent policy', () => {
             attributes: {},
             references: [],
             id: 'test-agent-policy',
-            type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
           },
         ],
       });
@@ -1760,7 +1757,7 @@ describe('Agent policy', () => {
 
       soClient.create.mockResolvedValueOnce({
         id: 'my-unique-id',
-        type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+        type: AGENT_POLICY_SAVED_OBJECT_TYPE,
         attributes: {},
         references: [],
       });
@@ -1772,7 +1769,7 @@ describe('Agent policy', () => {
       );
 
       expect(soClient.create).toHaveBeenCalledWith(
-        LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+        AGENT_POLICY_SAVED_OBJECT_TYPE,
         expect.anything(),
         expect.objectContaining({ id: 'my-unique-id' })
       );
@@ -1782,7 +1779,7 @@ describe('Agent policy', () => {
   describe('getInactivityTimeouts', () => {
     const createPolicySO = (id: string, inactivityTimeout: number) => ({
       id,
-      type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+      type: AGENT_POLICY_SAVED_OBJECT_TYPE,
       attributes: { inactivity_timeout: inactivityTimeout },
       references: [],
       score: 1,
@@ -1856,7 +1853,7 @@ describe('Agent policy', () => {
               return {
                 score: 1,
                 id: 'so-123',
-                type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+                type: AGENT_POLICY_SAVED_OBJECT_TYPE,
                 version: 'abc',
                 updated_at: soAttributes.updated_at,
                 attributes: soAttributes,
@@ -1905,7 +1902,7 @@ describe('Agent policy', () => {
 
         expect(soClientMock.find).toHaveBeenCalledWith(
           expect.objectContaining({
-            type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
             perPage: 1000,
             sortField: 'created_at',
             sortOrder: 'asc',
@@ -1925,7 +1922,7 @@ describe('Agent policy', () => {
 
         expect(soClientMock.find).toHaveBeenCalledWith(
           expect.objectContaining({
-            type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
             perPage: 13,
             sortField: 'created_at',
             sortOrder: 'asc',
@@ -1969,7 +1966,7 @@ describe('Agent policy', () => {
 
         expect(soClientMock.find).toHaveBeenCalledWith(
           expect.objectContaining({
-            type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
             perPage: 1000,
             sortField: 'created_at',
             sortOrder: 'asc',
@@ -2009,7 +2006,7 @@ describe('Agent policy', () => {
 
         expect(soClientMock.find).toHaveBeenCalledWith(
           expect.objectContaining({
-            type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
             perPage: 12,
             sortField: 'updated_by',
             sortOrder: 'desc',
@@ -2023,7 +2020,7 @@ describe('Agent policy', () => {
   describe('turnOffAgentTamperProtections', () => {
     const createPolicySO = (id: string, isProtected: boolean, error?: SavedObjectError) => ({
       id,
-      type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+      type: AGENT_POLICY_SAVED_OBJECT_TYPE,
       attributes: {
         is_protected: isProtected,
       },
@@ -2147,6 +2144,150 @@ describe('Agent policy', () => {
       await agentPolicyService.deleteFleetServerPoliciesForPolicyId(esClient, 'test-agent-policy');
 
       expect(esClient.deleteByQuery).toBeCalledTimes(2);
+    });
+  });
+
+  describe('requireUniqueName', () => {
+    const getAllSpacesSoClientSpy = jest.spyOn(
+      appContextService,
+      'getInternalUserSOClientWithoutSpaceExtension'
+    );
+    beforeAll(() => {
+      jest.spyOn(agentPolicyService, 'requireUniqueName').mockRestore();
+    });
+
+    const testAgentPolicy = {
+      id: 'policy1',
+      name: 'unique-policy-name',
+      space_ids: ['default'],
+    };
+    it('should not throw error when no policies with same name exist', async () => {
+      const soClient = createSavedObjectClientMock();
+      soClient.find.mockResolvedValue({
+        total: 0,
+        saved_objects: [],
+        page: 1,
+        per_page: 10,
+      });
+
+      await expect(
+        agentPolicyService.requireUniqueName(soClient, testAgentPolicy)
+      ).resolves.not.toThrow();
+
+      expect(soClient.find).toHaveBeenCalledWith({
+        type: AGENT_POLICY_SAVED_OBJECT_TYPE,
+        searchFields: ['name'],
+        search: `\"${testAgentPolicy.name}\"`,
+      });
+    });
+
+    it('should not throw error when the only other policy with the same name is the current policy', async () => {
+      const soClient = createSavedObjectClientMock();
+      soClient.find.mockResolvedValue({
+        total: 1,
+        saved_objects: [
+          {
+            id: testAgentPolicy.id,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
+            attributes: { name: testAgentPolicy.name },
+            references: [],
+            score: 1,
+          },
+        ],
+        page: 1,
+        per_page: 10,
+      });
+
+      await expect(
+        agentPolicyService.requireUniqueName(soClient, testAgentPolicy)
+      ).resolves.not.toThrow();
+
+      expect(soClient.find).toHaveBeenCalledWith({
+        type: AGENT_POLICY_SAVED_OBJECT_TYPE,
+        searchFields: ['name'],
+        search: `\"${testAgentPolicy.name}\"`,
+      });
+    });
+
+    it('should throw an error when policies exist with the same name', async () => {
+      const otherAgentPolicy = {
+        ...testAgentPolicy,
+        id: 'other-agent-policy',
+      };
+      const soClient = createSavedObjectClientMock();
+      soClient.find.mockResolvedValue({
+        total: 1,
+        saved_objects: [
+          {
+            id: otherAgentPolicy.id,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
+            attributes: { name: testAgentPolicy.name },
+            references: [],
+            score: 1,
+          },
+        ],
+        page: 1,
+        per_page: 10,
+      });
+
+      await expect(
+        agentPolicyService.requireUniqueName(soClient, testAgentPolicy)
+      ).rejects.toThrow();
+
+      expect(soClient.find).toHaveBeenCalledWith({
+        type: AGENT_POLICY_SAVED_OBJECT_TYPE,
+        searchFields: ['name'],
+        search: `\"${testAgentPolicy.name}\"`,
+      });
+    });
+
+    it('should query across spaces if multiple space ids are provided', async () => {
+      const otherAgentPolicy = {
+        ...testAgentPolicy,
+        id: 'other-agent-policy',
+      };
+
+      const multiSpacesTestAgentPolicy = {
+        ...testAgentPolicy,
+        space_ids: ['default', 'outerspace'],
+      };
+
+      const allSpacesSoClient = createSavedObjectClientMock();
+      getAllSpacesSoClientSpy.mockReturnValue(allSpacesSoClient);
+      const soClient = createSavedObjectClientMock();
+
+      soClient.find.mockResolvedValue({
+        total: 0,
+        saved_objects: [],
+        page: 1,
+        per_page: 10,
+      });
+
+      allSpacesSoClient.find.mockResolvedValue({
+        total: 1,
+        saved_objects: [
+          {
+            id: otherAgentPolicy.id,
+            type: AGENT_POLICY_SAVED_OBJECT_TYPE,
+            attributes: { name: multiSpacesTestAgentPolicy.name },
+            references: [],
+            score: 1,
+          },
+        ],
+        page: 1,
+        per_page: 10,
+      });
+
+      await expect(
+        agentPolicyService.requireUniqueName(soClient, multiSpacesTestAgentPolicy)
+      ).rejects.toThrow();
+
+      expect(allSpacesSoClient.find).toHaveBeenCalledWith({
+        type: AGENT_POLICY_SAVED_OBJECT_TYPE,
+        searchFields: ['name'],
+        search: `\"${multiSpacesTestAgentPolicy.name}\"`,
+        namespaces: multiSpacesTestAgentPolicy.space_ids,
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -472,21 +472,12 @@ class AgentPolicyService {
 
     validateRequiredVersions(agentPolicy.name, agentPolicy.required_versions);
 
+    const preparedAgentPolicySo = this.prepareAsNewSo(agentPolicy, {
+      username: options?.user?.username,
+    });
+
     const newSo = await soClient
-      .create<AgentPolicySOAttributes>(
-        savedObjectType,
-        {
-          ...agentPolicy,
-          status: 'active',
-          is_managed: agentPolicy.is_managed ?? false,
-          revision: 1,
-          updated_at: new Date().toISOString(),
-          updated_by: options?.user?.username || 'system',
-          schema_version: FLEET_AGENT_POLICIES_SCHEMA_VERSION,
-          is_protected: false,
-        } as AgentPolicy,
-        options
-      )
+      .create<AgentPolicySOAttributes>(savedObjectType, preparedAgentPolicySo, options)
       .catch(
         catchAndSetErrorStackTrace.withMessage(
           `Attempt to create agent policy [${agentPolicy.id}] failed`
@@ -502,7 +493,7 @@ class AgentPolicyService {
       spaceId: soClient.getCurrentNamespace(),
     });
     logger.debug(`Created new agent policy with id ${newSo.id}`);
-    return { id: newSo.id, ...newSo.attributes };
+    return mapAgentPolicySavedObjectToAgentPolicy(newSo);
   }
 
   public async createWithPackagePolicies({
@@ -631,44 +622,50 @@ class AgentPolicyService {
 
   public async requireUniqueName(
     soClient: SavedObjectsClientContract,
-    givenPolicy: { id?: string; name: string; supports_agentless?: boolean | null }
+    policy: {
+      id?: string;
+      name: string;
+      space_ids?: string[];
+      supports_agentless?: boolean | null;
+    }
   ) {
     const savedObjectType = await getAgentPolicySavedObjectType();
-
-    const results = await soClient
+    const isMultispace = (policy.space_ids ?? []).length > 1;
+    const _soClient = isMultispace
+      ? appContextService.getInternalUserSOClientWithoutSpaceExtension()
+      : soClient;
+    const results = await _soClient
       .find<AgentPolicySOAttributes>({
         type: savedObjectType,
         searchFields: ['name'],
-        search: escapeSearchQueryPhrase(givenPolicy.name),
+        search: escapeSearchQueryPhrase(policy.name),
+        ...(isMultispace ? { namespaces: policy.space_ids } : {}),
       })
       .catch(
         catchAndSetErrorStackTrace.withMessage(
-          `Failed to find agent policies with name [${givenPolicy.name}]`
+          `Failed to find agent policies with name [${policy.name}]`
         )
       );
 
-    const idsWithName = results.total && results.saved_objects.map(({ id }) => id);
-    if (Array.isArray(idsWithName)) {
-      const isEditingSelf = givenPolicy.id && idsWithName.includes(givenPolicy.id);
+    const idsWithName = results.total ? results.saved_objects.map(({ id }) => id) : [];
+    const othersWithName = idsWithName.filter((id) => id !== policy.id);
 
-      if (
-        (!givenPolicy?.supports_agentless && !givenPolicy.id) ||
-        (!givenPolicy?.supports_agentless && !isEditingSelf)
-      ) {
-        const isSinglePolicy = idsWithName.length === 1;
-        const existClause = isSinglePolicy
-          ? `Agent Policy '${idsWithName[0]}' already exists`
-          : `Agent Policies '${idsWithName.join(',')}' already exist`;
+    if (othersWithName.length === 0) {
+      return;
+    }
 
-        throw new AgentPolicyNameExistsError(`${existClause} with name '${givenPolicy.name}'`);
-      }
+    if (!policy?.supports_agentless) {
+      const isSinglePolicy = othersWithName.length === 1;
+      const existClause = isSinglePolicy
+        ? `Agent Policy '${othersWithName[0]}' already exists`
+        : `Agent Policies '${othersWithName.join(',')}' already exist`;
 
-      if (givenPolicy?.supports_agentless && !givenPolicy.id) {
-        const integrationName = givenPolicy.name.split(' ').pop();
-        throw new AgentlessPolicyExistsRequestError(
-          `${givenPolicy.name} already exist. Please rename the integration name ${integrationName}.`
-        );
-      }
+      throw new AgentPolicyNameExistsError(`${existClause} with name '${policy.name}'`);
+    } else {
+      const integrationName = policy.name.split(' ').pop();
+      throw new AgentlessPolicyExistsRequestError(
+        `${policy.name} already exist. Please rename the integration name ${integrationName}.`
+      );
     }
   }
 
@@ -966,13 +963,6 @@ class AgentPolicyService {
     const logger = this.getLogger('update');
     logger.debug(`Starting update of agent policy ${id}`);
 
-    if (agentPolicy.name) {
-      await this.requireUniqueName(soClient, {
-        id,
-        name: agentPolicy.name,
-        supports_agentless: agentPolicy?.supports_agentless,
-      });
-    }
     if (agentPolicy.namespace) {
       await validatePolicyNamespaceForSpace({
         spaceId: soClient.getCurrentNamespace(),
@@ -984,6 +974,15 @@ class AgentPolicyService {
 
     if (!existingAgentPolicy) {
       throw new AgentPolicyNotFoundError('Agent policy not found');
+    }
+
+    if (agentPolicy.name && agentPolicy.name !== existingAgentPolicy.name) {
+      await this.requireUniqueName(soClient, {
+        id,
+        name: agentPolicy.name,
+        space_ids: agentPolicy?.space_ids ?? existingAgentPolicy.space_ids,
+        supports_agentless: agentPolicy?.supports_agentless,
+      });
     }
 
     validateRequiredVersions(
@@ -1037,7 +1036,9 @@ class AgentPolicyService {
         force: options?.force,
       });
     }
-    return this._update(soClient, esClient, id, agentPolicy, options?.user, {
+
+    const { space_ids: _, ...preparedAgentPolicySo } = agentPolicy;
+    return this._update(soClient, esClient, id, { ...preparedAgentPolicySo }, options?.user, {
       bumpRevision: options?.bumpRevision ?? true,
       removeProtection: false,
       skipValidation: options?.skipValidation ?? false,
@@ -2304,6 +2305,23 @@ class AgentPolicyService {
       (policy) => policy?.policy_ids && policy?.policy_ids.length > 1
     );
     return { policiesWithSingleAP, policiesWithMultipleAP };
+  }
+
+  private prepareAsNewSo(
+    agentPolicy: NewAgentPolicy,
+    options: { username?: string }
+  ): AgentPolicySOAttributes {
+    const { space_ids: _, ...baseAgentPolicySo } = agentPolicy;
+    return {
+      ...baseAgentPolicySo,
+      status: 'active',
+      is_managed: agentPolicy.is_managed ?? false,
+      revision: 1,
+      updated_at: new Date().toISOString(),
+      updated_by: options?.username || 'system',
+      schema_version: FLEET_AGENT_POLICIES_SCHEMA_VERSION,
+      is_protected: false,
+    };
   }
 }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.test.ts
@@ -76,8 +76,9 @@ describe('createAgentPolicyWithPackages', () => {
     mockedPackagePolicyService.buildPackagePolicyFromPackage.mockImplementation(
       (soClient, packageToInstall) => Promise.resolve(getPackagePolicy(packageToInstall))
     );
-    mockIncrementPackageName.mockImplementation((soClient: any, pkg: string) =>
-      Promise.resolve(`${pkg}-1`)
+    mockIncrementPackageName.mockImplementation(
+      (soClient: any, packageName: string, spaceIds: string[]) =>
+        Promise.resolve(`${packageName}-1`)
     );
     mockedPackagePolicyService.create.mockImplementation((soClient, esClient, newPolicy) =>
       Promise.resolve({

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.ts
@@ -89,7 +89,11 @@ async function createPackagePolicy(
 
   newPackagePolicy.policy_id = agentPolicy.id;
   newPackagePolicy.policy_ids = [agentPolicy.id];
-  newPackagePolicy.name = await incrementPackageName(soClient, packageToInstall);
+  newPackagePolicy.name = await incrementPackageName(
+    soClient,
+    packageToInstall,
+    agentPolicy.space_ids ?? [options.spaceId]
+  );
   if (agentPolicy.supports_agentless) {
     newPackagePolicy.supports_agentless = agentPolicy.supports_agentless;
   }
@@ -184,13 +188,19 @@ export async function createAgentPolicyWithPackages({
     skipDeploy: true, // skip deploying the policy until package policies are added
   });
 
+  // Since agentPolicyService does not handle multispace assignments, we need to keep this context with package policy creation
+  const agentPolicyWithStagedSpaces = {
+    ...agentPolicy,
+    space_ids: newPolicy.space_ids,
+  };
+
   // Create the fleet server package policy and add it to agent policy.
   if (hasFleetServer) {
     await createPackagePolicy(
       soClient,
       esClient,
       agentPolicyService,
-      agentPolicy,
+      agentPolicyWithStagedSpaces,
       FLEET_SERVER_PACKAGE,
       {
         spaceId,
@@ -207,7 +217,7 @@ export async function createAgentPolicyWithPackages({
       soClient,
       esClient,
       agentPolicyService,
-      agentPolicy,
+      agentPolicyWithStagedSpaces,
       FLEET_SYSTEM_PACKAGE,
       {
         spaceId,

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/package_policy_name_helper.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/package_policy_name_helper.test.ts
@@ -11,24 +11,34 @@ import { packagePolicyService } from '../package_policy';
 
 import { incrementPackageName, incrementPackagePolicyCopyName } from './package_policy_name_helper';
 
+jest.mock('..', () => ({
+  appContextService: {
+    getInternalUserSOClientWithoutSpaceExtension: jest.fn(),
+  },
+}));
+
 describe('Package policy name helper', () => {
   describe('increment package name', () => {
     it('should return 1 if no existing policies', async () => {
-      packagePolicyService.list = jest.fn().mockResolvedValue(undefined);
-      const newName = await incrementPackageName(savedObjectsClientMock.create(), 'apache');
+      packagePolicyService.list = jest.fn().mockResolvedValue({ items: [] });
+      const newName = await incrementPackageName(savedObjectsClientMock.create(), 'apache', [
+        'default',
+      ]);
       expect(newName).toEqual('apache-1');
     });
 
     it('should return 11 if max policy name is 10', async () => {
       packagePolicyService.list = jest.fn().mockResolvedValue({
         items: [
-          { name: 'apache-1' },
-          { name: 'aws-11' },
-          { name: 'apache-10' },
-          { name: 'apache-9' },
+          { name: 'apache-1', spaceIds: ['default'] },
+          { name: 'aws-11', spaceIds: ['default'] },
+          { name: 'apache-10', spaceIds: ['default'] },
+          { name: 'apache-9', spaceIds: ['default'] },
         ],
       });
-      const newName = await incrementPackageName(savedObjectsClientMock.create(), 'apache');
+      const newName = await incrementPackageName(savedObjectsClientMock.create(), 'apache', [
+        'default',
+      ]);
       expect(newName).toEqual('apache-11');
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/upgrade.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/upgrade.test.ts
@@ -10,7 +10,7 @@ import type { SavedObjectsClientContract } from '@kbn/core/server';
 
 import type { PackagePolicyAssetsMap } from '../../../common/types';
 
-import { createPackagePolicyMock } from '../../../common/mocks';
+import { createPackagePolicyMock, createAgentPolicyMock } from '../../../common/mocks';
 
 import { createAppContextStartContractMock, createSavedObjectClientMock } from '../../mocks';
 
@@ -435,6 +435,9 @@ describe('Upgrade', () => {
       appContextService.stop();
     });
     it('should omit spaceIds when upgrading package policies with spaceIds', async () => {
+      mockAgentPolicyService.get.mockResolvedValue({
+        ...createAgentPolicyMock({ space_ids: ['test'] }),
+      });
       soClient.bulkGet.mockImplementation((objects) =>
         Promise.resolve({
           saved_objects: objects.map(({ id }) => ({

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -1938,6 +1938,9 @@ describe('Package policy service', () => {
   });
 
   describe('update', () => {
+    beforeEach(() => {
+      mockAgentPolicyGet();
+    });
     it('should fail to update on version conflict', async () => {
       const savedObjectsClient = createSavedObjectClientMock();
 
@@ -7742,6 +7745,8 @@ describe('Package policy service', () => {
       const soClient = createSavedObjectClientMock();
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
       const updateSpy = jest.spyOn(packagePolicyService, 'update');
+
+      mockAgentPolicyGet();
       soClient.find.mockResolvedValue({
         saved_objects: [
           {

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -419,10 +419,11 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       );
     }
 
+    const spaceIds = agentPolicies.flatMap((ap) => ap.space_ids ?? []);
     // trailing whitespace causes issues creating API keys
     enrichedPackagePolicy.name = enrichedPackagePolicy.name.trim();
     if (!options?.skipUniqueNameVerification) {
-      await requireUniqueName(soClient, enrichedPackagePolicy);
+      await requireUniqueName(soClient, enrichedPackagePolicy, undefined, spaceIds);
     }
     if (enrichedPackagePolicy.namespace) {
       await validatePolicyNamespaceForSpace({
@@ -1243,12 +1244,25 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       this.keepPolicyIdInSync(oldPackagePolicy);
     }
 
+    const agentPolicies: AgentPolicy[] = [];
+
+    for (const policyId of packagePolicyUpdate.policy_ids) {
+      const agentPolicy = await agentPolicyService.get(soClient, policyId, false);
+      if (!agentPolicy) {
+        throw new AgentPolicyNotFoundError('Agent policy not found');
+      }
+
+      agentPolicies.push(agentPolicy);
+    }
+
+    const spaceIds = agentPolicies.flatMap((ap) => ap.space_ids ?? []);
+
     if (
       packagePolicy.name &&
       packagePolicy.name !== oldPackagePolicy.name &&
       !options?.skipUniqueNameVerification
     ) {
-      await requireUniqueName(soClient, enrichedPackagePolicy, id);
+      await requireUniqueName(soClient, enrichedPackagePolicy, id, spaceIds);
     }
 
     if (packagePolicy.namespace) {
@@ -1323,8 +1337,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       };
     }
 
-    for (const policyId of packagePolicyUpdate.policy_ids) {
-      const agentPolicy = await agentPolicyService.get(soClient, policyId, true);
+    for (const agentPolicy of agentPolicies) {
       if (agentPolicy) {
         validateReusableIntegrationsAndSpaceAwareness(packagePolicy, [agentPolicy]);
       }
@@ -3932,17 +3945,37 @@ function removeStaleVars<T extends SupportsVars>(
 async function requireUniqueName(
   soClient: SavedObjectsClientContract,
   packagePolicy: UpdatePackagePolicy | NewPackagePolicy,
-  id?: string
+  id?: string,
+  spaceIds: string[] = []
 ) {
   const savedObjectType = await getPackagePolicySavedObjectType();
-  const existingPoliciesWithName = await packagePolicyService.list(soClient, {
+  const isMultiSpace = spaceIds.length > 1;
+  const baseSearchParams = {
     perPage: SO_SEARCH_LIMIT,
     kuery: `${savedObjectType}.name:"${packagePolicy.name}"`,
-  });
+  };
+
+  let existingPoliciesWithName;
+
+  if (isMultiSpace) {
+    existingPoliciesWithName = await packagePolicyService.list(
+      appContextService.getInternalUserSOClientWithoutSpaceExtension(),
+      {
+        ...baseSearchParams,
+        spaceId: '*',
+      }
+    );
+  } else {
+    existingPoliciesWithName = await packagePolicyService.list(soClient, baseSearchParams);
+  }
 
   const policiesToCheck = id
     ? // Check that the name does not exist already but exclude the current package policy
-      (existingPoliciesWithName?.items || []).filter((p) => p.id !== id)
+      (existingPoliciesWithName?.items || []).filter(
+        (p) =>
+          p.id !== id &&
+          (isMultiSpace ? (p.spaceIds ?? []).some((spaceId) => spaceIds.includes(spaceId)) : true)
+      )
     : existingPoliciesWithName?.items;
 
   if (policiesToCheck.length > 0) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/agent_policy.test.ts
@@ -74,10 +74,15 @@ describe('updateAgentPolicySpaces', () => {
   });
 
   it('does nothings if agent policy is already in correct space', async () => {
+    const agentPolicy = {
+      id: 'policy1',
+      name: 'Policy 1',
+      space_ids: ['default'],
+    };
+
     await updateAgentPolicySpaces({
-      agentPolicyId: 'policy1',
+      agentPolicy,
       currentSpaceId: 'default',
-      newSpaceIds: ['default'],
       authorizedSpaces: ['default'],
     });
     expect(
@@ -87,10 +92,15 @@ describe('updateAgentPolicySpaces', () => {
 
   it('does nothing if feature flag is not enabled', async () => {
     jest.mocked(isSpaceAwarenessEnabled).mockResolvedValue(false);
+    const agentPolicy = {
+      id: 'policy1',
+      name: 'Policy 1',
+      space_ids: ['default'],
+    };
+
     await updateAgentPolicySpaces({
-      agentPolicyId: 'policy1',
+      agentPolicy,
       currentSpaceId: 'default',
-      newSpaceIds: ['test'],
       authorizedSpaces: ['test', 'default'],
     });
 
@@ -100,10 +110,15 @@ describe('updateAgentPolicySpaces', () => {
   });
 
   it('allow to change spaces', async () => {
+    const agentPolicy = {
+      id: 'policy1',
+      name: 'Policy 1',
+      space_ids: ['test'],
+    };
+
     await updateAgentPolicySpaces({
-      agentPolicyId: 'policy1',
+      agentPolicy,
       currentSpaceId: 'default',
-      newSpaceIds: ['test'],
       authorizedSpaces: ['test', 'default'],
     });
 
@@ -144,11 +159,17 @@ describe('updateAgentPolicySpaces', () => {
         policy_ids: ['policy1', 'policy2'],
       },
     ] as any);
+
+    const agentPolicy = {
+      id: 'policy1',
+      name: 'Policy 1',
+      space_ids: ['test'],
+    };
+
     await expect(
       updateAgentPolicySpaces({
-        agentPolicyId: 'policy1',
+        agentPolicy,
         currentSpaceId: 'default',
-        newSpaceIds: ['test'],
         authorizedSpaces: ['test', 'default'],
       })
     ).rejects.toThrowError(
@@ -163,61 +184,71 @@ describe('updateAgentPolicySpaces', () => {
       is_managed: true,
     } as any);
     jest.mocked(packagePolicyService.findAllForAgentPolicy).mockResolvedValue([] as any);
+
+    const agentPolicy = {
+      id: 'policy1',
+      name: 'Policy 1',
+      space_ids: ['test'],
+    };
+
     await expect(
       updateAgentPolicySpaces({
-        agentPolicyId: 'policy1',
+        agentPolicy,
         currentSpaceId: 'default',
-        newSpaceIds: ['test'],
         authorizedSpaces: ['test', 'default'],
       })
     ).rejects.toThrowError(/Cannot update hosted agent policy policy1 space/);
   });
 
   it('throw when trying to add a space with missing permissions', async () => {
+    const agentPolicy = {
+      id: 'policy1',
+      name: 'Policy 1',
+      space_ids: ['default', 'test'],
+    };
+
     await expect(
       updateAgentPolicySpaces({
-        agentPolicyId: 'policy1',
+        agentPolicy,
         currentSpaceId: 'default',
-        newSpaceIds: ['default', 'test'],
         authorizedSpaces: ['default'],
       })
     ).rejects.toThrowError(/Not enough permissions to create policies in space test/);
   });
 
   it('throw when trying to remove a space with missing permissions', async () => {
+    const agentPolicy = {
+      id: 'policy1',
+      name: 'Policy 1',
+      space_ids: ['test'],
+    };
+
     await expect(
       updateAgentPolicySpaces({
-        agentPolicyId: 'policy1',
+        agentPolicy,
         currentSpaceId: 'default',
-        newSpaceIds: ['test'],
         authorizedSpaces: ['test'],
       })
     ).rejects.toThrowError(/Not enough permissions to remove policies from space default/);
   });
 
-  it('throw when validateUniqueName is true and policy name already exists on another space', async () => {
+  it('throw when policy name already exists on another space', async () => {
     jest
       .mocked(mockValidatePackagePoliciesUniqueNameAcrossSpaces)
       .mockRejectedValueOnce(new Error('Name already exists'));
+
+    const agentPolicy = {
+      id: 'policy1',
+      name: 'Policy 1',
+      space_ids: ['test'],
+    };
+
     await expect(
       updateAgentPolicySpaces({
-        agentPolicyId: 'policy1',
+        agentPolicy,
         currentSpaceId: 'default',
-        newSpaceIds: ['test'],
-        authorizedSpaces: ['test'],
-        options: { validateUniqueName: true },
+        authorizedSpaces: ['default', 'test'],
       })
     ).rejects.toThrowError(/Name already exists/);
-  });
-
-  it('do not call validatePackagePoliciesUniqueNameAcrossSpaces when validateUniqueName is false', async () => {
-    await updateAgentPolicySpaces({
-      agentPolicyId: 'policy1',
-      currentSpaceId: 'default',
-      newSpaceIds: ['default'],
-      authorizedSpaces: ['default'],
-      options: { validateUniqueName: false },
-    });
-    expect(validatePackagePoliciesUniqueNameAcrossSpaces).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/agent_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/agent_policies.ts
@@ -170,6 +170,58 @@ export default function (providerContext: FtrProviderContext) {
           /No enough permissions to create policies in space test1/
         );
       });
+
+      it('should correctly increment package policy names when creating agent policy with system package across multiple spaces', async () => {
+        const res = await apiClient.postOutput(
+          {
+            name: `test output ${Date.now()}`,
+            type: 'elasticsearch',
+            is_default: false,
+            is_default_monitoring: false,
+            hosts: ['https://test.fr'],
+          },
+          TEST_SPACE_1
+        );
+        const outputId = res.item.id;
+        await apiClient.installPackage({ pkgName: 'system', force: true, pkgVersion: '1.54.0' });
+
+        await apiClient.createAgentPolicy('default', {}, { sys_monitoring: true });
+
+        const newMultiSpacePolicy = await apiClient.createAgentPolicy(
+          TEST_SPACE_1,
+          {
+            space_ids: ['default', TEST_SPACE_1],
+            data_output_id: outputId,
+            monitoring_output_id: outputId,
+          },
+          { sys_monitoring: true }
+        );
+
+        const multiSpacePolicy = await apiClient.getAgentPolicy(
+          newMultiSpacePolicy.item.id,
+          'default'
+        );
+
+        const systemPackagePolicy = multiSpacePolicy.item.package_policies?.find(
+          (packagePolicy) => packagePolicy.package?.name === 'system'
+        );
+        expect(systemPackagePolicy?.name).to.be('system-2');
+      });
+
+      it('should prevent creating agent policy for multiple spaces with same name as policy in non-current namespace', async () => {
+        const testSpaceOnlyPolicy = await apiClient.createAgentPolicy(TEST_SPACE_1);
+
+        // Try to create a multi-space policy (default + test) from default space with same name
+        // This should fail because the name conflicts with policy in test space
+        await expectToRejectWithError(
+          () =>
+            apiClient.createAgentPolicy('default', {
+              name: testSpaceOnlyPolicy.item.name,
+              space_ids: ['default', TEST_SPACE_1],
+            }),
+          /409 "Conflict" Agent Policy\s.* already exists with name\s.*$/i
+        );
+      });
     });
 
     describe('GET /agent_policies_spaces', () => {

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/agent_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/agent_policies.ts
@@ -219,7 +219,7 @@ export default function (providerContext: FtrProviderContext) {
               name: testSpaceOnlyPolicy.item.name,
               space_ids: ['default', TEST_SPACE_1],
             }),
-          /409 "Conflict" Agent Policy\s.* already exists with name\s.*$/i
+          /409 Conflict Agent Policy\s.* already exists with name\s.*$/i
         );
       });
     });

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/api_helper.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/api_helper.ts
@@ -88,10 +88,12 @@ export class SpaceTestApiClient {
   // Agent policies
   async createAgentPolicy(
     spaceId?: string,
-    data: Partial<CreateAgentPolicyRequest['body']> = {}
+    data: Partial<CreateAgentPolicyRequest['body']> = {},
+    opts: CreateAgentPolicyRequest['query'] = {}
   ): Promise<CreateAgentPolicyResponse> {
+    const queryString = opts.sys_monitoring ? `?sys_monitoring=true` : '';
     const { body: res, statusCode } = await this.supertest
-      .post(`${this.getBaseUrl(spaceId)}/api/fleet/agent_policies`)
+      .post(`${this.getBaseUrl(spaceId)}/api/fleet/agent_policies${queryString}`)
       .auth(this.auth.username, this.auth.password)
       .set('kbn-xsrf', 'xxxx')
       .send({
@@ -670,6 +672,7 @@ export class SpaceTestApiClient {
   ): Promise<GetOneOutputResponse> {
     const { body: res } = await this.supertest
       .post(`${this.getBaseUrl(spaceId)}/api/fleet/outputs`)
+      .auth(this.auth.username, this.auth.password)
       .set('kbn-xsrf', 'xxxx')
       .send(data)
       .expect(200);

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/change_space_agent_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/change_space_agent_policies.ts
@@ -317,6 +317,90 @@ export default function (providerContext: FtrProviderContext) {
           /400 Bad Request Not enough permissions to remove policies from space test1/
         );
       });
+
+      it('should prevent updating agent policy to target multiple spaces when name conflicts exist', async () => {
+        const testSpaceOnlyPolicy = await apiClient.createAgentPolicy(TEST_SPACE_1);
+
+        const defaultSpaceOnlyPolicy = await apiClient.createAgentPolicy('default', {
+          name: testSpaceOnlyPolicy.item.name,
+        });
+
+        await expectToRejectWithError(
+          () =>
+            apiClient.putAgentPolicy(
+              defaultSpaceOnlyPolicy.item.id,
+              {
+                name: testSpaceOnlyPolicy.item.name,
+                namespace: 'default',
+                space_ids: ['default', TEST_SPACE_1],
+              },
+              'default'
+            ),
+          /409 "Conflict" Agent Policy\s.* already exists with name\s.*$/i
+        );
+      });
+
+      it('should prevent updating agent policy to target multiple spaces when name conflicts exists with integration policies', async () => {
+        const testSpaceOnlyPolicy = await apiClient.createAgentPolicy(TEST_SPACE_1);
+        const testSpacePackagePolicy = await apiClient.createPackagePolicy(TEST_SPACE_1, {
+          policy_ids: [testSpaceOnlyPolicy.item.id],
+          name: `test-nginx-${Date.now()}`,
+          description: 'test',
+          package: {
+            name: 'nginx',
+            version: '1.20.0',
+          },
+          inputs: {},
+        });
+
+        const defaultSpaceOnlyPolicy = await apiClient.createAgentPolicy('default');
+        await apiClient.createPackagePolicy(undefined, {
+          policy_ids: [defaultSpaceOnlyPolicy.item.id],
+          name: testSpacePackagePolicy.item.name,
+          description: 'test',
+          package: {
+            name: 'nginx',
+            version: '1.20.0',
+          },
+          inputs: {},
+        });
+
+        await expectToRejectWithError(
+          () =>
+            apiClient.putAgentPolicy(
+              defaultSpaceOnlyPolicy.item.id,
+              {
+                name: defaultSpaceOnlyPolicy.item.name,
+                namespace: 'default',
+                space_ids: ['default', TEST_SPACE_1],
+              },
+              'default'
+            ),
+          /409 "Conflict" An integration policy with the name\s.* already exists in space\s.*$/i
+        );
+      });
+
+      it('should prevent updating agent policy name already in multiple spaces when name conflicts exist', async () => {
+        const testSpaceOnlyPolicy = await apiClient.createAgentPolicy(TEST_SPACE_1);
+
+        const multiSpacePolicy = await apiClient.createAgentPolicy('default', {
+          name: `test policy ${Date.now()}}`,
+          space_ids: ['default', TEST_SPACE_1],
+        });
+
+        await expectToRejectWithError(
+          () =>
+            apiClient.putAgentPolicy(
+              multiSpacePolicy.item.id,
+              {
+                name: testSpaceOnlyPolicy.item.name,
+                namespace: 'default',
+              },
+              'default'
+            ),
+          /409 "Conflict" Agent Policy\s.* already exists with name\s.*$/i
+        );
+      });
     });
 
     describe('DELETE /agent_policies/{id}', () => {

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/change_space_agent_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/change_space_agent_policies.ts
@@ -336,7 +336,7 @@ export default function (providerContext: FtrProviderContext) {
               },
               'default'
             ),
-          /409 "Conflict" Agent Policy\s.* already exists with name\s.*$/i
+          /409 Conflict Agent Policy\s.* already exists with name\s.*$/i
         );
       });
 
@@ -376,7 +376,7 @@ export default function (providerContext: FtrProviderContext) {
               },
               'default'
             ),
-          /409 "Conflict" An integration policy with the name\s.* already exists in space\s.*$/i
+          /409 Conflict An integration policy with the name\s.* already exists in space\s.*$/i
         );
       });
 
@@ -398,7 +398,7 @@ export default function (providerContext: FtrProviderContext) {
               },
               'default'
             ),
-          /409 "Conflict" Agent Policy\s.* already exists with name\s.*$/i
+          /409 Conflict Agent Policy\s.* already exists with name\s.*$/i
         );
       });
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix enforcement of unique policy name of policies across spaces (#239631)](https://github.com/elastic/kibana/pull/239631)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michel Losier","email":"michel.losier@elastic.co"},"sourceCommit":{"committedDate":"2025-11-04T20:25:43Z","message":"Fix enforcement of unique policy name of policies across spaces (#239631)\n\nResolves: https://github.com/elastic/kibana/issues/228746\n\nFixes fleet policy name uniqueness not being consistently enforced\nacross spaces when name or space changes occur:\n\n* When creating an agent policy with packages\n(like system), the name incrementation accounts for package names that\nalready exist in the spaces to be set for the new policy.\n* Creating or updating an agent policy for multiple spaces that has the\nsame name of another policy that is not in the current namespace now\nresults in an error.\n* When an agent policy with multiple spaces has an integration policy\nname updated to one that already exists in another space that is not the\ncurrent namespace now results in an error.","sha":"e15311c5a7ad2052046f5da0cea0c5815dfd4d73","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:version","v9.3.0","v9.1.7","v9.2.1"],"title":"Fix enforcement of unique policy name of policies across spaces","number":239631,"url":"https://github.com/elastic/kibana/pull/239631","mergeCommit":{"message":"Fix enforcement of unique policy name of policies across spaces (#239631)\n\nResolves: https://github.com/elastic/kibana/issues/228746\n\nFixes fleet policy name uniqueness not being consistently enforced\nacross spaces when name or space changes occur:\n\n* When creating an agent policy with packages\n(like system), the name incrementation accounts for package names that\nalready exist in the spaces to be set for the new policy.\n* Creating or updating an agent policy for multiple spaces that has the\nsame name of another policy that is not in the current namespace now\nresults in an error.\n* When an agent policy with multiple spaces has an integration policy\nname updated to one that already exists in another space that is not the\ncurrent namespace now results in an error.","sha":"e15311c5a7ad2052046f5da0cea0c5815dfd4d73"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239631","number":239631,"mergeCommit":{"message":"Fix enforcement of unique policy name of policies across spaces (#239631)\n\nResolves: https://github.com/elastic/kibana/issues/228746\n\nFixes fleet policy name uniqueness not being consistently enforced\nacross spaces when name or space changes occur:\n\n* When creating an agent policy with packages\n(like system), the name incrementation accounts for package names that\nalready exist in the spaces to be set for the new policy.\n* Creating or updating an agent policy for multiple spaces that has the\nsame name of another policy that is not in the current namespace now\nresults in an error.\n* When an agent policy with multiple spaces has an integration policy\nname updated to one that already exists in another space that is not the\ncurrent namespace now results in an error.","sha":"e15311c5a7ad2052046f5da0cea0c5815dfd4d73"}},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->