### PR TITLE
[9.1] [scout] failed test reporter integration (#239771)

### DIFF
--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -11,6 +11,7 @@ IS_TEST_EXECUTION_STEP="$(buildkite-agent meta-data get "${BUILDKITE_JOB_ID}_is_
 if [[ "$IS_TEST_EXECUTION_STEP" == "true" ]]; then
   echo "--- Upload Artifacts"
   buildkite-agent artifact upload '.scout/reports/scout-playwright-test-failures-*/**/*'
+  buildkite-agent artifact upload '.scout/reports/scout-playwright-test-failures-*/scout-failures-*.ndjson'
   buildkite-agent artifact upload 'target/junit/**/*'
   buildkite-agent artifact upload 'target/kibana-coverage/jest/**/*'
   buildkite-agent artifact upload 'target/kibana-coverage/functional/**/*'
@@ -48,7 +49,9 @@ if [[ "$IS_TEST_EXECUTION_STEP" == "true" ]]; then
         --no-github-update --no-index-errors
     else
       echo "--- Run Failed Test Reporter"
-      node scripts/report_failed_tests --build-url="${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}" 'target/junit/**/*.xml'
+      node scripts/report_failed_tests --build-url="${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}" \
+        'target/junit/**/*.xml' \
+        '.scout/reports/scout-playwright-test-failures-*/scout-failures-*.ndjson'
     fi
   fi
 

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/existing_failed_test_issues.test.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/existing_failed_test_issues.test.ts
@@ -7,11 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { ToolingLog, ToolingLogCollectingWriter } from '@kbn/tooling-log';
 import { createStripAnsiSerializer } from '@kbn/jest-serializers';
+import { ToolingLog, ToolingLogCollectingWriter } from '@kbn/tooling-log';
 
+import type { FailedTestIssue } from './existing_failed_test_issues';
+import { ExistingFailedTestIssues } from './existing_failed_test_issues';
 import type { TestFailure } from './get_failures';
-import { ExistingFailedTestIssues, FailedTestIssue } from './existing_failed_test_issues';
 
 expect.addSnapshotSerializer(createStripAnsiSerializer());
 
@@ -164,4 +165,196 @@ it('captures a list of failed test issue, loads the bodies for each issue, and o
       ],
     }
   `);
+});
+
+describe('Scout failures', () => {
+  it('detects Scout failures correctly', () => {
+    const existing = new ExistingFailedTestIssues(log);
+
+    const scoutFailure: TestFailure & { id: string; target: string; location: string } = {
+      ...mockTestFailure,
+      classname: 'scout suite',
+      name: 'scout test',
+      id: 'test-id-1',
+      target: 'stateful',
+      location: '/path/to/test.ts',
+    };
+
+    const ftrFailure: TestFailure = {
+      ...mockTestFailure,
+      classname: 'ftr suite',
+      name: 'ftr test',
+    };
+
+    expect(existing.isScoutFailure(scoutFailure)).toBe(true);
+    expect(existing.isScoutFailure(ftrFailure)).toBe(false);
+  });
+
+  it('matches Scout failures by name only, ignoring target differences', async () => {
+    const existing = new ExistingFailedTestIssues(log);
+
+    Axios.request.mockImplementation(({ data }: any) => ({
+      data: {
+        existingIssues: data.failures
+          .filter((t: any) => t.name === 'scout test name')
+          .map(
+            (t: any): FailedTestIssue => ({
+              classname: t.classname || 'scout suite',
+              name: t.name,
+              github: {
+                htmlUrl: 'htmlurl(scout test name)',
+                nodeId: 'nodeid(scout test name)',
+                number: 123,
+                body: 'FAILURE: scout test name',
+              },
+            })
+          ),
+      },
+    }));
+
+    // First Scout failure with target chrome
+    const scoutFailure1: TestFailure & { id: string; target: string; location: string } = {
+      ...mockTestFailure,
+      classname: 'scout suite',
+      name: 'scout test name',
+      id: 'test-id-1',
+      target: 'serverless=es',
+      location: '/path/to/test.ts',
+    };
+
+    // Second Scout failure with same name but different target
+    const scoutFailure2: TestFailure & { id: string; target: string; location: string } = {
+      ...mockTestFailure,
+      classname: 'scout suite',
+      name: 'scout test name',
+      id: 'test-id-2',
+      target: 'stateful',
+      location: '/path/to/test.ts',
+    };
+
+    // Load the first failure
+    await existing.loadForFailures([scoutFailure1]);
+
+    // Both failures should match the same issue (by name only)
+    const issue1 = existing.getForFailure(scoutFailure1);
+    const issue2 = existing.getForFailure(scoutFailure2);
+
+    expect(issue1).toBeDefined();
+    expect(issue2).toBeDefined();
+    expect(issue1?.name).toBe('scout test name');
+    expect(issue2?.name).toBe('scout test name');
+    expect(issue1).toEqual(issue2);
+  });
+
+  it('correctly identifies seen Scout failures by name only', async () => {
+    const existing = new ExistingFailedTestIssues(log);
+
+    Axios.request.mockImplementation(() => ({
+      data: {
+        existingIssues: [],
+      },
+    }));
+
+    // First Scout failure with target chrome
+    const scoutFailure1: TestFailure & { id: string; target: string; location: string } = {
+      ...mockTestFailure,
+      classname: 'scout suite',
+      name: 'scout test name',
+      id: 'test-id-1',
+      target: 'serverless=es',
+      location: '/path/to/test.ts',
+    };
+
+    // Second Scout failure with same name but different target
+    const scoutFailure2: TestFailure & { id: string; target: string; location: string } = {
+      ...mockTestFailure,
+      classname: 'scout suite',
+      name: 'scout test name',
+      id: 'test-id-2',
+      target: 'stateful',
+      location: '/path/to/test.ts',
+    };
+
+    // Load the first failure
+    await existing.loadForFailures([scoutFailure1]);
+
+    // The second failure should be considered "seen" because it has the same name
+    // This tests the isFailureSeen logic
+    await existing.loadForFailures([scoutFailure1, scoutFailure2]);
+
+    // Should only make one API call (for the first failure, second is already seen)
+    expect(Axios.request).toHaveBeenCalledTimes(1);
+  });
+
+  it('distinguishes between Scout and FTR failures correctly', async () => {
+    const existing = new ExistingFailedTestIssues(log);
+
+    Axios.request.mockImplementation(({ data }: any) => ({
+      data: {
+        existingIssues: data.failures.map(
+          (t: any, i: number): FailedTestIssue => ({
+            classname: t.classname,
+            name: t.name,
+            github: {
+              htmlUrl: `htmlurl(${t.classname}/${t.name})`,
+              nodeId: `nodeid(${t.classname}/${t.name})`,
+              number: i + 1,
+              body: `FAILURE: ${t.classname}/${t.name}`,
+            },
+          })
+        ),
+      },
+    }));
+
+    const scoutFailure: TestFailure & { id: string; target: string; location: string } = {
+      ...mockTestFailure,
+      classname: 'scout suite',
+      name: 'scout test',
+      id: 'test-id-1',
+      target: 'serverless=es',
+      location: '/path/to/test.ts',
+    };
+
+    const ftrFailure: TestFailure = {
+      ...mockTestFailure,
+      classname: 'ftr suite',
+      name: 'ftr test',
+    };
+
+    // Load both failures
+    await existing.loadForFailures([scoutFailure, ftrFailure]);
+
+    // Each should find its own issue
+    const scoutIssue = existing.getForFailure(scoutFailure);
+    const ftrIssue = existing.getForFailure(ftrFailure);
+
+    expect(scoutIssue).toBeDefined();
+    expect(scoutIssue?.name).toBe('scout test');
+    expect(ftrIssue).toBeDefined();
+    expect(ftrIssue?.name).toBe('ftr test');
+  });
+
+  it('returns undefined for Scout failures when no matching issue exists', async () => {
+    const existing = new ExistingFailedTestIssues(log);
+
+    Axios.request.mockImplementation(() => ({
+      data: {
+        existingIssues: [],
+      },
+    }));
+
+    const scoutFailure: TestFailure & { id: string; target: string; location: string } = {
+      ...mockTestFailure,
+      classname: 'scout suite',
+      name: 'scout test',
+      id: 'test-id-1',
+      target: 'stateful',
+      location: '/path/to/test.ts',
+    };
+
+    await existing.loadForFailures([scoutFailure]);
+
+    const issue = existing.getForFailure(scoutFailure);
+    expect(issue).toBeUndefined();
+  });
 });

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/existing_failed_test_issues.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/existing_failed_test_issues.ts
@@ -9,12 +9,12 @@
 
 import { setTimeout } from 'timers/promises';
 
-import Axios from 'axios';
 import { isAxiosRequestError, isAxiosResponseError } from '@kbn/dev-utils';
-import { ToolingLog } from '@kbn/tooling-log';
+import type { ToolingLog } from '@kbn/tooling-log';
+import Axios from 'axios';
 
-import { GithubIssueMini } from './github_api';
-import { TestFailure } from './get_failures';
+import type { TestFailure } from './get_failures';
+import type { GithubIssueMini } from './github_api';
 
 export interface FailedTestIssue {
   classname: string;
@@ -84,12 +84,38 @@ export class ExistingFailedTestIssues {
     this.log.debug('loaded', this.results.size - initialResultSize, 'existing test issues');
   }
 
+  isScoutFailure(failure: TestFailure): boolean {
+    return 'id' in failure && 'target' in failure && 'location' in failure;
+  }
+
   getForFailure(failure: TestFailure) {
+    // Check if this is a Scout failure
+    const isScout = this.isScoutFailure(failure);
+
     for (const [f, issue] of this.results) {
-      if (f.classname === failure.classname && f.name === failure.name) {
-        return issue;
+      if (!issue) {
+        continue;
+      }
+
+      // Verify both input and key are the same type (both Scout or both FTR)
+      const isKeyScoutFailure = this.isScoutFailure(f);
+
+      if (isScout) {
+        // For Scout failures, match by test name only (ignore target)
+        // Both must be Scout failures and names must match
+        if (isKeyScoutFailure && f.name === failure.name) {
+          return issue;
+        }
+      } else {
+        // For FTR failures, match by classname and name
+        // Both must be FTR failures (not Scout) and classname+name must match
+        if (!isKeyScoutFailure && f.classname === failure.classname && f.name === failure.name) {
+          return issue;
+        }
       }
     }
+
+    return undefined;
   }
 
   addNewlyCreated(failure: TestFailure, newIssue: GithubIssueMini) {
@@ -148,9 +174,21 @@ export class ExistingFailedTestIssues {
   }
 
   private isFailureSeen(failure: TestFailure) {
+    // Check if this is a Scout failure
+    const isScout = this.isScoutFailure(failure);
+
     for (const seen of this.results.keys()) {
-      if (seen.classname === failure.classname && seen.name === failure.name) {
-        return true;
+      if (isScout) {
+        // For Scout failures, match by test name only (ignore target)
+        const isExistingScoutFailure = this.isScoutFailure(seen);
+        if (isExistingScoutFailure && seen.name === failure.name) {
+          return true;
+        }
+      } else {
+        // For FTR failures, use original matching logic
+        if (seen.classname === failure.classname && seen.name === failure.name) {
+          return true;
+        }
       }
     }
 

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/failed_tests_reporter_cli.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/failed_tests_reporter_cli.ts
@@ -9,23 +9,19 @@
 
 import Path from 'path';
 
-import { REPO_ROOT } from '@kbn/repo-info';
-import { run } from '@kbn/dev-cli-runner';
-import { createFailError, createFlagError } from '@kbn/dev-cli-errors';
 import { CiStatsReporter } from '@kbn/ci-stats-reporter';
+import { createFailError, createFlagError } from '@kbn/dev-cli-errors';
+import { run } from '@kbn/dev-cli-runner';
+import { REPO_ROOT } from '@kbn/repo-info';
 import globby from 'globby';
 import normalize from 'normalize-path';
-import { getFailures } from './get_failures';
-import { GithubApi } from './github_api';
-import { updateFailureIssue, createFailureIssue } from './report_failure';
-import { readTestReport, getRootMetadata } from './test_report';
-import { addMessagesToReport } from './add_messages_to_report';
-import { getReportMessageIter } from './report_metadata';
-import { reportFailuresToEs } from './report_failures_to_es';
-import { reportFailuresToFile } from './report_failures_to_file';
 import { getBuildkiteMetadata } from './buildkite_metadata';
 import { ExistingFailedTestIssues } from './existing_failed_test_issues';
 import { generateScoutTestFailureArtifacts } from './generate_scout_test_failure_artifacts';
+import { GithubApi } from './github_api';
+import { processJUnitReports } from './process_junit_reports';
+import type { ProcessReportsParams } from './process_reports_types';
+import { processScoutReports } from './process_scout_reports';
 
 const DEFAULT_PATTERNS = [Path.resolve(REPO_ROOT, 'target/junit/**/*.xml')];
 const DISABLE_MISSING_TEST_REPORT_ERRORS =
@@ -33,9 +29,10 @@ const DISABLE_MISSING_TEST_REPORT_ERRORS =
 
 run(
   async ({ log, flags }) => {
-    const indexInEs = flags['index-errors'];
+    const indexInEs = Boolean(flags['index-errors']);
+    const reportUpdate = Boolean(flags['report-update']);
 
-    let updateGithub = flags['github-update'];
+    let updateGithub = Boolean(flags['github-update']);
     if (updateGithub && !process.env.GITHUB_TOKEN) {
       throw createFailError(
         'GITHUB_TOKEN environment variable must be set, otherwise use --no-github-update flag'
@@ -105,85 +102,41 @@ run(
       await generateScoutTestFailureArtifacts({ log, bkMeta });
 
       if (reportPaths.length) {
-        log.info('found', reportPaths.length, 'junit reports', reportPaths);
+        log.info('found', reportPaths.length, 'reports', reportPaths);
+
+        // Separate JUnit and Scout reports
+        const junitReports = reportPaths.filter((p) => p.endsWith('.xml'));
+        const scoutReports = reportPaths.filter((p) => p.endsWith('.ndjson'));
+
+        log.info(
+          'Processing',
+          junitReports.length,
+          'JUnit reports and',
+          scoutReports.length,
+          'Scout reports'
+        );
 
         const existingIssues = new ExistingFailedTestIssues(log);
-        for (const reportPath of reportPaths) {
-          const report = await readTestReport(reportPath);
-          const messages = Array.from(getReportMessageIter(report));
-          const failures = getFailures(report);
 
-          await existingIssues.loadForFailures(failures);
+        const processParams: ProcessReportsParams = {
+          log,
+          existingIssues,
+          buildUrl,
+          githubApi,
+          branch,
+          pipeline,
+          prependTitle,
+          updateGithub,
+          indexInEs,
+          reportUpdate,
+          bkMeta,
+        };
 
-          if (indexInEs) {
-            await reportFailuresToEs(log, failures);
-          }
+        // Process FTR JUnit reports
+        await processJUnitReports(junitReports, processParams);
 
-          for (const failure of failures) {
-            const pushMessage = (msg: string) => {
-              messages.push({
-                classname: failure.classname,
-                name: failure.name,
-                message: msg,
-              });
-            };
-
-            if (failure.likelyIrrelevant) {
-              pushMessage(
-                'Failure is likely irrelevant' +
-                  (updateGithub ? ', so an issue was not created or updated' : '')
-              );
-              continue;
-            }
-
-            const existingIssue = existingIssues.getForFailure(failure);
-            if (existingIssue) {
-              const { newBody, newCount } = await updateFailureIssue(
-                buildUrl,
-                existingIssue,
-                githubApi,
-                branch,
-                pipeline
-              );
-              const url = existingIssue.github.htmlUrl;
-              existingIssue.github.body = newBody;
-              failure.githubIssue = url;
-              failure.failureCount = updateGithub ? newCount : newCount - 1;
-              pushMessage(`Test has failed ${newCount - 1} times on tracked branches: ${url}`);
-              if (updateGithub) {
-                pushMessage(`Updated existing issue: ${url} (fail count: ${newCount})`);
-              }
-              continue;
-            }
-
-            const newIssue = await createFailureIssue(
-              buildUrl,
-              failure,
-              githubApi,
-              branch,
-              pipeline,
-              prependTitle
-            );
-            existingIssues.addNewlyCreated(failure, newIssue);
-            pushMessage('Test has not failed recently on tracked branches');
-            if (updateGithub) {
-              pushMessage(`Created new issue: ${newIssue.html_url}`);
-              failure.githubIssue = newIssue.html_url;
-            }
-            failure.failureCount = updateGithub ? 1 : 0;
-          }
-
-          // mutates report to include messages and writes updated report to disk
-          await addMessagesToReport({
-            report,
-            messages,
-            log,
-            reportPath,
-            dryRun: !flags['report-update'],
-          });
-
-          await reportFailuresToFile(log, failures, bkMeta, getRootMetadata(report));
-        }
+        // Process Scout reports
+        await processScoutReports(scoutReports, processParams);
       }
     } finally {
       await CiStatsReporter.fromEnv(log).metrics([

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.ts
@@ -9,11 +9,11 @@
 
 import Path from 'path';
 
-import globby from 'globby';
-import fs from 'fs';
+import type { ToolingLog } from '@kbn/tooling-log';
 import { createHash } from 'crypto';
-import { ToolingLog } from '@kbn/tooling-log';
-import { BuildkiteMetadata } from './buildkite_metadata';
+import fs from 'fs';
+import globby from 'globby';
+import type { BuildkiteMetadata } from './buildkite_metadata';
 
 const SCOUT_TEST_FAILURE_DIR_PATTERN = '.scout/reports/scout-playwright-test-failures-*';
 const SUMMARY_REPORT_FILENAME = 'test-failures-summary.json';
@@ -41,7 +41,8 @@ export async function generateScoutTestFailureArtifacts({
     const summaryFilePath = Path.join(dirPath, SUMMARY_REPORT_FILENAME);
     // Check if summary JSON exists
     if (!fs.existsSync(summaryFilePath)) {
-      throw new Error(`Summary file not found in: ${dirPath}`);
+      log.info(`Summary file not found in: ${dirPath}, skipping artifact generation`);
+      continue;
     }
 
     const summaryData: Array<{ name: string; htmlReportFilename: string }> = JSON.parse(

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_scout_failures.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_scout_failures.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import fs from 'fs';
+import stripAnsi from 'strip-ansi';
+import type { TestFailure } from './get_failures';
+
+// Extended TestFailure type for Scout failures
+export interface ScoutTestFailureExtended extends TestFailure {
+  id: string;
+  target: string;
+  location: string;
+  duration: number;
+  owners: string;
+  file?: string;
+  kibanaModule?: {
+    id: string;
+    type: string;
+    visibility: string;
+    group: string;
+  };
+  attachments?: Array<{
+    name: string;
+    path?: string;
+    contentType: string;
+  }>;
+}
+
+// Scout Failure Tracking Entry interface
+interface ScoutFailureTrackingEntry {
+  id: string;
+  suite: string;
+  title: string;
+  target: string;
+  command: string;
+  location: string;
+  owner: string[];
+  kibanaModule?: {
+    id: string;
+    type: string;
+    visibility: string;
+    group: string;
+  };
+  duration: number;
+  error: {
+    message?: string;
+    stack_trace?: string;
+  };
+  stdout?: string;
+  attachments: Array<{
+    name: string;
+    path?: string;
+    contentType: string;
+  }>;
+  timestamp: string;
+  buildkite?: {
+    buildId?: string;
+    jobId?: string;
+    pipeline?: string;
+    branch?: string;
+  };
+}
+
+const isLikelyIrrelevant = (name: string, failure: string) => {
+  // no filters for Scout failures at the moment
+  return false;
+};
+
+export async function getScoutFailures(reportPath: string): Promise<ScoutTestFailureExtended[]> {
+  if (!fs.existsSync(reportPath)) {
+    return [];
+  }
+
+  const fileContent = fs.readFileSync(reportPath, 'utf-8');
+  const failures: ScoutTestFailureExtended[] = [];
+
+  // Parse NDJSON (newline-delimited JSON)
+  const lines = fileContent
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map((line) => {
+      try {
+        return JSON.parse(line) as ScoutFailureTrackingEntry;
+      } catch (error) {
+        // Failed to parse Scout failure tracking line
+        return null;
+      }
+    })
+    .filter((entry): entry is ScoutFailureTrackingEntry => entry !== null);
+
+  for (const entry of lines) {
+    // Convert Scout failure tracking entry to compatible TestFailure format
+    const failure = stripAnsi(entry.error.stack_trace || entry.error.message || '');
+    const likelyIrrelevant = isLikelyIrrelevant(entry.title, failure);
+
+    const testFailure: ScoutTestFailureExtended = {
+      // Map Scout fields to JUnit-compatible fields
+      classname: entry.suite,
+      name: entry.title,
+      failure,
+      likelyIrrelevant,
+      'system-out': entry.stdout ? stripAnsi(entry.stdout) : undefined,
+      owners: entry.owner.join(', '), // Convert array to string
+      commandLine: entry.command,
+
+      // Scout-specific metadata
+      id: entry.id,
+      target: entry.target,
+      location: entry.location,
+      kibanaModule: entry.kibanaModule,
+      duration: entry.duration,
+      attachments: entry.attachments,
+
+      // Additional fields for compatibility
+      time: String(entry.duration / 1000), // Convert ms to seconds
+      file: entry.location,
+    };
+
+    failures.push(testFailure);
+  }
+
+  return failures;
+}
+
+export function getScoutCommandLineFromFailures(failures: ScoutTestFailureExtended[]): string {
+  if (failures.length === 0) {
+    return '';
+  }
+
+  // TODO: Use the command from the first failure as representative
+  const firstFailure = failures[0] as TestFailure & { commandLine?: string };
+  return firstFailure.commandLine || '';
+}

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/process_junit_reports.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/process_junit_reports.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { addMessagesToReport } from './add_messages_to_report';
+import { getFailures } from './get_failures';
+import type { ProcessReportsParams } from './process_reports_types';
+import { createFailureIssue, updateFailureIssue } from './report_failure';
+import { reportFailuresToEs } from './report_failures_to_es';
+import { reportFailuresToFile } from './report_failures_to_file';
+import { getReportMessageIter } from './report_metadata';
+import { getRootMetadata, readTestReport } from './test_report';
+
+export async function processJUnitReports(
+  reportPaths: string[],
+  params: ProcessReportsParams
+): Promise<void> {
+  const {
+    log,
+    existingIssues,
+    buildUrl,
+    githubApi,
+    branch,
+    pipeline,
+    prependTitle,
+    updateGithub,
+    indexInEs,
+    reportUpdate,
+    bkMeta,
+  } = params;
+
+  for (const reportPath of reportPaths) {
+    const report = await readTestReport(reportPath);
+    const messages = Array.from(getReportMessageIter(report));
+    const failures = getFailures(report);
+
+    await existingIssues.loadForFailures(failures);
+
+    if (indexInEs) {
+      await reportFailuresToEs(log, failures);
+    }
+
+    for (const failure of failures) {
+      const pushMessage = (msg: string) => {
+        messages.push({
+          classname: failure.classname,
+          name: failure.name,
+          message: msg,
+        });
+      };
+
+      if (failure.likelyIrrelevant) {
+        pushMessage(
+          'Failure is likely irrelevant' +
+            (updateGithub ? ', so an issue was not created or updated' : '')
+        );
+        continue;
+      }
+
+      const existingIssue = existingIssues.getForFailure(failure);
+      if (existingIssue) {
+        const { newBody, newCount } = await updateFailureIssue(
+          buildUrl,
+          existingIssue,
+          githubApi,
+          branch,
+          pipeline,
+          failure
+        );
+        const url = existingIssue.github.htmlUrl;
+        existingIssue.github.body = newBody;
+        failure.githubIssue = url;
+        failure.failureCount = updateGithub ? newCount : newCount - 1;
+        pushMessage(`Test has failed ${newCount - 1} times on tracked branches: ${url}`);
+        if (updateGithub) {
+          pushMessage(`Updated existing issue: ${url} (fail count: ${newCount})`);
+        }
+        continue;
+      }
+
+      const newIssue = await createFailureIssue(
+        buildUrl,
+        failure,
+        githubApi,
+        branch,
+        pipeline,
+        prependTitle
+      );
+      existingIssues.addNewlyCreated(failure, newIssue);
+      pushMessage('Test has not failed recently on tracked branches');
+      if (updateGithub) {
+        pushMessage(`Created new issue: ${newIssue.html_url}`);
+        failure.githubIssue = newIssue.html_url;
+      }
+      failure.failureCount = updateGithub ? 1 : 0;
+    }
+
+    // mutates report to include messages and writes updated report to disk
+    await addMessagesToReport({
+      report,
+      messages,
+      log,
+      reportPath,
+      dryRun: !reportUpdate,
+    });
+
+    await reportFailuresToFile(log, failures, bkMeta, getRootMetadata(report));
+  }
+}

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/process_reports_types.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/process_reports_types.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ToolingLog } from '@kbn/tooling-log';
+
+import type { BuildkiteMetadata } from './buildkite_metadata';
+import type { ExistingFailedTestIssues } from './existing_failed_test_issues';
+import type { GithubApi } from './github_api';
+
+export interface ProcessReportsParams {
+  log: ToolingLog;
+  existingIssues: ExistingFailedTestIssues;
+  buildUrl: string;
+  githubApi: GithubApi;
+  branch: string;
+  pipeline: string;
+  prependTitle: string;
+  updateGithub: boolean;
+  indexInEs: boolean;
+  reportUpdate: boolean;
+  bkMeta: BuildkiteMetadata;
+}

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/process_scout_reports.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/process_scout_reports.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getScoutFailures, type ScoutTestFailureExtended } from './get_scout_failures';
+import type { ProcessReportsParams } from './process_reports_types';
+import { createFailureIssue, updateFailureIssue } from './report_failure';
+import { reportFailuresToEs } from './report_failures_to_es';
+import { reportFailuresToFile } from './report_failures_to_file';
+
+export async function processScoutReports(
+  reportPaths: string[],
+  params: ProcessReportsParams
+): Promise<void> {
+  const {
+    log,
+    existingIssues,
+    buildUrl,
+    githubApi,
+    branch,
+    pipeline,
+    prependTitle,
+    updateGithub,
+    indexInEs,
+    bkMeta,
+  } = params;
+
+  for (const reportPath of reportPaths) {
+    log.info('Processing Scout report:', reportPath);
+    const failures: ScoutTestFailureExtended[] = await getScoutFailures(reportPath);
+
+    if (failures.length === 0) {
+      log.info('No Scout failures found in:', reportPath);
+      continue;
+    }
+
+    log.info('Found', failures.length, 'Scout failures in:', reportPath);
+
+    await existingIssues.loadForFailures(failures);
+
+    if (indexInEs) {
+      await reportFailuresToEs(log, failures);
+    }
+
+    for (const failure of failures) {
+      if (failure.likelyIrrelevant) {
+        log.info(`Scout failure is likely irrelevant: ${failure.classname} - ${failure.name}`);
+        continue;
+      }
+
+      const existingIssue = existingIssues.getForFailure(failure);
+      if (existingIssue) {
+        const { newBody, newCount } = await updateFailureIssue(
+          buildUrl,
+          existingIssue,
+          githubApi,
+          branch,
+          pipeline,
+          failure
+        );
+        const url = existingIssue.github.htmlUrl;
+        existingIssue.github.body = newBody;
+        failure.githubIssue = url;
+        failure.failureCount = updateGithub ? newCount : newCount - 1;
+        log.info(`Updated existing Scout issue: ${url} (fail count: ${newCount})`);
+        continue;
+      }
+
+      const newIssue = await createFailureIssue(
+        buildUrl,
+        failure,
+        githubApi,
+        branch,
+        pipeline,
+        prependTitle
+      );
+      existingIssues.addNewlyCreated(failure, newIssue);
+      if (updateGithub) {
+        log.info(`Created new Scout issue: ${newIssue.html_url}`);
+        failure.githubIssue = newIssue.html_url;
+      }
+      failure.failureCount = updateGithub ? 1 : 0;
+    }
+
+    // Generate Scout failure artifacts (similar to JUnit report processing)
+    await reportFailuresToFile(log, failures, bkMeta, {});
+  }
+}

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.ts
@@ -7,56 +7,231 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { TestFailure } from './get_failures';
-import { GithubApi } from './github_api';
+import type { ExistingFailedTestIssue } from './existing_failed_test_issues';
+import type { TestFailure } from './get_failures';
+import type { ScoutTestFailureExtended } from './get_scout_failures';
+import type { GithubApi } from './github_api';
 import { getIssueMetadata, updateIssueMetadata } from './issue_metadata';
-import { ExistingFailedTestIssue } from './existing_failed_test_issues';
 
-export async function createFailureIssue(
+function isScoutFailure(failure: TestFailure): failure is ScoutTestFailureExtended {
+  return 'id' in failure && 'target' in failure && 'location' in failure;
+}
+
+function truncateFailureBody(failure: string, maxCharacters: number = 8192): string {
+  return failure.length <= maxCharacters
+    ? failure
+    : [
+        failure.substring(0, maxCharacters),
+        `[report_failure] output truncated to ${maxCharacters} characters`,
+      ].join('\n');
+}
+
+function createFTRTitle(failure: TestFailure, prependTitle: string): string {
+  if (prependTitle && prependTitle.trim() !== '') {
+    return `Failing test: ${prependTitle} ${failure.classname} - ${failure.name}`;
+  }
+  return `Failing test: ${failure.classname} - ${failure.name}`;
+}
+
+function createScoutTitle(failure: ScoutTestFailureExtended): string {
+  return `Failing test: ${failure.classname} - ${failure.name}`;
+}
+
+function createFTRBody(
+  failure: TestFailure,
+  buildUrl: string,
+  branch: string,
+  pipeline: string
+): string {
+  const failureBody = truncateFailureBody(failure.failure);
+
+  const bodyContent = [
+    'A test failed on a tracked branch',
+    '',
+    '```',
+    failureBody,
+    '```',
+    '',
+    `First failure: [${pipeline || 'CI Build'} - ${branch}](${buildUrl})`,
+  ];
+
+  return updateIssueMetadata(bodyContent.join('\n'), {
+    'test.class': failure.classname,
+    'test.name': failure.name,
+    'test.failCount': 1,
+  });
+}
+
+/**
+ * Extract Playwright config path from command
+ */
+function getPlaywrightConfigPath(command?: string): string {
+  if (!command) return 'N/A';
+  const configMatch = command.match(/--config\s+(\S+)/);
+  return configMatch ? configMatch[1] : 'N/A';
+}
+
+/**
+ * Create issue body for Scout failures
+ */
+function createScoutBody(
+  failure: ScoutTestFailureExtended,
+  buildUrl: string,
+  branch: string,
+  pipeline: string
+): string {
+  const failureBody = truncateFailureBody(failure.failure);
+
+  // Create table format for Scout test details
+  const scoutDetailsTable = [
+    '| Field | Value |',
+    '|-------|-------|',
+    `| Test ID | ${failure.id} |`,
+    `| Target | ${failure.target} |`,
+    `| Location | ${failure.location} |`,
+    `| Duration | ${(failure.duration / 1000).toFixed(2) + 's'} |`,
+    failure.kibanaModule
+      ? `| Module | ${failure.kibanaModule.id} (${failure.kibanaModule.type}) |`
+      : '| Module | N/A |',
+    `| Config path | ${getPlaywrightConfigPath(failure.commandLine)} |`,
+    `| Code Owners | ${failure.owners} |`,
+  ];
+
+  const bodyContent = [
+    'A test failed on a tracked branch',
+    '',
+    '**Scout Test Details:**',
+    '',
+    ...scoutDetailsTable,
+    '',
+    '```',
+    failureBody,
+    '```',
+    '',
+    `First failure: [${pipeline || 'CI Build'} - ${branch}](${buildUrl})`,
+  ];
+
+  // Add screenshot information if available
+  if (failure.attachments && failure.attachments.length > 0) {
+    const hasScreenshots = failure.attachments.some((attachment) =>
+      attachment.contentType.startsWith('image/')
+    );
+
+    if (hasScreenshots) {
+      bodyContent.push('');
+      bodyContent.push(
+        'Failure screenshots are available in the Buildkite HTML report and artifacts.'
+      );
+      bodyContent.push('');
+    }
+  }
+
+  return updateIssueMetadata(bodyContent.join('\n'), {
+    'test.class': failure.classname,
+    'test.name': failure.name,
+    'test.failCount': 1,
+    'test.type': 'scout',
+  });
+}
+
+async function createFTRFailureIssue(
   buildUrl: string,
   failure: TestFailure,
   api: GithubApi,
   branch: string,
   pipeline: string,
+  prependTitle: string
+) {
+  const title = createFTRTitle(failure, prependTitle);
+  const body = createFTRBody(failure, buildUrl, branch, pipeline);
+  const labels = ['failed-test'];
+
+  return await api.createIssue(title, body, labels);
+}
+
+async function createScoutFailureIssue(
+  buildUrl: string,
+  failure: ScoutTestFailureExtended,
+  api: GithubApi,
+  branch: string,
+  pipeline: string
+) {
+  const title = createScoutTitle(failure);
+  const body = createScoutBody(failure, buildUrl, branch, pipeline);
+  const labels = ['failed-test', 'scout-playwright'];
+
+  return await api.createIssue(title, body, labels);
+}
+
+export async function createFailureIssue(
+  buildUrl: string,
+  failure: TestFailure | ScoutTestFailureExtended,
+  api: GithubApi,
+  branch: string,
+  pipeline: string,
   prependTitle: string = ''
 ) {
-  // PrependTitle is introduced to provide some clarity by prepending the failing test title
-  // in order to give the whole info in the title according to each team's preference.
-  const title =
-    prependTitle && prependTitle.trim() !== ''
-      ? `Failing test: ${prependTitle} ${failure.classname} - ${failure.name}`
-      : `Failing test: ${failure.classname} - ${failure.name}`;
+  if (isScoutFailure(failure)) {
+    return createScoutFailureIssue(buildUrl, failure, api, branch, pipeline);
+  } else {
+    return createFTRFailureIssue(buildUrl, failure, api, branch, pipeline, prependTitle);
+  }
+}
 
