### PR TITLE
chore(NA): fix types at 9.2 for kbn-unified-metrics-grid

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/values_selector.stories.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/toolbar/values_selector.stories.tsx
@@ -48,7 +48,7 @@ const mockClient: MetricsExperienceClient = {
     ],
   }),
   getFields: async (params, signal) => ({ fields: [], total: 0, page: 1 }),
-  getIndexPatternMetadata: async (params, signal) => ({
+  getIndexPatternMetadata: async (params: Record<string, any>, signal: AbortSignal | null) => ({
     indexPatternMetadata: {},
   }),
 } as MetricsExperienceClient;


### PR DESCRIPTION
This fixes a types problems currently in 9.2 introduced with https://github.com/elastic/kibana/pull/241862