### PR TITLE
[PoC] Cached panel field specs

### DIFF
--- a/src/platform/packages/shared/content-management/table_list_view_table/src/components/item_details.tsx
+++ b/src/platform/packages/shared/content-management/table_list_view_table/src/components/item_details.tsx
@@ -89,7 +89,9 @@ export function ItemDetails<T extends UserContentCommonSchema>({
         {/* eslint-disable-next-line  @elastic/eui/href-or-on-click */}
         <EuiLink
           href={getDetailViewLink?.(item)}
-          onClick={onClickTitleHandler}
+          onClick={() => {
+            performance.mark('navigate');
+          }}
           data-test-subj={`${id}ListingTitleLink-${item.attributes.title.split(' ').join('-')}`}
         >
           <EuiHighlight highlightAll search={escapeRegExp(searchTerm)}>

--- a/src/platform/packages/shared/kbn-lens-common/datasources/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/datasources/types.ts
@@ -14,6 +14,7 @@ import type { VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
 import type { $Values } from '@kbn/utility-types';
 import type {
   DateRange,
+  IndexPatternField,
   IndexPatternRef,
   Operation,
   TimeScaleUnit,
@@ -77,7 +78,10 @@ export interface FormBasedLayer {
 }
 
 export interface FormBasedPersistedState {
-  layers: Record<string, Omit<FormBasedLayer, 'indexPatternId'>>;
+  layers: Record<
+    string,
+    Omit<FormBasedLayer, 'indexPatternId'> & { fieldSpecs?: IndexPatternField[] }
+  >;
 }
 
 export type PersistedIndexPatternLayer = Omit<FormBasedLayer, 'indexPatternId'>;

--- a/src/platform/packages/shared/kbn-lens-common/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/types.ts
@@ -890,6 +890,8 @@ export interface DatasourcePublicAPI {
   datasourceId: string;
   datasourceAliasIds?: string[];
   getTableSpec: () => Array<{ columnId: string; fields: string[] }>;
+  getIndexPatternId: () => string;
+  getLayerId: () => string;
   getOperationForColumnId: (columnId: string) => OperationDescriptor | null;
   /**
    * Collect all default visual values given the current state

--- a/src/platform/plugins/shared/data/common/search/search_source/create_search_source.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/create_search_source.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DataViewsContract, DataViewLazy } from '@kbn/data-views-plugin/common';
+import type { DataViewsContract, DataViewLazy, FieldSpec } from '@kbn/data-views-plugin/common';
 import { DataView } from '@kbn/data-views-plugin/common';
 import type { FieldFormatsStartCommon } from '@kbn/field-formats-plugin/common';
 import { migrateLegacyQuery } from './migrate_legacy_query';
@@ -40,7 +40,8 @@ export const createSearchSource = (
   let dataViewLazy: DataViewLazy | undefined;
   const createFields = async (
     searchSourceFields: SerializedSearchSourceFields = {},
-    useDataViewLazy = false
+    useDataViewLazy = false,
+    fieldSpecs?: FieldSpec[]
   ) => {
     const { index, parent, ...restOfFields } = searchSourceFields;
     const fields: SearchSourceFields = {
@@ -52,7 +53,7 @@ export const createSearchSource = (
       if (!useDataViewLazy) {
         fields.index =
           typeof searchSourceFields.index === 'string'
-            ? await indexPatterns.get(searchSourceFields.index)
+            ? await indexPatterns.get(searchSourceFields.index, undefined, undefined, fieldSpecs)
             : await indexPatterns.create(searchSourceFields.index);
       } else {
         dataViewLazy =
@@ -86,9 +87,10 @@ export const createSearchSource = (
 
   const createSearchSourceFn = async (
     searchSourceFields: SerializedSearchSourceFields = {},
-    useDataViewLazy?: boolean
+    useDataViewLazy?: boolean,
+    fieldSpecs?: FieldSpec[]
   ) => {
-    const fields = await createFields(searchSourceFields, !!useDataViewLazy);
+    const fields = await createFields(searchSourceFields, !!useDataViewLazy, fieldSpecs);
     const searchSource = new SearchSource(fields, searchSourceDependencies);
 
     // todo: move to migration script .. create issue

--- a/src/platform/plugins/shared/data/common/search/search_source/search_source_service.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/search_source_service.ts
@@ -10,7 +10,7 @@
 import { mapValues } from 'lodash';
 import type { MigrateFunctionsObject } from '@kbn/kibana-utils-plugin/common';
 import { mergeMigrationFunctionMaps } from '@kbn/kibana-utils-plugin/common';
-import type { DataViewsContract } from '@kbn/data-views-plugin/common';
+import type { DataViewsContract, FieldSpec } from '@kbn/data-views-plugin/common';
 import { DataViewPersistableStateService } from '@kbn/data-views-plugin/common';
 import type { SearchSourceDependencies, SerializedSearchSourceFields } from '.';
 import { createSearchSource, extractReferences, injectReferences, SearchSource } from '.';
@@ -54,7 +54,10 @@ export class SearchSourceService {
       /**
        * creates searchsource based on serialized search source fields
        */
-      create: createSearchSource(indexPatterns, dependencies),
+      create: (
+        searchSourceFields: SerializedSearchSourceFields = {},
+        fieldSpecs: FieldSpec[] = []
+      ) => createSearchSource(indexPatterns, dependencies)(searchSourceFields, false, fieldSpecs),
       createLazy: (searchSourceFields: SerializedSearchSourceFields = {}) => {
         const fn = createSearchSource(indexPatterns, dependencies);
         return fn(searchSourceFields, true);

--- a/src/platform/plugins/shared/data/common/search/search_source/types.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/types.ts
@@ -13,7 +13,7 @@ import type { AggregateQuery, Filter, Query } from '@kbn/es-query';
 import type { Serializable, SerializableRecord } from '@kbn/utility-types';
 import type { PersistableStateService } from '@kbn/kibana-utils-plugin/common';
 import type { ISearchOptions } from '@kbn/search-types';
-import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
+import type { DataView, DataViewSpec, FieldSpec } from '@kbn/data-views-plugin/common';
 import type { SearchField } from '@kbn/es-types';
 import type { AggConfigSerialized, IAggConfigs } from '../../../public';
 import type { SearchSource } from './search_source';
@@ -34,7 +34,10 @@ export interface ISearchStartSearchSource
    * creates {@link SearchSource} based on provided serialized {@link SearchSourceFields}
    * @param fields
    */
-  create: (fields?: SerializedSearchSourceFields) => Promise<ISearchSource>;
+  create: (
+    fields?: SerializedSearchSourceFields,
+    fieldSpecs?: FieldSpec[]
+  ) => Promise<ISearchSource>;
 
   createLazy: (fields?: SerializedSearchSourceFields) => Promise<ISearchSource>;
   /**

--- a/src/platform/plugins/shared/data/public/search/search_service.ts
+++ b/src/platform/plugins/shared/data/public/search/search_service.ts
@@ -231,6 +231,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
     const { http, uiSettings, chrome, application, notifications, ...startServices } = coreStart;
 
     const search = ((request, options = {}) => {
+      performance.mark('search_start');
       return this.searchInterceptor.search(request, options);
     }) as ISearchGeneric;
 
@@ -251,6 +252,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
       search,
       dataViews,
       onResponse: (request, response, options) => {
+        performance.mark('search_end');
         if (!options.disableWarningToasts) {
           const { rawResponse } = response;
 

--- a/src/platform/plugins/shared/data_views/common/data_views/data_views.ts
+++ b/src/platform/plugins/shared/data_views/common/data_views/data_views.ts
@@ -219,7 +219,12 @@ export interface DataViewsServicePublicMethods {
    * @param id - Id of the data view to get.
    * @param displayErrors - If set false, API consumer is responsible for displaying and handling errors.
    */
-  get: (id: string, displayErrors?: boolean, refreshFields?: boolean) => Promise<DataView>;
+  get: (
+    id: string,
+    displayErrors?: boolean,
+    refreshFields?: boolean,
+    fieldSpecs?: FieldSpec[]
+  ) => Promise<DataView>;
   /**
    * Get populated data view saved object cache.
    */

--- a/src/platform/plugins/shared/discover/public/embeddable/initialize_search_embeddable_api.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/initialize_search_embeddable_api.tsx
@@ -97,6 +97,7 @@ export const initializeSearchEmbeddableApi = async (
 
   /** This is the state that can be initialized from the saved initial state */
   const columns$ = new BehaviorSubject<string[] | undefined>(initialState.columns);
+  const fieldSpecs$ = new BehaviorSubject<FieldSpec[] | undefined>(initialState.fieldSpecs);
   const grid$ = new BehaviorSubject<DiscoverGridSettings | undefined>(initialState.grid);
   const headerRowHeight$ = new BehaviorSubject<number | undefined>(initialState.headerRowHeight);
   const rowHeight$ = new BehaviorSubject<number | undefined>(initialState.rowHeight);
@@ -132,6 +133,7 @@ export const initializeSearchEmbeddableApi = async (
    */
   const stateManager: SearchEmbeddableStateManager = {
     columns: columns$,
+    fieldSpecs: fieldSpecs$,
     columnsMeta: columnsMeta$,
     grid: grid$,
     headerRowHeight: headerRowHeight$,

--- a/src/platform/plugins/shared/discover/public/embeddable/types.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/types.ts
@@ -45,6 +45,7 @@ export type SearchEmbeddableState = Pick<
   | 'rowsPerPage'
   | 'headerRowHeight'
   | 'columns'
+  | 'fieldSpecs'
   | 'sort'
   | 'sampleSize'
   | 'viewMode'

--- a/src/platform/plugins/shared/discover/public/embeddable/utils/serialization_utils.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/utils/serialization_utils.ts
@@ -59,6 +59,7 @@ export const deserializeState = async ({
       // Overwrite SO state with dashboard state for title, description, columns, sort, etc.
       ...panelState,
       ...savedObjectOverride,
+      fieldSpecs: so.fieldSpecs,
 
       // back up the original saved object attributes for comparison
       rawSavedObjectAttributes,

--- a/src/platform/plugins/shared/saved_search/common/saved_searches_utils.ts
+++ b/src/platform/plugins/shared/saved_search/common/saved_searches_utils.ts
@@ -31,6 +31,7 @@ export const fromSavedSearchAttributes = <
     title,
     sort: attributes.sort,
     columns: attributes.columns,
+    fieldSpecs: attributes.fieldSpecs ?? [],
     description,
     tags,
     grid: attributes.grid,

--- a/src/platform/plugins/shared/saved_search/common/service/saved_searches_utils.ts
+++ b/src/platform/plugins/shared/saved_search/common/service/saved_searches_utils.ts
@@ -39,6 +39,7 @@ export const toSavedSearchAttributes = (
     title: savedSearch.title ?? '',
     sort: savedSearch.sort ?? [],
     columns: savedSearch.columns ?? [],
+    fieldSpecs: savedSearch.fieldSpecs ?? [],
     description: savedSearch.description ?? '',
     grid: savedSearch.grid ?? {},
     hideChart: savedSearch.hideChart ?? false,

--- a/src/platform/plugins/shared/saved_search/common/types.ts
+++ b/src/platform/plugins/shared/saved_search/common/types.ts
@@ -49,6 +49,7 @@ export interface SavedSearchAttributes {
   title: string;
   sort: SortOrder[];
   columns: string[];
+  fieldSpecs: FieldSpec[];
   description: string;
   grid: DiscoverGridSettings;
   hideChart: boolean;

--- a/src/platform/plugins/shared/saved_search/common/types.ts
+++ b/src/platform/plugins/shared/saved_search/common/types.ts
@@ -8,6 +8,7 @@
  */
 
 import type {
+  FieldSpec,
   ISearchSource,
   RefreshInterval,
   SerializedSearchSourceFields,
@@ -104,6 +105,8 @@ export interface DiscoverSessionTab {
   label: string;
   sort: SortOrder[];
   columns: string[];
+  // Cached field specs for the columns
+  fieldSpecs?: FieldSpec[];
   grid: DiscoverGridSettings;
   hideChart: boolean;
   isTextBasedQuery: boolean;

--- a/src/platform/plugins/shared/saved_search/public/plugin.ts
+++ b/src/platform/plugins/shared/saved_search/public/plugin.ts
@@ -134,7 +134,7 @@ export class SavedSearchPublicPlugin
   public start(
     _: CoreStart,
     {
-      data: { search },
+      data: { search, dataViews },
       spaces,
       savedObjectsTaggingOss,
       contentManagement: { client: contentManagement },
@@ -169,7 +169,7 @@ export class SavedSearchPublicPlugin
       },
       saveDiscoverSession: async (discoverSession, options) => {
         const service = await getSavedSearchesService(deps);
-        return service.saveDiscoverSession(discoverSession, options);
+        return service.saveDiscoverSession(discoverSession, options, dataViews);
       },
       checkForDuplicateTitle: async (props) => {
         const service = await getSavedSearchesService(deps);

--- a/src/platform/plugins/shared/saved_search/public/service/saved_searches_service.ts
+++ b/src/platform/plugins/shared/saved_search/public/service/saved_searches_service.ts
@@ -92,14 +92,16 @@ export class SavedSearchesService {
 
   saveDiscoverSession = (
     discoverSession: SaveDiscoverSessionParams,
-    options: SaveDiscoverSessionOptions = {}
+    options: SaveDiscoverSessionOptions = {},
+    dataViews: DataPublicPluginStart['dataViews']
   ) => {
     const { contentManagement, savedObjectsTaggingOss } = this.deps;
     return saveDiscoverSession(
       discoverSession,
       options,
       contentManagement,
-      savedObjectsTaggingOss?.getTaggingApi()
+      savedObjectsTaggingOss?.getTaggingApi(),
+      dataViews
     );
   };
 

--- a/src/platform/plugins/shared/saved_search/server/content_management/saved_search_storage.ts
+++ b/src/platform/plugins/shared/saved_search/server/content_management/saved_search_storage.ts
@@ -36,6 +36,7 @@ export class SavedSearchStorage extends SOContentStorage<SavedSearchCrudTypes> {
         'title',
         'sort',
         'columns',
+        'fieldSpecs',
         'description',
         'grid',
         'hideChart',

--- a/src/platform/plugins/shared/saved_search/server/saved_objects/schema.ts
+++ b/src/platform/plugins/shared/saved_search/server/saved_objects/schema.ts
@@ -22,6 +22,7 @@ const SCHEMA_SEARCH_BASE = schema.object({
 
   // Data grid
   columns: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  fieldSpecs: schema.arrayOf(schema.any(), { defaultValue: [] }),
   sort: schema.oneOf(
     [
       schema.arrayOf(schema.arrayOf(schema.string(), { maxSize: 2 })),

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
@@ -244,7 +244,25 @@ export function loadEmbeddableData(
         getExecutionContext,
         logError: getLogError(getExecutionContext),
         addUserMessages,
-        onRender,
+        onRender: (count) => {
+          performance.mark('render_complete');
+          performance.measure('time_to_request', 'navigate', 'search_start');
+          performance.measure('time_to_data', 'search_start', 'search_end');
+          performance.measure('time_to_render', 'search_end', 'render_complete');
+
+          // Print performance measures to console
+          const timeToRequest = performance.getEntriesByName('time_to_request')[0];
+          const timeToData = performance.getEntriesByName('time_to_data')[0];
+          const timeToRender = performance.getEntriesByName('time_to_render')[0];
+
+          console.log('Performance Measures:', {
+            time_to_request: timeToRequest ? `${timeToRequest.duration.toFixed(2)}ms` : 'N/A',
+            time_to_data: timeToData ? `${timeToData.duration.toFixed(2)}ms` : 'N/A',
+            time_to_render: timeToRender ? `${timeToRender.duration.toFixed(2)}ms` : 'N/A',
+          });
+
+          onRender?.(count);
+        },
         onData,
         handleEvent,
         disableTriggers,

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/update_data_views.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/update_data_views.ts
@@ -6,20 +6,22 @@
  */
 
 import { uniqBy } from 'lodash';
-import type { LensRuntimeState } from '@kbn/lens-common';
+import type { IndexPatternField, LensRuntimeState } from '@kbn/lens-common';
 import { getIndexPatternsObjects } from '../../utils';
 import type { LensEmbeddableStartServices } from '../types';
 
 export async function getUsedDataViews(
   references: LensRuntimeState['attributes']['references'],
   adHocDataViewsSpecs: LensRuntimeState['attributes']['state']['adHocDataViews'],
-  dataViews: LensEmbeddableStartServices['dataViews']
+  dataViews: LensEmbeddableStartServices['dataViews'],
+  dataViewFields: Map<string, IndexPatternField[]>
 ) {
   const [{ indexPatterns }, ...adHocDataViews] = await Promise.all([
     getIndexPatternsObjects(
       // get index pattern only references
       references.filter(({ type }) => type === 'index-pattern').map(({ id }) => id),
-      dataViews
+      dataViews,
+      dataViewFields
     ),
 
     ...Object.values(adHocDataViewsSpecs ?? {}).map((spec) => dataViews.create(spec)),

--- a/x-pack/platform/plugins/shared/lens/public/utils.ts
+++ b/x-pack/platform/plugins/shared/lens/public/utils.ts
@@ -34,6 +34,7 @@ import type {
   DatasourceStates,
   VisualizationState,
   TriggerEvent,
+  IndexPatternField,
 } from '@kbn/lens-common';
 import {
   isOperation,
@@ -225,9 +226,12 @@ export function getIndexPatternsIds({
 
 export async function getIndexPatternsObjects(
   ids: string[],
-  dataViews: DataViewsContract
+  dataViews: DataViewsContract,
+  dataViewFields?: Map<string, IndexPatternField[]>
 ): Promise<{ indexPatterns: DataView[]; rejectedIds: string[] }> {
-  const responses = await Promise.allSettled(ids.map((id) => dataViews.get(id)));
+  const responses = await Promise.allSettled(
+    ids.map((id) => dataViews.get(id, undefined, undefined, dataViewFields?.get(id)))
+  );
   const fullfilled = responses.filter(
     (response): response is PromiseFulfilledResult<DataView> => response.status === 'fulfilled'
   );

--- a/x-pack/platform/plugins/shared/lens/server/content_management/lens_storage.ts
+++ b/x-pack/platform/plugins/shared/lens/server/content_management/lens_storage.ts
@@ -66,6 +66,7 @@ export class LensStorage extends SOContentStorage<LensCrud> {
         'title',
         'description',
         'visualizationType',
+        'fieldSpecs',
         'version',
         'state',
       ],

--- a/x-pack/platform/plugins/shared/lens/server/content_management/v1/schema/common.ts
+++ b/x-pack/platform/plugins/shared/lens/server/content_management/v1/schema/common.ts
@@ -19,6 +19,7 @@ export const lensItemAttributesSchema = schema.object(
     state: schema.maybe(schema.any()),
     // TODO make version required
     version: schema.maybe(schema.literal(LENS_ITEM_VERSION)), // pin version explicitly
+    fieldSpecs: schema.maybe(schema.arrayOf(schema.object({}))),
   },
   { unknowns: 'forbid' }
 );


### PR DESCRIPTION
## Summary

In this PoC the field specs that panels depend on are cached in the state of each panel, removing the need to load any field information through the `fields` endpoint when the dashboard loads.

**Discover session** — all fields this panel depends on are cached on the `search` saved object. Then, they are used to hydrate the data view.

**Lens**  — all fields for all data views in the layers cached on the `lens` saved object. Then, they are used to hydrate the Lens "IndexPattern" objects which the panel depends on.

<img width="2046" height="1042" alt="Screenshot 2025-11-10 at 2 02 45 PM" src="https://github.com/user-attachments/assets/a38f5ebe-09e3-4710-bf0c-e93b4d110c2c" />

