### PR TITLE
[Agent Builder] fix input round styles

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_layout.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_layout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiPanel, useEuiTheme } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, euiTextBreakWord, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { ReactNode } from 'react';
 import React, { useEffect, useState } from 'react';
@@ -52,7 +52,7 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
     align-self: end;
     max-inline-size: 80%;
     background-color: ${euiTheme.colors.backgroundBasePrimary};
-    overflow-wrap: break-word;
+    ${euiTextBreakWord()}
   `;
 
   const roundContainerStyles = css`

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_layout.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_layout.tsx
@@ -49,7 +49,6 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
 
   const { euiTheme } = useEuiTheme();
   const inputContainerStyles = css`
-    width: 100%;
     align-self: end;
     max-inline-size: 80%;
     background-color: ${euiTheme.colors.backgroundBasePrimary};

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_layout.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_layout.tsx
@@ -52,6 +52,7 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
     align-self: end;
     max-inline-size: 80%;
     background-color: ${euiTheme.colors.backgroundBasePrimary};
+    overflow-wrap: break-word;
   `;
 
   const roundContainerStyles = css`


### PR DESCRIPTION
## Summary

- Fixes width of input round styles to match the size of the text content or 80% width whichever is smaller
- Fixes issues with long text growing outside the container

Before:
<img width="1114" height="953" alt="image" src="https://github.com/user-attachments/assets/728fd35f-0afb-446e-a4c9-e8f4cb4540ac" />

After:
<img width="781" height="951" alt="image" src="https://github.com/user-attachments/assets/241d3469-ae68-48ea-8d02-1e1e6699b0ab" />

