### PR TITLE
[Discover][Traces] Revert back to Overview trace tab title

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/document_profile/accessors/doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/document_profile/accessors/doc_viewer.tsx
@@ -21,7 +21,7 @@ export const createGetDocViewer =
   (params: DocViewerExtensionParams) => {
     const prevDocViewer = prev(params);
     const tabTitle = i18n.translate('discover.docViews.observability.traces.overview.title', {
-      defaultMessage: 'Trace Overview',
+      defaultMessage: 'Overview',
     });
     return {
       ...prevDocViewer,


### PR DESCRIPTION
## Summary

Quick fix for reverting the Trace Document overview tab title to be just "Overview".

## How to test

- Go to Discover whilst on an Observability space, select a traces index in either Classic or ES|QL mode.
- Open a trace document, ensure the initial tab is titled "Overview" and not "Trace Overview"


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->