### PR TITLE
[Dashboard][ESQL Controls] Fix flaky value control tests

### DIFF
--- a/test/functional/apps/dashboard/esql_controls/value_control.ts
+++ b/test/functional/apps/dashboard/esql_controls/value_control.ts
@@ -104,11 +104,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await dashboard.waitForRenderComplete();
       await testSubjects.waitForDeleted('euiOverlayMask');
       // change the control value
-      await comboBox.set('esqlControlValuesDropdown', 'ao');
-      await dashboard.waitForRenderComplete();
+      await comboBox.set('esqlControlValuesDropdown', 'AO');
 
-      const tableContent = await testSubjects.getVisibleText('lnsTableCellContent');
-      expect(tableContent).to.contain('AO');
+      await retry.tryForTime(5000, async () => {
+        await dashboard.waitForRenderComplete();
+        const tableContent = await testSubjects.getVisibleText('lnsTableCellContent');
+        expect(tableContent).to.contain('AO');
+      });
     });
 
     it('should handle properly a query to retrieve the values that return more than one column', async () => {

--- a/test/functional/apps/dashboard/esql_controls/value_control.ts
+++ b/test/functional/apps/dashboard/esql_controls/value_control.ts
@@ -101,10 +101,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       // save the changes
       await testSubjects.click('applyFlyoutButton');
-      await dashboard.waitForRenderComplete();
+      // await dashboard.waitForRenderComplete();
+      await testSubjects.waitForDeleted('euiOverlayMask');
       // change the control value
       await comboBox.set('esqlControlValuesDropdown', 'AO');
       await dashboard.waitForRenderComplete();
+      // console.log('__________________________&&&&&&&&&&&  22222  &&&&&&&&&&&&&&&&____________________________');
 
       const tableContent = await testSubjects.getVisibleText('lnsTableCellContent');
       expect(tableContent).to.contain('AO');
@@ -119,6 +121,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       // run the query
       await testSubjects.click('ESQLEditor-run-query-button');
       expect(await testSubjects.exists('esqlMoreThanOneColumnCallout')).to.be(true);
+      // console.log('__________________________&&&&&&&&&   33333333  &&&&&&&&&&&&&&&&&&____________________________');
       await testSubjects.click('chooseColumnBtn');
       const searchInput = await testSubjects.find('selectableColumnSearch');
       await searchInput.type('geo.dest');

--- a/test/functional/apps/dashboard/esql_controls/value_control.ts
+++ b/test/functional/apps/dashboard/esql_controls/value_control.ts
@@ -101,12 +101,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       // save the changes
       await testSubjects.click('applyFlyoutButton');
-      // await dashboard.waitForRenderComplete();
+      await dashboard.waitForRenderComplete();
       await testSubjects.waitForDeleted('euiOverlayMask');
       // change the control value
-      await comboBox.set('esqlControlValuesDropdown', 'AO');
+      await comboBox.set('esqlControlValuesDropdown', 'ao');
       await dashboard.waitForRenderComplete();
-      // console.log('__________________________&&&&&&&&&&&  22222  &&&&&&&&&&&&&&&&____________________________');
 
       const tableContent = await testSubjects.getVisibleText('lnsTableCellContent');
       expect(tableContent).to.contain('AO');
@@ -121,7 +120,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       // run the query
       await testSubjects.click('ESQLEditor-run-query-button');
       expect(await testSubjects.exists('esqlMoreThanOneColumnCallout')).to.be(true);
-      // console.log('__________________________&&&&&&&&&   33333333  &&&&&&&&&&&&&&&&&&____________________________');
       await testSubjects.click('chooseColumnBtn');
       const searchInput = await testSubjects.find('selectableColumnSearch');
       await searchInput.type('geo.dest');


### PR DESCRIPTION
Resolves #229865

All Flaky Test Runner executions passed for all tests - https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9762

### Summary
While running the tests in the Flaky Test Runner, around 5 out of 150 executions failed.
In the logs, the failure showed:

`expected '32.113.94.111 - - [2018-04-10T19:27:01.081Z] "GET /uploads/donald-holmquest.jpg HTTP/1.1" 200 4186 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)"' to contain 'AO'`

This indicated that the dashboard table didn’t have enough time to update (filter by the selected control value) before the assertion was made.

The screenshot of the failing test below:
<img width="1315" height="727" alt="Screenshot 2025-11-06 at 22 43 10" src="https://github.com/user-attachments/assets/7d6c6e5b-fae1-4259-99f3-dc35d13d2d1e" />


### The solution
To fix this, a retry with a timeout was added to ensure the UI has enough time to re-render before checking the result.

The screenshot of the desired UI below:
<img width="1087" height="645" alt="Screenshot 2025-11-06 at 22 43 36" src="https://github.com/user-attachments/assets/a4952ade-b2d8-4ff3-86ec-764313647e9b" />


Additionally, on some local runs, the test occasionally failed because the overlay mask prevented interaction with the elements.
To address that, waiting for the overlay to disappear was also added (`await testSubjects.waitForDeleted('euiOverlayMask')).`