-  // Github API body length maximum is 65536 characters
-  // Let's keep consistency with Mocha output that is truncated to 8192 characters
-  const failureMaxCharacters = 8192;
+function createFTRComment(buildUrl: string, branch: string, pipeline: string): string {
+  return `New failure: [${pipeline || 'CI Build'} - ${branch}](${buildUrl})`;
+}
 
-  const failureBody =
-    failure.failure.length <= failureMaxCharacters
-      ? failure.failure
-      : [
-          failure.failure.substring(0, failureMaxCharacters),
-          `[report_failure] output truncated to ${failureMaxCharacters} characters`,
-        ].join('\n');
+function createScoutComment(
+  failure: ScoutTestFailureExtended,
+  buildUrl: string,
+  branch: string,
+  pipeline: string
+): string {
+  return `New failure for "${failure.target}" target: [${
+    pipeline || 'CI Build'
+  } - ${branch}](${buildUrl})`;
+}
 
-  const body = updateIssueMetadata(
-    [
-      'A test failed on a tracked branch',
-      '',
-      '```',
-      failureBody,
-      '```',
-      '',
-      `First failure: [${pipeline || 'CI Build'} - ${branch}](${buildUrl})`,
-    ].join('\n'),
-    {
-      'test.class': failure.classname,
-      'test.name': failure.name,
-      'test.failCount': 1,
-    }
-  );
+async function updateFTRFailureIssue(
+  buildUrl: string,
+  issue: ExistingFailedTestIssue,
+  api: GithubApi,
+  branch: string,
+  pipeline: string
+) {
+  const newCount = getIssueMetadata(issue.github.body, 'test.failCount', 0) + 1;
+  const newBody = updateIssueMetadata(issue.github.body, {
+    'test.failCount': newCount,
+  });
 
-  return await api.createIssue(title, body, ['failed-test']);
+  await api.editIssueBodyAndEnsureOpen(issue.github.number, newBody);
+
+  const commentText = createFTRComment(buildUrl, branch, pipeline);
+  await api.addIssueComment(issue.github.number, commentText);
+
+  return { newBody, newCount };
+}
+
+async function updateScoutFailureIssue(
+  buildUrl: string,
+  issue: ExistingFailedTestIssue,
+  api: GithubApi,
+  branch: string,
+  pipeline: string,
+  failure: ScoutTestFailureExtended
+) {
+  const newCount = getIssueMetadata(issue.github.body, 'test.failCount', 0) + 1;
+  const newBody = updateIssueMetadata(issue.github.body, {
+    'test.failCount': newCount,
+  });
+
+  await api.editIssueBodyAndEnsureOpen(issue.github.number, newBody);
+
+  const commentText = createScoutComment(failure, buildUrl, branch, pipeline);
+  await api.addIssueComment(issue.github.number, commentText);
+
+  return { newBody, newCount };
 }
 
 export async function updateFailureIssue(
@@ -64,19 +239,12 @@ export async function updateFailureIssue(
   issue: ExistingFailedTestIssue,
   api: GithubApi,
   branch: string,
-  pipeline: string
+  pipeline: string,
+  failure?: TestFailure | ScoutTestFailureExtended
 ) {
-  // Increment failCount
-  const newCount = getIssueMetadata(issue.github.body, 'test.failCount', 0) + 1;
-  const newBody = updateIssueMetadata(issue.github.body, {
-    'test.failCount': newCount,
-  });
-
-  await api.editIssueBodyAndEnsureOpen(issue.github.number, newBody);
-  await api.addIssueComment(
-    issue.github.number,
-    `New failure: [${pipeline || 'CI Build'} - ${branch}](${buildUrl})`
-  );
-
-  return { newBody, newCount };
+  if (failure && isScoutFailure(failure)) {
+    return updateScoutFailureIssue(buildUrl, issue, api, branch, pipeline, failure);
+  } else {
+    return updateFTRFailureIssue(buildUrl, issue, api, branch, pipeline);
+  }
 }

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failure_tracking.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/failed_test/failure_tracking.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ToolingLog } from '@kbn/tooling-log';
+import fs from 'fs';
+import path from 'path';
+import type { TestFailure } from '../../report/failed_test/test_failure';
+
+export interface ScoutFailureTrackingEntry {
+  id: string;
+  suite: string;
+  title: string;
+  target: string;
+  command: string;
+  location: string;
+  owner: string[];
+  kibanaModule?: {
+    id: string;
+    type: string;
+    visibility: string;
+    group: string;
+  };
+  duration: number;
+  error: {
+    message?: string;
+    stack_trace?: string;
+  };
+  stdout?: string;
+  attachments: Array<{
+    name: string;
+    path?: string;
+    contentType: string;
+  }>;
+  timestamp: string;
+  buildkite?: {
+    buildId?: string;
+    jobId?: string;
+    pipeline?: string;
+    branch?: string;
+  };
+}
+
+export class ScoutFailureTracker {
+  private readonly log: ToolingLog;
+  private readonly trackingFilePath: string;
+  private failures: ScoutFailureTrackingEntry[] = [];
+
+  constructor(log: ToolingLog, reportRootPath: string, runId: string) {
+    this.log = log;
+    // Use the same runId as the main Scout reporting system for consistency
+    this.trackingFilePath = path.join(reportRootPath, `scout-failures-${runId}.ndjson`);
+  }
+
+  /**
+   * Add a test failure to the tracking file
+   */
+  addFailure(failure: TestFailure) {
+    const trackingEntry: ScoutFailureTrackingEntry = {
+      id: failure.id,
+      suite: failure.suite,
+      title: failure.title,
+      target: failure.target,
+      command: failure.command,
+      location: failure.location,
+      owner: failure.owner,
+      kibanaModule: failure.kibanaModule,
+      duration: failure.duration,
+      error: failure.error,
+      stdout: failure.stdout,
+      attachments: failure.attachments,
+      timestamp: new Date().toISOString(),
+      buildkite: {
+        buildId: process.env.BUILDKITE_BUILD_ID,
+        jobId: process.env.BUILDKITE_JOB_ID,
+        pipeline: process.env.BUILDKITE_PIPELINE_SLUG,
+        branch: process.env.BUILDKITE_BRANCH,
+      },
+    };
+
+    this.failures.push(trackingEntry);
+  }
+
+  /**
+   * Save all tracked failures to the tracking file
+   */
+  save() {
+    if (this.failures.length === 0) {
+      this.log.info('No Scout failures to track');
+      return;
+    }
+
+    // Ensure directory exists
+    const dir = path.dirname(this.trackingFilePath);
+    fs.mkdirSync(dir, { recursive: true });
+
+    // Write failures as NDJSON
+    const content = this.failures.map((failure) => JSON.stringify(failure)).join('\n') + '\n';
+
+    fs.writeFileSync(this.trackingFilePath, content, 'utf-8');
+
+    this.log.info(
+      `Saved ${this.failures.length} Scout failures to tracking file: ${this.trackingFilePath}`
+    );
+  }
+
+  /**
+   * Get the path to the tracking file
+   */
+  getTrackingFilePath(): string {
+    return this.trackingFilePath;
+  }
+}

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/report.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/failed_test/report.ts
@@ -7,12 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import path from 'node:path';
+import type { ToolingLog } from '@kbn/tooling-log';
 import fs from 'node:fs';
