### PR TITLE
[Security Solution] rename detections sourcererscope to alerts to prepare the new attacks page

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/app/home/global_header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/home/global_header/index.tsx
@@ -16,7 +16,7 @@ import { createHtmlPortalNode, InPortal, OutPortal } from 'react-reverse-portal'
 import { i18n } from '@kbn/i18n';
 
 import { toMountPoint } from '@kbn/react-kibana-mount';
-import { DataViewManagerScopeName } from '../../../data_view_manager/constants';
+import { PageScope } from '../../../data_view_manager/constants';
 import { SECURITY_FEATURE_ID } from '../../../../common';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { MlPopover } from '../../../common/components/ml_popover/ml_popover';
@@ -87,10 +87,7 @@ export const GlobalHeader = React.memo(() => {
   }, [portalNode, setHeaderActionMenu, theme, kibanaServiceI18n, dashboardViewPath]);
 
   const dataViewPicker = newDataViewPickerEnabled ? (
-    <DataViewPicker
-      scope={sourcererScope}
-      disabled={sourcererScope === DataViewManagerScopeName.alerts}
-    />
+    <DataViewPicker scope={sourcererScope} disabled={sourcererScope === PageScope.alerts} />
   ) : (
     <Sourcerer scope={sourcererScope} data-test-subj="sourcerer" />
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/app/home/global_header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/home/global_header/index.tsx
@@ -21,7 +21,7 @@ import { SECURITY_FEATURE_ID } from '../../../../common';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { MlPopover } from '../../../common/components/ml_popover/ml_popover';
 import { useKibana } from '../../../common/lib/kibana';
-import { isDetectionsPath, isDashboardViewPath } from '../../../helpers';
+import { isDashboardViewPath, isDetectionsPath } from '../../../helpers';
 import { Sourcerer } from '../../../sourcerer/components';
 import { TimelineId } from '../../../../common/types/timeline';
 import { timelineDefaults } from '../../../timelines/store/defaults';
@@ -89,7 +89,7 @@ export const GlobalHeader = React.memo(() => {
   const dataViewPicker = newDataViewPickerEnabled ? (
     <DataViewPicker
       scope={sourcererScope}
-      disabled={sourcererScope === DataViewManagerScopeName.detections}
+      disabled={sourcererScope === DataViewManagerScopeName.alerts}
     />
   ) : (
     <Sourcerer scope={sourcererScope} data-test-subj="sourcerer" />

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/send_to_timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/send_to_timeline/index.tsx
@@ -12,14 +12,14 @@ import type { Filter } from '@kbn/es-query';
 import { useDispatch, useSelector } from 'react-redux';
 import { css } from '@emotion/react';
 import { useAssistantContext } from '@kbn/elastic-assistant';
+import { PageScope } from '../../data_view_manager/constants';
 import { extractTimelineCapabilities } from '../../common/utils/timeline_capabilities';
 import { sourcererSelectors } from '../../common/store';
 import { sourcererActions } from '../../common/store/actions';
 import { inputsActions } from '../../common/store/inputs';
 import { InputsModelId } from '../../common/store/inputs/constants';
 import type { TimeRange } from '../../common/store/inputs/model';
-import { SourcererScopeName } from '../../sourcerer/store/model';
-import { TimelineTabs, TimelineId } from '../../../common/types/timeline';
+import { TimelineId, TimelineTabs } from '../../../common/types/timeline';
 import {
   ACTION_CANNOT_INVESTIGATE_IN_TIMELINE,
   ACTION_INVESTIGATE_IN_TIMELINE,
@@ -64,10 +64,10 @@ export const SendToTimelineButton: FC<PropsWithChildren<SendToTimelineButtonProp
   const [isTimelineBottomBarVisible] = useShowTimeline();
   const { discoverStateContainer, defaultDiscoverAppState } = useDiscoverInTimelineContext();
 
-  const { dataViewId: oldTimelineDataViewId } = useSourcererDataView(SourcererScopeName.timeline);
+  const { dataViewId: oldTimelineDataViewId } = useSourcererDataView(PageScope.timeline);
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
+  const { dataView: experimentalDataView } = useDataView(PageScope.timeline);
 
   const timelineDataViewId = newDataViewPickerEnabled
     ? experimentalDataView.id ?? null
@@ -229,7 +229,7 @@ export const SendToTimelineButton: FC<PropsWithChildren<SendToTimelineButtonProp
       if (!keepDataView) {
         dispatch(
           sourcererActions.setSelectedDataView({
-            id: SourcererScopeName.timeline,
+            id: PageScope.timeline,
             selectedDataViewId: defaultDataView.id,
             selectedPatterns: [signalIndexName || ''],
           })

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ease/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ease/table.tsx
@@ -12,7 +12,7 @@ import type { PackageListItem } from '@kbn/fleet-plugin/common';
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { AlertsTableImperativeApi } from '@kbn/response-ops-alerts-table/types';
 import { useBrowserFields } from '../../../../../../../data_view_manager/hooks/use_browser_fields';
-import { DataViewManagerScopeName } from '../../../../../../../data_view_manager/constants';
+import { PageScope } from '../../../../../../../data_view_manager/constants';
 import type { AdditionalTableContext } from '../../../../../../../detections/components/alert_summary/table/table';
 import {
   ACTION_COLUMN_WIDTH,
@@ -71,7 +71,7 @@ export const Table = memo(({ dataView, id, packages, query }: TableProps) => {
     [application, cases, data, fieldFormats, http, licensing, notifications, settings]
   );
 
-  const browserFields = useBrowserFields(DataViewManagerScopeName.alerts, dataView);
+  const browserFields = useBrowserFields(PageScope.alerts, dataView);
 
   const additionalContext: AdditionalTableContext = useMemo(
     () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ease/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ease/table.tsx
@@ -71,7 +71,7 @@ export const Table = memo(({ dataView, id, packages, query }: TableProps) => {
     [application, cases, data, fieldFormats, http, licensing, notifications, settings]
   );
 
-  const browserFields = useBrowserFields(DataViewManagerScopeName.detections, dataView);
+  const browserFields = useBrowserFields(DataViewManagerScopeName.alerts, dataView);
 
   const additionalContext: AdditionalTableContext = useMemo(
     () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_selection_query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_selection_query/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { OnTimeChangeProps, EuiSuperUpdateButtonProps } from '@elastic/eui';
+import type { EuiSuperUpdateButtonProps, OnTimeChangeProps } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiSuperDatePicker, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { FilterManager } from '@kbn/data-plugin/public';
@@ -14,11 +14,11 @@ import type { Filter, Query } from '@kbn/es-query';
 import { debounce } from 'lodash/fp';
 import React, { useCallback, useMemo } from 'react';
 
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { getCommonTimeRanges } from '../helpers/get_common_time_ranges';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import { useCreateDataView } from '../../../../../common/hooks/use_create_data_view';
 import type { AlertsSelectionSettings } from '../../types';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
@@ -51,11 +51,11 @@ const AlertSelectionQueryComponent: React.FC<Props> = ({
   const { euiTheme } = useEuiTheme();
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.alerts);
+  const { dataView: experimentalDataView, status } = useDataView(PageScope.alerts);
 
   // get the sourcerer `DataViewSpec` for alerts:
   const { sourcererDataView: oldSourcererDataViewSpec, loading: oldIsLoadingIndexPattern } =
-    useSourcererDataView(SourcererScopeName.alerts);
+    useSourcererDataView(PageScope.alerts);
 
   // create a `DataView` from the `DataViewSpec`:
   const { dataView: oldDataView, loading: oldIsLoadingDataView } = useCreateDataView({

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_selection_query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_selection_query/index.tsx
@@ -51,11 +51,11 @@ const AlertSelectionQueryComponent: React.FC<Props> = ({
   const { euiTheme } = useEuiTheme();
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.detections);
+  const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.alerts);
 
   // get the sourcerer `DataViewSpec` for alerts:
   const { sourcererDataView: oldSourcererDataViewSpec, loading: oldIsLoadingIndexPattern } =
-    useSourcererDataView(SourcererScopeName.detections);
+    useSourcererDataView(SourcererScopeName.alerts);
 
   // create a `DataView` from the `DataViewSpec`:
   const { dataView: oldDataView, loading: oldIsLoadingDataView } = useCreateDataView({

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { PreviewTab } from '.';
 import { useKibana } from '../../../../../common/lib/kibana';
@@ -170,7 +170,7 @@ describe('PreviewTab', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith({
       payload: {
-        id: 'detections',
+        id: 'alerts',
         selectedDataViewId: 'mock-signal-index',
         selectedPatterns: ['mock-signal-index'],
         shouldValidateSelectedPatterns: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.tsx
@@ -7,9 +7,9 @@
 
 import {
   EuiButtonEmpty,
+  EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiEmptyPrompt,
   EuiSpacer,
   EuiText,
   useEuiTheme,
@@ -30,7 +30,6 @@ import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import * as i18n from '../translations';
 import type { Sorting } from '../types';
 
-export const ATTACK_DISCOVERY_SETTINGS_ALERTS_COUNT_ID = 'attack-discovery-settings-alerts-count';
 export const RESET_FIELD = 'kibana.alert.rule.name';
 
 const DEFAULT_DATA_TEST_SUBJ = 'previewTab';
@@ -162,7 +161,7 @@ const PreviewTabComponent = ({
       // action to have any effect.
       dispatch(
         sourcererActions.setSelectedDataView({
-          id: SourcererScopeName.detections,
+          id: SourcererScopeName.alerts,
           selectedDataViewId: signalIndexName,
           selectedPatterns: [signalIndexName],
           shouldValidateSelectedPatterns: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.tsx
@@ -20,13 +20,13 @@ import { isEmpty } from 'lodash/fp';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useEuiComboBoxReset } from '../../../../../common/components/use_combo_box_reset';
 import { StackByComboBox } from '../../../../../detections/components/alerts_kpis/common/components';
 import { useSignalIndex } from '../../../../../detections/containers/detection_engine/alerts/use_signal_index';
 import type { LensAttributes } from '../../../../../common/components/visualization_actions/types';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { sourcererActions } from '../../../../../sourcerer/store';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import * as i18n from '../translations';
 import type { Sorting } from '../types';
 
@@ -161,7 +161,7 @@ const PreviewTabComponent = ({
       // action to have any effect.
       dispatch(
         sourcererActions.setSelectedDataView({
-          id: SourcererScopeName.alerts,
+          id: PageScope.alerts,
           selectedDataViewId: signalIndexName,
           selectedPatterns: [signalIndexName],
           shouldValidateSelectedPatterns: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.tsx
@@ -19,7 +19,7 @@ import {
 import { useAssistantContext, useLoadConnectors } from '@kbn/elastic-assistant';
 import React, { useCallback, useState } from 'react';
 
-import { DataViewManagerScopeName } from '../../../../../data_view_manager/constants';
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { ConfirmationModal } from '../confirmation_modal';
@@ -65,7 +65,7 @@ export const CreateFlyout: React.FC<Props> = React.memo(({ onClose }) => {
   });
 
   const { sourcererDataView } = useSourcererDataView();
-  const { dataView: experimentalDataView } = useDataView(DataViewManagerScopeName.alerts);
+  const { dataView: experimentalDataView } = useDataView(PageScope.alerts);
 
   const { mutateAsync: createAttackDiscoverySchedule, isLoading: isLoadingQuery } =
     useCreateAttackDiscoverySchedule();

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.tsx
@@ -65,7 +65,7 @@ export const CreateFlyout: React.FC<Props> = React.memo(({ onClose }) => {
   });
 
   const { sourcererDataView } = useSourcererDataView();
-  const { dataView: experimentalDataView } = useDataView(DataViewManagerScopeName.detections);
+  const { dataView: experimentalDataView } = useDataView(DataViewManagerScopeName.alerts);
 
   const { mutateAsync: createAttackDiscoverySchedule, isLoading: isLoadingQuery } =
     useCreateAttackDiscoverySchedule();

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/definition/filters.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/definition/filters.tsx
@@ -23,11 +23,11 @@ interface FiltersProps {
 
 export const Filters: React.FC<FiltersProps> = React.memo(({ filters }) => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.detections);
+  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
 
   // get the sourcerer `DataViewSpec` for alerts:
   const { sourcererDataView: oldSourcererDataView, loading: oldIsLoadingIndexPattern } =
-    useSourcererDataView(SourcererScopeName.detections);
+    useSourcererDataView(SourcererScopeName.alerts);
 
   // create a `DataView` from the `DataViewSpec`:
   const { dataView: oldDataView } = useCreateDataView({

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/definition/filters.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/definition/filters.tsx
@@ -11,8 +11,8 @@ import { mapAndFlattenFilters } from '@kbn/data-plugin/public';
 import type { Filter } from '@kbn/es-query';
 import { FilterItems } from '@kbn/unified-search-plugin/public';
 
+import { PageScope } from '../../../../../../data_view_manager/constants';
 import { useDataView } from '../../../../../../data_view_manager/hooks/use_data_view';
-import { SourcererScopeName } from '../../../../../../sourcerer/store/model';
 import { useSourcererDataView } from '../../../../../../sourcerer/containers';
 import { useCreateDataView } from '../../../../../../common/hooks/use_create_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../../../../../common/hooks/use_experimental_features';
@@ -23,11 +23,11 @@ interface FiltersProps {
 
 export const Filters: React.FC<FiltersProps> = React.memo(({ filters }) => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
+  const { dataView: experimentalDataView } = useDataView(PageScope.alerts);
 
   // get the sourcerer `DataViewSpec` for alerts:
   const { sourcererDataView: oldSourcererDataView, loading: oldIsLoadingIndexPattern } =
-    useSourcererDataView(SourcererScopeName.alerts);
+    useSourcererDataView(PageScope.alerts);
 
   // create a `DataView` from the `DataViewSpec`:
   const { dataView: oldDataView } = useCreateDataView({

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.tsx
@@ -85,7 +85,7 @@ export const DetailsFlyout: React.FC<Props> = React.memo(({ scheduleId, onClose 
     });
 
   const { sourcererDataView } = useSourcererDataView();
-  const { dataView: experimentalDataView } = useDataView(DataViewManagerScopeName.detections);
+  const { dataView: experimentalDataView } = useDataView(DataViewManagerScopeName.alerts);
 
   const [isEditing, setIsEditing] = useState(false);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.tsx
@@ -43,7 +43,7 @@ import { ScheduleDefinition } from './definition';
 import { Header } from './header';
 import { ScheduleExecutionLogs } from './execution_logs';
 import { convertFormDataInBaseSchedule } from '../utils/convert_form_data';
-import { DataViewManagerScopeName } from '../../../../../data_view_manager/constants';
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { WithMissingPrivileges } from '../missing_privileges';
 
 interface Props {
@@ -85,7 +85,7 @@ export const DetailsFlyout: React.FC<Props> = React.memo(({ scheduleId, onClose 
     });
 
   const { sourcererDataView } = useSourcererDataView();
-  const { dataView: experimentalDataView } = useDataView(DataViewManagerScopeName.alerts);
+  const { dataView: experimentalDataView } = useDataView(PageScope.alerts);
 
   const [isEditing, setIsEditing] = useState(false);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/ease/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/ease/table.tsx
@@ -78,7 +78,7 @@ export const Table = memo(({ dataView, id, onLoaded, packages, query }: TablePro
     [application, cases, data, fieldFormats, http, licensing, notifications, settings]
   );
 
-  const browserFields = useBrowserFields(DataViewManagerScopeName.detections, dataView);
+  const browserFields = useBrowserFields(DataViewManagerScopeName.alerts, dataView);
 
   const additionalContext: AdditionalTableContext = useMemo(() => ({ packages }), [packages]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/ease/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/ease/table.tsx
@@ -18,7 +18,7 @@ import { useKibana } from '../../../common/lib/kibana';
 import { ActionsCell } from '../../../detections/components/alert_summary/table/actions_cell';
 import { CellValue } from '../../../detections/components/alert_summary/table/render_cell';
 import { useBrowserFields } from '../../../data_view_manager/hooks/use_browser_fields';
-import { DataViewManagerScopeName } from '../../../data_view_manager/constants';
+import { PageScope } from '../../../data_view_manager/constants';
 import type { AdditionalTableContext } from '../../../detections/components/alert_summary/table/table';
 import {
   ACTION_COLUMN_WIDTH,
@@ -78,7 +78,7 @@ export const Table = memo(({ dataView, id, onLoaded, packages, query }: TablePro
     [application, cases, data, fieldFormats, http, licensing, notifications, settings]
   );
 
-  const browserFields = useBrowserFields(DataViewManagerScopeName.alerts, dataView);
+  const browserFields = useBrowserFields(PageScope.alerts, dataView);
 
   const additionalContext: AdditionalTableContext = useMemo(() => ({ packages }), [packages]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/pages/use_fetch_alert_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/pages/use_fetch_alert_data.ts
@@ -7,8 +7,8 @@
 
 import { useMemo } from 'react';
 import type { Ecs } from '@kbn/cases-plugin/common';
+import { PageScope } from '../../data_view_manager/constants';
 import { useSourcererDataView } from '../../sourcerer/containers';
-import { SourcererScopeName } from '../../sourcerer/store/model';
 import { useQueryAlerts } from '../../detections/containers/detection_engine/alerts/use_query';
 import { ALERTS_QUERY_NAMES } from '../../detections/containers/detection_engine/alerts/constants';
 import type { SignalHit } from '../../common/utils/alerts';
@@ -17,11 +17,11 @@ import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experime
 import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_patterns';
 
 export const useFetchAlertData = (alertIds: string[]): [boolean, Record<string, unknown>] => {
-  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(SourcererScopeName.alerts);
+  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(PageScope.alerts);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.alerts);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.alerts);
   const selectedPatterns = newDataViewPickerEnabled
     ? experimentalSelectedPatterns
     : oldSelectedPatterns;

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/pages/use_fetch_alert_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/pages/use_fetch_alert_data.ts
@@ -17,13 +17,11 @@ import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experime
 import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_patterns';
 
 export const useFetchAlertData = (alertIds: string[]): [boolean, Record<string, unknown>] => {
-  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(
-    SourcererScopeName.detections
-  );
+  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(SourcererScopeName.alerts);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.detections);
+  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.alerts);
   const selectedPatterns = newDataViewPickerEnabled
     ? experimentalSelectedPatterns
     : oldSelectedPatterns;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/cell_actions/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/cell_actions/index.tsx
@@ -5,18 +5,18 @@
  * 2.0.
  */
 
-import { CellActions, useDataGridColumnsCellActions } from '@kbn/cell-actions';
 import type {
   CellActionsProps,
   UseDataGridColumnsCellActions,
   UseDataGridColumnsCellActionsProps,
 } from '@kbn/cell-actions';
+import { CellActions, useDataGridColumnsCellActions } from '@kbn/cell-actions';
 import React, { useMemo } from 'react';
 import type { CellActionFieldValue, CellActionsData } from '@kbn/cell-actions/src/types';
 import type { EuiButtonIconProps } from '@elastic/eui';
+import { PageScope } from '../../../data_view_manager/constants';
 import type { SecurityCellActionMetadata } from '../../../app/actions/types';
 import { SecurityCellActionsTrigger, SecurityCellActionType } from '../../../app/actions/constants';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useGetFieldSpec } from '../../hooks/use_get_field_spec';
 import { useDataViewId } from '../../hooks/use_data_view_id';
 import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
@@ -40,7 +40,7 @@ export interface SecurityCellActionsData {
 
 export interface SecurityCellActionsProps
   extends Omit<CellActionsProps, 'data' | 'metadata' | 'disabledActionTypes' | 'triggerId'> {
-  sourcererScopeId?: SourcererScopeName;
+  sourcererScopeId?: PageScope;
   data: SecurityCellActionsData | SecurityCellActionsData[];
   triggerId: SecurityCellActionsTrigger;
   disabledActionTypes?: SecurityCellActionType[];
@@ -60,7 +60,7 @@ export const useDataGridColumnsSecurityCellActions: UseDataGridColumnsCellAction
   useDataGridColumnsCellActions;
 
 export const SecurityCellActions: React.FC<SecurityCellActionsProps> = ({
-  sourcererScopeId = SourcererScopeName.default,
+  sourcererScopeId = PageScope.default,
   data,
   metadata,
   children,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/events_tab/events_query_tab_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/events_tab/events_query_tab_body.tsx
@@ -12,6 +12,7 @@ import { EuiCheckbox } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
 import type { TableId } from '@kbn/securitysolution-data-table';
 import { dataTableActions } from '@kbn/securitysolution-data-table';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useBulkAddEventsToCaseActions } from '../../../cases/components/case_events/use_bulk_event_actions';
 import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
 import type { CustomBulkAction } from '../../../../common/types';
@@ -30,7 +31,6 @@ import {
 import { getDefaultControlColumn } from '../../../timelines/components/timeline/body/control_columns';
 import { defaultRowRenderers } from '../../../timelines/components/timeline/body/renderers';
 import { DefaultCellRenderer } from '../../../timelines/components/timeline/cell_rendering/default_cell_renderer';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import type { GlobalTimeArgs } from '../../containers/use_global_time';
 import type { QueryTabBodyProps as UserQueryTabBodyProps } from '../../../explore/users/pages/navigation/types';
 import type { QueryTabBodyProps as HostQueryTabBodyProps } from '../../../explore/hosts/pages/navigation/types';
@@ -171,7 +171,7 @@ const EventsQueryTabBodyComponent: React.FC<EventsQueryTabBodyComponentProps> = 
     tableId,
     from: startDate,
     to: endDate,
-    scopeId: SourcererScopeName.default,
+    scopeId: PageScope.default,
   }) as CustomBulkAction;
 
   const caseEventsBulkActions = useBulkAddEventsToCaseActions({
@@ -195,9 +195,7 @@ const EventsQueryTabBodyComponent: React.FC<EventsQueryTabBodyComponentProps> = 
           filterQuery={filterQuery}
           {...(showExternalAlerts ? alertsHistogramConfig : eventsHistogramConfig)}
           subtitle={getHistogramSubtitle}
-          sourcererScopeId={
-            newDataViewPickerEnabled ? SourcererScopeName.explore : SourcererScopeName.default
-          }
+          sourcererScopeId={newDataViewPickerEnabled ? PageScope.explore : PageScope.default}
         />
       )}
       <StatefulEventsViewer
@@ -208,9 +206,7 @@ const EventsQueryTabBodyComponent: React.FC<EventsQueryTabBodyComponentProps> = 
         leadingControlColumns={leadingControlColumns}
         renderCellValue={DefaultCellRenderer}
         rowRenderers={defaultRowRenderers}
-        sourcererScope={
-          newDataViewPickerEnabled ? SourcererScopeName.explore : SourcererScopeName.default
-        }
+        sourcererScope={newDataViewPickerEnabled ? PageScope.explore : PageScope.default}
         tableId={tableId}
         unit={showExternalAlerts ? i18n.EXTERNAL_ALERTS_UNIT : i18n.EVENTS_UNIT}
         defaultModel={defaultModel}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.test.tsx
@@ -15,7 +15,6 @@ import { mockEventViewerResponse } from './mock';
 import { type EventsViewerProps, StatefulEventsViewer } from '.';
 import { eventsDefaultModel } from './default_model';
 import { EntityType } from '@kbn/timelines-plugin/common';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { DefaultCellRenderer } from '../../../timelines/components/timeline/cell_rendering/default_cell_renderer';
 import { useTimelineEvents } from './use_timelines_events';
 import { getDefaultControlColumn } from '../../../timelines/components/timeline/body/control_columns';
@@ -23,6 +22,7 @@ import { defaultRowRenderers } from '../../../timelines/components/timeline/body
 import type { UseFieldBrowserOptionsProps } from '../../../timelines/components/fields_browser';
 import { TableId } from '@kbn/securitysolution-data-table';
 import { mount } from 'enzyme';
+import { PageScope } from '../../../data_view_manager/constants';
 
 jest.mock('../../lib/kibana');
 
@@ -62,7 +62,7 @@ const testProps: EventsViewerProps = {
   leadingControlColumns: getDefaultControlColumn(ACTION_BUTTON_COUNT),
   renderCellValue: DefaultCellRenderer,
   rowRenderers: defaultRowRenderers,
-  sourcererScope: SourcererScopeName.default,
+  sourcererScope: PageScope.default,
   start: from,
   tableId: TableId.test,
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -34,6 +34,7 @@ import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { EuiTheme } from '@kbn/kibana-react-plugin/common';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import type { PageScope } from '../../../data_view_manager/constants';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { InspectButton } from '../inspect';
 import type {
@@ -47,7 +48,6 @@ import type { RowRenderer, SortColumnTimeline as Sort } from '../../../../common
 import { InputsModelId } from '../../store/inputs/constants';
 import type { State } from '../../store';
 import { inputsActions } from '../../store/actions';
-import type { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useSourcererDataView } from '../../../sourcerer/containers';
 import type { CellValueElementProps } from '../../../timelines/components/timeline/cell_rendering';
 import { useKibana } from '../../lib/kibana';
@@ -82,7 +82,7 @@ export interface EventsViewerProps {
   pageFilters?: Filter[];
   renderCellValue: React.FC<CellValueElementProps>;
   rowRenderers: RowRenderer[];
-  sourcererScope: SourcererScopeName;
+  sourcererScope: PageScope;
   start: string;
   tableId: TableId;
   topRightMenuOptions?: React.ReactNode;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/modal.tsx
@@ -12,27 +12,27 @@ import {
   EuiIconTip,
   EuiModal,
   EuiModalBody,
+  EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
-  EuiModalFooter,
   EuiSpacer,
   EuiTabbedContent,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import numeral from '@elastic/numeral';
 import type { ReactNode } from 'react';
-import React, { useMemo, Fragment } from 'react';
+import React, { Fragment, useMemo } from 'react';
 import styled from '@emotion/styled';
 
 import { useLocation } from 'react-router-dom';
 import { isString } from 'lodash/fp';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useSelectedPatterns } from '../../../data_view_manager/hooks/use_selected_patterns';
 import type { InputsModelId } from '../../store/inputs/constants';
 import { NO_ALERT_INDEX } from '../../../../common/constants';
 import * as i18n from './translations';
 import { getScopeFromPath } from '../../../sourcerer/containers/sourcerer_paths';
 import { useSourcererDataView } from '../../../sourcerer/containers';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
 
 export interface ModalInspectProps {
@@ -130,8 +130,7 @@ export const ModalInspectQuery = ({
   title,
 }: ModalInspectProps) => {
   const { pathname } = useLocation();
-  const sourcererScope =
-    inputId === 'timeline' ? SourcererScopeName.timeline : getScopeFromPath(pathname);
+  const sourcererScope = inputId === 'timeline' ? PageScope.timeline : getScopeFromPath(pathname);
 
   const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(sourcererScope);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
@@ -5,29 +5,29 @@
  * 2.0.
  */
 
-import { pickBy, isEmpty } from 'lodash';
+import { isEmpty, pickBy } from 'lodash';
 import type { Plugin } from 'unified';
 import moment from 'moment';
-import React, { useContext, useMemo, useCallback, useState } from 'react';
-import type { RemarkTokenizer, EuiSelectProps } from '@elastic/eui';
+import React, { useCallback, useContext, useMemo, useState } from 'react';
+import type { EuiSelectProps, RemarkTokenizer } from '@elastic/eui';
 import {
-  EuiLoadingSpinner,
-  EuiIcon,
-  EuiSpacer,
-  EuiCallOut,
-  EuiCodeBlock,
-  EuiModalHeader,
-  EuiModalHeaderTitle,
-  EuiModalBody,
-  EuiModalFooter,
   EuiButton,
   EuiButtonEmpty,
-  EuiForm,
-  EuiFormRow,
+  EuiCallOut,
+  EuiCodeBlock,
   EuiFieldText,
-  EuiSelect,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiForm,
+  EuiFormRow,
+  EuiIcon,
+  EuiLoadingSpinner,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSelect,
+  EuiSpacer,
   EuiToolTip,
 } from '@elastic/eui';
 import numeral from '@elastic/numeral';
@@ -36,26 +36,26 @@ import type { EuiMarkdownEditorUiPluginEditorProps } from '@elastic/eui/src/comp
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { Filter } from '@kbn/es-query';
 import { FilterStateStore } from '@kbn/es-query';
-import { useForm, FormProvider, useController } from 'react-hook-form';
+import { FormProvider, useController, useForm } from 'react-hook-form';
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../../../hooks/use_experimental_features';
 import { useUpsellingMessage } from '../../../../hooks/use_upselling';
 import { useAppToasts } from '../../../../hooks/use_app_toasts';
 import { useKibana } from '../../../../lib/kibana';
 import { useInsightQuery } from './use_insight_query';
-import { useInsightDataProviders, type Provider } from './use_insight_data_providers';
+import { type Provider, useInsightDataProviders } from './use_insight_data_providers';
 import { BasicAlertDataContext } from '../../../../../flyout/document_details/left/components/investigation_guide_view';
 import { InvestigateInTimelineButton } from '../../../event_details/investigate_in_timeline_button';
 import {
-  getTimeRangeSettings,
-  parseDateWithDefault,
   DEFAULT_FROM_MOMENT,
   DEFAULT_TO_MOMENT,
+  getTimeRangeSettings,
+  parseDateWithDefault,
 } from '../../../../utils/default_date_settings';
 import type { TimeRange } from '../../../../store/inputs/model';
 import { DEFAULT_TIMEPICKER_QUICK_RANGES } from '../../../../../../common/constants';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import { filtersToInsightProviders } from './provider';
 import { useLicense } from '../../../../hooks/use_license';
 import { isProviderValid } from './helpers';
@@ -284,13 +284,11 @@ const InsightEditorComponent = ({
 }: EuiMarkdownEditorUiPluginEditorProps<InsightComponentProps & { relativeTimerange: string }>) => {
   const isEditMode = node != null;
 
-  const { sourcererDataView: oldSourcererDataView } = useSourcererDataView(
-    SourcererScopeName.default
-  );
+  const { sourcererDataView: oldSourcererDataView } = useSourcererDataView(PageScope.default);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.default);
+  const { dataView: experimentalDataView } = useDataView(PageScope.default);
   const dataViewName = newDataViewPickerEnabled
     ? experimentalDataView.name
     : oldSourcererDataView.name;
@@ -303,7 +301,7 @@ const InsightEditorComponent = ({
   } = useKibana().services;
 
   const oldDataView = useGetScopedSourcererDataView({
-    sourcererScope: SourcererScopeName.default,
+    sourcererScope: PageScope.default,
   });
 
   const dataView = newDataViewPickerEnabled ? experimentalDataView : oldDataView;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
@@ -10,13 +10,13 @@ import type { Filter } from '@kbn/es-query';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { DataProvider } from '@kbn/timelines-plugin/common';
 import { DataLoadingState } from '@kbn/unified-data-table';
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../hooks/use_experimental_features';
 import { TimelineId } from '../../../../../../common/types/timeline';
 import { useKibana } from '../../../../lib/kibana';
 import { combineQueries } from '../../../../lib/kuery';
 import { useTimelineEvents } from '../../../../../timelines/containers';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import type { TimeRange } from '../../../../store/inputs/model';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import { useSelectedPatterns } from '../../../../../data_view_manager/hooks/use_selected_patterns';
@@ -50,13 +50,13 @@ export const useInsightQuery = ({
     selectedPatterns: oldSelectedPatterns,
     sourcererDataView: oldSourcererDataView,
     dataViewId: oldDataViewId,
-  } = useSourcererDataView(SourcererScopeName.timeline);
+  } = useSourcererDataView(PageScope.timeline);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
-  const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);
+  const { dataView: experimentalDataView } = useDataView(PageScope.timeline);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const experimentalBrowserFields = useBrowserFields(PageScope.timeline);
 
   const selectedPatterns = newDataViewPickerEnabled
     ? experimentalSelectedPatterns

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
@@ -5,26 +5,26 @@
  * 2.0.
  */
 
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import styled from '@emotion/styled';
 
 import { EuiFlexGroup, EuiFlexItem, EuiSelect, EuiSpacer } from '@elastic/eui';
 import { isString } from 'lodash/fp';
+import type { PageScope } from '../../../data_view_manager/constants';
 import * as i18n from './translations';
 import { HeaderSection } from '../header_section';
 import { Panel } from '../panel';
 
 import type {
+  MatrixHistogramConfigs,
   MatrixHistogramOption,
   MatrixHistogramQueryProps,
-  MatrixHistogramConfigs,
 } from './types';
 import { HoverVisibilityContainer } from '../hover_visibility_container';
 import { useQueryToggle } from '../../containers/query_toggle';
 import { VISUALIZATION_ACTIONS_BUTTON_CLASS } from '../visualization_actions/utils';
 import { VisualizationEmbeddable } from '../visualization_actions/visualization_embeddable';
 import { useVisualizationResponse } from '../visualization_actions/use_visualization_response';
-import type { SourcererScopeName } from '../../../sourcerer/store/model';
 import { NO_BREAKDOWN_STACK_BY_VALUE } from '../events_tab/histogram_configurations';
 
 export type MatrixHistogramComponentProps = MatrixHistogramQueryProps &
@@ -33,7 +33,7 @@ export type MatrixHistogramComponentProps = MatrixHistogramQueryProps &
     hideHistogramIfEmpty?: boolean;
     id: string;
     showSpacer?: boolean;
-    sourcererScopeId?: SourcererScopeName;
+    sourcererScopeId?: PageScope;
     hideQueryToggle?: boolean;
     applyGlobalQueriesAndFilters?: boolean;
   };

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/rule_actions_field/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/rule_actions_field/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { isEmpty } from 'lodash/fp';
-import { EuiSpacer, EuiCallOut, EuiText } from '@elastic/eui';
+import { EuiCallOut, EuiSpacer, EuiText } from '@elastic/eui';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import deepMerge from 'deepmerge';
 import ReactMarkdown from 'react-markdown';
@@ -27,6 +27,7 @@ import type {
 import { SecurityConnectorFeatureId } from '@kbn/actions-plugin/common';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { AlertConsumers } from '@kbn/rule-data-utils';
+import type { SavedObjectAttribute } from '@kbn/core-saved-objects-common/src/server_types';
 import { NOTIFICATION_DEFAULT_FREQUENCY } from '../../../../common/constants';
 import type { FieldHook } from '../../../shared_imports';
 import { useFormContext } from '../../../shared_imports';
@@ -34,8 +35,8 @@ import { useKibana } from '../../lib/kibana';
 import {
   FORM_CUSTOM_FREQUENCY_OPTION,
   FORM_ERRORS_TITLE,
-  FORM_ON_ACTIVE_ALERT_OPTION,
   FORM_FOR_EACH_ALERT_BODY_MESSAGE,
+  FORM_ON_ACTIVE_ALERT_OPTION,
   FORM_SUMMARY_BODY_MESSAGE,
 } from './translations';
 
@@ -208,7 +209,7 @@ export const RuleActionsField: React.FC<Props> = ({
         const updatedAlertsFilter = { ...alertsFilter };
 
         if (value) {
-          updatedAlertsFilter[key] = value;
+          updatedAlertsFilter[key] = value as unknown as SavedObjectAttribute;
         } else {
           delete updatedAlertsFilter[key];
         }

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/sessions_viewer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/sessions_viewer/index.tsx
@@ -11,6 +11,7 @@ import { ENTRY_SESSION_ENTITY_ID_PROPERTY } from '@kbn/session-view-plugin/publi
 import { useDispatch } from 'react-redux';
 import { EVENT_ACTION } from '@kbn/rule-data-utils';
 import { dataTableActions, TableId } from '@kbn/securitysolution-data-table';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useAddBulkToTimelineAction } from '../../../detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline';
 import type { SessionsComponentsProps } from './types';
 import type { ESBoolQuery } from '../../../../common/typed_json';
@@ -19,7 +20,6 @@ import { getSessionsDefaultModel, sessionsHeaders } from './default_headers';
 import { defaultRowRenderers } from '../../../timelines/components/timeline/body/renderers';
 import { DefaultCellRenderer } from '../../../timelines/components/timeline/cell_rendering/default_cell_renderer';
 import * as i18n from './translations';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { getDefaultControlColumn } from '../../../timelines/components/timeline/body/control_columns';
 import { useLicense } from '../../hooks/use_license';
 import { eventsDefaultModel } from '../events_viewer/default_model';
@@ -132,7 +132,7 @@ const SessionsViewComponent: React.FC<SessionsComponentsProps> = ({
     tableId,
     from: startDate,
     to: endDate,
-    scopeId: SourcererScopeName.default,
+    scopeId: PageScope.default,
   });
 
   const bulkActions = useMemo<BulkActionsProp | boolean>(() => {
@@ -158,7 +158,7 @@ const SessionsViewComponent: React.FC<SessionsComponentsProps> = ({
         leadingControlColumns={leadingControlColumns}
         renderCellValue={DefaultCellRenderer}
         rowRenderers={defaultRowRenderers}
-        sourcererScope={SourcererScopeName.default}
+        sourcererScope={PageScope.default}
         start={startDate}
         unit={unit}
       />

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/helpers.test.tsx
@@ -14,14 +14,14 @@ import {
   defaultOptions,
   detectionAlertsTables,
   getOptions,
-  getSourcererScopeName,
+  getPageScope,
   isDetectionsAlertsTable,
   rawEvents,
   removeIgnoredAlertFilters,
   shouldIgnoreAlertFilters,
 } from './helpers';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { PageScope } from '../../../data_view_manager/constants';
 
 /** the following scopes are NOT detection alert tables */
 const otherScopes = [
@@ -234,34 +234,34 @@ describe('removeIgnoredAlertFilters', () => {
   });
 });
 
-describe('getSourcererScopeName', () => {
+describe('getPageScope', () => {
   detectionAlertsTables.forEach((tableId) => {
-    test(`it returns the 'default' SourcererScopeName when the view is 'raw' for detections alerts table '${tableId}'`, () => {
+    test(`it returns the 'default' PageScope when the view is 'raw' for Alerts alerts table '${tableId}'`, () => {
       const view = 'raw';
-      expect(getSourcererScopeName({ scopeId: tableId, view })).toEqual(SourcererScopeName.default);
+      expect(getPageScope({ scopeId: tableId, view })).toEqual(PageScope.default);
     });
 
-    test(`it returns the 'detections' SourcererScopeName when the view is NOT 'raw' for detections alerts table '${tableId}'`, () => {
+    test(`it returns the 'alerts' PageScope when the view is NOT 'raw' for Alerts alerts table '${tableId}'`, () => {
       const view = 'alert';
-      expect(getSourcererScopeName({ scopeId: tableId, view })).toEqual(SourcererScopeName.alerts);
+      expect(getPageScope({ scopeId: tableId, view })).toEqual(PageScope.alerts);
     });
   });
 
-  test(`it returns the 'default' SourcererScopeName when timelineId is undefined'`, () => {
+  test(`it returns the 'default' PageScope when timelineId is undefined'`, () => {
     const tableId = undefined;
     const view = 'raw';
-    expect(getSourcererScopeName({ scopeId: tableId, view })).toEqual(SourcererScopeName.default);
+    expect(getPageScope({ scopeId: tableId, view })).toEqual(PageScope.default);
   });
 
   othersWithoutActive.forEach((tableId) => {
-    test(`it returns the 'default' SourcererScopeName when the view is 'raw' for (NON alert table) timeline '${tableId}'`, () => {
+    test(`it returns the 'default' PageScope when the view is 'raw' for (NON alert table) timeline '${tableId}'`, () => {
       const view = 'raw';
-      expect(getSourcererScopeName({ scopeId: tableId, view })).toEqual(SourcererScopeName.default);
+      expect(getPageScope({ scopeId: tableId, view })).toEqual(PageScope.default);
     });
 
-    test(`it returns the 'default' SourcererScopeName when the view is NOT 'raw' for detections alerts table '${tableId}'`, () => {
+    test(`it returns the 'default' PageScope when the view is NOT 'raw' for detections alerts table '${tableId}'`, () => {
       const view = 'alert';
-      expect(getSourcererScopeName({ scopeId: tableId, view })).toEqual(SourcererScopeName.default);
+      expect(getPageScope({ scopeId: tableId, view })).toEqual(PageScope.default);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/helpers.test.tsx
@@ -12,13 +12,13 @@ import {
   alertEvents,
   allEvents,
   defaultOptions,
+  detectionAlertsTables,
   getOptions,
   getSourcererScopeName,
   isDetectionsAlertsTable,
   rawEvents,
   removeIgnoredAlertFilters,
   shouldIgnoreAlertFilters,
-  detectionAlertsTables,
 } from './helpers';
 import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { TableId } from '@kbn/securitysolution-data-table';
@@ -243,9 +243,7 @@ describe('getSourcererScopeName', () => {
 
     test(`it returns the 'detections' SourcererScopeName when the view is NOT 'raw' for detections alerts table '${tableId}'`, () => {
       const view = 'alert';
-      expect(getSourcererScopeName({ scopeId: tableId, view })).toEqual(
-        SourcererScopeName.detections
-      );
+      expect(getSourcererScopeName({ scopeId: tableId, view })).toEqual(SourcererScopeName.alerts);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/helpers.ts
@@ -54,9 +54,9 @@ import {
 } from '@kbn/rule-data-utils';
 import { TableId } from '@kbn/securitysolution-data-table';
 
+import { PageScope } from '../../../data_view_manager/constants';
 import type { TimelineEventsType } from '../../../../common/types/timeline';
 import { TimelineId } from '../../../../common/types/timeline';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 
 import * as i18n from './translations';
 
@@ -223,27 +223,27 @@ export const removeIgnoredAlertFilters = ({
   return filters.filter((x) => !IGNORED_ALERT_FILTERS.includes(`${x.meta.key}`));
 };
 
-/** returns the SourcererScopeName applicable to the specified timelineId and view */
-export const getSourcererScopeName = ({
+/** returns the PageScope applicable to the specified timelineId and view */
+export const getPageScope = ({
   scopeId,
   view,
 }: {
   scopeId: string | undefined;
   view: TimelineEventsType;
-}): SourcererScopeName => {
+}): PageScope => {
   // When alerts should be ignored, use the `default` Sourcerer scope,
   // because it does NOT include alert indexes:
   if (shouldIgnoreAlertFilters({ tableId: scopeId, view })) {
-    return SourcererScopeName.default; // no alerts in this scope
+    return PageScope.default; // no alerts in this scope
   }
 
   if (isDetectionsAlertsTable(scopeId)) {
-    return SourcererScopeName.alerts;
+    return PageScope.alerts;
   }
 
   if (scopeId === TimelineId.active) {
-    return SourcererScopeName.timeline;
+    return PageScope.timeline;
   }
 
-  return SourcererScopeName.default;
+  return PageScope.default;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/helpers.ts
@@ -238,7 +238,7 @@ export const getSourcererScopeName = ({
   }
 
   if (isDetectionsAlertsTable(scopeId)) {
-    return SourcererScopeName.detections;
+    return SourcererScopeName.alerts;
   }
 
   if (scopeId === TimelineId.active) {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.tsx
@@ -17,7 +17,7 @@ import { SignalsByCategory } from '../../../overview/components/signals_by_categ
 import type { InputsModelId } from '../../store/inputs/constants';
 import type { TimelineEventsType } from '../../../../common/types/timeline';
 import type { TopNOption } from './helpers';
-import { getSourcererScopeName, removeIgnoredAlertFilters } from './helpers';
+import { getPageScope, removeIgnoredAlertFilters } from './helpers';
 import * as i18n from './translations';
 import type { AlertsStackByField } from '../../../detections/components/alerts_kpis/common/types';
 
@@ -88,7 +88,7 @@ const TopNComponent: React.FC<Props> = ({
     (value: string) => setView(value as TimelineEventsType),
     [setView]
   );
-  const sourcererScopeId = getSourcererScopeName({ scopeId, view });
+  const sourcererScopeId = getPageScope({ scopeId, view });
 
   useEffect(() => {
     setView(defaultView);

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/actions.test.tsx
@@ -4,18 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import React from 'react';
 import { EuiContextMenu } from '@elastic/eui';
-
 import { fireEvent, render, waitFor } from '@testing-library/react';
-
 import { getDnsTopDomainsLensAttributes } from './lens_attributes/network/dns_top_domains';
 import { VisualizationActions } from './actions';
 import { TestProviders } from '../../mock';
-
 import type { VisualizationActionsProps } from './types';
 import * as useLensAttributesModule from './use_lens_attributes';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
+import { PageScope } from '../../../data_view_manager/constants';
 
 jest.mock('./use_actions');
 
@@ -64,7 +62,7 @@ describe('VisualizationActions', () => {
         extraOptions: props.extraOptions,
         getLensAttributes: props.getLensAttributes,
         lensAttributes: props.lensAttributes,
-        scopeId: SourcererScopeName.default,
+        scopeId: PageScope.default,
         stackByField: props.stackByField,
         title: '',
       })

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/actions.tsx
@@ -11,6 +11,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import styled from '@emotion/styled';
 
 import useAsync from 'react-use/lib/useAsync';
+import { PageScope } from '../../../data_view_manager/constants';
 import { InputsModelId } from '../../store/inputs/constants';
 import { ModalInspectQuery } from '../inspect/modal';
 
@@ -21,7 +22,6 @@ import type { VisualizationActionsProps } from './types';
 import { MORE_ACTIONS } from './translations';
 import { VISUALIZATION_ACTIONS_BUTTON_CLASS } from './utils';
 import { DEFAULT_ACTIONS, useActions, VISUALIZATION_CONTEXT_MENU_TRIGGER } from './use_actions';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 
 const Wrapper = styled.div`
   &.viz-actions {
@@ -50,7 +50,7 @@ const VisualizationActionsComponent: React.FC<VisualizationActionsProps> = ({
   queryId,
   timerange,
   title: inspectTitle,
-  scopeId = SourcererScopeName.default,
+  scopeId = PageScope.default,
   stackByField,
   withActions = DEFAULT_ACTIONS,
   casesAttachmentMetadata,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
@@ -18,6 +18,7 @@ import type {
   XYState,
 } from '@kbn/lens-plugin/public';
 import { css } from '@emotion/react';
+import { PageScope } from '../../../data_view_manager/constants';
 import { setAbsoluteRangeDatePicker } from '../../store/inputs/actions';
 import { useKibana } from '../../lib/kibana';
 import { useLensAttributes } from './use_lens_attributes';
@@ -26,7 +27,6 @@ import { DEFAULT_ACTIONS, useActions } from './use_actions';
 
 import { ModalInspectQuery } from '../inspect/modal';
 import { InputsModelId } from '../../store/inputs/constants';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { VisualizationActions } from './actions';
 import { useEmbeddableInspect } from './use_embeddable_inspect';
 import { useVisualizationResponse } from './use_visualization_response';
@@ -61,7 +61,7 @@ const LensEmbeddableComponent: React.FC<LensEmbeddableComponentProps> = ({
   inspectTitle,
   lensAttributes,
   onLoad,
-  scopeId = SourcererScopeName.default,
+  scopeId = PageScope.default,
   enableLegendActions = true,
   stackByField,
   timerange,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/types.ts
@@ -19,8 +19,8 @@ import type { Filter, Query } from '@kbn/es-query';
 import type { LensProps } from '@kbn/cases-plugin/public/types';
 import type { EuiThemeComputed } from '@elastic/eui';
 import type { TablesAdapter } from '@kbn/expressions-plugin/common';
+import type { PageScope } from '../../../data_view_manager/constants';
 import type { InputsModelId } from '../../store/inputs/constants';
-import type { SourcererScopeName } from '../../../sourcerer/store/model';
 import type { Status } from '../../../../common/api/detection_engine';
 
 export type ColorSchemas = Record<string, string>;
@@ -39,7 +39,7 @@ export interface UseLensAttributesProps {
   extraOptions?: ExtraOptions;
   getLensAttributes?: GetLensAttributes;
   lensAttributes?: LensAttributes | null;
-  scopeId?: SourcererScopeName;
+  scopeId?: PageScope;
   stackByField?: string;
   title?: string;
   esql?: string;
@@ -70,7 +70,7 @@ export interface VisualizationActionsProps {
   lensAttributes?: LensAttributes | null;
   onCloseInspect?: () => void;
   queryId: string;
-  scopeId?: SourcererScopeName;
+  scopeId?: PageScope;
   stackByField?: string;
   timerange: { from: string; to: string };
   title: React.ReactNode;
@@ -123,7 +123,7 @@ export interface LensEmbeddableComponentProps {
   lensAttributes?: LensAttributes;
   onLoad?: OnEmbeddableLoaded;
   enableLegendActions?: boolean;
-  scopeId?: SourcererScopeName;
+  scopeId?: PageScope;
   stackByField?: string;
   timerange: { from: string; to: string };
   /**

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
@@ -7,22 +7,22 @@
 
 import { useMemo } from 'react';
 import { useEuiTheme } from '@elastic/eui';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { SecurityPageName } from '../../../../common/constants';
 import { NetworkRouteType } from '../../../explore/network/pages/navigation/types';
 import { useSourcererDataView } from '../../../sourcerer/containers';
 import { useDeepEqualSelector } from '../../hooks/use_selector';
 import { inputsSelectors } from '../../store';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useRouteSpy } from '../../utils/route/use_route_spy';
 import type { LensAttributes, UseLensAttributesProps } from './types';
 import {
+  fieldNameExistsFilter,
   getDetailsPageFilter,
-  sourceOrDestinationIpExistsFilter,
+  getESQLGlobalFilters,
   getIndexFilters,
   getNetworkDetailsPageFilter,
-  fieldNameExistsFilter,
-  getESQLGlobalFilters,
+  sourceOrDestinationIpExistsFilter,
 } from './utils';
 import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
 import { useSelectedPatterns } from '../../../data_view_manager/hooks/use_selected_patterns';
@@ -34,7 +34,7 @@ export const useLensAttributes = ({
   extraOptions,
   getLensAttributes,
   lensAttributes,
-  scopeId = SourcererScopeName.default,
+  scopeId = PageScope.default,
   stackByField,
   title,
   esql,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/containers/source/use_data_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/containers/source/use_data_view.tsx
@@ -15,16 +15,16 @@ import type { DataViewSpec } from '@kbn/data-views-plugin/public';
 import type { FieldCategory } from '@kbn/timelines-plugin/common/search_strategy';
 
 import { getCategory } from '@kbn/response-ops-alerts-fields-browser/helpers';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useKibana } from '../../lib/kibana';
 import { sourcererActions } from '../../../sourcerer/store';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { getSourcererDataView } from '../../../sourcerer/containers/get_sourcerer_data_view';
 import * as i18n from './translations';
 import { useAppToasts } from '../../hooks/use_app_toasts';
 
 export type IndexFieldSearch = (param: {
   dataViewId: string;
-  scopeId?: SourcererScopeName;
+  scopeId?: PageScope;
   needToBeInit?: boolean;
   cleanCache?: boolean;
   skipScopeUpdate?: boolean;
@@ -90,7 +90,7 @@ export const useDataView = (): {
   const indexFieldsSearch = useCallback<IndexFieldSearch>(
     ({
       dataViewId,
-      scopeId = SourcererScopeName.default,
+      scopeId = PageScope.default,
       needToBeInit = false,
       cleanCache = false,
       skipScopeUpdate = false,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/timeline/use_investigate_in_timeline.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/timeline/use_investigate_in_timeline.ts
@@ -8,10 +8,10 @@
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type { Filter, Query } from '@kbn/es-query';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useSelectDataView } from '../../../data_view_manager/hooks/use_select_data_view';
 import { useCreateTimeline } from '../../../timelines/hooks/use_create_timeline';
 import { applyKqlFilterQuery, setFilters, updateProviders } from '../../../timelines/store/actions';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import type { DataProvider } from '../../../../common/types';
 import { sourcererSelectors } from '../../store';
 import { inputsActions } from '../../store/inputs';
@@ -131,14 +131,14 @@ export const useInvestigateInTimeline = () => {
         if (!keepDataView) {
           if (newDataViewPickerEnabled) {
             setSelectedDataView({
-              scope: SourcererScopeName.timeline,
+              scope: PageScope.timeline,
               id: defaultDataView.id,
               fallbackPatterns: [signalIndexName || ''],
             });
           } else {
             dispatch(
               sourcererActions.setSelectedDataView({
-                id: SourcererScopeName.timeline,
+                id: PageScope.timeline,
                 selectedDataViewId: defaultDataView.id,
                 selectedPatterns: [signalIndexName || ''],
               })

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_data_view_id.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_data_view_id.test.ts
@@ -7,22 +7,19 @@
 
 import { renderHook } from '@testing-library/react';
 import { TestProviders } from '../mock';
-import { SourcererScopeName } from '../../sourcerer/store/model';
 import { DEFAULT_DATA_VIEW_ID } from '../../../common/constants';
 import { useDataViewId } from './use_data_view_id';
 import * as sourcererSelectors from '../../sourcerer/store/selectors';
+import { PageScope } from '../../data_view_manager/constants';
 
 describe('useDataViewId', () => {
-  it.each(Object.values(SourcererScopeName))(
-    'should return the data view id for %s scope',
-    (scope) => {
-      const { result } = renderHook((props) => useDataViewId(props.scope), {
-        initialProps: { scope },
-        wrapper: TestProviders,
-      });
-      expect(result.current).toEqual(DEFAULT_DATA_VIEW_ID); // mocked value
-    }
-  );
+  it.each(Object.values(PageScope))('should return the data view id for %s scope', (scope) => {
+    const { result } = renderHook((props) => useDataViewId(props.scope), {
+      initialProps: { scope },
+      wrapper: TestProviders,
+    });
+    expect(result.current).toEqual(DEFAULT_DATA_VIEW_ID); // mocked value
+  });
 
   it('should return undefined if dataViewId selector returns null', () => {
     jest
@@ -30,7 +27,7 @@ describe('useDataViewId', () => {
       .mockImplementationOnce(() => null);
 
     const { result } = renderHook((props) => useDataViewId(props.scope), {
-      initialProps: { scope: SourcererScopeName.default },
+      initialProps: { scope: PageScope.default },
       wrapper: TestProviders,
     });
     expect(result.current).toEqual(undefined);

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_data_view_id.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_data_view_id.ts
@@ -6,11 +6,11 @@
  */
 
 import { useSelector } from 'react-redux';
+import type { PageScope } from '../../data_view_manager/constants';
 import { sourcererScopeSelectedDataViewId } from '../../sourcerer/store/selectors';
-import type { SourcererScopeName } from '../../sourcerer/store/model';
 import type { State } from '../store';
 
-export const useDataViewId = (scopeId: SourcererScopeName): string | undefined => {
+export const useDataViewId = (scopeId: PageScope): string | undefined => {
   const dataViewId = useSelector((state: State) =>
     sourcererScopeSelectedDataViewId(state, scopeId)
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_get_field_spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_get_field_spec.ts
@@ -7,11 +7,11 @@
 
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import type { SourcererScopeName } from '../../sourcerer/store/model';
+import type { PageScope } from '../../data_view_manager/constants';
 import { sourcererSelectors } from '../../sourcerer/store';
 import type { State } from '../store';
 
-export const useGetFieldSpec = (scopeId: SourcererScopeName) => {
+export const useGetFieldSpec = (scopeId: PageScope) => {
   const kibanaDataViews = useSelector(sourcererSelectors.kibanaDataViews);
   const selectedDataViewId = useSelector((state: State) =>
     sourcererSelectors.sourcererScopeSelectedDataViewId(state, scopeId)

--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/global_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/global_state.ts
@@ -479,12 +479,12 @@ export const mockGlobalState: State = {
           true
         ),
       },
-      [SourcererScopeName.detections]: {
-        ...mockSourcererState.sourcererScopes[SourcererScopeName.detections],
+      [SourcererScopeName.alerts]: {
+        ...mockSourcererState.sourcererScopes[SourcererScopeName.alerts],
         selectedDataViewId: mockSourcererState.defaultDataView.id,
         selectedPatterns: getScopePatternListSelection(
           mockSourcererState.defaultDataView,
-          SourcererScopeName.detections,
+          SourcererScopeName.alerts,
           mockSourcererState.signalIndexName,
           true
         ),

--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/global_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/global_state.ts
@@ -7,6 +7,7 @@
 
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+import { PageScope } from '../../data_view_manager/constants';
 import { AssociatedFilter } from '../../../common/notes/constants';
 import { ReqStatus } from '../../notes/store/notes.slice';
 import { HostsFields } from '../../../common/api/search_strategy/hosts/model/sort';
@@ -38,7 +39,7 @@ import { TimelineId, TimelineTabs } from '../../../common/types/timeline';
 import { TimelineStatusEnum, TimelineTypeEnum } from '../../../common/api/timeline';
 import { mockManagementState } from '../../management/store/reducer';
 import type { ManagementState } from '../../management/types';
-import { initialSourcererState, SourcererScopeName } from '../../sourcerer/store/model';
+import { initialSourcererState } from '../../sourcerer/store/model';
 import { allowedExperimentalValues } from '../../../common/experimental_features';
 import { getScopePatternListSelection } from '../../sourcerer/store/helpers';
 import { mockBrowserFields, mockIndexFields } from '../containers/source/mock';
@@ -469,62 +470,62 @@ export const mockGlobalState: State = {
     ],
     sourcererScopes: {
       ...mockSourcererState.sourcererScopes,
-      [SourcererScopeName.default]: {
-        ...mockSourcererState.sourcererScopes[SourcererScopeName.default],
+      [PageScope.default]: {
+        ...mockSourcererState.sourcererScopes[PageScope.default],
         selectedDataViewId: mockSourcererState.defaultDataView.id,
         selectedPatterns: getScopePatternListSelection(
           mockSourcererState.defaultDataView,
-          SourcererScopeName.default,
+          PageScope.default,
           mockSourcererState.signalIndexName,
           true
         ),
       },
-      [SourcererScopeName.alerts]: {
-        ...mockSourcererState.sourcererScopes[SourcererScopeName.alerts],
+      [PageScope.alerts]: {
+        ...mockSourcererState.sourcererScopes[PageScope.alerts],
         selectedDataViewId: mockSourcererState.defaultDataView.id,
         selectedPatterns: getScopePatternListSelection(
           mockSourcererState.defaultDataView,
-          SourcererScopeName.alerts,
+          PageScope.alerts,
           mockSourcererState.signalIndexName,
           true
         ),
       },
-      [SourcererScopeName.attacks]: {
-        ...mockSourcererState.sourcererScopes[SourcererScopeName.attacks],
+      [PageScope.attacks]: {
+        ...mockSourcererState.sourcererScopes[PageScope.attacks],
         selectedDataViewId: mockSourcererState.defaultDataView.id,
         selectedPatterns: getScopePatternListSelection(
           mockSourcererState.defaultDataView,
-          SourcererScopeName.attacks,
+          PageScope.attacks,
           mockSourcererState.signalIndexName,
           true
         ),
       },
-      [SourcererScopeName.timeline]: {
-        ...mockSourcererState.sourcererScopes[SourcererScopeName.timeline],
+      [PageScope.timeline]: {
+        ...mockSourcererState.sourcererScopes[PageScope.timeline],
         selectedDataViewId: mockSourcererState.defaultDataView.id,
         selectedPatterns: getScopePatternListSelection(
           mockSourcererState.defaultDataView,
-          SourcererScopeName.timeline,
+          PageScope.timeline,
           mockSourcererState.signalIndexName,
           true
         ),
       },
-      [SourcererScopeName.analyzer]: {
-        ...mockSourcererState.sourcererScopes[SourcererScopeName.default],
+      [PageScope.analyzer]: {
+        ...mockSourcererState.sourcererScopes[PageScope.default],
         selectedDataViewId: mockSourcererState.defaultDataView.id,
         selectedPatterns: getScopePatternListSelection(
           mockSourcererState.defaultDataView,
-          SourcererScopeName.default,
+          PageScope.default,
           mockSourcererState.signalIndexName,
           true
         ),
       },
-      [SourcererScopeName.explore]: {
-        ...mockSourcererState.sourcererScopes[SourcererScopeName.default],
+      [PageScope.explore]: {
+        ...mockSourcererState.sourcererScopes[PageScope.default],
         selectedDataViewId: mockSourcererState.defaultDataView.id,
         selectedPatterns: getScopePatternListSelection(
           mockSourcererState.defaultDataView,
-          SourcererScopeName.default,
+          PageScope.default,
           mockSourcererState.signalIndexName,
           true
         ),

--- a/x-pack/solutions/security/plugins/security_solution/public/common/store/reducer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/store/reducer.ts
@@ -11,6 +11,7 @@ import { combineReducers } from 'redux';
 import type { DataTableState } from '@kbn/securitysolution-data-table';
 import { dataTableReducer } from '@kbn/securitysolution-data-table';
 import { enableMapSet } from 'immer';
+import { PageScope } from '../../data_view_manager/constants';
 import { appReducer, initialAppState } from './app';
 import { dragAndDropReducer, initialDragAndDropState } from './drag_and_drop';
 import { createInitialInputsState, inputsReducer } from './inputs';
@@ -26,7 +27,7 @@ import type { ManagementPluginReducer } from '../../management';
 import type { State } from './types';
 import type { AppAction } from './actions';
 import type { SourcererModel } from '../../sourcerer/store/model';
-import { initDataView, SourcererScopeName } from '../../sourcerer/store/model';
+import { initDataView } from '../../sourcerer/store/model';
 import type { ExperimentalFeatures } from '../../../common/experimental_features';
 import { getScopePatternListSelection } from '../../sourcerer/store/helpers';
 import { globalUrlParamReducer, initialGlobalUrlParam } from './global_url_param';
@@ -76,21 +77,21 @@ export const createInitialState = (
   notesState: NotesState
 ): State => {
   const initialPatterns = {
-    [SourcererScopeName.default]: getScopePatternListSelection(
+    [PageScope.default]: getScopePatternListSelection(
       defaultDataView,
-      SourcererScopeName.default,
+      PageScope.default,
       signalIndexName,
       true
     ),
-    [SourcererScopeName.alerts]: getScopePatternListSelection(
+    [PageScope.alerts]: getScopePatternListSelection(
       defaultDataView,
-      SourcererScopeName.alerts,
+      PageScope.alerts,
       signalIndexName,
       true
     ),
-    [SourcererScopeName.timeline]: getScopePatternListSelection(
+    [PageScope.timeline]: getScopePatternListSelection(
       defaultDataView,
-      SourcererScopeName.timeline,
+      PageScope.timeline,
       signalIndexName,
       true
     ),
@@ -105,20 +106,20 @@ export const createInitialState = (
       ...sourcererModel.initialSourcererState,
       sourcererScopes: {
         ...sourcererModel.initialSourcererState.sourcererScopes,
-        [SourcererScopeName.default]: {
+        [PageScope.default]: {
           ...sourcererModel.initialSourcererState.sourcererScopes.default,
           selectedDataViewId: defaultDataView.id,
-          selectedPatterns: initialPatterns[SourcererScopeName.default],
+          selectedPatterns: initialPatterns[PageScope.default],
         },
-        [SourcererScopeName.alerts]: {
+        [PageScope.alerts]: {
           ...sourcererModel.initialSourcererState.sourcererScopes.alerts,
           selectedDataViewId: defaultDataView.id,
-          selectedPatterns: initialPatterns[SourcererScopeName.alerts],
+          selectedPatterns: initialPatterns[PageScope.alerts],
         },
-        [SourcererScopeName.timeline]: {
+        [PageScope.timeline]: {
           ...sourcererModel.initialSourcererState.sourcererScopes.timeline,
           selectedDataViewId: defaultDataView.id,
-          selectedPatterns: initialPatterns[SourcererScopeName.timeline],
+          selectedPatterns: initialPatterns[PageScope.timeline],
         },
       },
       defaultDataView,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/store/reducer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/store/reducer.ts
@@ -14,7 +14,7 @@ import { enableMapSet } from 'immer';
 import { appReducer, initialAppState } from './app';
 import { dragAndDropReducer, initialDragAndDropState } from './drag_and_drop';
 import { createInitialInputsState, inputsReducer } from './inputs';
-import { sourcererReducer, sourcererModel } from '../../sourcerer/store';
+import { sourcererModel, sourcererReducer } from '../../sourcerer/store';
 
 import type { HostsPluginReducer } from '../../explore/hosts/store';
 import type { NetworkPluginReducer } from '../../explore/network/store';
@@ -82,9 +82,9 @@ export const createInitialState = (
       signalIndexName,
       true
     ),
-    [SourcererScopeName.detections]: getScopePatternListSelection(
+    [SourcererScopeName.alerts]: getScopePatternListSelection(
       defaultDataView,
-      SourcererScopeName.detections,
+      SourcererScopeName.alerts,
       signalIndexName,
       true
     ),
@@ -110,10 +110,10 @@ export const createInitialState = (
           selectedDataViewId: defaultDataView.id,
           selectedPatterns: initialPatterns[SourcererScopeName.default],
         },
-        [SourcererScopeName.detections]: {
-          ...sourcererModel.initialSourcererState.sourcererScopes.detections,
+        [SourcererScopeName.alerts]: {
+          ...sourcererModel.initialSourcererState.sourcererScopes.alerts,
           selectedDataViewId: defaultDataView.id,
-          selectedPatterns: initialPatterns[SourcererScopeName.detections],
+          selectedPatterns: initialPatterns[SourcererScopeName.alerts],
         },
         [SourcererScopeName.timeline]: {
           ...sourcererModel.initialSourcererState.sourcererScopes.timeline,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline_for_path.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline_for_path.ts
@@ -8,13 +8,13 @@
 import { useCallback, useMemo } from 'react';
 import { matchPath } from 'react-router-dom';
 
+import { PageScope } from '../../../data_view_manager/constants';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import type { NormalizedLink } from '../../links';
 import { useNormalizedAppLinks } from '../../links/links_hooks';
 import { useKibana } from '../../lib/kibana';
 import { hasAccessToSecuritySolution } from '../../../helpers_access';
 
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useSourcererDataView } from '../../../sourcerer/containers';
 import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
 
@@ -37,12 +37,10 @@ export const useShowTimelineForGivenPath = () => {
   const { capabilities } = useKibana().services.application;
   const userHasSecuritySolutionVisible = hasAccessToSecuritySolution(capabilities);
 
-  const { indicesExist: oldIndicesExist, dataViewId } = useSourcererDataView(
-    SourcererScopeName.timeline
-  );
+  const { indicesExist: oldIndicesExist, dataViewId } = useSourcererDataView(PageScope.timeline);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView } = useDataView(SourcererScopeName.timeline);
+  const { dataView } = useDataView(PageScope.timeline);
 
   const indicesExist = newDataViewPickerEnabled ? dataView.hasMatchedIndices() : oldIndicesExist;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { DataViewPicker } from '.';
 import { useDispatch } from 'react-redux';
 import { useKibana } from '../../../common/lib/kibana';
@@ -15,7 +15,7 @@ import { useSelectDataView } from '../../hooks/use_select_data_view';
 import { useUpdateUrlParam } from '../../../common/utils/global_query_string';
 import { URL_PARAM_KEY } from '../../../common/hooks/constants';
 import { useKibana as mockUseKibana } from '../../../common/lib/kibana/__mocks__';
-import { DataViewManagerScopeName } from '../../constants';
+import { PageScope } from '../../constants';
 
 jest.mock('../../../common/utils/global_query_string', () => ({
   useUpdateUrlParam: jest.fn(),
@@ -98,7 +98,7 @@ describe('DataViewPicker', () => {
   it('renders with the current data view ID', () => {
     render(
       <TestProviders>
-        <DataViewPicker scope={DataViewManagerScopeName.default} />
+        <DataViewPicker scope={PageScope.default} />
       </TestProviders>
     );
 
@@ -109,7 +109,7 @@ describe('DataViewPicker', () => {
   it('calls selectDataView when changing data view', () => {
     render(
       <TestProviders>
-        <DataViewPicker scope={DataViewManagerScopeName.default} />
+        <DataViewPicker scope={PageScope.default} />
       </TestProviders>
     );
 
@@ -124,7 +124,7 @@ describe('DataViewPicker', () => {
   it('calls useUpdateUrlParam when changing the default scoped data view', () => {
     render(
       <TestProviders>
-        <DataViewPicker scope={DataViewManagerScopeName.default} />
+        <DataViewPicker scope={PageScope.default} />
       </TestProviders>
     );
 
@@ -141,7 +141,7 @@ describe('DataViewPicker', () => {
   it('calls useUpdateUrlParam when changing the explore scoped data view', () => {
     render(
       <TestProviders>
-        <DataViewPicker scope={DataViewManagerScopeName.explore} />
+        <DataViewPicker scope={PageScope.explore} />
       </TestProviders>
     );
 
@@ -163,7 +163,7 @@ describe('DataViewPicker', () => {
 
     render(
       <TestProviders>
-        <DataViewPicker scope={DataViewManagerScopeName.default} />
+        <DataViewPicker scope={PageScope.default} />
       </TestProviders>
     );
 
@@ -185,7 +185,7 @@ describe('DataViewPicker', () => {
 
       render(
         <TestProviders>
-          <DataViewPicker scope={DataViewManagerScopeName.default} />
+          <DataViewPicker scope={PageScope.default} />
         </TestProviders>
       );
 
@@ -199,7 +199,7 @@ describe('DataViewPicker', () => {
 
       render(
         <TestProviders>
-          <DataViewPicker scope={DataViewManagerScopeName.default} />
+          <DataViewPicker scope={PageScope.default} />
         </TestProviders>
       );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { DataViewPicker as UnifiedDataViewPicker } from '@kbn/unified-search-plugin/public';
-import React, { useCallback, useRef, useMemo, memo } from 'react';
+import React, { memo, useCallback, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { DataView } from '@kbn/data-views-plugin/public';
 import { EuiCode } from '@elastic/eui';
@@ -18,7 +18,7 @@ import { useKibana } from '../../../common/lib/kibana';
 import { sharedStateSelector } from '../../redux/selectors';
 import { sharedDataViewManagerSlice } from '../../redux/slices';
 import { useSelectDataView } from '../../hooks/use_select_data_view';
-import { DataViewManagerScopeName } from '../../constants';
+import { PageScope } from '../../constants';
 import { useSavedDataViews } from '../../hooks/use_saved_data_views';
 import { LOADING } from './translations';
 import { DATA_VIEW_PICKER_TEST_ID } from './constants';
@@ -28,7 +28,7 @@ interface DataViewPickerProps {
   /**
    * The scope of the data view picker
    */
-  scope: DataViewManagerScopeName;
+  scope: PageScope;
   /**
    * Optional callback when the data view picker is closed
    */
@@ -64,8 +64,8 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
 
   const savedDataViews = useSavedDataViews();
 
-  const isDefaultSourcerer = scope === DataViewManagerScopeName.default;
-  const isExploreSourcerer = scope === DataViewManagerScopeName.explore;
+  const isDefaultSourcerer = scope === PageScope.default;
+  const isExploreSourcerer = scope === PageScope.explore;
   const updateUrlParam = useUpdateUrlParam<SourcererUrlState>(URL_PARAM_KEY.sourcerer);
 
   const dataViewId = dataView?.id;
@@ -78,7 +78,7 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
 
       if (isDefaultSourcerer) {
         updateUrlParam({
-          [DataViewManagerScopeName.default]: {
+          [PageScope.default]: {
             id,
             // NOTE: Boolean filter for removing empty patterns
             selectedPatterns: indexPattern.split(',').filter(Boolean),
@@ -88,7 +88,7 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
 
       if (isExploreSourcerer) {
         updateUrlParam({
-          [DataViewManagerScopeName.explore]: {
+          [PageScope.explore]: {
             id,
             // NOTE: Boolean filter for removing empty patterns
             selectedPatterns: indexPattern.split(',').filter(Boolean),

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/constants.ts
@@ -7,6 +7,19 @@
 
 export const DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID = 'security-solution-default';
 
-export { SourcererScopeName as DataViewManagerScopeName } from '../sourcerer/store/model';
-
 export const SLICE_PREFIX = 'x-pack/security_solution/dataViewManager' as const;
+
+/**
+ * This helps developers use the dataview that is set by default in the page corresponding to the scope.
+ *
+ * For example, if from a random page I want to use the dataview used in the alerts page,
+ * I can use the @link{useDataView} hook with the PageScope.alerts to get it.
+ */
+export enum PageScope {
+  default = 'default',
+  alerts = 'alerts',
+  attacks = 'attacks',
+  timeline = 'timeline',
+  analyzer = 'analyzer',
+  explore = 'explore',
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.test.ts
@@ -8,7 +8,7 @@
 import { renderHook } from '@testing-library/react';
 import { TestProviders } from '../../common/mock';
 import { useBrowserFields } from './use_browser_fields';
-import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, DataViewManagerScopeName } from '../constants';
+import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, PageScope } from '../constants';
 import { useDataView } from './use_data_view';
 import { DataView } from '@kbn/data-views-plugin/common';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
@@ -46,7 +46,7 @@ describe('useBrowserFields', () => {
 
   it('should call the useDataView hook and return browser fields map', () => {
     jest.mocked(useIsExperimentalFeatureEnabled).mockReturnValue(true);
-    const wrapper = renderHook(() => useBrowserFields(DataViewManagerScopeName.default), {
+    const wrapper = renderHook(() => useBrowserFields(PageScope.default), {
       wrapper: TestProviders,
     });
 
@@ -91,12 +91,9 @@ describe('useBrowserFields', () => {
       // @ts-expect-error: DataView constructor expects more, but this is enough for our test
       fieldFormats: { getDefaultInstance: () => ({}) },
     });
-    const wrapper = renderHook(
-      () => useBrowserFields(DataViewManagerScopeName.default, oldDataView),
-      {
-        wrapper: TestProviders,
-      }
-    );
+    const wrapper = renderHook(() => useBrowserFields(PageScope.default, oldDataView), {
+      wrapper: TestProviders,
+    });
 
     expect(wrapper.result.current).toMatchInlineSnapshot(`
       Object {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
@@ -8,7 +8,7 @@
 import { useMemo } from 'react';
 import type { BrowserFields } from '@kbn/timelines-plugin/common';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import { DataViewManagerScopeName } from '../constants';
+import { PageScope } from '../constants';
 import { useDataView } from './use_data_view';
 import { buildBrowserFields } from '../utils/build_browser_fields';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
@@ -16,7 +16,7 @@ import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experime
 const emptyFields = {};
 
 export const useBrowserFields = (
-  scope: DataViewManagerScopeName = DataViewManagerScopeName.default,
+  scope: PageScope = PageScope.default,
   /**
    * @deprecated remove when newDataViewPickerEnabled is removed
    */

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.test.ts
@@ -8,7 +8,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { DataView } from '@kbn/data-views-plugin/public';
 
-import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, DataViewManagerScopeName } from '../constants';
+import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, PageScope } from '../constants';
 import { useDataView } from './use_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { useSelector } from 'react-redux';
@@ -111,9 +111,9 @@ describe('useDataView', () => {
   it('should not call get if newDataViewPickerEnabled is false', async () => {
     jest.mocked(useIsExperimentalFeatureEnabled).mockReturnValue(false);
 
-    const { result, rerender } = renderHook(() => useDataView(DataViewManagerScopeName.default));
+    const { result, rerender } = renderHook(() => useDataView(PageScope.default));
 
-    await act(async () => rerender(DataViewManagerScopeName.default));
+    await act(async () => rerender(PageScope.default));
     expect(mockGet).not.toHaveBeenCalled();
     expect(result.current.status).toBe('pristine');
   });
@@ -121,9 +121,9 @@ describe('useDataView', () => {
   it('should not call get if dataViewId is missing', async () => {
     jest.mocked(useSelector).mockReturnValue({ dataViewId: undefined, status: 'ready' });
 
-    const { result, rerender } = renderHook(() => useDataView(DataViewManagerScopeName.default));
+    const { result, rerender } = renderHook(() => useDataView(PageScope.default));
 
-    await act(async () => rerender(DataViewManagerScopeName.default));
+    await act(async () => rerender(PageScope.default));
     expect(mockGet).not.toHaveBeenCalled();
     expect(result.current.status).toBe('pristine');
   });
@@ -133,9 +133,9 @@ describe('useDataView', () => {
       .mocked(useSelector)
       .mockReturnValue({ dataViewId: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, status: 'loading' });
 
-    const { result, rerender } = renderHook(() => useDataView(DataViewManagerScopeName.default));
+    const { result, rerender } = renderHook(() => useDataView(PageScope.default));
 
-    await act(async () => rerender(DataViewManagerScopeName.default));
+    await act(async () => rerender(PageScope.default));
     expect(mockGet).not.toHaveBeenCalled();
     expect(result.current.status).toBe('pristine');
   });
@@ -143,9 +143,9 @@ describe('useDataView', () => {
   it('should set status to error and call toasts.addDanger on get error', async () => {
     mockGet.mockRejectedValue(new Error('fail!'));
 
-    const { result, rerender } = renderHook(() => useDataView(DataViewManagerScopeName.default));
+    const { result, rerender } = renderHook(() => useDataView(PageScope.default));
 
-    await act(async () => rerender(DataViewManagerScopeName.default));
+    await act(async () => rerender(PageScope.default));
     expect(result.current.status).toBe('error');
     expect(mockToastsDanger).toHaveBeenCalledWith({
       title: 'Error retrieving data view',
@@ -156,9 +156,9 @@ describe('useDataView', () => {
   it('should handle unknown error shape gracefully', async () => {
     mockGet.mockRejectedValue({});
 
-    const { result, rerender } = renderHook(() => useDataView(DataViewManagerScopeName.default));
+    const { result, rerender } = renderHook(() => useDataView(PageScope.default));
 
-    await act(async () => rerender(DataViewManagerScopeName.default));
+    await act(async () => rerender(PageScope.default));
     expect(result.current.status).toBe('error');
     expect(mockToastsDanger).toHaveBeenCalledWith({
       title: 'Error retrieving data view',

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.ts
@@ -11,7 +11,7 @@ import { DataView } from '@kbn/data-views-plugin/public';
 import { useSelector } from 'react-redux';
 import { type FieldFormatsStartCommon } from '@kbn/field-formats-plugin/common';
 import { useKibana } from '../../common/lib/kibana';
-import { DataViewManagerScopeName } from '../constants';
+import { PageScope } from '../constants';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { sourcererAdapterSelector } from '../redux/selectors';
 import type { SharedDataViewSelectionState } from '../redux/types';
@@ -30,7 +30,7 @@ export interface UseDataViewReturnValue {
  * selected data view.
  */
 export const useDataView = (
-  dataViewManagerScope: DataViewManagerScopeName = DataViewManagerScopeName.default
+  dataViewManagerScope: PageScope = PageScope.default
 ): UseDataViewReturnValue => {
   const {
     services: { dataViews, notifications },

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.test.ts
@@ -8,7 +8,7 @@
 import { renderHook } from '@testing-library/react';
 import { type DataView } from '@kbn/data-views-plugin/public';
 
-import { DataViewManagerScopeName } from '../constants';
+import { PageScope } from '../constants';
 import { useDataViewSpec } from './use_data_view_spec';
 import { useDataView } from './use_data_view';
 
@@ -28,18 +28,18 @@ describe('useDataViewSpec', () => {
 
   it('should return correct dataView from the store, based on the provided scope', () => {
     const wrapper = renderHook((scope) => useDataViewSpec(scope), {
-      initialProps: DataViewManagerScopeName.default,
+      initialProps: PageScope.default,
     });
 
-    expect(jest.mocked(useDataView)).toHaveBeenCalledWith(DataViewManagerScopeName.default);
+    expect(jest.mocked(useDataView)).toHaveBeenCalledWith(PageScope.default);
 
     expect(wrapper.result.current).toMatchObject({
       status: expect.any(String),
       dataViewSpec: expect.objectContaining({ id: expect.any(String) }),
     });
 
-    wrapper.rerender(DataViewManagerScopeName.timeline);
-    expect(jest.mocked(useDataView)).toHaveBeenCalledWith(DataViewManagerScopeName.timeline);
+    wrapper.rerender(PageScope.timeline);
+    expect(jest.mocked(useDataView)).toHaveBeenCalledWith(PageScope.timeline);
 
     expect(wrapper.result.current).toMatchObject({
       status: expect.any(String),

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
@@ -7,7 +7,7 @@
 
 import { useMemo } from 'react';
 import type { DataViewSpec, SharedDataViewSelectionState } from '../redux/types';
-import { DataViewManagerScopeName } from '../constants';
+import { PageScope } from '../constants';
 import { useDataView } from './use_data_view';
 
 export interface UseDataViewSpecResult {
@@ -26,7 +26,7 @@ export interface UseDataViewSpecResult {
  * IMPORTANT: If fields are not required, make sure to pass `includeFields = false`.
  */
 export const useDataViewSpec = (
-  scopeName: DataViewManagerScopeName = DataViewManagerScopeName.default,
+  scopeName: PageScope = PageScope.default,
   includeFields = true
 ): UseDataViewSpecResult => {
   const { dataView, status } = useDataView(scopeName);

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
@@ -102,7 +102,7 @@ export const useInitDataViewManager = () => {
     const listeners = [
       DataViewManagerScopeName.default,
       DataViewManagerScopeName.timeline,
-      DataViewManagerScopeName.detections,
+      DataViewManagerScopeName.alerts,
       DataViewManagerScopeName.attacks,
       DataViewManagerScopeName.analyzer,
       DataViewManagerScopeName.explore,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
@@ -19,7 +19,7 @@ import { createDataViewSelectedListener } from '../redux/listeners/data_view_sel
 import { createInitListener } from '../redux/listeners/init_listener';
 import { sharedDataViewManagerSlice } from '../redux/slices';
 import { type SelectDataViewAsyncPayload } from '../redux/actions';
-import { DataViewManagerScopeName } from '../constants';
+import { PageScope } from '../constants';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { useUserInfo } from '../../detections/components/user_info';
 
@@ -100,12 +100,12 @@ export const useInitDataViewManager = () => {
 
     // NOTE: Every scope has its own listener instance; this allows for cancellation
     const listeners = [
-      DataViewManagerScopeName.default,
-      DataViewManagerScopeName.timeline,
-      DataViewManagerScopeName.alerts,
-      DataViewManagerScopeName.attacks,
-      DataViewManagerScopeName.analyzer,
-      DataViewManagerScopeName.explore,
+      PageScope.default,
+      PageScope.timeline,
+      PageScope.alerts,
+      PageScope.attacks,
+      PageScope.analyzer,
+      PageScope.explore,
     ].map((scope) =>
       createDataViewSelectedListener({
         scope,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.test.ts
@@ -9,7 +9,7 @@ import { renderHook } from '@testing-library/react';
 import { TestProviders } from '../../common/mock';
 import { useSelectDataView } from './use_select_data_view';
 import { useDispatch } from 'react-redux';
-import { DataViewManagerScopeName } from '../constants';
+import { PageScope } from '../constants';
 
 jest.mock('react-redux', () => {
   const dispatch = jest.fn();
@@ -31,7 +31,7 @@ describe('useSelectDataView', () => {
       { wrapper: TestProviders }
     );
 
-    result.current({ id: 'test', scope: DataViewManagerScopeName.default });
+    result.current({ id: 'test', scope: PageScope.default });
 
     expect(useDispatch()).toHaveBeenCalledWith({
       payload: { id: 'test', scope: 'default' },
@@ -51,7 +51,7 @@ describe('useSelectDataView', () => {
       result.current({
         id: undefined,
         fallbackPatterns: [],
-        scope: DataViewManagerScopeName.default,
+        scope: PageScope.default,
       });
 
       expect(useDispatch()).not.toHaveBeenCalledWith({

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.ts
@@ -7,7 +7,7 @@
 
 import { useDispatch } from 'react-redux';
 import { useCallback } from 'react';
-import type { DataViewManagerScopeName } from '../constants';
+import type { PageScope } from '../constants';
 import { selectDataViewAsync } from '../redux/actions';
 
 interface UseSelectDataViewParams {
@@ -23,7 +23,7 @@ interface UseSelectDataViewParams {
   /**
    * Data view selection will be applied to the scopes listed here
    */
-  scope: DataViewManagerScopeName;
+  scope: PageScope;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.test.ts
@@ -8,7 +8,7 @@
 import { renderHook } from '@testing-library/react';
 import { useSelectedPatterns } from './use_selected_patterns';
 import { useDataView } from './use_data_view';
-import type { DataViewManagerScopeName } from '../constants';
+import type { PageScope } from '../constants';
 
 // Mock the useDataView hook
 jest.mock('./use_data_view');
@@ -27,9 +27,7 @@ describe('useSelectedPatterns', () => {
     });
 
     // Execute
-    const { result } = renderHook(() =>
-      useSelectedPatterns('mockScope' as DataViewManagerScopeName)
-    );
+    const { result } = renderHook(() => useSelectedPatterns('mockScope' as PageScope));
 
     // Verify
     expect(result.current).toEqual(['pattern1', 'pattern2', 'pattern3']);
@@ -45,9 +43,7 @@ describe('useSelectedPatterns', () => {
     });
 
     // Execute
-    const { result } = renderHook(() =>
-      useSelectedPatterns('mockScope' as DataViewManagerScopeName)
-    );
+    const { result } = renderHook(() => useSelectedPatterns('mockScope' as PageScope));
 
     // Verify
     expect(result.current).toEqual([]);
@@ -60,9 +56,7 @@ describe('useSelectedPatterns', () => {
     });
 
     // Execute
-    const { result } = renderHook(() =>
-      useSelectedPatterns('mockScope' as DataViewManagerScopeName)
-    );
+    const { result } = renderHook(() => useSelectedPatterns('mockScope' as PageScope));
 
     // Verify
     expect(result.current).toEqual([]);

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.ts
@@ -6,14 +6,12 @@
  */
 
 import { useMemo } from 'react';
-import { DataViewManagerScopeName } from '../constants';
+import { PageScope } from '../constants';
 import { useDataView } from './use_data_view';
 
 const emptyArray: string[] = [];
 
-export const useSelectedPatterns = (
-  scope: DataViewManagerScopeName = DataViewManagerScopeName.default
-): string[] => {
+export const useSelectedPatterns = (scope: PageScope = PageScope.default): string[] => {
   const { dataView } = useDataView(scope);
   const indexPattern = dataView?.getIndexPattern?.() ?? '';
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_sync_url_state.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_sync_url_state.test.ts
@@ -7,13 +7,14 @@
 
 import { renderHook } from '@testing-library/react';
 import {
-  useSyncSourcererUrlState,
   useRestoreDataViewManagerStateFromURL,
+  useSyncSourcererUrlState,
 } from './use_sync_url_state';
 import * as reactRedux from 'react-redux';
 import * as experimentalFeatures from '../../common/hooks/use_experimental_features';
 import * as globalQueryString from '../../common/utils/global_query_string';
-import { SourcererScopeName } from '../../sourcerer/store/model';
+
+import { PageScope } from '../constants';
 
 jest.mock('react-redux');
 jest.mock('../../common/hooks/use_experimental_features');
@@ -41,7 +42,7 @@ describe('useSyncSourcererUrlState', () => {
 
   it('should not dispatch or update url param if newDataViewPickerEnabled is true', () => {
     mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
-    renderHook(() => useSyncSourcererUrlState(SourcererScopeName.default));
+    renderHook(() => useSyncSourcererUrlState(PageScope.default));
     // Simulate onInitializeUrlParam call
     const onInitializeUrlParam = mockUseInitializeUrlParam.mock.calls[0][1];
     onInitializeUrlParam({ default: { id: 'test-id', selectedPatterns: ['a'] } });
@@ -51,7 +52,7 @@ describe('useSyncSourcererUrlState', () => {
 
   it('should dispatch setSelectedDataView if newDataViewPickerEnabled is false and initialState is provided', () => {
     mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
-    renderHook(() => useSyncSourcererUrlState(SourcererScopeName.default));
+    renderHook(() => useSyncSourcererUrlState(PageScope.default));
     const onInitializeUrlParam = mockUseInitializeUrlParam.mock.calls[0][1];
     onInitializeUrlParam({ default: { id: 'test-id', selectedPatterns: ['a'] } });
     expect(mockDispatch).toHaveBeenCalledWith({
@@ -69,7 +70,7 @@ describe('useSyncSourcererUrlState', () => {
     mockUseSelector
       .mockReturnValueOnce('test-id') // scopeDataViewId
       .mockReturnValueOnce(['a']); // selectedPatterns
-    renderHook(() => useSyncSourcererUrlState(SourcererScopeName.default));
+    renderHook(() => useSyncSourcererUrlState(PageScope.default));
     const onInitializeUrlParam = mockUseInitializeUrlParam.mock.calls[0][1];
     onInitializeUrlParam(null);
     expect(mockUpdateUrlParam).toHaveBeenCalledWith({
@@ -92,7 +93,7 @@ describe('useRestoreDataViewManagerStateFromURL', () => {
     const initDataViewSelection = jest.fn();
     mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
     renderHook(() =>
-      useRestoreDataViewManagerStateFromURL(initDataViewSelection, SourcererScopeName.default)
+      useRestoreDataViewManagerStateFromURL(initDataViewSelection, PageScope.default)
     );
     const onInitializeUrlParam = mockUseInitializeUrlParam.mock.calls[0][1];
     onInitializeUrlParam({ default: { id: 'test-id', selectedPatterns: ['a'] } });
@@ -103,7 +104,7 @@ describe('useRestoreDataViewManagerStateFromURL', () => {
     const initDataViewSelection = jest.fn();
     mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
     renderHook(() =>
-      useRestoreDataViewManagerStateFromURL(initDataViewSelection, SourcererScopeName.default)
+      useRestoreDataViewManagerStateFromURL(initDataViewSelection, PageScope.default)
     );
     const onInitializeUrlParam = mockUseInitializeUrlParam.mock.calls[0][1];
     onInitializeUrlParam({

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_sync_url_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_sync_url_state.ts
@@ -7,7 +7,8 @@
 
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { SourcererScopeName, type SourcererUrlState } from '../../sourcerer/store/model';
+import { PageScope } from '../constants';
+import { type SourcererUrlState } from '../../sourcerer/store/model';
 import { useInitializeUrlParam, useUpdateUrlParam } from '../../common/utils/global_query_string';
 import { URL_PARAM_KEY } from '../../common/hooks/constants';
 import type { State } from '../../common/store/types';
@@ -19,10 +20,10 @@ import { type SelectDataViewAsyncPayload } from '../redux/actions';
 // TODO: remove this in cleanup phase Remove deprecated sourcerer code https://github.com/elastic/security-team/issues/12665
 export const useSyncSourcererUrlState = (
   scopeId:
-    | SourcererScopeName.default
-    | SourcererScopeName.explore
-    | SourcererScopeName.attacks
-    | SourcererScopeName.alerts = SourcererScopeName.default
+    | PageScope.default
+    | PageScope.explore
+    | PageScope.attacks
+    | PageScope.alerts = PageScope.default
 ) => {
   const scopeDataViewId = useSelector((state: State) => {
     return sourcererSelectors.sourcererScopeSelectedDataViewId(state, scopeId);
@@ -47,8 +48,8 @@ export const useSyncSourcererUrlState = (
 
       // Initialize the store with value from UrlParam.
       if (initialState != null) {
-        (Object.keys(initialState) as SourcererScopeName[]).forEach((scope) => {
-          if (!(scope === SourcererScopeName.default && scopeId === SourcererScopeName.alerts)) {
+        (Object.keys(initialState) as PageScope[]).forEach((scope) => {
+          if (!(scope === PageScope.default && scopeId === PageScope.alerts)) {
             dispatch(
               sourcererActions.setSelectedDataView({
                 id: scope,
@@ -63,7 +64,7 @@ export const useSyncSourcererUrlState = (
         // It isn't strictly necessary but I am keeping it for compatibility with the previous implementation.
         if (scopeDataViewId) {
           updateUrlParam({
-            [SourcererScopeName.default]: {
+            [PageScope.default]: {
               id: scopeDataViewId,
               selectedPatterns,
             },
@@ -85,10 +86,10 @@ export const useSyncSourcererUrlState = (
 export const useRestoreDataViewManagerStateFromURL = (
   initDataViewPickerWithSelection: (initialSelection: SelectDataViewAsyncPayload[]) => void,
   scopeId:
-    | SourcererScopeName.default
-    | SourcererScopeName.explore
-    | SourcererScopeName.attacks
-    | SourcererScopeName.alerts = SourcererScopeName.default
+    | PageScope.default
+    | PageScope.explore
+    | PageScope.attacks
+    | PageScope.alerts = PageScope.default
 ) => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
@@ -105,11 +106,11 @@ export const useRestoreDataViewManagerStateFromURL = (
       }
 
       // Select data view for specific scope, based on the UrlParam.
-      const urlBasedSelection = (Object.keys(initialState) as SourcererScopeName[])
+      const urlBasedSelection = (Object.keys(initialState) as PageScope[])
         .map((scope) => {
-          // NOTE: looks like this is about skipping the init when the active page is detections
+          // NOTE: looks like this is about skipping the init when the active page is alerts
           // We should investigate this.
-          if (scope === SourcererScopeName.default && scopeId === SourcererScopeName.alerts) {
+          if (scope === PageScope.default && scopeId === PageScope.alerts) {
             return undefined;
           }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_sync_url_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_sync_url_state.ts
@@ -22,7 +22,7 @@ export const useSyncSourcererUrlState = (
     | SourcererScopeName.default
     | SourcererScopeName.explore
     | SourcererScopeName.attacks
-    | SourcererScopeName.detections = SourcererScopeName.default
+    | SourcererScopeName.alerts = SourcererScopeName.default
 ) => {
   const scopeDataViewId = useSelector((state: State) => {
     return sourcererSelectors.sourcererScopeSelectedDataViewId(state, scopeId);
@@ -48,9 +48,7 @@ export const useSyncSourcererUrlState = (
       // Initialize the store with value from UrlParam.
       if (initialState != null) {
         (Object.keys(initialState) as SourcererScopeName[]).forEach((scope) => {
-          if (
-            !(scope === SourcererScopeName.default && scopeId === SourcererScopeName.detections)
-          ) {
+          if (!(scope === SourcererScopeName.default && scopeId === SourcererScopeName.alerts)) {
             dispatch(
               sourcererActions.setSelectedDataView({
                 id: scope,
@@ -90,7 +88,7 @@ export const useRestoreDataViewManagerStateFromURL = (
     | SourcererScopeName.default
     | SourcererScopeName.explore
     | SourcererScopeName.attacks
-    | SourcererScopeName.detections = SourcererScopeName.default
+    | SourcererScopeName.alerts = SourcererScopeName.default
 ) => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
@@ -111,7 +109,7 @@ export const useRestoreDataViewManagerStateFromURL = (
         .map((scope) => {
           // NOTE: looks like this is about skipping the init when the active page is detections
           // We should investigate this.
-          if (scope === SourcererScopeName.default && scopeId === SourcererScopeName.detections) {
+          if (scope === SourcererScopeName.default && scopeId === SourcererScopeName.alerts) {
             return undefined;
           }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/actions.ts
@@ -7,7 +7,7 @@
 
 import { createAction } from '@reduxjs/toolkit';
 
-import type { DataViewManagerScopeName } from '../constants';
+import type { PageScope } from '../constants';
 import { SLICE_PREFIX } from '../constants';
 
 export interface SelectDataViewAsyncPayload {
@@ -19,7 +19,7 @@ export interface SelectDataViewAsyncPayload {
   /**
    * Specify one or more security solution scopes where the data view selection should be applied
    */
-  scope: DataViewManagerScopeName;
+  scope: PageScope;
 }
 
 // NOTE: You should not need to dispatch any actions by yourself. Instead, use one of the hooks that we built to faciliate data view selection and retrieval based on current scope.

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
@@ -10,7 +10,7 @@ import { selectDataViewAsync } from '../actions';
 import type { DataViewsServicePublic, FieldSpec } from '@kbn/data-views-plugin/public';
 import type { AnyAction, Dispatch, ListenerEffectAPI } from '@reduxjs/toolkit';
 import type { RootState } from '../reducer';
-import { DataViewManagerScopeName, DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID } from '../../constants';
+import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, PageScope } from '../../constants';
 import { DEFAULT_ALERT_DATA_VIEW_ID } from '../../../../common/constants';
 
 const mockDataViewsService = {
@@ -98,13 +98,13 @@ describe('createDataViewSelectedListener', () => {
     jest.clearAllMocks();
     listener = createDataViewSelectedListener({
       dataViews: mockDataViewsService,
-      scope: DataViewManagerScopeName.default,
+      scope: PageScope.default,
     });
   });
 
   it('should cancel previous effects that would set the data view for given scope', async () => {
     await listener.effect(
-      selectDataViewAsync({ id: 'adhoc_test-*', scope: DataViewManagerScopeName.default }),
+      selectDataViewAsync({ id: 'adhoc_test-*', scope: PageScope.default }),
       mockListenerApi
     );
 
@@ -113,7 +113,7 @@ describe('createDataViewSelectedListener', () => {
 
   it('should return cached adhoc data view first', async () => {
     await listener.effect(
-      selectDataViewAsync({ id: 'adhoc_test-*', scope: DataViewManagerScopeName.default }),
+      selectDataViewAsync({ id: 'adhoc_test-*', scope: PageScope.default }),
       mockListenerApi
     );
 
@@ -125,7 +125,7 @@ describe('createDataViewSelectedListener', () => {
       selectDataViewAsync({
         id: 'fetched-id',
         fallbackPatterns: ['test-*'],
-        scope: DataViewManagerScopeName.default,
+        scope: PageScope.default,
       }),
       mockListenerApi
     );
@@ -152,7 +152,7 @@ describe('createDataViewSelectedListener', () => {
     await listener.effect(
       selectDataViewAsync({
         fallbackPatterns: ['test-*'],
-        scope: DataViewManagerScopeName.default,
+        scope: PageScope.default,
       }),
       mockListenerApi
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
@@ -36,7 +36,7 @@ const mockedState: RootState = {
       dataViewId: null,
       status: 'pristine',
     },
-    detections: {
+    alerts: {
       dataViewId: null,
       status: 'pristine',
     },

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
@@ -12,7 +12,7 @@ import type { RootState } from '../reducer';
 import { scopes } from '../reducer';
 import { selectDataViewAsync } from '../actions';
 import { sharedDataViewManagerSlice } from '../slices';
-import type { DataViewManagerScopeName } from '../../constants';
+import type { PageScope } from '../../constants';
 
 /**
  * Creates a Redux listener for handling data view selection logic in the data view manager.
@@ -31,7 +31,7 @@ import type { DataViewManagerScopeName } from '../../constants';
  * @returns An object with the action creator and effect for Redux middleware.
  */
 export const createDataViewSelectedListener = (dependencies: {
-  scope: DataViewManagerScopeName;
+  scope: PageScope;
   dataViews: DataViewsServicePublic;
 }) => {
   return {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -11,7 +11,7 @@ import { createInitListener } from './init_listener';
 import type { DataViewsServicePublic } from '@kbn/data-views-plugin/public';
 import type { RootState } from '../reducer';
 import { sharedDataViewManagerSlice } from '../slices';
-import { DataViewManagerScopeName, DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID } from '../../constants';
+import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, PageScope } from '../../constants';
 import {
   DEFAULT_ALERT_DATA_VIEW_ID,
   DEFAULT_ATTACK_DATA_VIEW_ID,
@@ -104,31 +104,31 @@ describe('createInitListener', () => {
     expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(
       selectDataViewAsync({
         id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
-        scope: DataViewManagerScopeName.default,
+        scope: PageScope.default,
       })
     );
     expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(
       selectDataViewAsync({
         id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
-        scope: DataViewManagerScopeName.timeline,
+        scope: PageScope.timeline,
       })
     );
     expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(
       selectDataViewAsync({
         id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
-        scope: DataViewManagerScopeName.alerts,
+        scope: PageScope.alerts,
       })
     );
     expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(
       selectDataViewAsync({
         id: DEFAULT_ATTACK_DATA_VIEW_ID,
-        scope: DataViewManagerScopeName.attacks,
+        scope: PageScope.attacks,
       })
     );
     expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(
       selectDataViewAsync({
         id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
-        scope: DataViewManagerScopeName.analyzer,
+        scope: PageScope.analyzer,
       })
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -45,7 +45,7 @@ const mockGetState = jest.fn(() => {
   const state = structuredClone(mockDataViewManagerState);
 
   state.dataViewManager.default.dataViewId = null;
-  state.dataViewManager.detections = structuredClone(state.dataViewManager.default);
+  state.dataViewManager.alerts = structuredClone(state.dataViewManager.default);
   state.dataViewManager.attacks = structuredClone(state.dataViewManager.default);
   state.dataViewManager.timeline = structuredClone(state.dataViewManager.default);
   state.dataViewManager.analyzer = structuredClone(state.dataViewManager.default);
@@ -116,7 +116,7 @@ describe('createInitListener', () => {
     expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(
       selectDataViewAsync({
         id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
-        scope: DataViewManagerScopeName.detections,
+        scope: DataViewManagerScopeName.alerts,
       })
     );
     expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
@@ -11,7 +11,7 @@ import type { CoreStart } from '@kbn/core/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { RootState } from '../reducer';
 import { sharedDataViewManagerSlice } from '../slices';
-import { DataViewManagerScopeName } from '../../constants';
+import { PageScope } from '../../constants';
 import { selectDataViewAsync } from '../actions';
 import { createDefaultDataView } from '../../utils/create_default_data_view';
 import { createExploreDataView } from '../../utils/create_explore_data_view';
@@ -92,17 +92,17 @@ export const createInitListener = (
         // preventing race conditions
         // Whats more, portions of the state that already have selections applied to them will not be reset in the init listener.
         [
-          DataViewManagerScopeName.alerts,
-          DataViewManagerScopeName.attacks,
-          DataViewManagerScopeName.analyzer,
-          DataViewManagerScopeName.timeline,
-          DataViewManagerScopeName.default,
-          DataViewManagerScopeName.explore,
+          PageScope.alerts,
+          PageScope.attacks,
+          PageScope.analyzer,
+          PageScope.timeline,
+          PageScope.default,
+          PageScope.explore,
         ]
           // NOTE: only init default data view for slices that are not initialized yet
           .filter((scope) => !listenerApi.getState().dataViewManager[scope].dataViewId)
           .forEach((scope) => {
-            if (scope === DataViewManagerScopeName.explore) {
+            if (scope === PageScope.explore) {
               return listenerApi.dispatch(
                 selectDataViewAsync({
                   id: exploreDataView.id,
@@ -111,7 +111,7 @@ export const createInitListener = (
               );
             }
 
-            if (scope === DataViewManagerScopeName.attacks) {
+            if (scope === PageScope.attacks) {
               return listenerApi.dispatch(
                 selectDataViewAsync({
                   id: attackDataView.id,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
@@ -92,7 +92,7 @@ export const createInitListener = (
         // preventing race conditions
         // Whats more, portions of the state that already have selections applied to them will not be reset in the init listener.
         [
-          DataViewManagerScopeName.detections,
+          DataViewManagerScopeName.alerts,
           DataViewManagerScopeName.attacks,
           DataViewManagerScopeName.analyzer,
           DataViewManagerScopeName.timeline,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/reducer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/reducer.ts
@@ -7,7 +7,7 @@
 
 import { combineReducers } from '@reduxjs/toolkit';
 
-import { DataViewManagerScopeName } from '../constants';
+import { PageScope } from '../constants';
 import {
   createDataViewSelectionSlice,
   initialScopeState,
@@ -19,24 +19,22 @@ import {
  * Define registered scopes array.
  */
 const REGISTERED_SCOPES = [
-  DataViewManagerScopeName.default,
-  DataViewManagerScopeName.timeline,
-  DataViewManagerScopeName.alerts,
-  DataViewManagerScopeName.attacks,
-  DataViewManagerScopeName.analyzer,
-  DataViewManagerScopeName.explore,
+  PageScope.default,
+  PageScope.timeline,
+  PageScope.alerts,
+  PageScope.attacks,
+  PageScope.analyzer,
+  PageScope.explore,
 ] as const;
 
 /**
  * Helper function to create objects with Registered Scope names as keys
  */
-const createScopeMap = <T>(
-  valueCreator: (scopeName: DataViewManagerScopeName) => T
-): Record<DataViewManagerScopeName, T> => {
+const createScopeMap = <T>(valueCreator: (scopeName: PageScope) => T): Record<PageScope, T> => {
   return REGISTERED_SCOPES.reduce((acc, scopeName) => {
     acc[scopeName] = valueCreator(scopeName);
     return acc;
-  }, {} as Record<DataViewManagerScopeName, T>);
+  }, {} as Record<PageScope, T>);
 };
 
 /*

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/reducer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/reducer.ts
@@ -21,7 +21,7 @@ import {
 const REGISTERED_SCOPES = [
   DataViewManagerScopeName.default,
   DataViewManagerScopeName.timeline,
-  DataViewManagerScopeName.detections,
+  DataViewManagerScopeName.alerts,
   DataViewManagerScopeName.attacks,
   DataViewManagerScopeName.analyzer,
   DataViewManagerScopeName.explore,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/selectors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/selectors.ts
@@ -7,10 +7,10 @@
 
 import { createSelector } from '@reduxjs/toolkit';
 
-import type { DataViewManagerScopeName } from '../constants';
+import type { PageScope } from '../constants';
 import type { RootState } from './reducer';
 
-export const sourcererAdapterSelector = (scope: DataViewManagerScopeName) =>
+export const sourcererAdapterSelector = (scope: PageScope) =>
   createSelector([(state: RootState) => state.dataViewManager], (dataViewManager) => {
     const scopedState = dataViewManager[scope];
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/slices.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/slices.test.ts
@@ -7,13 +7,13 @@
 
 import type { DataView } from '@kbn/data-views-plugin/common';
 import {
-  sharedDataViewManagerSlice,
   createDataViewSelectionSlice,
-  initialSharedState,
   initialScopeState,
+  initialSharedState,
+  sharedDataViewManagerSlice,
 } from './slices';
 import { selectDataViewAsync } from './actions';
-import { DataViewManagerScopeName } from '../constants';
+import { PageScope } from '../constants';
 
 describe('slices', () => {
   describe('dataViewSelectionSlice', () => {});
@@ -114,7 +114,7 @@ describe('slices', () => {
   });
 
   describe('createDataViewSelectionSlice', () => {
-    const testScope = DataViewManagerScopeName.default;
+    const testScope = PageScope.default;
     const { reducer, actions } = createDataViewSelectionSlice(testScope);
 
     describe('setSelectedDataView', () => {
@@ -154,7 +154,7 @@ describe('slices', () => {
           initialScopeState,
           selectDataViewAsync({
             id: '1',
-            scope: DataViewManagerScopeName.analyzer,
+            scope: PageScope.analyzer,
           })
         );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/slices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/slices.ts
@@ -7,8 +7,8 @@
 
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import type { DataViewSpec, DataView } from '@kbn/data-views-plugin/common';
-import type { DataViewManagerScopeName } from '../constants';
+import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
+import type { PageScope } from '../constants';
 import { SLICE_PREFIX } from '../constants';
 import type {
   ScopedDataViewSelectionState,
@@ -81,7 +81,7 @@ export const sharedDataViewManagerSlice = createSlice({
   },
 });
 
-export const createDataViewSelectionSlice = <T extends DataViewManagerScopeName>(scopeName: T) =>
+export const createDataViewSelectionSlice = <T extends PageScope>(scopeName: T) =>
   createSlice({
     name: `${SLICE_PREFIX}/${scopeName}`,
     initialState: initialScopeState,

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_histogram.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_histogram.tsx
@@ -143,7 +143,7 @@ const PreviewHistogramComponent = ({
   return (
     <AlertTableCellContextProvider
       tableId={TableId.rulePreview}
-      sourcererScope={SourcererScopeName.detections}
+      sourcererScope={SourcererScopeName.alerts}
     >
       <Panel height={DEFAULT_HISTOGRAM_HEIGHT} data-test-subj={'preview-histogram-panel'}>
         <EuiFlexGroup gutterSize="none" direction="column">
@@ -165,7 +165,7 @@ const PreviewHistogramComponent = ({
               height={CHART_HEIGHT}
               id={previewEmbeddableId}
               inspectTitle={i18n.QUERY_GRAPH_HITS_TITLE}
-              scopeId={SourcererScopeName.detections}
+              scopeId={SourcererScopeName.alerts}
               stackByField={ruleType === 'machine_learning' ? 'host.name' : 'event.category'}
               timerange={timerange}
               withActions={INSPECT_ACTION}
@@ -196,7 +196,7 @@ const PreviewHistogramComponent = ({
           renderCellValue={PreviewRenderCellValue}
           rowRenderers={defaultRowRenderers}
           start={startDate}
-          sourcererScope={SourcererScopeName.detections}
+          sourcererScope={SourcererScopeName.alerts}
           indexNames={[`${DEFAULT_PREVIEW_INDEX}-${spaceId}`]}
           bulkActions={false}
         />

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_histogram.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_histogram.tsx
@@ -7,13 +7,14 @@
 
 import React, { useEffect, useMemo } from 'react';
 import usePrevious from 'react-use/lib/usePrevious';
-import { EuiFlexGroup, EuiFlexItem, EuiText, EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
 import styled from 'styled-components';
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { DataViewBase } from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { AlertTableCellContextProvider } from '../../../../detections/configurations/security_solution_detections/cell_value_context';
 import { StatefulEventsViewer } from '../../../../common/components/events_viewer';
 import { defaultRowRenderers } from '../../../../timelines/components/timeline/body/renderers';
@@ -23,7 +24,6 @@ import { Panel } from '../../../../common/components/panel';
 import { HeaderSection } from '../../../../common/components/header_section';
 
 import { getAlertsPreviewDefaultModel } from '../../../../detections/components/alerts_table/default_config';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { DEFAULT_PREVIEW_INDEX } from '../../../../../common/constants';
 import { PreviewRenderCellValue } from './preview_table_cell_renderer';
 import { getPreviewTableControlColumn } from './preview_table_control_columns';
@@ -141,10 +141,7 @@ const PreviewHistogramComponent = ({
   }, [config, indexPattern, previewId]);
 
   return (
-    <AlertTableCellContextProvider
-      tableId={TableId.rulePreview}
-      sourcererScope={SourcererScopeName.alerts}
-    >
+    <AlertTableCellContextProvider tableId={TableId.rulePreview} sourcererScope={PageScope.alerts}>
       <Panel height={DEFAULT_HISTOGRAM_HEIGHT} data-test-subj={'preview-histogram-panel'}>
         <EuiFlexGroup gutterSize="none" direction="column">
           <EuiFlexItem grow={1}>
@@ -165,7 +162,7 @@ const PreviewHistogramComponent = ({
               height={CHART_HEIGHT}
               id={previewEmbeddableId}
               inspectTitle={i18n.QUERY_GRAPH_HITS_TITLE}
-              scopeId={SourcererScopeName.alerts}
+              scopeId={PageScope.alerts}
               stackByField={ruleType === 'machine_learning' ? 'host.name' : 'event.category'}
               timerange={timerange}
               withActions={INSPECT_ACTION}
@@ -196,7 +193,7 @@ const PreviewHistogramComponent = ({
           renderCellValue={PreviewRenderCellValue}
           rowRenderers={defaultRowRenderers}
           start={startDate}
-          sourcererScope={SourcererScopeName.alerts}
+          sourcererScope={PageScope.alerts}
           indexNames={[`${DEFAULT_PREVIEW_INDEX}-${spaceId}`]}
           bulkActions={false}
         />

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_table_cell_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_table_cell_renderer.tsx
@@ -9,8 +9,8 @@ import React, { useMemo } from 'react';
 import type { EuiDataGridCellValueElementProps } from '@elastic/eui';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { LegacyField } from '@kbn/alerting-types';
+import { PageScope } from '../../../../data_view_manager/constants';
 import type { CellValueElementProps } from '../../../../../common/types';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { CellValue } from '../../../../detections/configurations/security_solution_detections';
 
 const emptyUserProfiles = { profiles: [], isLoading: false };
@@ -34,7 +34,7 @@ export const PreviewRenderCellValue: React.FC<
   return (
     <CellValue
       tableType={TableId.rulePreview}
-      sourcererScope={SourcererScopeName.alerts}
+      sourcererScope={PageScope.alerts}
       legacyAlert={legacyAlert}
       ecsAlert={ecsData}
       asPlainText={true}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_table_cell_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_table_cell_renderer.tsx
@@ -34,7 +34,7 @@ export const PreviewRenderCellValue: React.FC<
   return (
     <CellValue
       tableType={TableId.rulePreview}
-      sourcererScope={SourcererScopeName.detections}
+      sourcererScope={SourcererScopeName.alerts}
       legacyAlert={legacyAlert}
       ecsAlert={ecsData}
       asPlainText={true}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_table.tsx
@@ -10,23 +10,23 @@ import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import moment from 'moment';
 import type {
-  OnTimeChangeProps,
-  OnRefreshProps,
-  OnRefreshChangeProps,
-  EuiSwitchEvent,
   CriteriaWithPagination,
+  EuiSwitchEvent,
+  OnRefreshChangeProps,
+  OnRefreshProps,
+  OnTimeChangeProps,
 } from '@elastic/eui';
 import {
-  EuiTextColor,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiPanel,
-  EuiSuperDatePicker,
-  EuiSpacer,
-  EuiSwitch,
   EuiBasicTable,
   EuiButton,
   EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiSuperDatePicker,
+  EuiSwitch,
+  EuiTextColor,
 } from '@elastic/eui';
 
 import type { Filter, Query } from '@kbn/es-query';
@@ -37,6 +37,7 @@ import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
 import type { I18nStart } from '@kbn/core-i18n-browser';
 import type { ThemeServiceStart } from '@kbn/core-theme-browser';
 
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { dataViewSpecToViewBase } from '../../../../../common/lib/kuery';
 import { InputsModelId } from '../../../../../common/store/inputs/constants';
@@ -72,7 +73,6 @@ import type {
   RelativeTimeRange,
 } from '../../../../../common/store/inputs/model';
 import { isAbsoluteTimeRange, isRelativeTimeRange } from '../../../../../common/store/inputs/model';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import { useExecutionResults } from '../../../../rule_monitoring';
 import { useRuleDetailsContext } from '../rule_details_context';
 import { useExpandableRows } from '../../../../rule_monitoring/components/basic/tables/use_expandable_rows';
@@ -80,9 +80,9 @@ import { TextBlock } from '../../../../rule_monitoring/components/basic/text/tex
 import * as i18n from './translations';
 import {
   EXECUTION_LOG_COLUMNS,
-  getMessageColumn,
-  getExecutionLogMetricsColumns,
   expanderColumn,
+  getExecutionLogMetricsColumns,
+  getMessageColumn,
   getSourceEventTimeRangeColumns,
 } from './execution_log_columns';
 import { ExecutionLogSearchBar } from './execution_log_search_bar';
@@ -163,12 +163,10 @@ const ExecutionLogTableComponent: React.FC<ExecutionLogTableProps> = ({
   } = useRuleDetailsContext();
 
   // Index for `add filter` action and toasts for errors
-  const { sourcererDataView: oldSourcererDataView } = useSourcererDataView(
-    SourcererScopeName.alerts
-  );
+  const { sourcererDataView: oldSourcererDataView } = useSourcererDataView(PageScope.alerts);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
+  const { dataView: experimentalDataView } = useDataView(PageScope.alerts);
 
   const { addError, addSuccess, remove } = useAppToasts();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_table.tsx
@@ -164,11 +164,11 @@ const ExecutionLogTableComponent: React.FC<ExecutionLogTableProps> = ({
 
   // Index for `add filter` action and toasts for errors
   const { sourcererDataView: oldSourcererDataView } = useSourcererDataView(
-    SourcererScopeName.detections
+    SourcererScopeName.alerts
   );
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.detections);
+  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
 
   const { addError, addSuccess, remove } = useAppToasts();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -38,6 +38,7 @@ import {
   tableDefaults,
   TableId,
 } from '@kbn/securitysolution-data-table';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { RuleCustomizationsContextProvider } from '../../../rule_management/components/rule_details/rule_customizations_diff/rule_customizations_context';
 import { useGroupTakeActionsItems } from '../../../../detections/hooks/alerts_table/use_group_take_action_items';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
@@ -104,7 +105,6 @@ import {
   resetKeyboardFocus,
 } from '../../../../timelines/components/timeline/helpers';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import {
   canEditRuleWithActions,
   explainLackOfPermission,
@@ -269,9 +269,9 @@ export const RuleDetailsPage = connector(
       useListsConfig();
 
     const { sourcererDataView: oldSourcererDataViewSpec, loading: oldIsLoadingIndexPattern } =
-      useSourcererDataView(SourcererScopeName.alerts);
+      useSourcererDataView(PageScope.alerts);
     const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-    const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.alerts);
+    const { dataView: experimentalDataView, status } = useDataView(PageScope.alerts);
     const isLoadingIndexPattern = newDataViewPickerEnabled
       ? status !== 'ready'
       : oldIsLoadingIndexPattern;

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -269,9 +269,9 @@ export const RuleDetailsPage = connector(
       useListsConfig();
 
     const { sourcererDataView: oldSourcererDataViewSpec, loading: oldIsLoadingIndexPattern } =
-      useSourcererDataView(SourcererScopeName.detections);
+      useSourcererDataView(SourcererScopeName.alerts);
     const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-    const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.detections);
+    const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.alerts);
     const isLoadingIndexPattern = newDataViewPickerEnabled
       ? status !== 'ready'
       : oldIsLoadingIndexPattern;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
@@ -27,7 +27,7 @@ import type { PackageListItem } from '@kbn/fleet-plugin/common';
 import styled from '@emotion/styled';
 import { RELATED_INTEGRATION } from '../../../constants';
 import { useBrowserFields } from '../../../../data_view_manager/hooks/use_browser_fields';
-import { DataViewManagerScopeName } from '../../../../data_view_manager/constants';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useAdditionalBulkActions } from '../../../hooks/alert_summary/use_additional_bulk_actions';
 import { APP_ID, CASES_FEATURE_ID } from '../../../../../common';
 import { ActionsCell } from './actions_cell';
@@ -175,7 +175,7 @@ export const Table = memo(({ dataView, groupingFilters, packages }: TableProps) 
 
   const dataViewSpec = useMemo(() => dataView.toSpec(), [dataView]);
 
-  const browserFields = useBrowserFields(DataViewManagerScopeName.alerts, dataView);
+  const browserFields = useBrowserFields(PageScope.alerts, dataView);
 
   const getGlobalQuerySelector = useMemo(() => inputsSelectors.globalQuerySelector(), []);
   const globalQuery = useDeepEqualSelector(getGlobalQuerySelector);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
@@ -175,7 +175,7 @@ export const Table = memo(({ dataView, groupingFilters, packages }: TableProps) 
 
   const dataViewSpec = useMemo(() => dataView.toSpec(), [dataView]);
 
-  const browserFields = useBrowserFields(DataViewManagerScopeName.detections, dataView);
+  const browserFields = useBrowserFields(DataViewManagerScopeName.alerts, dataView);
 
   const getGlobalQuerySelector = useMemo(() => inputsSelectors.globalQuerySelector(), []);
   const globalQuery = useDeepEqualSelector(getGlobalQuerySelector);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
@@ -17,9 +17,9 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import { PageScope } from '../../../data_view_manager/constants';
 import { HeaderPage } from '../../../common/components/header_page';
 import { useSourcererDataView } from '../../../sourcerer/containers';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { AlertsPageContent } from './content';
@@ -42,10 +42,10 @@ export const Wrapper = memo(() => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
   const { sourcererDataView: oldSourcererDataViewSpec, loading: oldSourcererDataViewIsLoading } =
-    useSourcererDataView(SourcererScopeName.alerts);
+    useSourcererDataView(PageScope.alerts);
   // TODO rename to just dataView and status once we remove the newDataViewPickerEnabled feature flag
   const { dataView: experimentalDataView, status: experimentalDataViewStatus } = useDataView(
-    SourcererScopeName.alerts
+    PageScope.alerts
   );
 
   const isLoading: boolean = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
@@ -42,10 +42,10 @@ export const Wrapper = memo(() => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
   const { sourcererDataView: oldSourcererDataViewSpec, loading: oldSourcererDataViewIsLoading } =
-    useSourcererDataView(SourcererScopeName.detections);
+    useSourcererDataView(SourcererScopeName.alerts);
   // TODO rename to just dataView and status once we remove the newDataViewPickerEnabled feature flag
   const { dataView: experimentalDataView, status: experimentalDataViewStatus } = useDataView(
-    SourcererScopeName.detections
+    SourcererScopeName.alerts
   );
 
   const isLoading: boolean = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.tsx
@@ -127,7 +127,7 @@ export const AlertsCountPanel = memo<AlertsCountPanelProps>(
               height={CHART_HEIGHT}
               id={`${uniqueQueryId}-embeddable`}
               inspectTitle={inspectTitle}
-              scopeId={SourcererScopeName.detections}
+              scopeId={SourcererScopeName.alerts}
               stackByField={stackByField0}
               timerange={timerange}
             />

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.tsx
@@ -10,6 +10,7 @@ import type { Action } from '@kbn/ui-actions-plugin/public';
 import React, { memo, useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import type { Filter } from '@kbn/es-query';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { HeaderSection } from '../../../../common/components/header_section';
 import { InspectButtonContainer } from '../../../../common/components/inspect';
@@ -17,7 +18,6 @@ import * as i18n from './translations';
 import { KpiPanel } from '../common/components';
 import { FieldSelection } from '../common/field_selection';
 import { getAlertsTableLensAttributes as getLensAttributes } from '../../../../common/components/visualization_actions/lens_attributes/common/alerts/alerts_table';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { VisualizationEmbeddable } from '../../../../common/components/visualization_actions/visualization_embeddable';
 
 export const DETECTIONS_ALERTS_COUNT_ID = 'detections-alerts-count';
@@ -127,7 +127,7 @@ export const AlertsCountPanel = memo<AlertsCountPanelProps>(
               height={CHART_HEIGHT}
               id={`${uniqueQueryId}-embeddable`}
               inspectTitle={inspectTitle}
-              scopeId={SourcererScopeName.alerts}
+              scopeId={PageScope.alerts}
               stackByField={stackByField0}
               timerange={timerange}
             />

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/index.tsx
@@ -9,7 +9,7 @@ import type { Action } from '@kbn/ui-actions-plugin/public';
 import type { EuiComboBox, EuiTitleSize } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiToolTip } from '@elastic/eui';
 import type { SyntheticEvent } from 'react';
-import React, { memo, useCallback, useMemo, useState, useEffect } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { noop } from 'lodash/fp';
 import { v4 as uuidv4 } from 'uuid';
@@ -17,6 +17,7 @@ import numeral from '@elastic/numeral';
 
 import type { Filter } from '@kbn/es-query';
 
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { APP_UI_ID, DEFAULT_NUMBER_FORMAT } from '../../../../../common/constants';
 import type { UpdateDateRange } from '../../../../common/components/charts/common';
@@ -24,11 +25,12 @@ import { HeaderSection } from '../../../../common/components/header_section';
 import { getDetectionEngineUrl, useFormatUrl } from '../../../../common/components/link_to';
 import { useKibana, useUiSetting$ } from '../../../../common/lib/kibana';
 import {
-  showInitialLoadingSpinner,
-  createGenericSubtitle,
   createEmbeddedDataSubtitle,
+  createGenericSubtitle,
+  showInitialLoadingSpinner,
 } from './helpers';
 import * as i18n from './translations';
+import { SHOWING_ALERTS } from './translations';
 import { LinkButton } from '../../../../common/components/links';
 import { SecurityPageName } from '../../../../app/types';
 import { DEFAULT_STACK_BY_FIELD, PANEL_HEIGHT } from '../common/config';
@@ -38,10 +40,8 @@ import { KpiPanel, StackByComboBox } from '../common/components';
 import { useQueryToggle } from '../../../../common/containers/query_toggle';
 import { GROUP_BY_TOP_LABEL } from '../common/translations';
 import { getAlertsHistogramLensAttributes as getLensAttributes } from '../../../../common/components/visualization_actions/lens_attributes/common/alerts/alerts_histogram';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { VisualizationEmbeddable } from '../../../../common/components/visualization_actions/visualization_embeddable';
 import { useVisualizationResponse } from '../../../../common/components/visualization_actions/use_visualization_response';
-import { SHOWING_ALERTS } from './translations';
 
 export const DETECTIONS_HISTOGRAM_ID = 'detections-histogram';
 
@@ -293,7 +293,7 @@ export const AlertsHistogramPanel = memo<AlertsHistogramPanelProps>(
             height={chartHeight ?? CHART_HEIGHT}
             id={visualizationId}
             inspectTitle={inspectTitle ?? title}
-            scopeId={SourcererScopeName.alerts}
+            scopeId={PageScope.alerts}
             stackByField={selectedStackByOption}
             timerange={timerange}
           />

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/index.tsx
@@ -293,7 +293,7 @@ export const AlertsHistogramPanel = memo<AlertsHistogramPanelProps>(
             height={chartHeight ?? CHART_HEIGHT}
             id={visualizationId}
             inspectTitle={inspectTitle ?? title}
-            scopeId={SourcererScopeName.detections}
+            scopeId={SourcererScopeName.alerts}
             stackByField={selectedStackByOption}
             timerange={timerange}
           />

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/additional_toolbar_controls.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/additional_toolbar_controls.tsx
@@ -6,22 +6,22 @@
  */
 
 import type { ComponentProps } from 'react';
-import React, { useCallback, useMemo, memo } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
+import type { ViewSelection } from '@kbn/securitysolution-data-table';
 import {
   dataTableActions,
   dataTableSelectors,
   tableDefaults,
   TableId,
 } from '@kbn/securitysolution-data-table';
-import type { ViewSelection } from '@kbn/securitysolution-data-table';
 import { useGetGroupSelectorStateless } from '@kbn/grouping/src/hooks/use_get_group_selector';
 import { getTelemetryEvent } from '@kbn/grouping/src/telemetry/const';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { PageScope } from '../../../data_view_manager/constants';
 import type { GetSecurityAlertsTableProp } from './types';
 import { groupIdSelector } from '../../../common/store/grouping/selectors';
 import { useSourcererDataView } from '../../../sourcerer/containers';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { SummaryViewSelector } from '../../../common/components/events_viewer/summary_view_select';
 import { updateGroups } from '../../../common/store/grouping/actions';
 import { useKibana } from '../../../common/lib/kibana';
@@ -45,12 +45,10 @@ const AdditionalToolbarControlsComponent = ({
     services: { telemetry },
   } = useKibana();
 
-  const { sourcererDataView: oldSourcererDataView } = useSourcererDataView(
-    SourcererScopeName.alerts
-  );
+  const { sourcererDataView: oldSourcererDataView } = useSourcererDataView(PageScope.alerts);
 
   const isNewDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
+  const { dataView: experimentalDataView } = useDataView(PageScope.alerts);
 
   const groupId = useMemo(() => groupIdSelector(), []);
   const { options } = useDeepEqualSelector((state) => groupId(state, tableType)) ?? {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/additional_toolbar_controls.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/additional_toolbar_controls.tsx
@@ -46,11 +46,11 @@ const AdditionalToolbarControlsComponent = ({
   } = useKibana();
 
   const { sourcererDataView: oldSourcererDataView } = useSourcererDataView(
-    SourcererScopeName.detections
+    SourcererScopeName.alerts
   );
 
   const isNewDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.detections);
+  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
 
   const groupId = useMemo(() => groupIdSelector(), []);
   const { options } = useDeepEqualSelector((state) => groupId(state, tableType)) ?? {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -15,11 +15,11 @@ import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { DynamicGroupingProps } from '@kbn/grouping/src';
 import { parseGroupingQuery } from '@kbn/grouping/src';
 import type { TableIdLiteral } from '@kbn/securitysolution-data-table';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import type { GroupTakeActionItems } from './types';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import type { RunTimeMappings } from '../../../sourcerer/store/model';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { combineQueries } from '../../../common/lib/kuery';
 import type { AlertsGroupingAggregation } from './grouping_settings/types';
 import { InspectButton } from '../../../common/components/inspect';
@@ -115,12 +115,12 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
     services: { uiSettings },
   } = useKibana();
   const { browserFields: oldBrowserFields, sourcererDataView: oldSourcererDataView } =
-    useSourcererDataView(SourcererScopeName.alerts);
+    useSourcererDataView(PageScope.alerts);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
-  const experimentalBrowserFields = useBrowserFields(SourcererScopeName.alerts);
+  const { dataView: experimentalDataView } = useDataView(PageScope.alerts);
+  const experimentalBrowserFields = useBrowserFields(PageScope.alerts);
 
   const sourcererDataView = oldSourcererDataView;
   const browserFields = newDataViewPickerEnabled ? experimentalBrowserFields : oldBrowserFields;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -115,12 +115,12 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
     services: { uiSettings },
   } = useKibana();
   const { browserFields: oldBrowserFields, sourcererDataView: oldSourcererDataView } =
-    useSourcererDataView(SourcererScopeName.detections);
+    useSourcererDataView(SourcererScopeName.alerts);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.detections);
-  const experimentalBrowserFields = useBrowserFields(SourcererScopeName.detections);
+  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
+  const experimentalBrowserFields = useBrowserFields(SourcererScopeName.alerts);
 
   const sourcererDataView = oldSourcererDataView;
   const browserFields = newDataViewPickerEnabled ? experimentalBrowserFields : oldBrowserFields;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -23,6 +23,7 @@ import type { SetOptional } from 'type-fest';
 import { noop } from 'lodash';
 import type { Alert } from '@kbn/alerting-types';
 import { AlertsTable as ResponseOpsAlertsTable } from '@kbn/response-ops-alerts-table';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { useAlertsContext } from './alerts_context';
 import { useBulkActionsByTableType } from '../../hooks/trigger_actions_alert_table/use_bulk_actions';
@@ -46,7 +47,6 @@ import { useInvalidFilterQuery } from '../../../common/hooks/use_invalid_filter_
 import { StatefulEventContext } from '../../../common/components/events_viewer/stateful_event_context';
 import { useSourcererDataView } from '../../../sourcerer/containers';
 import type { RunTimeMappings } from '../../../sourcerer/store/model';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useKibana } from '../../../common/lib/kibana';
 import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
 import { CellValue, getColumns } from '../../configurations/security_solution_detections';
@@ -127,7 +127,7 @@ interface AlertTableProps
   extends SetOptional<SecurityAlertsTableProps, 'id' | 'ruleTypeIds' | 'query'> {
   inputFilters?: Filter[];
   tableType?: TableId;
-  sourcererScope?: SourcererScopeName;
+  sourcererScope?: PageScope;
   isLoading?: boolean;
   onRuleChange?: () => void;
   disableAdditionalToolbarControls?: boolean;
@@ -151,7 +151,7 @@ const emptyInputFilters: Filter[] = [];
 const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
   inputFilters = emptyInputFilters,
   tableType = TableId.alertsOnAlertsPage,
-  sourcererScope = SourcererScopeName.alerts,
+  sourcererScope = PageScope.alerts,
   isLoading,
   onRuleChange,
   disableAdditionalToolbarControls,
@@ -379,7 +379,7 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
   }, [alertsTableRef]);
 
   const fieldsBrowserOptions = useAlertsTableFieldsBrowserOptions(
-    SourcererScopeName.alerts,
+    PageScope.alerts,
     alertsTableRef.current?.toggleColumn
   );
   const cellActionsOptions = useCellActionsOptions(tableType, tableContext);
@@ -458,10 +458,7 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
     <FullWidthFlexGroupTable gutterSize="none">
       <StatefulEventContext.Provider value={activeStatefulEventContext}>
         <EuiDataGridContainer hideLastPage={false}>
-          <AlertTableCellContextProvider
-            tableId={tableType}
-            sourcererScope={SourcererScopeName.alerts}
-          >
+          <AlertTableCellContextProvider tableId={tableType} sourcererScope={PageScope.alerts}>
             <ResponseOpsAlertsTable<SecurityAlertsTableContext>
               ref={alertsTableRef}
               // Stores separate configuration based on the view of the table

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -151,7 +151,7 @@ const emptyInputFilters: Filter[] = [];
 const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
   inputFilters = emptyInputFilters,
   tableType = TableId.alertsOnAlertsPage,
-  sourcererScope = SourcererScopeName.detections,
+  sourcererScope = SourcererScopeName.alerts,
   isLoading,
   onRuleChange,
   disableAdditionalToolbarControls,
@@ -379,7 +379,7 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
   }, [alertsTableRef]);
 
   const fieldsBrowserOptions = useAlertsTableFieldsBrowserOptions(
-    SourcererScopeName.detections,
+    SourcererScopeName.alerts,
     alertsTableRef.current?.toggleColumn
   );
   const cellActionsOptions = useCellActionsOptions(tableType, tableContext);
@@ -460,7 +460,7 @@ const AlertsTableComponent: FC<Omit<AlertTableProps, 'services'>> = ({
         <EuiDataGridContainer hideLastPage={false}>
           <AlertTableCellContextProvider
             tableId={tableType}
-            sourcererScope={SourcererScopeName.detections}
+            sourcererScope={SourcererScopeName.alerts}
           >
             <ResponseOpsAlertsTable<SecurityAlertsTableContext>
               ref={alertsTableRef}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
@@ -18,6 +18,7 @@ import {
   TableId,
 } from '@kbn/securitysolution-data-table';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import type { PageScope } from '../../../../data_view_manager/constants';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
@@ -36,7 +37,6 @@ import { TimelineId } from '../../../../../common/types/timeline';
 import { TimelineTypeEnum } from '../../../../../common/api/timeline';
 import { sendBulkEventsToTimelineAction } from '../actions';
 import type { CreateTimelineProps } from '../types';
-import type { SourcererScopeName } from '../../../../sourcerer/store/model';
 import type { Direction } from '../../../../../common/search_strategy';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { globalFiltersQuerySelector } from '../../../../common/store/inputs/selectors';
@@ -53,7 +53,7 @@ export interface UseAddBulkToTimelineActionProps {
   /* End Time of the table being passed to the Events Table */
   to: string;
   /* Sourcerer Scope Id*/
-  scopeId: SourcererScopeName;
+  scopeId: PageScope;
 }
 
 const fields = ['_id', 'timestamp'];

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/types.ts
@@ -14,7 +14,7 @@ import type {
   EuiContextMenuPanelDescriptor,
   EuiContextMenuPanelItemDescriptor,
 } from '@elastic/eui';
-import type { SourcererScopeName } from '../../../sourcerer/store/model';
+import type { PageScope } from '../../../data_view_manager/constants';
 import type { AlertsUserProfilesData } from '../../configurations/security_solution_detections/fetch_page_context';
 import type { Status } from '../../../../common/api/detection_engine';
 import type { Note } from '../../../../common/api/timeline';
@@ -77,7 +77,7 @@ export interface SecurityAlertsTableContext {
   isDraggable: boolean;
   leadingControlColumn: ControlColumnProps;
   userProfiles: AlertsUserProfilesData;
-  sourcererScope: SourcererScopeName;
+  sourcererScope: PageScope;
 }
 
 export type SecurityAlertsTableProps = AlertsTablePropsWithRef<SecurityAlertsTableContext>;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/wrapper.tsx
@@ -16,8 +16,8 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { PageScope } from '../../../data_view_manager/constants';
 import { HeaderPage } from '../../../common/components/header_page';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { AttacksPageContent } from './content';
@@ -34,7 +34,7 @@ const DATAVIEW_ERROR = i18n.translate('xpack.securitySolution.attacksPage.dataVi
 export const Wrapper = React.memo(() => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataView, status } = useDataView(SourcererScopeName.attacks);
+  const { dataView, status } = useDataView(PageScope.attacks);
 
   const isLoading: boolean = useMemo(
     () => (newDataViewPickerEnabled && status === 'loading') || status === 'pristine',

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/cell_value_context.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/cell_value_context.tsx
@@ -7,17 +7,17 @@
 
 import React, { createContext, useMemo } from 'react';
 import type { FieldSpec } from '@kbn/data-views-plugin/common';
-import { tableDefaults, dataTableSelectors } from '@kbn/securitysolution-data-table';
+import { dataTableSelectors, tableDefaults } from '@kbn/securitysolution-data-table';
 import type { BrowserFields } from '@kbn/timelines-plugin/common';
+import type { PageScope } from '../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
-import type { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useLicense } from '../../../common/hooks/use_license';
 import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
 import { useSourcererDataView } from '../../../sourcerer/containers';
 import { VIEW_SELECTION } from '../../../../common/constants';
 import { getAllFieldsByName } from '../../../common/containers/source';
-import { eventRenderedViewColumns, getColumns } from './columns';
 import type { AlertColumnHeaders } from './columns';
+import { eventRenderedViewColumns, getColumns } from './columns';
 import { useBrowserFields } from '../../../data_view_manager/hooks/use_browser_fields';
 
 interface AlertTableCellContextProps {
@@ -34,7 +34,7 @@ export const AlertTableCellContextProvider = ({
   children,
 }: {
   tableId?: string;
-  sourcererScope: SourcererScopeName;
+  sourcererScope: PageScope;
   children: React.ReactNode;
 }) => {
   const { browserFields: oldBrowserFields } = useSourcererDataView(sourcererScope);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.test.tsx
@@ -18,8 +18,8 @@ import { defaultRowRenderers } from '../../../timelines/components/timeline/body
 import type { TimelineNonEcsData } from '../../../../common/search_strategy/timeline';
 import type { RenderCellValueProps } from './render_cell_value';
 import { CellValue } from './render_cell_value';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { AlertTableCellContextProvider } from './cell_value_context';
+import { PageScope } from '../../../data_view_manager/constants';
 
 jest.mock('../../../common/lib/kibana');
 jest.mock('../../../sourcerer/containers', () => ({
@@ -72,14 +72,11 @@ describe('RenderCellValue', () => {
     return (
       <TestProviders>
         <DragDropContextWrapper browserFields={mockBrowserFields}>
-          <AlertTableCellContextProvider
-            tableId={TableId.test}
-            sourcererScope={SourcererScopeName.alerts}
-          >
+          <AlertTableCellContextProvider tableId={TableId.test} sourcererScope={PageScope.alerts}>
             <CellValue
               {...defaultProps}
               {...props}
-              sourcererScope={SourcererScopeName.alerts}
+              sourcererScope={PageScope.alerts}
               tableType={TableId.test}
             />
           </AlertTableCellContextProvider>
@@ -95,7 +92,7 @@ describe('RenderCellValue', () => {
           <DragDropContextWrapper browserFields={mockBrowserFields}>
             <CellValue
               {...defaultProps}
-              sourcererScope={SourcererScopeName.alerts}
+              sourcererScope={PageScope.alerts}
               tableType={TableId.test}
             />
           </DragDropContextWrapper>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.test.tsx
@@ -74,12 +74,12 @@ describe('RenderCellValue', () => {
         <DragDropContextWrapper browserFields={mockBrowserFields}>
           <AlertTableCellContextProvider
             tableId={TableId.test}
-            sourcererScope={SourcererScopeName.detections}
+            sourcererScope={SourcererScopeName.alerts}
           >
             <CellValue
               {...defaultProps}
               {...props}
-              sourcererScope={SourcererScopeName.detections}
+              sourcererScope={SourcererScopeName.alerts}
               tableType={TableId.test}
             />
           </AlertTableCellContextProvider>
@@ -95,7 +95,7 @@ describe('RenderCellValue', () => {
           <DragDropContextWrapper browserFields={mockBrowserFields}>
             <CellValue
               {...defaultProps}
-              sourcererScope={SourcererScopeName.detections}
+              sourcererScope={SourcererScopeName.alerts}
               tableType={TableId.test}
             />
           </DragDropContextWrapper>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_actions.test.tsx
@@ -8,7 +8,6 @@
 import { renderHook } from '@testing-library/react';
 
 import { useBulkActionsByTableType } from './use_bulk_actions';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
 import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
 import * as useBulkAlertAssigneesItemsModule from '../../../common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items';
@@ -16,6 +15,7 @@ import * as useBulkAlertTagsItemsModule from '../../../common/components/toolbar
 import * as useAddBulkToTimelineActionModule from '../../components/alerts_table/timeline_actions/use_add_bulk_to_timeline';
 import * as useBulkAlertActionItemsModule from './use_alert_actions';
 import type { TableId } from '@kbn/securitysolution-data-table';
+import { PageScope } from '../../../data_view_manager/constants';
 
 jest.mock('../../../common/containers/use_global_time');
 jest.mock('../../../common/hooks/use_selector');
@@ -84,7 +84,7 @@ describe('useBulkActionsByTableType', () => {
     renderHook(() => useBulkActionsByTableType(mockTableId, mockQuery, mockRefresh));
 
     expect(useBulkAlertActionItemsModule.useBulkAlertActionItems).toHaveBeenCalledWith({
-      scopeId: SourcererScopeName.alerts,
+      scopeId: PageScope.alerts,
       filters: [],
       from: '2020-07-07T08:20:18.966Z',
       to: '2020-07-08T08:20:18.966Z',
@@ -96,7 +96,7 @@ describe('useBulkActionsByTableType', () => {
       localFilters: [],
       from: '2020-07-07T08:20:18.966Z',
       to: '2020-07-08T08:20:18.966Z',
-      scopeId: SourcererScopeName.alerts,
+      scopeId: PageScope.alerts,
       tableId: mockTableId,
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_actions.test.tsx
@@ -84,7 +84,7 @@ describe('useBulkActionsByTableType', () => {
     renderHook(() => useBulkActionsByTableType(mockTableId, mockQuery, mockRefresh));
 
     expect(useBulkAlertActionItemsModule.useBulkAlertActionItems).toHaveBeenCalledWith({
-      scopeId: SourcererScopeName.detections,
+      scopeId: SourcererScopeName.alerts,
       filters: [],
       from: '2020-07-07T08:20:18.966Z',
       to: '2020-07-08T08:20:18.966Z',
@@ -96,7 +96,7 @@ describe('useBulkActionsByTableType', () => {
       localFilters: [],
       from: '2020-07-07T08:20:18.966Z',
       to: '2020-07-08T08:20:18.966Z',
-      scopeId: SourcererScopeName.detections,
+      scopeId: SourcererScopeName.alerts,
       tableId: mockTableId,
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_actions.tsx
@@ -9,12 +9,12 @@ import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/type
 import type { SerializableRecord } from '@kbn/utility-types';
 import { isEqual } from 'lodash';
 import type { Filter } from '@kbn/es-query';
-import { useMemo, useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { TableId } from '@kbn/securitysolution-data-table';
 import type { AlertsTableProps } from '@kbn/response-ops-alerts-table/types';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useBulkAlertAssigneesItems } from '../../../common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items';
 import { useBulkAlertTagsItems } from '../../../common/components/toolbar/bulk_actions/use_bulk_alert_tags_items';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
 import { useAddBulkToTimelineAction } from '../../components/alerts_table/timeline_actions/use_add_bulk_to_timeline';
 import { useBulkAlertActionItems } from './use_alert_actions';
@@ -82,7 +82,7 @@ export const useBulkActionsByTableType = (
       localFilters: filters,
       from,
       to,
-      scopeId: SourcererScopeName.alerts,
+      scopeId: PageScope.alerts,
       tableId,
     };
   }, [filters, from, to, tableId]);
@@ -97,7 +97,7 @@ export const useBulkActionsByTableType = (
 
   const alertActionParams = useMemo(() => {
     return {
-      scopeId: SourcererScopeName.alerts,
+      scopeId: PageScope.alerts,
       filters,
       from,
       to,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_actions.tsx
@@ -82,7 +82,7 @@ export const useBulkActionsByTableType = (
       localFilters: filters,
       from,
       to,
-      scopeId: SourcererScopeName.detections,
+      scopeId: SourcererScopeName.alerts,
       tableId,
     };
   }, [filters, from, to, tableId]);
@@ -97,7 +97,7 @@ export const useBulkActionsByTableType = (
 
   const alertActionParams = useMemo(() => {
     return {
-      scopeId: SourcererScopeName.detections,
+      scopeId: SourcererScopeName.alerts,
       filters,
       from,
       to,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
@@ -9,16 +9,16 @@ import type { TimelineNonEcsData } from '@kbn/timelines-plugin/common';
 import { useCallback, useMemo } from 'react';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { RenderContext } from '@kbn/response-ops-alerts-table/types';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import type { UseDataGridColumnsSecurityCellActionsProps } from '../../../common/components/cell_actions';
 import { useDataGridColumnsSecurityCellActions } from '../../../common/components/cell_actions';
 import { SecurityCellActionsTrigger, SecurityCellActionType } from '../../../app/actions/constants';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useGetFieldSpec } from '../../../common/hooks/use_get_field_spec';
 import { useDataViewId } from '../../../common/hooks/use_data_view_id';
 import type {
-  SecurityAlertsTableContext,
   GetSecurityAlertsTableProp,
+  SecurityAlertsTableContext,
 } from '../../components/alerts_table/types';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 
@@ -30,7 +30,7 @@ export const useCellActionsOptions = (
   >
 ) => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
+  const { dataView: experimentalDataView } = useDataView(PageScope.alerts);
 
   const {
     columns = [],
@@ -39,8 +39,8 @@ export const useCellActionsOptions = (
     pageSize = 0,
     dataGridRef,
   } = context ?? {};
-  const oldGetFieldSpec = useGetFieldSpec(SourcererScopeName.alerts);
-  const oldDataViewId = useDataViewId(SourcererScopeName.alerts);
+  const oldGetFieldSpec = useGetFieldSpec(PageScope.alerts);
+  const oldDataViewId = useDataViewId(PageScope.alerts);
   const dataViewId = newDataViewPickerEnabled ? experimentalDataView.id : oldDataViewId;
 
   const cellActionsMetadata = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
@@ -30,7 +30,7 @@ export const useCellActionsOptions = (
   >
 ) => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.detections);
+  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
 
   const {
     columns = [],
@@ -39,8 +39,8 @@ export const useCellActionsOptions = (
     pageSize = 0,
     dataGridRef,
   } = context ?? {};
-  const oldGetFieldSpec = useGetFieldSpec(SourcererScopeName.detections);
-  const oldDataViewId = useDataViewId(SourcererScopeName.detections);
+  const oldGetFieldSpec = useGetFieldSpec(SourcererScopeName.alerts);
+  const oldDataViewId = useDataViewId(SourcererScopeName.alerts);
   const dataViewId = newDataViewPickerEnabled ? experimentalDataView.id : oldDataViewId;
 
   const cellActionsMetadata = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_trigger_actions_browser_fields_options.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_trigger_actions_browser_fields_options.tsx
@@ -7,11 +7,11 @@
 import { useCallback, useMemo } from 'react';
 import type { EuiDataGridColumn } from '@elastic/eui';
 import { noop } from 'lodash';
+import type { PageScope } from '../../../data_view_manager/constants';
 import { useFieldBrowserOptions } from '../../../timelines/components/fields_browser';
-import type { SourcererScopeName } from '../../../sourcerer/store/model';
 
 export const useAlertsTableFieldsBrowserOptions = (
-  scopeId: SourcererScopeName,
+  scopeId: PageScope,
   toggleColumn: (columnId: string) => void = noop
 ) => {
   const upsertColumn = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_rule_from_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_rule_from_timeline.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { i18n } from '@kbn/i18n';
 import type { EqlOptions } from '@kbn/timelines-plugin/common';
+import { PageScope } from '../../data_view_manager/constants';
 import { useSelectDataView } from '../../data_view_manager/hooks/use_select_data_view';
 import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_patterns';
 import { convertKueryToElasticSearchQuery } from '../../common/lib/kuery';
@@ -22,7 +23,6 @@ import { useQueryTimelineById } from '../../timelines/components/open_timeline/h
 import { useGetInitialUrlParamValue } from '../../common/utils/global_query_string/helpers';
 import { buildGlobalQuery } from '../../timelines/components/timeline/helpers';
 import { getDataProviderFilter } from '../../timelines/components/timeline/query_bar';
-import { SourcererScopeName } from '../../sourcerer/store/model';
 import { useBrowserFields } from '../../data_view_manager/hooks/use_browser_fields';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
@@ -61,13 +61,13 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
     browserFields: oldBrowserFields,
     dataViewId: oldDataViewId,
     selectedPatterns: oldSelectedPatterns,
-  } = useSourcererDataView(SourcererScopeName.timeline);
+  } = useSourcererDataView(PageScope.timeline);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
-  const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const experimentalBrowserFields = useBrowserFields(PageScope.timeline);
+  const { dataView: experimentalDataView } = useDataView(PageScope.timeline);
   const selectDataView = useSelectDataView();
 
   const selectedPatterns = newDataViewPickerEnabled
@@ -104,7 +104,7 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
         // sourcerer handles the logic of if the fields have been fetched or need to be fetched
         dispatch(
           sourcererActions.setSelectedDataView({
-            id: SourcererScopeName.timeline,
+            id: PageScope.timeline,
             selectedDataViewId: timeline.dataViewId,
             selectedPatterns: timeline.indexNames,
           })
@@ -112,7 +112,7 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
 
         if (newDataViewPickerEnabled) {
           selectDataView({
-            scope: SourcererScopeName.timeline,
+            scope: PageScope.timeline,
             id: timeline.dataViewId,
             fallbackPatterns: timeline.indexNames,
           });
@@ -199,7 +199,7 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
     if (originalDataView.dataViewId !== dataViewId) {
       dispatch(
         sourcererActions.setSelectedDataView({
-          id: SourcererScopeName.timeline,
+          id: PageScope.timeline,
           selectedDataViewId: originalDataView.dataViewId,
           selectedPatterns: originalDataView.selectedPatterns,
         })
@@ -207,7 +207,7 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
 
       if (newDataViewPickerEnabled) {
         selectDataView({
-          scope: SourcererScopeName.timeline,
+          scope: PageScope.timeline,
           id: originalDataView.dataViewId,
           fallbackPatterns: originalDataView.selectedPatterns,
         });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_risk_input_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_risk_input_actions.ts
@@ -12,8 +12,8 @@ import { AttachmentType } from '@kbn/cases-plugin/common';
 import type { CaseAttachmentsWithoutOwner } from '@kbn/cases-plugin/public';
 import { ALERT_RULE_NAME, ALERT_RULE_UUID } from '@kbn/rule-data-utils';
 
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useAddBulkToTimelineAction } from '../../../../detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline';
 import { useKibana } from '../../../../common/lib/kibana/kibana_react';
 import type { InputAlert } from '../../../hooks/use_risk_contributing_alerts';
@@ -28,7 +28,7 @@ export const useRiskInputActions = (inputs: InputAlert[], closePopover: () => vo
     localFilters: [],
     from,
     to,
-    scopeId: SourcererScopeName.alerts,
+    scopeId: PageScope.alerts,
     tableId: TableId.riskInputs,
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_risk_input_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_risk_input_actions.ts
@@ -28,7 +28,7 @@ export const useRiskInputActions = (inputs: InputAlert[], closePopover: () => vo
     localFilters: [],
     from,
     to,
-    scopeId: SourcererScopeName.detections,
+    scopeId: SourcererScopeName.alerts,
     tableId: TableId.riskInputs,
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/alert_filters_kql_bar.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/alert_filters_kql_bar.tsx
@@ -5,26 +5,26 @@
  * 2.0.
  */
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
 import {
-  EuiFormRow,
+  EuiButtonIcon,
+  EuiComboBox,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiComboBox,
-  EuiText,
-  EuiButtonIcon,
+  EuiFormRow,
   EuiPanel,
   EuiPopover,
   EuiSpacer,
+  EuiText,
   EuiTextColor,
 } from '@elastic/eui';
 import type { Query } from '@kbn/es-query';
 import { fromKueryExpression } from '@kbn/es-query';
 import type { DataView } from '@kbn/data-views-plugin/public';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useSourcererDataView } from '../../../sourcerer/containers';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useKibana } from '../../../common/lib/kibana';
 import * as i18n from '../../translations';
 import type { UIAlertFilter } from './common';
@@ -218,7 +218,7 @@ export const AlertFiltersKqlBar: React.FC<AlertFiltersKqlBarProps> = ({
   compressed = true,
   'data-test-subj': dataTestSubj = 'alertFiltersKqlBar',
 }) => {
-  const { sourcererDataView } = useSourcererDataView(SourcererScopeName.explore);
+  const { sourcererDataView } = useSourcererDataView(PageScope.explore);
   const {
     unifiedSearch: {
       ui: { SearchBar },

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_section.tsx
@@ -5,23 +5,24 @@
  * 2.0.
  */
 
-import React, { useState, useMemo, Fragment } from 'react';
+import React, { Fragment, useMemo, useState } from 'react';
 import {
   EuiAccordion,
-  EuiPanel,
-  EuiSpacer,
-  EuiTitle,
-  EuiCallOut,
   EuiButton,
-  EuiIcon,
-  EuiText,
-  EuiLoadingSpinner,
+  EuiCallOut,
+  EuiCode,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiCode,
+  EuiIcon,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
 } from '@elastic/eui';
 import type { BoolQuery } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { PageScope } from '../../../data_view_manager/constants';
 import type { EntityType } from '../../../../common/entity_analytics/types';
 import { EntityTypeToIdentifierField } from '../../../../common/entity_analytics/types';
 import type { EntityRiskScoreRecord } from '../../../../common/api/entity_analytics/common';
@@ -29,7 +30,6 @@ import { RISK_SCORE_INDEX_PATTERN } from '../../../../common/entity_analytics/ri
 import { RiskScorePreviewTable } from './risk_score_preview_table';
 import * as i18n from '../../translations';
 import { useRiskScorePreview } from '../../api/hooks/use_preview_risk_scores';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useSourcererDataView } from '../../../sourcerer/containers';
 import type { RiskEngineMissingPrivilegesResponse } from '../../hooks/use_missing_risk_engine_privileges';
 import { userHasRiskEngineReadPermissions } from '../../common';
@@ -38,6 +38,7 @@ import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_exper
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { useEntityAnalyticsTypes } from '../../hooks/use_enabled_entity_types';
 import type { AlertFilter } from './common';
+
 interface IRiskScorePreviewPanel {
   showMessage: React.ReactNode;
   hideMessage: React.ReactNode;
@@ -160,12 +161,10 @@ const RiskEnginePreview: React.FC<{
     bool: { must: [], filter: [], should: [], must_not: [] },
   });
 
-  const { sourcererDataView: oldSourcererDataView } = useSourcererDataView(
-    SourcererScopeName.alerts
-  );
+  const { sourcererDataView: oldSourcererDataView } = useSourcererDataView(PageScope.alerts);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
+  const { dataView: experimentalDataView } = useDataView(PageScope.alerts);
 
   const sourcererDataView = newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataView;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_section.tsx
@@ -161,11 +161,11 @@ const RiskEnginePreview: React.FC<{
   });
 
   const { sourcererDataView: oldSourcererDataView } = useSourcererDataView(
-    SourcererScopeName.detections
+    SourcererScopeName.alerts
   );
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.detections);
+  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
 
   const sourcererDataView = newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataView;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/top_risk_score_contributors_alerts/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/top_risk_score_contributors_alerts/index.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useMemo } from 'react';
 import { TableId } from '@kbn/securitysolution-data-table';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useGroupTakeActionsItems } from '../../../detections/hooks/alerts_table/use_group_take_action_items';
 import {
   defaultGroupingOptions,
@@ -32,7 +33,6 @@ import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
 import { inputsSelectors } from '../../../common/store/inputs';
 import { useUserData } from '../../../detections/components/user_info';
 import { useSourcererDataView } from '../../../sourcerer/containers';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { RiskInformationButtonEmpty } from '../risk_information';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 
@@ -54,11 +54,9 @@ export const TopRiskScoreContributorsAlerts = <T extends EntityType>({
   const { to, from } = useGlobalTime();
   const [{ loading: userInfoLoading, hasIndexWrite, hasIndexMaintenance }] = useUserData();
 
-  const { sourcererDataView: oldSourcererDataViewSpec } = useSourcererDataView(
-    SourcererScopeName.alerts
-  );
+  const { sourcererDataView: oldSourcererDataViewSpec } = useSourcererDataView(PageScope.alerts);
 
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
+  const { dataView: experimentalDataView } = useDataView(PageScope.alerts);
 
   const getGlobalFiltersQuerySelector = useMemo(
     () => inputsSelectors.globalFiltersQuerySelector(),

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/top_risk_score_contributors_alerts/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/top_risk_score_contributors_alerts/index.tsx
@@ -55,10 +55,10 @@ export const TopRiskScoreContributorsAlerts = <T extends EntityType>({
   const [{ loading: userInfoLoading, hasIndexWrite, hasIndexMaintenance }] = useUserData();
 
   const { sourcererDataView: oldSourcererDataViewSpec } = useSourcererDataView(
-    SourcererScopeName.detections
+    SourcererScopeName.alerts
   );
 
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.detections);
+  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.alerts);
 
   const getGlobalFiltersQuerySelector = useMemo(
     () => inputsSelectors.globalFiltersQuerySelector(),

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
@@ -43,7 +43,7 @@ import { UserLimitCallOut } from '../components/user_limit_callout';
 import { EmptyPrompt } from '../../common/components/empty_prompt';
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { PageLoader } from '../../common/components/page_loader';
-import { DataViewManagerScopeName } from '../../data_view_manager/constants';
+import { PageScope } from '../../data_view_manager/constants';
 import { forceHiddenTimeline } from '../../common/utils/timeline/force_hidden_timeline';
 
 type PageState =
@@ -114,8 +114,8 @@ export const EntityAnalyticsPrivilegedUserMonitoringPage = () => {
     sourcererDataView: oldSourcererDataViewSpec,
   } = useSourcererDataView();
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView, status } = useDataView(DataViewManagerScopeName.explore);
-  const { dataViewSpec } = useDataViewSpec(DataViewManagerScopeName.explore); // TODO: newDataViewPicker - this could be left, as the fieldMap spec is actually being used
+  const { dataView, status } = useDataView(PageScope.explore);
+  const { dataViewSpec } = useDataViewSpec(PageScope.explore); // TODO: newDataViewPicker - this could be left, as the fieldMap spec is actually being used
 
   const isSourcererLoading = useMemo(
     () => (newDataViewPickerEnabled ? status !== 'ready' : oldIsSourcererLoading),

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/metric_embeddable.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/metric_embeddable.tsx
@@ -6,7 +6,7 @@
  */
 import { EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
 import React from 'react';
-import { DataViewManagerScopeName } from '../../../data_view_manager/constants';
+import { PageScope } from '../../../data_view_manager/constants';
 import { FlexItem, StatValue } from './utils';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
 import type { FieldConfigs } from './types';
@@ -55,11 +55,7 @@ const MetricEmbeddableComponent = ({
                     lensAttributes={field.lensAttributes}
                     timerange={timerange}
                     inspectTitle={inspectTitle}
-                    scopeId={
-                      newDataViewPickerEnabled
-                        ? DataViewManagerScopeName.explore
-                        : DataViewManagerScopeName.default
-                    }
+                    scopeId={newDataViewPickerEnabled ? PageScope.explore : PageScope.default}
                   />
                 </div>
               )}

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/stat_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/stat_items.tsx
@@ -5,17 +5,17 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiPanel, EuiHorizontalRule } from '@elastic/eui';
+import { EuiFlexGroup, EuiHorizontalRule, EuiPanel } from '@elastic/eui';
 import React, { useMemo } from 'react';
 
 import { StatItemHeader } from './stat_item_header';
 import { useToggleStatus } from './use_toggle_status';
 import type { StatItemsProps } from './types';
-import { FlexItem, ChartHeight } from './utils';
+import { ChartHeight, FlexItem } from './utils';
 import { MetricEmbeddable } from './metric_embeddable';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
-import { DataViewManagerScopeName } from '../../../data_view_manager/constants';
+import { PageScope } from '../../../data_view_manager/constants';
 
 export const StatItemsComponent = React.memo<StatItemsProps>(({ statItems, from, id, to }) => {
   const timerange = useMemo(
@@ -67,11 +67,7 @@ export const StatItemsComponent = React.memo<StatItemsProps>(({ statItems, from,
                     id={`${id}-bar-embeddable`}
                     height={ChartHeight}
                     inspectTitle={description}
-                    scopeId={
-                      newDataViewPickerEnabled
-                        ? DataViewManagerScopeName.explore
-                        : DataViewManagerScopeName.default
-                    }
+                    scopeId={newDataViewPickerEnabled ? PageScope.explore : PageScope.default}
                   />
                 </FlexItem>
               )}
@@ -86,11 +82,7 @@ export const StatItemsComponent = React.memo<StatItemsProps>(({ statItems, from,
                       id={`${id}-area-embeddable`}
                       height={ChartHeight}
                       inspectTitle={description}
-                      scopeId={
-                        newDataViewPickerEnabled
-                          ? DataViewManagerScopeName.explore
-                          : DataViewManagerScopeName.default
-                      }
+                      scopeId={newDataViewPickerEnabled ? PageScope.explore : PageScope.default}
                     />
                   </FlexItem>
                 </>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/index.tsx
@@ -18,7 +18,7 @@ import { useDispatch } from 'react-redux';
 import type { Filter } from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
-import { DataViewManagerScopeName } from '../../../../data_view_manager/constants';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import type { NarrowDateRange } from '../../../../common/components/ml/types';
 import { dataViewSpecToViewBase } from '../../../../common/lib/kuery';
@@ -76,7 +76,6 @@ import { AlertCountByRuleByStatus } from '../../../../common/components/alert_co
 import { useLicense } from '../../../../common/hooks/use_license';
 import { ResponderActionButton } from '../../../../common/components/endpoint/responder';
 import { useRefetchOverviewPageRiskScore } from '../../../../entity_analytics/api/hooks/use_refetch_overview_page_risk_score';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 import { PageLoader } from '../../../../common/components/page_loader';
@@ -132,8 +131,8 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataView: experimentalDataView, status } = useDataView(DataViewManagerScopeName.explore);
-  const experimentalSelectedPatterns = useSelectedPatterns(DataViewManagerScopeName.explore);
+  const { dataView: experimentalDataView, status } = useDataView(PageScope.explore);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.explore);
 
   const indicesExist = newDataViewPickerEnabled
     ? !!experimentalDataView.matchedIndices?.length
@@ -295,7 +294,7 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
                     hostName={detailName}
                     indexNames={selectedPatterns}
                     jobNameById={jobNameById}
-                    scopeId={SourcererScopeName.explore}
+                    scopeId={PageScope.explore}
                   />
                 )}
               </AnomalyTableProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/hosts.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/hosts.tsx
@@ -14,7 +14,7 @@ import type { Filter } from '@kbn/es-query';
 import { isTab } from '@kbn/timelines-plugin/public';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import { LastEventIndexKey } from '@kbn/timelines-plugin/common';
-import { DataViewManagerScopeName } from '../../../data_view_manager/constants';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { InputsModelId } from '../../../common/store/inputs/constants';
 import { SecurityPageName } from '../../../app/types';
@@ -111,8 +111,8 @@ const HostsComponent = () => {
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataView: experimentalDataView, status } = useDataView(DataViewManagerScopeName.explore);
-  const experimentalSelectedPatterns = useSelectedPatterns(DataViewManagerScopeName.explore);
+  const { dataView: experimentalDataView, status } = useDataView(PageScope.explore);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.explore);
 
   const indicesExist = newDataViewPickerEnabled
     ? experimentalDataView.hasMatchedIndices()

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/index.test.tsx
@@ -19,7 +19,8 @@ import { mockData } from './mock';
 import { mockAnomalies } from '../../../../common/components/ml/mock';
 import type { NarrowDateRange } from '../../../../common/components/ml/types';
 import { FlowTargetSourceDest } from '../../../../../common/search_strategy';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
+
+import { PageScope } from '../../../../data_view_manager/constants';
 
 describe('IP Overview Component', () => {
   describe('rendering', () => {
@@ -41,7 +42,7 @@ describe('IP Overview Component', () => {
       }>,
       indexPatterns: [],
       jobNameById: {},
-      scopeId: SourcererScopeName.default,
+      scopeId: PageScope.default,
       isFlyoutOpen: false,
     };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/index.tsx
@@ -8,6 +8,7 @@
 import { euiDarkVars as darkTheme, euiLightVars as lightTheme } from '@kbn/ui-theme';
 import React from 'react';
 import { useKibanaIsDarkMode } from '@kbn/react-kibana-context-theme';
+import type { PageScope } from '../../../../data_view_manager/constants';
 import type { DescriptionList } from '../../../../../common/utility_types';
 import type {
   FlowTargetSourceDest,
@@ -36,7 +37,6 @@ import { useMlCapabilities } from '../../../../common/components/ml/hooks/use_ml
 import { hasMlUserPermissions } from '../../../../../common/machine_learning/has_ml_user_permissions';
 import { InspectButton, InspectButtonContainer } from '../../../../common/components/inspect';
 import { OverviewDescriptionList } from '../../../../common/components/overview_description_list';
-import type { SourcererScopeName } from '../../../../sourcerer/store/model';
 
 export interface IpOverviewProps {
   anomaliesData: Anomalies | null;
@@ -50,7 +50,7 @@ export interface IpOverviewProps {
   isLoadingAnomaliesData: boolean;
   loading: boolean;
   narrowDateRange: NarrowDateRange;
-  scopeId: SourcererScopeName;
+  scopeId: PageScope;
   startDate: string;
   type: networkModel.NetworkType;
   indexPatterns: string[];

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/embeddables/embedded_map.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/embeddables/embedded_map.tsx
@@ -17,6 +17,7 @@ import type { Filter, Query } from '@kbn/es-query';
 import { isEqual } from 'lodash/fp';
 import type { MapApi, RenderTooltipContentParams } from '@kbn/maps-plugin/public';
 import type { LayerDescriptor } from '@kbn/maps-plugin/common';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { buildTimeRangeFilter } from '../../../../detections/components/alerts_table/helpers';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useIsFieldInIndexPattern } from '../../../containers/fields';
@@ -30,7 +31,6 @@ import { getLayerList } from './map_config';
 import { sourcererSelectors } from '../../../../sourcerer/store';
 import type { State } from '../../../../common/store';
 import type { SourcererDataView } from '../../../../sourcerer/store/model';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 
@@ -116,11 +116,11 @@ export const EmbeddedMapComponent = ({
   const { addError } = useAppToasts();
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.explore);
+  const { dataView: experimentalDataView } = useDataView(PageScope.explore);
   // TODO This can be completely removed once we switch the newDataViewPickerEnabled on
   const kibanaDataViews = useSelector(sourcererSelectors.kibanaDataViews);
   const selectedPatterns = useSelector((state: State) => {
-    return sourcererSelectors.sourcererScopeSelectedPatterns(state, SourcererScopeName.default);
+    return sourcererSelectors.sourcererScopeSelectedPatterns(state, PageScope.default);
   });
 
   const isFieldInIndexPattern = useIsFieldInIndexPattern();

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/embeddables/map_tool_tip/point_tool_tip_content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/embeddables/map_tool_tip/point_tool_tip_content.tsx
@@ -7,6 +7,7 @@
 
 import React, { useMemo } from 'react';
 import type { ITooltipProperty } from '@kbn/maps-plugin/public/classes/tooltips/tooltip_property';
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { sourceDestinationFieldMappings } from '../map_config';
 import {
@@ -17,7 +18,6 @@ import { DescriptionListStyled } from '../../../../../common/components/page';
 import { HostDetailsLink, NetworkDetailsLink } from '../../../../../common/components/links';
 import { DefaultFieldRenderer } from '../../../../../timelines/components/field_renderers/default_renderer';
 import type { FlowTarget } from '../../../../../../common/search_strategy';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 
 interface PointToolTipContentProps {
   contextId: string;
@@ -46,11 +46,7 @@ export const PointToolTipContentComponent = ({
                   attrName={key}
                   idPrefix={`map-point-tooltip-${contextId}-${key}-${value}`}
                   render={(item) => getRenderedFieldValue(key, item)}
-                  scopeId={
-                    newDataViewPickerEnabled
-                      ? SourcererScopeName.explore
-                      : SourcererScopeName.default
-                  }
+                  scopeId={newDataViewPickerEnabled ? PageScope.explore : PageScope.default}
                 />
               ) : (
                 getEmptyTagValue()

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/field_renderers/field_renderers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/field_renderers/field_renderers.test.tsx
@@ -24,7 +24,7 @@ import type { AutonomousSystem } from '../../../../../common/search_strategy';
 import { FlowTarget } from '../../../../../common/search_strategy';
 import type { HostEcs } from '@kbn/securitysolution-ecs';
 import { mockGetUrlForApp } from '@kbn/security-solution-navigation/mocks/context';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
+import { PageScope } from '../../../../data_view_manager/constants';
 
 jest.mock('../../../../common/lib/kibana');
 jest.mock('@kbn/security-solution-navigation/src/context');
@@ -38,7 +38,7 @@ jest.mock('../../../../common/hooks/use_get_field_spec');
 const mockHost: HostEcs = mockData.complete.host as HostEcs;
 
 describe('Field Renderers', () => {
-  const scopeId = SourcererScopeName.default;
+  const scopeId = PageScope.default;
 
   describe('#locationRenderer', () => {
     test('it renders correctly against snapshot', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/field_renderers/field_renderers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/field_renderers/field_renderers.tsx
@@ -9,6 +9,7 @@ import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { getOr } from 'lodash/fp';
 import React, { Fragment } from 'react';
 import type { HostEcs } from '@kbn/securitysolution-ecs';
+import type { PageScope } from '../../../../data_view_manager/constants';
 import { DefaultFieldRenderer } from '../../../../timelines/components/field_renderers/default_renderer';
 import type {
   AutonomousSystem,
@@ -20,7 +21,6 @@ import { CellActionsRenderer } from '../../../../common/components/cell_actions/
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
 import { ReputationLink, WhoIsLink } from '../../../../common/components/links';
 import * as i18n from '../details/translations';
-import type { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { FlyoutLink } from '../../../../flyout/shared/components/flyout_link';
 
 export const IpOverviewId = 'ip-overview';
@@ -126,7 +126,7 @@ export const hostIdRenderer = ({
 };
 
 interface HostNameRendererTypes {
-  scopeId: SourcererScopeName;
+  scopeId: PageScope;
   host: HostEcs;
   ipFilter?: string;
   isFlyoutOpen: boolean;

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/details/index.tsx
@@ -13,7 +13,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiSpacer } from '@elasti
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 
 import { buildEsQuery } from '@kbn/es-query';
-import { DataViewManagerScopeName } from '../../../../data_view_manager/constants';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { dataViewSpecToViewBase } from '../../../../common/lib/kuery';
 import { AlertsByStatus } from '../../../../overview/components/detection_response/alerts_by_status';
@@ -62,7 +62,6 @@ import {
   SecurityCellActions,
   SecurityCellActionsTrigger,
 } from '../../../../common/components/cell_actions';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 
@@ -119,8 +118,8 @@ const NetworkDetailsComponent: React.FC = () => {
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataView: experimentalDataView, status } = useDataView(DataViewManagerScopeName.explore);
-  const experimentalSelectedPatterns = useSelectedPatterns(DataViewManagerScopeName.explore);
+  const { dataView: experimentalDataView, status } = useDataView(PageScope.explore);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.explore);
 
   const indicesExist = newDataViewPickerEnabled
     ? experimentalDataView.hasMatchedIndices()
@@ -265,7 +264,7 @@ const NetworkDetailsComponent: React.FC = () => {
               narrowDateRange={narrowDateRange}
               indexPatterns={selectedPatterns}
               jobNameById={jobNameById}
-              scopeId={SourcererScopeName.explore}
+              scopeId={PageScope.explore}
             />
 
             <EuiHorizontalRule />

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/navigation/dns_query_tab_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/navigation/dns_query_tab_body.tsx
@@ -5,19 +5,20 @@
  * 2.0.
  */
 
-import React, { useEffect, useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { getOr } from 'lodash/fp';
 
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { NetworkDnsTable } from '../../components/network_dns_table';
-import { useNetworkDns, ID } from '../../containers/network_dns';
+import { ID, useNetworkDns } from '../../containers/network_dns';
 import { manageQuery } from '../../../../common/components/page/manage_query';
 
 import type { NetworkComponentQueryProps } from './types';
 
 import type {
-  MatrixHistogramOption,
   MatrixHistogramConfigs,
+  MatrixHistogramOption,
 } from '../../../../common/components/matrix_histogram/types';
 import * as i18n from './translations';
 import { MatrixHistogram } from '../../../../common/components/matrix_histogram';
@@ -25,7 +26,6 @@ import { networkSelectors } from '../../store';
 import { useShallowEqualSelector } from '../../../../common/hooks/use_selector';
 import { getDnsTopDomainsLensAttributes } from '../../../../common/components/visualization_actions/lens_attributes/network/dns_top_domains';
 import { useQueryToggle } from '../../../../common/containers/query_toggle';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 
 const HISTOGRAM_ID = 'networkDnsHistogramQuery';
 
@@ -112,9 +112,7 @@ const DnsQueryTabBodyComponent: React.FC<NetworkComponentQueryProps> = ({
         filterQuery={filterQuery}
         startDate={startDate}
         {...dnsHistogramConfigs}
-        sourcererScopeId={
-          newDataViewPickerEnabled ? SourcererScopeName.explore : SourcererScopeName.default
-        }
+        sourcererScopeId={newDataViewPickerEnabled ? PageScope.explore : PageScope.default}
       />
       <NetworkDnsTableManage
         data={networkDns}

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/network.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/network.tsx
@@ -12,7 +12,7 @@ import { useParams } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { isTab } from '@kbn/timelines-plugin/public';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
-import { DataViewManagerScopeName } from '../../../data_view_manager/constants';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { InputsModelId } from '../../../common/store/inputs/constants';
 import { SecurityPageName } from '../../../app/types';
@@ -95,8 +95,8 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
 
     const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-    const { dataView, status } = useDataView(DataViewManagerScopeName.explore);
-    const experimentalSelectedPatterns = useSelectedPatterns(DataViewManagerScopeName.explore);
+    const { dataView, status } = useDataView(PageScope.explore);
+    const experimentalSelectedPatterns = useSelectedPatterns(PageScope.explore);
 
     const indicesExist = newDataViewPickerEnabled ? dataView.hasMatchedIndices() : oldIndicesExist;
     const selectedPatterns = newDataViewPickerEnabled

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/index.tsx
@@ -19,8 +19,7 @@ import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { Filter } from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
 import { LastEventIndexKey } from '@kbn/timelines-plugin/common';
-import { DataViewManagerScopeName } from '../../../../data_view_manager/constants';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { dataViewSpecToViewBase } from '../../../../common/lib/kuery';
 import { useCalculateEntityRiskScore } from '../../../../entity_analytics/api/hooks/use_calculate_entity_risk_score';
@@ -118,8 +117,8 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataView: experimentalDataView, status } = useDataView(DataViewManagerScopeName.explore);
-  const experimentalSelectedPatterns = useSelectedPatterns(DataViewManagerScopeName.explore);
+  const { dataView: experimentalDataView, status } = useDataView(PageScope.explore);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.explore);
 
   const indicesExist = newDataViewPickerEnabled
     ? experimentalDataView.hasMatchedIndices()
@@ -281,11 +280,7 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
                   narrowDateRange={narrowDateRange}
                   indexPatterns={selectedPatterns}
                   jobNameById={jobNameById}
-                  scopeId={
-                    newDataViewPickerEnabled
-                      ? SourcererScopeName.explore
-                      : SourcererScopeName.default
-                  }
+                  scopeId={newDataViewPickerEnabled ? PageScope.explore : PageScope.default}
                 />
               )}
             </AnomalyTableProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/navigation/authentications_query_tab_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/navigation/authentications_query_tab_body.tsx
@@ -6,12 +6,13 @@
  */
 
 import React from 'react';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { AuthenticationsUserTable } from '../../../components/authentication/authentications_user_table';
 import { histogramConfigs } from '../../../components/authentication/helpers';
 import type { AuthenticationsUserTableProps } from '../../../components/authentication/types';
 import { MatrixHistogram } from '../../../../common/components/matrix_histogram';
+
 export const ID = 'usersAuthenticationsQuery';
 
 const HISTOGRAM_QUERY_ID = 'usersAuthenticationsHistogramQuery';
@@ -37,9 +38,7 @@ export const AuthenticationsQueryTabBody = ({
         id={HISTOGRAM_QUERY_ID}
         startDate={startDate}
         {...histogramConfigs}
-        sourcererScopeId={
-          newDataViewPickerEnabled ? SourcererScopeName.explore : SourcererScopeName.default
-        }
+        sourcererScopeId={newDataViewPickerEnabled ? PageScope.explore : PageScope.default}
       />
 
       <AuthenticationsUserTable

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/users.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/users.tsx
@@ -14,7 +14,7 @@ import type { Filter } from '@kbn/es-query';
 import { isTab } from '@kbn/timelines-plugin/public';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import { LastEventIndexKey } from '@kbn/timelines-plugin/common';
-import { DataViewManagerScopeName } from '../../../data_view_manager/constants';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { InputsModelId } from '../../../common/store/inputs/constants';
 import { SecurityPageName } from '../../../app/types';
@@ -112,8 +112,8 @@ const UsersComponent = () => {
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataView: experimentalDataView, status } = useDataView(DataViewManagerScopeName.explore);
-  const experimentalSelectedPatterns = useSelectedPatterns(DataViewManagerScopeName.explore);
+  const { dataView: experimentalDataView, status } = useDataView(PageScope.explore);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.explore);
 
   const indicesExist = newDataViewPickerEnabled
     ? experimentalDataView.hasMatchedIndices()

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { i18n } from '@kbn/i18n';
 import { EuiPanel } from '@elastic/eui';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useWhichFlyout } from '../../shared/hooks/use_which_flyout';
 import { useDocumentDetailsContext } from '../../shared/context';
 import { ANALYZER_GRAPH_TEST_ID } from './test_ids';
@@ -49,10 +49,8 @@ export const AnalyzeGraph: FC = () => {
   const filters = useMemo(() => ({ from, to }), [from, to]);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { selectedPatterns: oldAnalyzerPatterns } = useSourcererDataView(
-    SourcererScopeName.analyzer
-  );
-  const experimentalAnalyzerPatterns = useSelectedPatterns(SourcererScopeName.analyzer);
+  const { selectedPatterns: oldAnalyzerPatterns } = useSourcererDataView(PageScope.analyzer);
+  const experimentalAnalyzerPatterns = useSelectedPatterns(PageScope.analyzer);
   const selectedPatterns = newDataViewPickerEnabled
     ? experimentalAnalyzerPatterns
     : oldAnalyzerPatterns;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/graph_visualization.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/graph_visualization.tsx
@@ -13,23 +13,23 @@ import dateMath from '@kbn/datemath';
 import { i18n } from '@kbn/i18n';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import {
-  GraphGroupedNodePreviewPanelKey,
-  GROUP_PREVIEW_BANNER,
+  type EntityOrEventItem,
   getNodeDocumentMode,
   getSingleDocumentData,
-  type NodeViewModel,
+  GraphGroupedNodePreviewPanelKey,
+  GROUP_PREVIEW_BANNER,
   groupedItemClick$,
-  type EntityOrEventItem,
   NETWORK_PREVIEW_BANNER,
+  type NodeViewModel,
 } from '@kbn/cloud-security-posture-graph';
 import { type NodeDocumentDataModel } from '@kbn/cloud-security-posture-common/types/graph/v1';
 import {
-  DOCUMENT_TYPE_ENTITY,
   DOCUMENT_TYPE_ALERT,
+  DOCUMENT_TYPE_ENTITY,
 } from '@kbn/cloud-security-posture-common/schema/graph/v1';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { useGetScopedSourcererDataView } from '../../../../sourcerer/components/use_get_sourcerer_data_view';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useDocumentDetailsContext } from '../../shared/context';
 import { GRAPH_VISUALIZATION_TEST_ID } from './test_ids';
 import { useGraphPreview } from '../../shared/hooks/use_graph_preview';
@@ -62,10 +62,10 @@ const MAX_DOCUMENTS_TO_LOAD = 50;
 export const GraphVisualization: React.FC = memo(() => {
   const toasts = useToasts();
   const oldDataView = useGetScopedSourcererDataView({
-    sourcererScope: SourcererScopeName.default,
+    sourcererScope: PageScope.default,
   });
 
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.default);
+  const { dataView: experimentalDataView } = useDataView(PageScope.default);
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
   const dataView = newDataViewPickerEnabled ? experimentalDataView : oldDataView;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
@@ -11,6 +11,7 @@ import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { EuiPanel } from '@elastic/eui';
 import type { Process } from '@kbn/session-view-plugin/common';
 import { i18n } from '@kbn/i18n';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import type { CustomProcess } from '../../session_view/context';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
@@ -22,7 +23,6 @@ import {
 } from '../../shared/constants/panel_keys';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useDocumentDetailsContext } from '../../shared/context';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { ALERT_PREVIEW_BANNER } from '../../preview/constants';
 import { useLicense } from '../../../../common/hooks/use_license';
 import { useSessionViewConfig } from '../../shared/hooks/use_session_view_config';
@@ -61,10 +61,10 @@ export const SessionView: FC = memo(() => {
   const isEnterprisePlus = useLicense().isEnterprise();
   const isEnabled = sessionViewConfig && isEnterprisePlus;
 
-  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(SourcererScopeName.alerts);
+  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(PageScope.alerts);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.alerts);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.alerts);
 
   const selectedPatterns = newDataViewPickerEnabled
     ? experimentalSelectedPatterns

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
@@ -61,12 +61,10 @@ export const SessionView: FC = memo(() => {
   const isEnterprisePlus = useLicense().isEnterprise();
   const isEnabled = sessionViewConfig && isEnterprisePlus;
 
-  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(
-    SourcererScopeName.detections
-  );
+  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(SourcererScopeName.alerts);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.detections);
+  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.alerts);
 
   const selectedPatterns = newDataViewPickerEnabled
     ? experimentalSelectedPatterns

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.ts
@@ -7,6 +7,7 @@
 
 import { useMemo } from 'react';
 import { SecurityPageName } from '@kbn/deeplinks-security';
+import { PageScope } from '../../../../data_view_manager/constants';
 import type { RunTimeMappings } from '../../../../../common/api/search_strategy';
 import type { CtiEnrichment, EventFields } from '../../../../../common/search_strategy';
 import { useBasicDataFromDetailsData } from '../../shared/hooks/use_basic_data_from_details_data';
@@ -16,7 +17,6 @@ import {
   parseExistingEnrichments,
   timelineDataToEnrichment,
 } from '../../shared/utils/threat_intelligence';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useInvestigationTimeEnrichment } from '../../shared/hooks/use_investigation_enrichment';
 import { useTimelineEventsDetails } from '../../../../timelines/containers/details';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
@@ -63,9 +63,7 @@ export const useThreatIntelligenceDetails = (): ThreatIntelligenceDetailsResult 
   const { indexName, eventId } = useDocumentDetailsContext();
   const [{ pageName }] = useRouteSpy();
   const sourcererScope =
-    pageName === SecurityPageName.detections
-      ? SourcererScopeName.alerts
-      : SourcererScopeName.default;
+    pageName === SecurityPageName.detections ? PageScope.alerts : PageScope.default;
   const sourcererDataView = useSourcererDataView(sourcererScope);
 
   const [isEventDataLoading, eventData] = useTimelineEventsDetails({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.ts
@@ -64,7 +64,7 @@ export const useThreatIntelligenceDetails = (): ThreatIntelligenceDetailsResult 
   const [{ pageName }] = useRouteSpy();
   const sourcererScope =
     pageName === SecurityPageName.detections
-      ? SourcererScopeName.detections
+      ? SourcererScopeName.alerts
       : SourcererScopeName.default;
   const sourcererDataView = useSourcererDataView(sourcererScope);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/session_view/tabs/alerts_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/session_view/tabs/alerts_tab.tsx
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { DetailPanelAlertTab, useFetchSessionViewAlerts } from '@kbn/session-view-plugin/public';
 import type { ProcessEvent } from '@kbn/session-view-plugin/common';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { LeftPanelVisualizeTab } from '../../left';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { SESSION_VIEW_ID } from '../../left/components/session_view';
@@ -20,7 +21,6 @@ import {
 } from '../../shared/constants/panel_keys';
 import { ALERT_PREVIEW_BANNER } from '../../preview/constants';
 import { useSessionViewPanelContext } from '../context';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 
@@ -38,9 +38,9 @@ export const AlertsTab = memo(() => {
     hasNextPage: hasNextPageAlerts,
   } = useFetchSessionViewAlerts(sessionEntityId, sessionStartTime, investigatedAlertId);
 
-  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(SourcererScopeName.alerts);
+  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(PageScope.alerts);
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.alerts);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.alerts);
 
   const selectedPatterns = newDataViewPickerEnabled
     ? experimentalSelectedPatterns

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/session_view/tabs/alerts_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/session_view/tabs/alerts_tab.tsx
@@ -38,11 +38,9 @@ export const AlertsTab = memo(() => {
     hasNextPage: hasNextPageAlerts,
   } = useFetchSessionViewAlerts(sessionEntityId, sessionStartTime, investigatedAlertId);
 
-  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(
-    SourcererScopeName.detections
-  );
+  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(SourcererScopeName.alerts);
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.detections);
+  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.alerts);
 
   const selectedPatterns = newDataViewPickerEnabled
     ? experimentalSelectedPatterns

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
@@ -8,12 +8,12 @@
 import type { BrowserFields, TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { SecurityPageName } from '@kbn/security-solution-navigation';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { DEFAULT_ALERTS_INDEX, DEFAULT_PREVIEW_INDEX } from '../../../../../common/constants';
 import type { RunTimeMappings } from '../../../../../common/api/search_strategy';
 import { useSpaceId } from '../../../../common/hooks/use_space_id';
 import { useRouteSpy } from '../../../../common/utils/route/use_route_spy';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { useTimelineEventsDetails } from '../../../../timelines/containers/details';
 import type { SearchHit } from '../../../../../common/search_strategy';
@@ -92,9 +92,7 @@ export const useEventDetails = ({
   const eventIndex = indexName ? getAlertIndexAlias(indexName, currentSpaceId) ?? indexName : '';
   const [{ pageName }] = useRouteSpy();
   const sourcererScope =
-    pageName === SecurityPageName.detections
-      ? SourcererScopeName.alerts
-      : SourcererScopeName.default;
+    pageName === SecurityPageName.detections ? PageScope.alerts : PageScope.default;
 
   const sourcererDataView = useSourcererDataView(sourcererScope);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
@@ -93,7 +93,7 @@ export const useEventDetails = ({
   const [{ pageName }] = useRouteSpy();
   const sourcererScope =
     pageName === SecurityPageName.detections
-      ? SourcererScopeName.detections
+      ? SourcererScopeName.alerts
       : SourcererScopeName.default;
 
   const sourcererDataView = useSourcererDataView(sourcererScope);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/components/network_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/components/network_details.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
+import { PageScope } from '../../../data_view_manager/constants';
 import { PageLoader } from '../../../common/components/page_loader';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { InputsModelId } from '../../../common/store/inputs/constants';
@@ -29,7 +30,6 @@ import { useAnomaliesTableData } from '../../../common/components/ml/anomaly/use
 import { useInstalledSecurityJobNameById } from '../../../common/components/ml/hooks/use_installed_security_jobs';
 import { EmptyPrompt } from '../../../common/components/empty_prompt';
 import type { NarrowDateRange } from '../../../common/components/ml/types';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { useSelectedPatterns } from '../../../data_view_manager/hooks/use_selected_patterns';
 
@@ -147,7 +147,7 @@ export const NetworkDetails = ({ ip, flowTarget }: NetworkDetailsProps) => {
       narrowDateRange={narrowDateRange}
       indexPatterns={selectedPatterns}
       jobNameById={jobNameById}
-      scopeId={SourcererScopeName.default}
+      scopeId={PageScope.default}
       isFlyoutOpen={true}
     />
   ) : (

--- a/x-pack/solutions/security/plugins/security_solution/public/helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/helpers.tsx
@@ -319,7 +319,7 @@ export const getSourcererScopeId = (scopeId: string): SourcererScopeName => {
   if (isTimelineScope(scopeId)) {
     return SourcererScopeName.timeline;
   } else if (isAlertsPageScope(scopeId)) {
-    return SourcererScopeName.detections;
+    return SourcererScopeName.alerts;
   } else {
     return SourcererScopeName.default;
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/helpers.tsx
@@ -16,6 +16,7 @@ import type { DocLinks } from '@kbn/doc-links';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { dataTableActions, TableId } from '@kbn/securitysolution-data-table';
 import { isObject } from 'lodash';
+import { PageScope } from './data_view_manager/constants';
 import {
   ALERTS_PATH,
   APP_UI_ID,
@@ -37,7 +38,6 @@ import type { InspectResponse, StartedSubPlugins, StartServices } from './types'
 import { CASES_SUB_PLUGIN_KEY } from './types';
 import { timelineActions } from './timelines/store';
 import { TimelineId } from '../common/types';
-import { SourcererScopeName } from './sourcerer/store/model';
 import { hasAccessToSecuritySolution } from './helpers_access';
 
 export const parseRoute = (location: Pick<Location, 'hash' | 'pathname' | 'search'>) => {
@@ -315,12 +315,12 @@ export const getScopedActions = (scopeId: string) => {
 
 export const isActiveTimeline = (timelineId: string) => timelineId === TimelineId.active;
 
-export const getSourcererScopeId = (scopeId: string): SourcererScopeName => {
+export const getSourcererScopeId = (scopeId: string): PageScope => {
   if (isTimelineScope(scopeId)) {
-    return SourcererScopeName.timeline;
+    return PageScope.timeline;
   } else if (isAlertsPageScope(scopeId)) {
-    return SourcererScopeName.alerts;
+    return PageScope.alerts;
   } else {
-    return SourcererScopeName.default;
+    return PageScope.default;
   }
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.tsx
@@ -11,9 +11,9 @@ import { EuiButtonIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { PageScope } from '../../data_view_manager/constants';
 import { OPEN_FLYOUT_BUTTON_TEST_ID } from './test_ids';
 import { useSourcererDataView } from '../../sourcerer/containers';
-import { SourcererScopeName } from '../../sourcerer/store/model';
 import { useKibana } from '../../common/lib/kibana';
 import { DocumentDetailsRightPanelKey } from '../../flyout/document_details/shared/constants/panel_keys';
 import { DocumentEventTypes } from '../../common/lib/telemetry';
@@ -48,12 +48,10 @@ export interface OpenFlyoutButtonIconProps {
  */
 export const OpenFlyoutButtonIcon = memo(
   ({ eventId, timelineId, iconType }: OpenFlyoutButtonIconProps) => {
-    const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(
-      SourcererScopeName.timeline
-    );
+    const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(PageScope.timeline);
 
     const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-    const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
+    const experimentalSelectedPatterns = useSelectedPatterns(PageScope.timeline);
 
     const selectedPatterns = newDataViewPickerEnabled
       ? experimentalSelectedPatterns

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/hooks/use_navigate_to_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/hooks/use_navigate_to_timeline.tsx
@@ -8,7 +8,7 @@
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { v4 as uuidv4 } from 'uuid';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { sourcererActions } from '../../../../sourcerer/store';
 import {
   getDataProvider,
@@ -53,7 +53,7 @@ export const useNavigateToTimeline = () => {
 
       dispatch(
         sourcererActions.setSelectedDataView({
-          id: SourcererScopeName.timeline,
+          id: PageScope.timeline,
           selectedDataViewId: defaultDataView.id,
           selectedPatterns: [signalIndexName || ''],
         })

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/host_alerts_table/host_alerts_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/host_alerts_table/host_alerts_table.tsx
@@ -163,7 +163,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
             }}
             mode={CellActionsMode.HOVER_RIGHT}
             triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-            sourcererScopeId={SourcererScopeName.detections}
+            sourcererScopeId={SourcererScopeName.alerts}
             metadata={{
               andFilters: [{ field: 'kibana.alert.workflow_status', value: 'open' }],
             }}
@@ -194,7 +194,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.detections}
+                sourcererScopeId={SourcererScopeName.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'critical' },
@@ -228,7 +228,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.detections}
+                sourcererScopeId={SourcererScopeName.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'high' },
@@ -259,7 +259,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.detections}
+                sourcererScopeId={SourcererScopeName.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'medium' },
@@ -290,7 +290,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.detections}
+                sourcererScopeId={SourcererScopeName.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'low' },

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/host_alerts_table/host_alerts_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/host_alerts_table/host_alerts_table.tsx
@@ -20,6 +20,7 @@ import {
 } from '@elastic/eui';
 
 import { ALERT_SEVERITY } from '@kbn/rule-data-utils';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useNavigateToAlertsPageWithFilters } from '../../../../common/hooks/use_navigate_to_alerts_page_with_filters';
 import { FormattedCount } from '../../../../common/components/formatted_number';
 import { HeaderSection } from '../../../../common/components/header_section';
@@ -39,7 +40,6 @@ import {
   SecurityCellActionsTrigger,
 } from '../../../../common/components/cell_actions';
 import { useGlobalFilterQuery } from '../../../../common/hooks/use_global_filter_query';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useRiskSeverityColors } from '../../../../common/utils/risk_color_palette';
 
 interface HostAlertsTableProps {
@@ -163,7 +163,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
             }}
             mode={CellActionsMode.HOVER_RIGHT}
             triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-            sourcererScopeId={SourcererScopeName.alerts}
+            sourcererScopeId={PageScope.alerts}
             metadata={{
               andFilters: [{ field: 'kibana.alert.workflow_status', value: 'open' }],
             }}
@@ -194,7 +194,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.alerts}
+                sourcererScopeId={PageScope.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'critical' },
@@ -228,7 +228,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.alerts}
+                sourcererScopeId={PageScope.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'high' },
@@ -259,7 +259,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.alerts}
+                sourcererScopeId={PageScope.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'medium' },
@@ -290,7 +290,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.alerts}
+                sourcererScopeId={PageScope.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'low' },

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/rule_alerts_table/rule_alerts_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/rule_alerts_table/rule_alerts_table.tsx
@@ -109,7 +109,7 @@ export const useGetTableColumns: GetTableColumns = ({
             }}
             mode={CellActionsMode.HOVER_RIGHT}
             triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-            sourcererScopeId={SourcererScopeName.detections}
+            sourcererScopeId={SourcererScopeName.alerts}
             metadata={{
               andFilters: [{ field: 'kibana.alert.workflow_status', value: 'open' }],
             }}

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/rule_alerts_table/rule_alerts_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/rule_alerts_table/rule_alerts_table.tsx
@@ -21,6 +21,7 @@ import {
 import { FormattedRelative } from '@kbn/i18n-react';
 import type { Severity } from '@kbn/securitysolution-io-ts-alerting-types';
 import { ALERT_RULE_NAME, ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { SecurityCellActionsTrigger } from '../../../../app/actions/constants';
 import { useNavigateToAlertsPageWithFilters } from '../../../../common/hooks/use_navigate_to_alerts_page_with_filters';
 import { HeaderSection } from '../../../../common/components/header_section';
@@ -28,7 +29,7 @@ import { HeaderSection } from '../../../../common/components/header_section';
 import * as i18n from '../translations';
 import type { RuleAlertsItem } from './use_rule_alerts_items';
 import { useRuleAlertsItems } from './use_rule_alerts_items';
-import type { NavigateTo, GetAppUrl } from '../../../../common/lib/kibana';
+import type { GetAppUrl, NavigateTo } from '../../../../common/lib/kibana';
 import { useNavigation } from '../../../../common/lib/kibana';
 import { SecurityPageName } from '../../../../../common/constants';
 import { useQueryToggle } from '../../../../common/containers/query_toggle';
@@ -36,9 +37,8 @@ import { HoverVisibilityContainer } from '../../../../common/components/hover_vi
 import { BUTTON_CLASS as INSPECT_BUTTON_CLASS } from '../../../../common/components/inspect';
 import { LastUpdatedAt } from '../../../../common/components/last_updated_at';
 import { FormattedCount } from '../../../../common/components/formatted_number';
-import { SecurityCellActions, CellActionsMode } from '../../../../common/components/cell_actions';
+import { CellActionsMode, SecurityCellActions } from '../../../../common/components/cell_actions';
 import { useGlobalFilterQuery } from '../../../../common/hooks/use_global_filter_query';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useRiskSeverityColors } from '../../../../common/utils/risk_color_palette';
 
 export interface RuleAlertsTableProps {
@@ -109,7 +109,7 @@ export const useGetTableColumns: GetTableColumns = ({
             }}
             mode={CellActionsMode.HOVER_RIGHT}
             triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-            sourcererScopeId={SourcererScopeName.alerts}
+            sourcererScopeId={PageScope.alerts}
             metadata={{
               andFilters: [{ field: 'kibana.alert.workflow_status', value: 'open' }],
             }}

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/user_alerts_table/user_alerts_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/user_alerts_table/user_alerts_table.tsx
@@ -158,7 +158,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
             }}
             mode={CellActionsMode.HOVER_RIGHT}
             triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-            sourcererScopeId={SourcererScopeName.detections}
+            sourcererScopeId={SourcererScopeName.alerts}
             metadata={{
               andFilters: [{ field: 'kibana.alert.workflow_status', value: 'open' }],
             }}
@@ -189,7 +189,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.detections}
+                sourcererScopeId={SourcererScopeName.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'critical' },
@@ -223,7 +223,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.detections}
+                sourcererScopeId={SourcererScopeName.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'high' },
@@ -254,7 +254,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.detections}
+                sourcererScopeId={SourcererScopeName.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'medium' },
@@ -285,7 +285,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.detections}
+                sourcererScopeId={SourcererScopeName.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'low' },

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/user_alerts_table/user_alerts_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/user_alerts_table/user_alerts_table.tsx
@@ -20,6 +20,7 @@ import {
 } from '@elastic/eui';
 
 import { ALERT_SEVERITY } from '@kbn/rule-data-utils';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { SecurityCellActionsTrigger } from '../../../../app/actions/constants';
 import { useNavigateToAlertsPageWithFilters } from '../../../../common/hooks/use_navigate_to_alerts_page_with_filters';
 import { FormattedCount } from '../../../../common/components/formatted_number';
@@ -33,9 +34,8 @@ import * as i18n from '../translations';
 import { ITEMS_PER_PAGE } from '../utils';
 import type { UserAlertsItem } from './use_user_alerts_items';
 import { useUserAlertsItems } from './use_user_alerts_items';
-import { SecurityCellActions, CellActionsMode } from '../../../../common/components/cell_actions';
+import { CellActionsMode, SecurityCellActions } from '../../../../common/components/cell_actions';
 import { useGlobalFilterQuery } from '../../../../common/hooks/use_global_filter_query';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useRiskSeverityColors } from '../../../../common/utils/risk_color_palette';
 
 interface UserAlertsTableProps {
@@ -158,7 +158,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
             }}
             mode={CellActionsMode.HOVER_RIGHT}
             triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-            sourcererScopeId={SourcererScopeName.alerts}
+            sourcererScopeId={PageScope.alerts}
             metadata={{
               andFilters: [{ field: 'kibana.alert.workflow_status', value: 'open' }],
             }}
@@ -189,7 +189,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.alerts}
+                sourcererScopeId={PageScope.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'critical' },
@@ -223,7 +223,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.alerts}
+                sourcererScopeId={PageScope.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'high' },
@@ -254,7 +254,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.alerts}
+                sourcererScopeId={PageScope.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'medium' },
@@ -285,7 +285,7 @@ const useGetTableColumns: GetTableColumns = (handleClick) => {
                 }}
                 mode={CellActionsMode.HOVER_RIGHT}
                 triggerId={SecurityCellActionsTrigger.ALERTS_COUNT}
-                sourcererScopeId={SourcererScopeName.alerts}
+                sourcererScopeId={PageScope.alerts}
                 metadata={{
                   andFilters: [
                     { field: 'kibana.alert.severity', value: 'low' },

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -14,6 +14,7 @@ import styled from '@emotion/styled';
 import { EuiButton } from '@elastic/eui';
 import type { DataView, DataViewSpec } from '@kbn/data-plugin/common';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
+import type { PageScope } from '../../../data_view_manager/constants';
 import { APP_UI_ID, DEFAULT_NUMBER_FORMAT } from '../../../../common/constants';
 import { SHOWING, UNIT } from '../../../common/components/events_viewer/translations';
 import { getTabsOnHostsUrl } from '../../../common/components/link_to/redirect_to_hosts';
@@ -36,7 +37,6 @@ import * as i18n from '../../pages/translations';
 import { SecurityPageName } from '../../../app/types';
 import { useFormatUrl } from '../../../common/components/link_to';
 import { useInvalidFilterQuery } from '../../../common/hooks/use_invalid_filter_query';
-import type { SourcererScopeName } from '../../../sourcerer/store/model';
 
 const DEFAULT_STACK_BY = NO_BREAKDOWN_STACK_BY_VALUE;
 
@@ -56,7 +56,7 @@ interface Props extends Pick<GlobalTimeArgs, 'from' | 'to' | 'deleteQuery'> {
   queryType: 'topN' | 'overview';
   showSpacer?: boolean;
   hideQueryToggle?: boolean;
-  sourcererScopeId?: SourcererScopeName;
+  sourcererScopeId?: PageScope;
   applyGlobalQueriesAndFilters?: boolean;
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.test.tsx
@@ -88,7 +88,7 @@ describe('AlertFilteringMetric', () => {
           to: defaultProps.to,
         },
         id: 'AlertFilteringMetricQuery-area-embeddable',
-        scopeId: SourcererScopeName.detections,
+        scopeId: SourcererScopeName.alerts,
         withActions: [
           VisualizationContextMenuActions.addToExistingCase,
           VisualizationContextMenuActions.addToNewCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.test.tsx
@@ -11,9 +11,9 @@ import { AlertFilteringMetric } from './alert_filtering_metric';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
 import { getExcludeAlertsFilters } from './utils';
 import { getAlertFilteringMetricLensAttributes } from '../../../common/components/visualization_actions/lens_attributes/ai/alert_filtering_metric';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { VisualizationContextMenuActions } from '../../../common/components/visualization_actions/types';
 import { useSignalIndexWithDefault } from '../../hooks/use_signal_index_with_default';
+import { PageScope } from '../../../data_view_manager/constants';
 
 jest.mock('../../../common/components/visualization_actions/visualization_embeddable', () => ({
   VisualizationEmbeddable: jest.fn(() => <div data-test-subj="mock-visualization-embeddable" />),
@@ -88,7 +88,7 @@ describe('AlertFilteringMetric', () => {
           to: defaultProps.to,
         },
         id: 'AlertFilteringMetricQuery-area-embeddable',
-        scopeId: SourcererScopeName.alerts,
+        scopeId: PageScope.alerts,
         withActions: [
           VisualizationContextMenuActions.addToExistingCase,
           VisualizationContextMenuActions.addToNewCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.tsx
@@ -86,7 +86,7 @@ const AlertFilteringMetricComponent: React.FC<Props> = ({
         timerange={{ from, to }}
         id={`${ID}-area-embeddable`}
         inspectTitle={i18n.FILTERING_RATE}
-        scopeId={SourcererScopeName.detections}
+        scopeId={SourcererScopeName.alerts}
         withActions={[
           VisualizationContextMenuActions.addToExistingCase,
           VisualizationContextMenuActions.addToNewCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.tsx
@@ -9,11 +9,11 @@ import React, { useCallback, useMemo } from 'react';
 
 import { css } from '@emotion/react';
 import { useEuiTheme } from '@elastic/eui';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useSignalIndexWithDefault } from '../../hooks/use_signal_index_with_default';
 import { getExcludeAlertsFilters } from './utils';
 import type { GetLensAttributes } from '../../../common/components/visualization_actions/types';
 import { VisualizationContextMenuActions } from '../../../common/components/visualization_actions/types';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { getAlertFilteringMetricLensAttributes } from '../../../common/components/visualization_actions/lens_attributes/ai/alert_filtering_metric';
 import * as i18n from './translations';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
@@ -86,7 +86,7 @@ const AlertFilteringMetricComponent: React.FC<Props> = ({
         timerange={{ from, to }}
         id={`${ID}-area-embeddable`}
         inspectTitle={i18n.FILTERING_RATE}
-        scopeId={SourcererScopeName.alerts}
+        scopeId={PageScope.alerts}
         withActions={[
           VisualizationContextMenuActions.addToExistingCase,
           VisualizationContextMenuActions.addToNewCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_processing_donut_lens.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_processing_donut_lens.test.tsx
@@ -60,7 +60,7 @@ describe('AlertProcessingDonut', () => {
         isDonut: true,
         donutTitleLabel: 'Total alerts processed',
         donutTextWrapperClassName: 'donutText',
-        scopeId: SourcererScopeName.detections,
+        scopeId: SourcererScopeName.alerts,
         timerange: { from: defaultProps.from, to: defaultProps.to },
         withActions: [
           VisualizationContextMenuActions.addToExistingCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_processing_donut_lens.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_processing_donut_lens.test.tsx
@@ -11,8 +11,8 @@ import { AlertProcessingDonut } from './alert_processing_donut_lens';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
 import { getAlertProcessingDonutAttributes } from '../../../common/components/visualization_actions/lens_attributes/ai/alert_processing_donut';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { VisualizationContextMenuActions } from '../../../common/components/visualization_actions/types';
+import { PageScope } from '../../../data_view_manager/constants';
 
 jest.mock('../../../common/components/visualization_actions/visualization_embeddable', () => ({
   VisualizationEmbeddable: jest.fn(() => <div data-test-subj="mock-visualization-embeddable" />),
@@ -60,7 +60,7 @@ describe('AlertProcessingDonut', () => {
         isDonut: true,
         donutTitleLabel: 'Total alerts processed',
         donutTextWrapperClassName: 'donutText',
-        scopeId: SourcererScopeName.alerts,
+        scopeId: PageScope.alerts,
         timerange: { from: defaultProps.from, to: defaultProps.to },
         withActions: [
           VisualizationContextMenuActions.addToExistingCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_processing_donut_lens.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_processing_donut_lens.tsx
@@ -73,7 +73,7 @@ export const AlertProcessingDonut: React.FC<Props> = ({ attackAlertIds, from, to
         isDonut={true}
         donutTitleLabel={'Total alerts processed'}
         donutTextWrapperClassName={'donutText'}
-        scopeId={SourcererScopeName.detections}
+        scopeId={SourcererScopeName.alerts}
         timerange={{ from, to }}
         withActions={[
           VisualizationContextMenuActions.addToExistingCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_processing_donut_lens.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_processing_donut_lens.tsx
@@ -9,10 +9,10 @@ import React from 'react';
 
 import { css } from '@emotion/react';
 import { useEuiTheme } from '@elastic/eui';
+import { PageScope } from '../../../data_view_manager/constants';
 import { VisualizationContextMenuActions } from '../../../common/components/visualization_actions/types';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { getAlertProcessingDonutAttributes } from '../../../common/components/visualization_actions/lens_attributes/ai/alert_processing_donut';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
 
 const ChartSize = 250;
@@ -73,7 +73,7 @@ export const AlertProcessingDonut: React.FC<Props> = ({ attackAlertIds, from, to
         isDonut={true}
         donutTitleLabel={'Total alerts processed'}
         donutTextWrapperClassName={'donutText'}
-        scopeId={SourcererScopeName.alerts}
+        scopeId={PageScope.alerts}
         timerange={{ from, to }}
         withActions={[
           VisualizationContextMenuActions.addToExistingCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_metric.tsx
@@ -9,12 +9,12 @@ import React, { useCallback, useMemo } from 'react';
 
 import { css } from '@emotion/react';
 import { useEuiTheme } from '@elastic/eui';
+import { PageScope } from '../../../data_view_manager/constants';
 import * as i18n from './translations';
 import {
   type GetLensAttributes,
   VisualizationContextMenuActions,
 } from '../../../common/components/visualization_actions/types';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
 import { getCostSavingsMetricLensAttributes } from '../../../common/components/visualization_actions/lens_attributes/ai/cost_savings_metric';
 import { useMetricAnimation } from '../../hooks/use_metric_animation';
@@ -96,7 +96,7 @@ const CostSavingsMetricComponent: React.FC<Props> = ({
         timerange={timerange}
         id={`${ID}-metric`}
         inspectTitle={i18n.COST_SAVINGS_TREND}
-        scopeId={SourcererScopeName.alerts}
+        scopeId={PageScope.alerts}
         withActions={[
           VisualizationContextMenuActions.addToExistingCase,
           VisualizationContextMenuActions.addToNewCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_metric.tsx
@@ -96,7 +96,7 @@ const CostSavingsMetricComponent: React.FC<Props> = ({
         timerange={timerange}
         id={`${ID}-metric`}
         inspectTitle={i18n.COST_SAVINGS_TREND}
-        scopeId={SourcererScopeName.detections}
+        scopeId={SourcererScopeName.alerts}
         withActions={[
           VisualizationContextMenuActions.addToExistingCase,
           VisualizationContextMenuActions.addToNewCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.tsx
@@ -112,7 +112,7 @@ const CostSavingsTrendComponent: React.FC<Props> = ({
             id={`${ID}-area-embeddable`}
             height={300}
             inspectTitle={i18n.COST_SAVINGS_TREND}
-            scopeId={SourcererScopeName.detections}
+            scopeId={SourcererScopeName.alerts}
             withActions={[
               VisualizationContextMenuActions.addToExistingCase,
               VisualizationContextMenuActions.addToNewCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.tsx
@@ -15,6 +15,7 @@ import {
   useIsWithinMaxBreakpoint,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useSignalIndexWithDefault } from '../../hooks/use_signal_index_with_default';
 import * as i18n from './translations';
 import type {
@@ -23,7 +24,6 @@ import type {
   VisualizationTablesWithMeta,
 } from '../../../common/components/visualization_actions/types';
 import { VisualizationContextMenuActions } from '../../../common/components/visualization_actions/types';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
 import { getCostSavingsTrendAreaLensAttributes } from '../../../common/components/visualization_actions/lens_attributes/ai/cost_savings_trend_area';
 import { CostSavingsKeyInsight } from './cost_savings_key_insight';
@@ -112,7 +112,7 @@ const CostSavingsTrendComponent: React.FC<Props> = ({
             id={`${ID}-area-embeddable`}
             height={300}
             inspectTitle={i18n.COST_SAVINGS_TREND}
-            scopeId={SourcererScopeName.alerts}
+            scopeId={PageScope.alerts}
             withActions={[
               VisualizationContextMenuActions.addToExistingCase,
               VisualizationContextMenuActions.addToNewCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.test.tsx
@@ -13,6 +13,7 @@ import { getTimeSavedMetricLensAttributes } from '../../../common/components/vis
 import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { VisualizationContextMenuActions } from '../../../common/components/visualization_actions/types';
 import { useSignalIndexWithDefault } from '../../hooks/use_signal_index_with_default';
+
 jest.mock('../../../common/components/visualization_actions/visualization_embeddable', () => ({
   VisualizationEmbeddable: jest.fn(() => <div data-test-subj="mock-visualization-embeddable" />),
 }));
@@ -102,7 +103,7 @@ describe('TimeSavedMetric', () => {
           to: defaultProps.to,
         },
         id: 'TimeSavedMetricQuery-metric',
-        scopeId: SourcererScopeName.detections,
+        scopeId: SourcererScopeName.alerts,
         withActions: [
           VisualizationContextMenuActions.addToExistingCase,
           VisualizationContextMenuActions.addToNewCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.test.tsx
@@ -10,9 +10,9 @@ import { render } from '@testing-library/react';
 import { TimeSavedMetric } from './time_saved_metric';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
 import { getTimeSavedMetricLensAttributes } from '../../../common/components/visualization_actions/lens_attributes/ai/time_saved_metric';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { VisualizationContextMenuActions } from '../../../common/components/visualization_actions/types';
 import { useSignalIndexWithDefault } from '../../hooks/use_signal_index_with_default';
+import { PageScope } from '../../../data_view_manager/constants';
 
 jest.mock('../../../common/components/visualization_actions/visualization_embeddable', () => ({
   VisualizationEmbeddable: jest.fn(() => <div data-test-subj="mock-visualization-embeddable" />),
@@ -103,7 +103,7 @@ describe('TimeSavedMetric', () => {
           to: defaultProps.to,
         },
         id: 'TimeSavedMetricQuery-metric',
-        scopeId: SourcererScopeName.alerts,
+        scopeId: PageScope.alerts,
         withActions: [
           VisualizationContextMenuActions.addToExistingCase,
           VisualizationContextMenuActions.addToNewCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.tsx
@@ -9,12 +9,12 @@ import React, { useCallback, useMemo } from 'react';
 
 import { css } from '@emotion/react';
 import { useEuiTheme } from '@elastic/eui';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useSignalIndexWithDefault } from '../../hooks/use_signal_index_with_default';
 import {
   type GetLensAttributes,
   VisualizationContextMenuActions,
 } from '../../../common/components/visualization_actions/types';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { getTimeSavedMetricLensAttributes } from '../../../common/components/visualization_actions/lens_attributes/ai/time_saved_metric';
 import * as i18n from './translations';
 import { VisualizationEmbeddable } from '../../../common/components/visualization_actions/visualization_embeddable';
@@ -82,7 +82,7 @@ const TimeSavedMetricComponent: React.FC<Props> = ({ from, to, minutesPerAlert }
         timerange={timerange}
         id={`${ID}-metric`}
         inspectTitle={i18n.TIME_SAVED}
-        scopeId={SourcererScopeName.alerts}
+        scopeId={PageScope.alerts}
         withActions={[
           VisualizationContextMenuActions.addToExistingCase,
           VisualizationContextMenuActions.addToNewCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.tsx
@@ -82,7 +82,7 @@ const TimeSavedMetricComponent: React.FC<Props> = ({ from, to, minutesPerAlert }
         timerange={timerange}
         id={`${ID}-metric`}
         inspectTitle={i18n.TIME_SAVED}
-        scopeId={SourcererScopeName.detections}
+        scopeId={SourcererScopeName.alerts}
         withActions={[
           VisualizationContextMenuActions.addToExistingCase,
           VisualizationContextMenuActions.addToNewCase,

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/sourcerer_selection.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/sourcerer_selection.tsx
@@ -4,13 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useCallback, memo } from 'react';
+import React, { memo, useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiPopover } from '@elastic/eui';
+import { PageScope } from '../../../data_view_manager/constants';
 import { StyledEuiButtonIcon } from './styles';
 import { useColors } from '../use_colors';
 import { Sourcerer } from '../../../sourcerer/components';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { DataViewPicker } from '../../../data_view_manager/components/data_view_picker';
 
@@ -60,9 +60,9 @@ export const SourcererButton = memo(
         anchorPosition="leftCenter"
       >
         {newDataViewPickerEnabled ? (
-          <DataViewPicker scope={SourcererScopeName.analyzer} onClosePopover={closePopover} />
+          <DataViewPicker scope={PageScope.analyzer} onClosePopover={closePopover} />
         ) : (
-          <Sourcerer scope={SourcererScopeName.analyzer} />
+          <Sourcerer scope={PageScope.analyzer} />
         )}
       </EuiPopover>
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/alerts_sourcerer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/alerts_sourcerer.test.tsx
@@ -8,11 +8,11 @@
 import React from 'react';
 
 import { Sourcerer } from '.';
-import { sourcererModel } from '../store';
 import { TestProviders } from '../../common/mock';
 import { useSourcererDataView } from '../containers';
 import { useSignalHelpers } from '../containers/use_signal_helpers';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PageScope } from '../../data_view_manager/constants';
 
 const mockDispatch = jest.fn();
 
@@ -59,7 +59,7 @@ const sourcererDataView = {
 // See https://github.com/elastic/security-team/issues/11959
 describe.skip('sourcerer on alerts page or rules details page', () => {
   const testProps = {
-    scope: sourcererModel.SourcererScopeName.alerts,
+    scope: PageScope.alerts,
   };
 
   const pollForSignalIndexMock = jest.fn();

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/alerts_sourcerer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/alerts_sourcerer.test.tsx
@@ -59,7 +59,7 @@ const sourcererDataView = {
 // See https://github.com/elastic/security-team/issues/11959
 describe.skip('sourcerer on alerts page or rules details page', () => {
   const testProps = {
-    scope: sourcererModel.SourcererScopeName.detections,
+    scope: sourcererModel.SourcererScopeName.alerts,
   };
 
   const pollForSignalIndexMock = jest.fn();

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.test.tsx
@@ -9,9 +9,9 @@ import React from 'react';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
 
-import { type SelectedDataView, SourcererScopeName } from '../store/model';
+import { type SelectedDataView } from '../store/model';
 import { Sourcerer } from '.';
-import { sourcererActions, sourcererModel } from '../store';
+import { sourcererActions } from '../store';
 import { createMockStore, mockGlobalState, TestProviders } from '../../common/mock';
 import type { EuiSuperSelectOption } from '@elastic/eui';
 import { fireEvent, render, waitFor } from '@testing-library/react';
@@ -19,6 +19,7 @@ import { useSourcererDataView } from '../containers';
 import { useSignalHelpers } from '../containers/use_signal_helpers';
 import { DEFAULT_INDEX_PATTERN } from '../../../common/constants';
 import { sortWithExcludesAtEnd } from '../../../common/utils/sourcerer';
+import { PageScope } from '../../data_view_manager/constants';
 
 const mockDispatch = jest.fn();
 
@@ -59,7 +60,7 @@ jest.mock('../../common/utils/global_query_string', () => {
 const mockOptions = DEFAULT_INDEX_PATTERN.map((index) => ({ label: index, value: index }));
 
 const defaultProps = {
-  scope: sourcererModel.SourcererScopeName.default,
+  scope: PageScope.default,
 };
 
 const checkOptionsAndSelections = (wrapper: ReactWrapper, patterns: string[]) => ({
@@ -190,8 +191,8 @@ describe.skip('Sourcerer component', () => {
         ],
         sourcererScopes: {
           ...mockGlobalState.sourcerer.sourcererScopes,
-          [SourcererScopeName.default]: {
-            ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+          [PageScope.default]: {
+            ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
             loading: false,
             selectedDataViewId: '1234',
             selectedPatterns: ['filebeat-*'],
@@ -236,8 +237,8 @@ describe.skip('Sourcerer component', () => {
         ],
         sourcererScopes: {
           ...mockGlobalState.sourcerer.sourcererScopes,
-          [SourcererScopeName.default]: {
-            ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+          [PageScope.default]: {
+            ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
             selectedDataViewId: '1234',
             selectedPatterns: ['filebeat-*'],
           },
@@ -283,8 +284,8 @@ describe.skip('Sourcerer component', () => {
         ],
         sourcererScopes: {
           ...mockGlobalState.sourcerer.sourcererScopes,
-          [SourcererScopeName.default]: {
-            ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+          [PageScope.default]: {
+            ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
             selectedDataViewId: id,
             selectedPatterns: patternListNoSignals.slice(0, 2),
           },
@@ -328,8 +329,8 @@ describe.skip('Sourcerer component', () => {
         ],
         sourcererScopes: {
           ...mockGlobalState.sourcerer.sourcererScopes,
-          [SourcererScopeName.timeline]: {
-            ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+          [PageScope.timeline]: {
+            ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
             selectedDataViewId: id,
             selectedPatterns: patternList.slice(0, 2),
           },
@@ -340,7 +341,7 @@ describe.skip('Sourcerer component', () => {
     const store = createMockStore(state2);
     const { getByTestId, queryByTitle, queryAllByTestId } = render(
       <TestProviders store={store}>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.timeline} />
+        <Sourcerer scope={PageScope.timeline} />
       </TestProviders>
     );
 
@@ -372,8 +373,8 @@ describe.skip('Sourcerer component', () => {
         ],
         sourcererScopes: {
           ...mockGlobalState.sourcerer.sourcererScopes,
-          [SourcererScopeName.default]: {
-            ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+          [PageScope.default]: {
+            ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
             selectedDataViewId: id,
             selectedPatterns: patternListNoSignals.slice(0, 2),
           },
@@ -401,7 +402,7 @@ describe.skip('Sourcerer component', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       sourcererActions.setSelectedDataView({
-        id: SourcererScopeName.default,
+        id: PageScope.default,
         selectedDataViewId: id,
         selectedPatterns: patternListNoSignals.slice(0, 3),
       })
@@ -424,8 +425,8 @@ describe.skip('Sourcerer component', () => {
         ],
         sourcererScopes: {
           ...mockGlobalState.sourcerer.sourcererScopes,
-          [SourcererScopeName.default]: {
-            ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+          [PageScope.default]: {
+            ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
             selectedDataViewId: id,
             selectedPatterns: patternListNoSignals.slice(0, 2),
           },
@@ -533,8 +534,8 @@ describe.skip('Sourcerer component', () => {
         ],
         sourcererScopes: {
           ...mockGlobalState.sourcerer.sourcererScopes,
-          [SourcererScopeName.timeline]: {
-            ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+          [PageScope.timeline]: {
+            ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
             loading: false,
             selectedDataViewId: id,
             selectedPatterns: patternListNoSignals.slice(0, 2),
@@ -546,7 +547,7 @@ describe.skip('Sourcerer component', () => {
     const store = createMockStore(state2);
     const el = render(
       <TestProviders store={store}>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.timeline} />
+        <Sourcerer scope={PageScope.timeline} />
       </TestProviders>
     );
 
@@ -581,8 +582,8 @@ describe.skip('Sourcerer component', () => {
         ],
         sourcererScopes: {
           ...mockGlobalState.sourcerer.sourcererScopes,
-          [SourcererScopeName.default]: {
-            ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+          [PageScope.default]: {
+            ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
             loading: false,
             selectedDataViewId: id,
             selectedPatterns: patternListNoSignals.slice(0, 2),
@@ -616,7 +617,7 @@ describe.skip('Sourcerer component', () => {
 
     mount(
       <TestProviders>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.timeline} />
+        <Sourcerer scope={PageScope.timeline} />
       </TestProviders>
     );
 
@@ -631,7 +632,7 @@ describe.skip('Sourcerer component', () => {
 
     mount(
       <TestProviders>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.default} />
+        <Sourcerer scope={PageScope.default} />
       </TestProviders>
     );
 
@@ -646,7 +647,7 @@ describe.skip('Sourcerer component', () => {
 
     mount(
       <TestProviders>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.timeline} />
+        <Sourcerer scope={PageScope.timeline} />
       </TestProviders>
     );
     expect(pollForSignalIndexMock).toHaveBeenCalledTimes(1);
@@ -660,7 +661,7 @@ describe.skip('Sourcerer component', () => {
 
     mount(
       <TestProviders>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.alerts} />
+        <Sourcerer scope={PageScope.alerts} />
       </TestProviders>
     );
     expect(pollForSignalIndexMock).toHaveBeenCalledTimes(1);
@@ -669,7 +670,7 @@ describe.skip('Sourcerer component', () => {
   it('renders without a popover when analyzer is the scope', () => {
     mount(
       <TestProviders>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.analyzer} />
+        <Sourcerer scope={PageScope.analyzer} />
       </TestProviders>
     );
     expect(wrapper.find(`[data-test-subj="sourcerer-popover"]`).exists()).toBeFalsy();

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.test.tsx
@@ -14,7 +14,7 @@ import { Sourcerer } from '.';
 import { sourcererActions, sourcererModel } from '../store';
 import { createMockStore, mockGlobalState, TestProviders } from '../../common/mock';
 import type { EuiSuperSelectOption } from '@elastic/eui';
-import { fireEvent, waitFor, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { useSourcererDataView } from '../containers';
 import { useSignalHelpers } from '../containers/use_signal_helpers';
 import { DEFAULT_INDEX_PATTERN } from '../../../common/constants';
@@ -660,7 +660,7 @@ describe.skip('Sourcerer component', () => {
 
     mount(
       <TestProviders>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.detections} />
+        <Sourcerer scope={sourcererModel.SourcererScopeName.alerts} />
       </TestProviders>
     );
     expect(pollForSignalIndexMock).toHaveBeenCalledTimes(1);

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.tsx
@@ -17,13 +17,12 @@ import type { ChangeEventHandler } from 'react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { PageScope } from '../../data_view_manager/constants';
 import * as i18n from './translations';
-import type { sourcererModel } from '../store';
 import { sourcererActions, sourcererSelectors } from '../store';
 import type { SourcererUrlState } from '../store/model';
 import type { State } from '../../common/store';
 import type { ModifiedTypes } from './use_pick_index_patterns';
-import { SourcererScopeName } from '../store/model';
 import { usePickIndexPatterns } from './use_pick_index_patterns';
 import { FormRow, PopoverContent, StyledButtonEmpty, StyledFormRow } from './helpers';
 import { TemporarySourcerer } from './temporary';
@@ -36,7 +35,7 @@ import { useUpdateUrlParam } from '../../common/utils/global_query_string';
 import { URL_PARAM_KEY } from '../../common/hooks/use_url_state';
 
 export interface SourcererComponentProps {
-  scope: sourcererModel.SourcererScopeName;
+  scope: PageScope;
 }
 
 interface SourcererPopoverProps {
@@ -58,7 +57,7 @@ interface SourcererPopoverProps {
   handleOutsideClick: () => void;
   setMissingPatterns: (missingPatterns: string[]) => void;
   setDataViewId: (dataViewId: string | null) => void;
-  scopeId: sourcererModel.SourcererScopeName;
+  scopeId: PageScope;
   children: React.ReactNode;
 }
 
@@ -86,7 +85,7 @@ const SourcererPopover = React.memo<SourcererPopoverProps>(
   }) => {
     if (!showSourcerer) {
       return null;
-    } else if (scopeId === SourcererScopeName.analyzer) {
+    } else if (scopeId === PageScope.analyzer) {
       return <div data-test-subj="analyzer-sourcerer">{children}</div>;
     } else {
       return (
@@ -127,9 +126,9 @@ SourcererPopover.displayName = 'SourcererPopover';
  */
 export const Sourcerer = React.memo<SourcererComponentProps>(({ scope: scopeId }) => {
   const dispatch = useDispatch();
-  const isDetectionsSourcerer = scopeId === SourcererScopeName.alerts;
-  const isTimelineSourcerer = scopeId === SourcererScopeName.timeline;
-  const isDefaultSourcerer = scopeId === SourcererScopeName.default;
+  const isDetectionsSourcerer = scopeId === PageScope.alerts;
+  const isTimelineSourcerer = scopeId === PageScope.timeline;
+  const isDefaultSourcerer = scopeId === PageScope.default;
   const updateUrlParam = useUpdateUrlParam<SourcererUrlState>(URL_PARAM_KEY.sourcerer);
 
   const signalIndexName = useSelector(sourcererSelectors.signalIndexName);
@@ -247,7 +246,7 @@ export const Sourcerer = React.memo<SourcererComponentProps>(({ scope: scopeId }
 
       if (isDefaultSourcerer) {
         updateUrlParam({
-          [SourcererScopeName.default]: {
+          [PageScope.default]: {
             id: newSelectedDataView,
             selectedPatterns: newSelectedPatterns,
           },
@@ -354,9 +353,7 @@ export const Sourcerer = React.memo<SourcererComponentProps>(({ scope: scopeId }
   }, []);
 
   const showSourcerer = useMemo(() => {
-    return (
-      indicesExist || [SourcererScopeName.analyzer, SourcererScopeName.timeline].includes(scopeId)
-    );
+    return indicesExist || [PageScope.analyzer, PageScope.timeline].includes(scopeId);
   }, [indicesExist, scopeId]);
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.tsx
@@ -127,7 +127,7 @@ SourcererPopover.displayName = 'SourcererPopover';
  */
 export const Sourcerer = React.memo<SourcererComponentProps>(({ scope: scopeId }) => {
   const dispatch = useDispatch();
-  const isDetectionsSourcerer = scopeId === SourcererScopeName.detections;
+  const isDetectionsSourcerer = scopeId === SourcererScopeName.alerts;
   const isTimelineSourcerer = scopeId === SourcererScopeName.timeline;
   const isDefaultSourcerer = scopeId === SourcererScopeName.default;
   const updateUrlParam = useUpdateUrlParam<SourcererUrlState>(URL_PARAM_KEY.sourcerer);

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/misc.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/misc.test.tsx
@@ -19,7 +19,7 @@ import { useSignalHelpers } from '../containers/use_signal_helpers';
 import { TimelineId } from '../../../common/types/timeline';
 import { type TimelineType, TimelineTypeEnum } from '../../../common/api/timeline';
 import { sortWithExcludesAtEnd } from '../../../common/utils/sourcerer';
-import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 const mockDispatch = jest.fn();
 
@@ -119,7 +119,7 @@ describe.skip('No data', () => {
   test('Hide sourcerer - detections ', () => {
     const wrapper = mount(
       <TestProviders store={store}>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.detections} />
+        <Sourcerer scope={sourcererModel.SourcererScopeName.alerts} />
       </TestProviders>
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/misc.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/misc.test.tsx
@@ -10,9 +10,9 @@ import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
 import { cloneDeep } from 'lodash';
 
-import { initialSourcererState, type SelectedDataView, SourcererScopeName } from '../store/model';
+import { initialSourcererState, type SelectedDataView } from '../store/model';
 import { Sourcerer } from '.';
-import { sourcererActions, sourcererModel } from '../store';
+import { sourcererActions } from '../store';
 import { createMockStore, mockGlobalState, TestProviders } from '../../common/mock';
 import { useSourcererDataView } from '../containers';
 import { useSignalHelpers } from '../containers/use_signal_helpers';
@@ -20,6 +20,7 @@ import { TimelineId } from '../../../common/types/timeline';
 import { type TimelineType, TimelineTypeEnum } from '../../../common/api/timeline';
 import { sortWithExcludesAtEnd } from '../../../common/utils/sourcerer';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PageScope } from '../../data_view_manager/constants';
 
 const mockDispatch = jest.fn();
 
@@ -58,7 +59,7 @@ jest.mock('../../common/utils/global_query_string', () => {
 });
 
 const defaultProps = {
-  scope: sourcererModel.SourcererScopeName.default,
+  scope: PageScope.default,
 };
 
 const checkOptionsAndSelections = (wrapper: ReactWrapper, patterns: string[]) => ({
@@ -119,7 +120,7 @@ describe.skip('No data', () => {
   test('Hide sourcerer - detections ', () => {
     const wrapper = mount(
       <TestProviders store={store}>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.alerts} />
+        <Sourcerer scope={PageScope.alerts} />
       </TestProviders>
     );
 
@@ -128,7 +129,7 @@ describe.skip('No data', () => {
   test('Hide sourcerer - timeline ', () => {
     const wrapper = mount(
       <TestProviders store={store}>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.timeline} />
+        <Sourcerer scope={PageScope.timeline} />
       </TestProviders>
     );
 
@@ -160,8 +161,8 @@ describe.skip('Update available', () => {
       ],
       sourcererScopes: {
         ...mockGlobalState.sourcerer.sourcererScopes,
-        [SourcererScopeName.timeline]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+        [PageScope.timeline]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
           loading: false,
           patternList,
           selectedDataViewId: null,
@@ -186,7 +187,7 @@ describe.skip('Update available', () => {
 
     render(
       <TestProviders store={store}>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.timeline} />
+        <Sourcerer scope={PageScope.timeline} />
       </TestProviders>
     );
   });
@@ -251,7 +252,7 @@ describe.skip('Update available', () => {
     await waitFor(() => {
       expect(mockDispatch).toHaveBeenCalledWith(
         sourcererActions.setSelectedDataView({
-          id: SourcererScopeName.timeline,
+          id: PageScope.timeline,
           selectedDataViewId: 'security-solution',
           selectedPatterns: ['myFakebeat-*'],
           shouldValidateSelectedPatterns: false,
@@ -295,8 +296,8 @@ describe.skip('Update available for timeline template', () => {
       ],
       sourcererScopes: {
         ...mockGlobalState.sourcerer.sourcererScopes,
-        [SourcererScopeName.timeline]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+        [PageScope.timeline]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
           loading: false,
           patternList,
           selectedDataViewId: null,
@@ -317,7 +318,7 @@ describe.skip('Update available for timeline template', () => {
 
     render(
       <TestProviders store={store}>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.timeline} />
+        <Sourcerer scope={PageScope.timeline} />
       </TestProviders>
     );
   });
@@ -373,8 +374,8 @@ describe.skip('Missing index patterns', () => {
       ],
       sourcererScopes: {
         ...mockGlobalState.sourcerer.sourcererScopes,
-        [SourcererScopeName.timeline]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+        [PageScope.timeline]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
           loading: false,
           patternList,
           selectedDataViewId: 'fake-data-view-id',
@@ -408,7 +409,7 @@ describe.skip('Missing index patterns', () => {
 
     render(
       <TestProviders store={store}>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.timeline} />
+        <Sourcerer scope={PageScope.timeline} />
       </TestProviders>
     );
 
@@ -439,7 +440,7 @@ describe.skip('Missing index patterns', () => {
 
     render(
       <TestProviders store={store}>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.timeline} />
+        <Sourcerer scope={PageScope.timeline} />
       </TestProviders>
     );
 
@@ -485,8 +486,8 @@ describe.skip('Sourcerer integration tests', () => {
       ],
       sourcererScopes: {
         ...mockGlobalState.sourcerer.sourcererScopes,
-        [SourcererScopeName.default]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+        [PageScope.default]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
           loading: false,
           selectedDataViewId: id,
           selectedPatterns: patternListNoSignals.slice(0, 2),
@@ -529,7 +530,7 @@ describe.skip('Sourcerer integration tests', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       sourcererActions.setSelectedDataView({
-        id: SourcererScopeName.default,
+        id: PageScope.default,
         selectedDataViewId: '1234',
         selectedPatterns: ['fakebeat-*'],
       })

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/sourcerer_integration.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/sourcerer_integration.test.tsx
@@ -9,13 +9,13 @@ import React from 'react';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
 
-import { SourcererScopeName } from '../store/model';
 import { Sourcerer } from '.';
 import { useSignalHelpers } from '../containers/use_signal_helpers';
-import { sourcererActions, sourcererModel } from '../store';
+import { sourcererActions } from '../store';
 import { createMockStore, mockGlobalState, TestProviders } from '../../common/mock';
 import { sortWithExcludesAtEnd } from '../../../common/utils/sourcerer';
 import { useSourcererDataView } from '../containers';
+import { PageScope } from '../../data_view_manager/constants';
 
 const mockDispatch = jest.fn();
 
@@ -54,7 +54,7 @@ jest.mock('../../common/utils/global_query_string', () => {
 });
 
 const defaultProps = {
-  scope: sourcererModel.SourcererScopeName.default,
+  scope: PageScope.default,
 };
 
 const checkOptionsAndSelections = (wrapper: ReactWrapper, patterns: string[]) => ({
@@ -93,8 +93,8 @@ describe.skip('Sourcerer integration tests', () => {
       ],
       sourcererScopes: {
         ...mockGlobalState.sourcerer.sourcererScopes,
-        [SourcererScopeName.default]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+        [PageScope.default]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
           loading: false,
           selectedDataViewId: id,
           selectedPatterns: patternListNoSignals.slice(0, 2),
@@ -134,7 +134,7 @@ describe.skip('Sourcerer integration tests', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       sourcererActions.setSelectedDataView({
-        id: SourcererScopeName.default,
+        id: PageScope.default,
         selectedDataViewId: '1234',
         selectedPatterns: ['fakebeat-*'],
       })

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/timeline_sourcerer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/timeline_sourcerer.test.tsx
@@ -7,13 +7,12 @@
 
 import React from 'react';
 
-import { render, cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
-import { SourcererScopeName } from '../store/model';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Sourcerer } from '.';
-import { sourcererModel } from '../store';
 import { createMockStore, mockGlobalState, TestProviders } from '../../common/mock';
 import { useSourcererDataView } from '../containers';
 import { useSignalHelpers } from '../containers/use_signal_helpers';
+import { PageScope } from '../../data_view_manager/constants';
 
 const mockDispatch = jest.fn();
 
@@ -61,7 +60,7 @@ const sourcererDataView = {
 
 describe('timeline sourcerer', () => {
   const testProps = {
-    scope: sourcererModel.SourcererScopeName.timeline,
+    scope: PageScope.timeline,
   };
 
   beforeEach(async () => {
@@ -146,8 +145,8 @@ describe('timeline sourcerer', () => {
         ...mockGlobalState.sourcerer,
         sourcererScopes: {
           ...mockGlobalState.sourcerer.sourcererScopes,
-          [SourcererScopeName.timeline]: {
-            ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+          [PageScope.timeline]: {
+            ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
             loading: false,
             selectedDataViewId: id,
             selectedPatterns: [`${mockGlobalState.sourcerer.signalIndexName}`],
@@ -158,7 +157,7 @@ describe('timeline sourcerer', () => {
 
     render(
       <TestProviders store={createMockStore(state2)}>
-        <Sourcerer scope={sourcererModel.SourcererScopeName.timeline} />
+        <Sourcerer scope={PageScope.timeline} />
       </TestProviders>
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_get_sourcerer_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_get_sourcerer_data_view.test.ts
@@ -9,10 +9,10 @@ import { DataView } from '@kbn/data-views-plugin/common';
 import { renderHook } from '@testing-library/react';
 import { useSourcererDataView } from '../containers';
 import { mockSourcererScope } from '../containers/mocks';
-import { SourcererScopeName } from '../store/model';
 import type { UseGetScopedSourcererDataViewArgs } from './use_get_sourcerer_data_view';
 import { useGetScopedSourcererDataView } from './use_get_sourcerer_data_view';
 import { TestProviders } from '../../common/mock';
+import { PageScope } from '../../data_view_manager/constants';
 
 const renderHookCustom = (args: UseGetScopedSourcererDataViewArgs) => {
   return renderHook(({ sourcererScope }) => useGetScopedSourcererDataView({ sourcererScope }), {
@@ -34,7 +34,7 @@ describe.skip('useGetScopedSourcererDataView', () => {
     (useSourcererDataView as jest.Mock).mockImplementation(mockGetSourcererDataView);
   });
   it('should return DataView when correct spec is provided', () => {
-    const { result } = renderHookCustom({ sourcererScope: SourcererScopeName.timeline });
+    const { result } = renderHookCustom({ sourcererScope: PageScope.timeline });
 
     expect(result.current).toBeInstanceOf(DataView);
   });
@@ -43,7 +43,7 @@ describe.skip('useGetScopedSourcererDataView', () => {
       ...mockSourcererScope,
       sourcererDataView: {},
     });
-    const { result } = renderHookCustom({ sourcererScope: SourcererScopeName.timeline });
+    const { result } = renderHookCustom({ sourcererScope: PageScope.timeline });
     expect(result.current).toBeUndefined();
   });
   it('should return undefined when no spec is provided and should update the return when spec is updated to correct value', () => {
@@ -51,10 +51,10 @@ describe.skip('useGetScopedSourcererDataView', () => {
       ...mockSourcererScope,
       sourcererDataView: {},
     });
-    const { rerender, result } = renderHookCustom({ sourcererScope: SourcererScopeName.timeline });
+    const { rerender, result } = renderHookCustom({ sourcererScope: PageScope.timeline });
     expect(result.current).toBeUndefined();
 
-    rerender({ sourcererScope: SourcererScopeName.timeline });
+    rerender({ sourcererScope: PageScope.timeline });
     expect(result.current).toBeInstanceOf(DataView);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_get_sourcerer_data_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_get_sourcerer_data_view.tsx
@@ -7,13 +7,13 @@
 
 import { useMemo } from 'react';
 import { DataView } from '@kbn/data-views-plugin/public';
+import type { PageScope } from '../../data_view_manager/constants';
 import { useSourcererDataView } from '../containers';
 import { useKibana } from '../../common/lib/kibana';
-import type { SourcererScopeName } from '../store/model';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 
 export interface UseGetScopedSourcererDataViewArgs {
-  sourcererScope: SourcererScopeName;
+  sourcererScope: PageScope;
 }
 
 /*

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_pick_index_patterns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_pick_index_patterns.tsx
@@ -5,14 +5,15 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { EuiComboBoxOptionOption, EuiSuperSelectOption } from '@elastic/eui';
 import { useDispatch } from 'react-redux';
 
+import { PageScope } from '../../data_view_manager/constants';
 import { getScopePatternListSelection } from '../store/helpers';
-import { sourcererActions, sourcererModel } from '../store';
+import type { sourcererModel } from '../store';
+import { sourcererActions } from '../store';
 import { getDataViewSelectOptions, getPatternListWithoutSignals } from './helpers';
-import { SourcererScopeName } from '../store/model';
 import { sortWithExcludesAtEnd } from '../../../common/utils/sourcerer';
 import { useKibana } from '../../common/lib/kibana';
 import { getSourcererDataView } from '../containers/get_sourcerer_data_view';
@@ -23,7 +24,7 @@ interface UsePickIndexPatternsProps {
   isOnlyDetectionAlerts: boolean;
   kibanaDataViews: sourcererModel.SourcererModel['kibanaDataViews'];
   missingPatterns: string[];
-  scopeId: sourcererModel.SourcererScopeName;
+  scopeId: PageScope;
   selectedDataViewId: string | null;
   selectedPatterns: string[];
   signalIndexName: string | null;
@@ -103,7 +104,7 @@ export const usePickIndexPatterns = ({
 
     const titleAsList = [...new Set(theDataView.title.split(','))];
 
-    return scopeId === sourcererModel.SourcererScopeName.default
+    return scopeId === PageScope.default
       ? {
           allPatterns: getPatternListWithoutSignals(titleAsList, signalIndexName),
           selectablePatterns: getPatternListWithoutSignals(
@@ -124,7 +125,7 @@ export const usePickIndexPatterns = ({
 
   const getDefaultSelectedOptionsByDataView = useCallback(
     (id: string, isAlerts: boolean = false): Array<EuiComboBoxOptionOption<string>> =>
-      scopeId === SourcererScopeName.alerts || isAlerts
+      scopeId === PageScope.alerts || isAlerts
         ? signalPatternListToOptions
         : patternListToOptions(
             getScopePatternListSelection(
@@ -165,7 +166,7 @@ export const usePickIndexPatterns = ({
 
   useEffect(() => {
     setSelectedOptions(
-      scopeId === SourcererScopeName.alerts ? signalPatternListToOptions : selectedPatternsAsOptions
+      scopeId === PageScope.alerts ? signalPatternListToOptions : selectedPatternsAsOptions
     );
   }, [selectedPatterns, scopeId, selectedPatternsAsOptions, signalPatternListToOptions]);
   // when scope updates, check modified to set/remove alerts label

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_pick_index_patterns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_pick_index_patterns.tsx
@@ -124,7 +124,7 @@ export const usePickIndexPatterns = ({
 
   const getDefaultSelectedOptionsByDataView = useCallback(
     (id: string, isAlerts: boolean = false): Array<EuiComboBoxOptionOption<string>> =>
-      scopeId === SourcererScopeName.detections || isAlerts
+      scopeId === SourcererScopeName.alerts || isAlerts
         ? signalPatternListToOptions
         : patternListToOptions(
             getScopePatternListSelection(
@@ -165,9 +165,7 @@ export const usePickIndexPatterns = ({
 
   useEffect(() => {
     setSelectedOptions(
-      scopeId === SourcererScopeName.detections
-        ? signalPatternListToOptions
-        : selectedPatternsAsOptions
+      scopeId === SourcererScopeName.alerts ? signalPatternListToOptions : selectedPatternsAsOptions
     );
   }, [selectedPatterns, scopeId, selectedPatternsAsOptions, signalPatternListToOptions]);
   // when scope updates, check modified to set/remove alerts label

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/hooks.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/hooks.test.tsx
@@ -27,12 +27,12 @@ import {
   TestProviders,
 } from '../../common/mock';
 import type { SelectedDataView } from '../store/model';
-import { SourcererScopeName } from '../store/model';
 import * as source from '../../common/containers/source/use_data_view';
 import { sourcererActions } from '../store';
 import { useInitializeUrlParam, useUpdateUrlParam } from '../../common/utils/global_query_string';
 import { createSourcererDataView } from './create_sourcerer_data_view';
 import { useInitSourcerer } from './use_init_sourcerer';
+import { PageScope } from '../../data_view_manager/constants';
 
 const mockRouteSpy: RouteSpyState = {
   pageName: SecurityPageName.overview,
@@ -253,7 +253,7 @@ describe.skip('Sourcerer Hooks', () => {
     const selectedDataViewId = 'security-solution-default';
     (useInitializeUrlParam as jest.Mock).mockImplementation((_, onInitialize) =>
       onInitialize({
-        [SourcererScopeName.default]: {
+        [PageScope.default]: {
           id: selectedDataViewId,
           selectedPatterns,
         },
@@ -266,7 +266,7 @@ describe.skip('Sourcerer Hooks', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       sourcererActions.setSelectedDataView({
-        id: SourcererScopeName.default,
+        id: PageScope.default,
         selectedDataViewId,
         selectedPatterns,
       })
@@ -285,7 +285,7 @@ describe.skip('Sourcerer Hooks', () => {
     });
 
     expect(updateUrlParam).toHaveBeenCalledWith({
-      [SourcererScopeName.default]: {
+      [PageScope.default]: {
         id: DEFAULT_DATA_VIEW_ID,
         selectedPatterns: DEFAULT_INDEX_PATTERN,
       },
@@ -396,7 +396,7 @@ describe.skip('Sourcerer Hooks', () => {
       signalIndexName: mockSourcererState.signalIndexName,
       isSignalIndexExists: true,
     }));
-    const { rerender } = renderHook(() => useInitSourcerer(SourcererScopeName.alerts), {
+    const { rerender } = renderHook(() => useInitSourcerer(PageScope.alerts), {
       wrapper: StoreProvider,
     });
     await waitFor(() => new Promise((resolve) => resolve(null)));
@@ -404,7 +404,7 @@ describe.skip('Sourcerer Hooks', () => {
     expect(mockDispatch.mock.calls[3][0]).toEqual({
       type: 'x-pack/security_solution/local/sourcerer/SET_SELECTED_DATA_VIEW',
       payload: {
-        id: 'detections',
+        id: 'alerts',
         selectedDataViewId: mockSourcererState.defaultDataView.id,
         selectedPatterns: [mockSourcererState.signalIndexName],
       },
@@ -427,8 +427,8 @@ describe.skip('Sourcerer Hooks', () => {
         ...mockGlobalState.sourcerer,
         sourcererScopes: {
           ...mockGlobalState.sourcerer.sourcererScopes,
-          [SourcererScopeName.timeline]: {
-            ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+          [PageScope.timeline]: {
+            ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
             selectedDataViewId: 'different-id',
           },
         },
@@ -463,7 +463,7 @@ describe.skip('Sourcerer Hooks', () => {
         expect(mockIndexFieldsSearch).toHaveBeenCalledWith({
           dataViewId: mockSourcererState.defaultDataView.id,
           needToBeInit: false,
-          scopeId: SourcererScopeName.default,
+          scopeId: PageScope.default,
         });
       });
     });
@@ -475,8 +475,8 @@ describe.skip('Sourcerer Hooks', () => {
           ...mockGlobalState.sourcerer,
           sourcererScopes: {
             ...mockGlobalState.sourcerer.sourcererScopes,
-            [SourcererScopeName.default]: {
-              ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+            [PageScope.default]: {
+              ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
               selectedPatterns: [],
               missingPatterns: [],
             },
@@ -492,7 +492,7 @@ describe.skip('Sourcerer Hooks', () => {
         expect(mockIndexFieldsSearch).toHaveBeenCalledWith({
           dataViewId: mockSourcererState.defaultDataView.id,
           needToBeInit: true,
-          scopeId: SourcererScopeName.default,
+          scopeId: PageScope.default,
         });
       });
     });
@@ -508,8 +508,8 @@ describe.skip('Sourcerer Hooks', () => {
           ],
           sourcererScopes: {
             ...mockGlobalState.sourcerer.sourcererScopes,
-            [SourcererScopeName.timeline]: {
-              ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+            [PageScope.timeline]: {
+              ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
               selectedDataViewId: 'something-weird',
               selectedPatterns: [],
               missingPatterns: [],
@@ -526,7 +526,7 @@ describe.skip('Sourcerer Hooks', () => {
         expect(mockIndexFieldsSearch).toHaveBeenNthCalledWith(2, {
           dataViewId: 'something-weird',
           needToBeInit: true,
-          scopeId: SourcererScopeName.timeline,
+          scopeId: PageScope.timeline,
           skipScopeUpdate: false,
         });
       });
@@ -543,8 +543,8 @@ describe.skip('Sourcerer Hooks', () => {
           ],
           sourcererScopes: {
             ...mockGlobalState.sourcerer.sourcererScopes,
-            [SourcererScopeName.timeline]: {
-              ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+            [PageScope.timeline]: {
+              ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
               selectedDataViewId: 'something-weird',
               selectedPatterns: ['ohboy'],
               missingPatterns: [],
@@ -561,7 +561,7 @@ describe.skip('Sourcerer Hooks', () => {
         expect(mockIndexFieldsSearch).toHaveBeenNthCalledWith(2, {
           dataViewId: 'something-weird',
           needToBeInit: true,
-          scopeId: SourcererScopeName.timeline,
+          scopeId: PageScope.timeline,
           skipScopeUpdate: true,
         });
       });
@@ -582,8 +582,8 @@ describe.skip('Sourcerer Hooks', () => {
           ],
           sourcererScopes: {
             ...mockGlobalState.sourcerer.sourcererScopes,
-            [SourcererScopeName.timeline]: {
-              ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+            [PageScope.timeline]: {
+              ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
               selectedDataViewId: 'something-weird',
               selectedPatterns: [],
               missingPatterns: [],
@@ -600,7 +600,7 @@ describe.skip('Sourcerer Hooks', () => {
         expect(mockIndexFieldsSearch).toHaveBeenNthCalledWith(2, {
           dataViewId: 'something-weird',
           needToBeInit: false,
-          scopeId: SourcererScopeName.timeline,
+          scopeId: PageScope.timeline,
         });
       });
     });
@@ -614,8 +614,8 @@ describe.skip('Sourcerer Hooks', () => {
           ...mockGlobalState.sourcerer,
           sourcererScopes: {
             ...mockGlobalState.sourcerer.sourcererScopes,
-            [SourcererScopeName.default]: {
-              ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+            [PageScope.default]: {
+              ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
               selectedPatterns: [
                 '-packetbeat-*',
                 'endgame-*',
@@ -632,12 +632,9 @@ describe.skip('Sourcerer Hooks', () => {
         },
       });
 
-      const { result, rerender } = renderHook<SelectedDataView, SourcererScopeName>(
-        useSourcererDataView,
-        {
-          wrapper: StoreProvider,
-        }
-      );
+      const { result, rerender } = renderHook<SelectedDataView, PageScope>(useSourcererDataView, {
+        wrapper: StoreProvider,
+      });
       await waitFor(() => new Promise((resolve) => resolve(null)));
       rerender();
       await waitFor(() =>
@@ -668,7 +665,7 @@ describe.skip('Sourcerer Hooks', () => {
       await act(async () => {
         store.dispatch(
           sourcererActions.setSelectedDataView({
-            id: SourcererScopeName.default,
+            id: PageScope.default,
             selectedDataViewId: 'security-solution-default',
             selectedPatterns: testPatterns,
           })
@@ -685,15 +682,15 @@ describe.skip('Sourcerer Hooks', () => {
 
 describe('getScopeFromPath', () => {
   it('should return default scope', async () => {
-    expect(getScopeFromPath('/')).toBe(SourcererScopeName.default);
-    expect(getScopeFromPath('/exceptions')).toBe(SourcererScopeName.default);
-    expect(getScopeFromPath('/rules')).toBe(SourcererScopeName.default);
-    expect(getScopeFromPath('/rules/create')).toBe(SourcererScopeName.default);
+    expect(getScopeFromPath('/')).toBe(PageScope.default);
+    expect(getScopeFromPath('/exceptions')).toBe(PageScope.default);
+    expect(getScopeFromPath('/rules')).toBe(PageScope.default);
+    expect(getScopeFromPath('/rules/create')).toBe(PageScope.default);
   });
 
   it('should return detections scope', async () => {
-    expect(getScopeFromPath('/alerts')).toBe(SourcererScopeName.alerts);
-    expect(getScopeFromPath('/rules/id/foo')).toBe(SourcererScopeName.alerts);
-    expect(getScopeFromPath('/rules/id/foo/edit')).toBe(SourcererScopeName.alerts);
+    expect(getScopeFromPath('/alerts')).toBe(PageScope.alerts);
+    expect(getScopeFromPath('/rules/id/foo')).toBe(PageScope.alerts);
+    expect(getScopeFromPath('/rules/id/foo/edit')).toBe(PageScope.alerts);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/hooks.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/hooks.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { act, waitFor, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
 import { useSourcererDataView } from '.';
@@ -19,12 +19,12 @@ import {
   SECURITY_FEATURE_ID,
   SecurityPageName,
 } from '../../../common/constants';
-import { useUserInfo, initialState as userInfoState } from '../../detections/components/user_info';
+import { initialState as userInfoState, useUserInfo } from '../../detections/components/user_info';
 import {
+  createMockStore,
   mockGlobalState,
   mockSourcererState,
   TestProviders,
-  createMockStore,
 } from '../../common/mock';
 import type { SelectedDataView } from '../store/model';
 import { SourcererScopeName } from '../store/model';
@@ -396,7 +396,7 @@ describe.skip('Sourcerer Hooks', () => {
       signalIndexName: mockSourcererState.signalIndexName,
       isSignalIndexExists: true,
     }));
-    const { rerender } = renderHook(() => useInitSourcerer(SourcererScopeName.detections), {
+    const { rerender } = renderHook(() => useInitSourcerer(SourcererScopeName.alerts), {
       wrapper: StoreProvider,
     });
     await waitFor(() => new Promise((resolve) => resolve(null)));
@@ -692,8 +692,8 @@ describe('getScopeFromPath', () => {
   });
 
   it('should return detections scope', async () => {
-    expect(getScopeFromPath('/alerts')).toBe(SourcererScopeName.detections);
-    expect(getScopeFromPath('/rules/id/foo')).toBe(SourcererScopeName.detections);
-    expect(getScopeFromPath('/rules/id/foo/edit')).toBe(SourcererScopeName.detections);
+    expect(getScopeFromPath('/alerts')).toBe(SourcererScopeName.alerts);
+    expect(getScopeFromPath('/rules/id/foo')).toBe(SourcererScopeName.alerts);
+    expect(getScopeFromPath('/rules/id/foo/edit')).toBe(SourcererScopeName.alerts);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/index.tsx
@@ -8,9 +8,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import type { FieldSpec } from '@kbn/data-plugin/common';
+import { PageScope } from '../../data_view_manager/constants';
 import { sourcererSelectors } from '../store';
-import type { SelectedDataView, SourcererDataView, RunTimeMappings } from '../store/model';
-import { SourcererScopeName } from '../store/model';
+import type { RunTimeMappings, SelectedDataView, SourcererDataView } from '../store/model';
 import { checkIfIndicesExist } from '../store/helpers';
 import { getDataViewStateFromIndexFields } from '../../common/containers/source/use_data_view';
 import { useFetchIndex } from '../../common/containers/source';
@@ -18,9 +18,7 @@ import type { State } from '../../common/store/types';
 import { sortWithExcludesAtEnd } from '../../../common/utils/sourcerer';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 
-export const useSourcererDataView = (
-  scopeId: SourcererScopeName = SourcererScopeName.default
-): SelectedDataView => {
+export const useSourcererDataView = (scopeId: PageScope = PageScope.default): SelectedDataView => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
   const kibanaDataViews = useSelector(sourcererSelectors.kibanaDataViews);

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/readme.md
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/readme.md
@@ -4,7 +4,7 @@
 
 - called at the top of the app in HomePageComponent to initialize the sourcerer state!
 - Calls `useSourcererDataView` (see below) for the active scope (ex:
-  `SourcererScopeName.default | SourcererScopeName.alerts`)
+  `PageScope.default | PageScope.alerts`)
 - If there is an error with the data view, thrown here
 - Run index field search for the active data view id, and when the active data view id updates
 - we changed the logic to not fetch all the index fields for every data view on the loading of the app because user can
@@ -51,7 +51,7 @@ interface SelectedDataView {
     - Our app uses `dataViewId`, getting the fields from a Data View that includes runtime fields. No matter what the
       sourcerer indices are set to, we will get the same fields always from the Data View. If we only requested
       `indices`, we would get just the fields for those indices (not all like Data View) and therefore would not get the
-      runtime fields. So even when we are in `SourcererScopeName.alerts` narrowed down to just
+      runtime fields. So even when we are in `PageScope.alerts` narrowed down to just
       `.alerts-security.alerts-default`, we get all the fields from the entire Security Solution Data View.
 
 ### `useSignalHelpers`

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/readme.md
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/readme.md
@@ -1,17 +1,25 @@
 # Sourcerer Container
 
 ### `useInitSourcerer`
- - called at the top of the app in HomePageComponent to initialize the sourcerer state!
- - Calls `useSourcererDataView` (see below) for the active scope (ex: `SourcererScopeName.default | SourcererScopeName.detections`)
- - If there is an error with the data view, thrown here
- - Run index field search for the active data view id, and when the active data view id updates 
- - we changed the logic to not fetch all the index fields for every data view on the loading of the app  because user can have a lot of them and it can slow down the loading of the app  and maybe blow up the memory of the browser. 
- - We decided to load the data view patternList and fields on demand, we know that will only have to load this data view on default and timeline scope.  We will use two conditions to see if we need to fetch and initialize the data view selected.  First, we will make sure that we did not already fetch them by using `searchedIds` and then we will init them if `selectedPatterns` and `missingPatterns` are empty.
- - onSignalIndexUpdated
-   - called when signal index first has data in order to add it to the defaultDataView and refresh the index fields
 
-### `useSourcererDataView` 
- - returns combined data from SourcererDataView and SourcererScope to create SelectedDataView state
+- called at the top of the app in HomePageComponent to initialize the sourcerer state!
+- Calls `useSourcererDataView` (see below) for the active scope (ex:
+  `SourcererScopeName.default | SourcererScopeName.alerts`)
+- If there is an error with the data view, thrown here
+- Run index field search for the active data view id, and when the active data view id updates
+- we changed the logic to not fetch all the index fields for every data view on the loading of the app because user can
+  have a lot of them and it can slow down the loading of the app and maybe blow up the memory of the browser.
+- We decided to load the data view patternList and fields on demand, we know that will only have to load this data view
+  on default and timeline scope. We will use two conditions to see if we need to fetch and initialize the data view
+  selected. First, we will make sure that we did not already fetch them by using `searchedIds` and then we will init
+  them if `selectedPatterns` and `missingPatterns` are empty.
+- onSignalIndexUpdated
+    - called when signal index first has data in order to add it to the defaultDataView and refresh the index fields
+
+### `useSourcererDataView`
+
+- returns combined data from SourcererDataView and SourcererScope to create SelectedDataView state
+
 ```typescript
 interface SelectedDataView {
   browserFields: SourcererDataView['browserFields'];
@@ -35,16 +43,25 @@ interface SelectedDataView {
 ```
 
 ### `useDataView`
-- called to get `indexFieldSearch`, which gets the fields and formats them in `getDataViewStateFromIndexFields` in `use_data_view.tsx`
-- `indexFieldSearch` calls the `IndexFieldsStrategyRequest` in the `timelines` plugin. This request takes an argument of either `dataViewId` or `indices` to get the fields. 
-  - Our app uses `dataViewId`, getting the fields from a Data View that includes runtime fields. No matter what the sourcerer indices are set to, we will get the same fields always from the Data View. If we only requested `indices`, we would get just the fields for those indices (not all like Data View) and therefore would not get the runtime fields. So even when we are in `SourcererScopeName.detections` narrowed down to just `.alerts-security.alerts-default`, we get all the fields from the entire Security Solution Data View.
+
+- called to get `indexFieldSearch`, which gets the fields and formats them in `getDataViewStateFromIndexFields` in
+  `use_data_view.tsx`
+- `indexFieldSearch` calls the `IndexFieldsStrategyRequest` in the `timelines` plugin. This request takes an argument of
+  either `dataViewId` or `indices` to get the fields.
+    - Our app uses `dataViewId`, getting the fields from a Data View that includes runtime fields. No matter what the
+      sourcerer indices are set to, we will get the same fields always from the Data View. If we only requested
+      `indices`, we would get just the fields for those indices (not all like Data View) and therefore would not get the
+      runtime fields. So even when we are in `SourcererScopeName.alerts` narrowed down to just
+      `.alerts-security.alerts-default`, we get all the fields from the entire Security Solution Data View.
 
 ### `useSignalHelpers`
- - called on from detections and timelines scopes
- - `signalIndexNeedsInit` - when defined, signal index has been initiated but does not exist
- - `pollForSignalIndex` - when false, signal index has been initiated
 
+- called on from detections and timelines scopes
+- `signalIndexNeedsInit` - when defined, signal index has been initiated but does not exist
+- `pollForSignalIndex` - when false, signal index has been initiated
 
 ### Adding sourcerer to a new page
+
 - In order for the sourcerer to show up on a page, it needs to be added to the array `sourcererPaths`
-- The scope of a sourcerer component will be default unless the path is added to the `detectionsPaths` array, in which case the scope can be detections
+- The scope of a sourcerer component will be default unless the path is added to the `detectionsPaths` array, in which
+  case the scope can be detections

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/sourcerer_paths.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/sourcerer_paths.ts
@@ -7,21 +7,21 @@
 
 import { matchPath } from 'react-router-dom';
 
+import { PageScope } from '../../data_view_manager/constants';
 import {
-  CASES_PATH,
   ALERTS_PATH,
   ATTACK_DISCOVERY_PATH,
+  ATTACKS_PATH,
+  CASES_PATH,
+  DATA_QUALITY_PATH,
+  ENTITY_ANALYTICS_MANAGEMENT_PATH,
+  ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_PATH,
   HOSTS_PATH,
-  USERS_PATH,
   NETWORK_PATH,
   OVERVIEW_PATH,
   RULES_PATH,
-  DATA_QUALITY_PATH,
-  ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_PATH,
-  ENTITY_ANALYTICS_MANAGEMENT_PATH,
-  ATTACKS_PATH,
+  USERS_PATH,
 } from '../../../common/constants';
-import { SourcererScopeName } from '../store/model';
 
 export const sourcererPaths = [
   ALERTS_PATH,
@@ -54,18 +54,14 @@ const explorePaths = [
 export const getScopeFromPath = (
   pathname: string,
   newDataViewPickerEnabled?: boolean
-):
-  | SourcererScopeName.default
-  | SourcererScopeName.alerts
-  | SourcererScopeName.attacks
-  | SourcererScopeName.explore => {
+): PageScope.default | PageScope.alerts | PageScope.attacks | PageScope.explore => {
   if (
     matchPath(pathname, {
       path: detectionsPaths,
       strict: false,
     })
   ) {
-    return SourcererScopeName.alerts;
+    return PageScope.alerts;
   }
 
   if (
@@ -75,7 +71,7 @@ export const getScopeFromPath = (
       strict: false,
     })
   ) {
-    return SourcererScopeName.attacks;
+    return PageScope.attacks;
   }
 
   if (
@@ -85,10 +81,10 @@ export const getScopeFromPath = (
       strict: false,
     })
   ) {
-    return SourcererScopeName.explore;
+    return PageScope.explore;
   }
 
-  return SourcererScopeName.default;
+  return PageScope.default;
 };
 
 export const showSourcererByPath = (pathname: string): boolean =>

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/sourcerer_paths.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/sourcerer_paths.ts
@@ -56,7 +56,7 @@ export const getScopeFromPath = (
   newDataViewPickerEnabled?: boolean
 ):
   | SourcererScopeName.default
-  | SourcererScopeName.detections
+  | SourcererScopeName.alerts
   | SourcererScopeName.attacks
   | SourcererScopeName.explore => {
   if (
@@ -65,7 +65,7 @@ export const getScopeFromPath = (
       strict: false,
     })
   ) {
-    return SourcererScopeName.detections;
+    return SourcererScopeName.alerts;
   }
 
   if (

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_init_sourcerer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_init_sourcerer.tsx
@@ -29,7 +29,7 @@ const defaultInitResult = { browserFields: {} };
 export const useInitSourcerer = (
   scopeId:
     | SourcererScopeName.default
-    | SourcererScopeName.detections
+    | SourcererScopeName.alerts
     | SourcererScopeName.attacks
     | SourcererScopeName.explore = SourcererScopeName.default
 ) => {
@@ -307,7 +307,7 @@ export const useInitSourcerer = (
   // Related to the detection page
   useEffect(() => {
     if (
-      scopeId === SourcererScopeName.detections &&
+      scopeId === SourcererScopeName.alerts &&
       isSignalIndexExists &&
       signalIndexName != null &&
       initialDetectionSourcerer.current &&
@@ -316,29 +316,29 @@ export const useInitSourcerer = (
       initialDetectionSourcerer.current = false;
       dispatch(
         sourcererActions.setSelectedDataView({
-          id: SourcererScopeName.detections,
+          id: SourcererScopeName.alerts,
           selectedDataViewId: defaultDataView.id,
           selectedPatterns: getScopePatternListSelection(
             defaultDataView,
-            SourcererScopeName.detections,
+            SourcererScopeName.alerts,
             signalIndexName,
             true
           ),
         })
       );
     } else if (
-      scopeId === SourcererScopeName.detections &&
+      scopeId === SourcererScopeName.alerts &&
       signalIndexNameSourcerer != null &&
       initialTimelineSourcerer.current &&
       defaultDataView.id.length > 0
     ) {
       initialDetectionSourcerer.current = false;
       sourcererActions.setSelectedDataView({
-        id: SourcererScopeName.detections,
+        id: SourcererScopeName.alerts,
         selectedDataViewId: defaultDataView.id,
         selectedPatterns: getScopePatternListSelection(
           defaultDataView,
-          SourcererScopeName.detections,
+          SourcererScopeName.alerts,
           signalIndexNameSourcerer,
           true
         ),

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_init_sourcerer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_init_sourcerer.tsx
@@ -8,8 +8,8 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { i18n } from '@kbn/i18n';
+import { PageScope } from '../../data_view_manager/constants';
 import { sourcererActions, sourcererSelectors } from '../store';
-import { SourcererScopeName } from '../store/model';
 import { useUserInfo } from '../../detections/components/user_info';
 import { timelineSelectors } from '../../timelines/store';
 import { TimelineId } from '../../../common/types';
@@ -28,10 +28,10 @@ const defaultInitResult = { browserFields: {} };
 
 export const useInitSourcerer = (
   scopeId:
-    | SourcererScopeName.default
-    | SourcererScopeName.alerts
-    | SourcererScopeName.attacks
-    | SourcererScopeName.explore = SourcererScopeName.default
+    | PageScope.default
+    | PageScope.alerts
+    | PageScope.attacks
+    | PageScope.explore = PageScope.default
 ) => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
@@ -88,13 +88,13 @@ export const useInitSourcerer = (
 
   const kibanaDataViews = useSelector(sourcererSelectors.kibanaDataViews);
   const timelineDataViewId = useSelector((state: State) => {
-    return sourcererSelectors.sourcererScopeSelectedDataViewId(state, SourcererScopeName.timeline);
+    return sourcererSelectors.sourcererScopeSelectedDataViewId(state, PageScope.timeline);
   });
   const timelineSelectedPatterns = useSelector((state: State) => {
-    return sourcererSelectors.sourcererScopeSelectedPatterns(state, SourcererScopeName.timeline);
+    return sourcererSelectors.sourcererScopeSelectedPatterns(state, PageScope.timeline);
   });
   const timelineMissingPatterns = useSelector((state: State) => {
-    return sourcererSelectors.sourcererScopeMissingPatterns(state, SourcererScopeName.timeline);
+    return sourcererSelectors.sourcererScopeMissingPatterns(state, PageScope.timeline);
   });
   const timelineSelectedDataView = useMemo(() => {
     return kibanaDataViews.find((dataView) => dataView.id === timelineDataViewId);
@@ -119,7 +119,7 @@ export const useInitSourcerer = (
       if (id != null && id.length > 0 && !searchedIds.current.includes(id)) {
         searchedIds.current = [...searchedIds.current, id];
 
-        const currentScope = i === 0 ? SourcererScopeName.default : SourcererScopeName.timeline;
+        const currentScope = i === 0 ? PageScope.default : PageScope.timeline;
 
         const needToBeInit =
           id === scopeDataViewId
@@ -133,7 +133,7 @@ export const useInitSourcerer = (
           dataViewId: id,
           scopeId: currentScope,
           needToBeInit,
-          ...(needToBeInit && currentScope === SourcererScopeName.timeline
+          ...(needToBeInit && currentScope === PageScope.timeline
             ? {
                 skipScopeUpdate: timelineSelectedPatterns.length > 0,
               }
@@ -165,11 +165,11 @@ export const useInitSourcerer = (
       initialTimelineSourcerer.current = false;
       dispatch(
         sourcererActions.setSelectedDataView({
-          id: SourcererScopeName.timeline,
+          id: PageScope.timeline,
           selectedDataViewId: defaultDataView.id,
           selectedPatterns: getScopePatternListSelection(
             defaultDataView,
-            SourcererScopeName.timeline,
+            PageScope.timeline,
             signalIndexName,
             true
           ),
@@ -177,11 +177,11 @@ export const useInitSourcerer = (
       );
       dispatch(
         sourcererActions.setSelectedDataView({
-          id: SourcererScopeName.analyzer,
+          id: PageScope.analyzer,
           selectedDataViewId: defaultDataView.id,
           selectedPatterns: getScopePatternListSelection(
             defaultDataView,
-            SourcererScopeName.analyzer,
+            PageScope.analyzer,
             signalIndexName,
             true
           ),
@@ -196,11 +196,11 @@ export const useInitSourcerer = (
       initialTimelineSourcerer.current = false;
       dispatch(
         sourcererActions.setSelectedDataView({
-          id: SourcererScopeName.timeline,
+          id: PageScope.timeline,
           selectedDataViewId: defaultDataView.id,
           selectedPatterns: getScopePatternListSelection(
             defaultDataView,
-            SourcererScopeName.timeline,
+            PageScope.timeline,
             signalIndexNameSourcerer,
             true
           ),
@@ -208,11 +208,11 @@ export const useInitSourcerer = (
       );
       dispatch(
         sourcererActions.setSelectedDataView({
-          id: SourcererScopeName.analyzer,
+          id: PageScope.analyzer,
           selectedDataViewId: defaultDataView.id,
           selectedPatterns: getScopePatternListSelection(
             defaultDataView,
-            SourcererScopeName.analyzer,
+            PageScope.analyzer,
             signalIndexNameSourcerer,
             true
           ),
@@ -307,7 +307,7 @@ export const useInitSourcerer = (
   // Related to the detection page
   useEffect(() => {
     if (
-      scopeId === SourcererScopeName.alerts &&
+      scopeId === PageScope.alerts &&
       isSignalIndexExists &&
       signalIndexName != null &&
       initialDetectionSourcerer.current &&
@@ -316,29 +316,29 @@ export const useInitSourcerer = (
       initialDetectionSourcerer.current = false;
       dispatch(
         sourcererActions.setSelectedDataView({
-          id: SourcererScopeName.alerts,
+          id: PageScope.alerts,
           selectedDataViewId: defaultDataView.id,
           selectedPatterns: getScopePatternListSelection(
             defaultDataView,
-            SourcererScopeName.alerts,
+            PageScope.alerts,
             signalIndexName,
             true
           ),
         })
       );
     } else if (
-      scopeId === SourcererScopeName.alerts &&
+      scopeId === PageScope.alerts &&
       signalIndexNameSourcerer != null &&
       initialTimelineSourcerer.current &&
       defaultDataView.id.length > 0
     ) {
       initialDetectionSourcerer.current = false;
       sourcererActions.setSelectedDataView({
-        id: SourcererScopeName.alerts,
+        id: PageScope.alerts,
         selectedDataViewId: defaultDataView.id,
         selectedPatterns: getScopePatternListSelection(
           defaultDataView,
-          SourcererScopeName.alerts,
+          PageScope.alerts,
           signalIndexNameSourcerer,
           true
         ),

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_signal_helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_signal_helpers.tsx
@@ -28,7 +28,7 @@ export const useSignalHelpers = (): {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
   const { indicesExist, dataViewId: oldDataViewId } = useSourcererDataView(
-    SourcererScopeName.detections
+    SourcererScopeName.alerts
   );
 
   const { indexFieldsSearch } = useOldDataView();
@@ -49,9 +49,7 @@ export const useSignalHelpers = (): {
     ? experimentalSignalIndexName
     : signalIndexNameSourcerer;
 
-  const { dataView: experimentalDefaultDataView, status } = useDataView(
-    SourcererScopeName.detections
-  );
+  const { dataView: experimentalDefaultDataView, status } = useDataView(SourcererScopeName.alerts);
   const dataViewId = newDataViewPickerEnabled
     ? experimentalDefaultDataView?.id ?? null
     : oldDataViewId;

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_signal_helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_signal_helpers.tsx
@@ -8,9 +8,9 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { i18n } from '@kbn/i18n';
 import { useDispatch, useSelector } from 'react-redux';
+import { PageScope } from '../../data_view_manager/constants';
 import { sourcererActions, sourcererSelectors } from '../store';
 import { useSourcererDataView } from '.';
-import { SourcererScopeName } from '../store/model';
 import { useDataView as useOldDataView } from '../../common/containers/source/use_data_view';
 import { useAppToasts } from '../../common/hooks/use_app_toasts';
 import { useKibana } from '../../common/lib/kibana';
@@ -27,9 +27,7 @@ export const useSignalHelpers = (): {
 } => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { indicesExist, dataViewId: oldDataViewId } = useSourcererDataView(
-    SourcererScopeName.alerts
-  );
+  const { indicesExist, dataViewId: oldDataViewId } = useSourcererDataView(PageScope.alerts);
 
   const { indexFieldsSearch } = useOldDataView();
   const dispatch = useDispatch();
@@ -49,7 +47,7 @@ export const useSignalHelpers = (): {
     ? experimentalSignalIndexName
     : signalIndexNameSourcerer;
 
-  const { dataView: experimentalDefaultDataView, status } = useDataView(SourcererScopeName.alerts);
+  const { dataView: experimentalDefaultDataView, status } = useDataView(PageScope.alerts);
   const dataViewId = newDataViewPickerEnabled
     ? experimentalDefaultDataView?.id ?? null
     : oldDataViewId;

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/actions.ts
@@ -7,7 +7,8 @@
 
 import actionCreatorFactory from 'typescript-fsa';
 
-import type { SelectedDataView, SourcererDataView, SourcererScopeName } from './model';
+import type { PageScope } from '../../data_view_manager/constants';
+import type { SelectedDataView, SourcererDataView } from './model';
 import type { SecurityDataView } from '../containers/create_sourcerer_data_view';
 
 const actionCreator = actionCreatorFactory('x-pack/security_solution/local/sourcerer');
@@ -26,12 +27,12 @@ export const setSignalIndexName = actionCreator<{ signalIndexName: string }>(
 export const setSourcererDataViews = actionCreator<SecurityDataView>('SET_SOURCERER_DATA_VIEWS');
 
 export const setSourcererScopeLoading = actionCreator<{
-  id?: SourcererScopeName;
+  id?: PageScope;
   loading: boolean;
 }>('SET_SOURCERER_SCOPE_LOADING');
 
 export interface SelectedDataViewPayload {
-  id: SourcererScopeName;
+  id: PageScope;
   selectedDataViewId: SelectedDataView['dataViewId'];
   selectedPatterns: SelectedDataView['selectedPatterns'];
   shouldValidateSelectedPatterns?: boolean;

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/helpers.test.ts
@@ -59,10 +59,10 @@ describe.skip('sourcerer store helpers', () => {
       );
       expect(result).toEqual(['auditbeat-*', 'packetbeat-*']);
     });
-    it('default data view, SourcererScopeName.detections, returns patternList with only signals index', () => {
+    it('default data view, SourcererScopeName.alerts, returns patternList with only signals index', () => {
       const result = getScopePatternListSelection(
         dataView,
-        SourcererScopeName.detections,
+        SourcererScopeName.alerts,
         signalIndexName,
         true
       );
@@ -105,14 +105,14 @@ describe.skip('sourcerer store helpers', () => {
         mockGlobalState.sourcerer,
         {
           ...payload,
-          id: SourcererScopeName.detections,
+          id: SourcererScopeName.alerts,
           selectedPatterns: [],
         },
         true
       );
       expect(result).toEqual({
-        [SourcererScopeName.detections]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.detections],
+        [SourcererScopeName.alerts]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.alerts],
           selectedDataViewId: dataView.id,
           selectedPatterns: [signalIndexName],
         },
@@ -291,7 +291,7 @@ describe.skip('checkIfIndicesExist', () => {
   it('should return true when scopeId is "detections" and patternList includes signalIndexName', () => {
     const result = checkIfIndicesExist({
       patternList: ['index1', 'index2', 'signalIndex'],
-      scopeId: SourcererScopeName.detections,
+      scopeId: SourcererScopeName.alerts,
       signalIndexName: 'signalIndex',
       isDefaultDataViewSelected: false,
     });
@@ -302,7 +302,7 @@ describe.skip('checkIfIndicesExist', () => {
   it('should return false when scopeId is "detections" and patternList does not include signalIndexName', () => {
     const result = checkIfIndicesExist({
       patternList: ['index1', 'index2'],
-      scopeId: SourcererScopeName.detections,
+      scopeId: SourcererScopeName.alerts,
       signalIndexName: 'signalIndex',
       isDefaultDataViewSelected: false,
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/helpers.test.ts
@@ -6,13 +6,13 @@
  */
 
 import { mockGlobalState, mockSourcererState } from '../../common/mock';
-import { SourcererScopeName } from './model';
 import {
   checkIfIndicesExist,
   getScopePatternListSelection,
   validateSelectedPatterns,
 } from './helpers';
 import { sortWithExcludesAtEnd } from '../../../common/utils/sourcerer';
+import { PageScope } from '../../data_view_manager/constants';
 
 const signalIndexName = mockGlobalState.sourcerer.signalIndexName;
 
@@ -35,34 +35,34 @@ describe.skip('sourcerer store helpers', () => {
           ...dataView,
           id: '1234',
         },
-        SourcererScopeName.default,
+        PageScope.default,
         signalIndexName,
         false
       );
       expect(result).toEqual([`${signalIndexName}`, 'auditbeat-*', 'packetbeat-*']);
     });
-    it('default data view, SourcererScopeName.timeline, returns patternList sorted', () => {
+    it('default data view, PageScope.timeline, returns patternList sorted', () => {
       const result = getScopePatternListSelection(
         dataView,
-        SourcererScopeName.timeline,
+        PageScope.timeline,
         signalIndexName,
         true
       );
       expect(result).toEqual([signalIndexName, 'auditbeat-*', 'packetbeat-*']);
     });
-    it('default data view, SourcererScopeName.default, returns patternList sorted without signals index', () => {
+    it('default data view, PageScope.default, returns patternList sorted without signals index', () => {
       const result = getScopePatternListSelection(
         dataView,
-        SourcererScopeName.default,
+        PageScope.default,
         signalIndexName,
         true
       );
       expect(result).toEqual(['auditbeat-*', 'packetbeat-*']);
     });
-    it('default data view, SourcererScopeName.alerts, returns patternList with only signals index', () => {
+    it('default data view, PageScope.alerts, returns patternList with only signals index', () => {
       const result = getScopePatternListSelection(
         dataView,
-        SourcererScopeName.alerts,
+        PageScope.alerts,
         signalIndexName,
         true
       );
@@ -71,15 +71,15 @@ describe.skip('sourcerer store helpers', () => {
   });
   describe('validateSelectedPatterns', () => {
     const payload = {
-      id: SourcererScopeName.default,
+      id: PageScope.default,
       selectedDataViewId: dataView.id,
       selectedPatterns: ['auditbeat-*'],
     };
     it('sets selectedPattern', () => {
       const result = validateSelectedPatterns(mockGlobalState.sourcerer, payload, true);
       expect(result).toEqual({
-        [SourcererScopeName.default]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+        [PageScope.default]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
           selectedPatterns: ['auditbeat-*'],
         },
       });
@@ -94,8 +94,8 @@ describe.skip('sourcerer store helpers', () => {
         true
       );
       expect(result).toEqual({
-        [SourcererScopeName.default]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+        [PageScope.default]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
           selectedPatterns: patternListNoSignals,
         },
       });
@@ -105,14 +105,14 @@ describe.skip('sourcerer store helpers', () => {
         mockGlobalState.sourcerer,
         {
           ...payload,
-          id: SourcererScopeName.alerts,
+          id: PageScope.alerts,
           selectedPatterns: [],
         },
         true
       );
       expect(result).toEqual({
-        [SourcererScopeName.alerts]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.alerts],
+        [PageScope.alerts]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[PageScope.alerts],
           selectedDataViewId: dataView.id,
           selectedPatterns: [signalIndexName],
         },
@@ -123,14 +123,14 @@ describe.skip('sourcerer store helpers', () => {
         mockGlobalState.sourcerer,
         {
           ...payload,
-          id: SourcererScopeName.timeline,
+          id: PageScope.timeline,
           selectedPatterns: [],
         },
         true
       );
       expect(result).toEqual({
-        [SourcererScopeName.timeline]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+        [PageScope.timeline]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
           selectedDataViewId: dataView.id,
           selectedPatterns: [],
         },
@@ -150,14 +150,14 @@ describe.skip('sourcerer store helpers', () => {
         stateNoSignals,
         {
           ...payload,
-          id: SourcererScopeName.timeline,
+          id: PageScope.timeline,
           selectedPatterns: [`${mockGlobalState.sourcerer.signalIndexName}`],
         },
         true
       );
       expect(result).toEqual({
-        [SourcererScopeName.timeline]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+        [PageScope.timeline]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
           selectedDataViewId: dataView.id,
           selectedPatterns: [signalIndexName],
         },
@@ -169,7 +169,7 @@ describe.skip('sourcerer store helpers', () => {
           mockGlobalState.sourcerer,
           {
             ...payload,
-            id: SourcererScopeName.timeline,
+            id: PageScope.timeline,
             selectedDataViewId: null,
             selectedPatterns: [
               mockGlobalState.sourcerer.defaultDataView.patternList[3],
@@ -179,8 +179,8 @@ describe.skip('sourcerer store helpers', () => {
           true
         );
         expect(result).toEqual({
-          [SourcererScopeName.timeline]: {
-            ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+          [PageScope.timeline]: {
+            ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
             selectedDataViewId: null,
             selectedPatterns: [
               mockGlobalState.sourcerer.defaultDataView.patternList[3],
@@ -194,7 +194,7 @@ describe.skip('sourcerer store helpers', () => {
           mockGlobalState.sourcerer,
           {
             ...payload,
-            id: SourcererScopeName.timeline,
+            id: PageScope.timeline,
             selectedDataViewId: null,
             selectedPatterns: [
               mockGlobalState.sourcerer.defaultDataView.patternList[3],
@@ -204,8 +204,8 @@ describe.skip('sourcerer store helpers', () => {
           true
         );
         expect(result).toEqual({
-          [SourcererScopeName.timeline]: {
-            ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+          [PageScope.timeline]: {
+            ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
             selectedDataViewId: null,
             selectedPatterns: [
               mockGlobalState.sourcerer.defaultDataView.patternList[3],
@@ -235,14 +235,14 @@ describe.skip('sourcerer store helpers', () => {
         state,
         {
           ...payload,
-          id: SourcererScopeName.default,
+          id: PageScope.default,
           selectedPatterns: ['auditbeat-*', 'yoohoo'],
         },
         true
       );
       expect(result).toEqual({
-        [SourcererScopeName.default]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+        [PageScope.default]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
           missingPatterns: ['yoohoo'],
           selectedPatterns: ['auditbeat-*', 'yoohoo'],
         },
@@ -268,15 +268,15 @@ describe.skip('sourcerer store helpers', () => {
         state,
         {
           ...payload,
-          id: SourcererScopeName.default,
+          id: PageScope.default,
           selectedDataViewId: 'wow',
           selectedPatterns: ['auditbeat-*', 'yoohoo'],
         },
         true
       );
       expect(result).toEqual({
-        [SourcererScopeName.default]: {
-          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+        [PageScope.default]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[PageScope.default],
           selectedDataViewId: 'wow',
           selectedPatterns: ['auditbeat-*', 'yoohoo'],
         },
@@ -291,7 +291,7 @@ describe.skip('checkIfIndicesExist', () => {
   it('should return true when scopeId is "detections" and patternList includes signalIndexName', () => {
     const result = checkIfIndicesExist({
       patternList: ['index1', 'index2', 'signalIndex'],
-      scopeId: SourcererScopeName.alerts,
+      scopeId: PageScope.alerts,
       signalIndexName: 'signalIndex',
       isDefaultDataViewSelected: false,
     });
@@ -302,7 +302,7 @@ describe.skip('checkIfIndicesExist', () => {
   it('should return false when scopeId is "detections" and patternList does not include signalIndexName', () => {
     const result = checkIfIndicesExist({
       patternList: ['index1', 'index2'],
-      scopeId: SourcererScopeName.alerts,
+      scopeId: PageScope.alerts,
       signalIndexName: 'signalIndex',
       isDefaultDataViewSelected: false,
     });
@@ -313,7 +313,7 @@ describe.skip('checkIfIndicesExist', () => {
   it('should return true when scopeId is "default" and isDefaultDataViewSelected is true and patternList has elements other than signalIndexName', () => {
     const result = checkIfIndicesExist({
       patternList: ['index1', 'index2', 'index3'],
-      scopeId: SourcererScopeName.default,
+      scopeId: PageScope.default,
       signalIndexName: 'signalIndex',
       isDefaultDataViewSelected: true,
     });
@@ -324,7 +324,7 @@ describe.skip('checkIfIndicesExist', () => {
   it('should return false when scopeId is "default" and isDefaultDataViewSelected is true and patternList only contains signalIndexName', () => {
     const result = checkIfIndicesExist({
       patternList: ['signalIndex'],
-      scopeId: SourcererScopeName.default,
+      scopeId: PageScope.default,
       signalIndexName: 'signalIndex',
       isDefaultDataViewSelected: true,
     });
@@ -335,7 +335,7 @@ describe.skip('checkIfIndicesExist', () => {
   it('should return true when scopeId is "default" and isDefaultDataViewSelected is false and patternList has elements', () => {
     const result = checkIfIndicesExist({
       patternList: ['index1', 'index2'],
-      scopeId: SourcererScopeName.default,
+      scopeId: PageScope.default,
       signalIndexName: 'signalIndex',
       isDefaultDataViewSelected: false,
     });
@@ -346,7 +346,7 @@ describe.skip('checkIfIndicesExist', () => {
   it('should return false when scopeId is "default" and isDefaultDataViewSelected is false and patternList is empty', () => {
     const result = checkIfIndicesExist({
       patternList: [],
-      scopeId: SourcererScopeName.default,
+      scopeId: PageScope.default,
       signalIndexName: 'signalIndex',
       isDefaultDataViewSelected: false,
     });
@@ -357,7 +357,7 @@ describe.skip('checkIfIndicesExist', () => {
   it('should return true when scopeId is not "detections" or "default" and patternList has elements', () => {
     const result = checkIfIndicesExist({
       patternList: ['index1', 'index2'],
-      scopeId: 'other' as SourcererScopeName,
+      scopeId: 'other' as PageScope,
       signalIndexName: 'signalIndex',
       isDefaultDataViewSelected: false,
     });
@@ -368,7 +368,7 @@ describe.skip('checkIfIndicesExist', () => {
   it('should return false when scopeId is not "detections" or "default" and patternList is empty', () => {
     const result = checkIfIndicesExist({
       patternList: [],
-      scopeId: 'other' as SourcererScopeName,
+      scopeId: 'other' as PageScope,
       signalIndexName: 'signalIndex',
       isDefaultDataViewSelected: false,
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/helpers.ts
@@ -6,37 +6,37 @@
  */
 
 import { isEmpty } from 'lodash';
+import { PageScope } from '../../data_view_manager/constants';
 import type { SourcererDataView, SourcererModel, SourcererScopeById } from './model';
 import type { sourcererModel } from '.';
-import { SourcererScopeName } from './model';
 import type { SelectedDataViewPayload } from './actions';
 import { ensurePatternFormat, sortWithExcludesAtEnd } from '../../../common/utils/sourcerer';
 
 const getPatternListFromScope = (
-  scope: SourcererScopeName,
+  scope: PageScope,
   patternList: string[],
   signalIndexName: string | null
 ) => {
   // when our SIEM data view is set, here are the defaults
   switch (scope) {
-    case SourcererScopeName.default:
-    case SourcererScopeName.explore:
+    case PageScope.default:
+    case PageScope.explore:
       return sortWithExcludesAtEnd(patternList.filter((index) => index !== signalIndexName));
-    case SourcererScopeName.alerts:
+    case PageScope.alerts:
       // set to signalIndexName whether or not it exists yet in the patternList
       return signalIndexName != null ? [signalIndexName] : [];
-    case SourcererScopeName.attacks:
+    case PageScope.attacks:
       return sortWithExcludesAtEnd(patternList);
-    case SourcererScopeName.timeline:
+    case PageScope.timeline:
       return sortWithExcludesAtEnd(patternList);
-    case SourcererScopeName.analyzer:
+    case PageScope.analyzer:
       return sortWithExcludesAtEnd(patternList);
   }
 };
 
 export const getScopePatternListSelection = (
   theDataView: SourcererDataView | undefined,
-  sourcererScope: SourcererScopeName,
+  sourcererScope: PageScope,
   signalIndexName: SourcererModel['signalIndexName'],
   isDefaultDataView: boolean
 ): string[] => {
@@ -101,7 +101,7 @@ export const validateSelectedPatterns = (
       missingPatterns,
       // if in timeline, allow for empty in case pattern was deleted
       // need flow for this
-      ...(isEmpty(selectedPatterns) && id !== SourcererScopeName.timeline
+      ...(isEmpty(selectedPatterns) && id !== PageScope.timeline
         ? {
             selectedPatterns: getScopePatternListSelection(
               dataView ?? state.defaultDataView,
@@ -118,7 +118,7 @@ export const validateSelectedPatterns = (
 
 interface CheckIfIndicesExistParams {
   patternList: sourcererModel.SourcererDataView['patternList'];
-  scopeId: sourcererModel.SourcererScopeName;
+  scopeId: PageScope;
   signalIndexName: string | null;
   isDefaultDataViewSelected: boolean;
 }
@@ -129,11 +129,11 @@ export const checkIfIndicesExist = ({
   signalIndexName,
   isDefaultDataViewSelected,
 }: CheckIfIndicesExistParams) => {
-  if (scopeId === SourcererScopeName.alerts) {
+  if (scopeId === PageScope.alerts) {
     return patternList.includes(`${signalIndexName}`);
   }
 
-  if (scopeId === SourcererScopeName.default) {
+  if (scopeId === PageScope.default) {
     if (isDefaultDataViewSelected) {
       return patternList.filter((i) => i !== signalIndexName).length > 0;
     }

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/helpers.ts
@@ -22,7 +22,7 @@ const getPatternListFromScope = (
     case SourcererScopeName.default:
     case SourcererScopeName.explore:
       return sortWithExcludesAtEnd(patternList.filter((index) => index !== signalIndexName));
-    case SourcererScopeName.detections:
+    case SourcererScopeName.alerts:
       // set to signalIndexName whether or not it exists yet in the patternList
       return signalIndexName != null ? [signalIndexName] : [];
     case SourcererScopeName.attacks:
@@ -129,7 +129,7 @@ export const checkIfIndicesExist = ({
   signalIndexName,
   isDefaultDataViewSelected,
 }: CheckIfIndicesExistParams) => {
-  if (scopeId === SourcererScopeName.detections) {
+  if (scopeId === SourcererScopeName.alerts) {
     return patternList.includes(`${signalIndexName}`);
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/model.ts
@@ -13,7 +13,7 @@ import type { RuntimeFieldSpec, RuntimePrimitiveTypes } from '@kbn/data-views-pl
 /** Uniquely identifies a Sourcerer Scope */
 export enum SourcererScopeName {
   default = 'default',
-  detections = 'detections',
+  alerts = 'alerts',
   attacks = 'attacks',
   timeline = 'timeline',
   analyzer = 'analyzer',
@@ -158,9 +158,9 @@ export const initialSourcererState: SourcererModel = {
       ...initSourcererScope,
       id: SourcererScopeName.default,
     },
-    [SourcererScopeName.detections]: {
+    [SourcererScopeName.alerts]: {
       ...initSourcererScope,
-      id: SourcererScopeName.detections,
+      id: SourcererScopeName.alerts,
     },
     [SourcererScopeName.attacks]: {
       ...initSourcererScope,

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/model.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/model.ts
@@ -9,23 +9,14 @@ import type { BrowserFields } from '@kbn/timelines-plugin/common';
 import { EMPTY_BROWSER_FIELDS } from '@kbn/timelines-plugin/common';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
 import type { RuntimeFieldSpec, RuntimePrimitiveTypes } from '@kbn/data-views-plugin/common';
-
-/** Uniquely identifies a Sourcerer Scope */
-export enum SourcererScopeName {
-  default = 'default',
-  alerts = 'alerts',
-  attacks = 'attacks',
-  timeline = 'timeline',
-  analyzer = 'analyzer',
-  explore = 'explore',
-}
+import { PageScope } from '../../data_view_manager/constants';
 
 /**
  * Data related to each sourcerer scope
  */
 export interface SourcererScope {
   /** Uniquely identifies a Sourcerer Scope */
-  id: SourcererScopeName;
+  id: PageScope;
   /** is an update being made to the sourcerer data view */
   loading: boolean;
   /** selected data view id, null if it is legacy index patterns*/
@@ -33,13 +24,13 @@ export interface SourcererScope {
   /** selected patterns within the data view */
   selectedPatterns: string[];
   /** if has length,
-   * id === SourcererScopeName.timeline
+   * id === PageScope.timeline
    * selectedDataViewId === null OR defaultDataView.id
    * saved timeline has pattern that is not in the default */
   missingPatterns: string[];
 }
 
-export type SourcererScopeById = Record<SourcererScopeName, SourcererScope>;
+export type SourcererScopeById = Record<PageScope, SourcererScope>;
 
 export interface KibanaDataView {
   /** Uniquely identifies a Kibana Data View */
@@ -123,7 +114,7 @@ export interface SourcererModel {
 }
 
 export type SourcererUrlState = Partial<{
-  [id in SourcererScopeName]: {
+  [id in PageScope]: {
     id: string;
     selectedPatterns: string[];
   };
@@ -154,29 +145,29 @@ export const initialSourcererState: SourcererModel = {
   signalIndexName: null,
   signalIndexMappingOutdated: null,
   sourcererScopes: {
-    [SourcererScopeName.default]: {
+    [PageScope.default]: {
       ...initSourcererScope,
-      id: SourcererScopeName.default,
+      id: PageScope.default,
     },
-    [SourcererScopeName.alerts]: {
+    [PageScope.alerts]: {
       ...initSourcererScope,
-      id: SourcererScopeName.alerts,
+      id: PageScope.alerts,
     },
-    [SourcererScopeName.attacks]: {
+    [PageScope.attacks]: {
       ...initSourcererScope,
-      id: SourcererScopeName.attacks,
+      id: PageScope.attacks,
     },
-    [SourcererScopeName.timeline]: {
+    [PageScope.timeline]: {
       ...initSourcererScope,
-      id: SourcererScopeName.timeline,
+      id: PageScope.timeline,
     },
-    [SourcererScopeName.analyzer]: {
+    [PageScope.analyzer]: {
       ...initSourcererScope,
-      id: SourcererScopeName.analyzer,
+      id: PageScope.analyzer,
     },
-    [SourcererScopeName.explore]: {
+    [PageScope.explore]: {
       ...initSourcererScope,
-      id: SourcererScopeName.explore,
+      id: PageScope.explore,
     },
   },
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/readme.md
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/readme.md
@@ -1,6 +1,7 @@
 # Sourcerer Redux
 
 Sourcerer model for redux
+
 ```typescript
 interface SourcererModel {
   /** default security-solution data view */
@@ -14,20 +15,12 @@ interface SourcererModel {
 }
 ```
 
-The SourcererScopeName uniquely identifies a Sourcerer Scope. There are 3 in our app:
-```typescript
-enum SourcererScopeName {
-  default = 'default',
-  detections = 'detections',
-  timeline = 'timeline',
-}
-```
-
 Data related to each sourcerer scope
+
 ```typescript
 interface SourcererScope {
   /** Uniquely identifies a Sourcerer Scope */
-  id: SourcererScopeName;
+  id: PageScope;
   /** is an update being made to the sourcerer data view */
   loading: boolean;
   /** selected data view id, null if it is legacy index patterns*/
@@ -35,13 +28,13 @@ interface SourcererScope {
   /** selected patterns within the data view */
   selectedPatterns: string[];
   /** if has length,
-   * id === SourcererScopeName.timeline
+   * id === PageScope.timeline
    * selectedDataViewId === null OR defaultDataView.id
    * saved timeline has pattern that is not in the default */
   missingPatterns: string[];
 }
 
-type SourcererScopeById = Record<SourcererScopeName, SourcererScope>;
+type SourcererScopeById = Record<PageScope, SourcererScope>;
 ```
 
 ```typescript
@@ -60,6 +53,7 @@ interface KibanaDataView {
 ```
 
 KibanaDataView + timelines/index_fields enhanced field data
+
 ```typescript
 interface SourcererDataView extends KibanaDataView {
   id: string;

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/reducer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/reducer.ts
@@ -62,8 +62,8 @@ export const sourcererReducer = reducerWithInitialState(initialSourcererState)
               ...state.sourcererScopes[SourcererScopeName.default],
               loading,
             },
-            [SourcererScopeName.detections]: {
-              ...state.sourcererScopes[SourcererScopeName.detections],
+            [SourcererScopeName.alerts]: {
+              ...state.sourcererScopes[SourcererScopeName.alerts],
               loading,
             },
             [SourcererScopeName.timeline]: {

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/reducer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/reducer.ts
@@ -7,16 +7,17 @@
 
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
 
+import { PageScope } from '../../data_view_manager/constants';
 import {
-  setSourcererDataViews,
-  setSourcererScopeLoading,
-  setSelectedDataView,
-  setSignalIndexName,
   setDataView,
   setDataViewLoading,
+  setSelectedDataView,
+  setSignalIndexName,
+  setSourcererDataViews,
+  setSourcererScopeLoading,
 } from './actions';
 import type { SourcererModel } from './model';
-import { initDataView, initialSourcererState, SourcererScopeName } from './model';
+import { initDataView, initialSourcererState } from './model';
 import { validateSelectedPatterns } from './helpers';
 
 export type SourcererState = SourcererModel;
@@ -58,16 +59,16 @@ export const sourcererReducer = reducerWithInitialState(initialSourcererState)
             },
           }
         : {
-            [SourcererScopeName.default]: {
-              ...state.sourcererScopes[SourcererScopeName.default],
+            [PageScope.default]: {
+              ...state.sourcererScopes[PageScope.default],
               loading,
             },
-            [SourcererScopeName.alerts]: {
-              ...state.sourcererScopes[SourcererScopeName.alerts],
+            [PageScope.alerts]: {
+              ...state.sourcererScopes[PageScope.alerts],
               loading,
             },
-            [SourcererScopeName.timeline]: {
-              ...state.sourcererScopes[SourcererScopeName.timeline],
+            [PageScope.timeline]: {
+              ...state.sourcererScopes[PageScope.timeline],
               loading,
             },
           }),

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/selectors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/selectors.ts
@@ -5,11 +5,11 @@
  * 2.0.
  */
 import { createSelector } from 'reselect';
+import { PageScope } from '../../data_view_manager/constants';
 import type { State } from '../../common/store/types';
 import type { SourcererModel } from './model';
-import { SourcererScopeName } from './model';
 
-const SOURCERER_SCOPE_MAX_SIZE = Object.keys(SourcererScopeName).length;
+const SOURCERER_SCOPE_MAX_SIZE = Object.keys(PageScope).length;
 
 const selectSourcerer = (state: State): SourcererModel => state.sourcerer;
 
@@ -20,7 +20,7 @@ export const sourcererScopes = createSelector(
 
 export const sourcererScope = createSelector(
   sourcererScopes,
-  (state: State, scopeId: SourcererScopeName) => scopeId,
+  (state: State, scopeId: PageScope) => scopeId,
   (scopes, scopeId) => scopes[scopeId],
   {
     memoizeOptions: {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/more_container/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/more_container/index.tsx
@@ -9,14 +9,14 @@ import React, { useContext, useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { css } from '@emotion/css';
 import classNames from 'classnames';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { TimelineContext } from '../../timeline/context';
 import { getSourcererScopeId } from '../../../../helpers';
 import { escapeDataProviderId } from '../../../../common/components/drag_and_drop/helpers';
 import { defaultToEmptyTag } from '../../../../common/components/empty_value';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import {
-  SecurityCellActions,
   CellActionsMode,
+  SecurityCellActions,
   SecurityCellActionsTrigger,
 } from '../../../../common/components/cell_actions';
 
@@ -61,7 +61,7 @@ export const MoreContainer = React.memo<MoreContainerProps>(
                   showActionTooltips
                   triggerId={SecurityCellActionsTrigger.DEFAULT}
                   data={{ value, field: fieldName }}
-                  sourcererScopeId={sourcererScopeId ?? SourcererScopeName.default}
+                  sourcererScopeId={sourcererScopeId ?? PageScope.default}
                   metadata={{ scopeId: defaultedScopeId ?? undefined }}
                 >
                   <>{render ? render(value) : defaultToEmptyTag(value)}</>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
@@ -7,9 +7,9 @@
 
 import React from 'react';
 import type { RenderHookResult } from '@testing-library/react';
-import { render, act, waitFor, renderHook } from '@testing-library/react';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
 import type { Store } from 'redux';
-import type { UseFieldBrowserOptionsProps, UseFieldBrowserOptions, FieldEditorActionsRef } from '.';
+import type { FieldEditorActionsRef, UseFieldBrowserOptions, UseFieldBrowserOptionsProps } from '.';
 import { useFieldBrowserOptions } from '.';
 import type { Start } from '@kbn/data-view-field-editor-plugin/public/mocks';
 import { indexPatternFieldEditorPluginMock } from '@kbn/data-view-field-editor-plugin/public/mocks';
@@ -17,11 +17,11 @@ import { indexPatternFieldEditorPluginMock } from '@kbn/data-view-field-editor-p
 import { TestProviders } from '../../../common/mock';
 import { useKibana } from '../../../common/lib/kibana';
 import type { DataView, DataViewField } from '@kbn/data-plugin/common';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { defaultColumnHeaderType } from '../timeline/body/column_headers/default_headers';
 import { DEFAULT_COLUMN_MIN_WIDTH } from '../timeline/body/constants';
 import { EuiInMemoryTable } from '@elastic/eui';
 import type { BrowserFieldItem } from '@kbn/response-ops-alerts-fields-browser/types';
+import { PageScope } from '../../../data_view_manager/constants';
 
 let mockIndexPatternFieldEditor: Start;
 jest.mock('../../../common/lib/kibana');
@@ -46,7 +46,7 @@ const renderUseFieldBrowserOptions = ({
   >(
     () =>
       useFieldBrowserOptions({
-        sourcererScope: SourcererScopeName.default,
+        sourcererScope: PageScope.default,
         removeColumn: mockRemoveColumn,
         upsertColumn: mockUpsertColumn,
         ...props,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.tsx
@@ -8,19 +8,19 @@
 import type { MutableRefObject } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import type { DataViewField, DataView } from '@kbn/data-views-plugin/common';
+import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import type {
   CreateFieldComponent,
   GetFieldTableColumns,
 } from '@kbn/response-ops-alerts-fields-browser/types';
+import type { PageScope } from '../../../data_view_manager/constants';
 import type { ColumnHeaderOptions } from '../../../../common/types';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { useDataView as useDataViewOld } from '../../../common/containers/source/use_data_view';
 import { useKibana } from '../../../common/lib/kibana';
-import { sourcererSelectors } from '../../../common/store';
 import type { State } from '../../../common/store';
-import type { SourcererScopeName } from '../../../sourcerer/store/model';
+import { sourcererSelectors } from '../../../common/store';
 import { defaultColumnHeaderType } from '../timeline/body/column_headers/default_headers';
 import { DEFAULT_COLUMN_MIN_WIDTH } from '../timeline/body/constants';
 import { useCreateFieldButton } from './create_field_button';
@@ -35,7 +35,7 @@ export type OpenFieldEditor = (fieldName?: string) => void;
 export type OpenDeleteFieldModal = (fieldName: string) => void;
 
 export interface UseFieldBrowserOptionsProps {
-  sourcererScope: SourcererScopeName;
+  sourcererScope: PageScope;
   removeColumn: (columnId: string) => void;
   upsertColumn: (column: ColumnHeaderOptions, index: number) => void;
   editorActionsRef?: FieldEditorActionsRef;

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
@@ -21,7 +21,6 @@ import styled from 'styled-components';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { NewTimelineButton } from '../actions/new_timeline_button';
 import { OpenTimelineButton } from '../actions/open_timeline_button';
 import { APP_ID } from '../../../../../common';
@@ -44,7 +43,7 @@ import { InputsModelId } from '../../../../common/store/inputs/constants';
 import { AttachToCaseButton } from '../actions/attach_to_case_button';
 import { SaveTimelineButton } from '../actions/save_timeline_button';
 import { useBrowserFields } from '../../../../data_view_manager/hooks/use_browser_fields';
-import { DataViewManagerScopeName } from '../../../../data_view_manager/constants';
+import { PageScope } from '../../../../data_view_manager/constants';
 
 const whiteSpaceNoWrapCSS = { 'white-space': 'nowrap' };
 const autoOverflowXCSS = { 'overflow-x': 'auto' };
@@ -77,9 +76,9 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
     const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
     const { browserFields: sourcererBrowserFields, sourcererDataView: oldSourcererDataViewSpec } =
-      useSourcererDataView(SourcererScopeName.timeline);
-    const { dataView: experimentalDataView } = useDataView(DataViewManagerScopeName.timeline);
-    const experimentalBrowserFields = useBrowserFields(DataViewManagerScopeName.timeline);
+      useSourcererDataView(PageScope.timeline);
+    const { dataView: experimentalDataView } = useDataView(PageScope.timeline);
+    const experimentalBrowserFields = useBrowserFields(PageScope.timeline);
     const browserFields = useMemo(
       () => (newDataViewPickerEnabled ? experimentalBrowserFields : sourcererBrowserFields),
       [experimentalBrowserFields, newDataViewPickerEnabled, sourcererBrowserFields]

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { encode } from '@kbn/rison';
 
+import { PageScope } from '../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { useSourcererDataView } from '../../../sourcerer/containers';
 import { useSelectedPatterns } from '../../../data_view_manager/hooks/use_selected_patterns';
@@ -53,7 +54,6 @@ import { useTimelineTypes } from './use_timeline_types';
 import { useTimelineStatus } from './use_timeline_status';
 import { deleteTimelinesByIds } from '../../containers/api';
 import type { Direction } from '../../../../common/search_strategy';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { useStartTransaction } from '../../../common/lib/apm/use_start_transaction';
 import { TIMELINE_ACTIONS } from '../../../common/lib/apm/user_actions';
 import { defaultUdtHeaders } from '../timeline/body/column_headers/default_headers';
@@ -161,11 +161,11 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
     );
 
     const { dataViewId: oldDataViewId, selectedPatterns: oldSelectedPatterns } =
-      useSourcererDataView(SourcererScopeName.timeline);
+      useSourcererDataView(PageScope.timeline);
     const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-    const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
-    const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
+    const { dataView: experimentalDataView } = useDataView(PageScope.timeline);
+    const experimentalSelectedPatterns = useSelectedPatterns(PageScope.timeline);
 
     const dataViewId = useMemo(
       () => (newDataViewPickerEnabled ? experimentalDataView.id || '' : oldDataViewId),

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
@@ -21,6 +21,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -33,7 +34,6 @@ import { NOTE_CONTENT_CLASS_NAME } from '../../timeline/body/helpers';
 import * as i18n from './translations';
 import { TimelineId } from '../../../../../common/types/timeline';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useDeleteNote } from './hooks/use_delete_note';
 import { getTimelineNoteSelector } from '../../timeline/tabs/notes/selectors';
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
@@ -55,10 +55,8 @@ const ToggleEventDetailsButtonComponent: React.FC<ToggleEventDetailsButtonProps>
   eventId,
   timelineId,
 }) => {
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
-  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(
-    SourcererScopeName.timeline
-  );
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(PageScope.timeline);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/use_update_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/use_update_timeline.tsx
@@ -9,13 +9,12 @@ import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { isEmpty } from 'lodash/fp';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
-import { DataViewManagerScopeName } from '../../../data_view_manager/constants';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useSelectDataView } from '../../../data_view_manager/hooks/use_select_data_view';
 import type { Note } from '../../../../common/api/timeline';
 import { TimelineStatusEnum, TimelineTypeEnum } from '../../../../common/api/timeline';
 import { createNote } from '../notes/helpers';
 import { sourcererActions } from '../../../sourcerer/store';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 
 import { InputsModelId } from '../../../common/store/inputs/constants';
 import {
@@ -69,13 +68,13 @@ export const useUpdateTimeline = () => {
         selectDataView({
           id: _timeline.dataViewId,
           fallbackPatterns: _timeline.indexNames,
-          scope: DataViewManagerScopeName.timeline,
+          scope: PageScope.timeline,
         });
       } else {
         if (!isEmpty(_timeline.indexNames) && !newDataViewPickerEnabled) {
           dispatch(
             sourcererActions.setSelectedDataView({
-              id: SourcererScopeName.timeline,
+              id: PageScope.timeline,
               selectedDataViewId: _timeline.dataViewId,
               selectedPatterns: _timeline.indexNames,
             })

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.tsx
@@ -8,6 +8,7 @@
 import type { ComponentProps, ReactElement } from 'react';
 import React, { useMemo } from 'react';
 import { RootDragDropProvider } from '@kbn/dom-drag-drop';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { useGetScopedSourcererDataView } from '../../../../sourcerer/components/use_get_sourcerer_data_view';
@@ -15,7 +16,6 @@ import { DataViewErrorComponent } from '../../../../common/components/data_view_
 import { StyledTableFlexGroup, StyledUnifiedTableFlexItem } from '../unified_components/styles';
 import { UnifiedTimeline } from '../unified_components';
 import { defaultUdtHeaders } from './column_headers/default_headers';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 
 export interface UnifiedTimelineBodyProps
   extends Omit<ComponentProps<typeof UnifiedTimeline>, 'dataView'> {
@@ -44,11 +44,11 @@ export const UnifiedTimelineBody = (props: UnifiedTimelineBodyProps) => {
     onUpdatePageIndex,
   } = props;
   const oldDataView = useGetScopedSourcererDataView({
-    sourcererScope: SourcererScopeName.timeline,
+    sourcererScope: PageScope.timeline,
   });
   const columnsHeader = useMemo(() => columns ?? defaultUdtHeaders, [columns]);
 
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
+  const { dataView: experimentalDataView } = useDataView(PageScope.timeline);
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
   const dataView = newDataViewPickerEnabled ? experimentalDataView : oldDataView;

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/data_providers/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/data_providers/index.tsx
@@ -12,9 +12,9 @@ import { v4 as uuidv4 } from 'uuid';
 import { IS_DRAGGING_CLASS_NAME } from '@kbn/securitysolution-t-grid';
 import { EuiFlexGroup, EuiFlexItem, EuiSuperSelect, EuiToolTip } from '@elastic/eui';
 
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useBrowserFields } from '../../../../data_view_manager/hooks/use_browser_fields';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { DroppableWrapper } from '../../../../common/components/drag_and_drop/droppable_wrapper';
 import { droppableTimelineProvidersPrefix } from '../../../../common/components/drag_and_drop/helpers';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
@@ -109,9 +109,9 @@ export const DataProviders = React.memo<Props>(({ timelineId }) => {
   const dispatch = useDispatch();
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { browserFields: oldBrowserFields } = useSourcererDataView(SourcererScopeName.timeline);
+  const { browserFields: oldBrowserFields } = useSourcererDataView(PageScope.timeline);
 
-  const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);
+  const experimentalBrowserFields = useBrowserFields(PageScope.timeline);
 
   const browserFields = newDataViewPickerEnabled ? experimentalBrowserFields : oldBrowserFields;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
@@ -14,11 +14,11 @@ import styled from 'styled-components';
 import { isTab } from '@kbn/timelines-plugin/public';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { DEFAULT_ALERTS_INDEX, DEFAULT_DATA_VIEW_ID } from '../../../../common/constants';
+import { PageScope } from '../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { timelineActions, timelineSelectors } from '../../store';
 import { timelineDefaults } from '../../store/defaults';
 import type { CellValueElementProps } from './cell_rendering';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { TimelineModalHeader } from '../modal/header';
 import type { RowRenderer, TimelineId } from '../../../../common/types/timeline';
 import { TimelineTypeEnum } from '../../../../common/api/timeline';
@@ -72,10 +72,10 @@ const StatefulTimelineComponent: React.FC<Props> = ({
   const containerElement = useRef<HTMLDivElement | null>(null);
   const getTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
   const selectedPatternsSourcerer = useSelector((state: State) => {
-    return sourcererSelectors.sourcererScopeSelectedPatterns(state, SourcererScopeName.timeline);
+    return sourcererSelectors.sourcererScopeSelectedPatterns(state, PageScope.timeline);
   });
   const selectedDataViewIdSourcerer = useSelector((state: State) => {
-    return sourcererSelectors.sourcererScopeSelectedDataViewId(state, SourcererScopeName.timeline);
+    return sourcererSelectors.sourcererScopeSelectedDataViewId(state, PageScope.timeline);
   });
   const {
     dataViewId: selectedDataViewIdTimeline,
@@ -104,8 +104,8 @@ const StatefulTimelineComponent: React.FC<Props> = ({
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
   const spaceId = useSpaceId();
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
-  const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.timeline);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const { dataView: experimentalDataView, status } = useDataView(PageScope.timeline);
 
   const selectedDataViewId = useMemo(
     () => (newDataViewPickerEnabled ? experimentalDataView.id ?? '' : selectedDataViewIdSourcerer),

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
@@ -11,13 +11,13 @@ import { useSelector } from 'react-redux';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { TimerangeInput } from '@kbn/timelines-plugin/common';
 import { EuiPanel } from '@elastic/eui';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useBrowserFields } from '../../../../data_view_manager/hooks/use_browser_fields';
 import { TimelineId } from '../../../../../common/types';
 import type { State } from '../../../../common/store';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { TimelineKPIs } from './kpis';
 import { useTimelineKpis } from '../../../containers/kpis';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -37,15 +37,15 @@ interface KpiExpandedProps {
 
 export const TimelineKpisContainer = ({ timelineId }: KpiExpandedProps) => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
+  const experimentalBrowserFields = useBrowserFields(PageScope.timeline);
+  const { dataView: experimentalDataView } = useDataView(PageScope.timeline);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.timeline);
 
   const {
     browserFields: oldBrowserFields,
     sourcererDataView: oldSourcererDataViewSpec,
     selectedPatterns: oldSelectedPatterns,
-  } = useSourcererDataView(SourcererScopeName.timeline);
+  } = useSourcererDataView(PageScope.timeline);
 
   const browserFields = useMemo(
     () => (newDataViewPickerEnabled ? experimentalBrowserFields : oldBrowserFields),

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
@@ -11,11 +11,11 @@ import { EuiOutsideClickDetector } from '@elastic/eui';
 import { useDispatch } from 'react-redux';
 import { css } from '@emotion/css';
 
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import type { EqlOptions } from '../../../../../../common/search_strategy';
 import { useDeepEqualSelector } from '../../../../../common/hooks/use_selector';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import { EqlQueryEdit } from '../../../../../detection_engine/rule_creation/components/eql_query_edit';
 import type { FieldValueQueryBar } from '../../../../../detection_engine/rule_creation_ui/components/query_bar_field';
 
@@ -66,12 +66,12 @@ export const EqlQueryBarTimeline = memo(({ timelineId }: { timelineId: string })
     loading: oldIndexPatternsLoading,
     sourcererDataView: oldSourcererDataViewSpec,
     selectedPatterns: oldSelectedPatterns,
-  } = useSourcererDataView(SourcererScopeName.timeline);
+  } = useSourcererDataView(PageScope.timeline);
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
-  const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.timeline);
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
+  const { dataView: experimentalDataView, status } = useDataView(PageScope.timeline);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.timeline);
 
   const indexPatternsLoading = useMemo(
     () => (newDataViewPickerEnabled ? status !== 'ready' : oldIndexPatternsLoading),

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/index.tsx
@@ -13,10 +13,10 @@ import type { Filter, Query } from '@kbn/es-query';
 import { FilterStateStore } from '@kbn/es-query';
 import type { FilterManager, SavedQuery, SavedQueryTimeFilter } from '@kbn/data-plugin/public';
 import styled from '@emotion/styled';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { InputsModelId } from '../../../../common/store/inputs/constants';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 
 import {
   convertKueryToElasticSearchQuery,
@@ -115,12 +115,12 @@ export const QueryBarTimeline = memo<QueryBarTimelineComponentProps>(
       toStr != null ? toStr : new Date(to).toISOString()
     );
     const { browserFields: oldBrowserFields, sourcererDataView: oldSourcererDataViewSpec } =
-      useSourcererDataView(SourcererScopeName.timeline);
+      useSourcererDataView(PageScope.timeline);
 
     const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-    const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
+    const { dataView: experimentalDataView } = useDataView(PageScope.timeline);
 
-    const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);
+    const experimentalBrowserFields = useBrowserFields(PageScope.timeline);
 
     const dataViewBase = useMemo(
       () => dataViewSpecToViewBase(oldSourcererDataViewSpec),

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/index.tsx
@@ -17,12 +17,12 @@ import type { FilterManager } from '@kbn/data-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import { FilterItems } from '@kbn/unified-search-plugin/public';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { useKibana } from '../../../../common/lib/kibana';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import type { inputsModel, State } from '../../../../common/store';
 import { inputsSelectors } from '../../../../common/store';
 import { timelineActions, timelineSelectors } from '../../../store';
@@ -75,9 +75,9 @@ const StatefulSearchOrFilterComponent = React.memo<Props>(
       services: { data },
     } = useKibana();
 
-    const { sourcererDataView: dataViewSpec } = useSourcererDataView(SourcererScopeName.timeline);
+    const { sourcererDataView: dataViewSpec } = useSourcererDataView(PageScope.timeline);
 
-    const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
+    const { dataView: experimentalDataView } = useDataView(PageScope.timeline);
     const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
     const getIsDataProviderVisible = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/search_or_filter.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/search_or_filter.tsx
@@ -11,6 +11,7 @@ import styled from 'styled-components';
 import type { Filter } from '@kbn/es-query';
 
 import type { FilterManager } from '@kbn/data-plugin/public';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { type TimelineType, TimelineTypeEnum } from '../../../../../common/api/timeline';
 import { InputsModelId } from '../../../../common/store/inputs/constants';
@@ -24,7 +25,6 @@ import { Sourcerer } from '../../../../sourcerer/components';
 import { DataViewPicker } from '../../../../data_view_manager/components/data_view_picker';
 
 import { TimelineDatePickerLock } from '../date_picker_lock';
-import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import {
   DATA_PROVIDER_HIDDEN_EMPTY,
   DATA_PROVIDER_HIDDEN_POPULATED,
@@ -116,9 +116,9 @@ export const SearchOrFilter = React.memo<Props>(
           >
             <EuiFlexItem grow={false}>
               {newDataViewPickerEnabled ? (
-                <DataViewPicker scope={SourcererScopeName.timeline} />
+                <DataViewPicker scope={PageScope.timeline} />
               ) : (
-                <Sourcerer scope={SourcererScopeName.timeline} />
+                <Sourcerer scope={PageScope.timeline} />
               )}
             </EuiFlexItem>
             <EuiFlexItem data-test-subj="timeline-search-or-filter-search-container" grow={1}>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/header/index.tsx
@@ -8,11 +8,11 @@
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import React, { memo } from 'react';
 
+import { PageScope } from '../../../../../../data_view_manager/constants';
 import { InputsModelId } from '../../../../../../common/store/inputs/constants';
 import { TimelineTabs } from '../../../../../../../common/types/timeline';
 import { ExitFullScreen } from '../../../../../../common/components/exit_full_screen';
 import { SuperDatePicker } from '../../../../../../common/components/super_date_picker';
-import { SourcererScopeName } from '../../../../../../sourcerer/store/model';
 import { TimelineDatePickerLock } from '../../../date_picker_lock';
 import type { TimelineFullScreen } from '../../../../../../common/containers/use_full_screen';
 import { EqlQueryBarTimeline } from '../../../query_bar/eql';
@@ -53,9 +53,9 @@ export const EqlTabHeader = memo(
             <EuiFlexItem grow={false}>
               {activeTab === TimelineTabs.eql &&
                 (newDataViewPickerEnabled ? (
-                  <DataViewPicker scope={SourcererScopeName.timeline} />
+                  <DataViewPicker scope={PageScope.timeline} />
                 ) : (
-                  <Sourcerer scope={SourcererScopeName.timeline} />
+                  <Sourcerer scope={PageScope.timeline} />
                 ))}
             </EuiFlexItem>
             <EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
@@ -16,6 +16,7 @@ import { InPortal } from 'react-reverse-portal';
 import { DataLoadingState } from '@kbn/unified-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useFetchNotes } from '../../../../../notes/hooks/use_fetch_notes';
 import { InputsModelId } from '../../../../../common/store/inputs/constants';
 import { useKibana } from '../../../../../common/lib/kibana';
@@ -30,7 +31,6 @@ import { useTimelineEvents } from '../../../../containers';
 import { TimelineId, TimelineTabs } from '../../../../../../common/types/timeline';
 import type { inputsModel, State } from '../../../../../common/store';
 import { inputsSelectors } from '../../../../../common/store';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import { timelineDefaults } from '../../../../store/defaults';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
 import { useEqlEventsCountPortal } from '../../../../../common/hooks/use_timeline_events_count';
@@ -83,10 +83,10 @@ export const EqlTabContentComponent: React.FC<Props> = ({
     loading: oldSourcererLoading,
     selectedPatterns: oldSelectedPatterns,
     sourcererDataView: oldSourcererDataViewSpec,
-  } = useSourcererDataView(SourcererScopeName.timeline);
+  } = useSourcererDataView(PageScope.timeline);
 
-  const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.timeline);
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
+  const { dataView: experimentalDataView, status } = useDataView(PageScope.timeline);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.timeline);
   const experimentalDataViewId = experimentalDataView.id ?? null;
 
   const dataViewId = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/esql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/esql/index.tsx
@@ -19,13 +19,13 @@ import type { TimeRange } from '@kbn/es-query';
 import { useDispatch } from 'react-redux';
 import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import { APP_STATE_URL_KEY } from '@kbn/discover-plugin/common';
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import { updateSavedSearchId } from '../../../../store/actions';
 import { useDiscoverInTimelineContext } from '../../../../../common/components/discover_in_timeline/use_discover_in_timeline_context';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useDiscoverState } from './use_discover_state';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import { useSetDiscoverCustomizationCallbacks } from './customizations/use_set_discover_customizations';
 import { EmbeddedDiscoverContainer, TimelineESQLGlobalStyles } from './styles';
 import { timelineSelectors } from '../../../../store';
@@ -63,9 +63,9 @@ export const DiscoverTabContent: FC<DiscoverTabContentProps> = ({ timelineId }) 
   const dispatch = useDispatch();
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { status: dataViewStatus } = useDataView(SourcererScopeName.alerts);
+  const { status: dataViewStatus } = useDataView(PageScope.alerts);
 
-  const { dataViewId } = useSourcererDataView(SourcererScopeName.alerts);
+  const { dataViewId } = useSourcererDataView(PageScope.alerts);
 
   const [oldDataViewSpec, setDataViewSpec] = useState<DataViewSpec | undefined>();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/esql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/esql/index.tsx
@@ -63,9 +63,9 @@ export const DiscoverTabContent: FC<DiscoverTabContentProps> = ({ timelineId }) 
   const dispatch = useDispatch();
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { status: dataViewStatus } = useDataView(SourcererScopeName.detections);
+  const { status: dataViewStatus } = useDataView(SourcererScopeName.alerts);
 
-  const { dataViewId } = useSourcererDataView(SourcererScopeName.detections);
+  const { dataViewId } = useSourcererDataView(SourcererScopeName.alerts);
 
   const [oldDataViewSpec, setDataViewSpec] = useState<DataViewSpec | undefined>();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
@@ -13,6 +13,7 @@ import deepEqual from 'fast-deep-equal';
 import type { EuiDataGridControlColumn } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import { useSelectedPatterns } from '../../../../../data_view_manager/hooks/use_selected_patterns';
@@ -26,7 +27,6 @@ import { timelineSelectors } from '../../../../store';
 import type { Direction } from '../../../../../../common/search_strategy';
 import { useTimelineEvents } from '../../../../containers';
 import { requiredFieldsForActions } from '../../../../../detections/components/alerts_table/default_config';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import { timelineDefaults } from '../../../../store/defaults';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import type { TimelineModel } from '../../../../store/model';
@@ -85,10 +85,10 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
     dataViewId: oldDataViewId,
     sourcererDataView: oldSourcererDataViewSpec,
     selectedPatterns: oldSelectedPatterns,
-  } = useSourcererDataView(SourcererScopeName.timeline);
+  } = useSourcererDataView(PageScope.timeline);
 
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.timeline);
+  const { dataView: experimentalDataView } = useDataView(PageScope.timeline);
 
   const selectedPatterns = useMemo(
     () => (newDataViewPickerEnabled ? experimentalSelectedPatterns : oldSelectedPatterns),

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
@@ -31,7 +31,6 @@ import type {
 } from '../../../../../../common/types/timeline';
 import type { inputsModel } from '../../../../../common/store';
 import { inputsSelectors } from '../../../../../common/store';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import { timelineDefaults } from '../../../../store/defaults';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
 import { isActiveTimeline } from '../../../../../helpers';
@@ -39,7 +38,7 @@ import type { TimelineModel } from '../../../../store/model';
 import { useTimelineColumns } from '../shared/use_timeline_columns';
 import { EventsCountBadge } from '../shared/layout';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
-import { DataViewManagerScopeName } from '../../../../../data_view_manager/constants';
+import { PageScope } from '../../../../../data_view_manager/constants';
 
 /**
  * TODO: This component is a pared down duplicate of the logic used in timeline/tabs/query/index.tsx
@@ -102,14 +101,14 @@ export const TimelineQueryTabEventsCountComponent: React.FC<{ timelineId: string
     // in order to include the exclude filters in the search that are not stored in the timeline
     selectedPatterns: oldSelectedPatterns,
     sourcererDataView,
-  } = useSourcererDataView(SourcererScopeName.timeline);
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
-  const experimentalBrowserfields = useBrowserFields(DataViewManagerScopeName.timeline);
+  } = useSourcererDataView(PageScope.timeline);
+  const { dataView: experimentalDataView } = useDataView(PageScope.timeline);
+  const experimentalBrowserfields = useBrowserFields(PageScope.timeline);
   const browserFields = newDataViewPickerEnabled ? experimentalBrowserfields : oldBrowserFields;
   const runtimeMappings: RunTimeMappings = newDataViewPickerEnabled
     ? (experimentalDataView?.getRuntimeMappings() as RunTimeMappings) ?? {}
     : (sourcererDataView.runtimeFieldMap as RunTimeMappings) ?? {};
-  const experimentalSelectedPatterns = useSelectedPatterns(DataViewManagerScopeName.timeline);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.timeline);
   const selectedPatterns = newDataViewPickerEnabled
     ? experimentalSelectedPatterns
     : oldSelectedPatterns;

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/hooks/use_add_alerts_only_filter.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/hooks/use_add_alerts_only_filter.ts
@@ -14,7 +14,7 @@ import { useDataView } from '../../../../../../data_view_manager/hooks/use_data_
 import { useKibana } from '../../../../../../common/lib/kibana';
 import { DEFAULT_ALERTS_INDEX } from '../../../../../../../common/constants';
 import { useSpaceId } from '../../../../../../common/hooks/use_space_id';
-import { DataViewManagerScopeName } from '../../../../../../data_view_manager/constants';
+import { PageScope } from '../../../../../../data_view_manager/constants';
 import { timelineActions } from '../../../../../store';
 
 const ALERTS_ONLY_FILTER_ALIAS = i18n.translate(
@@ -46,7 +46,7 @@ export const useAddAlertsOnlyFilter = ({
     application: { capabilities },
   } = useKibana().services;
 
-  const { dataView } = useDataView(DataViewManagerScopeName.timeline);
+  const { dataView } = useDataView(PageScope.timeline);
   const spaceId = useSpaceId();
 
   return useCallback(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/hooks/use_timeline_select_alerts_only_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/hooks/use_timeline_select_alerts_only_data_view.test.ts
@@ -10,7 +10,7 @@ import { useTimelineSelectAlertsOnlyDataView } from './use_timeline_select_alert
 import { useSelectDataView } from '../../../../../../data_view_manager/hooks/use_select_data_view';
 import { useSpaceId } from '../../../../../../common/hooks/use_space_id';
 import { DEFAULT_ALERT_DATA_VIEW_ID } from '../../../../../../../common/constants';
-import { DataViewManagerScopeName } from '../../../../../../data_view_manager/constants';
+import { PageScope } from '../../../../../../data_view_manager/constants';
 
 jest.mock('../../../../../../data_view_manager/hooks/use_select_data_view');
 jest.mock('../../../../../../common/hooks/use_space_id');
@@ -29,7 +29,7 @@ describe('useTimelineSelectAlertsOnlyDataView', () => {
 
     expect(selectDataView).toHaveBeenCalledWith({
       id: `${DEFAULT_ALERT_DATA_VIEW_ID}-${spaceId}`,
-      scope: DataViewManagerScopeName.timeline,
+      scope: PageScope.timeline,
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/hooks/use_timeline_select_alerts_only_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/hooks/use_timeline_select_alerts_only_data_view.ts
@@ -9,7 +9,7 @@ import { useCallback } from 'react';
 import { useSelectDataView } from '../../../../../../data_view_manager/hooks/use_select_data_view';
 import { DEFAULT_ALERT_DATA_VIEW_ID } from '../../../../../../../common/constants';
 import { useSpaceId } from '../../../../../../common/hooks/use_space_id';
-import { DataViewManagerScopeName } from '../../../../../../data_view_manager/constants';
+import { PageScope } from '../../../../../../data_view_manager/constants';
 
 /**
  * Returns a callback to select the alerts-only data view for the timeline
@@ -22,7 +22,7 @@ export const useTimelineSelectAlertsOnlyDataView = (): (() => void) => {
     () =>
       selectDataView({
         id: `${DEFAULT_ALERT_DATA_VIEW_ID}-${spaceId}`,
-        scope: DataViewManagerScopeName.timeline,
+        scope: PageScope.timeline,
       }),
     [selectDataView, spaceId]
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -15,6 +15,7 @@ import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import { DataLoadingState } from '@kbn/unified-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import { useSelectedPatterns } from '../../../../../data_view_manager/hooks/use_selected_patterns';
 import { useBrowserFields } from '../../../../../data_view_manager/hooks/use_browser_fields';
@@ -40,7 +41,6 @@ import type { KueryFilterQueryKind } from '../../../../../../common/types/timeli
 import { TimelineId, TimelineTabs } from '../../../../../../common/types/timeline';
 import type { inputsModel, State } from '../../../../../common/store';
 import { inputsSelectors } from '../../../../../common/store';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import { timelineDefaults } from '../../../../store/defaults';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
 import { isActiveTimeline } from '../../../../../helpers';
@@ -85,10 +85,10 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
 
   const { dataView: experimentalDataView, status: sourcererStatus } = useDataView(
-    SourcererScopeName.timeline
+    PageScope.timeline
   );
-  const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);
-  const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
+  const experimentalBrowserFields = useBrowserFields(PageScope.timeline);
+  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.timeline);
 
   const {
     browserFields: oldBrowserFields,
@@ -98,7 +98,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     // in order to include the exclude filters in the search that are not stored in the timeline
     selectedPatterns: oldSelectedPatterns,
     sourcererDataView: oldSourcererDataViewSpec,
-  } = useSourcererDataView(SourcererScopeName.timeline);
+  } = useSourcererDataView(PageScope.timeline);
 
   const loadingSourcerer = useMemo(
     () => (newDataViewPickerEnabled ? sourcererStatus !== 'ready' : oldLoadingSourcerer),

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_columns.tsx
@@ -6,9 +6,9 @@
  */
 
 import { useMemo } from 'react';
+import { PageScope } from '../../../../../data_view_manager/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { useBrowserFields } from '../../../../../data_view_manager/hooks/use_browser_fields';
-import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
 import { requiredFieldsForActions } from '../../../../../detections/components/alerts_table/default_config';
 import { defaultUdtHeaders } from '../../body/column_headers/default_headers';
@@ -17,8 +17,8 @@ import { memoizedGetTimelineColumnHeaders } from './utils';
 
 export const useTimelineColumns = (columns: ColumnHeaderOptions[]) => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { browserFields: oldBrowserFields } = useSourcererDataView(SourcererScopeName.timeline);
-  const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);
+  const { browserFields: oldBrowserFields } = useSourcererDataView(PageScope.timeline);
+  const experimentalBrowserFields = useBrowserFields(PageScope.timeline);
 
   const browserFields = newDataViewPickerEnabled ? experimentalBrowserFields : oldBrowserFields;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/use_timeline_data_filters.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/use_timeline_data_filters.test.tsx
@@ -6,10 +6,11 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { mockGlobalState, TestProviders, createMockStore } from '../../common/mock';
+import { createMockStore, mockGlobalState, TestProviders } from '../../common/mock';
 import { useTimelineDataFilters } from './use_timeline_data_filters';
 import React from 'react';
-import { SourcererScopeName } from '../../sourcerer/store/model';
+
+import { PageScope } from '../../data_view_manager/constants';
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -29,8 +30,8 @@ const store = createMockStore({
     },
     sourcererScopes: {
       ...mockGlobalState.sourcerer.sourcererScopes,
-      [SourcererScopeName.analyzer]: {
-        ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+      [PageScope.analyzer]: {
+        ...mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline],
         selectedPatterns: [timelinePattern],
       },
     },

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.test.tsx
@@ -15,10 +15,10 @@ import { timelineActions } from '../store';
 import { inputsActions } from '../../common/store/inputs';
 import { sourcererActions } from '../../sourcerer/store';
 import { appActions } from '../../common/store/app';
-import { SourcererScopeName } from '../../sourcerer/store/model';
 import { InputsModelId } from '../../common/store/inputs/constants';
-import { TestProviders, mockGlobalState } from '../../common/mock';
+import { mockGlobalState, TestProviders } from '../../common/mock';
 import { defaultUdtHeaders } from '../components/timeline/body/column_headers/default_headers';
+import { PageScope } from '../../data_view_manager/constants';
 
 jest.mock('../../common/components/discover_in_timeline/use_discover_in_timeline_context');
 jest.mock('../../common/containers/use_global_time', () => {
@@ -80,19 +80,19 @@ describe('useCreateTimeline', () => {
     );
     expect(createTimeline.mock.calls[0][0].indexNames).toEqual(
       expect.arrayContaining(
-        mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline].selectedPatterns
+        mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline].selectedPatterns
       )
     );
     expect(createTimeline.mock.calls[0][0].show).toEqual(true);
     expect(createTimeline.mock.calls[0][0].updated).toEqual(undefined);
     expect(createTimeline.mock.calls[0][0].excludedRowRendererIds).toHaveLength(RowRendererCount);
-    expect(setSelectedDataView.mock.calls[0][0].id).toEqual(SourcererScopeName.timeline);
+    expect(setSelectedDataView.mock.calls[0][0].id).toEqual(PageScope.timeline);
     expect(setSelectedDataView.mock.calls[0][0].selectedDataViewId).toEqual(
       mockGlobalState.sourcerer.defaultDataView.id
     );
     expect(setSelectedDataView.mock.calls[0][0].selectedPatterns).toEqual(
       expect.arrayContaining(
-        mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline].selectedPatterns
+        mockGlobalState.sourcerer.sourcererScopes[PageScope.timeline].selectedPatterns
       )
     );
     expect(addLinkTo).toHaveBeenCalledWith([InputsModelId.global, InputsModelId.timeline]);

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
@@ -20,9 +20,8 @@ import { useDiscoverInTimelineContext } from '../../common/components/discover_i
 import { defaultUdtHeaders } from '../components/timeline/body/column_headers/default_headers';
 import { timelineDefaults } from '../store/defaults';
 import { useSelectDataView } from '../../data_view_manager/hooks/use_select_data_view';
-import { DataViewManagerScopeName } from '../../data_view_manager/constants';
+import { PageScope } from '../../data_view_manager/constants';
 import { sourcererActions, sourcererSelectors } from '../../sourcerer/store';
-import { SourcererScopeName } from '../../sourcerer/store/model';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { useSecurityDefaultPatterns } from '../../data_view_manager/hooks/use_security_default_patterns';
 
@@ -100,12 +99,12 @@ export const useCreateTimeline = ({
       setSelectedDataView({
         id: dataViewId,
         fallbackPatterns: selectedPatterns,
-        scope: DataViewManagerScopeName.timeline,
+        scope: PageScope.timeline,
       });
 
       dispatch(
         sourcererActions.setSelectedDataView({
-          id: SourcererScopeName.timeline,
+          id: PageScope.timeline,
           selectedDataViewId: dataViewId,
           selectedPatterns,
         })

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/pages/timelines_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/pages/timelines_page.tsx
@@ -18,7 +18,7 @@ import * as i18n from './translations';
 import { SecurityPageName } from '../../app/types';
 import { EmptyPrompt } from '../../common/components/empty_prompt';
 import { SecurityRoutePageWrapper } from '../../common/components/security_route_page_wrapper';
-import { DataViewManagerScopeName } from '../../data_view_manager/constants';
+import { PageScope } from '../../data_view_manager/constants';
 import { useSourcererDataView } from '../../sourcerer/containers';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { useDataView } from '../../data_view_manager/hooks/use_data_view';
@@ -32,7 +32,7 @@ export const TimelinesPage = React.memo(() => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
   const { indicesExist: oldIndicesExist } = useSourcererDataView();
 
-  const { dataView, status } = useDataView(DataViewManagerScopeName.default);
+  const { dataView, status } = useDataView(PageScope.default);
   const experimentalIndicesExist = dataView?.hasMatchedIndices();
 
   const indicesExist = newDataViewPickerEnabled ? experimentalIndicesExist : oldIndicesExist;

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/store/middlewares/timeline_save.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/store/middlewares/timeline_save.ts
@@ -5,48 +5,48 @@
  * 2.0.
  */
 
-import { get, has, omit, isObject, toString as fpToString } from 'lodash/fp';
+import { get, has, isObject, omit, toString as fpToString } from 'lodash/fp';
 import { set } from '@kbn/safer-lodash-set/fp';
 import type { Action, Middleware } from 'redux';
 import type { CoreStart } from '@kbn/core/public';
 import type { Filter, MatchAllFilter } from '@kbn/es-query';
 import {
-  isScriptedRangeFilter,
   isExistsFilter,
-  isRangeFilter,
   isMatchAllFilter,
   isPhraseFilter,
-  isQueryStringFilter,
   isPhrasesFilter,
+  isQueryStringFilter,
+  isRangeFilter,
+  isScriptedRangeFilter,
 } from '@kbn/es-query';
 
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import { PageScope } from '../../../data_view_manager/constants';
 import { sourcererAdapterSelector } from '../../../data_view_manager/redux/selectors';
 import { sourcererSelectors } from '../../../sourcerer/store';
 import {
-  updateTimeline,
-  startTimelineSaving,
   endTimelineSaving,
-  showCallOutUnauthorizedMsg,
   saveTimeline,
   setChanged,
+  showCallOutUnauthorizedMsg,
+  startTimelineSaving,
+  updateTimeline,
 } from '../actions';
 import { copyTimeline, persistTimeline } from '../../containers/api';
 import type { State } from '../../../common/store/types';
+import type { inputsModel } from '../../../common/store/inputs';
 import { inputsSelectors } from '../../../common/store/inputs';
 import { selectTimelineById } from '../selectors';
 import * as i18n from '../../pages/translations';
-import type { inputsModel } from '../../../common/store/inputs';
-import { TimelineStatusEnum, TimelineTypeEnum } from '../../../../common/api/timeline';
 import type {
-  TimelineErrorResponse,
   PersistTimelineResponse,
   SavedTimeline,
+  TimelineErrorResponse,
 } from '../../../../common/api/timeline';
+import { TimelineStatusEnum, TimelineTypeEnum } from '../../../../common/api/timeline';
 import type { TimelineModel } from '../model';
 import type { ColumnHeaderOptions } from '../../../../common/types/timeline';
 import { extractTimelineIdsAndVersions, refreshTimelines } from './helpers';
-import { SourcererScopeName } from '../../../sourcerer/store/model';
 
 function isSaveTimelineAction(action: Action): action is ReturnType<typeof saveTimeline> {
   return action.type === saveTimeline.type;
@@ -70,16 +70,16 @@ export const saveTimelineMiddleware: (kibana: CoreStart) => Middleware<{}, State
     const timelineTimeRange = inputsSelectors.timelineTimeRangeSelector(storeState);
     const selectedDataViewIdSourcerer = sourcererSelectors.sourcererScopeSelectedDataViewId(
       storeState,
-      SourcererScopeName.timeline
+      PageScope.timeline
     );
     const selectedPatternsSourcerer = sourcererSelectors.sourcererScopeSelectedPatterns(
       storeState,
-      SourcererScopeName.timeline
+      PageScope.timeline
     );
 
-    const { dataViewId: experimentalDataViewId } = sourcererAdapterSelector(
-      SourcererScopeName.timeline
-    )(storeState);
+    const { dataViewId: experimentalDataViewId } = sourcererAdapterSelector(PageScope.timeline)(
+      storeState
+    );
 
     const experimentalIsDataViewEnabled =
       storeState.app.enableExperimental.newDataViewPickerEnabled;


### PR DESCRIPTION
## Summary

This PR renames the `SourcererScopeName` from `detections` to `alerts`. We will soon need a new scope called `attacks` so we can easily retrieve the new attack dataview (introduced in [this recent PR](https://github.com/elastic/kibana/pull/238750)). This renaming will avoid confusion.

> [!IMPORTANT]
> No UI changes should be introduced by this PR!

--------------------------------------------------------------

_Edit: after discussing with the team, I took this opportunity to do one more cleanup: the `DataViewManagerScopeName` enum (which is basically pointing to the `SourcererScopeName` enum are now one. I'm defining this new enum within the `data_view_manager` folder as the sourcerer folder will be soon removed (see this draft [PR](https://github.com/elastic/kibana/pull/238549)), and is now named `PageScope`. That way, it is much less confusing what this enum actually does..._

> [!NOTE]
> `PageScope` points to the location of the picker (using `useDataView(scope)` returns the current dataview selected in that scope)

## Files by codeowner

<details>
<summary>Expand to see all files by codeowners</summary>

### elastic/contextual-security-apps

* x-pack/solutions/security/plugins/security_solution/public/common/components/sessions_viewer/index.tsx

### elastic/kibana-cases

* x-pack/solutions/security/plugins/security_solution/public/cases/components/ease/table.tsx
* x-pack/solutions/security/plugins/security_solution/public/cases/pages/use_fetch_alert_data.ts

### elastic/security-detection-engine

* x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_histogram.tsx
* x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_table_cell_renderer.tsx

### elastic/security-detection-rule-management

* x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/execution_log_table/execution_log_table.tsx
* x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx

### elastic/security-entity-analytics

* x-pack/solutions/security/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_risk_input_actions.ts
* x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/alert_filters_kql_bar.tsx
* x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_preview_section.tsx
* x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/top_risk_score_contributors_alerts/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/metric_embeddable.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/components/stat_items/stat_items.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/hosts.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/index.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/network/components/details/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/network/components/embeddables/embedded_map.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/network/components/embeddables/map_tool_tip/point_tool_tip_content.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/network/components/field_renderers/field_renderers.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/network/components/field_renderers/field_renderers.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/details/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/navigation/dns_query_tab_body.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/network.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/navigation/authentications_query_tab_body.tsx
* x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/users.tsx

### elastic/security-generative-ai

* x-pack/solutions/security/plugins/security_solution/public/assistant/send_to_timeline/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ease/table.tsx
* x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_selection_query/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/create_flyout/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/definition/filters.tsx
* x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/schedule/details_flyout/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_filtering_metric.tsx
* x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_processing_donut_lens.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/alert_processing_donut_lens.tsx
* x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_metric.tsx
* x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/cost_savings_trend.tsx
* x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/reports/components/ai_value/time_saved_metric.tsx

### elastic/security-threat-hunting-investigations

* x-pack/solutions/security/plugins/security_solution/public/common/components/events_tab/events_query_tab_body.tsx
* x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/common/components/events_viewer/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/modal.tsx
* x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
* x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/helpers.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/helpers.ts
* x-pack/solutions/security/plugins/security_solution/public/common/components/top_n/top_n.tsx
* x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/actions.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/actions.tsx
* x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
* x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/types.ts
* x-pack/solutions/security/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/constants.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.test.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.test.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.test.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.test.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_select_data_view.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.test.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_sync_url_state.test.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_sync_url_state.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/actions.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/reducer.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/selectors.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/slices.test.ts
* x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/slices.ts
* x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/wrapper.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/additional_toolbar_controls.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/types.ts
* x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/cell_value_context.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_actions.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_actions.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_cell_actions.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_trigger_actions_browser_fields_options.tsx
* x-pack/solutions/security/plugins/security_solution/public/detections/hooks/use_rule_from_timeline.tsx
* x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
* x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/graph_visualization.tsx
* x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
* x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.ts
* x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/session_view/tabs/alerts_tab.tsx
* x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
* x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/components/network_details.tsx
* x-pack/solutions/security/plugins/security_solution/public/notes/components/open_flyout_button.tsx
* x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/hooks/use_navigate_to_timeline.tsx
* x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/host_alerts_table/host_alerts_table.tsx
* x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/rule_alerts_table/rule_alerts_table.tsx
* x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/user_alerts_table/user_alerts_table.tsx
* x-pack/solutions/security/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/resolver/view/controls/sourcerer_selection.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/alerts_sourcerer.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/misc.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/sourcerer_integration.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/timeline_sourcerer.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_get_sourcerer_data_view.test.ts
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_get_sourcerer_data_view.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/use_pick_index_patterns.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/hooks.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/readme.md
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/sourcerer_paths.ts
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_init_sourcerer.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_signal_helpers.tsx
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/actions.ts
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/helpers.test.ts
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/helpers.ts
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/model.ts
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/readme.md
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/reducer.ts
* x-pack/solutions/security/plugins/security_solution/public/sourcerer/store/selectors.ts
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/more_container/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/use_update_timeline.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/data_providers/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/search_or_filter.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/header/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/esql/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/events_count.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_columns.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/containers/use_timeline_data_filters.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.test.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/pages/timelines_page.tsx
* x-pack/solutions/security/plugins/security_solution/public/timelines/store/middlewares/timeline_save.ts

</details>

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/232815