### PR TITLE
[Background search] Delay enabling button to prevent flickering

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.test.tsx
@@ -309,7 +309,9 @@ describe('QueryBarTopRowTopRow', () => {
             )
           );
 
-          await user.click(getByTestId('queryCancelButton-secondary-button'));
+          const button = getByTestId('queryCancelButton-secondary-button');
+          await waitFor(() => expect(button).toBeEnabled(), { timeout: 1000 });
+          await user.click(button);
 
           // Then
           expect(onSendToBackground).toHaveBeenCalled();

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -12,7 +12,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import useObservable from 'react-use/lib/useObservable';
 import classNames from 'classnames';
 import deepEqual from 'fast-deep-equal';
-import { EMPTY } from 'rxjs';
+import { EMPTY, delay, mergeMap, of } from 'rxjs';
 import { map } from 'rxjs';
 import { throttle } from 'lodash';
 
@@ -331,7 +331,15 @@ export const QueryBarTopRow = React.memo(
 
     const isQueryLangSelected = props.query && !isOfQueryType(props.query);
 
-    const backgroundSearchState = useObservable(data.search.session.state$);
+    const backgroundSearchState = useObservable(
+      data.search.session.state$.pipe(
+        mergeMap((state) => {
+          // We want to delay enabling the button to avoid flickering when searches are quick
+          if (state === SearchSessionState.Loading) return of(state).pipe(delay(500));
+          return of(state);
+        })
+      )
+    );
     const canSendToBackground =
       backgroundSearchState === SearchSessionState.Loading && !isSendingToBackground;
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/242226

Delays enabling the send to background button to prevent flickering when fast searches happen.

| Before | After |
|--------|------|
| ![chrome-capture-2025-11-10 (2)](https://github.com/user-attachments/assets/d32696b1-c0dc-42cc-a18a-3171f3825bc5) | ![chrome-capture-2025-11-10](https://github.com/user-attachments/assets/269f71e8-a045-410d-be74-11212ced37ba) |
| ![chrome-capture-2025-11-10 (3)](https://github.com/user-attachments/assets/295c5e7c-7dea-4a82-94e9-2ff32101dfe2) | ![chrome-capture-2025-11-10 (1)](https://github.com/user-attachments/assets/49fd82af-4e5f-4551-a2a6-7b4113e16f46) |

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->