### PR TITLE
[Controls Anywhere] Fix initialization of control group renderer

### DIFF
--- a/src/platform/packages/shared/controls/control-group-renderer/src/control_group_renderer.tsx
+++ b/src/platform/packages/shared/controls/control-group-renderer/src/control_group_renderer.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import {
   BehaviorSubject,
   Subject,

--- a/src/platform/packages/shared/controls/control-group-renderer/src/control_group_renderer.tsx
+++ b/src/platform/packages/shared/controls/control-group-renderer/src/control_group_renderer.tsx
@@ -74,7 +74,6 @@ export const ControlGroupRenderer = ({
   }>();
 
   const lastSavedState$Ref = useRef(new BehaviorSubject<{ [id: string]: StickyControlState }>({}));
-  const [loaded, setLoaded] = useState<boolean>(true);
 
   /** Creation options management */
   const initialState = useInitialControlGroupState(getCreationOptions, lastSavedState$Ref);
@@ -200,7 +199,7 @@ export const ControlGroupRenderer = ({
   }, [parentApi, input$, uiActions]);
 
   /** Wait for parent API, which relies on the async creation options, before rendering */
-  return !parentApi || !loaded ? null : (
+  return !parentApi ? null : (
     <ControlsRenderer parentApi={parentApi as ControlsRendererParentApi} />
   );
 };

--- a/src/platform/packages/shared/controls/control-group-renderer/src/use_children_api.tsx
+++ b/src/platform/packages/shared/controls/control-group-renderer/src/use_children_api.tsx
@@ -143,7 +143,7 @@ export const useChildrenApi = (
         'esqlVariable$',
         apiPublishesESQLVariable,
         []
-      ),
+      ).pipe(distinctUntilChanged(deepEqual)),
       appliedTimeslice$: combineCompatibleChildrenApis<AppliesTimeslice, TimeSlice | undefined>(
         { children$: children$Ref.current },
         'appliedTimeslice$',
@@ -152,7 +152,7 @@ export const useChildrenApi = (
         (values) => {
           return values.length === 0 ? undefined : values[values.length - 1];
         }
-      ),
+      ).pipe(distinctUntilChanged(deepEqual)),
     };
   }, [state, lastSavedChildState$Ref]);
 

