### PR TITLE
[Onboarding] Unskip Auto-Detect test

### DIFF
--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/onboarding/auto_detect.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/onboarding/auto_detect.ts
@@ -18,8 +18,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const synthtrace = getService('svlLogsSynthtraceClient');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/239362
-  describe.skip('Onboarding Auto-Detect', () => {
+  describe('Onboarding Auto-Detect', () => {
     before(async () => {
       await PageObjects.svlCommonPage.loginAsAdmin(); // Onboarding requires admin role
       await PageObjects.common.navigateToUrlWithBrowserHistory(


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/239362

Un-skipping the test as it was due to a transient issue introduced by a change in the `system` integration (🔒 [slack discussion for more context](https://elastic.slack.com/archives/CJZ9U5G9X/p1760626340111779))

🟢 [Flaky tests run](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9745/steps/canvas)