### PR TITLE
[SecuritySolution] Fix Entity Highlight undefined Identifier bug

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_details/entity_details_highlights_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_details/entity_details_highlights_service.ts
@@ -250,7 +250,18 @@ export const entityDetailsHighlightsServiceFactory = ({
       );
       return { vulnerabilitiesAnonymized, vulnerabilitiesTotal };
     },
-    getLocalReplacements() {
+    getLocalReplacements(entityField: EntityIdentifierFields, entityIdentifier: string) {
+      // Ensure the entity identifier is present in the replacements
+      const anonymizedEntityIdentifier = getAnonymizedData({
+        anonymizationFields,
+        currentReplacements: {},
+        rawData: { [entityField]: [entityIdentifier] },
+        getAnonymizedValue,
+        getAnonymizedValues,
+      });
+
+      localOnNewReplacements(anonymizedEntityIdentifier.replacements);
+
       return localReplacements;
     },
   };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_details/routes/entity_details_highlight.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_details/routes/entity_details_highlight.ts
@@ -127,7 +127,7 @@ export const entityDetailsHighlightsRoute = (
                 vulnerabilitiesTotal, // Prevents the UI from displaying the wrong number of vulnerabilities
                 anomalies: anomaliesAnonymized,
               },
-              replacements: getLocalReplacements(),
+              replacements: getLocalReplacements(entityField, entityIdentifier),
               prompt,
             },
           });

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_details/trial_license_complete_tier/highlights.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/entity_details/trial_license_complete_tier/highlights.ts
@@ -304,7 +304,7 @@ export default function ({ getService }: FtrProviderContext) {
         },
         anomalies: [],
       });
-      expect(body.replacements).toEqual(expect.any(Object));
+      expect(Object.values(body.replacements)).toEqual(['un-existent-host']);
       expect(body.prompt).toContain('Generate markdown text with most important information');
     });
 


### PR DESCRIPTION
## Summary

When clicking on "Generate Entity Highlight" for an entity that only has risk score data, we submitted the "Entity Identifier" as undefined. This could result in lower accuracy, and some models may even refuse to generate the summary.

<img width="500" height="588" alt="Image" src="https://github.com/user-attachments/assets/a93b7699-071d-44c2-bd42-d729f285c431" />

To fix it, I forced the "replacements" to always have the entity identifier.


## How to reproduce it?
* Enable 'entityDetailsHighlightsEnabled' experimental flag
* Add user events
* Create Alerts
* Enable risk engine
* Open the flyout for a user and generate the highlight
* Check the network tab of your browser for the AI prompt 


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



