### PR TITLE
Vertically align star button favorite

### DIFF
--- a/src/platform/packages/shared/content-management/table_list_view_table/src/components/item_details.tsx
+++ b/src/platform/packages/shared/content-management/table_list_view_table/src/components/item_details.tsx
@@ -89,7 +89,7 @@ export function ItemDetails<T extends UserContentCommonSchema>({
           <FavoriteButton
             id={item.id}
             css={css`
-              margin-top: -${euiTheme.size.m}; // trying to nicer align the star with the title
+              margin-top: -${euiTheme.size.xxs}; // trying to nicer align the star with the title
               margin-bottom: -${euiTheme.size.s};
               margin-left: ${euiTheme.size.xxs};
             `}


### PR DESCRIPTION
## Summary
This PR resolves [[SharedUX] Fix vertical align of star button for favourite dashboards](https://github.com/elastic/kibana/issues/242139) issue.

Before
<img width="1728" height="415" alt="Screenshot 2025-11-06 at 15 49 33" src="https://github.com/user-attachments/assets/fbac0312-d2e2-4572-8c2e-3a2bf57f3f6e" />


After

<img width="1728" height="501" alt="Screenshot 2025-11-06 at 15 46 48" src="https://github.com/user-attachments/assets/34d089a0-1cb6-40b7-8b3a-c16799808ff2" />

<img width="1728" height="485" alt="Screenshot 2025-11-06 at 15 48 51" src="https://github.com/user-attachments/assets/f2d3ef90-ea77-4128-a52d-a2c793c4bccf" />


