### PR TITLE
[Agent Builder] [PoC] dashboard integration poc

### DIFF
--- a/src/platform/plugins/shared/dashboard/kibana.jsonc
+++ b/src/platform/plugins/shared/dashboard/kibana.jsonc
@@ -39,7 +39,8 @@
       "serverless",
       "noDataPage",
       "observabilityAIAssistant",
-      "lens"
+      "lens",
+      "onechat"
     ],
     "requiredBundles": [
       "kibanaReact",

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/_dashboard_app_strings.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/_dashboard_app_strings.ts
@@ -270,6 +270,14 @@ export const topNavStrings = {
       defaultMessage: 'Additional save options',
     }),
   },
+  onechat: {
+    label: i18n.translate('dashboard.topNave.onechatButtonAriaLabel', {
+      defaultMessage: 'AI Assistant',
+    }),
+    description: i18n.translate('dashboard.topNave.onechatConfigDescription', {
+      defaultMessage: 'Open AI Assistant',
+    }),
+  },
 };
 
 export const getControlButtonTitle = () =>

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/dashboard_app.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/dashboard_app.tsx
@@ -33,6 +33,7 @@ import { DASHBOARD_STATE_STORAGE_KEY, createDashboardEditUrl } from '../utils/ur
 import { useDashboardMountContext } from './hooks/dashboard_mount_context';
 import { useDashboardOutcomeValidation } from './hooks/use_dashboard_outcome_validation';
 import { useObservabilityAIAssistantContext } from './hooks/use_observability_ai_assistant_context';
