### PR TITLE
[9.1] [Discover][Traces] Revert back to Overview trace tab title (#242143)

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/accessors/doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/span_document_profile/accessors/doc_viewer.tsx
@@ -22,8 +22,8 @@ export const createGetDocViewer =
   (prev: (params: DocViewerExtensionParams) => DocViewerExtension) =>
   (params: DocViewerExtensionParams) => {
     const prevDocViewer = prev(params);
-    const tabTitle = i18n.translate('discover.docViews.observability.traces.spanOverview.title', {
-      defaultMessage: 'Span overview',
+    const tabTitle = i18n.translate('discover.docViews.observability.traces.overview.title', {
+      defaultMessage: 'Overview',
     });
     return {
       ...prevDocViewer,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Discover][Traces] Revert back to Overview trace tab title (#242143)](https://github.com/elastic/kibana/pull/242143)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gonçalo Rica Pais da Silva","email":"goncalo.rica@elastic.co"},"sourceCommit":{"committedDate":"2025-11-06T16:11:52Z","message":"[Discover][Traces] Revert back to Overview trace tab title (#242143)\n\n## Summary\n\nQuick fix for reverting the Trace Document overview tab title to be just\n\"Overview\".\n\n## How to test\n\n- Go to Discover whilst on an Observability space, select a traces index\nin either Classic or ES|QL mode.\n- Open a trace document, ensure the initial tab is titled \"Overview\" and\nnot \"Trace Overview\"","sha":"100697b5a54e44c753807b21845f7dc9541da225","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.3.0","v8.19.7","v9.1.7","v9.2.1"],"title":"[Discover][Traces] Revert back to Overview trace tab title","number":242143,"url":"https://github.com/elastic/kibana/pull/242143","mergeCommit":{"message":"[Discover][Traces] Revert back to Overview trace tab title (#242143)\n\n## Summary\n\nQuick fix for reverting the Trace Document overview tab title to be just\n\"Overview\".\n\n## How to test\n\n- Go to Discover whilst on an Observability space, select a traces index\nin either Classic or ES|QL mode.\n- Open a trace document, ensure the initial tab is titled \"Overview\" and\nnot \"Trace Overview\"","sha":"100697b5a54e44c753807b21845f7dc9541da225"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/242143","number":242143,"mergeCommit":{"message":"[Discover][Traces] Revert back to Overview trace tab title (#242143)\n\n## Summary\n\nQuick fix for reverting the Trace Document overview tab title to be just\n\"Overview\".\n\n## How to test\n\n- Go to Discover whilst on an Observability space, select a traces index\nin either Classic or ES|QL mode.\n- Open a trace document, ensure the initial tab is titled \"Overview\" and\nnot \"Trace Overview\"","sha":"100697b5a54e44c753807b21845f7dc9541da225"}},{"branch":"8.19","label":"v8.19.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/242172","number":242172,"state":"OPEN"}]}] BACKPORT-->