### PR TITLE
[8.19] [Discover][APM] Fix message warning not appearing from context (#242173)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_waterfall_context.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_waterfall_context.tsx
@@ -65,7 +65,7 @@ export function TraceWaterfallContextProvider({
   getRelatedErrorsHref?: IWaterfallGetRelatedErrorsHref;
   isEmbeddable: boolean;
 }) {
-  const { duration, traceWaterfall, maxDepth, rootItem, traceState } = useTraceWaterfall({
+  const { duration, traceWaterfall, maxDepth, rootItem, traceState, message } = useTraceWaterfall({
     traceItems,
   });
 
@@ -90,6 +90,7 @@ export function TraceWaterfallContextProvider({
         scrollElement,
         getRelatedErrorsHref,
         isEmbeddable,
+        message,
       }}
     >
       {children}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover][APM] Fix message warning not appearing from context (#242173)](https://github.com/elastic/kibana/pull/242173)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gonçalo Rica Pais da Silva","email":"goncalo.rica@elastic.co"},"sourceCommit":{"committedDate":"2025-11-07T09:06:18Z","message":"[Discover][APM] Fix message warning not appearing from context (#242173)\n\n## Summary\n\nFixes the warning messages not appearing in the Unified Trace Waterfall,\nas it wasn't getting passed into the context correctly.\n\n<img width=\"475\" height=\"193\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f35d4a99-2b74-4f54-9cf0-16902d95bbe0\"\n/>\n\n## How to test\n\n- Go to Discover whilst on Observability space, select an OTEL traces\nindex in either classic or ES|QL mode\n- Open a trace document and view the overview, find until you get a\ntrace with partial/incomplete data.\n- The warning should show in full on the focused trace waterfall, and on\nthe full trace waterfall","sha":"698bc828630f25a82afc556b739e87177577a1f7","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.3.0","v8.19.7","v9.1.7","v9.2.1"],"title":"[Discover][APM] Fix message warning not appearing from context","number":242173,"url":"https://github.com/elastic/kibana/pull/242173","mergeCommit":{"message":"[Discover][APM] Fix message warning not appearing from context (#242173)\n\n## Summary\n\nFixes the warning messages not appearing in the Unified Trace Waterfall,\nas it wasn't getting passed into the context correctly.\n\n<img width=\"475\" height=\"193\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f35d4a99-2b74-4f54-9cf0-16902d95bbe0\"\n/>\n\n## How to test\n\n- Go to Discover whilst on Observability space, select an OTEL traces\nindex in either classic or ES|QL mode\n- Open a trace document and view the overview, find until you get a\ntrace with partial/incomplete data.\n- The warning should show in full on the focused trace waterfall, and on\nthe full trace waterfall","sha":"698bc828630f25a82afc556b739e87177577a1f7"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/242173","number":242173,"mergeCommit":{"message":"[Discover][APM] Fix message warning not appearing from context (#242173)\n\n## Summary\n\nFixes the warning messages not appearing in the Unified Trace Waterfall,\nas it wasn't getting passed into the context correctly.\n\n<img width=\"475\" height=\"193\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/f35d4a99-2b74-4f54-9cf0-16902d95bbe0\"\n/>\n\n## How to test\n\n- Go to Discover whilst on Observability space, select an OTEL traces\nindex in either classic or ES|QL mode\n- Open a trace document and view the overview, find until you get a\ntrace with partial/incomplete data.\n- The warning should show in full on the focused trace waterfall, and on\nthe full trace waterfall","sha":"698bc828630f25a82afc556b739e87177577a1f7"}},{"branch":"8.19","label":"v8.19.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/242232","number":242232,"state":"MERGED","mergeCommit":{"sha":"b818b6351fb00bf2c921e5b3f4fea18ed6781190","message":"[9.2] [Discover][APM] Fix message warning not appearing from context (#242173) (#242232)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Discover][APM] Fix message warning not appearing from context\n(#242173)](https://github.com/elastic/kibana/pull/242173)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Gonçalo Rica Pais da Silva <goncalo.rica@elastic.co>"}}]}] BACKPORT-->