+import { useDashboardOnechat } from '../onechat/hooks/use_dashboard_onechat';
 import {
   DashboardAppNoDataPage,
   isDashboardAppInNoDataState,
@@ -105,6 +106,9 @@ export function DashboardApp({
   useObservabilityAIAssistantContext({
     dashboardApi,
   });
+
+  // Set up onechat integration with dashboard context
+  useDashboardOnechat(dashboardApi);
 
   useExecutionContext(coreServices.executionContext, {
     type: 'application',

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -21,7 +21,7 @@ import { confirmDiscardUnsavedChanges } from '../../dashboard_listing/confirm_ov
 import { openSettingsFlyout } from '../../dashboard_renderer/settings/open_settings_flyout';
 import { getDashboardBackupService } from '../../services/dashboard_backup_service';
 import type { SaveDashboardReturn } from '../../dashboard_api/save_modal/types';
-import { coreServices, shareService, dataService } from '../../services/kibana_services';
+import { coreServices, shareService, dataService, onechatService } from '../../services/kibana_services';
 import { getDashboardCapabilities } from '../../utils/get_dashboard_capabilities';
 import { topNavStrings } from '../_dashboard_app_strings';
 import { showAddMenu } from './add_menu/show_add_menu';
@@ -266,6 +266,22 @@ export const useDashboardMenuItems = ({
         run: (anchorElement: HTMLElement) =>
           showAddMenu({ dashboardApi, anchorElement, coreServices }),
       },
+
+      ...(onechatService
+        ? {
+            onechat: {
+              ...topNavStrings.onechat,
+              id: 'onechat',
+              iconType: 'sparkles',
+              iconOnly: true,
+              testId: 'dashboardOnechatButton',
+              disableButton: disableTopNav,
+              run: () => {
+                onechatService.openConversationFlyout();
+              },
+            } as TopNavMenuData,
+          }
+        : {}),
     };
   }, [
     disableTopNav,
@@ -283,6 +299,7 @@ export const useDashboardMenuItems = ({
     resetChanges,
     isResetting,
     appId,
+    onechatService,
   ]);
 
   const resetChangesMenuItem = useMemo(() => {

--- a/src/platform/plugins/shared/dashboard/public/onechat/hooks/use_dashboard_onechat.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/hooks/use_dashboard_onechat.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect } from 'react';
+import type { DashboardApi } from '../../dashboard_api/types';
+import { useOnechatIntegration } from './use_onechat_integration';
+import { coreServices, onechatService } from '../../services/kibana_services';
+
+/**
+ * Hook to manage onechat integration for dashboard
+ * Sets up the conversation flyout active config with dashboard context
+ */
+export function useDashboardOnechat(dashboardApi: DashboardApi | undefined) {
+  const { attachments, browserApiTools } = useOnechatIntegration(dashboardApi, coreServices);
+
+  useEffect(() => {
+    if (!dashboardApi || !onechatService) {
+      return;
+    }
+
+    // Set the active conversation config with dashboard attachments and tools
+    onechatService.setConversationFlyoutActiveConfig({
+      sessionTag: 'dashboard',
+      agentId: 'test_agent',
+      attachments,
+      browserApiTools,
+    });
+
+    // Cleanup: clear the config when dashboard unmounts or changes
+    return () => {
+      if (onechatService) {
+        onechatService.clearConversationFlyoutActiveConfig();
+      }
+    };
+  }, [dashboardApi, attachments, browserApiTools]);
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/hooks/use_onechat_integration.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/hooks/use_onechat_integration.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import type { DashboardApi } from '../../dashboard_api/types';
+import type { CoreStart } from '@kbn/core/public';
+import type { UiAttachment } from '@kbn/onechat-browser';
+import type { BrowserApiToolDefinition } from '@kbn/onechat-browser/tools/browser_api_tool';
+import { AttachmentType } from '@kbn/onechat-common/attachments';
+import { buildApplicationContextAttachment } from '../utils/build_application_context_attachment';
+import { buildDashboardTextAttachment } from '../utils/build_dashboard_text_attachment';
+import { createDashboardBrowserApiTools } from '../tools';
+
+export interface UseOnechatIntegrationResult {
+  attachments: UiAttachment[];
+  browserApiTools: BrowserApiToolDefinition<any>[];
+}
+
+/**
+ * Hook to build onechat attachments and browser API tools from dashboard API
+ */
+export function useOnechatIntegration(
+  dashboardApi: DashboardApi | undefined,
+  coreStart: CoreStart
+): UseOnechatIntegrationResult {
+  return useMemo(() => {
+    if (!dashboardApi) {
+      return {
+        attachments: [],
+        browserApiTools: [],
+      };
+    }
+
+    // Build attachments
+    const applicationContextAttachment: UiAttachment = {
+      id: 'dashboard-application-context',
+      type: AttachmentType.screenContext,
+      getContent: () => buildApplicationContextAttachment(dashboardApi),
+    };
+
+    const dashboardAttachment: UiAttachment = {
+      id: 'dashboard-configuration',
+      type: AttachmentType.text,
+      getContent: () => buildDashboardTextAttachment(dashboardApi),
+    };
+
+    // Build browser API tools
+    const browserApiTools = createDashboardBrowserApiTools(dashboardApi, coreStart);
+
+    return {
+      attachments: [applicationContextAttachment, dashboardAttachment],
+      browserApiTools,
+    };
+  }, [dashboardApi, coreStart]);
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/tools/add_panel.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/tools/add_panel.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import type { BrowserApiToolDefinition } from '@kbn/onechat-browser/tools/browser_api_tool';
+import type { DashboardApi } from '../../dashboard_api/types';
+import type { PanelPackage } from '@kbn/presentation-containers';
+import type { SerializedPanelState } from '@kbn/presentation-publishing';
+import type { GridData } from '@kbn/grid-layout';
+import { coreServices } from '../../services/kibana_services';
+
+const addPanelSchema = z.object({
+  panel: z
+    .object({
+      type: z.string().describe('The type of panel (e.g., "lens", "visualization", "map", "markdown")'),
+      config: z
+        .record(z.unknown())
+        .describe('Complete panel configuration object. Must include all required fields for the panel type.'),
+      grid: z
+        .object({
+          x: z.number().describe('X position in grid units (0-23)'),
+          y: z.number().describe('Y position in grid units'),
+          w: z.number().describe('Width in grid units (1-24)'),
+          h: z.number().describe('Height in grid units'),
+        })
+        .optional()
+        .describe('Grid position. If not provided, panel will be automatically placed.'),
+      uid: z
+        .string()
+        .optional()
+        .describe('Optional unique ID for the panel. If not provided, a new ID will be generated.'),
+    })
+    .describe('Complete panel configuration including type, config, and optional grid position'),
+});
+
+export function createAddPanelTool(
+  dashboardApi: DashboardApi
+): BrowserApiToolDefinition<z.infer<typeof addPanelSchema>> {
+  return {
+    id: 'dashboard_add_panel',
+    description: `Adds a new panel to the dashboard.
+    
+Use this tool when the user wants to add a visualization, chart, or other panel to the dashboard.
+You must provide a complete panel configuration including:
+- type: The panel type (e.g., "lens", "visualization", "map", "markdown")
+- config: The complete panel configuration object with all required fields for that panel type
+- grid (optional): Grid position (x, y, w, h). If not provided, panel will be automatically placed.
+- uid (optional): Unique panel ID. If not provided, a new ID will be generated.
+
+The config object must contain all required fields for the specified panel type to create a valid panel.`,
+    schema: addPanelSchema,
+    handler: async ({ panel }) => {
+      try {
+        const panelPackage: PanelPackage = {
+          panelType: panel.type,
+          maybePanelId: panel.uid,
+          serializedState: {
+            rawState: panel.config as Record<string, unknown>,
+          } as SerializedPanelState,
+        };
+
+        const grid: GridData | undefined = panel.grid
+          ? {
+              x: panel.grid.x,
+              y: panel.grid.y,
+              w: panel.grid.w,
+              h: panel.grid.h,
+            }
+          : undefined;
+
+        const result = await dashboardApi.addNewPanel(panelPackage, true, grid);
+        
+        // Verify panel was actually added
+        if (!result) {
+          throw new Error(`Failed to add panel: panel type "${panel.type}" may not be valid or panel configuration is incomplete`);
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        coreServices.notifications.toasts.addDanger({
+          title: 'Failed to add panel',
+          text: errorMessage,
+        });
+        throw error;
+      }
+    },
+  };
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/tools/change_filters.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/tools/change_filters.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import type { BrowserApiToolDefinition } from '@kbn/onechat-browser/tools/browser_api_tool';
+import type { DashboardApi } from '../../dashboard_api/types';
+import type { Filter } from '@kbn/es-query';
+
+const changeFiltersSchema = z.object({
+  filters: z
+    .array(z.record(z.unknown()))
+    .nullish()
+    .default([])
+    .describe('Array of filter objects to apply to the dashboard. Each filter should have meta.key, meta.value, and other filter properties. If empty array is provided or omitted, all filters will be removed.'),
+});
+
+export function createChangeFiltersTool(
+  dashboardApi: DashboardApi
+): BrowserApiToolDefinition<z.infer<typeof changeFiltersSchema>> {
+  return {
+    id: 'dashboard_change_filters',
+    description: `Changes the filters applied to the dashboard.
+    
+Use this tool when the user wants to add, remove, or modify filters on the dashboard.
+Filters control which data is displayed in all panels on the dashboard.
+Provide an array of filter objects with properties like meta.key, meta.value, meta.negate, etc.`,
+    schema: changeFiltersSchema,
+    handler: async ({ filters }) => {
+      // Convert the filter objects to Filter type
+      // filters will be [] if undefined/null due to .default([]) in schema
+      const dashboardFilters = (filters ?? []) as Filter[];
+      dashboardApi.setFilters(dashboardFilters);
+    },
+  };
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/tools/change_timerange.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/tools/change_timerange.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import type { BrowserApiToolDefinition } from '@kbn/onechat-browser/tools/browser_api_tool';
+import type { DashboardApi } from '../../dashboard_api/types';
+import type { TimeRange } from '@kbn/es-query';
+
+const changeTimerangeSchema = z.object({
+  from: z.string().describe('Start time for the time range (e.g., "now-15m", "2024-01-01T00:00:00Z")'),
+  to: z.string().describe('End time for the time range (e.g., "now", "2024-01-02T00:00:00Z")'),
+});
+
+export function createChangeTimerangeTool(
+  dashboardApi: DashboardApi
+): BrowserApiToolDefinition<z.infer<typeof changeTimerangeSchema>> {
+  return {
+    id: 'dashboard_change_timerange',
+    description: `Changes the time range for the dashboard.
+    
+Use this tool when the user wants to modify the time range that controls what data is displayed in all panels.
+The time range can use relative expressions like "now-15m" or absolute timestamps.`,
+    schema: changeTimerangeSchema,
+    handler: async ({ from, to }) => {
+      const timeRange: TimeRange = {
+        from,
+        to,
+      };
+      dashboardApi.setTimeRange(timeRange);
+    },
+  };
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/tools/create_dashboard.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/tools/create_dashboard.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import type { BrowserApiToolDefinition } from '@kbn/onechat-browser/tools/browser_api_tool';
+import type { CoreStart } from '@kbn/core/public';
+import { DASHBOARD_APP_ID } from '../../../common/constants';
+
+const createDashboardSchema = z.object({
+  title: z.string().describe('The title of the new dashboard'),
+  description: z
+    .string()
+    .optional()
+    .describe('Optional description for the new dashboard'),
+  panels: z
+    .array(
+      z.object({
+        type: z.string().describe('Panel type (e.g., "lens", "visualization")'),
+        config: z.record(z.unknown()).optional().describe('Panel configuration'),
+      })
+    )
+    .optional()
+    .describe('Optional array of panels to include in the new dashboard'),
+});
+
+export function createCreateDashboardTool(
+  coreStart: CoreStart
+): BrowserApiToolDefinition<z.infer<typeof createDashboardSchema>> {
+  return {
+    id: 'dashboard_create',
+    description: `Creates a new dashboard.
+    
+Use this tool when the user wants to create a brand new dashboard.
+This will navigate to a new dashboard creation page where the user can add panels and configure the dashboard.
+After creation, the user can save the dashboard with a title and description.`,
+    schema: createDashboardSchema,
+    handler: async ({ title, description, panels }) => {
+      // Navigate to dashboard creation page
+      await coreStart.application.navigateToApp(DASHBOARD_APP_ID, {
+        path: '#/create',
+        state: {
+          title,
+          description,
+          panels: panels?.map((panel) => ({
+            type: panel.type,
+            config: panel.config ?? {},
+          })),
+        },
+      });
+    },
+  };
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/tools/edit_panel.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/tools/edit_panel.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import type { BrowserApiToolDefinition } from '@kbn/onechat-browser/tools/browser_api_tool';
+import type { DashboardApi } from '../../dashboard_api/types';
+import type { PanelPackage } from '@kbn/presentation-containers';
+import type { SerializedPanelState } from '@kbn/presentation-publishing';
+
+const editPanelSchema = z.object({
+  panel_id: z.string().describe('The unique ID of the panel to edit'),
+  updates: z
+    .record(z.unknown())
+    .describe('Object containing the updates to apply to the panel (title, description, config, etc.)'),
+});
+
+export function createEditPanelTool(
+  dashboardApi: DashboardApi
+): BrowserApiToolDefinition<z.infer<typeof editPanelSchema>> {
+  return {
+    id: 'dashboard_edit_panel',
+    description: `Edits an existing panel in the dashboard.
+    
+Use this tool when the user wants to modify a panel's configuration, title, description, or other properties.
+The panel will be updated with the provided changes while maintaining its position and ID.`,
+    schema: editPanelSchema,
+    handler: async ({ panel_id, updates }) => {
+      try {
+        // Get current panel state
+        const panelData = dashboardApi.getDashboardPanelFromId(panel_id);
+        const currentType = panelData.type;
+        const currentGrid = panelData.grid;
+
+        // Merge updates with existing panel config
+        const currentConfig = (panelData.serializedState.rawState as Record<string, unknown>) ?? {};
+        const updatedConfig = {
+          ...currentConfig,
+          ...updates,
+        };
+
+        const panelPackage: PanelPackage = {
+          panelType: currentType,
+          serializedState: {
+            rawState: updatedConfig,
+          } as SerializedPanelState,
+        };
+
+        // Replace the panel with updated configuration
+        await dashboardApi.replacePanel(panel_id, panelPackage);
+      } catch (error) {
+        throw new Error(`Failed to edit panel: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  };
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/tools/index.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/tools/index.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BrowserApiToolDefinition } from '@kbn/onechat-browser/tools/browser_api_tool';
+import type { DashboardApi } from '../../dashboard_api/types';
+import type { CoreStart } from '@kbn/core/public';
+import { createAddPanelTool } from './add_panel';
+import { createRemovePanelTool } from './remove_panel';
+import { createEditPanelTool } from './edit_panel';
+import { createChangeFiltersTool } from './change_filters';
+import { createChangeTimerangeTool } from './change_timerange';
+import { createSetQueryTool } from './set_query';
+import { createCreateDashboardTool } from './create_dashboard';
+
+/**
+ * Creates all browser API tools for dashboard manipulation
+ */
+export function createDashboardBrowserApiTools(
+  dashboardApi: DashboardApi,
+  coreStart: CoreStart
+): BrowserApiToolDefinition<any>[] {
+  return [
+    createAddPanelTool(dashboardApi),
+    createRemovePanelTool(dashboardApi),
+    createEditPanelTool(dashboardApi),
+    createChangeFiltersTool(dashboardApi),
+    createChangeTimerangeTool(dashboardApi),
+    createSetQueryTool(dashboardApi),
+    createCreateDashboardTool(coreStart),
+  ];
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/tools/remove_panel.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/tools/remove_panel.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import type { BrowserApiToolDefinition } from '@kbn/onechat-browser/tools/browser_api_tool';
+import type { DashboardApi } from '../../dashboard_api/types';
+
+const removePanelSchema = z.object({
+  panel_id: z.string().describe('The unique ID of the panel to remove from the dashboard'),
+});
+
+export function createRemovePanelTool(
+  dashboardApi: DashboardApi
+): BrowserApiToolDefinition<z.infer<typeof removePanelSchema>> {
+  return {
+    id: 'dashboard_remove_panel',
+    description: `Removes a panel from the dashboard.
+    
+Use this tool when the user wants to delete a specific panel from the dashboard.
+The panel will be permanently removed from the dashboard layout.`,
+    schema: removePanelSchema,
+    handler: async ({ panel_id }) => {
+      dashboardApi.removePanel(panel_id);
+    },
+  };
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/tools/set_query.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/tools/set_query.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import type { BrowserApiToolDefinition } from '@kbn/onechat-browser/tools/browser_api_tool';
+import type { DashboardApi } from '../../dashboard_api/types';
+import type { Query, AggregateQuery } from '@kbn/es-query';
+
+const setQuerySchema = z.object({
+  query: z
+    .union([
+      z.object({
+        query: z.string().describe('The query string (e.g., KQL query or Lucene query)'),
+        language: z.string().describe('The query language (e.g., "kuery" for KQL or "lucene" for Lucene)'),
+      }),
+      z.object({
+        esql: z.string().describe('ESQL query string'),
+      }),
+    ])
+    .nullish()
+    .default(undefined)
+    .describe('Query object to set on the dashboard. Can be a KQL/Lucene query with query and language properties, or an ESQL query with esql property. If omitted or null, clears the query.'),
+});
+
+export function createSetQueryTool(
+  dashboardApi: DashboardApi
+): BrowserApiToolDefinition<z.infer<typeof setQuerySchema>> {
+  return {
+    id: 'dashboard_set_query',
+    description: `Sets the query applied to the dashboard.
+    
+Use this tool when the user wants to change the search query on the dashboard.
+The query controls which data is displayed in all panels on the dashboard.
+
+You can provide:
+- A KQL query: { query: "field:value", language: "kuery" }
+- A Lucene query: { query: "field:value", language: "lucene" }
+- An ESQL query: { esql: "FROM index | WHERE field = 'value'" }
+- null/undefined to clear the query`,
+    schema: setQuerySchema,
+    handler: async ({ query }) => {
+      if (!query) {
+        // Clear the query
+        dashboardApi.setQuery(undefined);
+        return;
+      }
+
+      // Convert to Query or AggregateQuery type
+      // The dashboard API accepts Query, but AggregateQuery (ESQL) should also work
+      const dashboardQuery = query as Query | AggregateQuery;
+      dashboardApi.setQuery(dashboardQuery as Query);
+    },
+  };
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/utils/build_application_context_attachment.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/utils/build_application_context_attachment.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ScreenContextAttachmentData } from '@kbn/onechat-common/attachments';
+import type { DashboardApi } from '../../dashboard_api/types';
+import { extractDashboardMetadata } from './extract_dashboard_state';
+
+/**
+ * Builds application context attachment data using the screen_context attachment type
+ */
+export function buildApplicationContextAttachment(
+  dashboardApi: DashboardApi
+): ScreenContextAttachmentData {
+  const metadata = extractDashboardMetadata(dashboardApi);
+  
+  // Build description with key dashboard info
+  const descriptionParts: string[] = [];
+  if (metadata.name) {
+    descriptionParts.push(`Dashboard: ${metadata.name}`);
+  }
+  if (metadata.mode) {
+    descriptionParts.push(`Mode: ${metadata.mode}`);
+  }
+  if (metadata.timerange) {
+    descriptionParts.push(`Time range: ${metadata.timerange.from} to ${metadata.timerange.to}`);
+  }
+  if (metadata.filters.length > 0) {
+    descriptionParts.push(`${metadata.filters.length} filter(s) applied`);
+  }
+  
+  const description = descriptionParts.length > 0 
+    ? descriptionParts.join(' | ')
+    : 'Dashboard context';
+
+  // Build additional_data with detailed context
+  const additionalData: Record<string, string> = {};
+  
+  if (metadata.id) {
+    additionalData.dashboard_id = metadata.id;
+  }
+  if (metadata.name) {
+    additionalData.name = metadata.name;
+  }
+  if (metadata.description) {
+    additionalData.description = metadata.description;
+  }
+  additionalData.mode = metadata.mode;
+  
+  if (metadata.timerange) {
+    additionalData.timerange_from = metadata.timerange.from;
+    additionalData.timerange_to = metadata.timerange.to;
+  }
+  
+  if (metadata.filters.length > 0) {
+    additionalData.filters_count = String(metadata.filters.length);
+    // Include filter details as JSON string
+    additionalData.filters = JSON.stringify(
+      metadata.filters.map((f) => ({
+        key: f.meta?.key,
+        value: f.meta?.value,
+        negate: f.meta?.negate,
+        disabled: f.meta?.disabled,
+      }))
+    );
+  }
+  
+  // Add short instructions for the AI
+  additionalData.instructions = 
+    'You are assisting with a dashboard. You can help modify panels, change filters, update time ranges, and create new dashboards.';
+
+  return {
+    app: 'dashboard',
+    description,
+    additional_data: additionalData,
+  };
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/utils/build_dashboard_text_attachment.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/utils/build_dashboard_text_attachment.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TextAttachmentData } from '@kbn/onechat-common/attachments';
+import type { DashboardApi } from '../../dashboard_api/types';
+import { extractDashboardMetadata } from './extract_dashboard_state';
+import { extractPanelInfo } from './extract_panel_info';
+import { formatDashboardMarkdown } from './format_dashboard_markdown';
+
+/**
+ * Builds dashboard text attachment data using the text attachment type
+ */
+export function buildDashboardTextAttachment(
+  dashboardApi: DashboardApi
+): TextAttachmentData {
+  const metadata = extractDashboardMetadata(dashboardApi);
+  const panels = extractPanelInfo(dashboardApi);
+  const markdown = formatDashboardMarkdown(metadata, panels);
+  
+  return {
+    content: markdown,
+  };
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/utils/extract_dashboard_state.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/utils/extract_dashboard_state.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DashboardApi } from '../../dashboard_api/types';
+import type { ViewMode } from '@kbn/presentation-publishing';
+import type { Filter, TimeRange } from '@kbn/es-query';
+
+export interface DashboardMetadata {
+  name: string;
+  id: string | undefined;
+  description: string | undefined;
+  mode: ViewMode;
+  timerange: TimeRange | undefined;
+  filters: Filter[];
+}
+
+/**
+ * Extracts dashboard metadata from the dashboard API
+ */
+export function extractDashboardMetadata(dashboardApi: DashboardApi): DashboardMetadata {
+  const title = dashboardApi.title$.value ?? '';
+  const savedObjectId = dashboardApi.savedObjectId$.value;
+  const description = dashboardApi.description$.value;
+  const viewMode = dashboardApi.viewMode$.value ?? 'view';
+  const timeRange = dashboardApi.timeRange$.value;
+  const filters = dashboardApi.filters$.value ?? [];
+
+  return {
+    name: title,
+    id: savedObjectId,
+    description,
+    mode: viewMode,
+    timerange: timeRange,
+    filters,
+  };
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/utils/extract_panel_info.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/utils/extract_panel_info.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DashboardApi } from '../../dashboard_api/types';
+import type { SerializedPanelState } from '@kbn/presentation-publishing';
+import { isOfAggregateQueryType, getAggregateQueryMode } from '@kbn/es-query';
+
+export interface PanelInfo {
+  id: string;
+  type: string;
+  title?: string;
+  description?: string;
+  esqlQueries?: string[];
+}
+
+/**
+ * Recursively searches for ESQL queries in an object
+ * Uses a Set to track visited objects and prevent infinite loops
+ */
+function findEsqlQueries(
+  obj: unknown,
+  queries: string[] = [],
+  visited: Set<unknown> = new Set(),
+  depth = 0,
+  maxDepth = 20
+): void {
+  // Limit recursion depth to prevent stack overflow
+  if (depth > maxDepth) {
+    return;
+  }
+
+  if (!obj || typeof obj !== 'object') {
+    return;
+  }
+
+  // Prevent infinite loops with circular references
+  if (visited.has(obj)) {
+    return;
+  }
+  visited.add(obj);
+
+  const objRecord = obj as Record<string, unknown>;
+
+  // Check if this object is an AggregateQuery with ESQL
+  // First try the proper type check
+  if (isOfAggregateQueryType(objRecord)) {
+    const mode = getAggregateQueryMode(objRecord);
+    if (mode === 'esql' && 'esql' in objRecord && typeof objRecord.esql === 'string') {
+      const esqlQuery = objRecord.esql;
+      // Avoid duplicates
+      if (!queries.includes(esqlQuery)) {
+        queries.push(esqlQuery);
+      }
+      // Don't return - continue searching for more queries in nested structures
+    }
+  }
+  
+  // Fallback: Direct check for esql property (in case type check fails)
+  if ('esql' in objRecord && typeof objRecord.esql === 'string' && objRecord.esql.trim().length > 0) {
+    const esqlQuery = objRecord.esql;
+    // Avoid duplicates
+    if (!queries.includes(esqlQuery)) {
+      queries.push(esqlQuery);
+    }
+  }
+
+  // Recursively search through all properties
+  if (Array.isArray(objRecord)) {
+    // Handle arrays
+    for (const item of objRecord) {
+      findEsqlQueries(item, queries, visited, depth + 1, maxDepth);
+    }
+  } else {
+    // Handle objects
+    for (const key in objRecord) {
+      if (Object.prototype.hasOwnProperty.call(objRecord, key)) {
+        const value = objRecord[key];
+        findEsqlQueries(value, queries, visited, depth + 1, maxDepth);
+      }
+    }
+  }
+}
+
+/**
+ * Extracts ESQL queries from a lens panel's serialized state
+ * Handles various structures:
+ * - rawState.query.esql (top-level query)
+ * - rawState.attributes.state.query.esql (main query in lens attributes)
+ * - rawState.attributes.state.datasourceStates.textBased.layers[].query.esql (layer queries)
+ * - Any other nested structure containing ESQL queries
+ */
+function extractEsqlQueriesFromLensPanel(
+  serializedState: SerializedPanelState
+): string[] | undefined {
+  const rawState = serializedState.rawState;
+  if (!rawState) {
+    return undefined;
+  }
+
+  // Check if this is a lens panel
+  if (rawState.type !== 'lens') {
+    return undefined;
+  }
+
+  const queries: string[] = [];
+
+  // Check if this is a by-reference panel
+  if ('savedObjectId' in rawState && rawState.savedObjectId) {
+    // By-reference panels don't have the query in the rawState, it's in the saved object
+    // We can't access it here without loading the saved object
+    return undefined;
+  }
+
+  // Check top-level query first (embeddableConfig.query.esql)
+  if ('query' in rawState && rawState.query) {
+    const query = rawState.query;
+    if (isOfAggregateQueryType(query)) {
+      const mode = getAggregateQueryMode(query);
+      if (mode === 'esql' && 'esql' in query && typeof query.esql === 'string') {
+        queries.push(query.esql);
+      }
+    }
+    // Fallback: direct esql check
+    if ('esql' in query && typeof (query as Record<string, unknown>).esql === 'string') {
+      const esqlQuery = (query as Record<string, unknown>).esql as string;
+      if (!queries.includes(esqlQuery)) {
+        queries.push(esqlQuery);
+      }
+    }
+  }
+
+  // Check for attributes.state.query (main query)
+  if ('attributes' in rawState && rawState.attributes && typeof rawState.attributes === 'object') {
+    const attributes = rawState.attributes as Record<string, unknown>;
+    if ('state' in attributes && attributes.state && typeof attributes.state === 'object') {
+      const state = attributes.state as Record<string, unknown>;
+      
+      // Check main query
+      if ('query' in state && state.query) {
+        const query = state.query;
+        if (isOfAggregateQueryType(query)) {
+          const mode = getAggregateQueryMode(query);
+          if (mode === 'esql' && 'esql' in query && typeof query.esql === 'string') {
+            queries.push(query.esql);
+          }
+        }
+        // Fallback: direct esql check
+        if ('esql' in query && typeof (query as Record<string, unknown>).esql === 'string') {
+          const esqlQuery = (query as Record<string, unknown>).esql as string;
+          if (!queries.includes(esqlQuery)) {
+            queries.push(esqlQuery);
+          }
+        }
+      }
+      
+      // Check datasourceStates.textBased.layers for layer queries
+      if ('datasourceStates' in state && state.datasourceStates && typeof state.datasourceStates === 'object') {
+        const datasourceStates = state.datasourceStates as Record<string, unknown>;
+        if ('textBased' in datasourceStates && datasourceStates.textBased && typeof datasourceStates.textBased === 'object') {
+          const textBased = datasourceStates.textBased as Record<string, unknown>;
+          if ('layers' in textBased && textBased.layers && typeof textBased.layers === 'object') {
+            const layers = textBased.layers as Record<string, unknown>;
+            for (const layerId in layers) {
+              if (Object.prototype.hasOwnProperty.call(layers, layerId)) {
+                const layer = layers[layerId] as Record<string, unknown>;
+                if ('query' in layer && layer.query) {
+                  const layerQuery = layer.query;
+                  if (isOfAggregateQueryType(layerQuery)) {
+                    const mode = getAggregateQueryMode(layerQuery);
+                    if (mode === 'esql' && 'esql' in layerQuery && typeof layerQuery.esql === 'string') {
+                      const esqlQuery = layerQuery.esql;
+                      if (!queries.includes(esqlQuery)) {
+                        queries.push(esqlQuery);
+                      }
+                    }
+                  }
+                  // Fallback: direct esql check
+                  if ('esql' in layerQuery && typeof (layerQuery as Record<string, unknown>).esql === 'string') {
+                    const esqlQuery = (layerQuery as Record<string, unknown>).esql as string;
+                    if (!queries.includes(esqlQuery)) {
+                      queries.push(esqlQuery);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Also use recursive search as a fallback to catch any other structures
+  findEsqlQueries(rawState, queries);
+
+  return queries.length > 0 ? queries : undefined;
+}
+
+/**
+ * Extracts panel information from dashboard API
+ */
+export function extractPanelInfo(dashboardApi: DashboardApi): PanelInfo[] {
+  const serializedState = dashboardApi.getSerializedState();
+  const panels = serializedState.attributes.panels ?? [];
+
+  return panels.map((panel) => {
+    const panelId = panel.uid ?? '';
+    const panelType = panel.type;
+    
+    // Try to get panel details from dashboard API
+    let panelInfo: PanelInfo = {
+      id: panelId,
+      type: panelType,
+    };
+
+    try {
+      const panelData = dashboardApi.getDashboardPanelFromId(panelId);
+      
+      // Extract title and description from panel config if available
+      const config = panel.config as Record<string, unknown>;
+      if (config.title) {
+        panelInfo.title = String(config.title);
+      }
+      if (config.description) {
+        panelInfo.description = String(config.description);
+      }
+
+      // Extract ESQL queries for lens panels
+      if (panelType === 'lens') {
+        const esqlQueries = extractEsqlQueriesFromLensPanel(panelData.serializedState);
+        if (esqlQueries) {
+          panelInfo.esqlQueries = esqlQueries;
+        }
+      }
+    } catch (error) {
+      // Panel might not be loaded yet, continue with basic info
+    }
+
+    return panelInfo;
+  });
+}
+

--- a/src/platform/plugins/shared/dashboard/public/onechat/utils/format_dashboard_markdown.ts
+++ b/src/platform/plugins/shared/dashboard/public/onechat/utils/format_dashboard_markdown.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DashboardMetadata } from './extract_dashboard_state';
+import type { PanelInfo } from './extract_panel_info';
+import type { Filter } from '@kbn/es-query';
+
+/**
+ * Formats a filter for display in markdown
+ */
+function formatFilter(filter: Filter): string {
+  const parts: string[] = [];
+  
+  if (filter.meta?.key) {
+    parts.push(`**${filter.meta.key}**`);
+  }
+  
+  if (filter.meta?.value) {
+    parts.push(String(filter.meta.value));
+  }
+  
+  if (filter.meta?.negate) {
+    parts.push('(negated)');
+  }
+  
+  if (filter.meta?.disabled) {
+    parts.push('(disabled)');
+  }
+  
+  return parts.join(' ');
+}
+
+/**
+ * Formats dashboard configuration as markdown
+ */
+export function formatDashboardMarkdown(
+  metadata: DashboardMetadata,
+  panels: PanelInfo[]
+): string {
+  const lines: string[] = [];
+  
+  // Dashboard header
+  lines.push('# Dashboard Configuration');
+  lines.push('');
+  
+  // Basic info
+  lines.push('## Dashboard Information');
+  lines.push('');
+  lines.push(`**Title:** ${metadata.name || 'Untitled Dashboard'}`);
+  if (metadata.id) {
+    lines.push(`**ID:** ${metadata.id}`);
+  }
+  if (metadata.description) {
+    lines.push(`**Description:** ${metadata.description}`);
+  }
+  lines.push(`**Mode:** ${metadata.mode}`);
+  lines.push('');
+  
+  // Time range
+  lines.push('## Time Range');
+  lines.push('');
+  if (metadata.timerange) {
+    lines.push(`- **From:** ${metadata.timerange.from}`);
+    lines.push(`- **To:** ${metadata.timerange.to}`);
+  } else {
+    lines.push('No time range set');
+  }
+  lines.push('');
+  
+  // Filters
+  lines.push('## Filters');
+  lines.push('');
+  if (metadata.filters.length > 0) {
+    metadata.filters.forEach((filter, index) => {
+      lines.push(`${index + 1}. ${formatFilter(filter)}`);
+    });
+  } else {
+    lines.push('No filters applied');
+  }
+  lines.push('');
+  
+  // Panels
+  lines.push('## Panels');
+  lines.push('');
+  if (panels.length > 0) {
+    panels.forEach((panel, index) => {
+      lines.push(`### Panel ${index + 1}: ${panel.title || panel.type || 'Untitled'}`);
+      lines.push('');
+      lines.push(`- **ID:** ${panel.id}`);
+      lines.push(`- **Type:** ${panel.type}`);
+      if (panel.description) {
+        lines.push(`- **Description:** ${panel.description}`);
+      }
+      
+      // ESQL queries for lens panels
+      if (panel.esqlQueries && panel.esqlQueries.length > 0) {
+        lines.push('- **ESQL Queries:**');
+        panel.esqlQueries.forEach((query, queryIndex) => {
+          lines.push(`  ${queryIndex + 1}. \`\`\`esql`);
+          lines.push(`  ${query}`);
+          lines.push(`  \`\`\``);
+        });
+      }
+      
+      lines.push('');
+    });
+  } else {
+    lines.push('No panels in dashboard');
+  }
+  
+  return lines.join('\n');
+}
+

--- a/src/platform/plugins/shared/dashboard/public/plugin.tsx
+++ b/src/platform/plugins/shared/dashboard/public/plugin.tsx
@@ -104,6 +104,7 @@ export interface DashboardStartDependencies {
   share?: SharePluginStart;
   spaces?: SpacesPluginStart;
   uiActions: UiActionsStart;
+  onechat?: import('@kbn/onechat-plugin/public').OnechatPluginStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
   urlForwarding: UrlForwardingStart;
   usageCollection?: UsageCollectionStart;

--- a/src/platform/plugins/shared/dashboard/public/services/kibana_services.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/kibana_services.ts
@@ -41,6 +41,7 @@ export let navigationService: NavigationPublicPluginStart;
 export let noDataPageService: NoDataPagePluginStart | undefined;
 export let observabilityAssistantService: ObservabilityAIAssistantPublicStart | undefined;
 export let lensService: LensPublicStart | undefined;
+export let onechatService: import('@kbn/onechat-plugin/public').OnechatPluginStart | undefined;
 export let presentationUtilService: PresentationUtilPluginStart;
 export let savedObjectsTaggingService: SavedObjectTaggingOssPluginStart | undefined;
 export let screenshotModeService: ScreenshotModePluginStart;
@@ -64,6 +65,7 @@ export const setKibanaServices = (kibanaCore: CoreStart, deps: DashboardStartDep
   noDataPageService = deps.noDataPage;
   observabilityAssistantService = deps.observabilityAIAssistant;
   lensService = deps.lens;
+  onechatService = deps.onechat;
   presentationUtilService = deps.presentationUtil;
   savedObjectsTaggingService = deps.savedObjectsTaggingOss;
   serverlessService = deps.serverless;

--- a/src/platform/plugins/shared/dashboard/server/onechat/tools/get_dashboard.ts
+++ b/src/platform/plugins/shared/dashboard/server/onechat/tools/get_dashboard.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import { ToolType, ToolResultType } from '@kbn/onechat-common';
+import type { BuiltinToolDefinition } from '@kbn/onechat-server';
+import type { AgentHandlerContext } from '@kbn/onechat-server';
+import type { SavedObjectsServiceStart } from '@kbn/core/server';
+import { DASHBOARD_SAVED_OBJECT_TYPE } from '../../dashboard_saved_object';
+import { savedObjectToItem } from '../../content_management/v1/transform_utils';
+
+const getDashboardSchema = z.object({
+  dashboard_id: z.string().describe('The ID of the dashboard to retrieve'),
+});
+
+export const getDashboardTool = (
+  savedObjects: SavedObjectsServiceStart
+): BuiltinToolDefinition<typeof getDashboardSchema> => {
+  return {
+    id: 'platform.dashboard.get_dashboard',
+    type: ToolType.builtin,
+    description: `Retrieves the full raw dashboard configuration object (JSON) by its ID.
+    
+This tool returns the complete dashboard state as a JSON object including:
+- Dashboard attributes (title, description, panels, filters, timeRange, etc.)
+- References to related saved objects
+- Metadata (id, type, timestamps, version, etc.)
+
+The returned data structure matches the dashboard saved object format and can be used to understand the exact dashboard configuration or to programmatically modify dashboards.
+
+Use this tool when you need to access the raw dashboard data structure for analysis or modification.`,
+    schema: getDashboardSchema,
+    handler: async (
+      { dashboard_id },
+      { request, logger }: AgentHandlerContext
+    ) => {
+      logger.debug(`get_dashboard tool called with dashboard_id: ${dashboard_id}`);
+
+      try {
+        // Get saved objects client scoped to the request
+        const savedObjectsClient = savedObjects.getScopedClient(request);
+
+        // Resolve dashboard (handles aliases)
+        const resolveResult = await savedObjectsClient.resolve(
+          DASHBOARD_SAVED_OBJECT_TYPE,
+          dashboard_id
+        );
+
+        if (!resolveResult.saved_object) {
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error: 'Dashboard not found',
+                  message: `Dashboard with ID "${dashboard_id}" does not exist.`,
+                },
+              },
+            ],
+          };
+        }
+
+        // Convert saved object to dashboard item
+        const conversionResult = savedObjectToItem(resolveResult.saved_object, false);
+        if (!conversionResult) {
+          logger.error('savedObjectToItem returned undefined');
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error: 'Invalid dashboard data',
+                  message: 'Failed to convert dashboard saved object',
+                },
+              },
+            ],
+          };
+        }
+
+        const { item, error: itemError } = conversionResult;
+        if (itemError) {
+          logger.error(`Error converting dashboard saved object: ${itemError instanceof Error ? itemError.message : String(itemError)}`);
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error: 'Invalid dashboard data',
+                  message: itemError instanceof Error ? itemError.message : String(itemError),
+                },
+              },
+            ],
+          };
+        }
+
+        if (!item) {
+          logger.error('savedObjectToItem returned null item');
+          return {
+            results: [
+              {
+                type: ToolResultType.error,
+                data: {
+                  error: 'Invalid dashboard data',
+                  message: 'Dashboard item is null',
+                },
+              },
+            ],
+          };
+        }
+
+        // Return raw dashboard object as JSON
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data: {
+                dashboard_id: dashboard_id,
+                dashboard: item.attributes,
+                references: item.references,
+                metadata: {
+                  id: item.id,
+                  type: item.type,
+                  updated_at: item.updatedAt,
+                  updated_by: item.updatedBy,
+                  created_at: item.createdAt,
+                  created_by: item.createdBy,
+                  version: item.version,
+                  managed: item.managed,
+                  namespaces: item.namespaces,
+                },
+              },
+            },
+          ],
+        };
+      } catch (error) {
+        logger.error(`Error retrieving dashboard: ${error}`);
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                error: 'Failed to retrieve dashboard',
+                message: error instanceof Error ? error.message : String(error),
+              },
+            },
+          ],
+        };
+      }
+    },
+    tags: ['dashboard', 'visualization'],
+  };
+};
+

