### PR TITLE
[Discover] Move aria-label to button trigger in fields list grouped

### DIFF
--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_grouped/fields_accordion.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_grouped/fields_accordion.tsx
@@ -72,16 +72,7 @@ function InnerFieldsAccordion<T extends FieldListItem = DataViewField>({
   const renderButton = useMemo(() => {
     return (
       <EuiText size="xs">
-        <strong
-          css={!!helpTooltip ? styles.titleTooltip : undefined}
-          aria-label={i18n.translate('unifiedFieldList.fieldsAccordion.accordionButtonAriaLabel', {
-            defaultMessage:
-              '{label}: {fieldsCount} {fieldsCount, plural, one {item} other {items}}',
-            values: { label, fieldsCount },
-          })}
-        >
-          {label}
-        </strong>
+        <strong css={!!helpTooltip ? styles.titleTooltip : undefined}>{label}</strong>
         {!!helpTooltip && (
           <EuiIconTip
             aria-label={helpTooltip}
@@ -97,7 +88,7 @@ function InnerFieldsAccordion<T extends FieldListItem = DataViewField>({
         )}
       </EuiText>
     );
-  }, [label, helpTooltip, fieldsCount, styles.titleTooltip]);
+  }, [label, helpTooltip, styles.titleTooltip]);
 
   const accordionExtraAction = useMemo(() => {
     if (showExistenceFetchError) {
@@ -154,6 +145,10 @@ function InnerFieldsAccordion<T extends FieldListItem = DataViewField>({
       id={id}
       buttonProps={{
         id: buttonId,
+        'aria-label': i18n.translate('unifiedFieldList.fieldsAccordion.accordionButtonAriaLabel', {
+          defaultMessage: '{label}: {fieldsCount} {fieldsCount, plural, one {item} other {items}}',
+          values: { label, fieldsCount },
+        }),
       }}
       buttonContent={renderButton}
       extraAction={accordionExtraAction}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/195068

|  | Before | After |
|-|--------|------|
| NVDA | <img width="489" height="495" alt="image (13)" src="https://github.com/user-attachments/assets/9d1f6494-92e3-4841-b93f-b8af9c9a988c" /> | <img width="489" height="495" alt="image (12)" src="https://github.com/user-attachments/assets/231951ba-8164-477f-93ff-9ccb89fe3e02" /> |
| VoiceOver | <img width="612" height="121" alt="image" src="https://github.com/user-attachments/assets/a5862c73-99af-4068-b02c-a58f1b9ab363" /> | <img width="603" height="116" alt="image" src="https://github.com/user-attachments/assets/bf31e92d-1854-4e19-8839-67bcbd94e121" /> |

(Sorry about the VoiceOver parts that are in spanish)

---

Before this PR we didn't have an aria-label in the button, which is the element that gets focused when tabbing, this means that following aria rules the label was the thing that should be read by screen readers. Moving the aria-label from the children elements to the button solves this as that's now the element that should be read.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->