### PR TITLE
[Search] fix(playground): add small padding to header

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/public/components/header.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/header.test.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import { Header } from './header';
 import { PlaygroundFormFields, PlaygroundPageMode, PlaygroundViewMode } from '../types';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
-import { EuiForm } from '@elastic/eui';
+import { EuiForm, EuiThemeProvider } from '@elastic/eui';
 import { FormProvider, useForm } from 'react-hook-form';
 
 jest.mock('../hooks/use_source_indices_field', () => ({
@@ -50,15 +50,17 @@ const MockPlaygroundForm = ({
   children: React.ReactElement;
   handleSubmit: React.FormEventHandler;
 }) => (
-  <MockFormProvider>
-    <EuiForm
-      onSubmit={handleSubmit}
-      data-test-subj="chatPage"
-      css={{ display: 'flex', flexGrow: 1 }}
-    >
-      {children}
-    </EuiForm>
-  </MockFormProvider>
+  <EuiThemeProvider>
+    <MockFormProvider>
+      <EuiForm
+        onSubmit={handleSubmit}
+        data-test-subj="chatPage"
+        css={{ display: 'flex', flexGrow: 1 }}
+      >
+        {children}
+      </EuiForm>
+    </MockFormProvider>
+  </EuiThemeProvider>
 );
 
 describe('Header', () => {

--- a/x-pack/solutions/search/plugins/search_playground/public/components/header.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/header.tsx
@@ -13,7 +13,6 @@ import {
   EuiPageTemplate,
   EuiSelect,
   EuiTitle,
-  useEuiTheme,
   type EuiButtonGroupOptionProps,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -43,7 +42,6 @@ export const Header: React.FC<HeaderProps> = ({
   onSelectPageModeChange,
 }) => {
   const isSearchModeEnabled = useSearchPlaygroundFeatureFlag();
-  const { euiTheme } = useEuiTheme();
   const options: Array<EuiButtonGroupOptionProps & { id: PlaygroundViewMode }> = [
     {
       id: PlaygroundViewMode.preview,
@@ -68,12 +66,12 @@ export const Header: React.FC<HeaderProps> = ({
 
   return (
     <EuiPageTemplate.Header
-      css={{
+      css={({ euiTheme }) => ({
         '.euiPageHeaderContent > .euiFlexGroup': { flexWrap: 'wrap' },
         backgroundColor: euiTheme.colors.emptyShade,
-      }}
-      paddingSize="s"
+      })}
       data-test-subj="chat-playground-home-page"
+      paddingSize="s"
     >
       <EuiPageHeaderSection>
         <EuiFlexGroup gutterSize="s" alignItems="center">
@@ -117,7 +115,11 @@ export const Header: React.FC<HeaderProps> = ({
           data-test-subj="viewModeSelector"
         />
       </EuiPageHeaderSection>
-      <EuiPageHeaderSection>
+      <EuiPageHeaderSection
+        css={({ euiTheme }) => ({
+          paddingRight: euiTheme.size.s,
+        })}
+      >
         <EuiFlexGroup alignItems="center">
           {showDocs && <PlaygroundHeaderDocs />}
           <Toolbar selectedPageMode={pageMode} />

--- a/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/saved_playground_header.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/saved_playground/saved_playground_header.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { css } from '@emotion/react';
 import {
   EuiBadge,
   EuiButtonGroup,
@@ -14,7 +13,6 @@ import {
   EuiPageHeaderSection,
   EuiPageTemplate,
   EuiSelect,
-  useEuiTheme,
   type EuiButtonGroupOptionProps,
   EuiSpacer,
 } from '@elastic/eui';
@@ -56,7 +54,6 @@ export const SavedPlaygroundHeader: React.FC<SavedPlaygroundHeaderProps> = ({
   onCopyPlayground,
 }) => {
   const isSearchModeEnabled = useSearchPlaygroundFeatureFlag();
-  const { euiTheme } = useEuiTheme();
   const options: Array<EuiButtonGroupOptionProps & { id: PlaygroundViewMode }> = [
     {
       id: PlaygroundViewMode.preview,
@@ -81,10 +78,10 @@ export const SavedPlaygroundHeader: React.FC<SavedPlaygroundHeaderProps> = ({
 
   return (
     <EuiPageTemplate.Header
-      css={{
+      css={({ euiTheme }) => ({
         '.euiPageHeaderContent > .euiFlexGroup': { flexWrap: 'wrap' },
         backgroundColor: euiTheme.colors.emptyShade,
-      }}
+      })}
       paddingSize="s"
       data-test-subj="saved-playground-header"
     >
@@ -126,10 +123,14 @@ export const SavedPlaygroundHeader: React.FC<SavedPlaygroundHeaderProps> = ({
           data-test-subj="viewModeSelector"
         />
       </EuiPageHeaderSection>
-      <EuiPageHeaderSection>
+      <EuiPageHeaderSection
+        css={({ euiTheme }) => ({
+          paddingRight: euiTheme.size.s,
+        })}
+      >
         <EuiFlexGroup gutterSize="s" alignItems="center" data-test-subj="playground-header-actions">
           <DataActionButton />
-          <EuiSpacer css={css({ borderLeft: euiTheme.border.thin })} />
+          <EuiSpacer css={({ euiTheme }) => ({ borderLeft: euiTheme.border.thin })} />
           <ViewCodeAction selectedPageMode={pageMode} />
           <EuiSpacer />
           <SavedPlaygroundSaveButton hasChanges={hasChanges} />

--- a/x-pack/solutions/search/plugins/search_playground/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_playground/tsconfig.json
@@ -8,6 +8,7 @@
     "common/**/*",
     "public/**/*",
     "server/**/*",
+    "../../../../../typings/emotion.d.ts"
   ],
   "kbn_references": [
     "@kbn/config-schema",


### PR DESCRIPTION
## Summary

Added a small right padding to the playground header to account for changes with the new grid layout. Without this the save button is sometimes covered by the scroll bar.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.