--- a/src/platform/plugins/shared/dashboard/server/onechat/utils/format_dashboard_markdown.ts
+++ b/src/platform/plugins/shared/dashboard/server/onechat/utils/format_dashboard_markdown.ts
@@ -1,0 +1,295 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DashboardState } from '../../content_management';
+import type { Filter } from '@kbn/es-query';
+import { isOfAggregateQueryType, getAggregateQueryMode } from '@kbn/es-query';
+
+/**
+ * Recursively searches for ESQL queries in an object
+ * Uses a Set to track visited objects and prevent infinite loops
+ */
+function findEsqlQueries(
+  obj: unknown,
+  queries: string[] = [],
+  visited: Set<unknown> = new Set(),
+  depth = 0,
+  maxDepth = 20
+): void {
+  // Limit recursion depth to prevent stack overflow
+  if (depth > maxDepth) {
+    return;
+  }
+
+  if (!obj || typeof obj !== 'object') {
+    return;
+  }
+
+  // Prevent infinite loops with circular references
+  if (visited.has(obj)) {
+    return;
+  }
+  visited.add(obj);
+
+  const objRecord = obj as Record<string, unknown>;
+
+  // Check if this object is an AggregateQuery with ESQL
+  // First try the proper type check
+  if (isOfAggregateQueryType(objRecord)) {
+    const mode = getAggregateQueryMode(objRecord);
+    if (mode === 'esql' && 'esql' in objRecord && typeof objRecord.esql === 'string') {
+      const esqlQuery = objRecord.esql;
+      // Avoid duplicates
+      if (!queries.includes(esqlQuery)) {
+        queries.push(esqlQuery);
+      }
+      // Don't return - continue searching for more queries in nested structures
+    }
+  }
+  
+  // Fallback: Direct check for esql property (in case type check fails)
+  if ('esql' in objRecord && typeof objRecord.esql === 'string' && objRecord.esql.trim().length > 0) {
+    const esqlQuery = objRecord.esql;
+    // Avoid duplicates
+    if (!queries.includes(esqlQuery)) {
+      queries.push(esqlQuery);
+    }
+  }
+
+  // Recursively search through all properties
+  if (Array.isArray(objRecord)) {
+    // Handle arrays
+    for (const item of objRecord) {
+      findEsqlQueries(item, queries, visited, depth + 1, maxDepth);
+    }
+  } else {
+    // Handle objects
+    for (const key in objRecord) {
+      if (Object.prototype.hasOwnProperty.call(objRecord, key)) {
+        const value = objRecord[key];
+        findEsqlQueries(value, queries, visited, depth + 1, maxDepth);
+      }
+    }
+  }
+}
+
+/**
+ * Extracts ESQL queries from lens panel config
+ * Handles various structures:
+ * - config.query.esql (top-level query)
+ * - config.attributes.state.query.esql (main query in lens attributes)
+ * - config.attributes.state.datasourceStates.textBased.layers[].query.esql (layer queries)
+ * - Any other nested structure containing ESQL queries
+ */
+function extractEsqlQueriesFromLensPanel(config: Record<string, unknown>): string[] | undefined {
+  const queries: string[] = [];
+
+  // Check if this is a by-reference panel (has savedObjectId)
+  if (config.savedObjectId) {
+    // By-reference panels don't have the query in the config, it's in the saved object
+    // We can't access it here without loading the saved object
+    return undefined;
+  }
+
+  // Check top-level query first (embeddableConfig.query.esql)
+  if (config.query) {
+    const query = config.query;
+    if (isOfAggregateQueryType(query)) {
+      const mode = getAggregateQueryMode(query);
+      if (mode === 'esql' && 'esql' in query && typeof query.esql === 'string') {
+        queries.push(query.esql);
+      }
+    }
+    // Fallback: direct esql check
+    if ('esql' in query && typeof (query as Record<string, unknown>).esql === 'string') {
+      const esqlQuery = (query as Record<string, unknown>).esql as string;
+      if (!queries.includes(esqlQuery)) {
+        queries.push(esqlQuery);
+      }
+    }
+  }
+
+  // Check for attributes.state.query (main query)
+  if (config.attributes && typeof config.attributes === 'object') {
+    const attributes = config.attributes as Record<string, unknown>;
+    if (attributes.state && typeof attributes.state === 'object') {
+      const state = attributes.state as Record<string, unknown>;
+      
+      // Check main query
+      if (state.query) {
+        const query = state.query;
+        if (isOfAggregateQueryType(query)) {
+          const mode = getAggregateQueryMode(query);
+          if (mode === 'esql' && 'esql' in query && typeof query.esql === 'string') {
+            queries.push(query.esql);
+          }
+        }
+        // Fallback: direct esql check
+        if ('esql' in query && typeof (query as Record<string, unknown>).esql === 'string') {
+          const esqlQuery = (query as Record<string, unknown>).esql as string;
+          if (!queries.includes(esqlQuery)) {
+            queries.push(esqlQuery);
+          }
+        }
+      }
+      
+      // Check datasourceStates.textBased.layers for layer queries
+      if (state.datasourceStates && typeof state.datasourceStates === 'object') {
+        const datasourceStates = state.datasourceStates as Record<string, unknown>;
+        if (datasourceStates.textBased && typeof datasourceStates.textBased === 'object') {
+          const textBased = datasourceStates.textBased as Record<string, unknown>;
+          if (textBased.layers && typeof textBased.layers === 'object') {
+            const layers = textBased.layers as Record<string, unknown>;
+            for (const layerId in layers) {
+              if (Object.prototype.hasOwnProperty.call(layers, layerId)) {
+                const layer = layers[layerId] as Record<string, unknown>;
+                if (layer.query) {
+                  const layerQuery = layer.query;
+                  if (isOfAggregateQueryType(layerQuery)) {
+                    const mode = getAggregateQueryMode(layerQuery);
+                    if (mode === 'esql' && 'esql' in layerQuery && typeof layerQuery.esql === 'string') {
+                      const esqlQuery = layerQuery.esql;
+                      if (!queries.includes(esqlQuery)) {
+                        queries.push(esqlQuery);
+                      }
+                    }
+                  }
+                  // Fallback: direct esql check
+                  if ('esql' in layerQuery && typeof (layerQuery as Record<string, unknown>).esql === 'string') {
+                    const esqlQuery = (layerQuery as Record<string, unknown>).esql as string;
+                    if (!queries.includes(esqlQuery)) {
+                      queries.push(esqlQuery);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Also use recursive search as a fallback to catch any other structures
+  findEsqlQueries(config, queries);
+
+  return queries.length > 0 ? queries : undefined;
+}
+
+/**
+ * Formats a filter for display in markdown
+ */
+function formatFilter(filter: Filter): string {
+  const parts: string[] = [];
+
+  if (filter.meta?.key) {
+    parts.push(`**${filter.meta.key}**`);
+  }
+
+  if (filter.meta?.value) {
+    parts.push(String(filter.meta.value));
+  }
+
+  if (filter.meta?.negate) {
+    parts.push('(negated)');
+  }
+
+  if (filter.meta?.disabled) {
+    parts.push('(disabled)');
+  }
+
+  return parts.join(' ');
+}
+
+/**
+ * Formats dashboard configuration as markdown
+ */
+export function formatDashboardMarkdown(
+  dashboardState: DashboardState,
+  dashboardId?: string
+): string {
+  const lines: string[] = [];
+
+  // Dashboard header
+  lines.push('# Dashboard Configuration');
+  lines.push('');
+
+  // Basic info
+  lines.push('## Dashboard Information');
+  lines.push('');
+  lines.push(`**Title:** ${dashboardState.title || 'Untitled Dashboard'}`);
+  if (dashboardId) {
+    lines.push(`**ID:** ${dashboardId}`);
+  }
+  if (dashboardState.description) {
+    lines.push(`**Description:** ${dashboardState.description}`);
+  }
+  lines.push('');
+
+  // Time range
+  lines.push('## Time Range');
+  lines.push('');
+  if (dashboardState.timeRange) {
+    lines.push(`- **From:** ${dashboardState.timeRange.from}`);
+    lines.push(`- **To:** ${dashboardState.timeRange.to}`);
+  } else {
+    lines.push('No time range set');
+  }
+  lines.push('');
+
+  // Filters
+  lines.push('## Filters');
+  lines.push('');
+  if (dashboardState.filters && dashboardState.filters.length > 0) {
+    dashboardState.filters.forEach((filter, index) => {
+      lines.push(`${index + 1}. ${formatFilter(filter as Filter)}`);
+    });
+  } else {
+    lines.push('No filters applied');
+  }
+  lines.push('');
+
+  // Panels
+  lines.push('## Panels');
+  lines.push('');
+  const panels = dashboardState.panels ?? [];
+  if (panels.length > 0) {
+    panels.forEach((panel, index) => {
+      const panelTitle = (panel.config as Record<string, unknown>)?.title as string | undefined;
+      const panelDescription = (panel.config as Record<string, unknown>)
+        ?.description as string | undefined;
+
+      lines.push(`### Panel ${index + 1}: ${panelTitle || panel.type || 'Untitled'}`);
+      lines.push('');
+      lines.push(`- **ID:** ${panel.uid ?? 'N/A'}`);
+      lines.push(`- **Type:** ${panel.type}`);
+      if (panelDescription) {
+        lines.push(`- **Description:** ${panelDescription}`);
+      }
+
+      // ESQL queries for lens panels
+      if (panel.type === 'lens') {
+        const esqlQueries = extractEsqlQueriesFromLensPanel(panel.config as Record<string, unknown>);
+        if (esqlQueries && esqlQueries.length > 0) {
+          lines.push('- **ESQL Queries:**');
+          esqlQueries.forEach((query, queryIndex) => {
+            lines.push(`  ${queryIndex + 1}. \`\`\`esql`);
+            lines.push(`  ${query}`);
+            lines.push(`  \`\`\``);
+          });
+        }
+      }
+
+      lines.push('');
+    });
+  } else {
+    lines.push('No panels in dashboard');
+  }
+
+  return lines.join('\n');
+}
+

--- a/src/platform/plugins/shared/dashboard/server/plugin.ts
+++ b/src/platform/plugins/shared/dashboard/server/plugin.ts
@@ -54,6 +54,7 @@ interface SetupDeps {
   usageCollection?: UsageCollectionSetup;
   taskManager: TaskManagerSetupContract;
   contentManagement: ContentManagementServerSetup;
+  onechat?: { tools: { register: (tool: any) => void } };
 }
 
 export interface StartDeps {
@@ -141,6 +142,17 @@ export class DashboardPlugin
       contentManagement: plugins.contentManagement,
       logger: this.logger,
     });
+
+    // Register onechat tool if onechat plugin is available
+    if (plugins.onechat?.tools) {
+      // Defer tool creation until start when savedObjects is available
+      core.getStartServices().then(([coreStart]) => {
+        const { getDashboardTool } = require('./onechat/tools/get_dashboard');
+        plugins.onechat!.tools.register(getDashboardTool(coreStart.savedObjects));
+      }).catch((error) => {
+        this.logger.warn(`Failed to register onechat tool: ${error.message}`);
+      });
+    }
 
     return {};
   }


### PR DESCRIPTION
## Summary

just to showcase how one could integrate with agent builder:
- add custom tools (get_dashboard)
- invoke panel with providing information about screen context
- invoke panel with whole configuration (transformed dashboard config, which includes panels esql queries)
- allow agent to call client side tools (to add a panel, update time filter, update query, filters, ...)

