### PR TITLE
[OneWorkflow][PoC] registerStep

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,6 +45,7 @@ examples/unified_field_list_examples @elastic/kibana-data-discovery
 examples/unified_tabs_examples @elastic/kibana-data-discovery
 examples/user_profile_examples @elastic/kibana-security
 examples/v8_profiler_examples @elastic/response-ops
+examples/workflows_step_example @elastic/workflows-eng
 packages/kbn-babel-preset @elastic/kibana-operations
 packages/kbn-capture-oas-snapshot-cli @elastic/kibana-core
 packages/kbn-check-prod-native-modules-cli @elastic/kibana-operations

--- a/examples/workflows_step_example/README.md
+++ b/examples/workflows_step_example/README.md
@@ -1,0 +1,459 @@
+# Workflows Step Example Plugin
+
+This example plugin demonstrates how to register custom workflow step types using the `registerStepType` API. It provides a working implementation of a "setvar" step that allows workflows to define and use variables.
+
+## Overview
+
+The registerStep mechanism allows any Kibana plugin to extend workflows with custom step types. This provides:
+
+- **Extensibility**: Plugins can add domain-specific step types without modifying core workflows code
+- **Type Safety**: Zod schemas provide runtime validation and TypeScript types
+- **Reusability**: Custom steps can be used across multiple workflows
+- **Maintainability**: Clear separation between core engine and custom functionality
+
+## Architecture
+
+### How It Works
+
+1. **Registration (Setup Phase)**: Plugins call `workflowsExecutionEngine.registerStepType()` during their setup phase
+2. **Execution (Runtime)**: When a workflow runs, the execution engine checks if a step type is registered
+3. **Delegation**: If registered, it delegates execution to the custom step handler
+4. **Context Access**: Handlers receive a rich context with access to workflow state, variables, logging, etc.
+
+### Key Components
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Example Plugin (workflowsStepExample)                       │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ plugin.setup()                                          │ │
+│ │   └─> registerStepType(setvarStepDefinition)          │ │
+│ └─────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Workflows Execution Engine Plugin                          │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ StepTypeRegistry                                        │ │
+│ │   ├─> register(definition)                            │ │
+│ │   ├─> get(stepType)                                   │ │
+│ │   └─> has(stepType)                                   │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ NodesFactory                                            │ │
+│ │   └─> if registry.has(stepType)                       │ │
+│ │         return CustomStepImpl                          │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ CustomStepImpl (delegates to handler)                  │ │
+│ │   ├─> Validate input with inputSchema                 │ │
+│ │   ├─> Call handler(context)                           │ │
+│ │   └─> Validate output with outputSchema               │ │
+│ └─────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Example: Set Variable Step
+
+The `setvar` step allows workflows to define variables that can be accessed in subsequent steps.
+
+### Step Definition
+
+```typescript
+export const setvarStepDefinition: StepTypeDefinition = {
+  id: 'setvar',
+  title: 'Set Variable',
+  description: 'Define variables accessible throughout the workflow',
+  
+  inputSchema: z.object({
+    variables: z.record(z.string(), z.any())
+  }),
+  
+  outputSchema: z.object({
+    success: z.boolean(),
+    variablesSet: z.array(z.string())
+  }),
+  
+  handler: async (context) => {
+    const { variables } = context.input;
+    
+    for (const [key, value] of Object.entries(variables)) {
+      context.contextManager.setVariable(key, value);
+    }
+    
+    return {
+      output: {
+        success: true,
+        variablesSet: Object.keys(variables)
+      }
+    };
+  }
+};
+```
+
+### Usage in Workflow YAML
+
+```yaml
+name: Variable Example Workflow
+enabled: true
+steps:
+  # Set variables
+  - name: setVarStep
+    type: setvar
+    with:
+      variables:
+        x: 10
+        userName: "Alice"
+        apiBaseUrl: "https://api.example.com"
+        
+  # Use variables in subsequent steps
+  - name: fetchData
+    type: http
+    with:
+      url: "{{ variables.apiBaseUrl }}/users"
+      method: GET
+      body:
+        count: "{{ variables.x }}"
+        name: "{{ variables.userName }}"
+        
+  - name: processData
+    type: http
+    with:
+      url: "{{ variables.apiBaseUrl }}/process"
+      method: POST
+      body:
+        data: "{{ steps.fetchData.output.data }}"
+        multiplier: "{{ variables.x }}"
+```
+
+## Creating Your Own Custom Step Type
+
+### 1. Define Your Step Type
+
+Create a file `my_custom_step.ts`:
+
+```typescript
+import { z } from '@kbn/zod';
+import type { StepTypeDefinition } from '@kbn/workflows';
+
+export const myCustomStepDefinition: StepTypeDefinition = {
+  id: 'my_custom_step',
+  title: 'My Custom Step',
+  description: 'Does something custom',
+  
+  // Define what inputs your step accepts
+  inputSchema: z.object({
+    message: z.string(),
+    count: z.number().optional().default(1)
+  }),
+  
+  // Define what outputs your step produces
+  outputSchema: z.object({
+    result: z.string(),
+    timestamp: z.string()
+  }),
+  
+  // Optional: custom timeout
+  timeout: '5m',
+  
+  // Implement your step logic
+  handler: async (context) => {
+    const { message, count } = context.input;
+    
+    // Access workflow context
+    const workflowContext = await context.contextManager.getContext();
+    
+    // Use logging
+    context.logger.info(`Processing message: ${message}`);
+    
+    // Set variables for later steps
+    context.contextManager.setVariable('processedCount', count);
+    
+    // Do your custom logic here
+    const result = `${message} (repeated ${count} times)`;
+    
+    // Check for cancellation
+    if (context.abortSignal.aborted) {
+      return {
+        error: {
+          message: 'Step was cancelled'
+        }
+      };
+    }
+    
+    return {
+      output: {
+        result,
+        timestamp: new Date().toISOString()
+      }
+    };
+  }
+};
+```
+
+### 2. Register in Your Plugin
+
+In your plugin's `server/plugin.ts`:
+
+```typescript
+import type { WorkflowsExecutionEnginePluginSetup } from '@kbn/workflows-execution-engine-plugin/server';
+import { myCustomStepDefinition } from './step_types/my_custom_step';
+
+export interface MyPluginSetupDeps {
+  workflowsExecutionEngine: WorkflowsExecutionEnginePluginSetup;
+}
+
+export class MyPlugin implements Plugin {
+  setup(core, plugins: MyPluginSetupDeps) {
+    // Register your custom step type
+    plugins.workflowsExecutionEngine.registerStepType(myCustomStepDefinition);
+    
+    return {};
+  }
+}
+```
+
+### 3. Add to Plugin Dependencies
+
+In your `kibana.jsonc`:
+
+```jsonc
+{
+  "plugin": {
+    "id": "myPlugin",
+    "server": true,
+    "requiredPlugins": [
+      "workflowsExecutionEngine"  // Add this dependency
+    ]
+  }
+}
+```
+
+## Handler Context API
+
+The `context` object provided to your handler gives you access to:
+
+### Input & Context
+
+```typescript
+// Validated input from the workflow
+const { myParam } = context.input;
+
+// Access full workflow context
+const workflowContext = await context.contextManager.getContext();
+// workflowContext contains: workflow, execution, inputs, steps, variables, etc.
+
+// Evaluate template strings
+const evaluated = await context.contextManager.evaluateTemplate('{{ steps.prev.output.data }}');
+```
+
+### Variables
+
+```typescript
+// Set a variable (accessible as {{ variables.myVar }} in other steps)
+context.contextManager.setVariable('myVar', 'value');
+
+// Get a variable
+const value = context.contextManager.getVariable('myVar');
+```
+
+### Logging
+
+```typescript
+context.logger.debug('Debug message', { metadata });
+context.logger.info('Info message');
+context.logger.warn('Warning message');
+context.logger.error('Error message', { error });
+```
+
+### Cancellation Support
+
+```typescript
+// Check if step was cancelled
+if (context.abortSignal.aborted) {
+  return { error: { message: 'Cancelled' } };
+}
+
+// Listen for cancellation
+context.abortSignal.addEventListener('abort', () => {
+  // Clean up resources
+});
+```
+
+### Step Metadata
+
+```typescript
+context.stepId;    // Current step's ID
+context.stepType;  // Current step's type
+```
+
+## Best Practices
+
+### 1. Schema Design
+
+```typescript
+// ✅ Use descriptive schemas with defaults
+inputSchema: z.object({
+  url: z.string().url().describe('API endpoint URL'),
+  timeout: z.number().default(30).describe('Request timeout in seconds'),
+  retries: z.number().min(0).max(5).default(3)
+})
+
+// ❌ Avoid overly permissive schemas
+inputSchema: z.object({
+  config: z.any()  // Too loose, hard to validate
+})
+```
+
+### 2. Error Handling
+
+```typescript
+handler: async (context) => {
+  try {
+    // Your logic here
+    
+    return { output: { ... } };
+  } catch (error) {
+    context.logger.error('Step failed', { error });
+    
+    return {
+      error: {
+        message: error instanceof Error ? error.message : 'Unknown error',
+        details: { /* additional context */ }
+      }
+    };
+  }
+}
+```
+
+### 3. Validation
+
+```typescript
+// Input is automatically validated against inputSchema
+// But you can add business logic validation:
+handler: async (context) => {
+  const { url } = context.input;
+  
+  // Business rule validation
+  if (!url.startsWith('https://')) {
+    return {
+      error: {
+        message: 'Only HTTPS URLs are allowed'
+      }
+    };
+  }
+  
+  // ... proceed with logic
+}
+```
+
+### 4. Async Operations
+
+```typescript
+handler: async (context) => {
+  // Long-running operations should check for cancellation
+  for (let i = 0; i < largeDataset.length; i++) {
+    if (context.abortSignal.aborted) {
+      return { error: { message: 'Cancelled' } };
+    }
+    
+    await processItem(largeDataset[i]);
+  }
+  
+  return { output: { processed: true } };
+}
+```
+
+## Testing
+
+To test your custom step:
+
+1. **Start Kibana** with your plugin enabled
+2. **Create a test workflow** using your custom step type
+3. **Execute the workflow** and check the execution logs
+4. **Verify** that variables/outputs are accessible in subsequent steps
+
+Example test workflow:
+
+```yaml
+name: Test My Custom Step
+enabled: true
+steps:
+  - name: test_custom
+    type: my_custom_step
+    with:
+      message: "Hello World"
+      count: 3
+      
+  - name: verify_output
+    type: http
+    with:
+      url: "https://httpbin.org/post"
+      method: POST
+      body:
+        result: "{{ steps.test_custom.output.result }}"
+        timestamp: "{{ steps.test_custom.output.timestamp }}"
+```
+
+## Troubleshooting
+
+### Step type not found
+
+**Error**: `Unknown node type: my_step`
+
+**Solution**: Ensure your plugin is loaded and `registerStepType` is called during setup.
+
+### Input validation failed
+
+**Error**: `Input validation failed for step type "my_step"`
+
+**Solution**: Check that your workflow YAML matches the `inputSchema`. Use the Zod error message for details.
+
+### Variables not accessible
+
+**Error**: Variable shows as `undefined` in template expressions
+
+**Solution**: Ensure `setVariable` is called before the step that uses it. Variables are not persisted across workflow executions.
+
+## Advanced Topics
+
+### Accessing Elasticsearch
+
+```typescript
+handler: async (context) => {
+  const workflowContext = await context.contextManager.getContext();
+  const esClient = context.contextManager.getEsClientAsUser();
+  
+  const result = await esClient.search({
+    index: 'my-index',
+    body: { query: { match_all: {} } }
+  });
+  
+  return { output: { hits: result.hits.total } };
+}
+```
+
+### Template Evaluation
+
+```typescript
+// Evaluate template strings from config
+const url = await context.contextManager.evaluateTemplate(
+  '{{ variables.apiBase }}/{{ workflow.id }}'
+);
+```
+
+## Resources
+
+- **Architecture Decision**: See `register-step-mechanism.plan.md` for the full architectural rationale
+- **kbn-workflows Package**: Contains shared types (`StepTypeDefinition`, `StepHandlerContext`)
+- **Execution Engine**: `workflowsExecutionEngine` plugin handles the runtime execution
+
+## Questions?
+
+For questions or issues with the registerStep mechanism:
+
+1. Check existing patterns in `x-pack/platform/plugins/shared/actions` (registerType)
+2. Review `x-pack/platform/plugins/shared/alerting` (registerType, registerConnectorAdapter)
+3. Contact the @elastic/workflows-eng team
+

