### PR TITLE
[9.2] [SideNav] Wrap SideNav in `ErrorBoundary` with retry   (#239945)

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/ui/project/sidenav_v2/navigation/navigation.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/project/sidenav_v2/navigation/navigation.tsx
@@ -22,6 +22,7 @@ import type { IBasePath as BasePath } from '@kbn/core-http-browser';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { NavigationTourManager } from '@kbn/core-chrome-navigation-tour';
 import { NavigationTour } from '@kbn/core-chrome-navigation-tour';
+import { KibanaSectionErrorBoundary } from '@kbn/shared-ux-error-boundary';
 import useObservable from 'react-use/lib/useObservable';
 import { RedirectNavigationAppLinks } from './redirect_app_links';
 import type { NavigationItems } from './to_navigation_items';
@@ -68,7 +69,7 @@ export const Navigation = (props: ChromeNavigationProps) => {
   const { navItems, logoItem, activeItemId, solutionId } = state;
 
   return (
-    <>
+    <KibanaSectionErrorBoundary sectionName={'Navigation'} maxRetries={3}>
       <NavigationTour
         tourManager={props.navigationTourManager}
         key={
@@ -92,7 +93,7 @@ export const Navigation = (props: ChromeNavigationProps) => {
           data-test-subj={classnames(dataTestSubj, 'projectSideNav', 'projectSideNavV2')}
         />
       </RedirectNavigationAppLinks>
-    </>
+    </KibanaSectionErrorBoundary>
   );
 };
 

--- a/src/core/packages/chrome/browser-internal/tsconfig.json
+++ b/src/core/packages/chrome/browser-internal/tsconfig.json
@@ -72,6 +72,7 @@
     "@kbn/core-chrome-layout-feature-flags",
     "@kbn/shared-ux-feedback-snippet",
     "@kbn/core-chrome-navigation-tour",
+    "@kbn/shared-ux-error-boundary",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/packages/shared/react/kibana_context/root/root_provider.tsx
+++ b/src/platform/packages/shared/react/kibana_context/root/root_provider.tsx
@@ -14,6 +14,7 @@ import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
 import type { I18nStart } from '@kbn/core-i18n-browser';
 import type { ExecutionContextStart } from '@kbn/core-execution-context-browser';
 import { SharedUXRouterContext } from '@kbn/shared-ux-router';
+import { KibanaErrorBoundaryProvider } from '@kbn/shared-ux-error-boundary';
 
 // @ts-expect-error EUI exports this component internally, but Kibana isn't picking it up its types
 import { useIsNestedEuiProvider } from '@elastic/eui/lib/components/provider/nested';
@@ -54,9 +55,11 @@ export const KibanaRootContextProvider: FC<PropsWithChildren<KibanaRootContextPr
 }) => {
   const hasEuiProvider = useIsNestedEuiProvider();
   const rootContextProvider = (
-    <SharedUXRouterContext.Provider value={{ services: { executionContext } }}>
-      <i18n.Context>{children}</i18n.Context>
-    </SharedUXRouterContext.Provider>
+    <KibanaErrorBoundaryProvider analytics={props.analytics}>
+      <SharedUXRouterContext.Provider value={{ services: { executionContext } }}>
+        <i18n.Context>{children}</i18n.Context>
+      </SharedUXRouterContext.Provider>
+    </KibanaErrorBoundaryProvider>
   );
 
   if (hasEuiProvider) {

--- a/src/platform/packages/shared/react/kibana_context/root/tsconfig.json
+++ b/src/platform/packages/shared/react/kibana_context/root/tsconfig.json
@@ -26,6 +26,7 @@
     "@kbn/core-execution-context-browser",
     "@kbn/core-execution-context-browser-mocks",
     "@kbn/shared-ux-router",
-    "@kbn/core-chrome-layout-constants"
+    "@kbn/core-chrome-layout-constants",
+    "@kbn/shared-ux-error-boundary"
   ]
 }

--- a/src/platform/packages/shared/shared-ux/error_boundary/README.mdx
+++ b/src/platform/packages/shared/shared-ux/error_boundary/README.mdx
@@ -9,14 +9,60 @@ date: 2023-10-03
 
 ## Description
 
-This package exports `KibanaErrorBoundary` and `KibanaSectionErrorBoundary` components.
+This package exports error boundary components to handle rendering errors gracefully:
 
-- `KibanaErrorBoundary` is designed to capture rendering errors by blocking the main part of the UI.
-- `KibanaSectionErrorBoundary` is designed to capture errors at a more granular level.
+- `KibanaErrorBoundary` - Captures rendering errors at the page level and blocks the main UI
+- `KibanaSectionErrorBoundary` - Captures errors at a granular section level with optional automatic retry capability
 
 In general, it's best to use `KibanaErrorBoundary` and block the whole page. If it is acceptable to assume the risk of allowing users to interact with a UI that has an error state, then using `KibanaSectionErrorBoundary` may be an acceptable alternative, but this must be judged on a case-by-case basis.
 
 ## API
+
+### KibanaErrorBoundary
+
+Page-level error boundary that captures rendering errors and blocks the main UI until refresh.
+
+```tsx
+<KibanaErrorBoundary>
+  <YourApp />
+</KibanaErrorBoundary>
+```
+
+**Props:**
+
+- `children` (ReactNode, required) - Child components to render and protect
+
+### KibanaSectionErrorBoundary
+
+Section-level error boundary that captures errors without blocking the entire page. Supports optional automatic retry with fresh component state.
+
+```tsx
+// Without retries (default)
+<KibanaSectionErrorBoundary sectionName="Dashboard Panel">
+  <YourComponent />
+</KibanaSectionErrorBoundary>
+
+// With automatic retry attempts
+<KibanaSectionErrorBoundary sectionName="Dashboard Panel" maxRetries={3}>
+  <YourComponent />
+</KibanaSectionErrorBoundary>
+```
+
+**Props:**
+
+- `sectionName` (string, required) - Name of the section for error messaging
+- `maxRetries` (number, optional, default: 0) - Number of times to automatically remount children when an error occurs. When > 0, the section will attempt to recover by remounting with fresh state before showing the error prompt.
+- `children` (ReactNode, required) - Child components to render and protect
+
+**Retry Behavior:**
+When `maxRetries > 0`, if an error is caught, the component will:
+
+1. Automatically remount children with a fresh Fragment key (forcing fresh component state)
+2. Increment retry counter
+3. If another error occurs and retries are exhausted, show the error prompt
+4. If no error occurs during retry, render normally
+
+This is useful for components that may have transient errors that resolve with fresh state, or where component state corruption could be recovered by remounting.
 
 ## EUI Promotion Status
 

--- a/src/platform/packages/shared/shared-ux/error_boundary/src/ui/error_boundary.recoverable.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/error_boundary/src/ui/error_boundary.recoverable.stories.tsx
@@ -64,6 +64,11 @@ export const SectionErrorInCallout: StoryFn = () => {
             <ChunkLoadErrorComponent />
           </KibanaSectionErrorBoundary>
         </EuiFormFieldset>
+        <EuiFormFieldset legend={{ children: 'Section C with 3 retries' }}>
+          <KibanaSectionErrorBoundary sectionName="sectionC" maxRetries={3}>
+            <ChunkLoadErrorComponent />
+          </KibanaSectionErrorBoundary>
+        </EuiFormFieldset>
       </KibanaErrorBoundaryDepsProvider>
     </Template>
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[SideNav] Wrap SideNav in `ErrorBoundary` with retry   (#239945)](https://github.com/elastic/kibana/pull/239945)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Anton Dosov","email":"anton.dosov@elastic.co"},"sourceCommit":{"committedDate":"2025-11-04T15:44:36Z","message":"[SideNav] Wrap SideNav in `ErrorBoundary` with retry   (#239945)\n\n## Summary\n\nSidenav is an important but complex component. It is also part of the\ncore React tree. An error there might break the whole app.\n\nHere is an example of such a sneaky bug\nhttps://github.com/elastic/kibana/pull/238460\n\nTo fix this, I suggest we wrap the component in an error boundary.\nInstead of showing an error, we will reset the component's state and\nstart over. when maxRetry hits, we show the error.","sha":"fe656a374db5fc65c471723080eb0986f3bc2ccc","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:SharedUX","backport:version","v9.3.0","v9.2.1"],"title":"[SideNav] Wrap SideNav in `ErrorBoundary` with retry  ","number":239945,"url":"https://github.com/elastic/kibana/pull/239945","mergeCommit":{"message":"[SideNav] Wrap SideNav in `ErrorBoundary` with retry   (#239945)\n\n## Summary\n\nSidenav is an important but complex component. It is also part of the\ncore React tree. An error there might break the whole app.\n\nHere is an example of such a sneaky bug\nhttps://github.com/elastic/kibana/pull/238460\n\nTo fix this, I suggest we wrap the component in an error boundary.\nInstead of showing an error, we will reset the component's state and\nstart over. when maxRetry hits, we show the error.","sha":"fe656a374db5fc65c471723080eb0986f3bc2ccc"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239945","number":239945,"mergeCommit":{"message":"[SideNav] Wrap SideNav in `ErrorBoundary` with retry   (#239945)\n\n## Summary\n\nSidenav is an important but complex component. It is also part of the\ncore React tree. An error there might break the whole app.\n\nHere is an example of such a sneaky bug\nhttps://github.com/elastic/kibana/pull/238460\n\nTo fix this, I suggest we wrap the component in an error boundary.\nInstead of showing an error, we will reset the component's state and\nstart over. when maxRetry hits, we show the error.","sha":"fe656a374db5fc65c471723080eb0986f3bc2ccc"}},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->