### PR TITLE
[Fleet] Fix fleet internal.retryOnBoot config

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.test.ts
@@ -142,6 +142,11 @@ describe('Config schema', () => {
     }).not.toThrow();
   });
 
+  it('should return default value for internal.retrySetupOnBoot', () => {
+    const validatedConfig = config.schema.validate({});
+    expect(validatedConfig.internal?.retrySetupOnBoot).toBe(true);
+  });
+
   describe('deprecations', () => {
     it('should add a depreciations when trying to enable a non existing experimental feature', () => {
       const res = applyConfigDeprecations({

--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -207,67 +207,65 @@ export const config: PluginConfigDescriptor = {
         defaultValue: () => [],
       }),
 
-      internal: schema.maybe(
-        schema.object({
-          useMeteringApi: schema.boolean({
-            defaultValue: false,
-          }),
-          disableILMPolicies: schema.boolean({
-            defaultValue: false,
-          }),
-          fleetServerStandalone: schema.boolean({
-            defaultValue: false,
-          }),
-          onlyAllowAgentUpgradeToKnownVersions: schema.boolean({
-            defaultValue: false,
-          }),
-          activeAgentsSoftLimit: schema.maybe(
-            schema.number({
-              min: 0,
-            })
-          ),
-          retrySetupOnBoot: schema.boolean({ defaultValue: true }),
-          registry: schema.object(
-            {
-              kibanaVersionCheckEnabled: schema.boolean({ defaultValue: true }),
-              excludePackages: schema.arrayOf(schema.string(), { defaultValue: [] }),
-              spec: schema.object(
-                {
-                  min: schema.maybe(schema.string()),
-                  max: schema.string({ defaultValue: REGISTRY_SPEC_MAX_VERSION }),
-                },
-                {
-                  defaultValue: {
-                    max: REGISTRY_SPEC_MAX_VERSION,
-                  },
-                }
-              ),
-              capabilities: schema.arrayOf(
-                schema.oneOf([
-                  // See package-spec for the list of available capiblities https://github.com/elastic/package-spec/blob/dcc37b652690f8a2bca9cf8a12fc28fd015730a0/spec/integration/manifest.spec.yml#L113
-                  schema.literal('apm'),
-                  schema.literal('enterprise_search'),
-                  schema.literal('observability'),
-                  schema.literal('security'),
-                  schema.literal('serverless_search'),
-                  schema.literal('uptime'),
-                ]),
-                { defaultValue: [] }
-              ),
-            },
-            {
-              defaultValue: {
-                kibanaVersionCheckEnabled: true,
-                capabilities: [],
-                excludePackages: [],
-                spec: {
+      internal: schema.object({
+        useMeteringApi: schema.boolean({
+          defaultValue: false,
+        }),
+        disableILMPolicies: schema.boolean({
+          defaultValue: false,
+        }),
+        fleetServerStandalone: schema.boolean({
+          defaultValue: false,
+        }),
+        onlyAllowAgentUpgradeToKnownVersions: schema.boolean({
+          defaultValue: false,
+        }),
+        activeAgentsSoftLimit: schema.maybe(
+          schema.number({
+            min: 0,
+          })
+        ),
+        retrySetupOnBoot: schema.boolean({ defaultValue: true }),
+        registry: schema.object(
+          {
+            kibanaVersionCheckEnabled: schema.boolean({ defaultValue: true }),
+            excludePackages: schema.arrayOf(schema.string(), { defaultValue: [] }),
+            spec: schema.object(
+              {
+                min: schema.maybe(schema.string()),
+                max: schema.string({ defaultValue: REGISTRY_SPEC_MAX_VERSION }),
+              },
+              {
+                defaultValue: {
                   max: REGISTRY_SPEC_MAX_VERSION,
                 },
+              }
+            ),
+            capabilities: schema.arrayOf(
+              schema.oneOf([
+                // See package-spec for the list of available capiblities https://github.com/elastic/package-spec/blob/dcc37b652690f8a2bca9cf8a12fc28fd015730a0/spec/integration/manifest.spec.yml#L113
+                schema.literal('apm'),
+                schema.literal('enterprise_search'),
+                schema.literal('observability'),
+                schema.literal('security'),
+                schema.literal('serverless_search'),
+                schema.literal('uptime'),
+              ]),
+              { defaultValue: [] }
+            ),
+          },
+          {
+            defaultValue: {
+              kibanaVersionCheckEnabled: true,
+              capabilities: [],
+              excludePackages: [],
+              spec: {
+                max: REGISTRY_SPEC_MAX_VERSION,
               },
-            }
-          ),
-        })
-      ),
+            },
+          }
+        ),
+      }),
       enabled: schema.boolean({ defaultValue: true }),
       /**
        * The max size of the artifacts encoded_size sum in a batch when more than one (there is at least one artifact in a batch).


### PR DESCRIPTION
## Summary

We recently backported a change to change the default value of `retryOnBoot` config (that allows to retries setup). 
That backport was not sufficient to work on 8.19 as other change were made to have a default internal config.

That PR fix that. 