--- a/examples/workflows_step_example/kibana.jsonc
+++ b/examples/workflows_step_example/kibana.jsonc
@@ -1,0 +1,17 @@
+{
+  "type": "plugin",
+  "id": "@kbn/workflows-step-example-plugin",
+  "owner": ["@elastic/workflows-eng"],
+  "group": "platform",
+  "visibility": "private",
+  "description": "Example plugin demonstrating how to register custom workflow step types",
+  "plugin": {
+    "id": "workflowsStepExample",
+    "server": true,
+    "browser": false,
+    "requiredPlugins": [
+      "workflowsExecutionEngine"
+    ]
+  }
+}
+

--- a/examples/workflows_step_example/server/index.ts
+++ b/examples/workflows_step_example/server/index.ts
@@ -15,4 +15,3 @@ export function plugin(initializerContext: PluginInitializerContext) {
 }
 
 export type { WorkflowsStepExamplePluginSetup, WorkflowsStepExamplePluginStart } from './types';
-

--- a/examples/workflows_step_example/server/index.ts
+++ b/examples/workflows_step_example/server/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { PluginInitializerContext } from '@kbn/core/server';
+import { WorkflowsStepExamplePlugin } from './plugin';
+
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new WorkflowsStepExamplePlugin(initializerContext);
+}
+
+export type { WorkflowsStepExamplePluginSetup, WorkflowsStepExamplePluginStart } from './types';
+

--- a/examples/workflows_step_example/server/plugin.ts
+++ b/examples/workflows_step_example/server/plugin.ts
@@ -7,7 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { CoreSetup, CoreStart, Logger, Plugin, PluginInitializerContext } from '@kbn/core/server';
+import type {
+  CoreSetup,
+  CoreStart,
+  Logger,
+  Plugin,
+  PluginInitializerContext,
+} from '@kbn/core/server';
 import type {
   WorkflowsStepExamplePluginSetup,
   WorkflowsStepExamplePluginSetupDeps,
@@ -82,4 +88,3 @@ export class WorkflowsStepExamplePlugin
     this.logger.debug('WorkflowsStepExample: Stop');
   }
 }
-

--- a/examples/workflows_step_example/server/plugin.ts
+++ b/examples/workflows_step_example/server/plugin.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CoreSetup, CoreStart, Logger, Plugin, PluginInitializerContext } from '@kbn/core/server';
+import type {
+  WorkflowsStepExamplePluginSetup,
+  WorkflowsStepExamplePluginSetupDeps,
+  WorkflowsStepExamplePluginStart,
+  WorkflowsStepExamplePluginStartDeps,
+} from './types';
+import { setvarStepDefinition } from './step_types/setvar_step';
+
+/**
+ * Example plugin demonstrating how to register custom workflow step types.
+ *
+ * This plugin shows the registerStep mechanism in action by implementing
+ * a "setvar" step type that allows workflows to define and use variables.
+ *
+ * @example
+ * Other plugins can follow this pattern to add their own custom step types:
+ *
+ * ```typescript
+ * export class MyPlugin implements Plugin {
+ *   setup(core, plugins) {
+ *     plugins.workflowsExecutionEngine.registerStepType({
+ *       id: 'my_custom_step',
+ *       title: 'My Custom Step',
+ *       description: 'Does something custom',
+ *       inputSchema: z.object({ ... }),
+ *       outputSchema: z.object({ ... }),
+ *       handler: async (context) => { ... }
+ *     });
+ *   }
+ * }
+ * ```
+ */
+export class WorkflowsStepExamplePlugin
+  implements
+    Plugin<
+      WorkflowsStepExamplePluginSetup,
+      WorkflowsStepExamplePluginStart,
+      WorkflowsStepExamplePluginSetupDeps,
+      WorkflowsStepExamplePluginStartDeps
+    >
+{
+  private readonly logger: Logger;
+
+  constructor(initializerContext: PluginInitializerContext) {
+    this.logger = initializerContext.logger.get();
+  }
+
+  public setup(
+    core: CoreSetup<WorkflowsStepExamplePluginStartDeps, WorkflowsStepExamplePluginStart>,
+    plugins: WorkflowsStepExamplePluginSetupDeps
+  ): WorkflowsStepExamplePluginSetup {
+    this.logger.info('WorkflowsStepExample: Setup');
+
+    // Register the setvar step type
+    try {
+      plugins.workflowsExecutionEngine.registerStepType(setvarStepDefinition);
+      this.logger.info('Successfully registered "setvar" step type');
+    } catch (error) {
+      this.logger.error('Failed to register "setvar" step type', error);
+      throw error;
+    }
+
+    return {};
+  }
+
+  public start(core: CoreStart): WorkflowsStepExamplePluginStart {
+    this.logger.debug('WorkflowsStepExample: Start');
+    return {};
+  }
+
+  public stop() {
+    this.logger.debug('WorkflowsStepExample: Stop');
+  }
+}
+

--- a/examples/workflows_step_example/server/step_types/setvar_step.ts
+++ b/examples/workflows_step_example/server/step_types/setvar_step.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { z } from '@kbn/zod';
+import type { StepTypeDefinition } from '@kbn/workflows';
+
+/**
+ * Set Variable Step
+ *
+ * This step type allows users to define variables that can be accessed
+ * throughout the workflow using {{ variables.variableName }} syntax.
+ *
+ * Example usage in workflow YAML:
+ * ```yaml
+ * steps:
+ *   - name: setVarStep
+ *     type: setvar
+ *     with:
+ *       variables:
+ *         x: 10
+ *         userName: "Alice"
+ *         isActive: true
+ *
+ *   - name: useVariable
+ *     type: http
+ *     with:
+ *       url: "https://api.example.com/user"
+ *       body:
+ *         count: "{{ variables.x }}"
+ *         name: "{{ variables.userName }}"
+ * ```
+ */
+export const setvarStepDefinition: StepTypeDefinition = {
+  id: 'setvar',
+  title: 'Set Variable',
+  description:
+    'Define variables that can be accessed throughout the workflow via {{ variables.variableName }}',
+
+  // Input schema: accepts a record of variable names to values
+  inputSchema: z.object({
+    variables: z.record(z.string(), z.any()).describe('Variables to set in the workflow context'),
+  }),
+
+  // Output schema: returns success status and the variables that were set
+  outputSchema: z.object({
+    success: z.boolean(),
+    variablesSet: z.array(z.string()),
+  }),
+
+  // Handler function that sets the variables
+  handler: async (context) => {
+    try {
+      const { variables } = context.input;
+
+      // Set each variable in the workflow context
+      const variableNames: string[] = [];
+      for (const [key, value] of Object.entries(variables)) {
+        context.contextManager.setVariable(key, value);
+        variableNames.push(key);
+        context.logger.debug(`Set variable: ${key}`, { value });
+      }
+
+      context.logger.info(`Successfully set ${variableNames.length} variable(s)`, {
+        variables: variableNames,
+      });
+
+      return {
+        output: {
+          success: true,
+          variablesSet: variableNames,
+        },
+      };
+    } catch (error) {
+      context.logger.error('Failed to set variables', { error });
+      return {
+        error: {
+          message: error instanceof Error ? error.message : 'Failed to set variables',
+          details: error,
+        },
+      };
+    }
+  },
+};
+

