### PR TITLE
[9.1] [One Discover] Fix filter actions not closing cell popups (#241749)

### DIFF
--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
@@ -75,6 +75,7 @@ export function CellActionsPopover({
   const makeFilterHandlerByOperator = (operator: '+' | '-') => () => {
     if (onFilter) {
       onFilter(property ?? name, rawValue, operator);
+      closePopover();
     }
   };
 

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/summary_column/summary_column.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/summary_column/summary_column.tsx
@@ -8,7 +8,7 @@
  */
 
 import { DataGridDensity, type DataGridCellValueElementProps } from '@kbn/unified-data-table';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { EuiButtonIcon, EuiCodeBlock, EuiFlexGroup, EuiText, EuiTitle } from '@elastic/eui';
 import { JsonCodeEditor } from '@kbn/unified-doc-viewer-plugin/public';
 import { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
@@ -128,6 +128,15 @@ export const SummaryCellPopover = (props: AllSummaryColumnProps) => {
   const { row, dataView, fieldFormats, onFilter, closePopover, share, core, isTracesSummary } =
     props;
 
+  const filterAndClosePopover: AllSummaryColumnProps['onFilter'] = useMemo(() => {
+    if (!onFilter) return undefined;
+
+    return (...params) => {
+      onFilter(...params);
+      closePopover();
+    };
+  }, [onFilter, closePopover]);
+
   const isTraceDoc = isTracesSummary && isTraceDocument(row);
 
   const resourceFields = createResourceFields(
@@ -180,7 +189,7 @@ export const SummaryCellPopover = (props: AllSummaryColumnProps) => {
           <EuiTitle size="xxs">
             <span>{isTraceDoc ? traceLabel : resourceLabel}</span>
           </EuiTitle>
-          <Resource fields={resourceFields} onFilter={onFilter} />
+          <Resource fields={resourceFields} onFilter={filterAndClosePopover} />
         </EuiFlexGroup>
       )}
       <EuiFlexGroup direction="column" gutterSize="s">

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
@@ -911,6 +911,7 @@ const InternalUnifiedDataTable = ({
         customGridColumnsConfiguration,
         onResize,
         sortedColumns,
+        dataGridRef,
       }),
     [
       cellActionsHandling,

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_columns.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_columns.tsx
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { MutableRefObject } from 'react';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import {
@@ -16,6 +17,7 @@ import {
   EuiListGroupItemProps,
   type EuiDataGridColumnSortingConfig,
   RenderCellValue,
+  type EuiDataGridRefProps,
 } from '@elastic/eui';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { getDataViewFieldOrCreateFromColumnMeta } from '@kbn/data-view-utils';
@@ -116,6 +118,7 @@ function buildEuiGridColumn({
   columnDisplay,
   onResize,
   sortedColumns,
+  dataGridRef,
 }: {
   numberOfColumns: number;
   columnName: string;
@@ -140,6 +143,7 @@ function buildEuiGridColumn({
   columnDisplay?: string;
   onResize: UnifiedDataTableProps['onResize'];
   sortedColumns?: EuiDataGridColumnSortingConfig[];
+  dataGridRef?: MutableRefObject<EuiDataGridRefProps | null>;
 }) {
   const dataViewField = getDataViewFieldOrCreateFromColumnMeta({
     dataView,
@@ -190,7 +194,8 @@ function buildEuiGridColumn({
           isPlainRecord,
           toastNotifications,
           valueToStringConverter,
-          onFilter
+          onFilter,
+          dataGridRef
         )
       : [];
 
@@ -324,6 +329,7 @@ export function getEuiGridColumns({
   customGridColumnsConfiguration,
   onResize,
   sortedColumns,
+  dataGridRef,
 }: {
   columns: string[];
   columnsCellActions?: EuiDataGridColumnCellAction[][];
@@ -349,6 +355,7 @@ export function getEuiGridColumns({
   customGridColumnsConfiguration?: CustomGridColumnsConfiguration;
   onResize: UnifiedDataTableProps['onResize'];
   sortedColumns?: EuiDataGridColumnSortingConfig[];
+  dataGridRef?: MutableRefObject<EuiDataGridRefProps | null>;
 }) {
   const getColWidth = (column: string) => settings?.columns?.[column]?.width ?? 0;
   const headerRowHeight = deserializeHeaderRowHeight(headerRowHeightLines);
@@ -379,6 +386,7 @@ export function getEuiGridColumns({
       columnDisplay: settings?.columns?.[column]?.display,
       onResize,
       sortedColumns,
+      dataGridRef,
     })
   );
 }

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/default_cell_actions.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/default_cell_actions.tsx
@@ -7,8 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { MutableRefObject } from 'react';
 import React, { useContext } from 'react';
-import { EuiDataGridColumnCellActionProps } from '@elastic/eui';
+import type { EuiDataGridColumnCellActionProps, EuiDataGridRefProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { DataViewField } from '@kbn/data-views-plugin/public';
 import { ToastsStart } from '@kbn/core/public';
@@ -22,13 +23,15 @@ function onFilterCell(
   rowIndex: EuiDataGridColumnCellActionProps['rowIndex'],
   columnId: EuiDataGridColumnCellActionProps['columnId'],
   mode: '+' | '-',
-  field: DataViewField
+  field: DataViewField,
+  dataGridRef?: MutableRefObject<EuiDataGridRefProps | null>
 ) {
   const row = context.getRowByIndex(rowIndex);
 
   if (row && field && context.onFilter) {
     const value = row.flattened[columnId];
     context.onFilter(field, value, mode);
+    dataGridRef?.current?.closeCellPopover();
   }
 }
 
@@ -43,10 +46,12 @@ export const FilterInBtn = ({
   cellActionProps: { Component, rowIndex, columnId },
   field,
   isPlainRecord,
+  dataGridRef,
 }: {
   cellActionProps: EuiDataGridColumnCellActionProps;
   field: DataViewField;
   isPlainRecord: boolean | undefined;
+  dataGridRef?: MutableRefObject<EuiDataGridRefProps | null>;
 }) => {
   const context = useContext(UnifiedDataTableContext);
   const filteringDisabled =
@@ -59,7 +64,7 @@ export const FilterInBtn = ({
   return (
     <Component
       onClick={() => {
-        onFilterCell(context, rowIndex, columnId, '+', field);
+        onFilterCell(context, rowIndex, columnId, '+', field, dataGridRef);
       }}
       iconType="plusInCircle"
       aria-label={buttonTitle}
@@ -78,10 +83,12 @@ export const FilterOutBtn = ({
   cellActionProps: { Component, rowIndex, columnId },
   field,
   isPlainRecord,
+  dataGridRef,
 }: {
   cellActionProps: EuiDataGridColumnCellActionProps;
   field: DataViewField;
   isPlainRecord: boolean | undefined;
+  dataGridRef?: MutableRefObject<EuiDataGridRefProps | null>;
 }) => {
   const context = useContext(UnifiedDataTableContext);
   const filteringDisabled =
@@ -94,7 +101,7 @@ export const FilterOutBtn = ({
   return (
     <Component
       onClick={() => {
-        onFilterCell(context, rowIndex, columnId, '-', field);
+        onFilterCell(context, rowIndex, columnId, '-', field, dataGridRef);
       }}
       iconType="minusInCircle"
       aria-label={buttonTitle}
@@ -146,7 +153,8 @@ export function buildCellActions(
   isPlainRecord: boolean | undefined,
   toastNotifications: ToastsStart,
   valueToStringConverter: ValueToStringConverter,
-  onFilter?: DocViewFilterFn
+  onFilter?: DocViewFilterFn,
+  dataGridRef?: MutableRefObject<EuiDataGridRefProps | null>
 ) {
   return [
     ...(onFilter && field.filterable
@@ -156,12 +164,14 @@ export function buildCellActions(
               cellActionProps,
               field,
               isPlainRecord,
+              dataGridRef,
             }),
           (cellActionProps: EuiDataGridColumnCellActionProps) =>
             FilterOutBtn({
               cellActionProps,
               field,
               isPlainRecord,
+              dataGridRef,
             }),
         ]
       : []),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[One Discover] Fix filter actions not closing cell popups (#241749)](https://github.com/elastic/kibana/pull/241749)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-11-06T14:32:47Z","message":"[One Discover] Fix filter actions not closing cell popups (#241749)\n\nCloses #215293 \n\n## Summary\n\n###  Discover\nThis PR introduces updates on how we handle cell popover visibility\nafter applying filtering quick actions (filter in/out) for the\n`UnifiedDataTable` in Discover.\n\nUp until now, applying filter actions wouldn't close expanded cell\npopovers. For filter in actions, this provides an inconsistent UX as the\npopover would sometimes remain open while other times it would close\nafter the filter is applied\n\n\nhttps://github.com/user-attachments/assets/237161eb-625e-41ee-adec-f41f28cd9236\n\nFor filter out actions, the situation is even worse as the popover will\nremain open even though the cell it belongs to is no longer in view (as\nwe just filtered it out!)\n\n\n\nhttps://github.com/user-attachments/assets/d12b566b-d0fd-4180-a289-44d63bb5fb1b\n\n### Contextual Components\n\nThis fix must also pay special attention to the observability solution\nview. In this mode, the summary column is enhanced with, among other\nthings, resource badge components that allow applying filtering actions\nscoped to the specific resource. When applying these filters the issue\nis much like before where no cell popovers are closed after applying\nfiltering actions\n\n\n\nhttps://github.com/user-attachments/assets/d47d708b-a87e-4858-8739-2ac6b5402ac4\n\n## Fixes\n### Discover\nAfter the fix in this PR, this is how the UX for regular discover works.\nNotice how the popover is closed right after pressing the quick action\nbutton, in both filter in and out cases and without inconsistent\nbehaviour.\n\n\nhttps://github.com/user-attachments/assets/43f954de-e38b-4549-ac18-daa1881c1455\n\n### Contextual Components\nFor contextual components too, notice how both the badge popover and the\ncell popover itself are closed after applying the quick action\n\n\nhttps://github.com/user-attachments/assets/79920b91-7be7-41f4-b769-e0f15aa0ff7a","sha":"fde9292eda2ccf16884227ab2b924956522c95e9","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:skip","backport:all-open","ci:project-deploy-observability","Team:obs-ux-logs","Project:OneDiscover","v9.3.0"],"title":"[One Discover] Fix filter actions not closing cell popups","number":241749,"url":"https://github.com/elastic/kibana/pull/241749","mergeCommit":{"message":"[One Discover] Fix filter actions not closing cell popups (#241749)\n\nCloses #215293 \n\n## Summary\n\n###  Discover\nThis PR introduces updates on how we handle cell popover visibility\nafter applying filtering quick actions (filter in/out) for the\n`UnifiedDataTable` in Discover.\n\nUp until now, applying filter actions wouldn't close expanded cell\npopovers. For filter in actions, this provides an inconsistent UX as the\npopover would sometimes remain open while other times it would close\nafter the filter is applied\n\n\nhttps://github.com/user-attachments/assets/237161eb-625e-41ee-adec-f41f28cd9236\n\nFor filter out actions, the situation is even worse as the popover will\nremain open even though the cell it belongs to is no longer in view (as\nwe just filtered it out!)\n\n\n\nhttps://github.com/user-attachments/assets/d12b566b-d0fd-4180-a289-44d63bb5fb1b\n\n### Contextual Components\n\nThis fix must also pay special attention to the observability solution\nview. In this mode, the summary column is enhanced with, among other\nthings, resource badge components that allow applying filtering actions\nscoped to the specific resource. When applying these filters the issue\nis much like before where no cell popovers are closed after applying\nfiltering actions\n\n\n\nhttps://github.com/user-attachments/assets/d47d708b-a87e-4858-8739-2ac6b5402ac4\n\n## Fixes\n### Discover\nAfter the fix in this PR, this is how the UX for regular discover works.\nNotice how the popover is closed right after pressing the quick action\nbutton, in both filter in and out cases and without inconsistent\nbehaviour.\n\n\nhttps://github.com/user-attachments/assets/43f954de-e38b-4549-ac18-daa1881c1455\n\n### Contextual Components\nFor contextual components too, notice how both the badge popover and the\ncell popover itself are closed after applying the quick action\n\n\nhttps://github.com/user-attachments/assets/79920b91-7be7-41f4-b769-e0f15aa0ff7a","sha":"fde9292eda2ccf16884227ab2b924956522c95e9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241749","number":241749,"mergeCommit":{"message":"[One Discover] Fix filter actions not closing cell popups (#241749)\n\nCloses #215293 \n\n## Summary\n\n###  Discover\nThis PR introduces updates on how we handle cell popover visibility\nafter applying filtering quick actions (filter in/out) for the\n`UnifiedDataTable` in Discover.\n\nUp until now, applying filter actions wouldn't close expanded cell\npopovers. For filter in actions, this provides an inconsistent UX as the\npopover would sometimes remain open while other times it would close\nafter the filter is applied\n\n\nhttps://github.com/user-attachments/assets/237161eb-625e-41ee-adec-f41f28cd9236\n\nFor filter out actions, the situation is even worse as the popover will\nremain open even though the cell it belongs to is no longer in view (as\nwe just filtered it out!)\n\n\n\nhttps://github.com/user-attachments/assets/d12b566b-d0fd-4180-a289-44d63bb5fb1b\n\n### Contextual Components\n\nThis fix must also pay special attention to the observability solution\nview. In this mode, the summary column is enhanced with, among other\nthings, resource badge components that allow applying filtering actions\nscoped to the specific resource. When applying these filters the issue\nis much like before where no cell popovers are closed after applying\nfiltering actions\n\n\n\nhttps://github.com/user-attachments/assets/d47d708b-a87e-4858-8739-2ac6b5402ac4\n\n## Fixes\n### Discover\nAfter the fix in this PR, this is how the UX for regular discover works.\nNotice how the popover is closed right after pressing the quick action\nbutton, in both filter in and out cases and without inconsistent\nbehaviour.\n\n\nhttps://github.com/user-attachments/assets/43f954de-e38b-4549-ac18-daa1881c1455\n\n### Contextual Components\nFor contextual components too, notice how both the badge popover and the\ncell popover itself are closed after applying the quick action\n\n\nhttps://github.com/user-attachments/assets/79920b91-7be7-41f4-b769-e0f15aa0ff7a","sha":"fde9292eda2ccf16884227ab2b924956522c95e9"}}]}] BACKPORT-->






