### PR TITLE
🌊 Streams: Decouple streams AI features from observability ai assistant

### DIFF
--- a/x-pack/platform/plugins/shared/streams/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/streams/kibana.jsonc
@@ -11,6 +11,7 @@
     "browser": true,
     "server": true,
     "requiredPlugins": [
+      "actions",
       "alerting",
       "console",
       "data",

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -240,6 +240,7 @@ export class StreamsPlugin
       this.server.core = core;
       this.server.isServerless = core.elasticsearch.getCapabilities().serverless;
       this.server.security = plugins.security;
+      this.server.actions = plugins.actions;
       this.server.encryptedSavedObjects = plugins.encryptedSavedObjects;
       this.server.taskManager = plugins.taskManager;
     }

--- a/x-pack/platform/plugins/shared/streams/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/index.ts
@@ -25,6 +25,7 @@ import { queryRoutes } from './queries/route';
 import { ruleRoutes } from './rules/route';
 import { failureStoreRoutes } from './internal/streams/failure_store/route';
 import { internalIngestRoutes } from './internal/streams/ingest/route';
+import { connectorRoutes } from './internal/connectors/route';
 
 export const streamsRouteRepository = {
   // internal APIs
@@ -38,6 +39,7 @@ export const streamsRouteRepository = {
   ...failureStoreRoutes,
   ...internalFeaturesRoutes,
   ...internalIngestRoutes,
+  ...connectorRoutes,
   // public APIs
   ...dashboardRoutes,
   ...crudRoutes,

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/connectors/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/connectors/route.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { isSupportedConnectorType, type InferenceConnector } from '@kbn/inference-common';
+import { createServerRoute } from '../../create_server_route';
+
+const INFERENCE_CONNECTOR_TYPE = '.inference';
+
+async function inferenceEndpointExists(
+  esClient: ElasticsearchClient,
+  inferenceId: string
+): Promise<boolean> {
+  try {
+    const endpoints = await esClient.inference.get({ inference_id: inferenceId });
+    return endpoints.endpoints.some((endpoint) => endpoint.inference_id === inferenceId);
+  } catch (error) {
+    return false;
+  }
+}
+
+export const getConnectorsRoute = createServerRoute({
+  endpoint: 'GET /internal/streams/connectors',
+  options: {
+    access: 'internal',
+    summary: 'Get GenAI connectors',
+    description: 'Fetches all available GenAI connectors for AI features',
+  },
+  security: {
+    authz: {
+      enabled: false,
+      reason: 'This route delegates authorization to the Actions plugin',
+    },
+  },
+  handler: async ({ request, getScopedClients, server }) => {
+    const { scopedClusterClient } = await getScopedClients({ request });
+
+    // Get actions client with request
+    const actionsClient = await server.actions.getActionsClientWithRequest(request);
+
+    if (!actionsClient) {
+      throw new Error('Actions client not available');
+    }
+
+    const connectors = await actionsClient.getAll();
+
+    // Filter to only supported GenAI connector types
+    const supportedConnectors = connectors.filter((connector) =>
+      isSupportedConnectorType(connector.actionTypeId)
+    );
+
+    // Validate inference connectors have endpoints
+    const validatedConnectors = await Promise.all(
+      supportedConnectors.map(async (connector) => {
+        if (connector.actionTypeId === INFERENCE_CONNECTOR_TYPE) {
+          const inferenceId = (connector.config as InferenceConnector['config'])?.inferenceId;
+          if (inferenceId) {
+            const exists = await inferenceEndpointExists(
+              scopedClusterClient.asCurrentUser,
+              inferenceId
+            );
+            if (!exists) {
+              return null;
+            }
+          }
+        }
+        return connector;
+      })
+    );
+
+    const filteredConnectors = validatedConnectors.filter(
+      (connector): connector is NonNullable<typeof connector> => connector !== null
+    );
+
+    return {
+      connectors: filteredConnectors,
+    };
+  },
+});
+
+export const connectorRoutes = {
+  ...getConnectorsRoute,
+};

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/connectors/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/connectors/route.ts
@@ -7,6 +7,7 @@
 
 import type { ElasticsearchClient } from '@kbn/core/server';
 import { isSupportedConnectorType, type InferenceConnector } from '@kbn/inference-common';
+import { STREAMS_API_PRIVILEGES } from '../../../../common/constants';
 import { createServerRoute } from '../../create_server_route';
 
 const INFERENCE_CONNECTOR_TYPE = '.inference';
@@ -32,8 +33,7 @@ export const getConnectorsRoute = createServerRoute({
   },
   security: {
     authz: {
-      enabled: false,
-      reason: 'This route delegates authorization to the Actions plugin',
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.read],
     },
   },
   handler: async ({ request, getScopedClients, server }) => {

--- a/x-pack/platform/plugins/shared/streams/server/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AlertingServerSetup, AlertingServerStart } from '@kbn/alerting-plugin/server';
+import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
 import type { CoreStart, ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { GlobalSearchPluginSetup } from '@kbn/global-search-plugin/server';
 import type {
@@ -35,6 +36,7 @@ export interface StreamsServer {
   config: StreamsConfig;
   logger: Logger;
   security: SecurityPluginStart;
+  actions: ActionsPluginStart;
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
   isServerless: boolean;
   taskManager: TaskManagerStartContract;
@@ -56,6 +58,7 @@ export interface StreamsPluginSetupDependencies {
 }
 
 export interface StreamsPluginStartDependencies {
+  actions: ActionsPluginStart;
   security: SecurityPluginStart;
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
   licensing: LicensingPluginStart;

--- a/x-pack/platform/plugins/shared/streams/tsconfig.json
+++ b/x-pack/platform/plugins/shared/streams/tsconfig.json
@@ -70,5 +70,6 @@
     "@kbn/usage-collection-plugin",
     "@kbn/utility-types",
     "@kbn/console-plugin",
+    "@kbn/actions-plugin",
   ]
 }

--- a/x-pack/platform/plugins/shared/streams_app/.storybook/get_mock_streams_app_context.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/.storybook/get_mock_streams_app_context.tsx
@@ -14,7 +14,6 @@ import { fieldsMetadataPluginPublicMock } from '@kbn/fields-metadata-plugin/publ
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
-import type { ObservabilityAIAssistantPublicStart } from '@kbn/observability-ai-assistant-plugin/public';
 import type { UnifiedDocViewerStart } from '@kbn/unified-doc-viewer-plugin/public';
 import type { IUnifiedSearchPluginServices } from '@kbn/unified-search-plugin/public';
 import { SearchBar } from '@kbn/unified-search-plugin/public';
@@ -95,28 +94,6 @@ export function getMockStreamsAppContext(): StreamsAppKibanaContext {
         indexManagement: {},
         ingestPipelines: {},
         discoverShared: {},
-        observabilityAIAssistant: {
-          service: {
-            isEnabled: () => true,
-          },
-          useGenAIConnectors: () => {
-            return {
-              loading: false,
-              selectedConnector: 'azure-gpt4o',
-              connectors: [
-                {
-                  id: 'azure-gpt4o',
-                  actionTypeId: '.gen-ai',
-                  name: 'GPT-4o Azure',
-                  config: {
-                    apiUrl: '',
-                    apiProvider: 'Azure OpenAI',
-                  },
-                },
-              ],
-            };
-          },
-        } as unknown as ObservabilityAIAssistantPublicStart,
         unifiedDocViewer: {} as unknown as UnifiedDocViewerStart,
         charts: {
           theme: {

--- a/x-pack/platform/plugins/shared/streams_app/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/streams_app/kibana.jsonc
@@ -29,7 +29,7 @@
       "unifiedDocViewer",
       "dashboard",
     ],
-    "optionalPlugins": ["observabilityAIAssistant", "cloud", "spaces"],
+    "optionalPlugins": ["cloud", "spaces"],
     "requiredBundles": [
       "discover",
       "kibanaReact",

--- a/x-pack/platform/plugins/shared/streams_app/public/components/connector_list_button/connector_list_button.stories.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/connector_list_button/connector_list_button.stories.tsx
@@ -44,7 +44,7 @@ export const NotEnabled: StoryFn<{}> = () => {
         enabled: false,
         genAiConnectors: {
           loading: false,
-          reloadConnectors: noop,
+          reloadConnectors: async () => {},
           selectConnector: noop,
         } as AIFeatures['genAiConnectors'],
       }}
@@ -65,7 +65,7 @@ export const EnabledLoading: StoryFn<{}> = () => {
         enabled: true,
         genAiConnectors: {
           loading: true,
-          reloadConnectors: noop,
+          reloadConnectors: async () => {},
           selectConnector: noop,
         } as AIFeatures['genAiConnectors'],
       }}
@@ -107,7 +107,7 @@ export const EnabledEmpty: StoryFn<{}> = () => {
         genAiConnectors: {
           loading: false,
           connectors: [],
-          reloadConnectors: noop,
+          reloadConnectors: async () => {},
           selectConnector: noop,
         } as Partial<AIFeatures['genAiConnectors']> as AIFeatures['genAiConnectors'],
       }}
@@ -129,7 +129,7 @@ export const EnabledSingle: StoryFn<{}> = () => {
         genAiConnectors: {
           loading: false,
           connectors: [ElasticLLMConnector],
-          reloadConnectors: noop,
+          reloadConnectors: async () => {},
           selectConnector: noop,
         } as AIFeatures['genAiConnectors'],
       }}
@@ -150,7 +150,7 @@ export const EnabledMultiple: StoryFn<{}> = () => {
         genAiConnectors: {
           loading: false,
           connectors: [ElasticLLMConnector, OpenAIConnector],
-          reloadConnectors: noop,
+          reloadConnectors: async () => {},
           selectConnector: noop,
         } as AIFeatures['genAiConnectors'],
       }}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/grok/grok_pattern_suggestion.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/grok/grok_pattern_suggestion.tsx
@@ -128,6 +128,7 @@ export const GrokPatternAISuggestions = ({
         </EuiFlexItem>
       </EuiFlexGroup>
       {aiFeatures &&
+        aiFeatures.enabled &&
         aiFeatures.isManagedAIConnector &&
         !aiFeatures.hasAcknowledgedAdditionalCharges && (
           <>

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_genai_connectors.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_genai_connectors.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+import type { IUiSettingsClient } from '@kbn/core/public';
+import type { StreamsRepositoryClient } from '@kbn/streams-plugin/public/api';
+import {
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
+  GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+} from '@kbn/management-settings-ids';
+
+const STREAMS_CONNECTOR_STORAGE_KEY = 'xpack.streamsApp.lastUsedConnector';
+const OLD_STORAGE_KEY = 'xpack.observabilityAiAssistant.lastUsedConnector';
+// TODO: Import from gen-ai-settings-plugin (package) once available
+const NO_DEFAULT_CONNECTOR = 'NO_DEFAULT_CONNECTOR';
+
+export interface Connector {
+  id: string;
+  name: string;
+  actionTypeId: string;
+  config?: Record<string, unknown>;
+  isPreconfigured?: boolean;
+  isDeprecated?: boolean;
+  isSystemAction?: boolean;
+  isMissingSecrets?: boolean;
+  referencedByCount?: number;
+}
+
+export interface UseGenAIConnectorsResult {
+  connectors: Connector[] | undefined;
+  selectedConnector: string | undefined;
+  loading: boolean;
+  error: Error | undefined;
+  selectConnector: (id: string) => void;
+  reloadConnectors: () => Promise<void>;
+  isConnectorSelectionRestricted: boolean;
+  defaultConnector: string | undefined;
+}
+
+export function useGenAIConnectors({
+  streamsRepositoryClient,
+  uiSettings,
+}: {
+  streamsRepositoryClient: StreamsRepositoryClient;
+  uiSettings: IUiSettingsClient;
+}): UseGenAIConnectorsResult {
+  const [connectors, setConnectors] = useState<Connector[] | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>();
+
+  // Read settings
+  const defaultConnector = uiSettings.get<string>(GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR);
+  const genAISettingsDefaultOnly = uiSettings.get<boolean>(
+    GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+    false
+  );
+
+  const isConnectorSelectionRestricted =
+    genAISettingsDefaultOnly && defaultConnector !== NO_DEFAULT_CONNECTOR;
+
+  // Read old localStorage key (for backward compatibility, don't modify it)
+  const [oldConnector] = useLocalStorage<string>(OLD_STORAGE_KEY);
+
+  // Use old connector as initial value for new key (only if new key doesn't exist yet)
+  const [lastUsedConnector, setLastUsedConnector] = useLocalStorage<string | undefined>(
+    STREAMS_CONNECTOR_STORAGE_KEY,
+    oldConnector
+  );
+
+  const fetchConnectors = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+
+    try {
+      const controller = new AbortController();
+      const response = await streamsRepositoryClient.fetch('GET /internal/streams/connectors', {
+        signal: controller.signal,
+      });
+      let results = response.connectors;
+
+      // If connector selection is restricted, only return the default connector
+      if (isConnectorSelectionRestricted) {
+        const defaultC = results.find((con) => con.id === defaultConnector);
+        results = defaultC ? [defaultC] : [];
+      }
+
+      setConnectors(results);
+
+      // Clear lastUsedConnector if it's no longer in the list
+      setLastUsedConnector((connectorId) => {
+        if (connectorId && results.findIndex((result) => result.id === connectorId) === -1) {
+          return undefined;
+        }
+        return connectorId;
+      });
+    } catch (err) {
+      setError(err as Error);
+      setConnectors(undefined);
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    streamsRepositoryClient,
+    isConnectorSelectionRestricted,
+    defaultConnector,
+    setLastUsedConnector,
+  ]);
+
+  useEffect(() => {
+    fetchConnectors();
+  }, [fetchConnectors]);
+
+  // Determine selected connector (follows observability pattern)
+  const selectedConnector = useMemo(() => {
+    // If restricted, always use default
+    if (isConnectorSelectionRestricted) {
+      return defaultConnector;
+    }
+
+    // Priority 1: User's explicit choice (localStorage)
+    if (lastUsedConnector) {
+      return lastUsedConnector;
+    }
+
+    // Priority 2: Global AI default setting
+    if (defaultConnector !== NO_DEFAULT_CONNECTOR) {
+      return defaultConnector;
+    }
+
+    return undefined;
+  }, [isConnectorSelectionRestricted, defaultConnector, lastUsedConnector]);
+
+  const selectConnector = useCallback(
+    (id: string) => {
+      setLastUsedConnector(id);
+    },
+    [setLastUsedConnector]
+  );
+
+  const reloadConnectors = useCallback(async () => {
+    await fetchConnectors();
+  }, [fetchConnectors]);
+
+  return {
+    connectors,
+    selectedConnector: selectedConnector || connectors?.[0]?.id,
+    loading,
+    error,
+    selectConnector,
+    reloadConnectors,
+    isConnectorSelectionRestricted,
+    defaultConnector: defaultConnector === NO_DEFAULT_CONNECTOR ? undefined : defaultConnector,
+  };
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_streams_app_fetch.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_streams_app_fetch.ts
@@ -113,6 +113,10 @@ export function showErrorToast(notifications: NotificationsStart, error: Error) 
     error.message = error.body.message;
   }
 
+  if (error instanceof AggregateError) {
+    error.message = error.errors.map((err) => err.message).join(', ');
+  }
+
   let requestUrl: string | undefined;
   if (
     'request' in error &&

--- a/x-pack/platform/plugins/shared/streams_app/public/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/types.ts
@@ -20,10 +20,6 @@ import type { IndexManagementPluginStart } from '@kbn/index-management-shared-ty
 import type { IngestPipelinesPluginStart } from '@kbn/ingest-pipelines-plugin/public';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { NavigationPublicStart } from '@kbn/navigation-plugin/public/types';
-import type {
-  ObservabilityAIAssistantPublicSetup,
-  ObservabilityAIAssistantPublicStart,
-} from '@kbn/observability-ai-assistant-plugin/public';
 import type { SavedObjectTaggingPluginStart } from '@kbn/saved-objects-tagging-plugin/public';
 import type { SharePublicSetup, SharePublicStart } from '@kbn/share-plugin/public/plugin';
 import type { StreamsPluginStart } from '@kbn/streams-plugin/public';
@@ -51,7 +47,6 @@ export interface StreamsAppSetupDependencies {
   discoverShared: DiscoverSharedPublicSetup;
   share: SharePublicSetup;
   unifiedSearch: {};
-  observabilityAIAssistant?: ObservabilityAIAssistantPublicSetup;
 }
 
 export interface StreamsAppStartDependencies {
@@ -71,7 +66,6 @@ export interface StreamsAppStartDependencies {
   streams: StreamsPluginStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
   unifiedDocViewer: UnifiedDocViewerStart;
-  observabilityAIAssistant?: ObservabilityAIAssistantPublicStart;
   dashboard: DashboardStart;
   cloud?: CloudStart;
   spaces?: SpacesPluginStart;

--- a/x-pack/platform/plugins/shared/streams_app/public/utils/get_elastic_managed_llm_connector.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/utils/get_elastic_managed_llm_connector.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Connector } from '../hooks/use_genai_connectors';
+
+export const INFERENCE_CONNECTOR_ACTION_TYPE_ID = '.inference';
+
+export const getElasticManagedLlmConnector = (connectors: Connector[] | undefined) => {
+  if (!Array.isArray(connectors) || connectors.length === 0) {
+    return undefined;
+  }
+
+  return connectors.find(
+    (connector) =>
+      connector.actionTypeId === INFERENCE_CONNECTOR_ACTION_TYPE_ID &&
+      connector.isPreconfigured &&
+      (connector.config as { provider?: string })?.provider === 'elastic'
+  );
+};


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/241450

Right now, streams AI features are coupled to the observability AI assistant. This means that in a security space, these features don't show up, even if an AI connector is available.

This PR changes the logic:
* Instead of checking for the observability ai assistant, check whether the current user has read permission for the connectors
* Fork the logic of the observability assistant for managing the list of connectors and implement it specifically for streams
* Picks the default connector that was used in the observability assistant, but then maintains streams-specific local state for which connector to use

This is a temporary workaround - once agent builder is integrated with security and observability, it can be removed and we can integrate with agent builder to manage access to AI features.


This also fixes an unrelated issue I stumbled over - we weren't handling aggregate errors very well (toast wouldn't have a message), now it shows the underlying error:
<img width="298" height="234" alt="Screenshot 2025-11-06 at 09 50 15" src="https://github.com/user-attachments/assets/802ca8ca-9325-40c0-8162-088613492268" />
