### PR TITLE
[Cases] Only take tags-changes into account when connector supports them

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.test.ts
@@ -2034,22 +2034,6 @@ describe('CaseUserActionService', () => {
                         Object {
                           "isQuoted": false,
                           "type": "literal",
-                          "value": "tags",
-                        },
-                      ],
-                      "function": "is",
-                      "type": "function",
-                    },
-                    Object {
-                      "arguments": Array [
-                        Object {
-                          "isQuoted": false,
-                          "type": "literal",
-                          "value": "cases-user-actions.attributes.type",
-                        },
-                        Object {
-                          "isQuoted": false,
-                          "type": "literal",
                           "value": "title",
                         },
                       ],
@@ -2126,22 +2110,6 @@ describe('CaseUserActionService', () => {
                         Object {
                           "isQuoted": false,
                           "type": "literal",
-                          "value": "tags",
-                        },
-                      ],
-                      "function": "is",
-                      "type": "function",
-                    },
-                    Object {
-                      "arguments": Array [
-                        Object {
-                          "isQuoted": false,
-                          "type": "literal",
-                          "value": "cases-user-actions.attributes.type",
-                        },
-                        Object {
-                          "isQuoted": false,
-                          "type": "literal",
                           "value": "title",
                         },
                       ],
@@ -2175,6 +2143,22 @@ describe('CaseUserActionService', () => {
                           "isQuoted": false,
                           "type": "literal",
                           "value": "status",
+                        },
+                      ],
+                      "function": "is",
+                      "type": "function",
+                    },
+                    Object {
+                      "arguments": Array [
+                        Object {
+                          "isQuoted": false,
+                          "type": "literal",
+                          "value": "cases-user-actions.attributes.type",
+                        },
+                        Object {
+                          "isQuoted": false,
+                          "type": "literal",
+                          "value": "tags",
                         },
                       ],
                       "function": "is",

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.ts
@@ -236,7 +236,7 @@ export class CaseUserActionService {
 
   public async getMostRecentUserAction(
     caseId: string,
-    isCasesWebhook = false
+    hasAdditionalUserActionsConnector = false
   ): Promise<UserActionSavedObjectTransformed | undefined> {
     try {
       this.context.log.debug(
@@ -250,14 +250,15 @@ export class CaseUserActionService {
         filters: [
           UserActionTypes.comment,
           UserActionTypes.description,
-          UserActionTypes.tags,
           UserActionTypes.title,
           /**
-           * TODO: Remove when all connectors support the status and
-           * the severity user actions or if there is a mechanism to
+           * TODO: Remove when all connectors support the status, severity
+           * and tags user actions or if there is a mechanism to
            * define supported user actions per connector type
            */
-          ...(isCasesWebhook ? [UserActionTypes.severity, UserActionTypes.status] : []),
+          ...(hasAdditionalUserActionsConnector
+            ? [UserActionTypes.severity, UserActionTypes.status, UserActionTypes.tags]
+            : []),
         ],
         field: 'type',
         operator: 'or',


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/180902

The `tags` of a cases are currently only sent to the cases connector and the `the hive` connector. For all other connectors, changes of `tags` should not show the `Push to XYZ` button.
