### PR TITLE
[Alerting] [POC] Detect flapping with rule on rule

### DIFF
--- a/src/platform/packages/shared/kbn-alerts-as-data-utils/src/schemas/generated/alert_schema.ts
+++ b/src/platform/packages/shared/kbn-alerts-as-data-utils/src/schemas/generated/alert_schema.ts
@@ -74,6 +74,7 @@ const AlertRequired = rt.type({
   'alert.id': schemaString,
   'rule.id': schemaString,
   'rule.query': schemaString,
+  'alert.start': schemaDate
 });
 // prettier-ignore
 const AlertOptional = rt.partial({
@@ -111,6 +112,8 @@ const AlertOptional = rt.partial({
   'kibana.alert.workflow_tags': schemaStringArray,
   'kibana.version': schemaString,
   tags: schemaStringArray,
+  'alert.end': schemaDate,
+  'alert.flapping': schemaBoolean,
 });
 
 // prettier-ignore

--- a/x-pack/platform/packages/shared/kbn-data-forge/example_config/flapping_data.yaml
+++ b/x-pack/platform/packages/shared/kbn-data-forge/example_config/flapping_data.yaml
@@ -1,0 +1,17 @@
+---
+elasticsearch:
+  installKibanaUser: false
+
+kibana:
+  installAssets: true
+
+indexing:
+  dataset: "fake_stack"
+  interval: 10000 # 10 seconds
+
+# The sequence of states and their duration
+schedule:
+  - template: "bad"
+    duration: "5m"
+  - template: "good"
+    duration: "5m"

--- a/x-pack/platform/packages/shared/kbn-data-forge/src/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-data-forge/src/constants.ts
@@ -38,4 +38,5 @@ export const DEFAULTS = {
   ALIGN_EVENTS_TO_INTERVAL: true,
   CARDINALITY: 1,
   SLASH_LOGS: false,
+  LOOP_SCHEDULE: false,
 };

--- a/x-pack/platform/packages/shared/kbn-data-forge/src/lib/cli_to_partial_config.ts
+++ b/x-pack/platform/packages/shared/kbn-data-forge/src/lib/cli_to_partial_config.ts
@@ -50,6 +50,7 @@ export function cliOptionsToPartialConfig(options: CliOptions) {
       ephemeralProjectIds: options.ephemeralProjectIds,
       alignEventsToInterval: options.alignEventsToInterval === true,
       slashLogs: options.slashLogs,
+      loopSchedule: options.loopSchedule === true,
     },
     schedule: [schedule],
   };

--- a/x-pack/platform/packages/shared/kbn-data-forge/src/lib/create_config.ts
+++ b/x-pack/platform/packages/shared/kbn-data-forge/src/lib/create_config.ts
@@ -66,6 +66,7 @@ export function createConfig(partialConfig: PartialConfig = {}) {
       alignEventsToInterval: DEFAULTS.ALIGN_EVENTS_TO_INTERVAL,
       artificialIndexDelay: 0,
       slashLogs: DEFAULTS.SLASH_LOGS,
+      loopSchedule: DEFAULTS.LOOP_SCHEDULE,
       ...(partialConfig.indexing ?? {}),
     },
     schedule: partialConfig.schedule ?? [schedule],

--- a/x-pack/platform/packages/shared/kbn-data-forge/src/lib/index_schedule.ts
+++ b/x-pack/platform/packages/shared/kbn-data-forge/src/lib/index_schedule.ts
@@ -9,14 +9,24 @@ import type { Moment } from 'moment';
 import moment from 'moment';
 import parser from '@kbn/datemath';
 import { isNumber, isString } from 'lodash';
+import ms from 'ms';
 import type { ToolingLog } from '@kbn/tooling-log';
 import type { Client } from '@elastic/elasticsearch';
 import type { Config, ParsedSchedule, Schedule } from '../types';
 import { createEvents } from './create_events';
+import { wait } from './wait';
 
 const parseSchedule =
   (now: Moment) =>
   (schedule: Schedule): ParsedSchedule => {
+    if (schedule.duration) {
+      const duration = ms(schedule.duration);
+      if (duration == null) {
+        throw new Error(`Unable to parse ${schedule.duration}`);
+      }
+      return { ...schedule, duration };
+    }
+
     const startTs = isNumber(schedule.start)
       ? schedule.start
       : parser.parse(schedule.start, { forceNow: now.toDate(), roundUp: false })?.valueOf();
@@ -26,45 +36,99 @@ const parseSchedule =
       ? parser.parse(schedule.end, { forceNow: now.toDate(), roundUp: true })?.valueOf()
       : false;
     if (startTs == null || endTs == null) {
-      throw new Error(`Unable to parse ${schedule.start}`);
+      throw new Error(`Unable to parse schedule: ${JSON.stringify(schedule)}`);
     }
     return { ...schedule, start: startTs, end: endTs };
   };
 
-export async function indexSchedule(config: Config, client: Client, logger: ToolingLog) {
-  const now = moment();
-  const compiledSchedule = config.schedule.map(parseSchedule(now));
-  for (const schedule of compiledSchedule) {
+async function indexDurationSchedule(config: Config, client: Client, logger: ToolingLog) {
+  const compiledSchedule = config.schedule.map(parseSchedule(moment()));
+  let scheduleIndex = 0;
+
+  while (true) {
+    const schedule = compiledSchedule[scheduleIndex];
     const interval = schedule.interval ?? config.indexing.interval;
-    const startTs = config.indexing.alignEventsToInterval
-      ? moment(schedule.start).startOf('minute')
-      : moment(schedule.start);
-    const end =
-      schedule.end === false && startTs.isAfter(now)
-        ? moment(schedule.start + interval)
-        : isNumber(schedule.end)
-        ? moment(schedule.end)
-        : false;
-    // We add one interval to the start to prevent overlap with the previous schedule.
-    if (end !== false && end.isBefore(startTs)) {
-      const errorMessage = `Start (${startTs.toISOString()} must come before the end (${end.toISOString()}))`;
-      logger.error(errorMessage);
-      throw new Error(errorMessage);
+    const duration = schedule.duration ?? 0;
+    const stateTimerEnd = Date.now() + duration;
+
+    logger.info(`Starting "${schedule.template}" state, continuing for ${duration}ms`);
+
+    while (Date.now() < stateTimerEnd) {
+      const startOfBatch = moment();
+      const endOfBatch = startOfBatch.clone().add(interval, 'ms');
+
+      await createEvents(
+        config,
+        client,
+        schedule,
+        endOfBatch,
+        startOfBatch,
+        logger,
+        false // We are not doing continuous indexing in the old sense
+      );
+
+      await wait(interval);
     }
 
-    logger.info(
-      `Indexing "${schedule.template}" events from ${startTs.toISOString()} to ${
-        end === false ? 'indefinitely' : end.toISOString()
-      }`
-    );
-    await createEvents(
-      config,
-      client,
-      schedule,
-      end,
-      startTs.clone().add(interval, 'ms'),
-      logger,
-      schedule.end === false
-    );
+    scheduleIndex = (scheduleIndex + 1) % compiledSchedule.length;
   }
+}
+
+async function indexStartEndSchedule(config: Config, client: Client, logger: ToolingLog) {
+  while (true) {
+    const now = moment();
+    const compiledSchedule = config.schedule.map(parseSchedule(now));
+    for (const schedule of compiledSchedule) {
+      const interval = schedule.interval ?? config.indexing.interval;
+      const startTs = config.indexing.alignEventsToInterval
+        ? moment(schedule.start).startOf('minute')
+        : moment(schedule.start);
+      const end =
+        schedule.end === false && startTs.isAfter(now)
+          ? moment(schedule.start + interval)
+          : isNumber(schedule.end)
+          ? moment(schedule.end)
+          : false;
+      // We add one interval to the start to prevent overlap with the previous schedule.
+      if (end !== false && end.isBefore(startTs)) {
+        const errorMessage = `Start (${startTs.toISOString()} must come before the end (${end.toISOString()}))`;
+        logger.error(errorMessage);
+        throw new Error(errorMessage);
+      }
+
+      logger.info(
+        `Indexing "${schedule.template}" events from ${startTs.toISOString()} to ${
+          end === false ? 'indefinitely' : end.toISOString()
+        }`
+      );
+      await createEvents(
+        config,
+        client,
+        schedule,
+        end,
+        startTs.clone().add(interval, 'ms'),
+        logger,
+        schedule.end === false
+      );
+    }
+    if (!config.indexing.loopSchedule) {
+      break;
+    }
+    const firstSchedule = compiledSchedule[0];
+    const lastSchedule = compiledSchedule[compiledSchedule.length - 1];
+    if (typeof lastSchedule.end === 'number' && typeof firstSchedule.start === 'number') {
+      const scheduleDuration = lastSchedule.end - firstSchedule.start;
+      if (scheduleDuration > 0) {
+        logger.info(`Waiting for ${scheduleDuration}ms before starting next loop.`);
+        await wait(scheduleDuration);
+      }
+    }
+  }
+}
+
+export async function indexSchedule(config: Config, client: Client, logger: ToolingLog) {
+  if (config.schedule[0]?.duration) {
+    return indexDurationSchedule(config, client, logger);
+  }
+  return indexStartEndSchedule(config, client, logger);
 }

--- a/x-pack/platform/packages/shared/kbn-data-forge/src/lib/parse_cli_options.ts
+++ b/x-pack/platform/packages/shared/kbn-data-forge/src/lib/parse_cli_options.ts
@@ -99,7 +99,8 @@ export function parseCliOptions(): CliOptions {
       '--slash-logs',
       'This will index everything through Streams slash logs endpoint',
       DEFAULTS.SLASH_LOGS
-    );
+    )
+    .option('--loop-schedule', 'This will loop the schedule indefinitely', DEFAULTS.LOOP_SCHEDULE);
 
   program.parse(process.argv);
   return program.opts() as CliOptions;

--- a/x-pack/platform/packages/shared/kbn-data-forge/src/types/index.ts
+++ b/x-pack/platform/packages/shared/kbn-data-forge/src/types/index.ts
@@ -83,8 +83,11 @@ const PartialScheduleBaseRT = rt.partial({
 export const ScheduleRT = rt.intersection([
   rt.type({
     template: rt.string,
+  }),
+  rt.partial({
     start: rt.string,
     end: rt.union([rt.string, rt.boolean]),
+    duration: rt.string,
   }),
   PartialScheduleBaseRT,
 ]);
@@ -94,8 +97,11 @@ export type Schedule = rt.TypeOf<typeof ScheduleRT>;
 export const ParsedScheduleRT = rt.intersection([
   rt.type({
     template: rt.string,
+  }),
+  rt.partial({
     start: rt.number,
     end: rt.union([rt.boolean, rt.number]),
+    duration: rt.number,
   }),
   PartialScheduleBaseRT,
 ]);
@@ -128,6 +134,7 @@ export const ConfigRT = rt.type({
     alignEventsToInterval: rt.boolean,
     artificialIndexDelay: rt.number,
     slashLogs: rt.boolean,
+    loopSchedule: rt.boolean,
   }),
   schedule: rt.array(ScheduleRT),
 });
@@ -189,4 +196,5 @@ export interface CliOptions {
   alignEventsToInterval: boolean;
   scheduleEnd?: string;
   slashLogs: boolean;
+  loopSchedule: boolean;
 }

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/constants.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/constants.ts
@@ -23,6 +23,7 @@ export const STACK_ALERTS_AAD_CONFIG: IRuleTypeAlerts<StackAlertType> = {
   context: STACK_AAD_INDEX_NAME,
   mappings: {
     fieldMap: {
+      'alert.flapping': { type: 'boolean', array: false, required: false },
       [ALERT_TITLE]: { type: 'keyword', array: false, required: false },
       [ALERT_EVALUATION_CONDITIONS]: { type: 'keyword', array: false, required: false },
       [ALERT_EVALUATION_VALUE]: { type: 'keyword', array: false, required: false },

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/constants.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/constants.ts
@@ -23,7 +23,10 @@ export const STACK_ALERTS_AAD_CONFIG: IRuleTypeAlerts<StackAlertType> = {
   context: STACK_AAD_INDEX_NAME,
   mappings: {
     fieldMap: {
+      'alert.start': { type: 'date', array: false, required: false },
+      'alert.end': { type: 'date', array: false, required: false },
       'alert.flapping': { type: 'boolean', array: false, required: false },
+      'lineage.parents': { type: 'keyword', array: true, required: false },
       [ALERT_TITLE]: { type: 'keyword', array: false, required: false },
       [ALERT_EVALUATION_CONDITIONS]: { type: 'keyword', array: false, required: false },
       [ALERT_EVALUATION_VALUE]: { type: 'keyword', array: false, required: false },

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/esql/executor.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/esql/executor.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CoreSetup } from '@kbn/core/server';
+import type { Alert } from '@kbn/alerts-as-data-utils';
 import { ALERT_GROUPING, ALERT_INSTANCE_ID } from '@kbn/rule-data-utils';
 import { AlertsClientError } from '@kbn/alerting-plugin/server';
 import type { ESQLParams } from '@kbn/response-ops-rule-params/esql';
@@ -55,36 +56,50 @@ export async function executor(
   });
 
   const trackedAlerts = alertsClient.getTrackedAlerts() ?? [];
+  const trackedAlertsByAlertId = new Map<string, Alert & { alertUuid: string }>();
   const activeAlerts: any = [];
-  for (const alertId of Object.keys(results)) {
-    const sourceFields = sourceFieldsPerResult[alertId];
-    const groupingObject = groupingObjectsPerResult[alertId]
-      ? unflattenObject(groupingObjectsPerResult[alertId])
-      : undefined;
-
-    activeAlerts.push({
-      id: alertId,
-      state: { latestTimestamp, dateStart, dateEnd },
-      payload: {
-        [ALERT_GROUPING]: groupingObject,
-        ...sourceFields,
-      },
-    });
-  }
-
   const recoveredAlerts: any = [];
   for (const alertUuid of Object.keys(trackedAlerts)) {
     const alert = trackedAlerts[alertUuid];
     const alertId = alert[ALERT_INSTANCE_ID];
+
+    trackedAlertsByAlertId.set(alertId, {
+      ...alert,
+      alertUuid,
+    });
+
     if (!results[alertId]) {
       recoveredAlerts.push({
         id: alertId,
         state: { latestTimestamp, dateStart, dateEnd },
         payload: {
           [ALERT_GROUPING]: alert[ALERT_GROUPING],
+          'lineage.parents': getLineage({ ...alert, alertUuid }),
+          'alert.start': alert['alert.start'],
+          'alert.end': new Date().toISOString(),
         },
       });
     }
+  }
+
+  for (const alertId of Object.keys(results)) {
+    const sourceFields = sourceFieldsPerResult[alertId];
+    const groupingObject = groupingObjectsPerResult[alertId]
+      ? unflattenObject(groupingObjectsPerResult[alertId])
+      : undefined;
+
+    const trackedAlert = trackedAlertsByAlertId.get(alertId);
+
+    activeAlerts.push({
+      id: alertId,
+      state: { latestTimestamp, dateStart, dateEnd },
+      payload: {
+        [ALERT_GROUPING]: groupingObject,
+        'lineage.parents': trackedAlert ? getLineage(trackedAlert) : [],
+        'alert.start': trackedAlert?.['alert.start'] ?? new Date().toISOString(),
+        ...sourceFields,
+      },
+    });
   }
 
   alertsClient.writeAlerts(activeAlerts, recoveredAlerts);
@@ -98,4 +113,11 @@ export function tryToParseAsDate(sortValue?: string | number | null): undefined 
   if (sortDate && !isNaN(sortDate)) {
     return new Date(sortDate).toISOString();
   }
+}
+
+export function getLineage(trackedAlert: {
+  'lineage.parents'?: string[];
+  alertUuid: string;
+}): string[] {
+  return [...(trackedAlert['lineage.parents'] || []), trackedAlert.alertUuid];
 }

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/esql/executor.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/esql/executor.ts
@@ -75,6 +75,7 @@ export async function executor(
         state: { latestTimestamp, dateStart, dateEnd },
         payload: {
           [ALERT_GROUPING]: alert[ALERT_GROUPING],
+          'alert.flapping': alert['alert.flapping'] ? false : undefined, // if alert was previously flapping and recovered, it is no longer flapping
           'lineage.parents': getLineage({ ...alert, alertUuid }),
           'alert.start': alert['alert.start'],
           'alert.end': new Date().toISOString(),

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/esql/executor.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/esql/executor.ts
@@ -39,21 +39,22 @@ export async function executor(
   const latestTimestamp: string | undefined = tryToParseAsDate(state.latestTimestamp);
   const { dateStart, dateEnd } = getTimeRange(`${params.timeWindowSize}${params.timeWindowUnit}`);
 
-  const { results, sourceFieldsPerResult, groupingObjectsPerResult } = await fetchEsqlQuery({
-    ruleId,
-    alertLimit,
-    params,
-    spacePrefix,
-    services: {
-      share,
-      scopedClusterClient,
-      logger,
-      ruleResultService,
-    },
-    dateStart,
-    dateEnd,
-    sourceFieldsParams,
-  });
+  const { results, sourceFieldsPerResult, groupingObjectsPerResult, flappingFieldsPerResult } =
+    await fetchEsqlQuery({
+      ruleId,
+      alertLimit,
+      params,
+      spacePrefix,
+      services: {
+        share,
+        scopedClusterClient,
+        logger,
+        ruleResultService,
+      },
+      dateStart,
+      dateEnd,
+      sourceFieldsParams,
+    });
 
   const trackedAlerts = alertsClient.getTrackedAlerts() ?? [];
   const trackedAlertsByAlertId = new Map<string, Alert & { alertUuid: string }>();
@@ -97,6 +98,7 @@ export async function executor(
         [ALERT_GROUPING]: groupingObject,
         'lineage.parents': trackedAlert ? getLineage(trackedAlert) : [],
         'alert.start': trackedAlert?.['alert.start'] ?? new Date().toISOString(),
+        'alert.flapping': flappingFieldsPerResult[alertId],
         ...sourceFields,
       },
     });

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/esql/fetch_esql_query.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/esql/fetch_esql_query.ts
@@ -81,12 +81,14 @@ export async function fetchEsqlQuery({
   const link = generateLink(params, discoverLocator, dateStart, dateEnd, spacePrefix);
   const sourceFieldsPerResult = getSourceFields(results, sourceFieldsParams);
   const groupingObjectsPerResult = getGroupingObjects(results, alertIdFields);
+  const flappingFieldsPerResult = getFlappingFields(results);
 
   return {
     link,
     results,
     sourceFieldsPerResult,
     groupingObjectsPerResult,
+    flappingFieldsPerResult,
   };
 }
 
@@ -200,4 +202,16 @@ function getGroupingObjects(results: Record<string, EsqlHit[]>, alertIdFields: s
     }
   }
   return groupingObjectsPerResult;
+}
+
+function getFlappingFields(results: Record<string, EsqlHit[]>) {
+  const flappingFieldsPerResult: Record<string, boolean | undefined> = {};
+  for (const alertId of Object.keys(results)) {
+    const hit = results[alertId].at(0);
+    if (hit) {
+      const flappingField = get(hit._source, 'alert.flapping');
+      flappingFieldsPerResult[alertId] = Boolean(flappingField) || undefined;
+    }
+  }
+  return flappingFieldsPerResult;
 }


### PR DESCRIPTION
### Summary

This PR introduces **flapping detection** via the ESQL rule. This enhancement allows the alerting framework to identify alerts that are rapidly alternating between `active` and `recovered` states.

The core alert mappings have been updated to include `alert.flapping` field.

The primary outcome of this work is a rule that operates on alert data to determine this flapping state. When this state is discovered, a new alert document is appended into the index with `alert.flapping: true`. This document can be reconciled to the existing alert documents by the `entity.key` and `rule.id`. This PR documents three attempted approaches.

All three approaches are captured in Discover Session named "Flapping test". Two of the approaches are captured in test rules. Those discover sessions and test rules can be found [here](https://p.elstc.co/paste/36cZPRqb#M0UIlEDGEkfpcVuI5q-nFke1Hu7/3fwjZdA2rfQP5GN). Copy file into an .ndjson file and upload it via Kibana saved object import.

### Approach 1: Counting Recovered Alerts

This approach identifies flapping by searching for more than one "recovered" alert for the same entity within a given time window. This approach **does not** require any schema changes.

The logic is implemented with the following ES|QL query:

```sql
FROM .alerts-*
| WHERE alert.flapping IS NULL
| STATS recovered_count = SUM(CASE(alert.status == "recovered", 1, 0)) BY entity.key, rule.id
| WHERE recovered_count > 1
| EVAL alert.flapping = true
```

### Approach 2: Counting Transitions with Lineage

This approach identifies flapping by looking for multiple distinct alert "lineages" for the same entity. A new lineage is started each time an alert transitions from `recovered` to `active`. By counting the number of active alerts that have no parents, we can count the number of transitions.

To support this, the PR implements the following schema and executor changes:

*   **Alert Lineage:** A new `lineage.parents` field has been added to the alert document. This field stores an array of previous alert UUIDs, creating a chain that allows the system to trace an alert's history through different states.

The logic is implemented with the following ES|QL query:

```sql
FROM .alerts-*
| WHERE alert.flapping IS NULL AND alert.status == "active" AND lineage.parents IS NULL
| STATS transitions = COUNT() BY entity.key, rule.id
| WHERE transitions > 1
| EVAL alert.flapping = true
```

### Approach 3: Windowing Functions (Hypothetical)

This approach would directly calculate state transitions within a sorted and partitioned dataset. However, this is **not currently possible** as ES|QL does not support windowing functions like `LAG()` and `PARTITION BY`. There is also no indication that the ES|QL team is actively considering implementing windowing.

The hypothetical query would look like this:

```sql
FROM .alerts-*
| WHERE alert.flapping IS NULL
| SORT entity.key, rule.id, @timestamp
| EVAL prev_status = LAG(alert.status) OVER (PARTITION BY entity.key, rule.id ORDER BY @timestamp)
| WHERE alert.status != prev_status
| STATS transitions = COUNT() BY entity.key, rule.id
| WHERE transitions > 1
| EVAL alert.flapping = true
```

### Supporting Changes for Testing

To enable robust testing of the chosen approach (Approach 2), the `kbn-data-forge` tool has been enhanced:

*   **Duration-Based Schedules:** A new scheduling mechanism allows for creating cyclical data patterns. Instead of fixed start/end times, a schedule can be defined as a sequence of states, each with a `duration`.
*   **Looping:** A `--loop-schedule` flag has been added to allow these schedules to run indefinitely, making it easier to observe flapping behavior over time.

### How to Test

This feature can be tested by using the new data forge capabilities to generate a flapping data pattern and creating an ESQL rule to monitor it.

1.  **Generate Flapping Data:**
    Run the new example configuration, which alternates between "good" and "bad" states every 5 minutes.
    ```bash
    node x-pack/platform/packages/shared/kbn-data-forge/bin/kbn-data-forge.js --config x-pack/platform/packages/shared/kbn-data-forge/example_config/flapping_data.yaml --loop-schedule
    ```

2.  **Create an ESQL Rule:**
   Create an ESQL for the source data, then also create an ESQL rule using the query from **Approach 2** above for flapping detection. Alternatively, you can use the [exported Kibana saved objects](https://p.elstc.co/paste/36cZPRqb#M0UIlEDGEkfpcVuI5q-nFke1Hu7/3fwjZdA2rfQP5GN) by importing them into your cluster. This will create two 3 test rules, one source rule and two flapping detection rules using approach 1 and 2.

3.  **Verify Behavior:**
    *   Observe the alerts generated by the rule. You can do this in the imported discover session.
    *   As the data flaps, you should see alert documents appended with the `alert.flapping` field `true`.

## Next Steps

Up next is testing the query that joins the flapping data with the original source alerts. 
