### PR TITLE
[Security Solution] Fix top n popover overlapping new case flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_actions.ts
@@ -104,6 +104,7 @@ export const useActions = ({
   const { services } = useKibana();
   const {
     lens: { navigateToPrefilledEditor, canUseEditor },
+    topValuesPopover,
   } = services;
 
   const onOpenInLens = useCallback(() => {
@@ -152,6 +153,7 @@ export const useActions = ({
           ...ACTION_DEFINITION[VisualizationContextMenuActions.addToNewCase],
           execute: async () => {
             onAddToNewCaseClicked();
+            topValuesPopover.closePopover();
           },
           disabled: isAddToNewCaseDisabled,
           isCompatible: async () =>
@@ -206,6 +208,7 @@ export const useActions = ({
       onOpenInLens,
       openSaveVisualizationFlyout,
       withActions,
+      topValuesPopover,
     ]
   );
 


### PR DESCRIPTION
## Summary

Ref:
- https://github.com/elastic/kibana/issues/222534
- https://github.com/elastic/kibana/issues/157732
- https://github.com/elastic/kibana/issues/209752
- https://github.com/elastic/kibana/issues/181231

The bug: when top n is opened via hover actions, clicking more options (3 dots) opens another popover. When user clicks open new case action, the second popover is closed, but the top n popover remains open.

This PR updated the new case action to always close the top n popover when the flyout is open.


https://github.com/user-attachments/assets/424b0c59-c129-43c4-b2f4-5fed41cdc2bc


### Checklist


- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->