### PR TITLE
[9.1] [Observability Onboarding] Copy update for landing page messages (#241767)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
@@ -66,7 +66,7 @@ export const OnboardingFlowForm: FunctionComponent = () => {
       'xpack.observability_onboarding.onboardingFlowForm.applicationDescription',
       {
         defaultMessage:
-          'Monitor the frontend and backend application that you have developed, set-up synthetic monitors',
+          'Monitor your frontend and backend applications, set up synthetic monitors, and track application performance across your stack',
       }
     ),
     logos: ['opentelemetry', 'java', 'ruby', 'dotnet'],
@@ -82,7 +82,7 @@ export const OnboardingFlowForm: FunctionComponent = () => {
       description: metricsOnboardingEnabled
         ? i18n.translate('xpack.observability_onboarding.onboardingFlowForm.hostDescription', {
             defaultMessage:
-              'Monitor your host and the services running on it, set-up SLO, get alerted, remediate performance issues',
+              'Track your host and its services by setting up SLOs, receiving alerts, and remediating performance issues',
           })
         : i18n.translate(
             'xpack.observability_onboarding.logsEssential.onboardingFlowForm.hostDescription',
@@ -103,7 +103,7 @@ export const OnboardingFlowForm: FunctionComponent = () => {
             'xpack.observability_onboarding.onboardingFlowForm.kubernetesDescription',
             {
               defaultMessage:
-                'Observe your Kubernetes cluster, and your container workloads using logs, metrics, traces and profiling data',
+                'Monitor your Kubernetes cluster and container workloads using logs, metrics, traces, and profiling data',
             }
           )
         : i18n.translate(
@@ -124,7 +124,8 @@ export const OnboardingFlowForm: FunctionComponent = () => {
       description: i18n.translate(
         'xpack.observability_onboarding.onboardingFlowForm.cloudDescription',
         {
-          defaultMessage: 'Ingest telemetry data from the Cloud for your applications and services',
+          defaultMessage:
+            'Ingest telemetry data from your cloud services to better understand application behavior and ensure service availability',
         }
       ),
       logos: ['azure', 'aws', 'gcp'],

--- a/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/README.md
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/README.md
@@ -26,12 +26,10 @@ Some tests are designed to run concurrently (preferred option):
 
 ```bash
 // ESS
-npx playwright test --config x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel_playwright.config.ts
---project=local --grep @ess
+npx playwright test --config x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel.playwright.config.ts --project=local --grep @ess
 
 // Serverless
-npx playwright test --config x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel_playwright.config.ts
---project=local --grep @svlOblt
+npx playwright test --config x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel.playwright.config.ts --project=local --grep @svlOblt
 ```
 
 Test results are available in `x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/output`


### PR DESCRIPTION
# Backport

This will backport the following commits from `backport/9.1/pr-241767` to `9.1`:
 - [Observability Onboarding] Copy update for landing page messages (#241767) (b8ed84df)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-11-05T09:49:41Z","message":"[Observability Onboarding] Copy update for landing page messages (#241767)\n\nCloses #241747\n\nUpdates messages in observability onboarding landing page when metrics\nonboarding is enabled.\n\n<img width=\"1236\" height=\"772\" alt=\"Screenshot 2025-11-04 at 11 44 03\"\nsrc=\"https://github.com/user-attachments/assets/75d9b5a0-e9f0-4e00-ac8d-99c5fdb85775\"\n/>\n\n(cherry picked from commit be870a70bb50914f9be60435759055cd8749010b)","sha":"b8ed84df381c8953881e1b996e015d4a8a864f38"},"sourceBranch":"backport/9.1/pr-241767","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->