-import { ToolingLog } from '@kbn/tooling-log';
-import { buildFailureHtml } from './html';
-import { TestFailure } from './test_failure';
+import path from 'node:path';
 import { ScoutReport, ScoutReportError } from '../base';
+import { buildFailureHtml } from './html';
+import type { TestFailure } from './test_failure';
 
 const saveTestFailuresReport = (
   reportPath: string,
@@ -73,6 +73,10 @@ export class ScoutFailureReport extends ScoutReport {
     );
     fs.mkdirSync(destination, { recursive: true });
 
+    // Create test-artifacts directory for individual PNG files
+    const testArtifactsDir = path.join('.scout', 'test-artifacts');
+    fs.mkdirSync(testArtifactsDir, { recursive: true });
+
     // Generate HTML report for each failed test with embedded screenshots
     for (const failure of testFailures) {
       const htmlContent = buildFailureHtml(failure);
@@ -83,6 +87,9 @@ export class ScoutFailureReport extends ScoutReport {
         this.log,
         `Html report for ${failure.id} is saved at ${htmlReportPath}`
       );
+
+      // Save individual PNG files for Buildkite artifact upload
+      this.saveAttachmentsAsPngFiles(failure, testArtifactsDir);
     }
 
     const summaryContent = testFailures.map((failure) => {
@@ -100,6 +107,43 @@ export class ScoutFailureReport extends ScoutReport {
       this.log,
       `Test Failures Summary is saved at ${testFailuresSummaryReportPath}`
     );
+  }
+
+  /**
+   * Save test failure attachments as individual PNG files for Buildkite artifact upload
+   */
+  private saveAttachmentsAsPngFiles(failure: TestFailure, testArtifactsDir: string) {
+    if (!failure.attachments || failure.attachments.length === 0) {
+      return;
+    }
+
+    // Filter for image attachments
+    const imageAttachments = failure.attachments.filter(
+      (attachment) =>
+        attachment.contentType.startsWith('image/') &&
+        attachment.path &&
+        fs.existsSync(attachment.path)
+    );
+
+    for (const attachment of imageAttachments) {
+      try {
+        // Create a unique filename for the screenshot
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const filename = `${failure.id}_${attachment.name}_${timestamp}.png`;
+        const destinationPath = path.join(testArtifactsDir, filename);
+
+        // Copy the attachment file to the test-artifacts directory
+        fs.copyFileSync(attachment.path!, destinationPath);
+
+        this.log.info(`Saved screenshot: ${filename} -> ${destinationPath}`);
+      } catch (error) {
+        this.log.error(
+          `Failed to save screenshot ${attachment.name}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[scout] failed test reporter integration (#239771)](https://github.com/elastic/kibana/pull/239771)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-11-10T13:31:13Z","message":"[scout] failed test reporter integration (#239771)\n\n## Summary\n\ncloses https://github.com/elastic/kibana/issues/241171\n\nThis PR extends existing `kbn/failed-test-reporter-cli` package to\ncreate/update GH issues for Scout test failures on upstream branches\nwith specific extras:\n\n- support **ndjson** input format:\n`.scout/reports/scout-playwright-test-failures-*/scout-failures-*.ndjson`\n- match existing GH issues for Scout test **by test name only**: don't\ncreate a new issue _for each target_ where the same test fails, but only\nadd a new comment with the specified target\n- use a different issue template for scout with extended details\n\nIssue example: https://github.com/elastic/kibana/issues/241472\n\nComments example: https://github.com/elastic/kibana/issues/239777\n\n---------\n\nCo-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9c436b83b672f5c44f91ff313c10d46292cea239","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","test:scout","v9.3.0","v8.19.7","v9.1.7","v9.2.1"],"title":"[scout] failed test reporter integration","number":239771,"url":"https://github.com/elastic/kibana/pull/239771","mergeCommit":{"message":"[scout] failed test reporter integration (#239771)\n\n## Summary\n\ncloses https://github.com/elastic/kibana/issues/241171\n\nThis PR extends existing `kbn/failed-test-reporter-cli` package to\ncreate/update GH issues for Scout test failures on upstream branches\nwith specific extras:\n\n- support **ndjson** input format:\n`.scout/reports/scout-playwright-test-failures-*/scout-failures-*.ndjson`\n- match existing GH issues for Scout test **by test name only**: don't\ncreate a new issue _for each target_ where the same test fails, but only\nadd a new comment with the specified target\n- use a different issue template for scout with extended details\n\nIssue example: https://github.com/elastic/kibana/issues/241472\n\nComments example: https://github.com/elastic/kibana/issues/239777\n\n---------\n\nCo-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9c436b83b672f5c44f91ff313c10d46292cea239"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/239771","number":239771,"mergeCommit":{"message":"[scout] failed test reporter integration (#239771)\n\n## Summary\n\ncloses https://github.com/elastic/kibana/issues/241171\n\nThis PR extends existing `kbn/failed-test-reporter-cli` package to\ncreate/update GH issues for Scout test failures on upstream branches\nwith specific extras:\n\n- support **ndjson** input format:\n`.scout/reports/scout-playwright-test-failures-*/scout-failures-*.ndjson`\n- match existing GH issues for Scout test **by test name only**: don't\ncreate a new issue _for each target_ where the same test fails, but only\nadd a new comment with the specified target\n- use a different issue template for scout with extended details\n\nIssue example: https://github.com/elastic/kibana/issues/241472\n\nComments example: https://github.com/elastic/kibana/issues/239777\n\n---------\n\nCo-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9c436b83b672f5c44f91ff313c10d46292cea239"}},{"branch":"8.19","label":"v8.19.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/242419","number":242419,"state":"OPEN"}]}] BACKPORT-->