### PR TITLE
[9.1] [Infra] Replace flaky node sorting FTR tests with component tests (#241879)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/map_sorting.test.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/map_sorting.test.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Map } from './map';
+import type { SnapshotNode } from '../../../../../../common/http_api/snapshot_api';
+import type { InfraWaffleMapOptions } from '../../../../../common/inventory/types';
+import type { InventoryItemType } from '@kbn/metrics-data-access-plugin/common';
+import { InfraFormatterType } from '@kbn/observability-plugin/common/custom_threshold_rule/types';
+
+// Mock GroupOfNodes to simplify rendering
+jest.mock('./group_of_nodes', () => ({
+  GroupOfNodes: ({ group }: any) => {
+    return (
+      <div data-test-subj="groupOfNodes">
+        {group.nodes.map((node: any) => (
+          <div key={node.id} data-test-subj="nodeContainer">
+            <span data-test-subj="nodeName">{node.name}</span>
+            <span data-test-subj="nodeValue">{node.metrics?.[0]?.value || 0}</span>
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+const createMockNode = (name: string, value: number): SnapshotNode => ({
+  name,
+  path: [{ value: name, label: name }],
+  metrics: [
+    {
+      name: 'cpu',
+      value,
+      avg: value,
+      max: value,
+    },
+  ],
+});
+
+const hostNodes: SnapshotNode[] = [
+  createMockNode('host-1', 0.5),
+  createMockNode('host-2', 0.7),
+  createMockNode('host-3', 0.9),
+  createMockNode('host-4', 0.3),
+  createMockNode('host-5', 0.1),
+];
+
+const defaultOptions: InfraWaffleMapOptions = {
+  formatter: InfraFormatterType.percent,
+  formatTemplate: '{{value}}',
+  sort: { by: 'name', direction: 'asc' },
+  metric: { type: 'cpu' },
+  groupBy: [],
+  legend: {
+    type: 'gradient',
+    rules: [],
+  },
+};
+
+const defaultProps = {
+  nodes: hostNodes,
+  nodeType: 'host' as InventoryItemType,
+  options: defaultOptions,
+  formatter: (value: string | number) => `${value}`,
+  currentTime: Date.now(),
+  onFilter: jest.fn(),
+  bounds: { min: 0, max: 1, legend: { min: 0, max: 1 } },
+  bottomMargin: 0,
+  staticHeight: false,
+  detailsItemId: null,
+};
+
+describe('Map sorting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const getNodeNames = () => {
+    const nodeContainers = screen.getAllByTestId('nodeContainer');
+
+    return nodeContainers.map((container) => {
+      const nodeName = container.querySelector('[data-test-subj="nodeName"]');
+      return nodeName?.textContent || '';
+    });
+  };
+
+  const getNodeValues = () => {
+    const nodeContainers = screen.getAllByTestId('nodeContainer');
+
+    return nodeContainers.map((container) => {
+      const nodeValue = container.querySelector('[data-test-subj="nodeValue"]');
+      const valueText = nodeValue?.textContent || '';
+      return parseFloat(valueText);
+    });
+  };
+
+  it('renders nodes in correct order when sorted by value descending', () => {
+    const options: InfraWaffleMapOptions = {
+      ...defaultOptions,
+      sort: { by: 'value', direction: 'desc' },
+    };
+
+    render(<Map {...defaultProps} options={options} />);
+
+    const nodeNames = getNodeNames();
+    const nodeValues = getNodeValues();
+
+    expect(nodeNames).toEqual(['host-3', 'host-2', 'host-1', 'host-4', 'host-5']);
+    expect(nodeValues).toEqual([0.9, 0.7, 0.5, 0.3, 0.1]);
+  });
+
+  it('renders nodes in correct order when sorted by value ascending', () => {
+    const options: InfraWaffleMapOptions = {
+      ...defaultOptions,
+      sort: { by: 'value', direction: 'asc' },
+    };
+
+    render(<Map {...defaultProps} options={options} />);
+
+    const nodeNames = getNodeNames();
+    const nodeValues = getNodeValues();
+
+    expect(nodeNames).toEqual(['host-5', 'host-4', 'host-1', 'host-2', 'host-3']);
+    expect(nodeValues).toEqual([0.1, 0.3, 0.5, 0.7, 0.9]);
+  });
+
+  it('updates node order when sort option changes from desc to asc', () => {
+    const { rerender } = render(<Map {...defaultProps} />);
+
+    let nodeNames = getNodeNames();
+    let nodeValues = getNodeValues();
+
+    expect(nodeNames).toEqual(['host-1', 'host-2', 'host-3', 'host-4', 'host-5']);
+    expect(nodeValues).toEqual([0.5, 0.7, 0.9, 0.3, 0.1]);
+
+    const descOptions: InfraWaffleMapOptions = {
+      ...defaultOptions,
+      sort: { by: 'value', direction: 'desc' },
+    };
+    rerender(<Map {...defaultProps} options={descOptions} />);
+
+    nodeNames = getNodeNames();
+    nodeValues = getNodeValues();
+
+    expect(nodeNames).toEqual(['host-3', 'host-2', 'host-1', 'host-4', 'host-5']);
+    expect(nodeValues).toEqual([0.9, 0.7, 0.5, 0.3, 0.1]);
+
+    const ascOptions: InfraWaffleMapOptions = {
+      ...defaultOptions,
+      sort: { by: 'value', direction: 'asc' },
+    };
+    rerender(<Map {...defaultProps} options={ascOptions} />);
+
+    nodeNames = getNodeNames();
+    nodeValues = getNodeValues();
+
+    expect(nodeNames).toEqual(['host-5', 'host-4', 'host-1', 'host-2', 'host-3']);
+    expect(nodeValues).toEqual([0.1, 0.3, 0.5, 0.7, 0.9]);
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_sort_controls.test.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_sort_controls.test.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WaffleSortControls } from './waffle_sort_controls';
+import type { WaffleSortOption } from '../../hooks/use_waffle_options';
+
+describe('WaffleSortControls', () => {
+  const mockOnChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the sort dropdown', () => {
+    render(<WaffleSortControls sort={{ by: 'name', direction: 'asc' }} onChange={mockOnChange} />);
+
+    const waffleSortByDropdown = screen.getByTestId('waffleSortByDropdown');
+    expect(waffleSortByDropdown).toBeInTheDocument();
+  });
+
+  it('displays correct label when sorted by name', () => {
+    render(<WaffleSortControls sort={{ by: 'name', direction: 'asc' }} onChange={mockOnChange} />);
+
+    const waffleSortByDropdown = screen.getByTestId('waffleSortByDropdown');
+    expect(waffleSortByDropdown).toHaveTextContent('Name');
+  });
+
+  it('displays correct label when sorted by value', () => {
+    render(<WaffleSortControls sort={{ by: 'value', direction: 'asc' }} onChange={mockOnChange} />);
+
+    const waffleSortByDropdown = screen.getByTestId('waffleSortByDropdown');
+    expect(waffleSortByDropdown).toHaveTextContent('Metric value');
+  });
+
+  it('opens popover when dropdown is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<WaffleSortControls sort={{ by: 'name', direction: 'asc' }} onChange={mockOnChange} />);
+
+    const waffleSortByDropdown = screen.getByTestId('waffleSortByDropdown');
+    await user.click(waffleSortByDropdown);
+
+    expect(screen.getByTestId('waffleSortByName')).toBeInTheDocument();
+    expect(screen.getByTestId('waffleSortByValue')).toBeInTheDocument();
+    expect(screen.getByTestId('waffleSortByDirection')).toBeInTheDocument();
+  });
+
+  it('calls onChange with name sort when "Sort by name" is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<WaffleSortControls sort={{ by: 'value', direction: 'asc' }} onChange={mockOnChange} />);
+
+    const waffleSortByDropdown = screen.getByTestId('waffleSortByDropdown');
+    await user.click(waffleSortByDropdown);
+
+    const waffleSortByName = await screen.findByTestId('waffleSortByName');
+    fireEvent.click(waffleSortByName);
+
+    expect(mockOnChange).toHaveBeenCalledWith({ by: 'name', direction: 'asc' });
+  });
+
+  it('calls onChange with value sort when "Sort by value" is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<WaffleSortControls sort={{ by: 'name', direction: 'asc' }} onChange={mockOnChange} />);
+
+    const waffleSortByDropdown = screen.getByTestId('waffleSortByDropdown');
+    await user.click(waffleSortByDropdown);
+
+    const waffleSortByValue = await screen.findByTestId('waffleSortByValue');
+    fireEvent.click(waffleSortByValue);
+
+    expect(mockOnChange).toHaveBeenCalledWith({ by: 'value', direction: 'asc' });
+  });
+
+  it('toggles sort direction from asc to desc when direction switch is clicked', async () => {
+    const user = userEvent.setup();
+
+    const valueSortAsc: WaffleSortOption = { by: 'value', direction: 'asc' };
+    render(<WaffleSortControls sort={valueSortAsc} onChange={mockOnChange} />);
+
+    const waffleSortByDropdown = screen.getByTestId('waffleSortByDropdown');
+    await user.click(waffleSortByDropdown);
+
+    const waffleSortByDirection = await screen.findByTestId('waffleSortByDirection');
+    fireEvent.click(waffleSortByDirection);
+
+    expect(mockOnChange).toHaveBeenCalledWith({ by: 'value', direction: 'desc' });
+  });
+
+  it('toggles sort direction from desc to asc when direction switch is clicked', async () => {
+    const user = userEvent.setup();
+
+    const valueSortDesc: WaffleSortOption = { by: 'value', direction: 'desc' };
+    render(<WaffleSortControls sort={valueSortDesc} onChange={mockOnChange} />);
+
+    const waffleSortByDropdown = screen.getByTestId('waffleSortByDropdown');
+    await user.click(waffleSortByDropdown);
+
+    const waffleSortByDirection = await screen.findByTestId('waffleSortByDirection');
+    fireEvent.click(waffleSortByDirection);
+
+    expect(mockOnChange).toHaveBeenCalledWith({ by: 'value', direction: 'asc' });
+  });
+
+  describe('complete sort flow', () => {
+    it('should sort by value then toggle sort direction', async () => {
+      const user = userEvent.setup();
+
+      const { rerender } = render(
+        <WaffleSortControls sort={{ by: 'name', direction: 'asc' }} onChange={mockOnChange} />
+      );
+
+      const waffleSortByDropdown = screen.getByTestId('waffleSortByDropdown');
+      expect(waffleSortByDropdown).toHaveTextContent('Name');
+
+      await user.click(waffleSortByDropdown);
+
+      const waffleSortByValue = await screen.findByTestId('waffleSortByValue');
+      expect(waffleSortByValue).toHaveTextContent('Metric value');
+
+      fireEvent.click(waffleSortByValue);
+
+      const valueSortAsc: WaffleSortOption = { by: 'value', direction: 'asc' };
+      expect(mockOnChange).toHaveBeenCalledWith(valueSortAsc);
+
+      rerender(<WaffleSortControls sort={valueSortAsc} onChange={mockOnChange} />);
+
+      expect(waffleSortByDropdown).toHaveTextContent('Metric value');
+
+      await user.click(waffleSortByDropdown);
+
+      const waffleSortByDirection = await screen.findByTestId('waffleSortByDirection');
+      fireEvent.click(waffleSortByDirection);
+
+      expect(mockOnChange).toHaveBeenLastCalledWith({ by: 'value', direction: 'desc' });
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/lib/sort_nodes.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/lib/sort_nodes.test.ts
@@ -8,52 +8,67 @@
 import { sortNodes } from './sort_nodes';
 import type { SnapshotNode } from '../../../../../common/http_api/snapshot_api';
 
-const nodes: SnapshotNode[] = [
-  {
-    name: 'host-01',
-    path: [{ value: 'host-01', label: 'host-01' }],
-    metrics: [
-      {
-        name: 'cpu',
-        value: 0.5,
-        max: 1.5,
-        avg: 0.7,
-      },
-    ],
-  },
-  {
-    name: 'host-02',
-    path: [{ value: 'host-02', label: 'host-02' }],
-    metrics: [
-      {
-        name: 'cpu',
-        value: 0.2,
-        max: 0.7,
-        avg: 0.4,
-      },
-    ],
-  },
+const createMockNode = (name: string, value: number): SnapshotNode => ({
+  name,
+  path: [{ value: name, label: name }],
+  metrics: [
+    {
+      name: 'cpu',
+      value,
+      avg: value,
+      max: value,
+    },
+  ],
+});
+
+const hostNodes: SnapshotNode[] = [
+  createMockNode('host-1', 0.5),
+  createMockNode('host-2', 0.7),
+  createMockNode('host-3', 0.9),
+  createMockNode('host-4', 0.3),
+  createMockNode('host-5', 0.1),
 ];
 
 describe('sortNodes', () => {
-  describe('asc', () => {
-    it('should sort by name', () => {
-      const sortedNodes = sortNodes({ by: 'name', direction: 'asc' }, nodes);
-      expect(sortedNodes).toEqual(nodes);
-    });
-    it('should sort by merics', () => {
-      const sortedNodes = sortNodes({ by: 'value', direction: 'asc' }, nodes);
-      expect(sortedNodes).toEqual(nodes.reverse());
+  describe('sort by value descending', () => {
+    it('should sort nodes by value in descending order', () => {
+      const sortedNodes = sortNodes({ by: 'value', direction: 'desc' }, hostNodes);
+      const nodeNames = sortedNodes.map((node) => node.name);
+
+      expect(nodeNames).toEqual(['host-3', 'host-2', 'host-1', 'host-4', 'host-5']);
+
+      const nodeValues = sortedNodes.map((node) => node.metrics[0].value);
+
+      expect(nodeValues).toEqual([0.9, 0.7, 0.5, 0.3, 0.1]);
     });
   });
-  describe('desc', () => {
-    it('should sort by name', () => {
-      const sortedNodes = sortNodes({ by: 'name', direction: 'desc' }, nodes);
-      expect(sortedNodes).toEqual(nodes.reverse());
+
+  describe('sort by value ascending', () => {
+    it('should sort nodes by value in ascending order', () => {
+      const sortedNodes = sortNodes({ by: 'value', direction: 'asc' }, hostNodes);
+      const nodeNames = sortedNodes.map((node) => node.name);
+
+      expect(nodeNames).toEqual(['host-5', 'host-4', 'host-1', 'host-2', 'host-3']);
+
+      const nodeValues = sortedNodes.map((node) => node.metrics[0].value);
+
+      expect(nodeValues).toEqual([0.1, 0.3, 0.5, 0.7, 0.9]);
     });
-    it('should sort by merics', () => {
-      const sortedNodes = sortNodes({ by: 'value', direction: 'desc' }, nodes);
-      expect(sortedNodes).toEqual(nodes);
+  });
+
+  describe('sort by name', () => {
+    it('should sort by name ascending', () => {
+      const sortedNodes = sortNodes({ by: 'name', direction: 'asc' }, hostNodes);
+      const nodeNames = sortedNodes.map((node) => node.name);
+
+      expect(nodeNames).toEqual(['host-1', 'host-2', 'host-3', 'host-4', 'host-5']);
+    });
+
+    it('should sort by name descending', () => {
+      const sortedNodes = sortNodes({ by: 'name', direction: 'desc' }, hostNodes);
+      const nodeNames = sortedNodes.map((node) => node.name);
+
+      expect(nodeNames).toEqual(['host-5', 'host-4', 'host-3', 'host-2', 'host-1']);
     });
   });
 });

--- a/x-pack/solutions/observability/test/functional/apps/infra/home_page.ts
+++ b/x-pack/solutions/observability/test/functional/apps/infra/home_page.ts
@@ -354,15 +354,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         });
       });
 
-      it('shows query suggestions', async () => {
-        await pageObjects.infraHome.goToTime(DATE_WITH_HOSTS_DATA);
-        await pageObjects.infraHome.clickQueryBar();
-        await pageObjects.infraHome.inputQueryData();
-        await pageObjects.infraHome.ensureSuggestionsPanelVisible();
-        await pageObjects.infraHome.clearSearchTerm();
-      });
-
-      it('sort nodes by descending value', async () => {
+      // skipping until tests are migrated to Scout, covered by unit tests
+      it.skip('sort nodes by descending value', async () => {
         await pageObjects.infraHome.goToTime(DATE_WITH_HOSTS_DATA);
         await pageObjects.infraHome.getWaffleMap();
         await pageObjects.infraHome.sortNodesBy('value');
@@ -378,7 +371,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         });
       });
 
-      it('sort nodes by ascending value', async () => {
+      // skipping until tests are migrated to Scout, covered by unit tests
+      it.skip('sort nodes by ascending value', async () => {
         await pageObjects.infraHome.goToTime(DATE_WITH_HOSTS_DATA);
         await pageObjects.infraHome.getWaffleMap();
         await pageObjects.infraHome.sortNodesBy('value');
@@ -425,9 +419,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           expect(nodesWithValue).to.eql([
             { name: 'host-5', value: 10, color: '#61a2ff' },
             { name: 'host-4', value: 30, color: '#b5d2ff' },
-            { name: 'host-1', value: 50, color: '#fbefee' },
-            { name: 'host-2', value: 70, color: '#ffbab3' },
             { name: 'host-3', value: 90, color: '#f6726a' },
+            { name: 'host-2', value: 70, color: '#ffbab3' },
+            { name: 'host-1', value: 50, color: '#fbefee' },
           ]);
         });
       });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Infra] Replace flaky node sorting FTR tests with component tests (#241879)](https://github.com/elastic/kibana/pull/241879)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tiago Marques","email":"tiago.marques@elastic.co"},"sourceCommit":{"committedDate":"2025-11-05T17:33:57Z","message":"[Infra] Replace flaky node sorting FTR tests with component tests (#241879)\n\n## Summary\n- extended sort nodes helper function test with more scenarios\n- added component tests (`map_sorting` and `waffle_sort_controls`) for\nsorting host nodes\n- skiped flaky tests (after migration to Scout these should come back)\n\nFixes #238995","sha":"22f5cd6468f15b6888f0a2789ec54f2706cec652","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.1.0","v9.2.0","v9.3.0","v9.2.1"],"title":"[Infra] Replace flaky node sorting FTR tests with component tests","number":241879,"url":"https://github.com/elastic/kibana/pull/241879","mergeCommit":{"message":"[Infra] Replace flaky node sorting FTR tests with component tests (#241879)\n\n## Summary\n- extended sort nodes helper function test with more scenarios\n- added component tests (`map_sorting` and `waffle_sort_controls`) for\nsorting host nodes\n- skiped flaky tests (after migration to Scout these should come back)\n\nFixes #238995","sha":"22f5cd6468f15b6888f0a2789ec54f2706cec652"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/242023","number":242023,"state":"MERGED","mergeCommit":{"sha":"e505018a946e0770bcc2b70886b2866f490af151","message":"[9.2] [Infra] Replace flaky node sorting FTR tests with component tests (#241879) (#242023)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Infra] Replace flaky node sorting FTR tests with component tests\n(#241879)](https://github.com/elastic/kibana/pull/241879)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Tiago Marques <tiago.marques@elastic.co>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241879","number":241879,"mergeCommit":{"message":"[Infra] Replace flaky node sorting FTR tests with component tests (#241879)\n\n## Summary\n- extended sort nodes helper function test with more scenarios\n- added component tests (`map_sorting` and `waffle_sort_controls`) for\nsorting host nodes\n- skiped flaky tests (after migration to Scout these should come back)\n\nFixes #238995","sha":"22f5cd6468f15b6888f0a2789ec54f2706cec652"}}]}] BACKPORT-->