### PR TITLE
[Search] Default semantic text endpoint select input to ELSER in EIS

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/create_field.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/create_field.test.tsx
@@ -1,0 +1,291 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { ComponentProps } from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { CreateField } from '../../../public/application/components/mappings_editor/components/document_fields/fields/create_field/create_field';
+import type { NormalizedFields } from '../../../public/application/components/mappings_editor/types';
+
+const createInitialFormState = () => ({
+  name: '',
+  type: undefined as string | undefined,
+  subType: undefined as string | undefined,
+});
+
+type FormState = ReturnType<typeof createInitialFormState>;
+
+interface MockForm {
+  submit: jest.Mock<Promise<{ isValid: boolean; data: FormState }>, []>;
+  reset: jest.Mock<void, []>;
+  getErrors: jest.Mock<unknown[], []>;
+  getFormData: jest.Mock<FormState, []>;
+  setFieldValue: jest.Mock<void, [keyof FormState, unknown]>;
+  getFields: jest.Mock<{ name: { value: string } }, []>;
+  subscribe: jest.Mock<{ unsubscribe: () => void }, [unknown?]>;
+}
+
+let mockFormState: FormState = createInitialFormState();
+let mockForm: MockForm | null = null;
+
+const resetForm = () => {
+  mockFormState = createInitialFormState();
+};
+
+const updateMockFormState = (field: keyof FormState, value: unknown) => {
+  mockFormState = { ...mockFormState, [field]: value as never };
+};
+
+const mockDispatch = jest.fn();
+
+jest.mock('../../../public/application/components/mappings_editor/shared_imports', () => {
+  const actual = jest.requireActual(
+    '../../../public/application/components/mappings_editor/shared_imports'
+  );
+  const DefaultFormWrapper = ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => <form {...props}>{children}</form>;
+  return {
+    ...actual,
+    Form: ({
+      children,
+      onSubmit,
+      FormWrapper: FormWrapperComponent,
+      form: _form,
+      ...rest
+    }: {
+      children: React.ReactNode;
+      onSubmit: React.FormEventHandler;
+      FormWrapper?: React.ComponentType<any>;
+      form?: unknown;
+      [key: string]: unknown;
+    }) => {
+      const Wrapper = FormWrapperComponent ?? DefaultFormWrapper;
+      const { 'data-test-subj': dataTestSubj, ...wrapperProps } = rest;
+      return (
+        <Wrapper onSubmit={onSubmit} data-test-subj={dataTestSubj} {...wrapperProps}>
+          {children}
+        </Wrapper>
+      );
+    },
+    useForm: () => {
+      const submit = jest.fn(async () => ({ isValid: true, data: mockFormState }));
+      const reset = jest.fn(() => {
+        resetForm();
+      });
+      const getErrors = jest.fn(() => []);
+      const getFormData = jest.fn(() => mockFormState);
+      const setFieldValue = jest.fn((field: keyof FormState, value: unknown) => {
+        updateMockFormState(field, value);
+      });
+      const getFields = jest.fn(() => ({
+        name: { value: mockFormState.name },
+      }));
+      const unsubscribe = jest.fn();
+      const subscribe = jest.fn((_listener?: unknown) => ({
+        unsubscribe,
+      }));
+
+      mockForm = {
+        submit,
+        reset,
+        getErrors,
+        getFormData,
+        setFieldValue,
+        getFields,
+        subscribe,
+      };
+      return { form: mockForm };
+    },
+    useFormData: () => [{ type: mockFormState.type, subType: mockFormState.subType }],
+  };
+});
+
+jest.mock(
+  '../../../public/application/components/mappings_editor/components/document_fields/field_parameters',
+  () => ({
+    TypeParameter: ({
+      fieldTypeInputRef,
+      ...rest
+    }: {
+      fieldTypeInputRef: React.RefObject<HTMLInputElement>;
+    }) => {
+      const { isRootLevelField, isMultiField, showDocLink, isSemanticTextEnabled, ...inputProps } =
+        rest as Record<string, unknown>;
+      return (
+        <input {...inputProps} data-test-subj="fieldTypeInput" ref={fieldTypeInputRef} readOnly />
+      );
+    },
+    NameParameter: ({ isSemanticText, ...rest }: { isSemanticText?: boolean }) => (
+      <input
+        {...rest}
+        data-test-subj="nameParameterInput"
+        value={mockFormState.name}
+        onChange={(event) => {
+          updateMockFormState('name', event.target.value);
+        }}
+      />
+    ),
+    SubTypeParameter: () => null,
+  })
+);
+
+jest.mock(
+  '../../../public/application/components/mappings_editor/components/document_fields/field_parameters/reference_field_selects',
+  () => ({
+    ReferenceFieldSelects: () => null,
+  })
+);
+
+jest.mock(
+  '../../../public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id',
+  () => ({
+    SelectInferenceId: () => null,
+  })
+);
+
+jest.mock('../../../public/application/components/mappings_editor/mappings_state_context', () => ({
+  ...jest.requireActual(
+    '../../../public/application/components/mappings_editor/mappings_state_context'
+  ),
+  useMappingsState: () => ({
+    fields: { byId: {}, rootLevelFields: [], aliases: {}, maxNestedDepth: 0 },
+    mappingViewFields: { byId: {}, rootLevelFields: [], aliases: {}, maxNestedDepth: 0 },
+  }),
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('../../../public/application/app_context', () => ({
+  ...jest.requireActual('../../../public/application/app_context'),
+  useAppContext: jest.fn(() => ({
+    config: { enforceAdaptiveAllocations: false },
+    services: {
+      notificationService: {
+        toasts: {},
+      },
+    },
+  })),
+}));
+
+jest.mock('../../../public/application/services/api', () => ({
+  ...jest.requireActual('../../../public/application/services/api'),
+  useLoadInferenceEndpoints: jest.fn().mockReturnValue({
+    data: [],
+    isLoading: false,
+    resendRequest: jest.fn(),
+  }),
+}));
+
+const emptyAllFields: NormalizedFields['byId'] = {};
+
+const defaultProps: ComponentProps<typeof CreateField> = {
+  allFields: emptyAllFields,
+  isRootLevelField: true,
+  isMultiField: false,
+  isCancelable: true,
+  isAddingFields: false,
+};
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.restoreAllMocks();
+  mockForm = null;
+  resetForm();
+});
+
+describe('<CreateField />', () => {
+  describe('WHEN clicking outside the form', () => {
+    describe('AND the name is empty', () => {
+      it('SHOULD cancel the flow', async () => {
+        render(<CreateField {...defaultProps} />);
+        screen.getByTestId('createFieldForm');
+
+        fireEvent.mouseDown(document.body);
+        fireEvent.mouseUp(document.body);
+        fireEvent.click(document.body);
+        await act(async () => {
+          await jest.runOnlyPendingTimersAsync();
+        });
+
+        expect(mockDispatch).toHaveBeenCalledWith({
+          type: 'documentField.changeStatus',
+          value: 'idle',
+        });
+
+        expect(mockForm!.submit).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('AND the name has a value', () => {
+      it('SHOULD not refocus the field type input or dispatch', async () => {
+        render(<CreateField {...defaultProps} />);
+        screen.getByTestId('createFieldForm');
+
+        const nameInput = screen.getByTestId('nameParameterInput');
+        fireEvent.change(nameInput, { target: { value: 'semantic_field' } });
+
+        const fieldTypeInput = screen.getByTestId('fieldTypeInput') as HTMLInputElement;
+        const focusSpy = jest.spyOn(fieldTypeInput, 'focus');
+
+        fireEvent.mouseDown(document.body);
+        fireEvent.mouseUp(document.body);
+        fireEvent.click(document.body);
+
+        expect(mockForm!.submit).toHaveBeenCalledTimes(1);
+
+        expect(mockDispatch).not.toHaveBeenCalled();
+        expect(focusSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('WHEN submitting the form', () => {
+    it('SHOULD dispatch the new field, reset the form, and refocus the field type input', async () => {
+      render(<CreateField {...defaultProps} />);
+      screen.getByTestId('createFieldForm');
+
+      const nameInput = screen.getByTestId('nameParameterInput');
+      fireEvent.change(nameInput, { target: { value: 'semantic_field' } });
+
+      mockForm!.setFieldValue('type', 'keyword');
+
+      const fieldTypeInput = screen.getByTestId('fieldTypeInput') as HTMLInputElement;
+      const focusSpy = jest.spyOn(fieldTypeInput, 'focus');
+
+      const addButton = screen.getByTestId('addButton');
+      fireEvent.click(addButton);
+      await act(async () => {
+        await jest.runOnlyPendingTimersAsync();
+      });
+
+      expect(mockForm!.submit).toHaveBeenCalledTimes(1);
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'field.add',
+        value: expect.objectContaining({ name: 'semantic_field', type: 'keyword' }),
+      });
+
+      expect(mockForm!.reset).toHaveBeenCalledTimes(1);
+      expect(mockFormState.name).toBe('');
+
+      expect(focusSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -5,28 +5,32 @@
  * 2.0.
  */
 
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import {
   Form,
   useForm,
 } from '../../../public/application/components/mappings_editor/shared_imports';
-import { findTestSubject, registerTestBed } from '@kbn/test-jest-helpers';
-import { act } from 'react-dom/test-utils';
 import type { SelectInferenceIdProps } from '../../../public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id';
 import { SelectInferenceId } from '../../../public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id';
-import React from 'react';
-import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 
 const mockDispatch = jest.fn();
+const mockNavigateToUrl = jest.fn();
 const INFERENCE_LOCATOR = 'SEARCH_INFERENCE_ENDPOINTS';
-const createMockLocator = (id: string) => ({
+
+const createMockLocator = () => ({
   useUrl: jest.fn().mockReturnValue('https://redirect.me/to/inference_endpoints'),
 });
-const mockInferenceManagementLocator = createMockLocator(INFERENCE_LOCATOR);
 
 jest.mock('../../../public/application/app_context', () => ({
-  useAppContext: jest.fn().mockReturnValue({
+  ...jest.requireActual('../../../public/application/app_context'),
+  useAppContext: jest.fn(() => ({
     core: {
-      application: {},
+      application: {
+        navigateToUrl: mockNavigateToUrl,
+      },
       http: {
         basePath: {
           get: jest.fn().mockReturnValue('/base-path'),
@@ -51,192 +55,524 @@ jest.mock('../../../public/application/app_context', () => ({
         url: {
           locators: {
             get: jest.fn((id) => {
-              switch (id) {
-                case INFERENCE_LOCATOR:
-                  return mockInferenceManagementLocator;
-                default:
-                  throw new Error(`Unknown locator id: ${id}`);
+              if (id === INFERENCE_LOCATOR) {
+                return createMockLocator();
               }
+              throw new Error(`Unknown locator id: ${id}`);
             }),
           },
         },
       },
     },
-  }),
+  })),
 }));
 
 jest.mock(
   '../../../public/application/components/component_templates/component_templates_context',
   () => ({
-    useComponentTemplatesContext: jest.fn().mockReturnValue({
+    ...jest.requireActual(
+      '../../../public/application/components/component_templates/component_templates_context'
+    ),
+    useComponentTemplatesContext: jest.fn(() => ({
       toasts: {
         addError: jest.fn(),
         addSuccess: jest.fn(),
       },
-    }),
+    })),
   })
 );
 
 jest.mock('../../../public/application/components/mappings_editor/mappings_state_context', () => ({
+  ...jest.requireActual(
+    '../../../public/application/components/mappings_editor/mappings_state_context'
+  ),
   useMappingsState: () => ({ inferenceToModelIdMap: {} }),
   useDispatch: () => mockDispatch,
 }));
 
-jest.mock('../../../public/application/services/api', () => ({
-  useLoadInferenceEndpoints: jest.fn().mockReturnValue({
-    data: [
-      { inference_id: '.preconfigured-elser', task_type: 'sparse_embedding' },
-      { inference_id: '.preconfigured-e5', task_type: 'text_embedding' },
-      { inference_id: 'endpoint-1', task_type: 'text_embedding' },
-      { inference_id: 'endpoint-2', task_type: 'sparse_embedding' },
-      { inference_id: 'endpoint-3', task_type: 'completion' },
-    ] as InferenceAPIConfigResponse[],
-    isLoading: false,
-    error: null,
-  }),
+const mockResendRequest = jest.fn();
+
+const MockInferenceFlyoutWrapper = ({
+  onFlyoutClose,
+  onSubmitSuccess,
+}: {
+  onFlyoutClose: () => void;
+  onSubmitSuccess: (id: string) => void;
+  http?: unknown;
+  toasts?: unknown;
+  isEdit?: boolean;
+  enforceAdaptiveAllocations?: boolean;
+}) => (
+  <div data-test-subj="inference-flyout-wrapper">
+    <button data-test-subj="mock-flyout-close" onClick={onFlyoutClose}>
+      Close Flyout
+    </button>
+    <button data-test-subj="mock-flyout-submit" onClick={() => onSubmitSuccess('new-endpoint-id')}>
+      Submit
+    </button>
+  </div>
+);
+
+jest.mock('@kbn/inference-endpoint-ui-common', () => ({
+  __esModule: true,
+  default: MockInferenceFlyoutWrapper,
 }));
 
-function getTestForm(
-  Component: React.FC<SelectInferenceIdProps>,
-  selectedInferenceId: string = '.preconfigured-elser'
-) {
-  return (defaultProps: SelectInferenceIdProps) => {
-    const { form } = useForm();
-    form.setFieldValue('inference_id', selectedInferenceId);
-    return (
-      <Form form={form}>
-        <Component {...(defaultProps as any)} />
-      </Form>
-    );
-  };
+jest.mock('../../../public/application/services/api', () => ({
+  ...jest.requireActual('../../../public/application/services/api'),
+  useLoadInferenceEndpoints: jest.fn(),
+}));
+
+const DEFAULT_ENDPOINTS: InferenceAPIConfigResponse[] = [
+  { inference_id: '.preconfigured-elser', task_type: 'sparse_embedding' },
+  { inference_id: '.preconfigured-e5', task_type: 'text_embedding' },
+  { inference_id: 'endpoint-1', task_type: 'text_embedding' },
+  { inference_id: 'endpoint-2', task_type: 'sparse_embedding' },
+] as InferenceAPIConfigResponse[];
+
+function TestFormWrapper({
+  children,
+  initialValue = '.preconfigured-elser',
+}: {
+  children: React.ReactElement;
+  initialValue?: string;
+}) {
+  const { form } = useForm();
+
+  React.useEffect(() => {
+    if (initialValue) {
+      form.setFieldValue('inference_id', initialValue);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <Form form={form}>{children}</Form>;
 }
 
+function setupMocks(
+  data: InferenceAPIConfigResponse[] | undefined = DEFAULT_ENDPOINTS,
+  isLoading: boolean = false,
+  error: Error | null = null
+) {
+  const { useLoadInferenceEndpoints } = jest.requireMock(
+    '../../../public/application/services/api'
+  );
+
+  mockResendRequest.mockClear();
+  useLoadInferenceEndpoints.mockReturnValue({
+    data,
+    isLoading,
+    error,
+    resendRequest: mockResendRequest,
+  });
+}
+
+const defaultProps: SelectInferenceIdProps = {
+  'data-test-subj': 'data-inference-endpoint-list',
+};
+
+const flushPendingTimers = async () => {
+  await act(async () => {
+    await jest.runOnlyPendingTimersAsync();
+  });
+};
+
+const actClick = async (element: Element) => {
+  // EUI's popover positioning happens async (via MutationObserver/requestAnimationFrame).
+  // When a test ends, RTL unmounts the component but those async callbacks are
+  // already queued. They still fire after unmount, trying to setState on a
+  // now-dead component, which triggers React's "update not wrapped in
+  // act(...)" warning in the next test's setup. Running a test in isolation
+  // usually doesn't show it because timing works out differently. This helper
+  // clicks, then flushes pending timers so the popover's async work completes
+  // before the test ends.
+  fireEvent.click(element);
+  await flushPendingTimers();
+};
+
+let consoleErrorSpy: jest.SpyInstance;
+let originalConsoleError: typeof console.error;
+
+beforeAll(() => {
+  /* eslint-disable no-console */
+  originalConsoleError = console.error;
+  consoleErrorSpy = jest
+    .spyOn(console, 'error')
+    .mockImplementation((message?: unknown, ...rest: unknown[]) => {
+      if (
+        typeof message === 'string' &&
+        message.includes('The truncation ellipsis is larger than the available width')
+      ) {
+        return;
+      }
+      originalConsoleError(message, ...rest);
+    });
+  /* eslint-enable no-console */
+});
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+  const { useLoadInferenceEndpoints } = jest.requireMock(
+    '../../../public/application/services/api'
+  );
+  useLoadInferenceEndpoints.mockReset();
+});
+
+afterEach(async () => {
+  await flushPendingTimers();
+  jest.useRealTimers();
+});
+
 describe('SelectInferenceId', () => {
-  let exists: any;
-  let find: any;
-
-  beforeAll(async () => {
-    const defaultProps: SelectInferenceIdProps = {
-      'data-test-subj': 'data-inference-endpoint-list',
-    };
-    const setup = registerTestBed(getTestForm(SelectInferenceId), {
-      defaultProps,
-      memoryRouter: { wrapComponent: false },
+  describe('WHEN component is rendered', () => {
+    beforeEach(() => {
+      setupMocks();
     });
 
-    await act(async () => {
-      const testBed = await setup();
-      exists = testBed.exists;
-      find = testBed.find;
+    it('SHOULD display the component with button', async () => {
+      render(
+        <TestFormWrapper>
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
+
+      expect(await screen.findByTestId('selectInferenceId')).toBeInTheDocument();
+      expect(await screen.findByTestId('inferenceIdButton')).toBeInTheDocument();
+    });
+
+    it('SHOULD display selected endpoint in button', async () => {
+      render(
+        <TestFormWrapper>
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
+
+      const button = await screen.findByTestId('inferenceIdButton');
+      expect(button).toHaveTextContent('.preconfigured-elser');
+    });
+
+    it('SHOULD prioritize ELSER endpoint as default selection', async () => {
+      render(
+        <TestFormWrapper>
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
+
+      const button = await screen.findByTestId('inferenceIdButton');
+      expect(button).toHaveTextContent('.preconfigured-elser');
+      expect(button).not.toHaveTextContent('endpoint-1');
+      expect(button).not.toHaveTextContent('endpoint-2');
     });
   });
 
-  it('should display the select inference endpoint combo', () => {
-    expect(exists('selectInferenceId')).toBe(true);
+  describe('WHEN popover button is clicked', () => {
+    beforeEach(() => {
+      setupMocks();
+    });
+
+    it('SHOULD open popover with management buttons', async () => {
+      render(
+        <TestFormWrapper>
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
+
+      await actClick(await screen.findByTestId('inferenceIdButton'));
+
+      expect(await screen.findByTestId('createInferenceEndpointButton')).toBeInTheDocument();
+      expect(await screen.findByTestId('manageInferenceEndpointButton')).toBeInTheDocument();
+    });
+
+    describe('AND button is clicked again', () => {
+      it('SHOULD close the popover', async () => {
+        render(
+          <TestFormWrapper>
+            <SelectInferenceId {...defaultProps} />
+          </TestFormWrapper>
+        );
+
+        const toggle = await screen.findByTestId('inferenceIdButton');
+
+        await actClick(toggle);
+        expect(await screen.findByTestId('createInferenceEndpointButton')).toBeInTheDocument();
+
+        await actClick(toggle);
+        expect(screen.queryByTestId('createInferenceEndpointButton')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('AND "Add inference endpoint" button is clicked', () => {
+      it('SHOULD close popover', async () => {
+        render(
+          <TestFormWrapper>
+            <SelectInferenceId {...defaultProps} />
+          </TestFormWrapper>
+        );
+
+        await actClick(await screen.findByTestId('inferenceIdButton'));
+        expect(await screen.findByTestId('createInferenceEndpointButton')).toBeInTheDocument();
+
+        await actClick(await screen.findByTestId('createInferenceEndpointButton'));
+        expect(screen.queryByTestId('createInferenceEndpointButton')).not.toBeInTheDocument();
+      });
+    });
   });
 
-  it('should contain the buttons for InferenceEndpoint management', () => {
-    find('inferenceIdButton').simulate('click');
-    expect(exists('learn-how-to-create-inference-endpoints')).toBe(true);
-    expect(exists('manageInferenceEndpointButton')).toBe(true);
-    expect(exists('createInferenceEndpointButton')).toBe(true);
+  describe('WHEN endpoint is created optimistically', () => {
+    beforeEach(() => {
+      setupMocks();
+    });
+
+    it('SHOULD display newly created endpoint even if not in loaded list', async () => {
+      render(
+        <TestFormWrapper initialValue="newly-created-endpoint">
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
+
+      await actClick(await screen.findByTestId('inferenceIdButton'));
+
+      const newEndpoint = await screen.findByTestId('custom-inference_newly-created-endpoint');
+      expect(newEndpoint).toBeInTheDocument();
+      expect(newEndpoint).toHaveAttribute('aria-checked', 'true');
+    });
   });
 
-  it('should display the inference endpoints in the combo', () => {
-    find('inferenceIdButton').simulate('click');
-    expect(find('data-inference-endpoint-list').contains('.preconfigured-elser')).toBe(true);
-    expect(find('data-inference-endpoint-list').contains('.preconfigured-e5')).toBe(true);
-    expect(find('data-inference-endpoint-list').contains('endpoint-1')).toBe(true);
-    expect(find('data-inference-endpoint-list').contains('endpoint-2')).toBe(true);
-    expect(find('data-inference-endpoint-list').contains('endpoint-3')).toBe(false);
+  describe('WHEN flyout is opened', () => {
+    beforeEach(() => {
+      setupMocks();
+    });
+
+    it('SHOULD show flyout when "Add inference endpoint" is clicked', async () => {
+      render(
+        <TestFormWrapper>
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
+
+      await actClick(await screen.findByTestId('inferenceIdButton'));
+      await actClick(await screen.findByTestId('createInferenceEndpointButton'));
+
+      expect(await screen.findByTestId('inference-flyout-wrapper')).toBeInTheDocument();
+    });
+
+    describe('AND flyout close is triggered', () => {
+      it('SHOULD close the flyout', async () => {
+        render(
+          <TestFormWrapper>
+            <SelectInferenceId {...defaultProps} />
+          </TestFormWrapper>
+        );
+
+        await actClick(await screen.findByTestId('inferenceIdButton'));
+        await actClick(await screen.findByTestId('createInferenceEndpointButton'));
+        expect(await screen.findByTestId('inference-flyout-wrapper')).toBeInTheDocument();
+
+        await actClick(await screen.findByTestId('mock-flyout-close'));
+
+        expect(screen.queryByTestId('inference-flyout-wrapper')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('AND endpoint is successfully created', () => {
+      it('SHOULD call resendRequest when submitted', async () => {
+        render(
+          <TestFormWrapper>
+            <SelectInferenceId {...defaultProps} />
+          </TestFormWrapper>
+        );
+
+        await actClick(await screen.findByTestId('inferenceIdButton'));
+        await actClick(await screen.findByTestId('createInferenceEndpointButton'));
+
+        expect(await screen.findByTestId('inference-flyout-wrapper')).toBeInTheDocument();
+
+        await actClick(await screen.findByTestId('mock-flyout-submit'));
+
+        expect(mockResendRequest).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
-  it('select the first endpoint by default', () => {
-    find('inferenceIdButton').simulate('click');
-    const defaultElser = findTestSubject(
-      find('data-inference-endpoint-list'),
-      'custom-inference_.preconfigured-elser'
-    );
-    expect(defaultElser.prop('aria-checked')).toEqual(true);
+  describe('WHEN endpoint is selected from list', () => {
+    beforeEach(() => {
+      setupMocks();
+    });
+
+    it('SHOULD update form value with selected endpoint', async () => {
+      render(
+        <TestFormWrapper>
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
+
+      await actClick(await screen.findByTestId('inferenceIdButton'));
+
+      const endpoint1 = await screen.findByTestId('custom-inference_endpoint-1');
+      await actClick(endpoint1);
+
+      const button = await screen.findByTestId('inferenceIdButton');
+      expect(button).toHaveTextContent('endpoint-1');
+    });
   });
 
-  it('does not select the other endpoints by default', () => {
-    find('inferenceIdButton').simulate('click');
-    const defaultE5 = findTestSubject(
-      find('data-inference-endpoint-list'),
-      'custom-inference_.preconfigured-e5'
-    );
-    expect(defaultE5.prop('aria-checked')).toEqual(false);
+  describe('WHEN user searches for endpoints', () => {
+    beforeEach(() => {
+      setupMocks();
+    });
 
-    const endpoint1 = findTestSubject(
-      find('data-inference-endpoint-list'),
-      'custom-inference_endpoint-1'
-    );
-    expect(endpoint1.prop('aria-checked')).toEqual(false);
+    it('SHOULD filter endpoints based on search input', async () => {
+      render(
+        <TestFormWrapper>
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
 
-    const endpoint2 = findTestSubject(
-      find('data-inference-endpoint-list'),
-      'custom-inference_endpoint-2'
-    );
-    expect(endpoint2.prop('aria-checked')).toEqual(false);
+      await actClick(await screen.findByTestId('inferenceIdButton'));
+
+      const searchInput = await screen.findByRole('combobox', {
+        name: /Existing endpoints/i,
+      });
+      fireEvent.change(searchInput, { target: { value: 'endpoint-1' } });
+
+      expect(await screen.findByTestId('custom-inference_endpoint-1')).toBeInTheDocument();
+      expect(screen.queryByTestId('custom-inference_endpoint-2')).not.toBeInTheDocument();
+    });
   });
 
-  describe('when ELSER endpoint is available', () => {
-    const endpointsMock = [
-      { inference_id: '.preconfigured-e5', task_type: 'text_embedding' },
-      { inference_id: '.elser-2-elastic', task_type: 'sparse_embedding' },
-      { inference_id: '.elser-2-elasticsearch', task_type: 'sparse_embedding' },
-      { inference_id: 'endpoint-1', task_type: 'text_embedding' },
+  describe('WHEN endpoints are loading', () => {
+    it('SHOULD display loading spinner', async () => {
+      setupMocks(undefined, true, null);
+
+      render(
+        <TestFormWrapper>
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
+
+      await actClick(await screen.findByTestId('inferenceIdButton'));
+      await screen.findByTestId('createInferenceEndpointButton');
+
+      const progressBars = screen.getAllByRole('progressbar');
+      expect(progressBars.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('WHEN endpoints list is empty', () => {
+    it('SHOULD not set default value', async () => {
+      setupMocks([], false, null);
+
+      render(
+        <TestFormWrapper initialValue="">
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
+
+      await flushPendingTimers();
+
+      const button = screen.getByTestId('inferenceIdButton');
+      expect(button).toHaveTextContent('No inference endpoint selected');
+    });
+
+    it('SHOULD display "No inference endpoint selected" message', () => {
+      setupMocks([], false, null);
+
+      render(
+        <TestFormWrapper initialValue="">
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
+
+      const button = screen.getByTestId('inferenceIdButton');
+      expect(button).toHaveTextContent('No inference endpoint selected');
+    });
+  });
+
+  describe('WHEN only incompatible endpoints are available', () => {
+    const incompatibleEndpoints: InferenceAPIConfigResponse[] = [
+      { inference_id: 'incompatible-1', task_type: 'completion' },
+      { inference_id: 'incompatible-2', task_type: 'rerank' },
     ] as InferenceAPIConfigResponse[];
 
-    beforeAll(async () => {
-      const mockUseLoadInferenceEndpoints = jest.requireMock(
-        '../../../public/application/services/api'
-      ).useLoadInferenceEndpoints;
-      mockUseLoadInferenceEndpoints.mockReturnValue({
-        data: endpointsMock,
-        isLoading: false,
-        error: null,
-      });
-
-      const defaultProps: SelectInferenceIdProps = {
-        'data-test-subj': 'data-inference-endpoint-list',
-      };
-
-      const setup = registerTestBed(getTestForm(SelectInferenceId, ''), {
-        defaultProps,
-        memoryRouter: { wrapComponent: false },
-      });
-
-      await act(async () => {
-        const testBed = await setup();
-        exists = testBed.exists;
-        find = testBed.find;
-      });
-
-      find('inferenceIdButton').simulate('click');
+    beforeEach(() => {
+      setupMocks(incompatibleEndpoints);
     });
 
-    it('should prioritize ELSER endpoint as selected by default', () => {
-      const elserOption = findTestSubject(
-        find('data-inference-endpoint-list'),
-        'custom-inference_.elser-2-elastic'
+    it('SHOULD not display incompatible endpoints in list', async () => {
+      render(
+        <TestFormWrapper initialValue="">
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
       );
-      expect(elserOption.prop('aria-checked')).toEqual(true);
+
+      await actClick(await screen.findByTestId('inferenceIdButton'));
+      await screen.findByTestId('createInferenceEndpointButton');
+
+      expect(screen.queryByTestId('custom-inference_incompatible-1')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('custom-inference_incompatible-2')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('WHEN API returns error', () => {
+    it('SHOULD handle error gracefully and still render UI', async () => {
+      setupMocks([], false, new Error('Failed to load endpoints'));
+
+      render(
+        <TestFormWrapper>
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
+
+      expect(screen.getByTestId('selectInferenceId')).toBeInTheDocument();
+
+      await actClick(await screen.findByTestId('inferenceIdButton'));
+      expect(await screen.findByTestId('createInferenceEndpointButton')).toBeInTheDocument();
+
+      expect(screen.queryByTestId('custom-inference_endpoint-1')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('custom-inference_endpoint-2')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('WHEN component mounts with empty value', () => {
+    it('SHOULD automatically select default endpoint', async () => {
+      setupMocks();
+
+      render(
+        <TestFormWrapper initialValue="">
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
+
+      await flushPendingTimers();
+
+      const button = screen.getByTestId('inferenceIdButton');
+      expect(button).toHaveTextContent('.preconfigured-elser');
     });
 
-    it('should not select other endpoints by default', () => {
-      const e5Option = findTestSubject(
-        find('data-inference-endpoint-list'),
-        'custom-inference_.preconfigured-e5'
-      );
-      expect(e5Option.prop('aria-checked')).toEqual(false);
+    describe('AND .elser-2-elastic is available', () => {
+      it('SHOULD prioritize .elser-2-elastic over other endpoints', async () => {
+        setupMocks([
+          { inference_id: '.elser-2-elastic', task_type: 'sparse_embedding' },
+          { inference_id: '.preconfigured-elser', task_type: 'sparse_embedding' },
+          { inference_id: 'endpoint-1', task_type: 'text_embedding' },
+        ] as InferenceAPIConfigResponse[]);
 
-      const endpoint1Option = findTestSubject(
-        find('data-inference-endpoint-list'),
-        'custom-inference_endpoint-1'
-      );
-      expect(endpoint1Option.prop('aria-checked')).toEqual(false);
+        render(
+          <TestFormWrapper initialValue="">
+            <SelectInferenceId {...defaultProps} />
+          </TestFormWrapper>
+        );
+
+        await flushPendingTimers();
+
+        const button = screen.getByTestId('inferenceIdButton');
+        expect(button).toHaveTextContent('.elser-2-elastic');
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -96,10 +96,13 @@ jest.mock('../../../public/application/services/api', () => ({
   }),
 }));
 
-function getTestForm(Component: React.FC<SelectInferenceIdProps>) {
+function getTestForm(
+  Component: React.FC<SelectInferenceIdProps>,
+  selectedInferenceId: string = '.preconfigured-elser'
+) {
   return (defaultProps: SelectInferenceIdProps) => {
     const { form } = useForm();
-    form.setFieldValue('inference_id', '.preconfigured-elser');
+    form.setFieldValue('inference_id', selectedInferenceId);
     return (
       <Form form={form}>
         <Component {...(defaultProps as any)} />
@@ -181,11 +184,12 @@ describe('SelectInferenceId', () => {
   describe('when ELSER endpoint is available', () => {
     const endpointsMock = [
       { inference_id: '.preconfigured-e5', task_type: 'text_embedding' },
+      { inference_id: '.elser-2-elastic', task_type: 'sparse_embedding' },
       { inference_id: '.elser-2-elasticsearch', task_type: 'sparse_embedding' },
       { inference_id: 'endpoint-1', task_type: 'text_embedding' },
     ] as InferenceAPIConfigResponse[];
 
-    beforeEach(() => {
+    beforeAll(async () => {
       const mockUseLoadInferenceEndpoints = jest.requireMock(
         '../../../public/application/services/api'
       ).useLoadInferenceEndpoints;
@@ -195,13 +199,28 @@ describe('SelectInferenceId', () => {
         error: null,
       });
 
+      const defaultProps: SelectInferenceIdProps = {
+        'data-test-subj': 'data-inference-endpoint-list',
+      };
+
+      const setup = registerTestBed(getTestForm(SelectInferenceId, ''), {
+        defaultProps,
+        memoryRouter: { wrapComponent: false },
+      });
+
+      await act(async () => {
+        const testBed = await setup();
+        exists = testBed.exists;
+        find = testBed.find;
+      });
+
       find('inferenceIdButton').simulate('click');
     });
 
     it('should prioritize ELSER endpoint as selected by default', () => {
       const elserOption = findTestSubject(
         find('data-inference-endpoint-list'),
-        'custom-inference_.elser-2-elasticsearch'
+        'custom-inference_.elser-2-elastic'
       );
       expect(elserOption.prop('aria-checked')).toEqual(true);
     });

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -25,7 +25,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { defaultInferenceEndpoints } from '@kbn/inference-common';
-import React, { useState, useCallback, useMemo, lazy, Suspense } from 'react';
+import React, { useState, useCallback, useMemo, lazy, Suspense, useEffect } from 'react';
 
 import { getFieldConfig } from '../../../lib';
 import { useAppContext } from '../../../../../app_context';
@@ -75,18 +75,18 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
     docLinks,
     plugins: { cloud, share },
   } = useAppContext();
-  const config = getFieldConfig('inference_id');
+  const { isLoading, data: endpoints, resendRequest } = useLoadInferenceEndpoints();
+  const [isInferenceFlyoutVisible, setIsInferenceFlyoutVisible] = useState<boolean>(false);
+  const [isInferencePopoverVisible, setIsInferencePopoverVisible] = useState<boolean>(false);
 
+  const config = getFieldConfig('inference_id');
   const inferenceEndpointsPageLink = share?.url.locators
     .get('SEARCH_INFERENCE_ENDPOINTS')
     ?.useUrl({});
 
-  const [isInferenceFlyoutVisible, setIsInferenceFlyoutVisible] = useState<boolean>(false);
   const onFlyoutClose = useCallback(() => {
-    setIsInferenceFlyoutVisible(!isInferenceFlyoutVisible);
-  }, [isInferenceFlyoutVisible]);
-
-  const { isLoading, data: endpoints, resendRequest } = useLoadInferenceEndpoints();
+    setIsInferenceFlyoutVisible((prev) => !prev);
+  }, []);
 
   const onSubmitSuccess = useCallback(
     (newEndpointId: string) => {
@@ -96,60 +96,40 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
     [resendRequest, setValue]
   );
 
-  const options: EuiSelectableOption[] = useMemo(() => {
-    const filteredEndpoints = endpoints?.filter(
-      (endpoint) =>
-        endpoint.task_type === 'text_embedding' || endpoint.task_type === 'sparse_embedding'
+  // Get the ID of the default inference endpoint (.elser-2-elastic), and if that's not an option
+  // then return the ID of the first endpoint in the list
+  const getDefaultInferenceId = useCallback((endpointsList: typeof endpoints) => {
+    const elserInEis = endpointsList?.find(
+      (e) => e.inference_id === defaultInferenceEndpoints.ELSER_IN_EIS_INFERENCE_ID
     );
+    return elserInEis?.inference_id || endpointsList?.[0]?.inference_id;
+  }, []);
 
-    const newOptions: EuiSelectableOption[] = [...(filteredEndpoints || [])].map((endpoint) => ({
+  // Compute selectable options from endpoints and current value
+  const options: EuiSelectableOption[] = useMemo(() => {
+    const filteredEndpoints =
+      endpoints?.filter(
+        (endpoint) =>
+          endpoint.task_type === 'text_embedding' || endpoint.task_type === 'sparse_embedding'
+      ) || [];
+
+    const baseOptions: EuiSelectableOption[] = filteredEndpoints.map((endpoint) => ({
       label: endpoint.inference_id,
       'data-test-subj': `custom-inference_${endpoint.inference_id}`,
       checked: value === endpoint.inference_id ? 'on' : undefined,
     }));
-    /**
-     * Adding this check to ensure we have the preconfigured elser endpoint selected by default.
-     */
-    const hasInferenceSelected = newOptions.some((option) => option.checked === 'on');
-    // If nothing has been selected, select .elser-2-elasticsearch as default if it exists.
-    // Use a constant for the ELSER inference endpoint label instead of a hard-coded string
 
-    if (!hasInferenceSelected && newOptions.length > 0) {
-      const elserOption = newOptions.find(
-        (option) => option.label === defaultInferenceEndpoints.ELSER
-      );
-      if (elserOption) {
-        elserOption.checked = 'on';
-        if (!value) {
-          setValue(defaultInferenceEndpoints.ELSER);
-        }
-      } else {
-        // fallback: select the first option if the Elser option does not exist
-        // This line uses array destructuring to select the first element from newOptions array.
-        // `firstOption` will be assigned the first option object from newOptions, or undefined if the array is empty.
-        const firstOption = newOptions[0];
-        if (firstOption) {
-          firstOption.checked = 'on';
-          if (!value) {
-            setValue(firstOption.label);
-          }
-        }
-      }
-    }
-
-    if (value && !newOptions.find((option) => option.label === value)) {
-      // Sometimes we create a new endpoint but the backend is slow in updating so we need to optimistically update
-      const newOption: EuiSelectableOption = {
+    // Sometimes we create a new endpoint but the backend is slow in updating so we need to optimistically update
+    if (value && !baseOptions.find((o) => o.label === value)) {
+      baseOptions.push({
         label: value,
         checked: 'on',
         'data-test-subj': `custom-inference_${value}`,
-      };
-      return [...newOptions, newOption];
+      });
     }
-    return newOptions;
-  }, [endpoints, value, setValue]);
 
-  const [isInferencePopoverVisible, setIsInferencePopoverVisible] = useState<boolean>(false);
+    return baseOptions;
+  }, [endpoints, value]);
 
   const selectedOptionLabel = options.find((option) => option.checked)?.label;
 
@@ -169,7 +149,7 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
             color="text"
             data-test-subj="inferenceIdButton"
             onClick={() => {
-              setIsInferencePopoverVisible(!isInferencePopoverVisible);
+              setIsInferencePopoverVisible((prev) => !prev);
             }}
           >
             {selectedOptionLabel ||
@@ -184,7 +164,7 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
       }
       isOpen={isInferencePopoverVisible}
       panelPaddingSize="none"
-      closePopover={() => setIsInferencePopoverVisible(!isInferencePopoverVisible)}
+      closePopover={() => setIsInferencePopoverVisible((prev) => !prev)}
     >
       <EuiContextMenuPanel>
         <EuiContextMenuItem
@@ -195,7 +175,7 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
           onClick={(e) => {
             e.preventDefault();
             setIsInferenceFlyoutVisible(true);
-            setIsInferencePopoverVisible(!isInferencePopoverVisible);
+            setIsInferencePopoverVisible((prev) => !prev);
           }}
         >
           {i18n.translate(
@@ -291,6 +271,17 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
       </EuiContextMenuItem>
     </EuiPopover>
   );
+
+  // When no inference endpoint is selected, automatically set it to the default endpoint
+  useEffect(() => {
+    if (!value && endpoints?.length) {
+      const defaultId = getDefaultInferenceId(endpoints);
+      if (defaultId) {
+        setValue(defaultId);
+      }
+    }
+  }, [endpoints, value, setValue, getDefaultInferenceId]);
+
   return (
     <>
       <EuiSpacer />
@@ -302,7 +293,7 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
             inferencePopover()
           )}
 
-          {isInferenceFlyoutVisible ? (
+          {isInferenceFlyoutVisible && (
             <Suspense fallback={<EuiLoadingSpinner size="l" />}>
               <InferenceFlyoutWrapper
                 onFlyoutClose={onFlyoutClose}
@@ -313,7 +304,7 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
                 enforceAdaptiveAllocations={enforceAdaptiveAllocations}
               />
             </Suspense>
-          ) : null}
+          )}
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiPanel color="transparent" paddingSize="s">

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/create_field.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/create_field.tsx
@@ -175,7 +175,7 @@ export const CreateField = React.memo(function CreateFieldComponent({
       form.reset();
     }
 
-    if (fieldTypeInputRef.current) {
+    if (!clickOutside && fieldTypeInputRef.current) {
       fieldTypeInputRef.current.focus();
     }
   };


### PR DESCRIPTION
## Summary

This PR sets `.elser-2-elastic` (ELSER in EIS) as the selected default inference endpoint when adding semantic text field mappings.

In addition, this PR also refactors parts of the `SelectInferenceId` component to improve clarity, reduce the potential for bugs, and fixes a console error. The following updates were made:
- Minor naming and structure cleanups to improve readability.
- Refactored `options` so that it focused purely on setting the options array for `EuiSelectable`. The default endpoint is now determined in a helper function `getDefaultInferenceId`, and the default `value` state is updated in a `useEffect`. These changes fixed the following console error:
`Warning: Cannot update a component (UseFieldComp) while rendering a different component (SelectInferenceIdContent)`

A separate commit was also made by Karen, to fix a bug where clicking anywhere on the page after the semantic text field was selected would retrigger the dropdown.

### Video

https://github.com/user-attachments/assets/f55ce940-037a-4a19-9c34-2bad449a6bc4

## Testing

**Note**: This PR currently can't be tested locally as the EIS script isn't set up to show the `.elser-2-elastic` endpoint, so you will need to use the CI cloud/serverless deployment in this PR

1. Create an index with a mapping that has a field of type `semantic_text`. Easiest way to do this with semantic search console tutorial on the home page.
2. Go to index management and click on the index you created
3. Click on the `Mappings` tab
4. Confirm that the field mapping you created uses the `.elser-2-elastic` inference endpoint (it should show as a tag on the field mapping)
5. Add a new field with a `semantic_text` type, and confirm that the `.elser-2-elastic` inference endpoint is automatically selected by default
6. Click anywhere outside the dropdown field to confirm that the dropdown is no longer retriggered
7. Save the new mapping and confirm that the field has been created using the `.elser-2-elastic` inference endpoint

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~

## Release note

.`elser-2-elastic` (ELSER in EIS) is now automatically selected as the default inference endpoint when adding semantic text fields. The `SelectInferenceId` component has been refactored for clarity and stability, resolving a console warning and improving popover and flyout state handling.