### PR TITLE
[Discover][Unified Tabs] Remove redundant margin for tabs bar

### DIFF
--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_visual_glue_to_header/tabs_bar_with_background.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_visual_glue_to_header/tabs_bar_with_background.tsx
@@ -13,7 +13,6 @@ import { css } from '@emotion/react';
 import { css as cssString } from '@emotion/css';
 import { useEuiTheme } from '@elastic/eui';
 import { getTabsShadowGradient } from './get_tabs_shadow_gradient';
-import { useChromeStyle } from './use_chrome_style';
 import type { TabsServices } from '../../types';
 
 const globalCss = cssString`
@@ -40,7 +39,6 @@ export const TabsBarWithBackground: React.FC<TabsBarWithBackgroundProps> = ({
   children,
   ...otherProps
 }) => {
-  const { isProjectChromeStyle } = useChromeStyle(services);
   const euiThemeContext = useEuiTheme();
   const { euiTheme } = euiThemeContext;
 
@@ -58,9 +56,6 @@ export const TabsBarWithBackground: React.FC<TabsBarWithBackgroundProps> = ({
       css={css`
         // tabs bar background
         background: ${euiTheme.colors.lightestShade};
-
-        // for some reason the header slightly overlaps the tabs bar in a solution view
-        margin-top: ${isProjectChromeStyle ? '1px' : '0'};
       `}
     >
       <div


### PR DESCRIPTION
## Summary
A part of [[Workspace Chrome][Data Discovery] Scroll issues in Discover](https://github.com/elastic/kibana/issues/242129#top)

In a new grid layout the workaround with 1px margin for the tabs bar is redundant and is closing scroll issues.

As a new grid layout is about to be the default one in couple of days I just removed the margin without any conditions for keeping it in legacy layout, however I'm open for changes if it's a desired approach. Below screenshots of each version and a video of two margin states.

Grid layout, 1px margin:
<img width="3444" height="1744" alt="image" src="https://github.com/user-attachments/assets/a25df3aa-1dd1-4627-86c9-29e1b45e2f6c" />

Grid layout, removed margin:
<img width="1726" height="880" alt="Screenshot 2025-11-10 at 13 58 06" src="https://github.com/user-attachments/assets/001fa145-8db3-46be-9b03-cef4d4b51cd1" />

Legacy layout, 1px margin:
<img width="1723" height="828" alt="Screenshot 2025-11-10 at 14 00 09" src="https://github.com/user-attachments/assets/dd5356e2-548a-4307-8471-eb76f4cb9e9f" />

Legacy layout, removed margin:
<img width="1720" height="875" alt="Screenshot 2025-11-10 at 14 00 36" src="https://github.com/user-attachments/assets/b8a10ead-45b2-4eed-aeef-b2d382b4e6ae" />

Live visual changes of margin/no margin state for legacy layout:

https://github.com/user-attachments/assets/d03edb39-2267-4113-af70-66d9cc8dae4e




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



