### PR TITLE
chore: suppress CSS @container query parsing warnings in Jest

### DIFF
--- a/src/platform/packages/shared/kbn-test/src/jest/setup/emotion.js
+++ b/src/platform/packages/shared/kbn-test/src/jest/setup/emotion.js
@@ -42,5 +42,19 @@ console.error = (message, ...rest) => {
   ) {
     return;
   }
+  // @see https://github.com/jsdom/jsdom/issues/3597
+  // @see https://github.com/jsdom/jsdom/issues/3858
+  // jsdom 20.0.1 (our current version) fails to parse @container queries, causing console errors.
+  // Parsing was fixed in jsdom 24.1.0+ (May 2024), but actual container query evaluation
+  // is still not implemented (issue #3858 remains open). For tests, this is acceptable since
+  // container queries are progressive enhancement and don't affect test functionality.
+  // TODO: Remove this suppression after upgrading jsdom to 24.1.0+ (eliminates parse errors)
+  if (
+    typeof message === 'string' &&
+    message.includes('There was a problem inserting the following rule') &&
+    message.includes('@container')
+  ) {
+    return;
+  }
   consoleError(message, ...rest);
 };


### PR DESCRIPTION
## Summary

Suppresses `console.error` warnings from jsdom when parsing CSS `@container` queries in Jest tests.

## Problem

When running Jest tests with components that use EUI's responsive container queries (e.g., `EuiPageHeader`), jsdom 20.0.1 fails to parse `@container` syntax and floods the console with errors:

```
console.error
  There was a problem inserting the following rule: "@container (max-width: 768px){.css-13dn9dx-euiPageHeaderContent__leftSideItems{min-inline-size:50%;}}" Error: Unexpected } (line 1, char 101)
    at parseError (node_modules/cssom/lib/parse.js:62:15)
    at Object.parse (node_modules/cssom/lib/parse.js:385:7)
    at CSSStyleSheet.CSSOM.CSSStyleSheet.insertRule (node_modules/cssom/lib/CSSStyleSheet.js:43:22)
    at StyleSheet.insert (node_modules/@emotion/sheet/dist/emotion-sheet.cjs.dev.js:129:15)
```

This warning appears 4 times per test render, polluting test output and making it harder to spot real issues.

## Root Cause

- **jsdom 20.0.1** (Oct 2022) uses **cssom 0.5.0** which doesn't support `@container` queries
- EUI components use `@container` for progressive responsive design via Emotion
- When Emotion tries to insert these rules, cssom fails to parse them and logs errors

## Solution

Added `console.error` suppression in `emotion.js` test setup for `@container`-related parsing errors.

## Why This Is Safe

1. **Not a real error** - Just a jsdom/cssom limitation, not a test failure
2. **Doesn't affect test functionality** - Container queries are progressive enhancement; tests verify logic, not responsive behavior  
3. **Established pattern** - The file already suppresses similar CSS parsing warnings
4. **Temporary** - Can be removed after upgrading jsdom to 24.1.0+

## Future Work

- **Short term** (this PR): Suppress warnings ✅
- **Medium term**: Upgrade jsdom from 20.0.1 to 24.1.0+ (May 2024) to eliminate parse errors
- **Long term**: Full `@container` evaluation support (jsdom#3858 remains open, but not needed for tests)

## References

- https://github.com/jsdom/jsdom/issues/3597 - Parsing errors (fixed in jsdom 24.1.0+)
- https://github.com/jsdom/jsdom/issues/3858 - Evaluation support (still open, but acceptable)

## Test Plan

1. Run any Jest test that renders EUI components with container queries
2. Verify no console warnings appear
3. Verify tests still pass