### PR TITLE
[9.1] [ResponseOps][Alerting] Set the `alerts` consumer as default in the stack mngt page (#240692)

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_definition.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_definition.tsx
@@ -126,12 +126,15 @@ export const RuleDefinition = () => {
     if (consumer !== ALERTING_FEATURE_ID) {
       return [];
     }
+
     const selectedAvailableRuleType = availableRuleTypes.find((ruleType) => {
       return ruleType.id === selectedRuleType.id;
     });
+
     if (!selectedAvailableRuleType?.authorizedConsumers) {
       return [];
     }
+
     return getAuthorizedConsumers({
       ruleType: selectedAvailableRuleType,
       validConsumers,

--- a/src/platform/packages/shared/response-ops/rule_form/src/translations.ts
+++ b/src/platform/packages/shared/response-ops/rule_form/src/translations.ts
@@ -191,6 +191,12 @@ export const FEATURE_NAME_MAP: Record<string, string> = {
       defaultMessage: 'Stack Rules',
     }
   ),
+  [AlertConsumers.ALERTS]: i18n.translate(
+    'responseOpsRuleForm.ruleForm.ruleFormConsumerSelection.alerts',
+    {
+      defaultMessage: 'All',
+    }
+  ),
 };
 
 export const CONSUMER_SELECT_COMBO_BOX_TITLE = i18n.translate(

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/get_app_menu.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/get_app_menu.tsx
@@ -115,13 +115,15 @@ const registerCustomThresholdRuleAction = (
               ruleTypeRegistry,
               actionTypeRegistry,
             }}
-            consumer={AlertConsumers.LOGS}
+            consumer={AlertConsumers.ALERTS}
             validConsumers={[
               AlertConsumers.LOGS,
               AlertConsumers.INFRASTRUCTURE,
               AlertConsumers.OBSERVABILITY,
               AlertConsumers.STACK_ALERTS,
+              AlertConsumers.ALERTS,
             ]}
+            multiConsumerSelection={AlertConsumers.ALERTS}
             ruleTypeId={OBSERVABILITY_THRESHOLD_RULE_TYPE_ID}
             initialValues={{
               params: {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_form/rule_form_route.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_form/rule_form_route.tsx
@@ -8,7 +8,7 @@
 import React, { useEffect } from 'react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { RuleForm } from '@kbn/response-ops-rule-form';
-import { getRuleDetailsRoute } from '@kbn/rule-data-utils';
+import { AlertConsumers, getRuleDetailsRoute } from '@kbn/rule-data-utils';
 import { useLocation, useParams } from 'react-router-dom';
 import { useKibana } from '../../../common/lib/kibana';
 import { getAlertingSectionBreadcrumb } from '../../lib/breadcrumb';
@@ -93,6 +93,7 @@ export const RuleFormRoute = () => {
             path: `insightsAndAlerting/triggersActions/${getRuleDetailsRoute(ruleId)}`,
           });
         }}
+        multiConsumerSelection={AlertConsumers.ALERTS}
       />
     </IntlProvider>
   );

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/rule_flyout_component.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/rule_flyout_component.tsx
@@ -12,7 +12,7 @@ import type { EsQueryRuleParams } from '@kbn/response-ops-rule-params/es_query';
 import { isValidRuleFormPlugins } from '@kbn/response-ops-rule-form/lib';
 import { ESQLControlVariable, apiPublishesESQLVariables } from '@kbn/esql-types';
 import { tracksOverlays } from '@kbn/presentation-containers';
-import { ES_QUERY_ID } from '@kbn/rule-data-utils';
+import { AlertConsumers, ES_QUERY_ID } from '@kbn/rule-data-utils';
 import React from 'react';
 import { ChartsPluginSetup } from '@kbn/charts-plugin/public';
 import { ContentManagementPublicStart } from '@kbn/content-management-plugin/public';
@@ -101,6 +101,7 @@ export async function getRuleFlyoutComponent(
         }}
         onCancel={closeRuleForm}
         onSubmit={closeRuleForm}
