### PR TITLE
[Search] Update stateless promo banner for iteration 12

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/cta_button.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/cta_button.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiButton } from '@elastic/eui';
+
+export interface HeaderCTAButtonProps {
+  handleOnClick: () => void;
+  'data-telemetry-id': string;
+  children: React.ReactNode | React.ReactNode[];
+  ariaLabel: string;
+}
+
+export const HeaderCTAButton = (props: HeaderCTAButtonProps) => (
+  <EuiButton
+    // keep "search-promo-homepage" as the prefix for every tracking ID so we can filter on that prefix for the total homepage promo clicks overall
+    data-telemetry-id={`search-promo-homepage-${props['data-telemetry-id']}`}
+    data-test-subj="searchHomepageHeaderButton"
+    onClick={props.handleOnClick}
+    aria-label={props.ariaLabel}
+  >
+    {props.children}
+  </EuiButton>
+);

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/cta_button.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/cta_button.tsx
@@ -10,6 +10,7 @@ import { EuiButton } from '@elastic/eui';
 export interface HeaderCTAButtonProps {
   handleOnClick: () => void;
   'data-telemetry-id': string;
+  'data-test-subj'?: string;
   children: React.ReactNode | React.ReactNode[];
   ariaLabel: string;
 }
@@ -18,7 +19,7 @@ export const HeaderCTAButton = (props: HeaderCTAButtonProps) => (
   <EuiButton
     // keep "search-promo-homepage" as the prefix for every tracking ID so we can filter on that prefix for the total homepage promo clicks overall
     data-telemetry-id={`search-promo-homepage-${props['data-telemetry-id']}`}
-    data-test-subj="searchHomepageHeaderButton"
+    data-test-subj={props['data-test-subj'] || 'searchHomepageHeaderButton'}
     onClick={props.handleOnClick}
     aria-label={props.ariaLabel}
   >

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/cta_link.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/cta_link.tsx
@@ -10,12 +10,13 @@ import { EuiLink } from '@elastic/eui';
 export interface HeaderCTALinkProps {
   href: string;
   'data-telemetry-id': string;
+  'data-test-subj'?: string;
   children: React.ReactNode | React.ReactNode[];
 }
 
 export const HeaderCTALink = (props: HeaderCTALinkProps) => (
   <EuiLink
-    data-test-subj="searchHomepageSearchHomepageHeaderCTA"
+    data-test-subj={props['data-test-subj'] || 'searchHomepageHeaderCTA'}
     href={props.href}
     target="_blank"
     // keep "search-promo-homepage" as the prefix for every tracking ID so we can filter on that prefix for the total homepage promo clicks overall

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/promo.tsx
@@ -5,17 +5,17 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiPanel, EuiText, EuiTitle, EuiSpacer } from '@elastic/eui';
+import { EuiPanel, EuiText, EuiTitle, EuiSpacer, EuiFlexGroup } from '@elastic/eui';
 import { FeatureUpdateGroup } from './feature_update_group';
 
 export interface HeaderPromoProps {
   title: React.ReactNode;
   description: React.ReactNode;
   updates?: React.ReactNode[];
-  cta: React.ReactNode;
+  actions: React.ReactNode[];
 }
 
-export const HeaderPromo = ({ title, description, updates, cta }: HeaderPromoProps) => {
+export const HeaderPromo = ({ title, description, updates, actions }: HeaderPromoProps) => {
   return (
     <EuiPanel color="transparent" paddingSize="xl">
       <EuiTitle size="l">
@@ -27,7 +27,9 @@ export const HeaderPromo = ({ title, description, updates, cta }: HeaderPromoPro
       </EuiText>
       <EuiSpacer size="xl" />
       {updates && updates.length > 0 ? <FeatureUpdateGroup updates={updates} /> : null}
-      {cta}
+      <EuiFlexGroup alignItems="center" gutterSize="m">
+        {actions.map((cta) => cta)}
+      </EuiFlexGroup>
     </EuiPanel>
   );
 };

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/promo.tsx
@@ -28,7 +28,7 @@ export const HeaderPromo = ({ title, description, updates, actions }: HeaderProm
       <EuiSpacer size="xl" />
       {updates && updates.length > 0 ? <FeatureUpdateGroup updates={updates} /> : null}
       <EuiFlexGroup alignItems="center" gutterSize="m">
-        {actions.map((cta) => cta)}
+        {actions}
       </EuiFlexGroup>
     </EuiPanel>
   );

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateful_promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateful_promo.tsx
@@ -20,7 +20,7 @@ export const StatefulHeaderPromo = () => {
         defaultMessage:
           'We are thrilled to launch ELSER on ElS -- get state-of-the-art semantic search relevance without having to manage your own machine learning nodes.',
       })}
-      cta={
+      actions={[
         <HeaderCTALink
           data-test-subj="searchHomepageSearchHomepageHeaderCTA"
           // "search-promo-homepage-" is prepended to the telemetry id in HeaderCTALink
@@ -30,8 +30,8 @@ export const StatefulHeaderPromo = () => {
           {i18n.translate('xpack.searchHomepage.statefulPromo.content', {
             defaultMessage: 'View docs',
           })}
-        </HeaderCTALink>
-      }
+        </HeaderCTALink>,
+      ]}
     />
   );
 };

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateful_promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateful_promo.tsx
@@ -22,7 +22,7 @@ export const StatefulHeaderPromo = () => {
       })}
       actions={[
         <HeaderCTALink
-          data-test-subj="searchHomepageSearchHomepageHeaderCTA"
+          key="10-elser-on-eis"
           // "search-promo-homepage-" is prepended to the telemetry id in HeaderCTALink
           data-telemetry-id="10-elser-on-eis"
           href="https://www.elastic.co/docs/explore-analyze/elastic-inference/eis#elser-on-eis"

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateless_promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateless_promo.tsx
@@ -9,28 +9,46 @@ import { i18n } from '@kbn/i18n';
 
 import { HeaderPromo } from './promo';
 import { HeaderCTALink } from './cta_link';
+import { useKibana } from '../../hooks/use_kibana';
+import { HeaderCTAButton } from './cta_button';
 
 export const StatelessHeaderPromo = () => {
+  const {
+    services: { application },
+  } = useKibana();
+
+  const ctaButtonLabel = i18n.translate('xpack.searchHomepage.statelessPromo.content.ctaButton', {
+    defaultMessage: 'Start Building',
+  });
   return (
     <HeaderPromo
       title={i18n.translate('xpack.searchHomepage.header.statelessPromo.title', {
-        defaultMessage: 'Building AI Agentic workflows with Elasticsearch',
+        defaultMessage: 'Get started building AI Agents and chatting with your data',
       })}
       description={i18n.translate('xpack.searchHomepage.header.statelessPromo.description', {
         defaultMessage:
-          'Learn about Agent Builder, a new AI layer in Elasticsearch that provides a framework for building AI agentic workflows, using hybrid search to provide agents with the context they need to reason and act.',
+          'Start building AI agents. Try Agent Builder to chat with your data using powerful native tools, or create your own agents and tools with hybrid search and ES|QL.',
       })}
-      cta={
+      actions={[
+        <HeaderCTAButton
+          data-telemetry-id="12-agent-builder-button"
+          handleOnClick={() => {
+            application.navigateToApp('agent_builder');
+          }}
+          ariaLabel={ctaButtonLabel}
+        >
+          {ctaButtonLabel}
+        </HeaderCTAButton>,
         <HeaderCTALink
           // "search-promo-homepage-" is prepended to the telemetry id in HeaderCTALink
           data-telemetry-id="12-agent-builder-blog"
           href="https://www.elastic.co/search-labs/blog/ai-agentic-workflows-elastic-ai-agent-builder"
         >
-          {i18n.translate('xpack.searchHomepage.statelessPromo.content', {
-            defaultMessage: 'Read the blog',
+          {i18n.translate('xpack.searchHomepage.statelessPromo.content.ctaLink', {
+            defaultMessage: 'Check out the docs',
           })}
-        </HeaderCTALink>
-      }
+        </HeaderCTALink>,
+      ]}
     />
   );
 };

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateless_promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateless_promo.tsx
@@ -17,20 +17,21 @@ export const StatelessHeaderPromo = () => {
     services: { application },
   } = useKibana();
 
-  const ctaButtonLabel = i18n.translate('xpack.searchHomepage.statelessPromo.content.ctaButton', {
+  const ctaButtonLabel = i18n.translate('xpack.searchHomepage.statelessPromo12.content.ctaButton', {
     defaultMessage: 'Start Building',
   });
   return (
     <HeaderPromo
-      title={i18n.translate('xpack.searchHomepage.header.statelessPromo.title', {
+      title={i18n.translate('xpack.searchHomepage.header.statelessPromo12.title', {
         defaultMessage: 'Get started building AI Agents and chatting with your data',
       })}
-      description={i18n.translate('xpack.searchHomepage.header.statelessPromo.description', {
+      description={i18n.translate('xpack.searchHomepage.header.statelessPromo12.description', {
         defaultMessage:
           'Start building AI agents. Try Agent Builder to chat with your data using powerful native tools, or create your own agents and tools with hybrid search and ES|QL.',
       })}
       actions={[
         <HeaderCTAButton
+          key="12-agent-builder-button"
           data-telemetry-id="12-agent-builder-button"
           handleOnClick={() => {
             application.navigateToApp('agent_builder');
@@ -40,11 +41,12 @@ export const StatelessHeaderPromo = () => {
           {ctaButtonLabel}
         </HeaderCTAButton>,
         <HeaderCTALink
+          key="12-agent-builder-blog"
           // "search-promo-homepage-" is prepended to the telemetry id in HeaderCTALink
           data-telemetry-id="12-agent-builder-blog"
           href="https://www.elastic.co/search-labs/blog/ai-agentic-workflows-elastic-ai-agent-builder"
         >
-          {i18n.translate('xpack.searchHomepage.statelessPromo.content.ctaLink', {
+          {i18n.translate('xpack.searchHomepage.statelessPromo12.content.ctaLink', {
             defaultMessage: 'Check out the docs',
           })}
         </HeaderCTALink>,

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateless_promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/stateless_promo.tsx
@@ -14,20 +14,20 @@ export const StatelessHeaderPromo = () => {
   return (
     <HeaderPromo
       title={i18n.translate('xpack.searchHomepage.header.statelessPromo.title', {
-        defaultMessage: 'GPUs go brrr! GPU-accelerated inference for ELSER',
+        defaultMessage: 'Building AI Agentic workflows with Elasticsearch',
       })}
       description={i18n.translate('xpack.searchHomepage.header.statelessPromo.description', {
         defaultMessage:
-          'We are thrilled to launch ELSER on ElS -- get state-of-the-art semantic search relevance without having to manage your own machine learning nodes.',
+          'Learn about Agent Builder, a new AI layer in Elasticsearch that provides a framework for building AI agentic workflows, using hybrid search to provide agents with the context they need to reason and act.',
       })}
       cta={
         <HeaderCTALink
           // "search-promo-homepage-" is prepended to the telemetry id in HeaderCTALink
-          data-telemetry-id="11-elser-on-eis"
-          href="https://www.elastic.co/docs/explore-analyze/elastic-inference/eis#elser-on-eis"
+          data-telemetry-id="12-agent-builder-blog"
+          href="https://www.elastic.co/search-labs/blog/ai-agentic-workflows-elastic-ai-agent-builder"
         >
           {i18n.translate('xpack.searchHomepage.statelessPromo.content', {
-            defaultMessage: 'View docs',
+            defaultMessage: 'Read the blog',
           })}
         </HeaderCTALink>
       }


### PR DESCRIPTION
## Summary

This PR updates the stateless homepage promo banner for iteration 12. Along with copy and telemetry updates the following changes were made:

- Update the `HeaderPromo` component to accept an array of actions instead of a single CTA.
- Add a `HeaderCTAButton` component 
- Update both `StatelessHeaderPromo` and `StatefulHeaderPromo` to pass the `actions` prop to `HeaderPromo` instead of the `cta` prop.

<img width="700" alt="Screenshot 2025-11-13 at 15 28 11" src="https://github.com/user-attachments/assets/a6d6c713-488c-4e93-b263-9fb154f82562" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] ~Review the [backport guidelines]~(https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~