### PR TITLE
[8.19] [Discover][APM] Create `accessKnownApmEventFields` for validating unified traces API (#241976)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/services/get_service_instance_metadata_details.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/services/get_service_instance_metadata_details.ts
@@ -8,7 +8,7 @@ import { merge } from 'lodash';
 import { rangeQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
-import type { FlattenedApmEvent } from '@kbn/apm-data-access-plugin/server/utils/unflatten_known_fields';
+import type { FlattenedApmEvent } from '@kbn/apm-data-access-plugin/server/utils/utility_types';
 import {
   AGENT_NAME,
   AT_TIMESTAMP,

--- a/x-pack/solutions/observability/plugins/apm/server/routes/services/get_service_metadata_details.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/services/get_service_metadata_details.ts
@@ -8,7 +8,7 @@
 import { rangeQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
-import type { FlattenedApmEvent } from '@kbn/apm-data-access-plugin/server/utils/unflatten_known_fields';
+import type { FlattenedApmEvent } from '@kbn/apm-data-access-plugin/server/utils/utility_types';
 import { getAgentName } from '@kbn/elastic-agent-utils';
 import { environmentQuery } from '../../../common/utils/environment_query';
 import {

--- a/x-pack/solutions/observability/plugins/apm/server/routes/services/get_service_metadata_icons.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/services/get_service_metadata_icons.ts
@@ -8,7 +8,7 @@
 import { rangeQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
-import type { FlattenedApmEvent } from '@kbn/apm-data-access-plugin/server/utils/unflatten_known_fields';
+import type { FlattenedApmEvent } from '@kbn/apm-data-access-plugin/server/utils/utility_types';
 import { getAgentName } from '@kbn/elastic-agent-utils';
 import { maybe } from '../../../common/utils/maybe';
 import { asMutableArray } from '../../../common/utils/as_mutable_array';

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.ts
@@ -7,7 +7,7 @@
 
 import type { Sort } from '@elastic/elasticsearch/lib/api/types';
 import type { APMEventClient } from '@kbn/apm-data-access-plugin/server';
-import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
+import { accessKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
 import type { APMConfig } from '../..';
@@ -156,28 +156,27 @@ export async function getUnifiedTraceItems({
   return {
     traceItems: unifiedTraceItems.hits.hits
       .map((hit) => {
-        const event = unflattenKnownApmEventFields(hit.fields, fields);
-        const apmDuration = event.span?.duration?.us || event.transaction?.duration?.us;
-        const id = event.span?.id || event.transaction?.id;
-        if (!id) {
+        const event = accessKnownApmEventFields(hit.fields, fields);
+        const apmDuration = event[SPAN_DURATION] ?? event[TRANSACTION_DURATION];
+        const id = event[SPAN_ID] ?? event[TRANSACTION_ID];
+        const name = event[SPAN_NAME] ?? event[TRANSACTION_NAME];
+
+        if (!id || !name) {
           return undefined;
         }
 
         const docErrorCount = errorCountByDocId[id] || 0;
+        const statusCode = event[STATUS_CODE];
         return {
-          id: event.span?.id ?? event.transaction?.id,
-          timestampUs: event.timestamp?.us ?? toMicroseconds(event[AT_TIMESTAMP]),
-          name: event.span?.name ?? event.transaction?.name,
-          traceId: event.trace.id,
-          duration: resolveDuration(apmDuration, event.duration),
-          hasError:
-            docErrorCount > 0 ||
-            (event.status?.code && Array.isArray(event.status.code)
-              ? event.status.code[0] === 'Error'
-              : false),
-          parentId: event.parent?.id,
-          serviceName: event.service.name,
-        } as TraceItem;
+          id,
+          name,
+          timestampUs: event[TIMESTAMP_US] ?? toMicroseconds(event[AT_TIMESTAMP]),
+          traceId: event[TRACE_ID],
+          duration: resolveDuration(apmDuration, event[DURATION]),
+          hasError: docErrorCount > 0 || statusCode === 'Error',
+          parentId: event[PARENT_ID],
+          serviceName: event['service.name'],
+        } satisfies TraceItem;
       })
       .filter((_) => _) as TraceItem[],
     unifiedTraceErrors,

--- a/x-pack/solutions/observability/plugins/apm/server/routes/transactions/get_span/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/transactions/get_span/index.ts
@@ -8,7 +8,7 @@
 import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
-import type { FlattenedApmEvent } from '@kbn/apm-data-access-plugin/server/utils/unflatten_known_fields';
+import type { FlattenedApmEvent } from '@kbn/apm-data-access-plugin/server/utils/utility_types';
 import { merge, omit } from 'lodash';
 import { maybe } from '../../../../common/utils/maybe';
 import { SPAN_ID, SPAN_STACKTRACE, TRACE_ID } from '../../../../common/es_fields/apm';

--- a/x-pack/solutions/observability/plugins/apm_data_access/server/utils.ts
+++ b/x-pack/solutions/observability/plugins/apm_data_access/server/utils.ts
@@ -16,3 +16,4 @@ export {
 
 export { withApmSpan } from './utils/with_apm_span';
 export { unflattenKnownApmEventFields } from './utils/unflatten_known_fields';
+export { accessKnownApmEventFields } from './utils/access_known_fields';

--- a/x-pack/solutions/observability/plugins/apm_data_access/server/utils/access_known_fields.test.ts
+++ b/x-pack/solutions/observability/plugins/apm_data_access/server/utils/access_known_fields.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { accessKnownApmEventFields } from './access_known_fields';
+import type { FlattenedApmEvent } from './utility_types';
+
+describe('accessKnownApmEventFields', () => {
+  const input = {
+    '@timestamp': ['2024-10-10T10:10:10.000Z'],
+    'service.name': ['node-svc'],
+    'service.version': ['1.0.0'],
+    'service.environment': ['production'],
+    'agent.name': ['nodejs'],
+    'links.span_id': ['link1', 'link2'],
+  };
+
+  it('should return either single or array values for the various known field types', () => {
+    const event = accessKnownApmEventFields(input as Partial<FlattenedApmEvent>, [
+      '@timestamp',
+      'service.name',
+    ]);
+
+    expect(event['service.name']).not.toBeUndefined();
+    expect(event['agent.name']).toBe('nodejs');
+    expect(event['agent.version']).toBeUndefined();
+    expect(event['links.span_id']).toEqual(['link1', 'link2']);
+    expect(event['links.trace_id']).toBeUndefined();
+  });
+
+  it('should validate all required fields are present in the input document', () => {
+    expect(() => accessKnownApmEventFields(input, ['@timestamp', 'service.name'])).not.toThrow();
+
+    expect(() => accessKnownApmEventFields({}, ['@timestamp', 'service.name'])).toThrowError(
+      'Missing required fields (@timestamp, service.name) in event'
+    );
+
+    expect(() =>
+      accessKnownApmEventFields({ ...input, 'service.name': [] }, ['@timestamp', 'service.name'])
+    ).toThrowError('Missing required fields (service.name) in event');
+  });
+
+  it('exposes an `unflatten` method', () => {
+    const smallInput = {
+      '@timestamp': ['2024-10-10T10:10:10.000Z'],
+      'service.name': ['node-svc'],
+      'links.span_id': ['link1', 'link2'],
+    };
+
+    const event = accessKnownApmEventFields(smallInput, ['@timestamp', 'service.name']);
+
+    expect(typeof event.unflatten).toBe('function');
+
+    const unflattened = event.unflatten();
+
+    expect(unflattened).toEqual({
+      '@timestamp': '2024-10-10T10:10:10.000Z',
+      service: { name: 'node-svc' },
+      links: { span_id: ['link1', 'link2'] },
+    });
+  });
+
+  it('prevents mutations on the original object', () => {
+    const smallInput = {
+      '@timestamp': ['2024-10-10T10:10:10.000Z'],
+      'service.name': ['node-svc'],
+      'links.span_id': ['link1', 'link2'],
+    };
+
+    const event = accessKnownApmEventFields(smallInput as Partial<FlattenedApmEvent>);
+
+    // The proxied object is immutable. It will prevent mutations and will throw a TypeError
+    expect(() => {
+      // Disabling type checking here to ensure we also have runtime protection of immutability,
+      // so people can't just cast their way out of this. Normally, doing the setter op will
+      // error at compile time.
+      // @ts-ignore
+      event['agent.name'] = 'nodejs';
+    }).toThrowError("'set' on proxy: trap returned falsish for property 'agent.name'");
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm_data_access/server/utils/access_known_fields.ts
+++ b/x-pack/solutions/observability/plugins/apm_data_access/server/utils/access_known_fields.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { unflattenKnownApmEventFields } from './unflatten_known_fields';
+import {
+  type UnflattenedKnownFields,
+  type FlattenedApmEvent,
+  type MapToSingleOrMultiValue,
+  KNOWN_SINGLE_VALUED_FIELDS_SET,
+} from './utility_types';
+
+type RequiredApmFields<
+  T extends Partial<FlattenedApmEvent>,
+  R extends keyof FlattenedApmEvent = never
+> = Partial<T> & Required<Pick<T, R>>;
+
+/**
+ * A Proxied APM document that is strongly typed and runtime checked to be correct.
+ * Accessing fields from the document will correctly return single or multi values
+ * according to known field types.
+ */
+type ProxiedApmEvent<
+  T extends Partial<FlattenedApmEvent>,
+  R extends keyof FlattenedApmEvent = never
+> = Readonly<MapToSingleOrMultiValue<RequiredApmFields<T, R>>>;
+
+/**
+ * Interface for exposing an `unflatten()` method on proxied APM documents.
+ */
+interface UnflattenApmDocument<
+  T extends Partial<FlattenedApmEvent>,
+  R extends keyof FlattenedApmEvent = never
+> {
+  /**
+   * Unflattens the APM Event, so fields can be accessed via `event.service?.name`.
+   *
+   * ```ts
+   * const unflattened = accessKnownApmEventFields(hit, ['service.name']).unflatten();
+   *
+   * console.log(unflattened.service.name); // outputs "node-svc" for example
+   * ```
+   */
+  unflatten(): UnflattenedKnownFields<RequiredApmFields<T, R>>;
+}
+
+/**
+ * An APM document that is strongly typed and runtime checked to be correct.
+ * Accessing fields from the document will correctly return single or multi values
+ * according to known field types.
+ *
+ * An `unflatten()` method is also exposed by this document to return an unflattened
+ * version of the document.
+ */
+type ApmDocument<
+  T extends Partial<FlattenedApmEvent>,
+  R extends keyof FlattenedApmEvent = never
+> = ProxiedApmEvent<T, R> & UnflattenApmDocument<T, R>;
+
+/**
+ * Validates an APM Event document, checking if it has all the required fields if provided,
+ * returning a proxied version of the document to allow strongly typed access to known single
+ * or multi-value fields. The proxy also exposes an `unflatten()` method to return an unflattened
+ * version of the document.
+ *
+ * ## Example
+ *
+ * ```ts
+ * const event = accessKnownApmEventFields(hit, ['service.name']);
+ *
+ * // The key is strongly typed to be `keyof FlattenedApmEvent`.
+ * console.log(event['service.name']) // => outputs `"node-svc"`, not `["node-svc"]` as in the original doc
+ *
+ * const unflattened = event.unflatten();
+ *
+ * console.log(unflattened.service.name); // => outputs "node-svc" like above
+ */
+export function accessKnownApmEventFields<
+  T extends Partial<FlattenedApmEvent>,
+  R extends keyof FlattenedApmEvent = never
+>(fields: T, required?: R[]): ApmDocument<T, R>;
+
+export function accessKnownApmEventFields(fields: Record<string, any>, required?: string[]) {
+  if (required) {
+    const missingRequiredFields = required.filter((key) => {
+      const value = fields[key];
+
+      return value == null || (Array.isArray(value) && value.length === 0);
+    });
+
+    if (missingRequiredFields.length) {
+      throw new Error(`Missing required fields (${missingRequiredFields.join(', ')}) in event`);
+    }
+  }
+
+  return new Proxy(fields, accessHandler);
+}
+
+const accessHandler = {
+  get(fields: Record<string, any>, key: string) {
+    if (key === 'unflatten') {
+      return () => unflattenKnownApmEventFields(fields);
+    }
+
+    const value = fields[key];
+
+    return KNOWN_SINGLE_VALUED_FIELDS_SET.has(key) && Array.isArray(value) ? value[0] : value;
+  },
+
+  // Trap any setters to make the proxied object immutable.
+  set() {
+    return false;
+  },
+};

--- a/x-pack/solutions/observability/plugins/apm_data_access/server/utils/unflatten_known_fields.ts
+++ b/x-pack/solutions/observability/plugins/apm_data_access/server/utils/unflatten_known_fields.ts
@@ -5,93 +5,16 @@
  * 2.0.
  */
 
-import type { DedotObject } from '@kbn/utility-types';
-import * as APM_EVENT_FIELDS_MAP from '@kbn/apm-types/es_fields';
 import type { ValuesType } from 'utility-types';
 import { unflattenObject } from '@kbn/observability-utils-common/object/unflatten_object';
 import { mergePlainObjects } from '@kbn/observability-utils-common/object/merge_plain_objects';
-import { castArray, isArray } from 'lodash';
-import type { AgentName } from '@kbn/elastic-agent-utils';
-import type { EventOutcome } from '@kbn/apm-types/src/es_schemas/raw/fields';
-import type { ProcessorEvent } from '@kbn/observability-plugin/common';
-
-const {
-  CLOUD,
-  AGENT,
-  SERVICE,
-  ERROR_EXCEPTION,
-  SPAN_LINKS,
-  HOST,
-  KUBERNETES,
-  CONTAINER,
-  TIER,
-  INDEX,
-  DATA_STEAM_TYPE,
-  VALUE_OTEL_JVM_PROCESS_MEMORY_HEAP,
-  VALUE_OTEL_JVM_PROCESS_MEMORY_NON_HEAP,
-  SPAN_STACKTRACE,
-  ...CONCRETE_FIELDS
-} = APM_EVENT_FIELDS_MAP;
-
-const ALL_FIELDS = Object.values(CONCRETE_FIELDS);
-
-const KNOWN_MULTI_VALUED_FIELDS = [
-  APM_EVENT_FIELDS_MAP.CHILD_ID,
-  APM_EVENT_FIELDS_MAP.PROCESS_ARGS,
-  APM_EVENT_FIELDS_MAP.OTEL_SPAN_LINKS_TRACE_ID,
-  APM_EVENT_FIELDS_MAP.OTEL_SPAN_LINKS_SPAN_ID,
-] as const;
-
-type KnownField = ValuesType<typeof CONCRETE_FIELDS>;
-
-type KnownSingleValuedField = Exclude<KnownField, KnownMultiValuedField>;
-type KnownMultiValuedField = ValuesType<typeof KNOWN_MULTI_VALUED_FIELDS>;
-
-const KNOWN_SINGLE_VALUED_FIELDS = ALL_FIELDS.filter(
-  (field): field is KnownSingleValuedField => !KNOWN_MULTI_VALUED_FIELDS.includes(field as any)
-);
-
-interface TypeOverrideMap {
-  [APM_EVENT_FIELDS_MAP.SPAN_DURATION]: number;
-  [APM_EVENT_FIELDS_MAP.AGENT_NAME]: AgentName;
-  [APM_EVENT_FIELDS_MAP.EVENT_OUTCOME]: EventOutcome;
-  [APM_EVENT_FIELDS_MAP.FAAS_COLDSTART]: true;
-  [APM_EVENT_FIELDS_MAP.TRANSACTION_DURATION]: number;
-  [APM_EVENT_FIELDS_MAP.TIMESTAMP_US]: number;
-  [APM_EVENT_FIELDS_MAP.PROCESSOR_EVENT]: ProcessorEvent;
-  [APM_EVENT_FIELDS_MAP.SPAN_COMPOSITE_COUNT]: number;
-  [APM_EVENT_FIELDS_MAP.SPAN_COMPOSITE_SUM]: number;
-  [APM_EVENT_FIELDS_MAP.SPAN_SYNC]: boolean;
-  [APM_EVENT_FIELDS_MAP.TRANSACTION_SAMPLED]: boolean;
-  [APM_EVENT_FIELDS_MAP.PROCESSOR_NAME]: 'transaction' | 'metric' | 'error';
-  [APM_EVENT_FIELDS_MAP.HTTP_RESPONSE_STATUS_CODE]: number;
-  [APM_EVENT_FIELDS_MAP.PROCESS_PID]: number;
-  [APM_EVENT_FIELDS_MAP.OBSERVER_VERSION_MAJOR]: number;
-  [APM_EVENT_FIELDS_MAP.ERROR_EXC_HANDLED]: boolean;
-}
-
-type MaybeMultiValue<T extends KnownField, U> = T extends KnownMultiValuedField ? U[] : U;
-
-type TypeOfKnownField<T extends KnownField> = MaybeMultiValue<
-  T,
-  T extends keyof TypeOverrideMap ? TypeOverrideMap[T] : string
->;
-
-type MapToSingleOrMultiValue<T extends Record<string, any>> = {
-  [TKey in keyof T]: TKey extends KnownField
-    ? T[TKey] extends undefined
-      ? TypeOfKnownField<TKey> | undefined
-      : TypeOfKnownField<TKey>
-    : unknown;
-};
-
-type UnflattenedKnownFields<T extends Record<string, any>> = DedotObject<
-  MapToSingleOrMultiValue<T>
->;
-
-export type FlattenedApmEvent = Record<KnownSingleValuedField | KnownMultiValuedField, unknown[]>;
-
-export type UnflattenedApmEvent = UnflattenedKnownFields<FlattenedApmEvent>;
+import {
+  ALL_FIELDS,
+  KNOWN_SINGLE_VALUED_FIELDS,
+  type KnownField,
+  type MapToSingleOrMultiValue,
+  type UnflattenedKnownFields,
+} from './utility_types';
 
 export function unflattenKnownApmEventFields<T extends Record<string, any> | undefined = undefined>(
   fields: T
@@ -122,7 +45,7 @@ export function unflattenKnownApmEventFields(
   const missingRequiredFields =
     requiredFields?.filter((key) => {
       const value = hitFields?.[key];
-      return value === null || value === undefined || (isArray(value) && value.length === 0);
+      return value === null || value === undefined || (Array.isArray(value) && value.length === 0);
     }) ?? [];
 
   if (missingRequiredFields.length > 0) {
@@ -135,7 +58,7 @@ export function unflattenKnownApmEventFields(
 
   const [knownFields, unknownFields] = Object.entries(copy).reduce(
     (prev, [key, value]) => {
-      if (ALL_FIELDS.includes(key as KnownField)) {
+      if (ALL_FIELDS.has(key as KnownField)) {
         prev[0][key as KnownField] = value;
       } else {
         prev[1][key] = value;
@@ -146,7 +69,6 @@ export function unflattenKnownApmEventFields(
   );
 
   const unflattened = mergePlainObjects(
-    {},
     unflattenObject(unknownFields),
     unflattenObject(knownFields)
   );
@@ -160,7 +82,7 @@ export function mapToSingleOrMultiValue<T extends Record<string, any>>(
   KNOWN_SINGLE_VALUED_FIELDS.forEach((field) => {
     const value = fields[field];
     if (value !== null && value !== undefined) {
-      fields[field as keyof T] = castArray(value)[0];
+      fields[field as keyof T] = Array.isArray(value) ? value[0] : value;
     }
   });
 

--- a/x-pack/solutions/observability/plugins/apm_data_access/server/utils/utility_types.ts
+++ b/x-pack/solutions/observability/plugins/apm_data_access/server/utils/utility_types.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as APM_EVENT_FIELDS_MAP from '@kbn/apm-types/es_fields';
+import type { DedotObject } from '@kbn/utility-types';
+import type { ValuesType } from 'utility-types';
+import type { AgentName } from '@kbn/elastic-agent-utils';
+import type { EventOutcome } from '@kbn/apm-types/src/es_schemas/raw/fields';
+import type { ProcessorEvent } from '@kbn/observability-plugin/common';
+
+const {
+  CLOUD,
+  AGENT,
+  SERVICE,
+  ERROR_EXCEPTION,
+  SPAN_LINKS,
+  HOST,
+  KUBERNETES,
+  CONTAINER,
+  TIER,
+  INDEX,
+  DATA_STEAM_TYPE,
+  VALUE_OTEL_JVM_PROCESS_MEMORY_HEAP,
+  VALUE_OTEL_JVM_PROCESS_MEMORY_NON_HEAP,
+  SPAN_STACKTRACE,
+  ...CONCRETE_FIELDS
+} = APM_EVENT_FIELDS_MAP;
+
+export const ALL_FIELDS = new Set(Object.values(CONCRETE_FIELDS));
+
+export const KNOWN_MULTI_VALUED_FIELDS = [
+  APM_EVENT_FIELDS_MAP.CHILD_ID,
+  APM_EVENT_FIELDS_MAP.PROCESS_ARGS,
+  APM_EVENT_FIELDS_MAP.OTEL_SPAN_LINKS_TRACE_ID,
+  APM_EVENT_FIELDS_MAP.OTEL_SPAN_LINKS_SPAN_ID,
+] as const;
+
+export type KnownField = ValuesType<typeof CONCRETE_FIELDS>;
+
+type KnownSingleValuedField = Exclude<KnownField, KnownMultiValuedField>;
+type KnownMultiValuedField = ValuesType<typeof KNOWN_MULTI_VALUED_FIELDS>;
+
+export const KNOWN_SINGLE_VALUED_FIELDS = [...ALL_FIELDS].filter(
+  (field): field is KnownSingleValuedField => !KNOWN_MULTI_VALUED_FIELDS.includes(field as any)
+);
+
+export const KNOWN_SINGLE_VALUED_FIELDS_SET = new Set<string>(KNOWN_SINGLE_VALUED_FIELDS);
+
+interface TypeOverrideMap {
+  [APM_EVENT_FIELDS_MAP.SPAN_DURATION]: number;
+  [APM_EVENT_FIELDS_MAP.AGENT_NAME]: AgentName;
+  [APM_EVENT_FIELDS_MAP.EVENT_OUTCOME]: EventOutcome;
+  [APM_EVENT_FIELDS_MAP.FAAS_COLDSTART]: true;
+  [APM_EVENT_FIELDS_MAP.TRANSACTION_DURATION]: number;
+  [APM_EVENT_FIELDS_MAP.TIMESTAMP_US]: number;
+  [APM_EVENT_FIELDS_MAP.PROCESSOR_EVENT]: ProcessorEvent;
+  [APM_EVENT_FIELDS_MAP.SPAN_COMPOSITE_COUNT]: number;
+  [APM_EVENT_FIELDS_MAP.SPAN_COMPOSITE_SUM]: number;
+  [APM_EVENT_FIELDS_MAP.SPAN_SYNC]: boolean;
+  [APM_EVENT_FIELDS_MAP.TRANSACTION_SAMPLED]: boolean;
+  [APM_EVENT_FIELDS_MAP.PROCESSOR_NAME]: 'transaction' | 'metric' | 'error';
+  [APM_EVENT_FIELDS_MAP.HTTP_RESPONSE_STATUS_CODE]: number;
+  [APM_EVENT_FIELDS_MAP.PROCESS_PID]: number;
+  [APM_EVENT_FIELDS_MAP.OBSERVER_VERSION_MAJOR]: number;
+  [APM_EVENT_FIELDS_MAP.ERROR_EXC_HANDLED]: boolean;
+}
+
+type MaybeMultiValue<T extends KnownField, U> = T extends KnownMultiValuedField ? U[] : U;
+
+type TypeOfKnownField<T extends KnownField> = MaybeMultiValue<
+  T,
+  T extends keyof TypeOverrideMap ? TypeOverrideMap[T] : string
+>;
+
+export type MapToSingleOrMultiValue<T extends Record<string, any>> = {
+  [TKey in keyof T]: TKey extends KnownField
+    ? T[TKey] extends undefined
+      ? TypeOfKnownField<TKey> | undefined
+      : TypeOfKnownField<TKey>
+    : unknown;
+};
+
+export type UnflattenedKnownFields<T extends Record<string, any>> = DedotObject<
+  MapToSingleOrMultiValue<T>
+>;
+
+export type FlattenedApmEvent = Record<KnownSingleValuedField | KnownMultiValuedField, unknown[]>;
+
+export type UnflattenedApmEvent = UnflattenedKnownFields<FlattenedApmEvent>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover][APM] Create `accessKnownApmEventFields` for validating unified traces API (#241976)](https://github.com/elastic/kibana/pull/241976)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gonçalo Rica Pais da Silva","email":"goncalo.rica@elastic.co"},"sourceCommit":{"committedDate":"2025-11-10T15:47:33Z","message":"[Discover][APM] Create `accessKnownApmEventFields` for validating unified traces API (#241976)\n\n## Summary\n\nCloses #240857\n\nThis PR implements a new validation scheme for validating APM events,\nand applying it to the Unified Trace Waterfall APIs as an initial\nproving ground. `accessKnownApmEventFields` replaces\n`unflattenKnownApmEventFields` in its use for validating the\n`getUnifiedTraceItems` responses, removing a source of overhead with a\nmuch, much simpler and faster approach to validating and strongly typing\nthe APM Event. This changes what is at least an `O(n^2)` operation for\nan entire object, to just an `O(n)` operation per validation, with `n`\nbeing the number of required fields (which in reality is a small\nnumber).\n\nPotentially, if the checks are made lazy (when the field is accessed),\nthis could become `O(1)`, but with the downside that we won't be able to\ncollect all the missing fields, only the one which the access failed\nfor. With `accessKnownApmEventFields`, we are avoiding having to process\nan entire object just to have the correct single/multi values per field,\nwe only do it for the fields we are accessing and without needing to\nallocate any new objects/arrays whilst doing so. And the best part is we\nstill benefit from strong type checking and type inference around keys,\nso you still get auto-complete in the IDE.\n\nThe implementation proxies the original object, and then when we access\nthe fields, it resolves the single or multi-value types, as well as\nvalidating any required fields during construction. As part of the\nproxied object, we expose an `unflatten` method which then takes the\nvalidated object and well, unflattens it while still being type-checked.\nAs such, usage is as follows:\n\n```ts\nconst event = accessKnownApmEventFields(hit, [SERVICE_NAME]);\nconsole.log(event[SERVICE_NAME]); // outputs `\"node-svc\"` instead of `[\"node-svc\"]` as in the original object\nconst unflattened = event.unflatten();\nconsole.log(unflattened.service.name); // outputs `\"node-svc\"` like above\n```\n\nAs well in this PR is a couple of tweaks to\n`unflattenKnownApmEventFields` to improve perf there as well, by using a\n`Set` instead of array for `ALL_FIELDS` (making checks there go from\n`O(n)` to `O(1)` ), as well as removing `lodash` usage for Array\nchecking when there is standard JS APIs for this.\n\n## How to test\n\nThis PR needs to be able to pass CI, but also should not regress on the\nUI:\n\n- Go to Discover while in an Observability space, select a traces index\nin either classic or ES|QL mode.\n- Open a trace overview, the Focused Trace Waterfall should not error\nwhen trying to render the focused trace.\n- Open a full trace waterfall, that too should not error when trying to\nrender.\n- In both cases, traces should look as expected.","sha":"050b80dd7ceee80b4d5315e48001546e09e9ccc9","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.3.0","v8.19.7","v9.1.7","v9.2.1"],"title":"[Discover][APM] Create `accessKnownApmEventFields` for validating unified traces API","number":241976,"url":"https://github.com/elastic/kibana/pull/241976","mergeCommit":{"message":"[Discover][APM] Create `accessKnownApmEventFields` for validating unified traces API (#241976)\n\n## Summary\n\nCloses #240857\n\nThis PR implements a new validation scheme for validating APM events,\nand applying it to the Unified Trace Waterfall APIs as an initial\nproving ground. `accessKnownApmEventFields` replaces\n`unflattenKnownApmEventFields` in its use for validating the\n`getUnifiedTraceItems` responses, removing a source of overhead with a\nmuch, much simpler and faster approach to validating and strongly typing\nthe APM Event. This changes what is at least an `O(n^2)` operation for\nan entire object, to just an `O(n)` operation per validation, with `n`\nbeing the number of required fields (which in reality is a small\nnumber).\n\nPotentially, if the checks are made lazy (when the field is accessed),\nthis could become `O(1)`, but with the downside that we won't be able to\ncollect all the missing fields, only the one which the access failed\nfor. With `accessKnownApmEventFields`, we are avoiding having to process\nan entire object just to have the correct single/multi values per field,\nwe only do it for the fields we are accessing and without needing to\nallocate any new objects/arrays whilst doing so. And the best part is we\nstill benefit from strong type checking and type inference around keys,\nso you still get auto-complete in the IDE.\n\nThe implementation proxies the original object, and then when we access\nthe fields, it resolves the single or multi-value types, as well as\nvalidating any required fields during construction. As part of the\nproxied object, we expose an `unflatten` method which then takes the\nvalidated object and well, unflattens it while still being type-checked.\nAs such, usage is as follows:\n\n```ts\nconst event = accessKnownApmEventFields(hit, [SERVICE_NAME]);\nconsole.log(event[SERVICE_NAME]); // outputs `\"node-svc\"` instead of `[\"node-svc\"]` as in the original object\nconst unflattened = event.unflatten();\nconsole.log(unflattened.service.name); // outputs `\"node-svc\"` like above\n```\n\nAs well in this PR is a couple of tweaks to\n`unflattenKnownApmEventFields` to improve perf there as well, by using a\n`Set` instead of array for `ALL_FIELDS` (making checks there go from\n`O(n)` to `O(1)` ), as well as removing `lodash` usage for Array\nchecking when there is standard JS APIs for this.\n\n## How to test\n\nThis PR needs to be able to pass CI, but also should not regress on the\nUI:\n\n- Go to Discover while in an Observability space, select a traces index\nin either classic or ES|QL mode.\n- Open a trace overview, the Focused Trace Waterfall should not error\nwhen trying to render the focused trace.\n- Open a full trace waterfall, that too should not error when trying to\nrender.\n- In both cases, traces should look as expected.","sha":"050b80dd7ceee80b4d5315e48001546e09e9ccc9"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241976","number":241976,"mergeCommit":{"message":"[Discover][APM] Create `accessKnownApmEventFields` for validating unified traces API (#241976)\n\n## Summary\n\nCloses #240857\n\nThis PR implements a new validation scheme for validating APM events,\nand applying it to the Unified Trace Waterfall APIs as an initial\nproving ground. `accessKnownApmEventFields` replaces\n`unflattenKnownApmEventFields` in its use for validating the\n`getUnifiedTraceItems` responses, removing a source of overhead with a\nmuch, much simpler and faster approach to validating and strongly typing\nthe APM Event. This changes what is at least an `O(n^2)` operation for\nan entire object, to just an `O(n)` operation per validation, with `n`\nbeing the number of required fields (which in reality is a small\nnumber).\n\nPotentially, if the checks are made lazy (when the field is accessed),\nthis could become `O(1)`, but with the downside that we won't be able to\ncollect all the missing fields, only the one which the access failed\nfor. With `accessKnownApmEventFields`, we are avoiding having to process\nan entire object just to have the correct single/multi values per field,\nwe only do it for the fields we are accessing and without needing to\nallocate any new objects/arrays whilst doing so. And the best part is we\nstill benefit from strong type checking and type inference around keys,\nso you still get auto-complete in the IDE.\n\nThe implementation proxies the original object, and then when we access\nthe fields, it resolves the single or multi-value types, as well as\nvalidating any required fields during construction. As part of the\nproxied object, we expose an `unflatten` method which then takes the\nvalidated object and well, unflattens it while still being type-checked.\nAs such, usage is as follows:\n\n```ts\nconst event = accessKnownApmEventFields(hit, [SERVICE_NAME]);\nconsole.log(event[SERVICE_NAME]); // outputs `\"node-svc\"` instead of `[\"node-svc\"]` as in the original object\nconst unflattened = event.unflatten();\nconsole.log(unflattened.service.name); // outputs `\"node-svc\"` like above\n```\n\nAs well in this PR is a couple of tweaks to\n`unflattenKnownApmEventFields` to improve perf there as well, by using a\n`Set` instead of array for `ALL_FIELDS` (making checks there go from\n`O(n)` to `O(1)` ), as well as removing `lodash` usage for Array\nchecking when there is standard JS APIs for this.\n\n## How to test\n\nThis PR needs to be able to pass CI, but also should not regress on the\nUI:\n\n- Go to Discover while in an Observability space, select a traces index\nin either classic or ES|QL mode.\n- Open a trace overview, the Focused Trace Waterfall should not error\nwhen trying to render the focused trace.\n- Open a full trace waterfall, that too should not error when trying to\nrender.\n- In both cases, traces should look as expected.","sha":"050b80dd7ceee80b4d5315e48001546e09e9ccc9"}},{"branch":"8.19","label":"v8.19.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/242443","number":242443,"state":"OPEN"}]}] BACKPORT-->