### PR TITLE
[Data Streams] Remove api integration tests for index mode

### DIFF
--- a/x-pack/platform/test/api_integration/apis/management/index_management/data_streams_index_mode.ts
+++ b/x-pack/platform/test/api_integration/apis/management/index_management/data_streams_index_mode.ts
@@ -37,55 +37,5 @@ export default function ({ getService }: FtrProviderContext) {
 
       await deleteDataStream(logsdbDataStreamName);
     });
-
-    describe('index mode of logs-*-* data streams', () => {
-      const logsdbDataStreamName = 'logs-test-ds';
-
-      before(async () => {
-        await createDataStream(logsdbDataStreamName);
-      });
-
-      after(async () => {
-        await deleteDataStream(logsdbDataStreamName);
-      });
-
-      const logsdbSettings: Array<{
-        enabled: boolean | null;
-        prior_logs_usage: boolean;
-        indexMode: string;
-      }> = [
-        { enabled: true, prior_logs_usage: true, indexMode: 'logsdb' },
-        { enabled: false, prior_logs_usage: true, indexMode: 'standard' },
-        // In stateful Kibana, if prior_logs_usage is set to true, the cluster.logsdb.enabled setting is false by default, so standard index mode
-        { enabled: null, prior_logs_usage: true, indexMode: 'standard' },
-        // In stateful Kibana, if prior_logs_usage is set to false, the cluster.logsdb.enabled setting is true by default, so logsdb index mode
-        { enabled: null, prior_logs_usage: false, indexMode: 'logsdb' },
-      ];
-
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      logsdbSettings.forEach(({ enabled, prior_logs_usage, indexMode }) => {
-        it(`returns ${indexMode} index mode if logsdb.enabled setting is ${enabled} and logs.prior_logs_usage is ${prior_logs_usage}`, async () => {
-          await es.cluster.putSettings({
-            persistent: {
-              cluster: {
-                logsdb: {
-                  enabled,
-                },
-              },
-              logsdb: {
-                prior_logs_usage,
-              },
-            },
-          });
-
-          const { body: dataStream } = await supertest
-            .get(`${API_BASE_PATH}/data_streams/${logsdbDataStreamName}`)
-            .set('kbn-xsrf', 'xxx')
-            .expect(200);
-
-          expect(dataStream.indexMode).to.eql(indexMode);
-        });
-      });
-    });
   });
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/241906
Fixes https://github.com/elastic/kibana/issues/241907

## Summary

This PR removes the tests related to index mode as they are no longer relevant since the `index_mode` field was added to the `GET _data_stream` API in https://github.com/elastic/elasticsearch/pull/122486. Previously, the `GET _data_stream` API  didn't have `index_mode` in the response body so we would assume the index_mode based on cluster settings and the data stream name (if it is `logs-*-*`). Now that the index_mode field is there, it takes precedence so we don't have to make assumptions based on cluster settings, and so these tests are irrelevant. Also, they often create noise on Es promotions if the behavior in Es changes.



