### PR TITLE
[Chrome Grid] Remove unwanted overscroll behavior; fix `EuiBottomBar` position 

### DIFF
--- a/src/core/packages/chrome/layout/core-chrome-layout/layouts/grid/grid_global_app_style.tsx
+++ b/src/core/packages/chrome/layout/core-chrome-layout/layouts/grid/grid_global_app_style.tsx
@@ -38,6 +38,11 @@ const globalLayoutStyles = (euiTheme: UseEuiTheme['euiTheme']) => css`
     --kbnProjectHeaderAppActionMenuHeight: ${layoutVar('application.topBar.height', '0px')};
   }
 
+  :root {
+    // disable document-level scroll, since the application area handles it
+    overflow: hidden;
+  }
+
   #kibana-body {
     // DO NOT ADD ANY OVERFLOW BEHAVIORS HERE
     // It will break the sticky navigation
@@ -67,9 +72,17 @@ const globalLayoutStyles = (euiTheme: UseEuiTheme['euiTheme']) => css`
     position: relative; // This is temporary for apps that relied on this being present on \`.application\`
   }
 
+  // make data grid full screen mode respect the header banner
   #kibana-body .euiDataGrid--fullScreen {
     height: calc(100vh - var(--kbnHeaderBannerHeight));
     top: var(--kbnHeaderBannerHeight);
+  }
+
+  // make sure fixed bottom bars are positioned relative to the application area
+  .euiBottomBar.euiBottomBar--fixed {
+    left: ${layoutVar('application.left', '0px')} !important; /* override EUI inline style */
+    right: ${layoutVar('application.right', '0px')} !important; /* override EUI inline style */
+    bottom: ${layoutVar('application.bottom', '0px')} !important; /* override EUI inline style */
   }
 `;
 


### PR DESCRIPTION
## Summary

1. Fixes unwanted overscroll; see https://github.com/elastic/kibana/issues/242129#issuecomment-3504617683
2. Fix EuiBottomBar position 

**Before:**

<img width="1624" height="1056" alt="Screenshot 2025-11-10 at 10 57 46" src="https://github.com/user-attachments/assets/d17617c0-65e2-4b1a-91c2-bd4c97674862" />


**After:**

<img width="1624" height="1056" alt="Screenshot 2025-11-10 at 10 57 30" src="https://github.com/user-attachments/assets/ad0b69cf-3326-45bd-9c11-4363f0c02a6f" />


