### PR TITLE
[Agent Builder] increase socket timeout for converse APIs

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/routes/chat.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/routes/chat.ts
@@ -29,6 +29,8 @@ import type { AttachmentServiceStart } from '../services/attachments';
 import type { RouteDependencies } from './types';
 import { getHandlerWrapper } from './wrap_handler';
 
+const SOCKET_TIMEOUT_MS = 5 * 60 * 1000;
+
 export function registerChatRoutes({
   router,
   getInternalServices,
@@ -194,6 +196,9 @@ export function registerChatRoutes({
       description:
         'Send a message to an agent and receive a complete response. This synchronous endpoint waits for the agent to fully process your request before returning the final result. Use this for simple chat interactions where you need the complete response.',
       options: {
+        timeout: {
+          idleSocket: SOCKET_TIMEOUT_MS,
+        },
         tags: ['oas-tag:agent builder'],
         availability: {
           stability: 'experimental',
@@ -391,6 +396,9 @@ export function registerChatRoutes({
         '7. `message_complete`\n' +
         '8. `round_complete`',
       options: {
+        timeout: {
+          idleSocket: SOCKET_TIMEOUT_MS,
+        },
         tags: ['oas-tag:agent builder'],
         availability: {
           stability: 'experimental',

--- a/x-pack/platform/plugins/shared/onechat/server/routes/chat.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/routes/chat.ts
@@ -28,8 +28,7 @@ import type { ChatService } from '../services/chat';
 import type { AttachmentServiceStart } from '../services/attachments';
 import type { RouteDependencies } from './types';
 import { getHandlerWrapper } from './wrap_handler';
-
-const SOCKET_TIMEOUT_MS = 5 * 60 * 1000;
+import { AGENT_SOCKET_TIMEOUT_MS } from './utils';
 
 export function registerChatRoutes({
   router,
@@ -197,7 +196,7 @@ export function registerChatRoutes({
         'Send a message to an agent and receive a complete response. This synchronous endpoint waits for the agent to fully process your request before returning the final result. Use this for simple chat interactions where you need the complete response.',
       options: {
         timeout: {
-          idleSocket: SOCKET_TIMEOUT_MS,
+          idleSocket: AGENT_SOCKET_TIMEOUT_MS,
         },
         tags: ['oas-tag:agent builder'],
         availability: {
@@ -397,7 +396,7 @@ export function registerChatRoutes({
         '8. `round_complete`',
       options: {
         timeout: {
-          idleSocket: SOCKET_TIMEOUT_MS,
+          idleSocket: AGENT_SOCKET_TIMEOUT_MS,
         },
         tags: ['oas-tag:agent builder'],
         availability: {

--- a/x-pack/platform/plugins/shared/onechat/server/routes/tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/routes/tools.ts
@@ -22,6 +22,7 @@ import type {
 } from '../../common/http_api/tools';
 import { apiPrivileges } from '../../common/features';
 import { publicApiPath } from '../../common/constants';
+import { AGENT_SOCKET_TIMEOUT_MS } from './utils';
 
 export function registerToolsRoutes({ router, getInternalServices, logger }: RouteDependencies) {
   const wrapHandler = getHandlerWrapper({ logger });
@@ -312,6 +313,9 @@ export function registerToolsRoutes({ router, getInternalServices, logger }: Rou
       description:
         'Execute a tool with parameters. Use this endpoint to run a tool directly with specified inputs and optional external connector integration.',
       options: {
+        timeout: {
+          idleSocket: AGENT_SOCKET_TIMEOUT_MS,
+        },
         tags: ['tools', 'oas-tag:agent builder'],
         availability: {
           stability: 'experimental',

--- a/x-pack/platform/plugins/shared/onechat/server/routes/utils.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/routes/utils.ts
@@ -8,3 +8,8 @@
 export const getTechnicalPreviewWarning = (featureName: string) => {
   return `${featureName} is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.`;
 };
+
+/**
+ * Timeout for agentic features
+ */
+export const AGENT_SOCKET_TIMEOUT_MS = 5 * 60 * 1000;


### PR DESCRIPTION
## Summary

By nature, the converse API can take a long time to return a response, especially in certain situations such as executing a workflow. 

This doesn't fully address the problem, but is a quick win to mitigates it as much as we can by increasing the timeout from the default of 2mins to 5mins. **Note**: we can't really increase it further easily because we will hit then the Cloud proxy timeout anyway.
 


