### PR TITLE
[APM] Make 'sampling_rate' agent central config options available to …

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/edot_sdk_settings.ts
@@ -118,6 +118,7 @@ export const edotSDKSettings: RawSettingDefinition[] = [
     includeAgents: [
       'opentelemetry/java/elastic',
       'opentelemetry/nodejs/elastic',
+      'opentelemetry/php/elastic',
       'opentelemetry/python/elastic',
     ],
   },

--- a/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -228,11 +228,7 @@ describe('filterByAgent', () => {
 
     it('opentelemetry/php/elastic', () => {
       expect(getSettingKeysForAgent('opentelemetry/php/elastic')).toEqual(
-        expect.arrayContaining([
-            'infer_spans',
-            'logging_level',
-            'sampling_rate',
-        ])
+        expect.arrayContaining(['infer_spans', 'logging_level', 'sampling_rate'])
       );
     });
 

--- a/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -228,7 +228,11 @@ describe('filterByAgent', () => {
 
     it('opentelemetry/php/elastic', () => {
       expect(getSettingKeysForAgent('opentelemetry/php/elastic')).toEqual(
-        expect.arrayContaining(['logging_level', 'infer_spans'])
+        expect.arrayContaining([
+            'infer_spans',
+            'logging_level',
+            'sampling_rate',
+        ])
       );
     });
 


### PR DESCRIPTION
Ref: PR elastic/elastic-otel-php#296 implements handling of `sampling_rate` central config option on the EDOT PHP side

## Summary

This makes one more central-config setting available to EDOT PHP SDK/agents.
An earlier equivalent PR was: #241048





