### PR TITLE
[Security Solution] fix flakiness in alerts generation FTR test

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/create_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/create_rules.ts
@@ -29,6 +29,7 @@ import {
   generateEvent,
   fetchRule,
   waitForAlertToComplete,
+  refreshIndex,
 } from '../../../utils';
 import {
   deleteAllRules,
@@ -480,12 +481,13 @@ export default ({ getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/240929
-    describe.skip('@skipInServerless missing timestamps', () => {
+    describe('@skipInServerless missing timestamps', () => {
+      const EVENTS_INDEX_NAME = 'myfakeindex-1';
+
       beforeEach(async () => {
-        await es.indices.delete({ index: 'myfakeindex-1', ignore_unavailable: true });
+        await es.indices.delete({ index: EVENTS_INDEX_NAME, ignore_unavailable: true });
         await es.indices.create({
-          index: 'myfakeindex-1',
+          index: EVENTS_INDEX_NAME,
           mappings: {
             properties: {
               '@timestamp': {
@@ -495,13 +497,14 @@ export default ({ getService }: FtrProviderContext) => {
           },
         });
         await es.index({
-          index: 'myfakeindex-1',
+          index: EVENTS_INDEX_NAME,
           document: generateEvent({ '@timestamp': Date.now() - 1 }),
         });
         await es.index({
-          index: 'myfakeindex-1',
+          index: EVENTS_INDEX_NAME,
           document: generateEvent({ '@timestamp': Date.now() - 2 }),
         });
+        await refreshIndex(es, EVENTS_INDEX_NAME);
         await deleteAllAlerts(supertest, log, es);
         await deleteAllRules(supertest, log);
       });
@@ -512,7 +515,7 @@ export default ({ getService }: FtrProviderContext) => {
         } = await detectionsApi
           .createRule({
             body: getCustomQueryRuleParams({
-              index: ['myfakeindex-1'],
+              index: [EVENTS_INDEX_NAME],
               timestamp_override: 'event.ingested',
               enabled: true,
             }),
@@ -530,17 +533,17 @@ export default ({ getService }: FtrProviderContext) => {
 
         expect(rule?.execution_summary?.last_execution.status).toEqual('partial failure');
         expect(rule?.execution_summary?.last_execution.message).toEqual(
-          'The following indices are missing the timestamp override field "event.ingested": ["myfakeindex-1"]'
+          `The following indices are missing the timestamp override field "event.ingested": ["${EVENTS_INDEX_NAME}"]`
         );
       });
 
-      it('generates two signals with a "partial failure" status', async () => {
+      it('generates two alerts with a "partial failure" status', async () => {
         const {
           body: { id },
         } = await detectionsApi
           .createRule({
             body: getCustomQueryRuleParams({
-              index: ['myfa*'],
+              index: [EVENTS_INDEX_NAME],
               timestamp_override: 'event.ingested',
               enabled: true,
             }),


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/240929**

## Summary

This PR fixes a flakiness in a Detection Rule Creation + Alerts Generation FTR test.

## Details

The flakiness is caused by missing Elasticsearch index refresh command after source events creation. It causes a race condition between rule execution and Elasticsearch index refresh.

Looking at the failed test [logs](https://web.buildkiteartifacts.com/e0f3970e-3a75-4621-919f-e6c773e2bb12/b1106efc-ba5e-4e90-a857-11c4a899c05d/019a2921-01ed-4f10-bdfe-2ebf3d0b6332/019a2947-780a-44fd-8311-d225caf38f9c/target/test_failures/019a2947-780a-44fd-8311-d225caf38f9c_5eface5b65eba3dd481141bc3ac8a2a2.html?jwt=eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI2MjM2NzoxODgxNDAiLCJhdWQiOiJ3ZWIuYnVpbGRraXRlYXJ0aWZhY3RzLmNvbSIsInBhdGgiOiJlMGYzOTcwZS0zYTc1LTQ2MjEtOTE5Zi1lNmM3NzNlMmJiMTIvYjExMDZlZmMtYmE1ZS00ZTkwLWE4NTctMTFjNGE4OTljMDVkLzAxOWEyOTIxLTAxZWQtNGYxMC1iZGZlLTJlYmYzZDBiNjMzMi8wMTlhMjk0Ny03ODBhLTQ0ZmQtODMxMS1kMjI1Y2FmMzhmOWMiLCJpc3MiOiJidWlsZGtpdGUuY29tIiwiZXhwIjoxNzYyMzMzNDgwLCJpYXQiOjE3NjIzMzI4ODB9.Slq_EhaYSCLNSl9xRyEC_V0OD1KWrvffFyvDAdToXp3BuF-DgMeOt9Y6fxCNRblX) it's easy to find a confirmation for the missing index refresh.

<img width="1390" height="522" alt="image" src="https://github.com/user-attachments/assets/4eafb83b-d472-4800-ba95-d099ab4aa123" />

The created rule finds 0 source events while there are 2 source events in the index the rule reads.

The test above (the first test in the same block) is able to find these 2 source events

<img width="1391" height="633" alt="image" src="https://github.com/user-attachments/assets/b847c674-d7b8-4409-86ed-913239159cf2" />

Apparently Elasticsearch delays with an index refresh when the same index gets created and removed sequentially multiple times as it happens in the **beforeEach** section for the tests mentioned above.

## Flaky test runner

- ✅ ECH 200 runs ([Buildkite](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9743))

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->