### PR TITLE
Display the ES|QL query response in tabular format

### DIFF
--- a/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/esql_tutorial.ts
+++ b/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/esql_tutorial.ts
@@ -52,8 +52,10 @@ POST /kibana_sample_data_esql/_bulk?refresh=wait_for
 # Step 3: Run a basic full-text search. 🔎
 # -----------------------------------------------
 # Note: when ES|QL queries are run from within the Kibana Console, they must be wrapped in triple quotes syntax.
+# The 'format=txt' parameter allows you to see the output in a tabular format.
+# To view the raw response instead, omit the 'format=txt' parameter.
 
-POST /_query
+POST /_query?format=txt
 {
   "query": """
     FROM kibana_sample_data_esql
@@ -70,7 +72,7 @@ POST /_query
 # -----------------------------------------------
 # You can specify the exact fields to include in your results using the KEEP command.
 
-POST /_query
+POST /_query?format=txt
 {
   "query": """
     FROM kibana_sample_data_esql
@@ -88,7 +90,7 @@ POST /_query
 # 'METADATA _score' tells ES|QL to include relevance scores in the results.
 # Without explicit sorting, results aren't ordered by relevance even when scores are calculated.
 
-POST /_query
+POST /_query?format=txt
 {
   "query": """
     FROM kibana_sample_data_esql METADATA _score
@@ -106,7 +108,7 @@ POST /_query
 # -----------------------------------------------
 # This is fundamentally different from full-text search - it's a binary yes/no filter that doesn't affect relevance scoring.
 
-POST /_query
+POST /_query?format=txt
 {
   "query": """
     FROM kibana_sample_data_esql
@@ -124,7 +126,7 @@ POST /_query
 # -----------------------------------------------
 # The MATCH function with AND logic doesn't require terms to be adjacent or in order.
 
-POST /_query
+POST /_query?format=txt
 {
   "query": """
     FROM kibana_sample_data_esql
@@ -139,7 +141,7 @@ POST /_query
 # Step 8: Minimum number of terms to match 🧮
 # -----------------------------------------------
 
-POST /_query
+POST /_query?format=txt
 {
   "query": """
     FROM kibana_sample_data_esql
@@ -154,7 +156,7 @@ POST /_query
 # Step 9: Search for exact phrases 🔤
 # -----------------------------------------------
 
-POST /_query
+POST /_query?format=txt
 {
   "query": """
     FROM kibana_sample_data_esql
@@ -170,7 +172,7 @@ POST /_query
 # Step 10: Date range filtering 📅
 # -----------------------------------------------
 
-POST /_query
+POST /_query?format=txt
 {
   "query": """
     FROM kibana_sample_data_esql
@@ -186,7 +188,7 @@ POST /_query
 # Step 11: Numerical range filtering 🔢
 # -----------------------------------------------
 
-POST /_query
+POST /_query?format=txt
 {
   "query": """
     FROM kibana_sample_data_esql
@@ -203,7 +205,7 @@ POST /_query
 # Step 12: Search across multiple fields 🔦
 # -----------------------------------------------
 
-POST /_query
+POST /_query?format=txt
 {
   "query": """
     FROM kibana_sample_data_esql
@@ -218,7 +220,7 @@ POST /_query
 # Step 13: Weight different fields ⚖️
 # -----------------------------------------------
 
-POST /_query
+POST /_query?format=txt
 {
   "query": """
     FROM kibana_sample_data_esql METADATA _score
@@ -237,7 +239,7 @@ POST /_query
 # The QSTR function enables powerful search patterns using a compact query language.
 # It's ideal for when you need wildcards, fuzzy matching, and boolean logic in a single expression
 
-POST /_query
+POST /_query?format=txt 
 {
   "query": """
     FROM kibana_sample_data_esql
@@ -253,7 +255,7 @@ POST /_query
 # Step 15: Advanced relevance scoring (custom score) 🏆
 # -----------------------------------------------
 
-POST /_query
+POST /_query?format=txt
 {
   "query": """
     FROM kibana_sample_data_esql METADATA _score


### PR DESCRIPTION
## Summary

We have an ES|QL console tutorial as well. We show users how tweaking the query provides different results, we want to showcase this to demonstrate all the capabilities, but it's hard to understand how the output changes when it is just the api response object. 

This PR adds format=txt parameter to the query so that the response is printed in tabular format.

https://github.com/user-attachments/assets/826e075f-f260-42ee-8b39-d266111e209b



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