+        multiConsumerSelection={AlertConsumers.ALERTS}
       />
     </KibanaContextProvider>
   );

--- a/x-pack/solutions/observability/plugins/observability/common/constants.ts
+++ b/x-pack/solutions/observability/plugins/observability/common/constants.ts
@@ -30,6 +30,7 @@ export const observabilityAlertFeatureIds: ValidFeatureId[] = [
 export const observabilityRuleCreationValidConsumers: RuleCreationValidConsumer[] = [
   AlertConsumers.INFRASTRUCTURE,
   AlertConsumers.LOGS,
+  AlertConsumers.ALERTS,
 ];
 
 export const EventsAsUnit = 'events';

--- a/x-pack/solutions/observability/plugins/observability/public/pages/rules/rule.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/rules/rule.tsx
@@ -104,7 +104,7 @@ export function RulePage() {
         id={id}
         ruleTypeId={ruleTypeId}
         validConsumers={observabilityRuleCreationValidConsumers}
-        multiConsumerSelection={AlertConsumers.LOGS}
+        multiConsumerSelection={AlertConsumers.ALERTS}
         onCancel={() => {
           if (returnApp && returnPath) {
             application.navigateToApp(returnApp, { path: returnPath });

--- a/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/alerts/custom_threshold.ts
+++ b/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/alerts/custom_threshold.ts
@@ -231,7 +231,7 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
         expect.objectContaining({
           name: 'test custom threshold rule',
           tags: ['tag1'],
-          consumer: 'logs',
+          consumer: 'alerts',
           params: expect.objectContaining({
             alertOnGroupDisappear: false,
             alertOnNoData: false,

--- a/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/rules_page.ts
+++ b/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/rules_page.ts
@@ -239,9 +239,10 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
         const consumerOptions = await consumerOptionsList.findAllByClassName(
           'euiComboBoxOption__content'
         );
-        expect(consumerOptions.length).eql(2);
-        expect(await consumerOptions[0].getVisibleText()).eql('Metrics');
-        expect(await consumerOptions[1].getVisibleText()).eql('Logs');
+        expect(consumerOptions.length).eql(3);
+        expect(await consumerOptions[0].getVisibleText()).eql('All');
+        expect(await consumerOptions[1].getVisibleText()).eql('Metrics');
+        expect(await consumerOptions[2].getVisibleText()).eql('Logs');
       });
     });
 

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/rules/custom_threshold_consumer.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/rules/custom_threshold_consumer.ts
@@ -22,7 +22,13 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
   const samlAuth = getService('samlAuth');
   let roleAuthc: RoleCredentials;
 
-  function createCustomThresholdRule({ ruleName }: { ruleName: string }) {
+  function createCustomThresholdRule({
+    ruleName,
+    consumersToVerify,
+  }: {
+    ruleName: string;
+    consumersToVerify: Set<string>;
+  }) {
     it('navigates to the rules page', async () => {
       await retry.try(async () => {
         await svlCommonNavigation.sidenav.clickLink({ text: 'Alerts' });
@@ -50,6 +56,31 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       const input = await testSubjects.find('ruleDetailsNameInput');
       await input.clearValueWithKeyboard();
       await testSubjects.setValue('ruleDetailsNameInput', ruleName);
+
+      const consumerSelect = await testSubjects.find('ruleConsumerSelection');
+      await consumerSelect.click();
+
+      const consumerOptionsList = await testSubjects.find(
+        'comboBoxOptionsList ruleConsumerSelectionInput-optionsList'
+      );
+
+      const consumerOptions = await consumerOptionsList.findAllByClassName(
+        'euiComboBoxOption__content'
+      );
+
+      const allAvailableConsumers: Set<string> = new Set();
+
+      for (const option of consumerOptions) {
+        allAvailableConsumers.add(await option.getVisibleText());
+      }
+
+      // Check if sets are equal by verifying they have the same size and all elements match
+      const areConsumersEqual =
+        allAvailableConsumers.size === consumersToVerify.size &&
+        [...consumersToVerify].every((consumer) => allAvailableConsumers.has(consumer));
+
+      expect(areConsumersEqual).toBe(true);
+
       await retry.try(async () => {
         await testSubjects.click('rulePageFooterSaveButton');
         const doesConfirmModalExist = await testSubjects.exists('confirmModalConfirmButton');
@@ -101,15 +132,18 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await svlCommonPage.loginWithPrivilegedRole();
       });
 
-      createCustomThresholdRule({ ruleName });
+      createCustomThresholdRule({
+        ruleName,
+        consumersToVerify: new Set(['All', 'Logs', 'Metrics']),
+      });
 
-      it('should have logs consumer by default', async () => {
+      it('should have alerts consumer by default', async () => {
         const searchResults = (await alertingApi.searchRules(
           roleAuthc,
           `alert.attributes.name:"${ruleName}"`
         )) as { body: { data: Array<{ consumer: string; id: string }> } };
         const rule = searchResults.body.data[0];
-        expect(rule.consumer).toEqual('logs');
+        expect(rule.consumer).toEqual('alerts');
         ruleIdList.push(rule.id);
       });
     });
@@ -123,15 +157,15 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await svlCommonPage.loginWithCustomRole();
       });
 
-      createCustomThresholdRule({ ruleName });
+      createCustomThresholdRule({ ruleName, consumersToVerify: new Set(['All', 'Logs']) });
 
-      it('should have logs consumer by default', async () => {
+      it('should have alerts consumer by default', async () => {
         const searchResults = await alertingApi.searchRules(
           roleAuthc,
           `alert.attributes.name:"${ruleName}"`
         );
         const rule = searchResults.body.data[0];
-        expect(rule.consumer).toEqual('logs');
+        expect(rule.consumer).toEqual('alerts');
         ruleIdList.push(rule.id);
       });
     });
@@ -146,15 +180,15 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await svlCommonPage.loginWithCustomRole();
       });
 
-      createCustomThresholdRule({ ruleName });
+      createCustomThresholdRule({ ruleName, consumersToVerify: new Set(['All', 'Metrics']) });
 
-      it('should have infrastructure consumer by default', async () => {
+      it('should have alerts consumer by default', async () => {
         const searchResults = await alertingApi.searchRules(
           roleAuthc,
           `alert.attributes.name:"${ruleName}"`
         );
         const rule = searchResults.body.data[0];
-        expect(rule.consumer).toEqual('infrastructure');
+        expect(rule.consumer).toEqual('alerts');
         ruleIdList.push(rule.id);
       });
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ResponseOps][Alerting] Set the `alerts` consumer as default in the stack mngt page (#240692)](https://github.com/elastic/kibana/pull/240692)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Christos Nasikas","email":"christos.nasikas@elastic.co"},"sourceCommit":{"committedDate":"2025-11-04T17:14:58Z","message":"[ResponseOps][Alerting] Set the `alerts` consumer as default in the stack mngt page (#240692)\n\n## Summary\n\nThis PR sets the `alerts` consumer as the default when creating\nmulti-consumer rule types. This is a product decision, and the\nimplications are known.\n\n> [!IMPORTANT]  \n> This is not a breaking change. Users can still select the other\noptions.\n\n## Screenshot with the new option\n\n<img width=\"1145\" height=\"232\" alt=\"Screenshot 2025-10-25 at 1 38 21 PM\"\nsrc=\"https://github.com/user-attachments/assets/4dc44c30-724a-41df-947c-71868330583a\"\n/>\n\nFixes: https://github.com/elastic/rna-program/issues/48\nFixes: https://github.com/elastic/kibana/issues/238413\n\n\n## Testing instructions\n\nGo to stack management, o11y, discover, and ML, and check that the \"All\"\noption is shown for multi-consumer rule types (EsQuery, Custom\nthreshold, and Anomaly detection). Test different users with different\nfeature privileges. Test serverless.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: tommyers-elastic <106530686+tommyers-elastic@users.noreply.github.com>","sha":"d4f2f6512182059027cfae65bac1039ef9bcba94","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","ci:project-deploy-observability","Team:obs-ux-management","backport:version","v9.3.0","v8.19.7","v9.1.7","v9.2.1"],"title":"[ResponseOps][Alerting] Set the `alerts` consumer as default in the stack mngt page","number":240692,"url":"https://github.com/elastic/kibana/pull/240692","mergeCommit":{"message":"[ResponseOps][Alerting] Set the `alerts` consumer as default in the stack mngt page (#240692)\n\n## Summary\n\nThis PR sets the `alerts` consumer as the default when creating\nmulti-consumer rule types. This is a product decision, and the\nimplications are known.\n\n> [!IMPORTANT]  \n> This is not a breaking change. Users can still select the other\noptions.\n\n## Screenshot with the new option\n\n<img width=\"1145\" height=\"232\" alt=\"Screenshot 2025-10-25 at 1 38 21 PM\"\nsrc=\"https://github.com/user-attachments/assets/4dc44c30-724a-41df-947c-71868330583a\"\n/>\n\nFixes: https://github.com/elastic/rna-program/issues/48\nFixes: https://github.com/elastic/kibana/issues/238413\n\n\n## Testing instructions\n\nGo to stack management, o11y, discover, and ML, and check that the \"All\"\noption is shown for multi-consumer rule types (EsQuery, Custom\nthreshold, and Anomaly detection). Test different users with different\nfeature privileges. Test serverless.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: tommyers-elastic <106530686+tommyers-elastic@users.noreply.github.com>","sha":"d4f2f6512182059027cfae65bac1039ef9bcba94"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/240692","number":240692,"mergeCommit":{"message":"[ResponseOps][Alerting] Set the `alerts` consumer as default in the stack mngt page (#240692)\n\n## Summary\n\nThis PR sets the `alerts` consumer as the default when creating\nmulti-consumer rule types. This is a product decision, and the\nimplications are known.\n\n> [!IMPORTANT]  \n> This is not a breaking change. Users can still select the other\noptions.\n\n## Screenshot with the new option\n\n<img width=\"1145\" height=\"232\" alt=\"Screenshot 2025-10-25 at 1 38 21 PM\"\nsrc=\"https://github.com/user-attachments/assets/4dc44c30-724a-41df-947c-71868330583a\"\n/>\n\nFixes: https://github.com/elastic/rna-program/issues/48\nFixes: https://github.com/elastic/kibana/issues/238413\n\n\n## Testing instructions\n\nGo to stack management, o11y, discover, and ML, and check that the \"All\"\noption is shown for multi-consumer rule types (EsQuery, Custom\nthreshold, and Anomaly detection). Test different users with different\nfeature privileges. Test serverless.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: tommyers-elastic <106530686+tommyers-elastic@users.noreply.github.com>","sha":"d4f2f6512182059027cfae65bac1039ef9bcba94"}},{"branch":"8.19","label":"v8.19.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/241864","number":241864,"state":"MERGED","mergeCommit":{"sha":"717f12c972acc1ac6fe4668474a2bb2b9d5489ec","message":"[9.2] [ResponseOps][Alerting] Set the `alerts` consumer as default in the stack mngt page (#240692) (#241864)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[ResponseOps][Alerting] Set the `alerts` consumer as default in the\nstack mngt page\n(#240692)](https://github.com/elastic/kibana/pull/240692)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Christos Nasikas <christos.nasikas@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: tommyers-elastic <106530686+tommyers-elastic@users.noreply.github.com>"}}]}] BACKPORT-->