### PR TITLE
[Defend Workflows] Unskip endpoint exceptions cypress tests

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -77,11 +77,7 @@ export const getCypressBaseConfig = (
         // baseUrl: To override, set Env. variable `CYPRESS_BASE_URL`
         baseUrl: 'http://localhost:5601',
         supportFile: 'public/management/cypress/support/e2e.ts',
-
-        // TODO: RESTORE ORIGINAL PATTERN BEFORE MERGE
-        specPattern:
-          'public/management/cypress/e2e/artifacts/endpoint_exceptions*.cy.{js,jsx,ts,tsx}',
-
+        specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
         experimentalRunAllSpecs: true,
         experimentalMemoryManagement: true,
         experimentalInteractiveRunEvents: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -77,7 +77,11 @@ export const getCypressBaseConfig = (
         // baseUrl: To override, set Env. variable `CYPRESS_BASE_URL`
         baseUrl: 'http://localhost:5601',
         supportFile: 'public/management/cypress/support/e2e.ts',
-        specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+
+        // TODO: RESTORE ORIGINAL PATTERN BEFORE MERGE
+        specPattern:
+          'public/management/cypress/e2e/artifacts/endpoint_exceptions*.cy.{js,jsx,ts,tsx}',
+
         experimentalRunAllSpecs: true,
         experimentalMemoryManagement: true,
         experimentalInteractiveRunEvents: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/artifacts/endpoint_exceptions.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/artifacts/endpoint_exceptions.cy.ts
@@ -68,8 +68,7 @@ describe(
       // todo: add 'should NOT' test case when Endpoint Exceptions sub-feature privilege is separated from Security
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/240814
-    describe.skip('Serverless', { tags: ['@serverless', '@skipInServerlessMKI'] }, () => {
+    describe('Serverless', { tags: ['@serverless', '@skipInServerlessMKI'] }, () => {
       it('should display Endpoint Exceptions in Assets side panel ', () => {
         // testing with t3_analyst with WRITE access, as we don't support custom roles on serverless yet
         login(ROLE.t3_analyst);

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/artifacts/endpoint_exceptions.no_ff.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/artifacts/endpoint_exceptions.no_ff.cy.ts
@@ -13,8 +13,7 @@ import {
 } from '../../../../../common/constants';
 import { login, ROLE } from '../../tasks/login';
 
-// Failing: See https://github.com/elastic/kibana/issues/240815
-describe.skip('Endpoint exceptions - preserving behaviour without `endpointExceptionsMovedUnderManagement` feature flag', () => {
+describe('Endpoint exceptions - preserving behaviour without `endpointExceptionsMovedUnderManagement` feature flag', () => {
   describe('ESS', { tags: ['@ess'] }, () => {
     const loginWithReadAccess = () => {
       login.withCustomKibanaPrivileges({
@@ -47,7 +46,8 @@ describe.skip('Endpoint exceptions - preserving behaviour without `endpointExcep
 
   describe('Serverless', { tags: ['@serverless', '@skipInServerlessMKI'] }, () => {
     it('should not display Endpoint Exceptions in Assets side panel ', () => {
-      // testing with t3_analyst with WRITE access, as we don't support custom roles on serverless yet
+      // instead of testing with the lowest access (READ), we're testing with t3_analyst with WRITE access,
+      // as we neither have any role with READ access, nor custom roles on serverless yet
       login(ROLE.t3_analyst);
       cy.visit(APP_PATH);
 


### PR DESCRIPTION
## Summary

Unskipping 2 endpoint exceptions related cypress tests, as they were failing due to a UI flakiness, which should have been fixed since (#239888 and #239721).

Flaky runner: ✅ 100% (25/25) for both tests on both ESS and serverless:
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9786/steps/canvas
<img width="735" height="210" alt="image" src="https://github.com/user-attachments/assets/e3ad3645-8872-48d5-98a5-8d2e11e679ce" />



> [!warning]
> Undo temporary commit before merge: 7e47cb1c2d6b11c8280ce9eb259381d853a25970 -> done ✅ 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
