### PR TITLE
[Streams] Show field data type in partitioning UI

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/autocomplete_selector.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/autocomplete_selector.test.tsx
@@ -159,14 +159,20 @@ describe('AutocompleteSelector', () => {
   });
 
   describe('Field Type Icons', () => {
-    it('renders field type icons when suggestions include type information', async () => {
+    it('renders field type icons when showIcon is true and suggestions include type information', async () => {
       const suggestionsWithTypes = [
         { name: '@timestamp', type: 'date' },
         { name: 'log.level', type: 'keyword' },
         { name: 'message', type: 'text' },
       ];
 
-      render(<AutocompleteSelector {...defaultProps} suggestions={suggestionsWithTypes} />);
+      render(
+        <AutocompleteSelector
+          {...defaultProps}
+          suggestions={suggestionsWithTypes}
+          showIcon={true}
+        />
+      );
 
       const toggleButton = screen.getByTestId('comboBoxToggleListButton');
       await userEvent.click(toggleButton);
@@ -177,10 +183,16 @@ describe('AutocompleteSelector', () => {
       expect(screen.getByTestId('field-icon-text')).toBeInTheDocument();
     });
 
-    it('renders unknown icons for fields without type information', async () => {
+    it('renders unknown icons when showIcon is true and fields have no type information', async () => {
       const suggestionsWithoutTypes = [{ name: '@timestamp' }, { name: 'log.level' }];
 
-      render(<AutocompleteSelector {...defaultProps} suggestions={suggestionsWithoutTypes} />);
+      render(
+        <AutocompleteSelector
+          {...defaultProps}
+          suggestions={suggestionsWithoutTypes}
+          showIcon={true}
+        />
+      );
 
       const toggleButton = screen.getByTestId('comboBoxToggleListButton');
       await userEvent.click(toggleButton);
@@ -189,7 +201,29 @@ describe('AutocompleteSelector', () => {
       expect(screen.getAllByTestId('field-icon-unknown')).toHaveLength(2);
     });
 
-    it('shows icon for selected field when type is available', () => {
+    it('does not render icons when showIcon is false', async () => {
+      const suggestionsWithTypes = [
+        { name: '@timestamp', type: 'date' },
+        { name: 'log.level', type: 'keyword' },
+      ];
+
+      render(
+        <AutocompleteSelector
+          {...defaultProps}
+          suggestions={suggestionsWithTypes}
+          showIcon={false}
+        />
+      );
+
+      const toggleButton = screen.getByTestId('comboBoxToggleListButton');
+      await userEvent.click(toggleButton);
+
+      // Verify that no icons are rendered
+      expect(screen.queryByTestId('field-icon-date')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('field-icon-keyword')).not.toBeInTheDocument();
+    });
+
+    it('shows icon for selected field when showIcon is true and type is available', () => {
       const suggestionsWithTypes = [
         { name: 'log.level', type: 'keyword' },
         { name: 'message', type: 'text' },
@@ -200,6 +234,7 @@ describe('AutocompleteSelector', () => {
           {...defaultProps}
           value="log.level"
           suggestions={suggestionsWithTypes}
+          showIcon={true}
         />
       );
 
@@ -207,7 +242,7 @@ describe('AutocompleteSelector', () => {
       expect(screen.getByTestId('field-icon-keyword')).toBeInTheDocument();
     });
 
-    it('shows unknown icon for selected field when type is not available', () => {
+    it('shows unknown icon for selected field when showIcon is true and type is not available', () => {
       const suggestionsWithoutTypes = [{ name: 'log.level' }, { name: 'message' }];
 
       render(
@@ -215,11 +250,31 @@ describe('AutocompleteSelector', () => {
           {...defaultProps}
           value="log.level"
           suggestions={suggestionsWithoutTypes}
+          showIcon={true}
         />
       );
 
       // Unknown icon should be visible in the selected value
       expect(screen.getByTestId('field-icon-unknown')).toBeInTheDocument();
+    });
+
+    it('does not show icon for selected field when showIcon is false', () => {
+      const suggestionsWithTypes = [
+        { name: 'log.level', type: 'keyword' },
+        { name: 'message', type: 'text' },
+      ];
+
+      render(
+        <AutocompleteSelector
+          {...defaultProps}
+          value="log.level"
+          suggestions={suggestionsWithTypes}
+          showIcon={false}
+        />
+      );
+
+      // Icon should not be visible
+      expect(screen.queryByTestId('field-icon-keyword')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/autocomplete_selector.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/autocomplete_selector.test.tsx
@@ -223,7 +223,7 @@ describe('AutocompleteSelector', () => {
       expect(screen.queryByTestId('field-icon-keyword')).not.toBeInTheDocument();
     });
 
-    it('shows icon for selected field when showIcon is true and type is available', () => {
+    it('does not show icon for selected value (icons only in dropdown)', () => {
       const suggestionsWithTypes = [
         { name: 'log.level', type: 'keyword' },
         { name: 'message', type: 'text' },
@@ -238,43 +238,9 @@ describe('AutocompleteSelector', () => {
         />
       );
 
-      // Icon should be visible in the selected value
-      expect(screen.getByTestId('field-icon-keyword')).toBeInTheDocument();
-    });
-
-    it('shows unknown icon for selected field when showIcon is true and type is not available', () => {
-      const suggestionsWithoutTypes = [{ name: 'log.level' }, { name: 'message' }];
-
-      render(
-        <AutocompleteSelector
-          {...defaultProps}
-          value="log.level"
-          suggestions={suggestionsWithoutTypes}
-          showIcon={true}
-        />
-      );
-
-      // Unknown icon should be visible in the selected value
-      expect(screen.getByTestId('field-icon-unknown')).toBeInTheDocument();
-    });
-
-    it('does not show icon for selected field when showIcon is false', () => {
-      const suggestionsWithTypes = [
-        { name: 'log.level', type: 'keyword' },
-        { name: 'message', type: 'text' },
-      ];
-
-      render(
-        <AutocompleteSelector
-          {...defaultProps}
-          value="log.level"
-          suggestions={suggestionsWithTypes}
-          showIcon={false}
-        />
-      );
-
-      // Icon should not be visible
+      // Selected value should not have icon (only dropdown options have icons)
       expect(screen.queryByTestId('field-icon-keyword')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('field-icon-unknown')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/autocomplete_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/autocomplete_selector.tsx
@@ -32,6 +32,7 @@ export interface AutocompleteSelectorProps {
   autoFocus?: boolean;
   hideSuggestions?: boolean;
   labelAppend?: React.ReactNode;
+  showIcon?: boolean;
 }
 
 /**
@@ -53,18 +54,21 @@ export const AutocompleteSelector = ({
   autoFocus,
   hideSuggestions = false,
   labelAppend,
+  showIcon = false,
 }: AutocompleteSelectorProps) => {
   const comboBoxOptions = useMemo(
     () =>
       suggestions.map((suggestion) => ({
         label: suggestion.name,
         value: suggestion.name,
-        prepend: (
-          <FieldIcon type={suggestion.type || 'unknown'} size="s" className="eui-alignMiddle" />
-        ),
+        ...(showIcon && {
+          prepend: (
+            <FieldIcon type={suggestion.type || 'unknown'} size="s" className="eui-alignMiddle" />
+          ),
+        }),
         'data-test-subj': `autocomplete-suggestion-${suggestion.name}`,
       })),
-    [suggestions]
+    [suggestions, showIcon]
   );
 
   const selectedOptions = useMemo(() => {
@@ -81,16 +85,18 @@ export const AutocompleteSelector = ({
       {
         label: value,
         value,
-        prepend: (
-          <FieldIcon
-            type={suggestionWithType?.type || 'unknown'}
-            size="s"
-            className="eui-alignMiddle"
-          />
-        ),
+        ...(showIcon && {
+          prepend: (
+            <FieldIcon
+              type={suggestionWithType?.type || 'unknown'}
+              size="s"
+              className="eui-alignMiddle"
+            />
+          ),
+        }),
       },
     ];
-  }, [value, comboBoxOptions, suggestions]);
+  }, [value, comboBoxOptions, suggestions, showIcon]);
 
   const handleSelectionChange = useCallback(
     (newSelectedOptions: Array<EuiComboBoxOptionOption<string>>) => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/autocomplete_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/autocomplete_selector.tsx
@@ -74,29 +74,25 @@ export const AutocompleteSelector = ({
   const selectedOptions = useMemo(() => {
     if (!value) return [];
 
-    const matchingSuggestion = comboBoxOptions.find((option) => option.value === value);
-    if (matchingSuggestion) {
-      return [matchingSuggestion];
+    const matchingOption = comboBoxOptions.find((option) => option.value === value);
+    if (matchingOption) {
+      // Return the option but without the prepend (icon)
+      return [
+        {
+          label: matchingOption.label,
+          value: matchingOption.value,
+          'data-test-subj': matchingOption['data-test-subj'],
+        },
+      ];
     }
 
-    // For custom values not in suggestions, try to find the type
-    const suggestionWithType = suggestions.find((s) => s.name === value);
     return [
       {
         label: value,
         value,
-        ...(showIcon && {
-          prepend: (
-            <FieldIcon
-              type={suggestionWithType?.type || 'unknown'}
-              size="s"
-              className="eui-alignMiddle"
-            />
-          ),
-        }),
       },
     ];
-  }, [value, comboBoxOptions, suggestions, showIcon]);
+  }, [value, comboBoxOptions]);
 
   const handleSelectionChange = useCallback(
     (newSelectedOptions: Array<EuiComboBoxOptionOption<string>>) => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_editor.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/condition_editor.tsx
@@ -166,6 +166,7 @@ function FilterConditionForm(props: {
           compressed
           disabled={disabled}
           dataTestSubj="streamsAppConditionEditorFieldText"
+          showIcon={true}
         />
       </EuiFlexItem>
       <EuiFlexItem grow={showValueField ? 1 : 2}>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processor_condition_editor.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processor_condition_editor.tsx
@@ -24,7 +24,7 @@ export function ProcessorConditionEditorWrapper(props: ProcessorConditionEditorP
   const valueSuggestions = useEnrichmentValueSuggestions(getFilterConditionField(props.condition));
   const streamName = useSimulatorSelector((state) => state.context.streamName);
 
-  // Fetch DataView field types with automatic caching via React Query
+  // Fetch DataView field types for displaying field type icons
   const { fieldTypeMap } = useStreamDataViewFieldTypes(streamName);
 
   // Enrich field suggestions with types from DataView

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processor_outcome_preview.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processor_outcome_preview.tsx
@@ -174,11 +174,9 @@ const PreviewDocumentsGroupBy = () => {
 };
 
 const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRecord[] }) => {
-  // Original logic - used for column determination
   const detectedFields = useSimulatorSelector((state) => state.context.simulation?.detected_fields);
   const streamName = useSimulatorSelector((state) => state.context.streamName);
 
-  // Fetch DataView field types with automatic caching via React Query
   const { fieldTypes: dataViewFieldTypes, dataView: streamDataView } =
     useStreamDataViewFieldTypes(streamName);
   const previewDocsFilter = useSimulatorSelector((state) => state.context.previewDocsFilter);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/processor_field_selector.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/processor_field_selector.test.tsx
@@ -186,6 +186,7 @@ describe('ProcessorFieldSelector', () => {
           placeholder: 'Custom placeholder',
           fullWidth: true,
           dataTestSubj: 'streamsAppProcessorFieldSelectorComboFieldText',
+          showIcon: true,
           suggestions: [
             { name: '@timestamp', type: 'date' },
             { name: 'log.level', type: 'keyword' },
@@ -207,6 +208,7 @@ describe('ProcessorFieldSelector', () => {
             expect.objectContaining({ name: '@timestamp', type: 'date' }),
             expect.objectContaining({ name: 'log.level', type: 'keyword' }),
           ]),
+          showIcon: true,
         }),
         expect.anything()
       );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/processor_field_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/processor_field_selector.tsx
@@ -90,6 +90,7 @@ export const ProcessorFieldSelector = ({
       isInvalid={fieldState.invalid}
       error={fieldState.error?.message}
       labelAppend={labelAppend}
+      showIcon={true}
     />
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/preview_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/preview_panel.tsx
@@ -21,6 +21,7 @@ import { isEmpty } from 'lodash';
 import React, { useMemo, useState } from 'react';
 import { useDocViewerSetup } from '../../../hooks/use_doc_viewer_setup';
 import { useDocumentExpansion } from '../../../hooks/use_document_expansion';
+import { useStreamDataViewFieldTypes } from '../../../hooks/use_stream_data_view_field_types';
 import { AssetImage } from '../../asset_image';
 import { StreamsAppSearchBar } from '../../streams_app_search_bar';
 import { MemoPreviewTable, PreviewFlyout } from '../shared';
@@ -120,6 +121,8 @@ const SamplePreviewPanel = ({ enableActions }: { enableActions: boolean }) => {
     (snapshot) => snapshot.context.definition.stream.name
   );
 
+  const { fieldTypes, dataView: streamDataView } = useStreamDataViewFieldTypes(streamName);
+
   const { documentsError, approximateMatchingPercentage } = samplesSnapshot.context;
   const documents = useStreamSamplesSelector((snapshot) =>
     selectPreviewDocuments(snapshot.context)
@@ -208,6 +211,7 @@ const SamplePreviewPanel = ({ enableActions }: { enableActions: boolean }) => {
             displayColumns={visibleColumns}
             setVisibleColumns={setVisibleColumns}
             cellActions={cellActions}
+            dataViewFieldTypes={fieldTypes}
           />
         </RowSelectionContext.Provider>
         <PreviewFlyout
@@ -216,6 +220,7 @@ const SamplePreviewPanel = ({ enableActions }: { enableActions: boolean }) => {
           setExpandedDoc={setExpandedDoc}
           docViewsRegistry={docViewsRegistry}
           streamName={streamName}
+          streamDataView={streamDataView}
         />
       </EuiFlexItem>
     );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/routing_condition_editor.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/routing_condition_editor.tsx
@@ -9,12 +9,14 @@ import { EuiFlexGroup, EuiForm, EuiFormRow, EuiIconTip, EuiSwitch } from '@elast
 import { i18n } from '@kbn/i18n';
 import type { RoutingDefinition } from '@kbn/streams-schema';
 import { isRoutingEnabled } from '@kbn/streams-schema';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useRoutingFieldSuggestions } from '../../../hooks/use_field_suggestions';
+import { useStreamDataViewFieldTypes } from '../../../hooks/use_stream_data_view_field_types';
 import { useRoutingValueSuggestions } from '../../../hooks/use_value_suggestions';
 import { getFilterConditionField } from '../../../util/condition';
 import type { ConditionEditorProps } from '../shared/condition_editor';
 import { ConditionEditor } from '../shared/condition_editor';
+import { useStreamSamplesSelector } from './state_management/stream_routing_state_machine';
 
 type RoutingConditionChangeParams = Omit<RoutingDefinition, 'destination'>;
 
@@ -26,6 +28,22 @@ export function RoutingConditionEditor(props: RoutingConditionEditorProps) {
   const isEnabled = isRoutingEnabled(props.status);
   const fieldSuggestions = useRoutingFieldSuggestions();
   const valueSuggestions = useRoutingValueSuggestions(getFilterConditionField(props.condition));
+
+  // Get stream name for DataView field types
+  const streamName = useStreamSamplesSelector(
+    (snapshot) => snapshot.context.definition.stream.name
+  );
+
+  // Fetch DataView field types for displaying field type icons
+  const { fieldTypeMap } = useStreamDataViewFieldTypes(streamName);
+
+  // Enrich field suggestions with types from DataView
+  const enrichedFieldSuggestions = useMemo(() => {
+    return fieldSuggestions.map((suggestion) => ({
+      ...suggestion,
+      type: fieldTypeMap.get(suggestion.name),
+    }));
+  }, [fieldSuggestions, fieldTypeMap]);
 
   return (
     <EuiForm fullWidth>
@@ -55,7 +73,7 @@ export function RoutingConditionEditor(props: RoutingConditionEditorProps) {
       </EuiFormRow>
       <ConditionEditor
         {...props}
-        fieldSuggestions={fieldSuggestions}
+        fieldSuggestions={enrichedFieldSuggestions}
         valueSuggestions={valueSuggestions}
       />
     </EuiForm>


### PR DESCRIPTION
## Summary

Related to #240954 

Added field type icons throughout the Streams Partitioning UI to improve field identification and user experience. Icons are sourced from DataView field types (ES types) for reliability.

Small change to the AutocompleSelector to only show the Type Icons in the selector fields only (and not on the value selector) to reduce UI pollution.