### PR TITLE
[9.2] [Metrics][Discover] Change the fields count loading indicator (#241920)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_experience_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/metrics_experience_grid.tsx
@@ -135,18 +135,28 @@ export const MetricsExperienceGrid = ({
             direction="row"
           >
             <EuiFlexItem grow={false}>
-              {isFieldsLoading ? (
-                <EuiLoadingSpinner size="s" />
-              ) : (
-                <EuiText size="s">
-                  <strong>
-                    {i18n.translate('metricsExperience.grid.metricsCount.label', {
-                      defaultMessage: '{count} {count, plural, one {metric} other {metrics}}',
-                      values: { count: filteredFieldsBySearch.length },
-                    })}
-                  </strong>
-                </EuiText>
-              )}
+              <EuiFlexGroup
+                justifyContent="spaceBetween"
+                alignItems="center"
+                responsive={false}
+                gutterSize="s"
+              >
+                <EuiFlexItem grow={false}>
+                  <EuiText size="s">
+                    <strong>
+                      {i18n.translate('metricsExperience.grid.metricsCount.label', {
+                        defaultMessage: '{count} {count, plural, one {metric} other {metrics}}',
+                        values: { count: filteredFieldsBySearch.length },
+                      })}
+                    </strong>
+                  </EuiText>
+                </EuiFlexItem>
+                {isFieldsLoading && (
+                  <EuiFlexItem grow={false}>
+                    <EuiLoadingSpinner size="s" />
+                  </EuiFlexItem>
+                )}
+              </EuiFlexGroup>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiBetaBadge


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Metrics][Discover] Change the fields count loading indicator (#241920)](https://github.com/elastic/kibana/pull/241920)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-11-07T08:36:38Z","message":"[Metrics][Discover] Change the fields count loading indicator (#241920)\n\ncloses [#240939](https://github.com/elastic/kibana/issues/240939)\n\n## Summary\n\nThis PR updates the loading indicator for the field count. Instead of\ndisplaying the count only after all requests have completed, it now\nshows the count as soon as any data becomes available.\n\n\n\n![loading_indicator](https://github.com/user-attachments/assets/c56f91c1-e886-4270-8efe-bdfe140e17ed)\n\n>[!NOTE]\n> When **reloading** the grid, the field count may take a few seconds to\nupdate from the previously known value to the new one. This happens\nbecause the grid preserves the currently loaded data while new requests\nare still in progress.\n\n\n### How to test\n- Start a local Kibana instance and point it to an oblt cluster - the\nbug is more likely to occur when the performance is worse\n```yml\nfeature_flags.overrides:\n  metricsExperienceEnabled: true\n ```\n- Navigate to Discover and Switch to ESQL mode\n- Click on refresh\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"968d4ac1ce9d9ec2e379b95a9452865dba6b3eef","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.2.0","v9.3.0"],"title":"[Metrics][Discover] Change the fields count loading indicator","number":241920,"url":"https://github.com/elastic/kibana/pull/241920","mergeCommit":{"message":"[Metrics][Discover] Change the fields count loading indicator (#241920)\n\ncloses [#240939](https://github.com/elastic/kibana/issues/240939)\n\n## Summary\n\nThis PR updates the loading indicator for the field count. Instead of\ndisplaying the count only after all requests have completed, it now\nshows the count as soon as any data becomes available.\n\n\n\n![loading_indicator](https://github.com/user-attachments/assets/c56f91c1-e886-4270-8efe-bdfe140e17ed)\n\n>[!NOTE]\n> When **reloading** the grid, the field count may take a few seconds to\nupdate from the previously known value to the new one. This happens\nbecause the grid preserves the currently loaded data while new requests\nare still in progress.\n\n\n### How to test\n- Start a local Kibana instance and point it to an oblt cluster - the\nbug is more likely to occur when the performance is worse\n```yml\nfeature_flags.overrides:\n  metricsExperienceEnabled: true\n ```\n- Navigate to Discover and Switch to ESQL mode\n- Click on refresh\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"968d4ac1ce9d9ec2e379b95a9452865dba6b3eef"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241920","number":241920,"mergeCommit":{"message":"[Metrics][Discover] Change the fields count loading indicator (#241920)\n\ncloses [#240939](https://github.com/elastic/kibana/issues/240939)\n\n## Summary\n\nThis PR updates the loading indicator for the field count. Instead of\ndisplaying the count only after all requests have completed, it now\nshows the count as soon as any data becomes available.\n\n\n\n![loading_indicator](https://github.com/user-attachments/assets/c56f91c1-e886-4270-8efe-bdfe140e17ed)\n\n>[!NOTE]\n> When **reloading** the grid, the field count may take a few seconds to\nupdate from the previously known value to the new one. This happens\nbecause the grid preserves the currently loaded data while new requests\nare still in progress.\n\n\n### How to test\n- Start a local Kibana instance and point it to an oblt cluster - the\nbug is more likely to occur when the performance is worse\n```yml\nfeature_flags.overrides:\n  metricsExperienceEnabled: true\n ```\n- Navigate to Discover and Switch to ESQL mode\n- Click on refresh\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"968d4ac1ce9d9ec2e379b95a9452865dba6b3eef"}}]}] BACKPORT-->