### PR TITLE
[dashboard] fix 'sync colors' and 'sync tooltips' must be ON by default

### DIFF
--- a/src/platform/plugins/shared/dashboard/common/content_management/constants.ts
+++ b/src/platform/plugins/shared/dashboard/common/content_management/constants.ts
@@ -19,7 +19,7 @@ export const DEFAULT_PANEL_HEIGHT = 15;
 export const DEFAULT_DASHBOARD_OPTIONS = {
   hidePanelTitles: false,
   useMargins: true,
-  syncColors: true,
+  syncColors: false,
   syncCursor: true,
-  syncTooltips: true,
+  syncTooltips: false,
 } as const;

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/settings_manager.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/settings_manager.test.tsx
@@ -11,7 +11,7 @@ import { BehaviorSubject } from 'rxjs';
 import { getSampleDashboardState } from '../mocks';
 import type { DashboardState } from '../../common';
 import { initializeSettingsManager } from './settings_manager';
-import { DEFAULT_DASHBOARD_OPTIONS } from '@kbn/dashboard-plugin/common/content_management';
+import { DEFAULT_DASHBOARD_OPTIONS } from '../../common/content_management';
 
 describe('initializeSettingsManager', () => {
   describe('default values', () => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/settings_manager.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/settings_manager.test.tsx
@@ -11,8 +11,44 @@ import { BehaviorSubject } from 'rxjs';
 import { getSampleDashboardState } from '../mocks';
 import type { DashboardState } from '../../common';
 import { initializeSettingsManager } from './settings_manager';
+import { DEFAULT_DASHBOARD_OPTIONS } from '@kbn/dashboard-plugin/common/content_management';
 
 describe('initializeSettingsManager', () => {
+  describe('default values', () => {
+    test('Should set syncCursor to false when value not provided', () => {
+      const settingsManager = initializeSettingsManager({
+        title: 'dashboard 1',
+        panels: [],
+      });
+      expect(settingsManager.api.getSettings().syncColors).toBe(false);
+    });
+
+    test('Should set syncTooltips to false when value not provided', () => {
+      const settingsManager = initializeSettingsManager({
+        title: 'dashboard 1',
+        panels: [],
+      });
+      expect(settingsManager.api.getSettings().syncTooltips).toBe(false);
+    });
+  });
+
+  describe('setSettings', () => {
+    test('Should not overwrite settings when setting partial state', () => {
+      const settingsManager = initializeSettingsManager({
+        title: 'dashboard 1',
+        panels: [],
+        options: {
+          ...DEFAULT_DASHBOARD_OPTIONS,
+          useMargins: false,
+        },
+      });
+      settingsManager.api.setSettings({ timeRestore: true });
+      const settings = settingsManager.api.getSettings();
+      expect(settings.timeRestore).toBe(true);
+      expect(settings.useMargins).toBe(false);
+    });
+  });
+
   describe('startComparing$', () => {
     test('Should return no changes when there are no changes', (done) => {
       const lastSavedState$ = new BehaviorSubject<DashboardState>(getSampleDashboardState());

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/settings_manager.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/settings_manager.tsx
@@ -83,7 +83,7 @@ export function initializeSettingsManager(initialState: DashboardState) {
         stateManager.reinitializeState({
           ...stateManager.getLatestState(),
           ...settings,
-        })
+        });
       },
       setTags: stateManager.api.setTags,
       timeRestore$: stateManager.api.timeRestore$,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/settings_manager.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/settings_manager.tsx
@@ -79,7 +79,12 @@ export function initializeSettingsManager(initialState: DashboardState) {
         syncTooltips$: stateManager.api.syncTooltips$,
         useMargins$: stateManager.api.useMargins$,
       },
-      setSettings: stateManager.reinitializeState,
+      setSettings: (settings: Partial<DashboardSettings>) => {
+        stateManager.reinitializeState({
+          ...stateManager.getLatestState(),
+          ...settings,
+        })
+      },
       setTags: stateManager.api.setTags,
       timeRestore$: stateManager.api.timeRestore$,
       title$: stateManager.api.title$,

--- a/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/in/transform_dashboard_in.test.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/v1/transforms/in/transform_dashboard_in.test.ts
@@ -114,7 +114,7 @@ describe('transformDashboardIn', () => {
           "kibanaSavedObjectMeta": Object {
             "searchSourceJSON": "{}",
           },
-          "optionsJSON": "{\\"hidePanelTitles\\":false,\\"useMargins\\":true,\\"syncColors\\":true,\\"syncCursor\\":true,\\"syncTooltips\\":true}",
+          "optionsJSON": "{\\"hidePanelTitles\\":false,\\"useMargins\\":true,\\"syncColors\\":false,\\"syncCursor\\":true,\\"syncTooltips\\":false}",
           "panelsJSON": "[]",
           "timeRestore": false,
           "title": "title",

--- a/src/platform/plugins/shared/dashboard/tsconfig.json
+++ b/src/platform/plugins/shared/dashboard/tsconfig.json
@@ -92,7 +92,8 @@
     "@kbn/controls-constants",
     "@kbn/presentation-util",
     "@kbn/react-query",
-    "@kbn/core-chrome-layout-utils"
+    "@kbn/core-chrome-layout-utils",
+    "@kbn/dashboard-plugin"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/dashboard/tsconfig.json
+++ b/src/platform/plugins/shared/dashboard/tsconfig.json
@@ -92,8 +92,7 @@
     "@kbn/controls-constants",
     "@kbn/presentation-util",
     "@kbn/react-query",
-    "@kbn/core-chrome-layout-utils",
-    "@kbn/dashboard-plugin"
+    "@kbn/core-chrome-layout-utils"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/242373

Regression caused by https://github.com/elastic/kibana/pull/238129. PR removed options from `DEFAULT_DASHBOARD_STATE` and starting using existing [DEFAULT_DASHBOARD_OPTIONS](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/dashboard/common/content_management/constants.ts#L19).  `DEFAULT_DASHBOARD_OPTIONS` added in https://github.com/elastic/kibana/pull/193067. The problem is that `DEFAULT_DASHBOARD_OPTIONS` does not have the same values as options in `DEFAULT_DASHBOARD_STATE` and this was missed during review.