--- a/src/platform/packages/shared/controls/control-group-renderer/src/use_layout_api.tsx
+++ b/src/platform/packages/shared/controls/control-group-renderer/src/use_layout_api.tsx
@@ -25,9 +25,7 @@ export const useLayoutApi = (
   childrenApi: ReturnType<typeof useChildrenApi>['childrenApi'],
   lastSavedState$Ref: React.MutableRefObject<BehaviorSubject<{ [id: string]: StickyControlState }>>
 ) => {
-  const layout$Ref = useRef(
-    new BehaviorSubject<ControlsLayout>({ controls: {}, panels: {}, sections: {} })
-  );
+  const layout$Ref = useRef(new BehaviorSubject<ControlsLayout>({ controls: {} }));
 
   useEffect(() => {
     /** Keep `layout$` in sync with `lastSavedState$Ref` */
@@ -78,8 +76,6 @@ export const useLayoutApi = (
           },
         };
         layout$Ref.current.next({
-          panels: {},
-          sections: {},
           controls: {
             ...oldControls,
             [uuid]: {

--- a/src/platform/packages/shared/controls/control-group-renderer/src/use_layout_api.tsx
+++ b/src/platform/packages/shared/controls/control-group-renderer/src/use_layout_api.tsx
@@ -9,7 +9,7 @@
 
 import { pick } from 'lodash';
 import { useEffect, useMemo, useRef } from 'react';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, combineLatest, distinctUntilChanged, map } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import { DEFAULT_CONTROL_GROW, DEFAULT_CONTROL_WIDTH } from '@kbn/controls-constants';
@@ -54,7 +54,7 @@ export const useLayoutApi = (
   }, [lastSavedState$Ref]);
 
   const layoutApi = useMemo(() => {
-    if (!state) return;
+    if (!state || !childrenApi) return;
 
     layout$Ref.current.next({
       controls: getControlsLayout(state.initialState?.initialChildControlState),
@@ -124,6 +124,15 @@ export const useLayoutApi = (
         }
         childrenApi?.removeChild(idToRemove);
       },
+
+      childrenLoading$: combineLatest([childrenApi.children$, layout$Ref.current]).pipe(
+        map(([children, layout]) => {
+          const expectedChildCount = Object.values(layout.controls).length;
+          const currentChildCount = Object.keys(children).length;
+          return expectedChildCount !== currentChildCount;
+        }),
+        distinctUntilChanged()
+      ),
     };
   }, [state, childrenApi]);
 

--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/fetch/fetch.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/fetch/fetch.ts
@@ -157,6 +157,8 @@ export function fetch$(api: unknown): Observable<FetchContext> {
           api.parentApi.searchSessionId$.getValue();
       }
       const { reloadTimestamp, ...rest } = reloadTimeFetchContext;
+      console.log(api.uuid, { reloadTimeFetchContext });
+
       return {
         ...rest,
         searchSessionId,

--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/fetch/fetch.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/fetch/fetch.ts
@@ -157,8 +157,6 @@ export function fetch$(api: unknown): Observable<FetchContext> {
           api.parentApi.searchSessionId$.getValue();
       }
       const { reloadTimestamp, ...rest } = reloadTimeFetchContext;
-      console.log(api.uuid, { reloadTimeFetchContext });
-
       return {
         ...rest,
         searchSessionId,

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.ts
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.ts
@@ -181,7 +181,7 @@ export function initializeESQLControlSelections(
     availableOptions$,
     singleSelect$,
   ])
-    .pipe(debounceTime(0), skip(1)) // esqlVariable$ is initialized above
+    .pipe(skip(1)) // esqlVariable$ is initialized above
     .subscribe(([sectionId]) => {
       const newVariables = getEsqlVariable(sectionId);
       if (!deepEqual(esqlVariable$.getValue(), newVariables))

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.ts
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.ts
@@ -16,6 +16,7 @@ import {
   map,
   merge,
   of,
+  skip,
   switchMap,
 } from 'rxjs';
 
@@ -179,7 +180,13 @@ export function initializeESQLControlSelections(
     selectedOptions$,
     availableOptions$,
     singleSelect$,
-  ]).subscribe(([sectionId]) => esqlVariable$.next(getEsqlVariable(sectionId)));
+  ])
+    .pipe(debounceTime(0), skip(1)) // esqlVariable$ is initialized above
+    .subscribe(([sectionId]) => {
+      const newVariables = getEsqlVariable(sectionId);
+      if (!deepEqual(esqlVariable$.getValue(), newVariables))
+        esqlVariable$.next(getEsqlVariable(sectionId));
+    });
 
   return {
     cleanup: () => {

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_esql_variables.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_esql_variables.ts
@@ -6,7 +6,7 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { isEqual } from 'lodash';
+import { isEqual, omit } from 'lodash';
 import { useCallback, useEffect, useRef } from 'react';
 import { ESQL_CONTROL } from '@kbn/controls-constants';
 import type { ESQLControlVariable } from '@kbn/esql-types';
@@ -97,9 +97,11 @@ export const useESQLVariables = ({
     }
 
     const variableSubscription = controlGroupApi.esqlVariables$.subscribe((newVariables) => {
-      if (!isEqual(newVariables, currentEsqlVariables)) {
+      // ignore meta data when comparing and storing filters, since we do not use it
+      const variablesWithoutMetaData = newVariables.map((variable) => omit(variable, 'meta'));
+      if (!isEqual(variablesWithoutMetaData, currentEsqlVariables)) {
         // Update the ESQL variables in the internal state
-        dispatch(setEsqlVariables({ esqlVariables: newVariables }));
+        dispatch(setEsqlVariables({ esqlVariables: variablesWithoutMetaData }));
         stateContainer.dataState.fetch();
       }
     });


### PR DESCRIPTION
> [!WARNING]
> **_This work is being merged into a feature branch, not main!_**
> Because of this, we only need a review from @elastic/kibana-presentation for now.

Closes https://github.com/elastic/kibana/issues/241680

## Summary

This PR ensures that `fetch$` only emits **once** when reloading a Discover session with variables. This prevents the histogram from trying to load **before** the variables are ready,  which caused an error.

**Before**

https://github.com/user-attachments/assets/018645f7-7290-4ad7-9408-619c18c69566

**After**


https://github.com/user-attachments/assets/8e387f57-2bd4-47d6-98bc-68bfc7d465c8

