### PR TITLE
[Automated Rollback Tests] Enforce users to provide fixtures for updated SO types

### DIFF
--- a/packages/kbn-check-saved-objects-cli/src/commands/run_check_saved_objects_cli.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/run_check_saved_objects_cli.ts
@@ -15,23 +15,30 @@ export function runCheckSavedObjectsCli() {
 
   run(
     async ({ log, flagsReader }) => {
-      const shas: string[] = flagsReader.arrayOfStrings('baseline') ?? [];
-      if (!shas.length) {
+      const gitRev = flagsReader.string('gitRev');
+      const fix = flagsReader.boolean('fix');
+
+      if (!gitRev) {
         throw new Error(
-          'No baseline SHAs provided, cannot check changes in Saved Objects. Please provide one or more --baseline SHAs'
+          'No baseline SHA provided, cannot check changes in Saved Objects. Please provide a --baseline <gitRev>'
         );
+      } else {
+        await checkSavedObjects({ gitRev, log, fix });
+        process.exit(0);
       }
-      await checkSavedObjects({ shas, log });
-      process.exit(0);
     },
     {
       description: `
       Determine if the changes performed to the Saved Objects mappings are following our standards.
 
-      Usage: node ${scriptName} --baseline <mergeBaseSHA> --baseline <serverlessSHA>
+      Usage: node ${scriptName} --baseline <gitRev>
     `,
       flags: {
-        string: ['baseline'],
+        alias: {
+          baseline: 'gitRev',
+        },
+        boolean: ['fix'],
+        string: ['gitRev'],
         default: {
           verify: true,
           mappings: true,

--- a/packages/kbn-check-saved-objects-cli/src/mappings_additions/current_fields.ts
+++ b/packages/kbn-check-saved-objects-cli/src/mappings_additions/current_fields.ts
@@ -7,25 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { readFile, writeFile } from 'fs/promises';
 import Path from 'path';
 import type { FieldListMap } from '@kbn/core-saved-objects-base-server-internal';
 import { prettyPrintAndSortKeys } from '@kbn/utils';
+import { fileToJson, jsonToFile } from '../util/json';
 
 const CURRENT_FIELDS_FILE_PATH = Path.resolve(__dirname, '../../current_fields.json');
 
 export const readCurrentFields = async (): Promise<FieldListMap> => {
-  try {
-    const fileContent = await readFile(CURRENT_FIELDS_FILE_PATH, 'utf-8');
-    return JSON.parse(fileContent);
-  } catch (error) {
-    if (error.code === 'ENOENT') {
-      return {};
-    }
-    throw error;
-  }
+  return (await fileToJson(CURRENT_FIELDS_FILE_PATH, {})) as FieldListMap;
 };
 
 export const writeCurrentFields = async (fieldMap: FieldListMap) => {
-  await writeFile(CURRENT_FIELDS_FILE_PATH, prettyPrintAndSortKeys(fieldMap) + '\n', 'utf-8');
+  await jsonToFile(CURRENT_FIELDS_FILE_PATH, prettyPrintAndSortKeys(fieldMap) + '\n');
 };

--- a/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/constants.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/constants.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { resolve } from 'path';
+
+export const FIXTURES_BASE_PATH = resolve(__dirname, '../__fixtures__/');

--- a/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/create_fixture_file.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/create_fixture_file.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ModelVersionIdentifier, SavedObjectsType } from '@kbn/core-saved-objects-server';
+import { createFixtureTemplate } from './create_fixture_template';
+import { jsonToFile } from '../../util/json';
+
+export async function createFixtureFile({
+  type,
+  path,
+  previous,
+  current,
+}: {
+  type: SavedObjectsType<any>;
+  path: string;
+  previous: string;
+  current: string;
+}) {
+  // auto-generate the file
+  const modelVersions =
+    typeof type.modelVersions === 'function' ? type.modelVersions() : type.modelVersions!;
+  const lastModelVersion = modelVersions[current.split('.')[1] as ModelVersionIdentifier];
+  const typeTemplate = createFixtureTemplate(lastModelVersion!);
+
+  await jsonToFile(path, {
+    [previous]: [
+      {
+        TODO: `Please create one or more test objects with properties that reflect real '${type}' objects`,
+        NOTE: `That each modelVersion has a corresponding fixture file, which defines the previous and current versions.`,
+        HINT: `You can use the template below and create sample objects for ${previous} and ${current} versions.`,
+        HINT2: `Alternatively, you can copy the contents from older fixture files (if they exist) and adapt them accordingly.`,
+      },
+    ],
+    [current]: [typeTemplate],
+  });
+}

--- a/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/create_fixture_template.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/create_fixture_template.test.ts
@@ -13,7 +13,7 @@ function mkModelVersion(props: Array<{ path: string[]; type: any }>) {
   return {
     schemas: {
       create: {
-        getPropSchemas: () => props,
+        getSchemaStructure: () => props,
       },
     },
   } as any;

--- a/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/create_fixture_template.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/create_fixture_template.test.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createFixtureTemplate } from './create_fixture_template';
+
+function mkModelVersion(props: Array<{ path: string[]; type: any }>) {
+  return {
+    schemas: {
+      create: {
+        getPropSchemas: () => props,
+      },
+    },
+  } as any;
+}
+
+describe('createFixtureTemplate', () => {
+  it('creates fixture for a single root property', () => {
+    const props = [{ path: ['title'], type: 'text' }];
+    const modelVersion = mkModelVersion(props);
+    expect(createFixtureTemplate(modelVersion)).toEqual({ title: 'text' });
+  });
+
+  it('creates fixture for a nested property (2 levels)', () => {
+    const props = [{ path: ['meta', 'author'], type: 'keyword' }];
+    const modelVersion = mkModelVersion(props);
+    expect(createFixtureTemplate(modelVersion)).toEqual({ meta: { author: 'keyword' } });
+  });
+
+  it('creates fixture for a deep nested property (3 levels)', () => {
+    const props = [{ path: ['a', 'b', 'c'], type: 'number' }];
+    const modelVersion = mkModelVersion(props);
+    expect(createFixtureTemplate(modelVersion)).toEqual({ a: { b: { c: 'number' } } });
+  });
+
+  it('merges multiple properties that share parents', () => {
+    const props = [
+      { path: ['meta', 'author'], type: 'keyword' },
+      { path: ['meta', 'date'], type: 'date' },
+      { path: ['meta', 'nested', 'id'], type: 'uuid' },
+    ];
+    const modelVersion = mkModelVersion(props);
+    expect(createFixtureTemplate(modelVersion)).toEqual({
+      meta: {
+        author: 'keyword',
+        date: 'date',
+        nested: {
+          id: 'uuid',
+        },
+      },
+    });
+  });
+
+  it('works regardless of property order', () => {
+    const props = [
+      { path: ['meta', 'nested', 'id'], type: 'uuid' },
+      { path: ['meta', 'author'], type: 'keyword' },
+      { path: ['meta', 'date'], type: 'date' },
+    ];
+    const modelVersion = mkModelVersion(props);
+    expect(createFixtureTemplate(modelVersion)).toEqual({
+      meta: {
+        nested: {
+          id: 'uuid',
+        },
+        author: 'keyword',
+        date: 'date',
+      },
+    });
+  });
+
+  it('can create sample templates from SO schemas, e.g. dashboards', () => {
+    const props = [
+      {
+        path: ['title'],
+        type: 'string',
+      },
+      {
+        path: ['description'],
+        type: 'string?',
+      },
+      {
+        path: ['kibanaSavedObjectMeta', 'searchSourceJSON'],
+        type: 'string?',
+      },
+      {
+        path: ['timeRestore'],
+        type: 'boolean?',
+      },
+      {
+        path: ['timeFrom'],
+        type: 'string?',
+      },
+      {
+        path: ['timeTo'],
+        type: 'string?',
+      },
+      {
+        path: ['refreshInterval', 'pause'],
+        type: 'boolean',
+      },
+      {
+        path: ['refreshInterval', 'value'],
+        type: 'number',
+      },
+      {
+        path: ['refreshInterval', 'display'],
+        type: 'string?',
+      },
+      {
+        path: ['refreshInterval', 'section'],
+        type: 'number?',
+      },
+      {
+        path: ['controlGroupInput', 'panelsJSON'],
+        type: 'string?',
+      },
+      {
+        path: ['controlGroupInput', 'controlStyle'],
+        type: 'string?',
+      },
+      {
+        path: ['controlGroupInput', 'chainingSystem'],
+        type: 'string?',
+      },
+      {
+        path: ['controlGroupInput', 'ignoreParentSettingsJSON'],
+        type: 'string?',
+      },
+      {
+        path: ['controlGroupInput', 'showApplySelections'],
+        type: 'boolean?',
+      },
+      {
+        path: ['panelsJSON'],
+        type: 'string?',
+      },
+      {
+        path: ['optionsJSON'],
+        type: 'string?',
+      },
+      {
+        path: ['hits'],
+        type: 'number?',
+      },
+      {
+        path: ['version'],
+        type: 'number?',
+      },
+      {
+        path: ['sections'],
+        type: 'array?',
+      },
+    ];
+    const modelVersion = mkModelVersion(props);
+
+    expect(createFixtureTemplate(modelVersion)).toEqual({
+      title: 'string',
+      description: 'string?',
+      kibanaSavedObjectMeta: {
+        searchSourceJSON: 'string?',
+      },
+      timeRestore: 'boolean?',
+      timeFrom: 'string?',
+      timeTo: 'string?',
+      refreshInterval: {
+        pause: 'boolean',
+        value: 'number',
+        display: 'string?',
+        section: 'number?',
+      },
+      controlGroupInput: {
+        panelsJSON: 'string?',
+        controlStyle: 'string?',
+        chainingSystem: 'string?',
+        ignoreParentSettingsJSON: 'string?',
+        showApplySelections: 'boolean?',
+      },
+      panelsJSON: 'string?',
+      optionsJSON: 'string?',
+      hits: 'number?',
+      version: 'number?',
+      sections: 'array?',
+    });
+  });
+});

--- a/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/create_fixture_template.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/create_fixture_template.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SavedObjectsModelVersion } from '@kbn/core-saved-objects-server';
+import type { FixtureTemplate, ModelVersionSchemaProperty } from './types';
+
+export function createFixtureTemplate(modelVersion: SavedObjectsModelVersion): FixtureTemplate {
+  const props = modelVersion.schemas!.create!.getSchemaStructure() as ModelVersionSchemaProperty[];
+
+  // Sort props by path length to ensure parent paths are created before nested ones
+  props.sort((a, b) => a.path.length - b.path.length);
+  const template: Record<string, any> = {};
+  for (const { path, type } of props) {
+    let current = template;
+    for (let i = 0; i < path.length; i++) {
+      const segment = path[i];
+      if (i === path.length - 1) {
+        current[segment] = type;
+      } else {
+        current[segment] = current[segment] || {};
+        current = current[segment];
+      }
+    }
+  }
+  return template;
+}

--- a/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/get_fixtures.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/get_fixtures.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { asyncForEach } from '@kbn/std';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { MigrationSnapshot, ServerHandles } from '../../types';
+import type { FixtureTemplate } from './types';
+import { getVersions } from '../versions';
+import { getTypeFixtures } from './get_type_fixtures';
+
+interface TestForwardAndBackwardMigrationsParams {
+  snapshot: MigrationSnapshot;
+  serverHandles: ServerHandles;
+  types: string[];
+  fix?: boolean;
+  log: ToolingLog;
+}
+
+export async function getFixtures({
+  snapshot,
+  serverHandles: {
+    coreStart: { savedObjects },
+  },
+  types,
+  fix,
+  log,
+}: TestForwardAndBackwardMigrationsParams) {
+  log.info(`Obtaining sample objects (fixtures) for the following types: ${types}`);
+  const registry = savedObjects.getTypeRegistry();
+  let previousVersionObjects: FixtureTemplate[] = [];
+  let currentVersionObjects: FixtureTemplate[] = [];
+
+  // validate fixture files for each of the updated types; obtain sample SOs for testing
+  asyncForEach(types, async (name) => {
+    const type = registry.getType(name)!;
+    const typeSnapshot = snapshot.typeDefinitions[name];
+    const [current, previous] = getVersions(typeSnapshot);
+    const fixtures = await getTypeFixtures({ type, current, previous, generate: Boolean(fix) });
+    previousVersionObjects = previousVersionObjects.concat(fixtures[previous]);
+    currentVersionObjects = currentVersionObjects.concat(fixtures[current]);
+  });
+
+  return { previousVersionObjects, currentVersionObjects };
+}

--- a/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/get_type_fixtures.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/get_type_fixtures.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { join } from 'path';
+import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
+import { fileToJson } from '../../util/json';
+import type { ModelVersionFixtures } from './types';
+import { FIXTURES_BASE_PATH } from './constants';
+import { createFixtureFile } from './create_fixture_file';
+import { isValidFixtureFile } from './is_valid_fixture_file';
+
+export async function getTypeFixtures({
+  type,
+  previous,
+  current,
+  generate,
+}: {
+  type: SavedObjectsType<any>;
+  previous: string;
+  current: string;
+  generate: boolean;
+}) {
+  const name = type.name;
+  const fixturesPath = join(FIXTURES_BASE_PATH, name, `${current}.json`);
+  const fixtures = (await fileToJson(fixturesPath)) as ModelVersionFixtures;
+  if (!fixtures) {
+    if (generate) {
+      await createFixtureFile({
+        type,
+        path: fixturesPath,
+        current,
+        previous,
+      });
+      throw new Error(
+        `❌ '${name}' SO type is missing test fixtures for '${current}'. Please populate sample data on '${fixturesPath}'.`
+      );
+    } else {
+      throw new Error(
+        `❌ '${name}' SO type is missing test fixtures for the new modelVersion '${current}'. Please run with --fix to generate '${fixturesPath}' and then add sample data.`
+      );
+    }
+  } else if (!isValidFixtureFile(fixtures, previous, current)) {
+    throw new Error(
+      `❌ The contents of '${fixturesPath}' are invalid. Please ensure it:
+{
+  "${previous}": [
+    // has one or more documents of type ${name} on version ${previous}
+  ],
+  "${current}": [
+    // what the documents above should look like after migrating them to ${current}
+  ],
+}`
+    );
+  } else {
+    return fixtures;
+  }
+}

--- a/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/index.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { getFixtures } from './get_fixtures';

--- a/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/is_valid_fixture_file.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/is_valid_fixture_file.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ModelVersionFixtures } from './types';
+
+export function isValidFixtureFile(
+  fixtures: ModelVersionFixtures,
+  previous: string,
+  current: string
+): boolean {
+  return (
+    typeof fixtures !== 'object' ||
+    !fixtures[previous]?.length ||
+    !fixtures[current]?.length ||
+    fixtures[previous]?.length !== fixtures[current]?.length ||
+    (Boolean(fixtures[previous]?.[0]?.TODO) &&
+      Boolean(fixtures[previous]?.[0]?.NOTE) &&
+      Boolean(fixtures[previous]?.[0]?.HINT) &&
+      Boolean(fixtures[previous]?.[0]?.HINT2))
+  );
+}

--- a/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/types.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/types.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export interface ModelVersionFixtures {
+  [modelVersion: string]: FixtureTemplate[];
+}
+
+export interface FixtureTemplate {
+  [propName: string]: PropValue | PropValue[] | FixtureTemplate;
+}
+
+export type PropValue = string | boolean | number;
+
+export interface ModelVersionSchemaProperty {
+  path: string[];
+  type: string;
+}

--- a/packages/kbn-check-saved-objects-cli/src/migrations/index.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { getFixtures } from './fixtures';

--- a/packages/kbn-check-saved-objects-cli/src/migrations/versions.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/versions.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getVersions } from './versions';
+import type { MigrationInfoRecord } from '../types';
+
+function makeTypeSnapshot(
+  migrationVersions: string[],
+  modelCount: number
+): Pick<MigrationInfoRecord, 'migrationVersions' | 'modelVersions'> {
+  // Construct minimal model version entries that conform to the expected shape.
+  const modelVersions = Array.from({ length: modelCount }, (_, i) => ({
+    version: `${i + 1}`,
+    changeTypes: [] as string[],
+    hasTransformation: false,
+    newMappings: [] as string[],
+    schemas: { create: false, forwardCompatibility: false },
+  }));
+  return { migrationVersions, modelVersions } as Pick<
+    MigrationInfoRecord,
+    'migrationVersions' | 'modelVersions'
+  >;
+}
+
+describe('getVersions', () => {
+  it('returns ["0.0.0"] when there are no migrations or model versions', () => {
+    const typeSnapshot = makeTypeSnapshot([], 0);
+    expect(getVersions(typeSnapshot)).toEqual(['0.0.0']);
+  });
+
+  it('includes migrationVersions and generated model versions and reverses newest-to-oldest', () => {
+    const typeSnapshot = makeTypeSnapshot(['7.10.0', '8.0.0'], 2); // modelVersions -> 10.1.0, 10.2.0
+
+    expect(getVersions(typeSnapshot)).toEqual(['10.2.0', '10.1.0', '8.0.0', '7.10.0', '0.0.0']);
+  });
+
+  it('handles single migrationVersion and single modelVersion', () => {
+    const typeSnapshot = makeTypeSnapshot(['1.0.0'], 1); // -> 10.1.0
+
+    expect(getVersions(typeSnapshot)).toEqual(['10.1.0', '1.0.0', '0.0.0']);
+  });
+
+  it('preserves duplicates from migrationVersions and includes model versions accordingly', () => {
+    const typeSnapshot = makeTypeSnapshot(['2.0.0', '2.0.0'], 3); // -> 10.1.0,10.2.0,10.3.0
+
+    expect(getVersions(typeSnapshot)).toEqual([
+      '10.3.0',
+      '10.2.0',
+      '10.1.0',
+      '2.0.0',
+      '2.0.0',
+      '0.0.0',
+    ]);
+  });
+});

--- a/packages/kbn-check-saved-objects-cli/src/migrations/versions.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/versions.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { MigrationInfoRecord } from '../types';
+
+/**
+ * Returns the list of versions defined for a given SO type; sorted from newest to oldest.
+ * 0.0.0 is also included for convenience, as the "initial" version
+ * @param typeSnapshot the snapshot from which versions are extracted
+ * @returns list of versions
+ */
+export function getVersions(
+  typeSnapshot: Pick<MigrationInfoRecord, 'migrationVersions' | 'modelVersions'>
+): string[] {
+  return [
+    '0.0.0',
+    ...typeSnapshot.migrationVersions,
+    ...typeSnapshot.modelVersions.map(({ version }) => `10.${version}.0`),
+  ].reverse() as string[];
+}

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/compare.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/compare.ts
@@ -20,7 +20,9 @@ export function assertValidUpdates({
   log: ToolingLog;
   from: MigrationSnapshot;
   to: MigrationSnapshot;
-}) {
+}): string[] {
+  const udpatedTypes = [];
+
   log.info(`Checking SO type updates between base branch and current branch`);
   for (const name in to.typeDefinitions) {
     if (!Object.prototype.hasOwnProperty.call(to.typeDefinitions, name)) {
@@ -72,14 +74,17 @@ export function assertValidUpdates({
               `❌ The new model version '${newModelVersion.version}' for SO type '${name}' is missing the 'schemas' definition.`
             );
           }
-          if (newModelVersion.schemas.forwardCompatibility === false)
+          if (newModelVersion.schemas.forwardCompatibility === false) {
             throw new Error(
               `❌ The new model version '${newModelVersion.version}' for SO type '${name}' is missing the 'forwardCompatibility' schema definition.`
             );
-          if (newModelVersion.schemas.create === false)
+          }
+          if (newModelVersion.schemas.create === false) {
             throw new Error(
               `❌ The new model version '${newModelVersion.version}' for SO type '${name}' is missing the 'create' schema definition.`
             );
+          }
+          udpatedTypes.push(name);
         }
 
         // check that existing model versions have not been mutated
@@ -125,6 +130,7 @@ export function assertValidUpdates({
     }
   }
   log.info('✅ Current SO type definitions are compatible with the baseline');
+  return udpatedTypes;
 }
 
 function getMutatedModelVersions(

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/take.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/take.ts
@@ -31,7 +31,7 @@ export async function takeSnapshot({
   serverHandles: ServerHandles;
 }): Promise<MigrationSnapshot> {
   try {
-    log.info(`Capturing current SO type definitions`);
+    log.info(`Taking snapshot of current SO type definitions`);
     const { coreStart } = serverHandles;
     const typeRegistry = coreStart.savedObjects.getTypeRegistry();
     const allTypes = typeRegistry.getAllTypes();
@@ -57,7 +57,9 @@ export async function takeSnapshot({
     log.error(
       '⚠️ Failed to obtain snapshot for current working tree. Skipping Saved Objects checks.'
     );
-    log.error(err);
+    if (err instanceof Error || typeof err === 'string') {
+      log.error(err);
+    }
     throw err;
   }
 }

--- a/packages/kbn-check-saved-objects-cli/src/util/json.ts
+++ b/packages/kbn-check-saved-objects-cli/src/util/json.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { mkdir, readFile, writeFile } from 'fs/promises';
+
+export const fileToJson = async (path: string, def?: Object): Promise<Object | undefined> => {
+  try {
+    const dir = path.substring(0, path.lastIndexOf('/'));
+    await mkdir(dir, { recursive: true });
+    const fileContent = await readFile(path, 'utf-8');
+    return JSON.parse(fileContent);
+  } catch (error) {
+    if ((error as unknown as any)?.code === 'ENOENT') {
+      return def;
+    }
+    throw error;
+  }
+};
+
+export const jsonToFile = async (path: string, value: Object | string) => {
+  await writeFile(path, typeof value === 'string' ? value : JSON.stringify(value, null, 2), {
+    encoding: 'utf-8',
+    flag: 'w',
+  });
+};

--- a/packages/kbn-check-saved-objects-cli/src/util/servers.ts
+++ b/packages/kbn-check-saved-objects-cli/src/util/servers.ts
@@ -15,9 +15,10 @@ import { ENABLE_ALL_PLUGINS_CONFIG_PATH } from '@kbn/core-plugins-server-interna
 import { ToolingLog } from '@kbn/tooling-log';
 import type { ServerHandles } from '../types';
 
-export async function startServers(): Promise<ServerHandles> {
-  const kibanaLog = resolve(os.tmpdir(), 'kibana.log');
+export async function startServers(log: ToolingLog): Promise<ServerHandles> {
+  log.info(`Starting ES + Kibana`);
 
+  const kibanaLog = resolve(os.tmpdir(), 'kibana.log');
   const { startES } = createTestServers({
     adjustTimeout: () => {},
     settings: {
@@ -76,14 +77,16 @@ export async function stopServers({
   try {
     await delay(2);
     await Promise.race([
-      serverHandles.kibanaRoot?.shutdown(),
+      serverHandles.kibanaRoot.shutdown(),
       timeout(8, 'Timeout waiting for Kibana to stop'),
     ]);
 
     log.info("Kibana's shutdown done!");
-  } catch (ex) {
+  } catch (err) {
     log.error('Error while stopping kibana.');
-    log.error(ex);
+    if (err instanceof Error || typeof err === 'string') {
+      log.error(err);
+    }
   }
 
   try {
@@ -93,9 +96,11 @@ export async function stopServers({
       timeout(5, 'Timeout waiting for ES to stop'),
     ]);
     log.info('ES Stopped!');
-  } catch (ex) {
+  } catch (err) {
     log.error('Error while stopping ES.');
-    log.error(ex);
+    if (err instanceof Error || typeof err === 'string') {
+      log.error(err);
+    }
   }
 }
 

--- a/packages/kbn-check-saved-objects-cli/tsconfig.json
+++ b/packages/kbn-check-saved-objects-cli/tsconfig.json
@@ -32,5 +32,6 @@
     "@kbn/core-root-server-internal",
     "@kbn/core-lifecycle-server-internal",
     "@kbn/core-test-helpers-so-type-serializer",
+    "@kbn/std",
   ]
 }

--- a/src/core/packages/saved-objects/server/index.ts
+++ b/src/core/packages/saved-objects/server/index.ts
@@ -126,6 +126,7 @@ export {
 } from './src/saved_objects_error_helpers';
 
 export type {
+  ModelVersionIdentifier,
   SavedObjectsModelVersion,
   SavedObjectsModelVersionMap,
   SavedObjectsModelVersionMapProvider,

--- a/src/core/packages/saved-objects/server/src/model_version/index.ts
+++ b/src/core/packages/saved-objects/server/src/model_version/index.ts
@@ -8,6 +8,7 @@
  */
 
 export type {
+  ModelVersionIdentifier,
   SavedObjectsModelVersion,
   SavedObjectsModelVersionMap,
   SavedObjectsModelVersionMapProvider,

--- a/src/core/packages/saved-objects/server/src/model_version/model_version.ts
+++ b/src/core/packages/saved-objects/server/src/model_version/model_version.ts
@@ -168,29 +168,51 @@ export interface SavedObjectsFullModelVersion {
  *
  * @public
  */
+
+export type ModelVersionIdentifier =
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | '11'
+  | '12'
+  | '13'
+  | '14'
+  | '15'
+  | '16'
+  | '17'
+  | '18'
+  | '19'
+  | '20'
+  | '21'
+  | '22'
+  | '23'
+  | '24'
+  | '25'
+  | '26'
+  | '27'
+  | '28'
+  | '29'
+  | '30'
+  | '31'
+  | '32'
+  | '33'
+  | '34'
+  | '35'
+  | '36'
+  | '37'
+  | '38'
+  | '39'
+  | '40';
+
 export type SavedObjectsModelVersionMap = {
-  [mv in
-    | '1'
-    | '2'
-    | '3'
-    | '4'
-    | '5'
-    | '6'
-    | '7'
-    | '8'
-    | '9'
-    | '10'
-    | '11'
-    | '12'
-    | '13'
-    | '14'
-    | '15'
-    | '16'
-    | '17'
-    | '18'
-    | '19'
-    | '20'
-    | '21']?: SavedObjectsModelVersion | SavedObjectsFullModelVersion;
+  [mv in ModelVersionIdentifier]?: SavedObjectsModelVersion | SavedObjectsFullModelVersion;
 };
 
 /**


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana-team/issues/1872

This PR leverages the newly introduced _Saved Objects_ check, adding an extra step to make sure users provide sample SO fixtures when defining new model versions.