### PR TITLE
[Discover][APM] Fix message warning not appearing from context

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_waterfall_context.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_waterfall_context.tsx
@@ -88,7 +88,7 @@ export function TraceWaterfallContextProvider({
   serviceName,
   isFiltered,
 }: Props) {
-  const { duration, traceWaterfall, maxDepth, rootItem, legends, colorBy, traceState } =
+  const { duration, traceWaterfall, maxDepth, rootItem, legends, colorBy, traceState, message } =
     useTraceWaterfall({
       traceItems,
       isFiltered,
@@ -119,6 +119,7 @@ export function TraceWaterfallContextProvider({
         colorBy,
         showLegend,
         serviceName,
+        message,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary

Fixes the warning messages not appearing in the Unified Trace Waterfall, as it wasn't getting passed into the context correctly.

<img width="475" height="193" alt="image" src="https://github.com/user-attachments/assets/f35d4a99-2b74-4f54-9cf0-16902d95bbe0" />

## How to test

- Go to Discover whilst on Observability space, select an OTEL traces index in either classic or ES|QL mode
- Open a trace document and view the overview, find until you get a trace with partial/incomplete data.
- The warning should show in full on the focused trace waterfall, and on the full trace waterfall

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->