--- a/examples/workflows_step_example/server/step_types/setvar_step.ts
+++ b/examples/workflows_step_example/server/step_types/setvar_step.ts
@@ -58,7 +58,7 @@ export const setvarStepDefinition: StepTypeDefinition = {
   documentation: {
     summary: 'Store values in step state for use throughout the workflow',
     details:
-      'Variables are stored in the step\'s persistent state and can be accessed in subsequent steps using `{{ steps.stepName.variableName }}` syntax.',
+      "Variables are stored in the step's persistent state and can be accessed in subsequent steps using `{{ steps.stepName.variableName }}` syntax.",
     examples: [
       `- name: setVarStep
   type: setvar
@@ -109,4 +109,3 @@ export const setvarStepDefinition: StepTypeDefinition = {
     }
   },
 };
-

--- a/examples/workflows_step_example/server/types.ts
+++ b/examples/workflows_step_example/server/types.ts
@@ -21,4 +21,3 @@ export interface WorkflowsStepExamplePluginSetupDeps {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface WorkflowsStepExamplePluginStartDeps {}
-

--- a/examples/workflows_step_example/server/types.ts
+++ b/examples/workflows_step_example/server/types.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { WorkflowsExecutionEnginePluginSetup } from '@kbn/workflows-execution-engine-plugin/server';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface WorkflowsStepExamplePluginSetup {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface WorkflowsStepExamplePluginStart {}
+
+export interface WorkflowsStepExamplePluginSetupDeps {
+  workflowsExecutionEngine: WorkflowsExecutionEnginePluginSetup;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface WorkflowsStepExamplePluginStartDeps {}
+

--- a/examples/workflows_step_example/tsconfig.json
+++ b/examples/workflows_step_example/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types"
+  },
+  "include": [
+    "server/**/*"
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/core",
+    "@kbn/zod",
+    "@kbn/workflows",
+    "@kbn/workflows-execution-engine-plugin"
+  ]
+}
+

--- a/examples/workflows_step_example/tsconfig.json
+++ b/examples/workflows_step_example/tsconfig.json
@@ -13,7 +13,6 @@
     "@kbn/core",
     "@kbn/zod",
     "@kbn/workflows",
-    "@kbn/workflows-execution-engine-plugin"
   ]
 }
 

--- a/package.json
+++ b/package.json
@@ -1148,6 +1148,7 @@
     "@kbn/workflows": "link:src/platform/packages/shared/kbn-workflows",
     "@kbn/workflows-execution-engine": "link:src/platform/plugins/shared/workflows_execution_engine",
     "@kbn/workflows-management-plugin": "link:src/platform/plugins/shared/workflows_management",
+    "@kbn/workflows-step-example-plugin": "link:examples/workflows_step_example",
     "@kbn/workplace-ai-app": "link:x-pack/solutions/workplaceai/plugins/workplace_ai_app",
     "@kbn/xstate-utils": "link:src/platform/packages/shared/kbn-xstate-utils",
     "@kbn/zod": "link:src/platform/packages/shared/kbn-zod",

--- a/src/platform/packages/shared/kbn-workflows/common/step_registry_types.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/step_registry_types.ts
@@ -46,6 +46,27 @@ export interface StepHandlerContext {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getVariable(key: string): any;
+
+    /**
+     * Set the persistent state for this step.
+     * State is persisted and accessible in subsequent steps via {{ steps.stepName.key }}
+     * This allows custom steps to store data that can be referenced later in the workflow.
+     * 
+     * @example
+     * // In a setvar step:
+     * context.contextManager.setStepState({ x: 10, userName: "Alice" });
+     * 
+     * // In a later step, access via:
+     * // {{ steps.setVarStep.x }} or {{ steps.setVarStep.userName }}
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setStepState(state: Record<string, any>): Promise<void>;
+
+    /**
+     * Get the current persistent state for this step
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getStepState(): Record<string, any> | undefined;
   };
 
   /**
@@ -144,5 +165,42 @@ export interface StepTypeDefinition {
    * If not specified, uses workflow-level or default timeout
    */
   timeout?: string;
+
+  /**
+   * Optional documentation/help configuration for the UI
+   * This controls what users see when hovering over the step in the editor
+   */
+  documentation?: {
+    /**
+     * Short summary shown in hover (one line)
+     * @example "Define variables accessible throughout the workflow"
+     */
+    summary?: string;
+
+    /**
+     * Detailed description with usage examples (markdown supported)
+     * @example "This step allows you to set variables that can be accessed in subsequent steps via `{{ steps.stepName.variableName }}`"
+     */
+    details?: string;
+
+    /**
+     * External documentation URL
+     * @example "https://docs.example.com/custom-steps/setvar"
+     */
+    url?: string;
+
+    /**
+     * Usage examples in YAML format
+     * @example
+     * ```yaml
+     * - name: myStep
+     *   type: setvar
+     *   with:
+     *     variables:
+     *       x: 10
+     * ```
+     */
+    examples?: string[];
+  };
 }
 

--- a/src/platform/packages/shared/kbn-workflows/common/step_registry_types.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/step_registry_types.ts
@@ -51,11 +51,11 @@ export interface StepHandlerContext {
      * Set the persistent state for this step.
      * State is persisted and accessible in subsequent steps via {{ steps.stepName.key }}
      * This allows custom steps to store data that can be referenced later in the workflow.
-     * 
+     *
      * @example
      * // In a setvar step:
      * context.contextManager.setStepState({ x: 10, userName: "Alice" });
-     * 
+     *
      * // In a later step, access via:
      * // {{ steps.setVarStep.x }} or {{ steps.setVarStep.userName }}
      */
@@ -203,4 +203,3 @@ export interface StepTypeDefinition {
     examples?: string[];
   };
 }
-

--- a/src/platform/packages/shared/kbn-workflows/common/step_registry_types.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/step_registry_types.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ZodSchema } from '@kbn/zod';
+
+/**
+ * Context provided to custom step handlers during execution.
+ * This gives access to runtime services needed for step execution.
+ */
+export interface StepHandlerContext {
+  /**
+   * The validated input provided to the step based on inputSchema
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  input: any;
+
+  /**
+   * Runtime context manager for accessing workflow state, context, and template evaluation
+   */
+  contextManager: {
+    /**
+     * Get the full workflow context including inputs, steps, env, and variables
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getContext(): Promise<Record<string, any>>;
+
+    /**
+     * Evaluate a template string using the workflow context
+     */
+    evaluateTemplate(template: string): Promise<string>;
+
+    /**
+     * Set a variable in the workflow context
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setVariable(key: string, value: any): void;
+
+    /**
+     * Get a variable from the workflow context
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getVariable(key: string): any;
+  };
+
+  /**
+   * Logger scoped to this step execution
+   */
+  logger: {
+    debug(message: string, meta?: object): void;
+    info(message: string, meta?: object): void;
+    warn(message: string, meta?: object): void;
+    error(message: string, meta?: object): void;
+  };
+
+  /**
+   * Abort signal for cancellation support
+   */
+  abortSignal: AbortSignal;
+
+  /**
+   * Current step's ID
+   */
+  stepId: string;
+
+  /**
+   * Current step's type
+   */
+  stepType: string;
+}
+
+/**
+ * Result returned by a custom step handler
+ */
+export interface StepHandlerResult {
+  /**
+   * Output data from the step execution
+   * This will be available to subsequent steps via template expressions
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  output?: any;
+
+  /**
+   * Optional error information if the step failed
+   */
+  error?: {
+    message: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    details?: any;
+  };
+}
+
+/**
+ * Handler function signature for custom step types
+ */
+export type StepHandler = (context: StepHandlerContext) => Promise<StepHandlerResult>;
+
+/**
+ * Definition of a custom step type that can be registered
+ */
+export interface StepTypeDefinition {
+  /**
+   * Unique identifier for this step type (e.g., 'setvar', 'custom_http')
+   * This will be used in workflow YAML as the step type
+   */
+  id: string;
+
+  /**
+   * Human-readable title for the step type
+   */
+  title: string;
+
+  /**
+   * Optional detailed description of what this step does
+   */
+  description?: string;
+
+  /**
+   * Zod schema defining the expected input structure for this step
+   * Input will be validated against this schema before handler execution
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  inputSchema: ZodSchema<any>;
+
+  /**
+   * Zod schema defining the output structure from this step
+   * This helps document what data subsequent steps can access
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  outputSchema: ZodSchema<any>;
+
+  /**
+   * The handler function that executes this step's logic
+   */
+  handler: StepHandler;
+
+  /**
+   * Optional timeout for this step type (e.g., '5m', '30s')
+   * If not specified, uses workflow-level or default timeout
+   */
+  timeout?: string;
+}
+

--- a/src/platform/packages/shared/kbn-workflows/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/index.ts
@@ -17,6 +17,7 @@ export * from './common/privileges';
 export * from './common/elasticsearch_request_builder';
 export * from './common/kibana_request_builder';
 export * from './common/connector_utils';
+export * from './common/step_registry_types';
 
 // Export specific types that are commonly used
 export type { BuiltInStepType, TriggerType } from './spec/schema';

--- a/src/platform/packages/shared/kbn-workflows/spec/lib/generate_yaml_schema_from_connectors.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/generate_yaml_schema_from_connectors.ts
@@ -49,7 +49,10 @@ function generateStepSchemaForRegisteredType(
 ) {
   return BaseStepSchema.extend({
     type: z.literal(registeredType.id),
-    with: z.record(z.string(), z.any()).optional().describe(registeredType.description || ''),
+    with: z
+      .record(z.string(), z.any())
+      .optional()
+      .describe(registeredType.description || ''),
     // Add common step properties
     if: z.string().optional(),
     foreach: z.string().optional(),

--- a/src/platform/packages/shared/kbn-workflows/spec/schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/schema.ts
@@ -431,14 +431,17 @@ export const WorkflowConstsSchema = z.record(
 
 const StepSchema = z.lazy(() =>
   z.union([
+    // Control flow steps
     ForEachStepSchema,
     IfStepSchema,
+    ParallelStepSchema,
+    MergeStepSchema,
+    // Built-in action steps
     WaitStepSchema,
     HttpStepSchema,
     ElasticsearchStepSchema,
     KibanaStepSchema,
-    ParallelStepSchema,
-    MergeStepSchema,
+    // Connector steps
     BaseConnectorStepSchema,
   ])
 );
@@ -470,9 +473,9 @@ export const WorkflowSchema = z.object({
 
 export type WorkflowYaml = z.infer<typeof WorkflowSchema>;
 
-// Schema is required for autocomplete because WorkflowGraph and WorkflowDefinition use it to build the autocomplete context.
-// The schema captures all possible fields and passes them through for consumption by WorkflowGraph.
-export const WorkflowSchemaForAutocomplete = WorkflowSchema.partial()
+// Lightweight schema for autocomplete - gracefully handles parsing errors
+// to enable building workflow graphs even with partial/invalid YAML
+export const WorkflowSchemaForAutocomplete: z.ZodType<any> = WorkflowSchema.partial()
   .extend({
     triggers: z
       .array(z.object({ type: z.string().catch('') }).passthrough())
@@ -550,6 +553,7 @@ export const WorkflowContextSchema = z.object({
     )
     .optional(),
   consts: z.record(z.string(), z.any()).optional(),
+  variables: z.record(z.string(), z.any()).optional(),
   now: z.date().optional(),
 });
 export type WorkflowContext = z.infer<typeof WorkflowContextSchema>;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/resume_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/resume_workflow.ts
@@ -15,10 +15,10 @@ import type { WorkflowsExecutionEngineConfig } from '../config';
 import type { LogsRepository } from '../repositories/logs_repository';
 import type { StepExecutionRepository } from '../repositories/step_execution_repository';
 import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import type { StepTypeRegistry } from '../step_type_registry';
 import type { WorkflowsExecutionEnginePluginStartDeps } from '../types';
 import type { ContextDependencies } from '../workflow_context_manager/types';
 import { workflowExecutionLoop } from '../workflow_execution_loop';
-import type { StepTypeRegistry } from '../step_type_registry';
 
 export async function resumeWorkflow({
   workflowRunId,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/resume_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/resume_workflow.ts
@@ -18,6 +18,7 @@ import type { WorkflowExecutionRepository } from '../repositories/workflow_execu
 import type { WorkflowsExecutionEnginePluginStartDeps } from '../types';
 import type { ContextDependencies } from '../workflow_context_manager/types';
 import { workflowExecutionLoop } from '../workflow_execution_loop';
+import type { StepTypeRegistry } from '../step_type_registry';
 
 export async function resumeWorkflow({
   workflowRunId,
@@ -34,6 +35,7 @@ export async function resumeWorkflow({
   logger,
   config,
   fakeRequest,
+  stepTypeRegistry,
 }: {
   workflowRunId: string;
   spaceId: string;
@@ -49,6 +51,7 @@ export async function resumeWorkflow({
   config: WorkflowsExecutionEngineConfig;
   fakeRequest: KibanaRequest;
   dependencies: ContextDependencies;
+  stepTypeRegistry: StepTypeRegistry;
 }): Promise<void> {
   const {
     workflowRuntime,
@@ -73,6 +76,7 @@ export async function resumeWorkflow({
     logsRepository,
     coreStart,
     dependencies,
+    stepTypeRegistry,
     fakeRequest // Provided by Task Manager's first-class API key support
   );
   await workflowRuntime.resume();

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow.ts
@@ -17,6 +17,7 @@ import type { WorkflowExecutionRepository } from '../repositories/workflow_execu
 import type { WorkflowsExecutionEnginePluginStartDeps } from '../types';
 import type { ContextDependencies } from '../workflow_context_manager/types';
 import { workflowExecutionLoop } from '../workflow_execution_loop';
+import type { StepTypeRegistry } from '../step_type_registry';
 
 export async function runWorkflow({
   workflowRunId,
@@ -33,6 +34,7 @@ export async function runWorkflow({
   config,
   fakeRequest,
   dependencies,
+  stepTypeRegistry,
 }: {
   workflowRunId: string;
   spaceId: string;
@@ -48,6 +50,7 @@ export async function runWorkflow({
   config: WorkflowsExecutionEngineConfig;
   fakeRequest: KibanaRequest;
   dependencies: ContextDependencies;
+  stepTypeRegistry: StepTypeRegistry;
 }): Promise<void> {
   const {
     workflowRuntime,
@@ -72,6 +75,7 @@ export async function runWorkflow({
     logsRepository,
     coreStart,
     dependencies,
+    stepTypeRegistry,
     fakeRequest // Provided by Task Manager's first-class API key support
   );
   await workflowRuntime.start();

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/run_workflow.ts
@@ -14,10 +14,10 @@ import type { WorkflowsExecutionEngineConfig } from '../config';
 import type { LogsRepository } from '../repositories/logs_repository';
 import type { StepExecutionRepository } from '../repositories/step_execution_repository';
 import type { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import type { StepTypeRegistry } from '../step_type_registry';
 import type { WorkflowsExecutionEnginePluginStartDeps } from '../types';
 import type { ContextDependencies } from '../workflow_context_manager/types';
 import { workflowExecutionLoop } from '../workflow_execution_loop';
-import type { StepTypeRegistry } from '../step_type_registry';
 
 export async function runWorkflow({
   workflowRunId,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.ts
@@ -45,6 +45,7 @@ export async function setupDependencies(
   logsRepository: LogsRepository,
   coreStart: CoreStart, // CoreStart for creating esClientAsUser
   dependencies: ContextDependencies,
+  stepTypeRegistry: import('../step_type_registry').StepTypeRegistry,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fakeRequest?: any // KibanaRequest from task manager
 ) {
@@ -136,7 +137,8 @@ export async function setupDependencies(
     workflowTaskManager,
     urlValidator,
     workflowExecutionGraph,
-    stepExecutionRuntimeFactory
+    stepExecutionRuntimeFactory,
+    stepTypeRegistry
   );
 
   return {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -33,6 +33,7 @@ import { resumeWorkflow, runWorkflow } from './execution_functions';
 import { LogsRepository } from './repositories/logs_repository';
 import { StepExecutionRepository } from './repositories/step_execution_repository';
 import { WorkflowExecutionRepository } from './repositories/workflow_execution_repository';
+import { StepTypeRegistry } from './step_type_registry';
 import type {
   ExecuteWorkflowStepResponse,
   WorkflowsExecutionEnginePluginSetup,
@@ -47,7 +48,6 @@ import type {
   StartWorkflowExecutionParams,
 } from './workflow_task_manager/types';
 import { createIndexes } from '../common';
-import { StepTypeRegistry } from './step_type_registry';
 
 type SetupDependencies = Pick<ContextDependencies, 'cloudSetup'>;
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -19,7 +19,11 @@ import type {
   Plugin,
   PluginInitializerContext,
 } from '@kbn/core/server';
-import type { EsWorkflowExecution, WorkflowExecutionEngineModel } from '@kbn/workflows';
+import type {
+  EsWorkflowExecution,
+  StepTypeDefinition,
+  WorkflowExecutionEngineModel,
+} from '@kbn/workflows';
 import { ExecutionStatus } from '@kbn/workflows';
 import { WorkflowExecutionNotFoundError } from '@kbn/workflows/common/errors';
 
@@ -121,7 +125,7 @@ export class WorkflowsExecutionEnginePlugin
                 logger,
                 fakeRequest: fakeRequest!,
                 dependencies,
-                stepTypeRegistry: pluginInstance.stepTypeRegistry,
+                stepTypeRegistry: this.stepTypeRegistry,
               });
             },
             cancel: async () => {
@@ -171,7 +175,7 @@ export class WorkflowsExecutionEnginePlugin
                 logger,
                 fakeRequest: fakeRequest!,
                 dependencies,
-                stepTypeRegistry: pluginInstance.stepTypeRegistry,
+                stepTypeRegistry: this.stepTypeRegistry,
               });
             },
             cancel: async () => {
@@ -183,7 +187,7 @@ export class WorkflowsExecutionEnginePlugin
     });
 
     return {
-      registerStepType: (definition) => {
+      registerStepType: (definition: StepTypeDefinition) => {
         this.stepTypeRegistry.register(definition);
       },
     };

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// TODO: Remove eslint exceptions comments and fix the issues
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { StepTypeDefinition, StepHandlerContext } from '@kbn/workflows';
+import type { AtomicGraphNode } from '@kbn/workflows/graph';
+import { BaseAtomicNodeImplementation, type RunStepResult } from './node_implementation';
+import type { StepExecutionRuntime } from '../workflow_context_manager/step_execution_runtime';
+import type { WorkflowExecutionRuntimeManager } from '../workflow_context_manager/workflow_execution_runtime_manager';
+import type { IWorkflowEventLogger } from '../workflow_event_logger/workflow_event_logger';
+import type { ConnectorExecutor } from '../connector_executor';
+
+/**
+ * Implementation for custom registered step types.
+ *
+ * This class executes custom step types registered via the registerStepType API.
+ * It validates input against the step's schema, executes the handler function,
+ * and validates the output.
+ */
+export class CustomStepImpl extends BaseAtomicNodeImplementation<any> {
+  constructor(
+    private node: AtomicGraphNode,
+    private stepDefinition: StepTypeDefinition,
+    stepExecutionRuntime: StepExecutionRuntime,
+    connectorExecutor: ConnectorExecutor,
+    workflowExecutionRuntime: WorkflowExecutionRuntimeManager,
+    private workflowLogger: IWorkflowEventLogger
+  ) {
+    // Convert node to BaseStep format for parent class
+    const baseStep = {
+      name: node.stepId,
+      type: node.stepType,
+      spaceId: '', // Will be available from context
+    };
+    super(baseStep, stepExecutionRuntime, connectorExecutor, workflowExecutionRuntime);
+  }
+
+  /**
+   * Get and validate the input for this step
+   */
+  public override async getInput(): Promise<any> {
+    const configuration = this.node.configuration;
+
+    // Evaluate templates in the configuration
+    const evaluatedConfig = this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(
+      configuration
+    );
+
+    // Validate input against the step's input schema
+    try {
+      const validatedInput = this.stepDefinition.inputSchema.parse(evaluatedConfig);
+      return validatedInput;
+    } catch (error) {
+      throw new Error(
+        `Input validation failed for step type "${this.stepDefinition.id}": ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  /**
+   * Execute the custom step handler
+   */
+  protected override async _run(input: any): Promise<RunStepResult> {
+    try {
+      // Create the handler context
+      const handlerContext: StepHandlerContext = {
+        input,
+        contextManager: {
+          getContext: async () => {
+            return this.stepExecutionRuntime.contextManager.getContext();
+          },
+          evaluateTemplate: async (template: string) => {
+            const result = this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(
+              template
+            );
+            return result;
+          },
+          setVariable: (key: string, value: any) => {
+            this.stepExecutionRuntime.contextManager.setVariable(key, value);
+          },
+          getVariable: (key: string) => {
+            return this.stepExecutionRuntime.contextManager.getVariable(key);
+          },
+        },
+        logger: {
+          debug: (message: string, meta?: object) => {
+            this.workflowLogger.debug(message, meta);
+          },
+          info: (message: string, meta?: object) => {
+            this.workflowLogger.info(message, meta);
+          },
+          warn: (message: string, meta?: object) => {
+            this.workflowLogger.warn(message, meta);
+          },
+          error: (message: string, meta?: object) => {
+            this.workflowLogger.error(message, meta);
+          },
+        },
+        abortSignal: this.stepExecutionRuntime.abortController.signal,
+        stepId: this.node.stepId,
+        stepType: this.node.stepType,
+      };
+
+      // Execute the handler
+      const result = await this.stepDefinition.handler(handlerContext);
+
+      // Check if handler returned an error
+      if (result.error) {
+        return {
+          input,
+          output: result.output,
+          error: result.error.message || 'Unknown error from custom step handler',
+        };
+      }
+
+      // Validate output against the step's output schema
+      let validatedOutput = result.output;
+      if (result.output !== undefined && result.output !== null) {
+        try {
+          validatedOutput = this.stepDefinition.outputSchema.parse(result.output);
+        } catch (error) {
+          throw new Error(
+            `Output validation failed for step type "${this.stepDefinition.id}": ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      }
+
+      return {
+        input,
+        output: validatedOutput,
+        error: undefined,
+      };
+    } catch (error) {
+      // Handle any unexpected errors
+      return {
+        input,
+        output: undefined,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}
+

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl.ts
@@ -10,13 +10,13 @@
 // TODO: Remove eslint exceptions comments and fix the issues
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { StepTypeDefinition, StepHandlerContext } from '@kbn/workflows';
+import type { StepHandlerContext, StepTypeDefinition } from '@kbn/workflows';
 import type { AtomicGraphNode } from '@kbn/workflows/graph';
 import { BaseAtomicNodeImplementation, type RunStepResult } from './node_implementation';
+import type { ConnectorExecutor } from '../connector_executor';
 import type { StepExecutionRuntime } from '../workflow_context_manager/step_execution_runtime';
 import type { WorkflowExecutionRuntimeManager } from '../workflow_context_manager/workflow_execution_runtime_manager';
 import type { IWorkflowEventLogger } from '../workflow_event_logger/workflow_event_logger';
-import type { ConnectorExecutor } from '../connector_executor';
 
 /**
  * Implementation for custom registered step types.
@@ -48,14 +48,13 @@ export class CustomStepImpl extends BaseAtomicNodeImplementation<any> {
    */
   public override async getInput(): Promise<any> {
     const configuration = this.node.configuration;
-    
+
     // Extract the 'with' property which contains the step inputs
     const withData = configuration.with || {};
 
     // Evaluate templates in the 'with' data
-    const evaluatedConfig = this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(
-      withData
-    );
+    const evaluatedConfig =
+      this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(withData);
 
     // Validate input against the step's input schema
     try {
@@ -83,9 +82,8 @@ export class CustomStepImpl extends BaseAtomicNodeImplementation<any> {
             return this.stepExecutionRuntime.contextManager.getContext();
           },
           evaluateTemplate: async (template: string) => {
-            const result = this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(
-              template
-            );
+            const result =
+              this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(template);
             return result;
           },
           setVariable: (key: string, value: any) => {
@@ -114,7 +112,12 @@ export class CustomStepImpl extends BaseAtomicNodeImplementation<any> {
           error: (message: string, meta?: object) => {
             // logError expects (message, error?, additionalData?)
             // If meta contains an error property, pass it as the error parameter
-            const errorObj = meta && typeof meta === 'object' && 'error' in meta ? (meta.error instanceof Error ? meta.error : undefined) : undefined;
+            const errorObj =
+              meta && typeof meta === 'object' && 'error' in meta
+                ? meta.error instanceof Error
+                  ? meta.error
+                  : undefined
+                : undefined;
             this.workflowLogger.logError(message, errorObj, meta);
           },
         },
@@ -164,4 +167,3 @@ export class CustomStepImpl extends BaseAtomicNodeImplementation<any> {
     }
   }
 }
-

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/nodes_factory.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/nodes_factory.ts
@@ -31,6 +31,7 @@ import {
   isExitWorkflowTimeoutZone,
 } from '@kbn/workflows/graph';
 import { AtomicStepImpl } from './atomic_step/atomic_step_impl';
+import { CustomStepImpl } from './custom_step_impl';
 import { ElasticsearchActionStepImpl } from './elasticsearch_action_step';
 import { EnterForeachNodeImpl, ExitForeachNodeImpl } from './foreach_step';
 import { HttpStepImpl } from './http_step';
@@ -62,13 +63,12 @@ import {
 import { WaitStepImpl } from './wait_step/wait_step';
 import type { ConnectorExecutor } from '../connector_executor';
 import type { UrlValidator } from '../lib/url_validator';
+import type { StepTypeRegistry } from '../step_type_registry';
 import type { StepExecutionRuntime } from '../workflow_context_manager/step_execution_runtime';
 import type { StepExecutionRuntimeFactory } from '../workflow_context_manager/step_execution_runtime_factory';
 import type { WorkflowExecutionRuntimeManager } from '../workflow_context_manager/workflow_execution_runtime_manager';
 import type { IWorkflowEventLogger } from '../workflow_event_logger/workflow_event_logger';
 import type { WorkflowTaskManager } from '../workflow_task_manager/workflow_task_manager';
-import type { StepTypeRegistry } from '../step_type_registry';
-import { CustomStepImpl } from './custom_step_impl';
 
 export class NodesFactory {
   constructor(

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step_type_registry.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step_type_registry.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { StepTypeDefinition } from '@kbn/workflows';
+import type { Logger } from '@kbn/core/server';
+
+/**
+ * Registry for custom workflow step types.
+ *
+ * This registry allows plugins to register custom step type implementations
+ * that can be used in workflows. It follows the same pattern as other Kibana
+ * registries (e.g., ActionTypeRegistry, RuleTypeRegistry).
+ *
+ * @example
+ * ```typescript
+ * const registry = new StepTypeRegistry(logger);
+ * registry.register({
+ *   id: 'custom_step',
+ *   title: 'Custom Step',
+ *   inputSchema: z.object({ value: z.string() }),
+ *   outputSchema: z.object({ result: z.string() }),
+ *   handler: async (context) => ({ output: { result: 'done' } })
+ * });
+ * ```
+ */
+export class StepTypeRegistry {
+  private readonly stepTypes = new Map<string, StepTypeDefinition>();
+  private readonly logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  /**
+   * Register a new custom step type.
+   *
+   * @param definition - The step type definition including id, schemas, and handler
+   * @throws Error if a step type with the same id is already registered
+   */
+  public register(definition: StepTypeDefinition): void {
+    if (this.stepTypes.has(definition.id)) {
+      throw new Error(
+        `Step type with id "${definition.id}" is already registered. Each step type must have a unique id.`
+      );
+    }
+
+    // Validate the definition
+    this.validateDefinition(definition);
+
+    this.stepTypes.set(definition.id, definition);
+    this.logger.debug(`Registered custom step type: ${definition.id}`);
+  }
+
+  /**
+   * Get a registered step type by id.
+   *
+   * @param id - The step type id
+   * @returns The step type definition, or undefined if not found
+   */
+  public get(id: string): StepTypeDefinition | undefined {
+    return this.stepTypes.get(id);
+  }
+
+  /**
+   * Check if a step type is registered.
+   *
+   * @param id - The step type id
+   * @returns true if the step type is registered
+   */
+  public has(id: string): boolean {
+    return this.stepTypes.has(id);
+  }
+
+  /**
+   * Get all registered step type ids.
+   *
+   * @returns Array of registered step type ids
+   */
+  public getAllIds(): string[] {
+    return Array.from(this.stepTypes.keys());
+  }
+
+  /**
+   * Get all registered step type definitions.
+   *
+   * @returns Array of all registered step type definitions
+   */
+  public getAll(): StepTypeDefinition[] {
+    return Array.from(this.stepTypes.values());
+  }
+
+  /**
+   * Get metadata for all registered step types (without handler functions).
+   * This is useful for exposing step type information to the UI.
+   *
+   * @returns Array of step type metadata (id, title, description)
+   */
+  public getAllMetadata(): Array<{ id: string; title: string; description?: string }> {
+    return Array.from(this.stepTypes.values()).map((def) => ({
+      id: def.id,
+      title: def.title,
+      description: def.description,
+    }));
+  }
+
+  /**
+   * Validate a step type definition.
+   *
+   * @param definition - The step type definition to validate
+   * @throws Error if the definition is invalid
+   */
+  private validateDefinition(definition: StepTypeDefinition): void {
+    if (!definition.id || typeof definition.id !== 'string') {
+      throw new Error('Step type definition must have a valid "id" string property');
+    }
+
+    if (!definition.title || typeof definition.title !== 'string') {
+      throw new Error(`Step type "${definition.id}" must have a valid "title" string property`);
+    }
+
+    if (!definition.inputSchema) {
+      throw new Error(`Step type "${definition.id}" must have an "inputSchema" property`);
+    }
+
+    if (!definition.outputSchema) {
+      throw new Error(`Step type "${definition.id}" must have an "outputSchema" property`);
+    }
+
+    if (!definition.handler || typeof definition.handler !== 'function') {
+      throw new Error(`Step type "${definition.id}" must have a "handler" function`);
+    }
+
+    // Validate that id doesn't conflict with built-in step types
+    const reservedPrefixes = ['http', 'elasticsearch.', 'kibana.', 'wait'];
+    const isReserved = reservedPrefixes.some(
+      (prefix) => definition.id === prefix || definition.id.startsWith(prefix)
+    );
+
+    if (isReserved) {
+      throw new Error(
+        `Step type id "${definition.id}" uses a reserved prefix. ` +
+          `Custom step types cannot start with: ${reservedPrefixes.join(', ')}`
+      );
+    }
+  }
+}
+

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step_type_registry.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step_type_registry.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { StepTypeDefinition } from '@kbn/workflows';
 import type { Logger } from '@kbn/core/server';
+import type { StepTypeDefinition } from '@kbn/workflows';
 
 /**
  * Registry for custom workflow step types.
@@ -150,4 +150,3 @@ export class StepTypeRegistry {
     }
   }
 }
-

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -17,7 +17,7 @@ import type {
   TaskManagerSetupContract,
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
-import type { WorkflowExecutionEngineModel } from '@kbn/workflows';
+import type { WorkflowExecutionEngineModel, StepTypeDefinition } from '@kbn/workflows';
 
 export interface ExecuteWorkflowResponse {
   workflowExecutionId: string;
@@ -27,8 +27,31 @@ export interface ExecuteWorkflowStepResponse {
   workflowExecutionId: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface WorkflowsExecutionEnginePluginSetup {}
+export interface WorkflowsExecutionEnginePluginSetup {
+  /**
+   * Register a custom step type that can be used in workflows.
+   *
+   * @param definition - The step type definition including id, schemas, and handler
+   * @throws Error if a step type with the same id is already registered
+   *
+   * @example
+   * ```typescript
+   * setup(core, plugins) {
+   *   plugins.workflowsExecutionEngine.registerStepType({
+   *     id: 'custom_step',
+   *     title: 'Custom Step',
+   *     description: 'A custom step implementation',
+   *     inputSchema: z.object({ value: z.string() }),
+   *     outputSchema: z.object({ result: z.string() }),
+   *     handler: async (context) => {
+   *       return { output: { result: 'done' } };
+   *     }
+   *   });
+   * }
+   * ```
+   */
+  registerStepType(definition: StepTypeDefinition): void;
+}
 export interface WorkflowsExecutionEnginePluginStart {
   executeWorkflow(
     workflow: WorkflowExecutionEngineModel,
@@ -43,6 +66,12 @@ export interface WorkflowsExecutionEnginePluginStart {
   ): Promise<ExecuteWorkflowStepResponse>;
 
   cancelWorkflowExecution(workflowExecutionId: string, spaceId: string): Promise<void>;
+
+  /**
+   * Get all registered custom step types
+   * @returns Array of registered step type IDs with their metadata (id, title, description)
+   */
+  getRegisteredStepTypes(): Array<{ id: string; title: string; description?: string }>;
 }
 
 export interface WorkflowsExecutionEnginePluginSetupDeps {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -17,7 +17,7 @@ import type {
   TaskManagerSetupContract,
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
-import type { WorkflowExecutionEngineModel, StepTypeDefinition } from '@kbn/workflows';
+import type { StepTypeDefinition, WorkflowExecutionEngineModel } from '@kbn/workflows';
 
 export interface ExecuteWorkflowResponse {
   workflowExecutionId: string;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
@@ -41,6 +41,8 @@ export class WorkflowContextManager {
   private fakeRequest?: KibanaRequest;
   private coreStart?: CoreStart;
   private dependencies: ContextDependencies;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private variables: Record<string, any> = {};
 
   private stackFrames: StackFrame[];
   public readonly node: GraphNodeUnion;
@@ -215,7 +217,33 @@ export class WorkflowContextManager {
       consts: workflowExecution.workflowDefinition.consts || {},
       event: workflowExecution.context?.event,
       inputs: workflowExecution.context?.inputs,
+      variables: this.variables, // Add variables to context
     };
+  }
+
+  /**
+   * Set a variable in the workflow context.
+   * Variables are accessible throughout the workflow via {{ variables.variableName }}
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public setVariable(key: string, value: any): void {
+    this.variables[key] = value;
+  }
+
+  /**
+   * Get a variable from the workflow context.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public getVariable(key: string): any {
+    return this.variables[key];
+  }
+
+  /**
+   * Get all variables from the workflow context.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public getAllVariables(): Record<string, any> {
+    return { ...this.variables };
   }
 
   private enrichStepContextWithMockedData(stepContext: StepContext): void {

--- a/src/platform/plugins/shared/workflows_management/common/lib/yaml/parse_workflow_yaml_for_autocomplete.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/yaml/parse_workflow_yaml_for_autocomplete.ts
@@ -15,12 +15,7 @@ import { formatZodError } from '../zod/format_zod_error';
 
 export function parseWorkflowYamlForAutocomplete(
   yamlString: string
-):
-  | z.SafeParseReturnType<
-      z.input<typeof WorkflowSchemaForAutocomplete>,
-      z.output<typeof WorkflowSchemaForAutocomplete>
-    >
-  | { success: false; error: Error } {
+): z.SafeParseReturnType<any, any> | { success: false; error: Error } {
   const parseResult = parseYamlToJSONWithoutValidation(yamlString);
   if (!parseResult.success) {
     return {

--- a/src/platform/plugins/shared/workflows_management/common/lib/yaml/parse_workflow_yaml_for_autocomplete.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/yaml/parse_workflow_yaml_for_autocomplete.ts
@@ -15,6 +15,7 @@ import { formatZodError } from '../zod/format_zod_error';
 
 export function parseWorkflowYamlForAutocomplete(
   yamlString: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): z.SafeParseReturnType<any, any> | { success: false; error: Error } {
   const parseResult = parseYamlToJSONWithoutValidation(yamlString);
   if (!parseResult.success) {

--- a/src/platform/plugins/shared/workflows_management/common/schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/schema.ts
@@ -936,24 +936,28 @@ export function getAllConnectorsWithDynamic(
 
 // Dynamic schemas that include all connectors (static + Elasticsearch + dynamic)
 // These use lazy loading to keep large generated files out of the main bundle
-export const getWorkflowZodSchema = (dynamicConnectorTypes: Record<string, ConnectorTypeInfo>) => {
+export const getWorkflowZodSchema = (
+  dynamicConnectorTypes: Record<string, ConnectorTypeInfo>,
+  registeredStepTypes: Array<{ id: string; title: string; description?: string }> = []
+) => {
   const allConnectors = getAllConnectorsWithDynamic(dynamicConnectorTypes);
-  return generateYamlSchemaFromConnectors(allConnectors);
+  return generateYamlSchemaFromConnectors(allConnectors, registeredStepTypes);
 };
 export type WorkflowZodSchemaType = z.infer<ReturnType<typeof getWorkflowZodSchema>>;
 
 export const getWorkflowZodSchemaLoose = (
-  dynamicConnectorTypes: Record<string, ConnectorTypeInfo>
+  dynamicConnectorTypes: Record<string, ConnectorTypeInfo>,
+  registeredStepTypes: Array<{ id: string; title: string; description?: string }> = []
 ) => {
   const allConnectors = getAllConnectorsWithDynamic(dynamicConnectorTypes);
-  return generateYamlSchemaFromConnectors(allConnectors, true);
+  return generateYamlSchemaFromConnectors(allConnectors, registeredStepTypes, true);
 };
 export type WorkflowZodSchemaLooseType = z.infer<ReturnType<typeof getWorkflowZodSchemaLoose>>;
 
 // Legacy exports for backward compatibility - these will be deprecated
 // TODO: Remove these once all consumers are updated to use the lazy-loaded versions
-export const WORKFLOW_ZOD_SCHEMA = generateYamlSchemaFromConnectors(staticConnectors);
-export const WORKFLOW_ZOD_SCHEMA_LOOSE = generateYamlSchemaFromConnectors(staticConnectors, true);
+export const WORKFLOW_ZOD_SCHEMA = generateYamlSchemaFromConnectors(staticConnectors, []);
+export const WORKFLOW_ZOD_SCHEMA_LOOSE = generateYamlSchemaFromConnectors(staticConnectors, [], true);
 
 // Partially recreated from x-pack/platform/plugins/shared/alerting/server/connector_adapters/types.ts
 // TODO: replace with dynamic schema

--- a/src/platform/plugins/shared/workflows_management/common/schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/schema.ts
@@ -957,7 +957,11 @@ export type WorkflowZodSchemaLooseType = z.infer<ReturnType<typeof getWorkflowZo
 // Legacy exports for backward compatibility - these will be deprecated
 // TODO: Remove these once all consumers are updated to use the lazy-loaded versions
 export const WORKFLOW_ZOD_SCHEMA = generateYamlSchemaFromConnectors(staticConnectors, []);
-export const WORKFLOW_ZOD_SCHEMA_LOOSE = generateYamlSchemaFromConnectors(staticConnectors, [], true);
+export const WORKFLOW_ZOD_SCHEMA_LOOSE = generateYamlSchemaFromConnectors(
+  staticConnectors,
+  [],
+  true
+);
 
 // Partially recreated from x-pack/platform/plugins/shared/alerting/server/connector_adapters/types.ts
 // TODO: replace with dynamic schema

--- a/src/platform/plugins/shared/workflows_management/public/entities/registered_steps/model/use_registered_step_types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/registered_steps/model/use_registered_step_types.ts
@@ -11,4 +11,3 @@ import { useSelector } from 'react-redux';
 import { selectRegisteredStepTypes } from '../../workflows/store/workflow_detail/selectors';
 
 export const useRegisteredStepTypes = () => useSelector(selectRegisteredStepTypes);
-

--- a/src/platform/plugins/shared/workflows_management/public/entities/registered_steps/model/use_registered_step_types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/registered_steps/model/use_registered_step_types.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useSelector } from 'react-redux';
+import { selectRegisteredStepTypes } from '../../workflows/store/workflow_detail/selectors';
+
+export const useRegisteredStepTypes = () => useSelector(selectRegisteredStepTypes);
+

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/types.ts
@@ -16,6 +16,10 @@ import type { WorkflowLookup } from './utils/build_workflow_lookup';
 import type { WorkflowZodSchemaType } from '../../../../common/schema';
 import type { ConnectorsResponse } from '../../connectors/model/types';
 
+export interface RegisteredStepTypesResponse {
+  stepTypes: Array<{ id: string; title: string; description?: string }>;
+}
+
 export interface WorkflowDetailState {
   /** The yaml string used by the workflow yaml editor */
   yamlString: string;
@@ -33,6 +37,8 @@ export interface WorkflowDetailState {
   isTestModalOpen: boolean;
   /** The connectors data */
   connectors?: ConnectorsResponse;
+  /** The registered custom step types */
+  registeredStepTypes?: RegisteredStepTypesResponse;
   /** The schema for the workflow */
   schema: WorkflowZodSchemaType;
 }

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/selectors.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/selectors.ts
@@ -88,4 +88,8 @@ export const selectIsTestModalOpen = createSelector(
 );
 
 export const selectConnectors = createSelector(selectDetailState, (detail) => detail.connectors);
+export const selectRegisteredStepTypes = createSelector(
+  selectDetailState,
+  (detail) => detail.registeredStepTypes
+);
 export const selectSchema = createSelector(selectDetailState, (detail) => detail.schema);

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/slice.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/slice.ts
@@ -19,7 +19,8 @@ const initialState: WorkflowDetailState = {
   workflow: undefined,
   computed: undefined,
   connectors: undefined,
-  schema: getWorkflowZodSchema({}),
+  registeredStepTypes: undefined,
+  schema: getWorkflowZodSchema({}, []),
   focusedStepId: undefined,
   stepExecutions: undefined,
   highlightedStepId: undefined,
@@ -67,6 +68,12 @@ const workflowDetailSlice = createSlice({
     setConnectors: (state, action: { payload: WorkflowDetailState['connectors'] }) => {
       state.connectors = action.payload;
     },
+    setRegisteredStepTypes: (
+      state,
+      action: { payload: WorkflowDetailState['registeredStepTypes'] }
+    ) => {
+      state.registeredStepTypes = action.payload;
+    },
 
     // Internal actions - these are not for components usage
     _setComputedDataInternal: (state, action: { payload: ComputedData }) => {
@@ -94,6 +101,7 @@ export const {
   setHighlightedStepId,
   setIsTestModalOpen,
   setConnectors,
+  setRegisteredStepTypes,
 
   // Internal action creators for middleware use only
   _setComputedDataInternal,

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_connectors_thunk.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_connectors_thunk.ts
@@ -43,7 +43,9 @@ export const loadConnectorsThunk = createAsyncThunk<
       if (hasChanged) {
         addDynamicConnectorsToCache(currentConnectorTypes);
 
-        const schema = getWorkflowZodSchema(currentConnectorTypes);
+        // Get registered step types from state to pass to schema generation
+        const registeredStepTypes = state.detail.registeredStepTypes?.stepTypes ?? [];
+        const schema = getWorkflowZodSchema(currentConnectorTypes, registeredStepTypes);
         dispatch(_setGeneratedSchemaInternal(schema));
       }
 

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_registered_step_types_thunk.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_registered_step_types_thunk.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { i18n } from '@kbn/i18n';
+import { getWorkflowZodSchema } from '../../../../../../common/schema';
+import { setRegisteredStepTypes, _setGeneratedSchemaInternal } from '../slice';
+import type { RootState, RegisteredStepTypesResponse } from '../../types';
+import type { WorkflowsServices } from '../../../../../types';
+import { clearConnectorTypeSuggestionsCache } from '../../../../../widgets/workflow_yaml_editor/lib/autocomplete/suggestions/connector_type/get_connector_type_suggestions';
+
+export interface LoadRegisteredStepTypesParams {}
+
+export type LoadRegisteredStepTypesResponse = RegisteredStepTypesResponse;
+
+export const loadRegisteredStepTypesThunk = createAsyncThunk<
+  LoadRegisteredStepTypesResponse,
+  LoadRegisteredStepTypesParams,
+  { state: RootState; extra: { services: WorkflowsServices } }
+>(
+  'detail/loadRegisteredStepTypesThunk',
+  async (_, { getState, dispatch, rejectWithValue, extra: { services } }) => {
+    const { http, notifications } = services;
+    const state = getState();
+    const lastRegisteredStepTypes = state.detail.registeredStepTypes?.stepTypes;
+    try {
+      const response = await http.get<RegisteredStepTypesResponse>(
+        '/api/workflows/registered_step_types'
+      );
+      dispatch(setRegisteredStepTypes(response));
+
+      const currentRegisteredStepTypes = response.stepTypes;
+      // Simple check: compare the number of step types
+      const hasChanged =
+        !lastRegisteredStepTypes ||
+        currentRegisteredStepTypes.length !== lastRegisteredStepTypes.length ||
+        !currentRegisteredStepTypes.every((stepType) =>
+          lastRegisteredStepTypes.some((last) => last.id === stepType.id)
+        );
+
+      if (hasChanged) {
+        // Clear autocomplete cache so new step types appear in suggestions
+        clearConnectorTypeSuggestionsCache();
+        
+        // Get connectors from state to pass to schema generation
+        const connectorTypes = state.detail.connectors?.connectorTypes ?? {};
+        const schema = getWorkflowZodSchema(connectorTypes, currentRegisteredStepTypes);
+        dispatch(_setGeneratedSchemaInternal(schema));
+      }
+
+      return response;
+    } catch (error) {
+      // Extract error message from HTTP error body if available
+      const errorMessage =
+        error.body?.message || error.message || 'Failed to load registered step types';
+
+      notifications.toasts.addError(errorMessage, {
+        title: i18n.translate('workflows.detail.loadRegisteredStepTypes.error', {
+          defaultMessage: 'Failed to load registered step types',
+        }),
+      });
+      return rejectWithValue(errorMessage);
+    }
+  }
+);
+

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_registered_step_types_thunk.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/load_registered_step_types_thunk.ts
@@ -10,12 +10,12 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { i18n } from '@kbn/i18n';
 import { getWorkflowZodSchema } from '../../../../../../common/schema';
-import { setRegisteredStepTypes, _setGeneratedSchemaInternal } from '../slice';
-import type { RootState, RegisteredStepTypesResponse } from '../../types';
 import type { WorkflowsServices } from '../../../../../types';
 import { clearConnectorTypeSuggestionsCache } from '../../../../../widgets/workflow_yaml_editor/lib/autocomplete/suggestions/connector_type/get_connector_type_suggestions';
+import type { RegisteredStepTypesResponse, RootState } from '../../types';
+import { _setGeneratedSchemaInternal, setRegisteredStepTypes } from '../slice';
 
-export interface LoadRegisteredStepTypesParams {}
+export type LoadRegisteredStepTypesParams = Record<string, never>;
 
 export type LoadRegisteredStepTypesResponse = RegisteredStepTypesResponse;
 
@@ -47,7 +47,7 @@ export const loadRegisteredStepTypesThunk = createAsyncThunk<
       if (hasChanged) {
         // Clear autocomplete cache so new step types appear in suggestions
         clearConnectorTypeSuggestionsCache();
-        
+
         // Get connectors from state to pass to schema generation
         const connectorTypes = state.detail.connectors?.connectorTypes ?? {};
         const schema = getWorkflowZodSchema(connectorTypes, currentRegisteredStepTypes);
@@ -69,4 +69,3 @@ export const loadRegisteredStepTypesThunk = createAsyncThunk<
     }
   }
 );
-

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_steps_collection_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_steps_collection_schema.ts
@@ -45,10 +45,12 @@ export function getStepsCollectionSchema(
 
     if (!isEnterForeach(node)) {
       stepsSchema = stepsSchema.extend({
-        [node.stepId]: z.object({
-          output: getOutputSchemaForStepType(node.stepType).optional(),
-          error: z.any().optional(),
-        }),
+        [node.stepId]: z
+          .object({
+            output: getOutputSchemaForStepType(node.stepType).optional(),
+            error: z.any().optional(),
+          })
+          .passthrough(), // Allow additional properties from step state
       });
     } else {
       // if the step is a foreach, add the foreach schema to the step state schema

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_page.tsx
@@ -21,6 +21,7 @@ import { WorkflowDetailTestModal } from './workflow_detail_test_modal';
 import { setYamlString } from '../../../entities/workflows/store';
 import { selectWorkflowName } from '../../../entities/workflows/store/workflow_detail/selectors';
 import { loadConnectorsThunk } from '../../../entities/workflows/store/workflow_detail/thunks/load_connectors_thunk';
+import { loadRegisteredStepTypesThunk } from '../../../entities/workflows/store/workflow_detail/thunks/load_registered_step_types_thunk';
 import { loadWorkflowThunk } from '../../../entities/workflows/store/workflow_detail/thunks/load_workflow_thunk';
 import { WorkflowExecutionDetail } from '../../../features/workflow_execution_detail';
 import { WorkflowExecutionList } from '../../../features/workflow_execution_list/ui/workflow_execution_list_stateful';
@@ -31,11 +32,13 @@ import { useWorkflowUrlState } from '../../../hooks/use_workflow_url_state';
 export function WorkflowDetailPage({ id }: { id?: string }) {
   const dispatch = useDispatch();
   const loadConnectors = useAsyncThunk(loadConnectorsThunk);
+  const loadRegisteredStepTypes = useAsyncThunk(loadRegisteredStepTypesThunk);
   const [loadWorkflow, { isLoading, error }] = useAsyncThunkState(loadWorkflowThunk);
 
   useEffect(() => {
     loadConnectors(); // dispatch load connectors on mount
-  }, [loadConnectors]);
+    loadRegisteredStepTypes(); // dispatch load registered step types on mount
+  }, [loadConnectors, loadRegisteredStepTypes]);
 
   useEffect(() => {
     if (id) {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/context/autocomplete.types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/context/autocomplete.types.ts
@@ -30,6 +30,7 @@ export interface AutocompleteContext {
   path: (string | number)[];
   absoluteOffset: number;
   dynamicConnectorTypes: Record<string, ConnectorTypeInfo> | null;
+  registeredStepTypes: Array<{ id: string; title: string; description?: string }> | null;
   isInLiquidBlock: boolean;
   isInTriggersContext: boolean;
   isInScheduledTriggerWithBlock: boolean;

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/context/build_autocomplete_context.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/context/build_autocomplete_context.ts
@@ -40,6 +40,7 @@ export function buildAutocompleteContext({
 }: BuildAutocompleteContextParams): AutocompleteContext | null {
   // derived from workflow state
   const currentDynamicConnectorTypes = editorState?.connectors?.connectorTypes;
+  const registeredStepTypes = editorState?.registeredStepTypes?.stepTypes;
   const workflowGraph = editorState?.computed?.workflowGraph;
   const yamlDocument = editorState?.computed?.yamlDocument;
   const workflowLookup = editorState?.computed?.workflowLookup;
@@ -153,6 +154,7 @@ export function buildAutocompleteContext({
 
     // dynamic connector types
     dynamicConnectorTypes: currentDynamicConnectorTypes ?? null,
+    registeredStepTypes: registeredStepTypes ?? null,
 
     // formatting
     shouldUseCurlyBraces,

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/get_suggestions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/get_suggestions.ts
@@ -114,7 +114,8 @@ export function getSuggestions(
     return getConnectorTypeSuggestions(
       lineParseResult.fullKey,
       adjustedRange,
-      autocompleteContext.dynamicConnectorTypes
+      autocompleteContext.dynamicConnectorTypes,
+      autocompleteContext.registeredStepTypes ?? undefined
     );
   }
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/index.ts
@@ -13,4 +13,5 @@ export { BaseMonacoConnectorHandler } from './base_monaco_connector_handler';
 // Specific connector handlers
 export { ElasticsearchMonacoConnectorHandler } from './elasticsearch_connector_handler';
 export { KibanaMonacoConnectorHandler } from './kibana_monaco_connector_handler';
+export { RegisteredStepMonacoHandler } from './registered_step_monaco_handler';
 export { GenericMonacoConnectorHandler } from './generic_monaco_connector_handler';

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/registered_step_monaco_handler.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/registered_step_monaco_handler.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import type { StepTypeDefinition } from '@kbn/workflows';
+import type { ActionContext, HoverContext } from '../monaco_providers/provider_interfaces';
+import type { ActionInfo } from '../monaco_providers/types';
+import { BaseMonacoConnectorHandler } from './base_monaco_connector_handler';
+
+/**
+ * Handler for registered custom step types.
+ * Provides hover documentation and actions for steps registered via the registerStepType API.
+ */
+export class RegisteredStepMonacoHandler extends BaseMonacoConnectorHandler {
+  constructor(private registeredStepTypes: StepTypeDefinition[]) {
+    // Higher priority than generic handler (10) to catch registered steps first
+    super(15);
+  }
+
+  /**
+   * Check if this handler can handle the given connector type
+   */
+  canHandle(connectorType: string): boolean {
+    return this.registeredStepTypes.some((step) => step.id === connectorType);
+  }
+
+  /**
+   * Get the step definition for a given type
+   */
+  private getStepDefinition(connectorType: string): StepTypeDefinition | undefined {
+    return this.registeredStepTypes.find((step) => step.id === connectorType);
+  }
+
+  /**
+   * Generate hover content for registered custom steps
+   */
+  async generateHoverContent(context: HoverContext): Promise<monaco.IMarkdownString | null> {
+    try {
+      const { connectorType } = context;
+      const stepDef = this.getStepDefinition(connectorType);
+
+      if (!stepDef) {
+        return null;
+      }
+
+      const doc = stepDef.documentation;
+      const content: string[] = [];
+
+      // Title and Summary
+      content.push(`**${stepDef.title}**`);
+      content.push('');
+      
+      // Summary/Description (use documentation.summary if available, otherwise use description)
+      const summary = doc?.summary || stepDef.description;
+      if (summary) {
+        content.push(summary);
+        content.push('');
+      }
+
+      // Details
+      if (doc?.details) {
+        content.push(doc.details);
+        content.push('');
+      }
+
+      // Documentation URL
+      if (doc?.url) {
+        content.push(
+          `📖 **[View Documentation](${doc.url})** - Opens in new tab`
+        );
+        content.push('');
+      }
+
+      // Usage examples
+      if (doc?.examples && doc.examples.length > 0) {
+        content.push('### Examples');
+        content.push('');
+        for (const example of doc.examples) {
+          content.push('```yaml');
+          content.push(example);
+          content.push('```');
+          content.push('');
+        }
+      } else {
+        // Default example if none provided
+        content.push('### Usage');
+        content.push('```yaml');
+        content.push(`- name: myStep`);
+        content.push(`  type: ${stepDef.id}`);
+        content.push(`  with:`);
+        content.push(`    # Configure step parameters here`);
+        content.push('```');
+        content.push('');
+      }
+
+      // Tip
+      content.push('---');
+      content.push(
+        '_💡 Tip: Press Ctrl+Space (Ctrl+I on Mac) inside the "with:" block for parameter suggestions_'
+      );
+
+      return this.createMarkdownContent(content.join('\n'));
+    } catch (error) {
+      // console.warn('RegisteredStepMonacoHandler: Error generating hover content', error);
+      return null;
+    }
+  }
+
+  /**
+   * Generate actions for registered custom steps
+   */
+  async generateActions(context: ActionContext): Promise<ActionInfo[]> {
+    const actions: ActionInfo[] = [];
+    const { connectorType } = context;
+    const stepDef = this.getStepDefinition(connectorType);
+
+    if (!stepDef?.documentation?.url) {
+      return actions;
+    }
+
+    // Add documentation link action
+    actions.push({
+      id: 'view-docs',
+      icon: '📖',
+      label: 'View Documentation',
+      tooltip: 'Open step documentation in new tab',
+      callback: () => {
+        if (stepDef.documentation?.url) {
+          window.open(stepDef.documentation.url, '_blank', 'noopener,noreferrer');
+        }
+      },
+    });
+
+    return actions;
+  }
+}
+

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/registered_step_monaco_handler.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/registered_step_monaco_handler.ts
@@ -9,9 +9,9 @@
 
 import type * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import type { StepTypeDefinition } from '@kbn/workflows';
+import { BaseMonacoConnectorHandler } from './base_monaco_connector_handler';
 import type { ActionContext, HoverContext } from '../monaco_providers/provider_interfaces';
 import type { ActionInfo } from '../monaco_providers/types';
-import { BaseMonacoConnectorHandler } from './base_monaco_connector_handler';
 
 /**
  * Handler for registered custom step types.
@@ -55,7 +55,7 @@ export class RegisteredStepMonacoHandler extends BaseMonacoConnectorHandler {
       // Title and Summary
       content.push(`**${stepDef.title}**`);
       content.push('');
-      
+
       // Summary/Description (use documentation.summary if available, otherwise use description)
       const summary = doc?.summary || stepDef.description;
       if (summary) {
@@ -71,9 +71,7 @@ export class RegisteredStepMonacoHandler extends BaseMonacoConnectorHandler {
 
       // Documentation URL
       if (doc?.url) {
-        content.push(
-          `📖 **[View Documentation](${doc.url})** - Opens in new tab`
-        );
+        content.push(`📖 **[View Documentation](${doc.url})** - Opens in new tab`);
         content.push('');
       }
 
@@ -140,4 +138,3 @@ export class RegisteredStepMonacoHandler extends BaseMonacoConnectorHandler {
     return actions;
   }
 }
-

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_providers/unified_hover_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_providers/unified_hover_provider.ts
@@ -16,6 +16,8 @@ import type { HoverContext, ProviderConfig } from './provider_interfaces';
 import { getMonacoConnectorHandler } from './provider_registry';
 import { getPathAtOffset } from '../../../../../common/lib/yaml';
 import { isYamlValidationMarkerOwner } from '../../../../features/validate_workflow_yaml/model/types';
+import { getWorkflowsStore } from '../../../../entities/workflows/store/store';
+import { selectRegisteredStepTypes } from '../../../../entities/workflows/store/workflow_detail/selectors';
 
 /**
  * Unified hover provider that delegates to connector-specific handlers
@@ -206,6 +208,23 @@ export class UnifiedHoverProvider implements monaco.languages.HoverProvider {
       //   stepContext: context.stepContext,
       //   parameterContext: context.parameterContext,
       // });
+
+      // Check if this is a registered custom step type - if so, skip connector hover
+      // (Registered custom steps are not connectors, they're custom step implementations)
+      try {
+        const store = getWorkflowsStore();
+        const registeredStepTypes = selectRegisteredStepTypes(store.getState());
+        const isRegisteredCustomStep = registeredStepTypes?.stepTypes?.some(
+          (stepType) => stepType.id === context.connectorType
+        );
+        if (isRegisteredCustomStep) {
+          // console.log('UnifiedHoverProvider: Skipping hover for registered custom step:', context.connectorType);
+          return null;
+        }
+      } catch (error) {
+        // If we can't access the store, continue with connector hover as fallback
+        // console.warn('UnifiedHoverProvider: Could not check registered step types', error);
+      }
 
       // Find appropriate Monaco handler
       const handler = getMonacoConnectorHandler(context.connectorType);

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_providers/unified_hover_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_providers/unified_hover_provider.ts
@@ -15,9 +15,9 @@ import { monaco } from '@kbn/monaco';
 import type { HoverContext, ProviderConfig } from './provider_interfaces';
 import { getMonacoConnectorHandler } from './provider_registry';
 import { getPathAtOffset } from '../../../../../common/lib/yaml';
-import { isYamlValidationMarkerOwner } from '../../../../features/validate_workflow_yaml/model/types';
 import { getWorkflowsStore } from '../../../../entities/workflows/store/store';
 import { selectRegisteredStepTypes } from '../../../../entities/workflows/store/workflow_detail/selectors';
+import { isYamlValidationMarkerOwner } from '../../../../features/validate_workflow_yaml/model/types';
 
 /**
  * Unified hover provider that delegates to connector-specific handlers

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -35,6 +35,7 @@ import { WorkflowYAMLEditorShortcuts } from './workflow_yaml_editor_shortcuts';
 import { WorkflowYAMLValidationErrors } from './workflow_yaml_validation_errors';
 import { addDynamicConnectorsToCache } from '../../../../common/schema';
 import { useAvailableConnectors } from '../../../entities/connectors/model/use_available_connectors';
+import { useRegisteredStepTypes } from '../../../entities/registered_steps/model/use_registered_step_types';
 import { useSaveYaml } from '../../../entities/workflows/model/use_save_yaml';
 import type { StepInfo } from '../../../entities/workflows/store';
 import {
@@ -62,6 +63,7 @@ import {
   ElasticsearchMonacoConnectorHandler,
   GenericMonacoConnectorHandler,
   KibanaMonacoConnectorHandler,
+  RegisteredStepMonacoHandler,
 } from '../lib/monaco_connectors';
 import {
   registerMonacoConnectorHandler,
@@ -204,6 +206,7 @@ export const WorkflowYAMLEditor = ({
 
   // Data
   const connectorsData = useAvailableConnectors();
+  const registeredStepTypesData = useRegisteredStepTypes();
 
   useEffect(() => {
     if (connectorsData?.connectorTypes) {
@@ -338,6 +341,15 @@ export const WorkflowYAMLEditor = ({
         // Monaco YAML hover is now disabled via configuration (hover: false)
         // The unified hover provider will handle all hover content including validation errors
 
+        // Register custom step types handler BEFORE generic handler (higher priority)
+        if (registeredStepTypesData?.stepTypes && registeredStepTypesData.stepTypes.length > 0) {
+          const registeredStepHandler = new RegisteredStepMonacoHandler(
+            registeredStepTypesData.stepTypes
+          );
+          registerMonacoConnectorHandler(registeredStepHandler);
+        }
+
+        // Register generic handler last (lowest priority, catches everything else)
         const genericHandler = new GenericMonacoConnectorHandler();
         registerMonacoConnectorHandler(genericHandler);
 

--- a/src/platform/plugins/shared/workflows_management/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/server/plugin.ts
@@ -187,7 +187,7 @@ export class WorkflowsPlugin
     this.spaces = plugins.spaces?.spacesService;
 
     // Register server side APIs
-    defineRoutes(router, this.api, this.logger, this.spaces!);
+    defineRoutes(router, this.api, this.logger, this.spaces!, getWorkflowExecutionEngine);
 
     return {
       management: this.api,

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_registered_step_types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_registered_step_types.ts
@@ -40,4 +40,3 @@ export function registerGetRegisteredStepTypesRoute({
     }
   );
 }
-

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_registered_step_types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_registered_step_types.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
+import { handleRouteError } from './route_error_handlers';
+import { WORKFLOW_READ_SECURITY } from './route_security';
+import type { RouteDependencies } from './types';
+
+export function registerGetRegisteredStepTypesRoute({
+  router,
+  logger,
+  getWorkflowExecutionEngine,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workflows/registered_step_types',
+      options: WORKFLOW_ROUTE_OPTIONS,
+      security: WORKFLOW_READ_SECURITY,
+      validate: false,
+    },
+    async (context, request, response) => {
+      try {
+        const workflowsExecutionEngine = await getWorkflowExecutionEngine();
+        const registeredStepTypes = workflowsExecutionEngine.getRegisteredStepTypes();
+        return response.ok({
+          body: {
+            stepTypes: registeredStepTypes,
+          },
+        });
+      } catch (error) {
+        logger.error(`Failed to fetch registered step types: ${error.message}`);
+        return handleRouteError(response, error);
+      }
+    }
+  );
+}
+

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/index.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/index.ts
@@ -9,11 +9,13 @@
 
 import type { IRouter, Logger } from '@kbn/core/server';
 import type { SpacesServiceStart } from '@kbn/spaces-plugin/server';
+import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
 
 // Import all route registration functions
 import { registerDeleteWorkflowByIdRoute } from './delete_workflow_by_id';
 import { registerDeleteWorkflowsBulkRoute } from './delete_workflows_bulk';
 import { registerGetConnectorsRoute } from './get_connectors';
+import { registerGetRegisteredStepTypesRoute } from './get_registered_step_types';
 import { registerGetStepExecutionRoute } from './get_step_execution';
 import { registerGetWorkflowAggsRoute } from './get_workflow_aggs';
 import { registerGetWorkflowByIdRoute } from './get_workflow_by_id';
@@ -37,15 +39,17 @@ export function defineRoutes(
   router: IRouter,
   api: WorkflowsManagementApi,
   logger: Logger,
-  spaces: SpacesServiceStart
+  spaces: SpacesServiceStart,
+  getWorkflowExecutionEngine: () => Promise<WorkflowsExecutionEnginePluginStart>
 ) {
-  const deps: RouteDependencies = { router, api, logger, spaces };
+  const deps: RouteDependencies = { router, api, logger, spaces, getWorkflowExecutionEngine };
 
   // Register all routes
   registerGetWorkflowStatsRoute(deps);
   registerGetWorkflowAggsRoute(deps);
   registerGetWorkflowByIdRoute(deps);
   registerGetConnectorsRoute(deps);
+  registerGetRegisteredStepTypesRoute(deps);
   registerPostSearchWorkflowsRoute(deps);
   registerPostCreateWorkflowRoute(deps);
   registerPutUpdateWorkflowRoute(deps);

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/types.ts
@@ -10,6 +10,7 @@
 import type { IRouter, Logger } from '@kbn/core/server';
 import type { SpacesServiceStart } from '@kbn/spaces-plugin/server';
 import type { ExecutionStatus } from '@kbn/workflows';
+import type { WorkflowsExecutionEnginePluginStart } from '@kbn/workflows-execution-engine/server';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
 // Pagination constants
@@ -31,6 +32,7 @@ export interface RouteDependencies {
   api: WorkflowsManagementApi;
   logger: Logger;
   spaces: SpacesServiceStart;
+  getWorkflowExecutionEngine: () => Promise<WorkflowsExecutionEnginePluginStart>;
 }
 
 export type RouteHandler = (deps: RouteDependencies) => void;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
@@ -133,10 +133,13 @@ export class WorkflowsManagementApi {
     request: KibanaRequest
   ): Promise<WorkflowDetailDto> {
     // Parse and update the YAML to change the name
+    const workflowsExecutionEngine = await this.getWorkflowsExecutionEngine();
+    const registeredStepTypes = workflowsExecutionEngine.getRegisteredStepTypes();
     const zodSchema = await this.workflowsService.getWorkflowZodSchema(
       { loose: false },
       spaceId,
-      request
+      request,
+      registeredStepTypes
     );
     const parsedYaml = parseWorkflowYamlToJSON(workflow.yaml, zodSchema);
     if (parsedYaml.error) {
@@ -203,10 +206,13 @@ export class WorkflowsManagementApi {
     spaceId: string,
     request: KibanaRequest
   ): Promise<string> {
+    const workflowsExecutionEngine = await this.getWorkflowsExecutionEngine();
+    const registeredStepTypes = workflowsExecutionEngine.getRegisteredStepTypes();
     const zodSchema = await this.workflowsService.getWorkflowZodSchema(
       { loose: false },
       spaceId,
-      request
+      request,
+      registeredStepTypes
     );
     const parsedYaml = parseWorkflowYamlToJSON(workflowYaml, zodSchema);
 
@@ -233,7 +239,6 @@ export class WorkflowsManagementApi {
       spaceId,
       inputs: manualInputs,
     };
-    const workflowsExecutionEngine = await this.getWorkflowsExecutionEngine();
     const executeResponse = await workflowsExecutionEngine.executeWorkflow(
       {
         id: 'test-workflow',
@@ -256,9 +261,11 @@ export class WorkflowsManagementApi {
     spaceId: string,
     request: KibanaRequest
   ): Promise<string> {
+    const workflowsExecutionEngine = await this.getWorkflowsExecutionEngine();
+    const registeredStepTypes = workflowsExecutionEngine.getRegisteredStepTypes();
     const parsedYaml = parseWorkflowYamlToJSON(
       workflowYaml,
-      await this.workflowsService.getWorkflowZodSchema({ loose: false }, spaceId, request)
+      await this.workflowsService.getWorkflowZodSchema({ loose: false }, spaceId, request, registeredStepTypes)
     );
 
     if (parsedYaml.error) {
@@ -266,7 +273,6 @@ export class WorkflowsManagementApi {
     }
 
     const workflowToCreate = transformWorkflowYamlJsontoEsWorkflow(parsedYaml.data as WorkflowYaml);
-    const workflowsExecutionEngine = await this.getWorkflowsExecutionEngine();
     const executeResponse = await workflowsExecutionEngine.executeWorkflowStep(
       {
         id: 'test-workflow',
@@ -385,10 +391,13 @@ export class WorkflowsManagementApi {
     spaceId: string,
     request: KibanaRequest
   ): Promise<JsonSchema7Type> {
+    const workflowsExecutionEngine = await this.getWorkflowsExecutionEngine();
+    const registeredStepTypes = workflowsExecutionEngine.getRegisteredStepTypes();
     const zodSchema = await this.workflowsService.getWorkflowZodSchema(
       { loose: false },
       spaceId,
-      request
+      request,
+      registeredStepTypes
     );
     return getJsonSchemaFromYamlSchema(zodSchema);
   }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
@@ -265,7 +265,12 @@ export class WorkflowsManagementApi {
     const registeredStepTypes = workflowsExecutionEngine.getRegisteredStepTypes();
     const parsedYaml = parseWorkflowYamlToJSON(
       workflowYaml,
-      await this.workflowsService.getWorkflowZodSchema({ loose: false }, spaceId, request, registeredStepTypes)
+      await this.workflowsService.getWorkflowZodSchema(
+        { loose: false },
+        spaceId,
+        request,
+        registeredStepTypes
+      )
     );
 
     if (parsedYaml.error) {

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
@@ -1164,9 +1164,10 @@ export class WorkflowsService {
       loose?: false;
     },
     spaceId: string,
-    request: KibanaRequest
+    request: KibanaRequest,
+    registeredStepTypes: Array<{ id: string; title: string; description?: string }> = []
   ): Promise<z.ZodType> {
     const { connectorsByType } = await this.getAvailableConnectors(spaceId, request);
-    return getWorkflowZodSchema(connectorsByType);
+    return getWorkflowZodSchema(connectorsByType, registeredStepTypes);
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2394,6 +2394,8 @@
       "@kbn/workflows-execution-engine/*": ["src/platform/plugins/shared/workflows_execution_engine/*"],
       "@kbn/workflows-management-plugin": ["src/platform/plugins/shared/workflows_management"],
       "@kbn/workflows-management-plugin/*": ["src/platform/plugins/shared/workflows_management/*"],
+      "@kbn/workflows-step-example-plugin": ["examples/workflows_step_example"],
+      "@kbn/workflows-step-example-plugin/*": ["examples/workflows_step_example/*"],
       "@kbn/workplace-ai-app": ["x-pack/solutions/workplaceai/plugins/workplace_ai_app"],
       "@kbn/workplace-ai-app/*": ["x-pack/solutions/workplaceai/plugins/workplace_ai_app/*"],
       "@kbn/workspaces": ["src/platform/packages/shared/kbn-workspaces"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,7 +2696,7 @@
   resolved "https://registry.yarnpkg.com/@elastic/filesaver/-/filesaver-1.1.2.tgz#1998ffb3cd89c9da4ec12a7793bfcae10e30c77a"
   integrity sha512-YZbSufYFBhAj+S2cJgiKALoxIJevqXN2MSr6Yqr42rJdaPuM31cj6pUDwflkql1oDjupqD9la+MfxPFjXI1JFQ==
 
-"@elastic/kibana-d3-color@npm:@elastic/kibana-d3-color@2.0.1", "d3-color@1 - 2", "d3-color@npm:@elastic/kibana-d3-color@2.0.1":
+"@elastic/kibana-d3-color@npm:@elastic/kibana-d3-color@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@elastic/kibana-d3-color/-/kibana-d3-color-2.0.1.tgz#f83b9c2fea09273a918659de04d5e8098c82f65c"
   integrity sha512-YZ8hV2bWNyYi833Yj3UWczmTxdHzmo/Xc2IVkNXr/ZqtkrTDlTLysCyJm7SfAt9iBy6EVRGWTn8cPz8QOY6Ixw==
@@ -9280,6 +9280,10 @@
   uid ""
 
 "@kbn/workflows-management-plugin@link:src/platform/plugins/shared/workflows_management":
+  version "0.0.0"
+  uid ""
+
+"@kbn/workflows-step-example-plugin@link:examples/workflows_step_example":
   version "0.0.0"
   uid ""
 
@@ -18529,6 +18533,11 @@ d3-collection@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
+
+"d3-color@1 - 2", "d3-color@npm:@elastic/kibana-d3-color@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@elastic/kibana-d3-color/-/kibana-d3-color-2.0.1.tgz#f83b9c2fea09273a918659de04d5e8098c82f65c"
+  integrity sha512-YZ8hV2bWNyYi833Yj3UWczmTxdHzmo/Xc2IVkNXr/ZqtkrTDlTLysCyJm7SfAt9iBy6EVRGWTn8cPz8QOY6Ixw==
 
 "d3-color@1 - 3", d3-color@^3.1.0:
   version "3.1.0"
@@ -31646,7 +31655,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -31663,6 +31672,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -31756,7 +31774,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -31769,6 +31787,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -34581,7 +34606,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -34602,6 +34627,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -34717,7 +34751,7 @@ xpath@^0.0.33:
   resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.33.tgz#5136b6094227c5df92002e7c3a13516a5074eb07"
   integrity sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==
 
-"xstate5@npm:xstate@^5.19.2", xstate@^5.19.2:
+"xstate5@npm:xstate@^5.19.2":
   version "5.19.2"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.19.2.tgz#db3f1ee614bbb6a49ad3f0c96ddbf98562d456ba"
   integrity sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==
@@ -34726,6 +34760,11 @@ xstate@^4.38.3:
   version "4.38.3"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.38.3.tgz#4e15e7ad3aa0ca1eea2010548a5379966d8f1075"
   integrity sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==
+
+xstate@^5.19.2:
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.19.2.tgz#db3f1ee614bbb6a49ad3f0c96ddbf98562d456ba"
+  integrity sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
# Custom Workflow Step Registration - PoC

## Summary

This PR introduces a **step registry mechanism** that allows Kibana plugins to register custom workflow step types without modifying the core workflow engine. This is a proof of concept to validate the extensibility approach.

## Motivation

The workflow engine currently has a fixed set of built-in step types (HTTP, Elasticsearch, Kibana, etc.). Teams need the ability to create domain-specific step types (e.g., enrichment steps, custom actions, ML inference) without requiring changes to the core engine.

## Changes

### Core Engine (`workflows_execution_engine`)

**New Components:**
- `StepTypeRegistry`: Registry class for managing custom step types
- `CustomStepImpl`: Execution handler for registered steps
- `registerStepType()`: Public API in plugin setup contract

**Step Type Definition:**
```typescript
interface StepTypeDefinition {
  id: string;
  title: string;
  description?: string;
  inputSchema: ZodSchema;     // Validates inputs
  outputSchema: ZodSchema;    // Validates outputs
  handler: StepHandler;       // Execution logic
  documentation?: {           // Optional UI docs
    summary, details, url, examples
  }
}
```

**Handler Context:**
Custom step handlers receive:
- Validated input based on `inputSchema`
- Context manager for accessing workflow state
- Step state persistence API: `setStepState()` / `getStepState()`
- Logger scoped to the step execution
- Abort signal for cancellation support

### UI/Validation (`workflows_management`)

**Schema Updates:**
- Added `.passthrough()` to step schemas to allow dynamic state properties
- Updated `getSchemaAtPath()` to recognize passthrough objects
- Registered steps included in workflow YAML schema generation

**Hover Documentation:**
- New `RegisteredStepMonacoHandler` for custom step tooltips
- Shows step title, description, examples, and documentation links
- Removes generic "Connector" terminology for registered steps

### Example Plugin (`workflows_step_example`)

Created a proof-of-concept plugin demonstrating registration of a `setvar` step type:

**Registration (plugin setup):**
```typescript
plugins.workflowsExecutionEngine.registerStepType(setvarStepDefinition);
```

**Usage in workflows:**
```yaml
steps:
  - name: setVarStep
    type: setvar
    with:
      variables:
        x: 10
        userName: "Alice"
        
  - name: useVariable
    type: console
    with:
      message: "User {{ steps.setVarStep.userName }} has count {{ steps.setVarStep.x }}"
```

## Technical Approach

### Encapsulated State Management
Custom steps persist data using `context.contextManager.setStepState()`. The state is automatically spread into the step context, making it accessible to subsequent steps via `{{ steps.stepName.property }}`. This approach requires no changes to the core context management system.

### Priority-Based Handler Resolution
The hover provider uses a priority system:
1. Elasticsearch/Kibana handlers (priority 20/15)
2. Registered step handler (priority 15)
3. Generic connector handler (priority 0, fallback)

This ensures registered steps get appropriate documentation instead of generic connector hints.

### Schema Validation Flow
```
YAML → Zod schema validation → Handler execution → Output validation
         ↓                                              ↓
    inputSchema                                   outputSchema
```

## Files Changed

**Core:**
- `src/platform/plugins/shared/workflows_execution_engine/server/step_type_registry.ts` (new)
- `src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl.ts` (new)
- `src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts` (modified)
- `src/platform/plugins/shared/workflows_execution_engine/server/types.ts` (modified)

**Types:**
- `src/platform/packages/shared/kbn-workflows/common/step_registry_types.ts` (new)

**UI/Validation:**
- `src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/monaco_connectors/registered_step_monaco_handler.ts` (new)
- `src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_steps_collection_schema.ts` (modified)
- `src/platform/plugins/shared/workflows_management/common/lib/zod/zod_utils.ts` (modified)

**Example:**
- `examples/workflows_step_example/` (new)

## Testing

Manual testing performed:
- Step registration during plugin setup
- Step execution with input validation
- State persistence across steps
- UI validation of dynamic properties
- Hover documentation display

**TODO for production:**
- Unit tests for `StepTypeRegistry`
- Integration tests for custom step execution
- UI tests for hover provider
- Error handling test cases

## Breaking Changes

None. This is an additive change that introduces new APIs without modifying existing behavior.

## Next Steps

If this approach is validated, next steps would include:
1. Comprehensive test coverage
2. Developer documentation
3. API stability review
4. Consider autocomplete improvements for registered step types

