### PR TITLE
[dashboard][9.2] fix legacy visualize, links, and maps panel references lost when dashboard updated from listing page

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/update_dashboard_meta.ts
@@ -44,8 +44,12 @@ export const updateDashboardMeta = async ({
   await contentManagementService.client.update<DashboardUpdateIn, DashboardUpdateOut>({
     contentTypeId: DASHBOARD_CONTENT_ID,
     id,
-    data: { title, description },
-    options: { references },
+    data: { ...dashboard.attributes, title, description },
+    options: {
+      references,
+      /** perform a "full" update instead, where the provided attributes will fully replace the existing ones */
+      mergeAttributes: false,
+    },
   });
 
   getDashboardContentManagementCache().deleteDashboard(id);


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/241891 for 9.2 branch. Fix is same as https://github.com/elastic/kibana/pull/241381 althought the root cause is different. This regression is cause by moving reference handling to the server in [links](https://github.com/elastic/kibana/pull/228511), [maps](https://github.com/elastic/kibana/pull/234806), and [legacy vis](https://github.com/elastic/kibana/pull/234249)