### PR TITLE
[ES|QL] Move cursor outside function autocomplete if it has no args

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/__tests__/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/__tests__/autocomplete.ts
@@ -334,6 +334,11 @@ export function getFunctionSignaturesByReturnType(
           ? `${name.toUpperCase()} $0`
           : name.toUpperCase();
       }
+
+      const hasNoArguments = signatures.every((sig) => sig.params.length === 0);
+      if (hasNoArguments) {
+        return `${name.toUpperCase()}()`;
+      }
       return customParametersSnippet
         ? `${name.toUpperCase()}(${customParametersSnippet})`
         : `${name.toUpperCase()}($0)`;

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/functions.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/functions.ts
@@ -263,11 +263,18 @@ export function getFunctionSuggestion(fn: FunctionDefinition): ISuggestionItem {
     detail = `[${labels.join('] [')}] ${detail}`;
   }
   const fullSignatures = getFunctionSignatures(fn, { capitalize: true, withTypes: true });
+  const hasNoArguments = fn.signatures.every((sig) => sig.params.length === 0);
 
   let text = `${fn.name.toUpperCase()}($0)`;
+
+  if (hasNoArguments) {
+    text = `${fn.name.toUpperCase()}()`;
+  }
+
   if (fn.customParametersSnippet) {
     text = `${fn.name.toUpperCase()}(${fn.customParametersSnippet})`;
   }
+
   let functionsPriority = fn.type === FunctionDefinitionTypes.AGG ? 'A' : 'C';
   if (fn.type === FunctionDefinitionTypes.TIME_SERIES_AGG) {
     functionsPriority = '1A';

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
@@ -306,6 +306,15 @@ export function getFunctionSignaturesByReturnType(
           label: name.toUpperCase(),
         };
       }
+
+      const hasNoArguments = signatures.every((sig) => sig.params.length === 0);
+      if (hasNoArguments) {
+        return {
+          text: `${name.toUpperCase()}()`,
+          label: name.toUpperCase(),
+        };
+      }
+
       return {
         text: customParametersSnippet
           ? `${name.toUpperCase()}(${customParametersSnippet})`

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/hidden_functions_and_commands.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/hidden_functions_and_commands.test.ts
@@ -48,8 +48,8 @@ describe('hidden functions', () => {
 
     const { suggest } = await setup();
     const suggestedFunctions = (await suggest('FROM index | EVAL /')).map((s) => s.text);
-    expect(suggestedFunctions).toContain('VISIBLE_FUNCTION($0)');
-    expect(suggestedFunctions).not.toContain('HIDDEN_FUNCTION($0)');
+    expect(suggestedFunctions).toContain('VISIBLE_FUNCTION()');
+    expect(suggestedFunctions).not.toContain('HIDDEN_FUNCTION()');
   });
 
   it('does not suggest hidden agg functions', async () => {
@@ -74,8 +74,8 @@ describe('hidden functions', () => {
 
     const { suggest } = await setup();
     const suggestedFunctions = (await suggest('FROM index | STATS /')).map((s) => s.text);
-    expect(suggestedFunctions).toContain('VISIBLE_FUNCTION($0)');
-    expect(suggestedFunctions).not.toContain('HIDDEN_FUNCTION($0)');
+    expect(suggestedFunctions).toContain('VISIBLE_FUNCTION()');
+    expect(suggestedFunctions).not.toContain('HIDDEN_FUNCTION()');
   });
 
   it('does not suggest hidden operators', async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/240766
## Summary
If a function has no arguments, don't place the cursor inside the parentheses in the autocomplete.

## Before
`WHERE NOW(/cursor)`

## After
`WHERE NOW()/cursor`