### PR TITLE
[9.2] [Discover][Unified Waterfall] Add recursion guard for flattening item map (#241329)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_warning.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_warning.tsx
@@ -6,47 +6,29 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
 import { EuiCallOut, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { useTraceWaterfallContext } from './trace_waterfall_context';
 import { TraceDataState } from './use_trace_waterfall';
 
-const FALLBACK_WARNING = i18n.translate(
-  'xpack.apm.traceWaterfallContext.warningMessage.fallbackWarning',
-  {
-    defaultMessage:
-      'The trace document is incomplete and not all spans have arrived yet. Try refreshing the page or adjusting the time range.',
-  }
-);
-
 export function TraceWarning({ children }: { children: React.ReactNode }) {
-  const { traceState } = useTraceWaterfallContext();
+  const { traceState, message } = useTraceWaterfallContext();
 
   switch (traceState) {
     case TraceDataState.Partial:
       return (
         <EuiFlexGroup direction="column">
           <EuiFlexItem>
-            <EuiCallOut
-              data-test-subj="traceWarning"
-              color="warning"
-              size="s"
-              title={FALLBACK_WARNING}
-            />
+            <EuiCallOut data-test-subj="traceWarning" color="warning" size="s" title={message} />
           </EuiFlexItem>
           <EuiFlexItem>{children}</EuiFlexItem>
         </EuiFlexGroup>
       );
 
     case TraceDataState.Empty:
-      return (
-        <EuiCallOut
-          data-test-subj="traceWarning"
-          color="warning"
-          size="s"
-          title={FALLBACK_WARNING}
-        />
-      );
+      return <EuiCallOut data-test-subj="traceWarning" color="warning" size="s" title={message} />;
+
+    case TraceDataState.Invalid:
+      return <EuiCallOut data-test-subj="traceWarning" color="danger" size="s" title={message} />;
 
     default:
       return children;

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_waterfall_context.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_waterfall_context.tsx
@@ -33,6 +33,7 @@ export interface TraceWaterfallContextProps {
   colorBy: WaterfallLegendType;
   showLegend: boolean;
   serviceName?: string;
+  message?: string;
 }
 
 export const TraceWaterfallContext = createContext<TraceWaterfallContextProps>({

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/use_trace_watefall.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/use_trace_watefall.test.ts
@@ -169,6 +169,73 @@ describe('getFlattenedTraceWaterfall', () => {
     expect(result[1].id).toBe('4');
     expect(result[1].depth).toBe(1);
   });
+
+  it('errors when it encounters invalid trace documents', () => {
+    // We have a duplicate span id, that is both a root span and a child span
+    // This indicates an instrumentation error. We should never be hitting this
+    // particular case in normal/correctly configured tracing.
+    const invalidSpans: TraceItem[] = [
+      {
+        id: 'b5',
+        timestampUs: 1761915724030561,
+        name: 'GET /a/{b}',
+        traceId: 'dd31',
+        duration: 22750,
+        status: { fieldName: 'event.outcome', value: 'success' },
+        errors: [],
+        serviceName: 'svcA',
+      },
+      {
+        id: 'd8',
+        timestampUs: 1761915725590821,
+        name: 'a/2',
+        traceId: 'dd31',
+        duration: 140000,
+        status: { fieldName: 'event.outcome', value: 'unknown' },
+        errors: [],
+        serviceName: 'svcb',
+        parentId: 'b5',
+      },
+      {
+        id: '9d',
+        timestampUs: 1761915725590821,
+        name: 'Redirect',
+        traceId: 'dd31',
+        duration: 54000,
+        status: { fieldName: 'event.outcome', value: 'unknown' },
+        errors: [],
+        parentId: 'd8',
+        serviceName: 'svcb',
+        type: 'browser-timing',
+      },
+      {
+        id: 'b5',
+        timestampUs: 1761915725645821,
+        name: 'Request',
+        traceId: 'dd31',
+        duration: 24000,
+        status: { fieldName: 'event.outcome', value: 'unknown' },
+        errors: [],
+        parentId: 'd8',
+        serviceName: 'svcb',
+        type: 'browser-timing',
+      },
+    ];
+
+    const invalidMap = getTraceParentChildrenMap(invalidSpans, false);
+
+    const { orphans, rootItem } = getRootItemOrFallback(invalidMap, invalidSpans);
+
+    expect(() =>
+      getTraceWaterfall({
+        rootItem: rootItem!,
+        parentChildMap: invalidMap,
+        orphans: orphans!,
+        colorMap: serviceColorsMap,
+        colorBy: WaterfallLegendType.ServiceName,
+      })
+    ).toThrowError('Duplicate span id detected');
+  });
 });
 
 describe('getLegends', () => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/use_trace_watefall.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/use_trace_watefall.test.ts
@@ -222,7 +222,7 @@ describe('getFlattenedTraceWaterfall', () => {
       },
     ];
 
-    const invalidMap = getTraceParentChildrenMap(invalidSpans, false);
+    const invalidMap = getTraceParentChildrenMap(invalidSpans);
 
     const { orphans, rootItem } = getRootItemOrFallback(invalidMap, invalidSpans);
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/use_trace_waterfall.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/use_trace_waterfall.ts
@@ -7,9 +7,25 @@
 
 import { euiPaletteColorBlind } from '@elastic/eui';
 import { useMemo } from 'react';
-import type { IWaterfallLegend } from '../../../../common/waterfall/legend';
-import { WaterfallLegendType } from '../../../../common/waterfall/legend';
+import { i18n } from '@kbn/i18n';
+import { type IWaterfallLegend, WaterfallLegendType } from '../../../../common/waterfall/legend';
 import type { TraceItem } from '../../../../common/waterfall/unified_trace_item';
+
+const FALLBACK_WARNING = i18n.translate(
+  'xpack.apm.traceWaterfallItem.warningMessage.fallbackWarning',
+  {
+    defaultMessage:
+      'The trace document is incomplete and not all spans have arrived yet. Try refreshing the page or adjusting the time range.',
+  }
+);
+
+const INSTRUMENTATION_WARNING = i18n.translate(
+  'xpack.apm.traceWaterfallItem.euiCallOut.aDuplicatedSpanWasLabel',
+  {
+    defaultMessage:
+      'A duplicated span was detected. This indicates a problem with how your services have been instrumented, as span IDs are meant to be unique.',
+  }
+);
 
 export interface TraceWaterfallItem extends TraceItem {
   depth: number;
@@ -21,36 +37,49 @@ export interface TraceWaterfallItem extends TraceItem {
 
 export function useTraceWaterfall({ traceItems }: { traceItems: TraceItem[] }) {
   const waterfall = useMemo(() => {
-    const legends = getLegends(traceItems);
-    const colorBy =
-      legends.filter(({ type }) => type === WaterfallLegendType.ServiceName).length > 1
+    try {
+      const legends = getLegends(traceItems);
+      const colorBy = legends.filter(({ type }) => type === WaterfallLegendType.ServiceName).length > 1
         ? WaterfallLegendType.ServiceName
         : WaterfallLegendType.Type;
-    const colorMap = createColorLookupMap(legends);
-    const traceParentChildrenMap = getTraceParentChildrenMap(traceItems);
-    const { rootItem, traceState, orphans } = getRootItemOrFallback(
-      traceParentChildrenMap,
-      traceItems
-    );
-    const traceWaterfall = rootItem
-      ? getTraceWaterfall({
-          rootItem,
-          parentChildMap: traceParentChildrenMap,
-          orphans,
-          colorMap,
-          colorBy,
-        })
-      : [];
+      const colorMap = createColorLookupMap(legends);
+      const traceParentChildrenMap = getTraceParentChildrenMap(traceItems);
+      const { rootItem, traceState, orphans } = getRootItemOrFallback(
+        traceParentChildrenMap,
+        traceItems
+      );
 
-    return {
-      rootItem,
-      traceState,
-      traceWaterfall,
-      duration: getTraceWaterfallDuration(traceWaterfall),
-      maxDepth: Math.max(...traceWaterfall.map((item) => item.depth)),
-      legends,
-      colorBy,
-    };
+      const traceWaterfall = rootItem
+        ? getTraceWaterfall({
+            rootItem,
+            parentChildMap: traceParentChildrenMap,
+            orphans,
+            colorMap,
+            colorBy,
+          })
+        : [];
+
+      return {
+        rootItem,
+        traceState,
+        message: traceState !== TraceDataState.Full ? FALLBACK_WARNING : undefined,
+        traceWaterfall,
+        duration: getTraceWaterfallDuration(traceWaterfall),
+        maxDepth: Math.max(...traceWaterfall.map((item) => item.depth)),
+        legends,
+        colorBy,
+      };
+    } catch (e) {
+      return {
+        traceState: TraceDataState.Invalid,
+        message: INSTRUMENTATION_WARNING,
+        traceWaterfall: [],
+        legends: [],
+        duration: 0,
+        maxDepth: 0,
+        colorBy: WaterfallLegendType.Type,
+      };
+    }
   }, [traceItems]);
 
   return waterfall;
@@ -109,6 +138,7 @@ export enum TraceDataState {
   Full = 'full',
   Partial = 'partial',
   Empty = 'empty',
+  Invalid = 'invalid',
 }
 
 export function getRootItemOrFallback(
@@ -173,6 +203,8 @@ export function getTraceWaterfall({
 }): TraceWaterfallItem[] {
   const rootStartMicroseconds = rootItem.timestampUs;
 
+  const visitor = new Set<string>([rootItem.id]);
+
   reparentOrphansToRoot(rootItem, parentChildMap, orphans);
 
   function getTraceWaterfallItem(
@@ -196,9 +228,19 @@ export function getTraceWaterfall({
     const sortedChildren =
       parentChildMap[item.id]?.sort((a, b) => a.timestampUs - b.timestampUs) || [];
 
-    const flattenedChildren = sortedChildren.flatMap((child) =>
-      getTraceWaterfallItem(child, depth + 1, traceWaterfallItem)
-    );
+    const flattenedChildren = sortedChildren.flatMap((child) => {
+      // Check if we have encountered the trace item before.
+      // If we have visited the trace item before, then the child waterfall items are already
+      // present in the flattened list, so we throw an error to alert the user of duplicated
+      // spans. This should guard against circular or unusual links between spans.
+      if (visitor.has(child.id)) {
+        throw new Error('Duplicate span id detected');
+      }
+
+      // If we haven't visited it before, then we can process the waterfall item.
+      visitor.add(child.id);
+      return getTraceWaterfallItem(child, depth + 1, traceWaterfallItem);
+    });
 
     return [traceWaterfallItem, ...flattenedChildren];
   }

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/use_trace_waterfall.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/use_trace_waterfall.ts
@@ -39,9 +39,10 @@ export function useTraceWaterfall({ traceItems }: { traceItems: TraceItem[] }) {
   const waterfall = useMemo(() => {
     try {
       const legends = getLegends(traceItems);
-      const colorBy = legends.filter(({ type }) => type === WaterfallLegendType.ServiceName).length > 1
-        ? WaterfallLegendType.ServiceName
-        : WaterfallLegendType.Type;
+      const colorBy =
+        legends.filter(({ type }) => type === WaterfallLegendType.ServiceName).length > 1
+          ? WaterfallLegendType.ServiceName
+          : WaterfallLegendType.Type;
       const colorMap = createColorLookupMap(legends);
       const traceParentChildrenMap = getTraceParentChildrenMap(traceItems);
       const { rootItem, traceState, orphans } = getRootItemOrFallback(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Discover][Unified Waterfall] Add recursion guard for flattening item map (#241329)](https://github.com/elastic/kibana/pull/241329)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gonçalo Rica Pais da Silva","email":"goncalo.rica@elastic.co"},"sourceCommit":{"committedDate":"2025-11-06T10:30:19Z","message":"[Discover][Unified Waterfall] Add recursion guard for flattening item map (#241329)\n\n## Summary\n\nFixes one potential bug within\nhttps://github.com/elastic/kibana/issues/240421, by adding a recursion\nguard to prevent going any further if we have somehow encountered the\nsame child item more than once. There exists a pathological case where\nthere is an infinite loop due to wonky data for Focused Trace Waterfall,\nand preventing that means putting a recursion guard on any visited trace\nitem.\n\n~~This PR is set to draft mode, as I'm currently unable to find a set of\ndata that triggers this case, which I would like to put as a unit test\nto ensure this pathological case is dealt with for all future work.~~\n\nThe recursion guard will detect the duplicate span case and error. This\nis then caught and communicated to the user that a problem has been\ndetected with their configuration:\n\n<img alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/016fa250-2e98-4488-99d6-a3e2e3c27bd4\"\n/>\n\n### How to test\n\n- Set up environment as in\nhttps://github.com/elastic/kibana/issues/240421\n- Open up transaction overviews and see if the Focused Trace Waterfall\ncrashes or not.","sha":"88194e453c448f24a361cbc03eebfe20855b3e6b","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:obs-ux-infra_services","backport:version","v9.3.0","v8.19.7","v9.1.7","v9.2.1"],"title":"[Discover][Unified Waterfall] Add recursion guard for flattening item map","number":241329,"url":"https://github.com/elastic/kibana/pull/241329","mergeCommit":{"message":"[Discover][Unified Waterfall] Add recursion guard for flattening item map (#241329)\n\n## Summary\n\nFixes one potential bug within\nhttps://github.com/elastic/kibana/issues/240421, by adding a recursion\nguard to prevent going any further if we have somehow encountered the\nsame child item more than once. There exists a pathological case where\nthere is an infinite loop due to wonky data for Focused Trace Waterfall,\nand preventing that means putting a recursion guard on any visited trace\nitem.\n\n~~This PR is set to draft mode, as I'm currently unable to find a set of\ndata that triggers this case, which I would like to put as a unit test\nto ensure this pathological case is dealt with for all future work.~~\n\nThe recursion guard will detect the duplicate span case and error. This\nis then caught and communicated to the user that a problem has been\ndetected with their configuration:\n\n<img alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/016fa250-2e98-4488-99d6-a3e2e3c27bd4\"\n/>\n\n### How to test\n\n- Set up environment as in\nhttps://github.com/elastic/kibana/issues/240421\n- Open up transaction overviews and see if the Focused Trace Waterfall\ncrashes or not.","sha":"88194e453c448f24a361cbc03eebfe20855b3e6b"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241329","number":241329,"mergeCommit":{"message":"[Discover][Unified Waterfall] Add recursion guard for flattening item map (#241329)\n\n## Summary\n\nFixes one potential bug within\nhttps://github.com/elastic/kibana/issues/240421, by adding a recursion\nguard to prevent going any further if we have somehow encountered the\nsame child item more than once. There exists a pathological case where\nthere is an infinite loop due to wonky data for Focused Trace Waterfall,\nand preventing that means putting a recursion guard on any visited trace\nitem.\n\n~~This PR is set to draft mode, as I'm currently unable to find a set of\ndata that triggers this case, which I would like to put as a unit test\nto ensure this pathological case is dealt with for all future work.~~\n\nThe recursion guard will detect the duplicate span case and error. This\nis then caught and communicated to the user that a problem has been\ndetected with their configuration:\n\n<img alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/016fa250-2e98-4488-99d6-a3e2e3c27bd4\"\n/>\n\n### How to test\n\n- Set up environment as in\nhttps://github.com/elastic/kibana/issues/240421\n- Open up transaction overviews and see if the Focused Trace Waterfall\ncrashes or not.","sha":"88194e453c448f24a361cbc03eebfe20855b3e6b"}},{"branch":"8.19","label":"v8.19.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->