### PR TITLE
[ResponseOps][Reporting] Fix reports page title and links inconsistency

### DIFF
--- a/x-pack/platform/plugins/private/reporting/public/management/components/reporting_tabs.tsx
+++ b/x-pack/platform/plugins/private/reporting/public/management/components/reporting_tabs.tsx
@@ -121,7 +121,7 @@ export const ReportingTabs: React.FunctionComponent<{ config: ClientConfigType }
         }
         data-test-subj="reportingPageHeader"
         pageTitle={
-          <FormattedMessage id="xpack.reporting.reports.titleStateful" defaultMessage="Reports" />
+          <FormattedMessage id="xpack.reporting.reports.titleStateful" defaultMessage="Reporting" />
         }
         description={
           <FormattedMessage


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/241247

## Summary

- changed the page header from `Reports` to `Reporting`



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->