### PR TITLE
[9.2] add encoding of cloudFormation url params (#242365)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/components/cloud_security_posture/hooks/use_create_cloud_formation_url.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/components/cloud_security_posture/hooks/use_create_cloud_formation_url.ts
@@ -75,14 +75,14 @@ const createCloudFormationUrl = (
     template url has `&param_ElasticAgentVersion=KIBANA_VERSION` part. KIBANA_VERSION is used for templating as agent version used to match Kibana version, but now it's not necessarily the case
    */
   cloudFormationUrl = templateURL
-    .replace('FLEET_ENROLLMENT_TOKEN', enrollmentToken)
-    .replace('FLEET_URL', fleetUrl)
-    .replace('KIBANA_VERSION', agentVersion);
+    .replace('FLEET_ENROLLMENT_TOKEN', encodeURIComponent(enrollmentToken))
+    .replace('FLEET_URL', encodeURIComponent(fleetUrl))
+    .replace('KIBANA_VERSION', encodeURIComponent(agentVersion));
 
   if (cloudFormationUrl.includes('ACCOUNT_TYPE')) {
     cloudFormationUrl = cloudFormationUrl.replace(
       'ACCOUNT_TYPE',
-      getAwsAccountType(awsAccountType)
+      encodeURIComponent(getAwsAccountType(awsAccountType))
     );
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [add encoding of cloudFormation url params (#242365)](https://github.com/elastic/kibana/pull/242365)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Prozorov","email":"alex.prozorov@elastic.co"},"sourceCommit":{"committedDate":"2025-11-10T19:26:34Z","message":"add encoding of cloudFormation url params (#242365)\n\n## Summary\n\nThis PR addresses the following\n[issue](https://github.com/elastic/security-team/issues/14627).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n**Screen Recording - Fix**\n\n\nhttps://github.com/user-attachments/assets/85687888-25cf-4a26-b0fb-91a3c2c5ef46","sha":"370ec0e3298a60a778070b7b04cc2723198f9a63","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","Team:Cloud Security","ci:cloud-deploy","ci:cloud-redeploy","ci:project-deploy-security","backport:version","v9.3.0","backport:version + v9.2.0","v9.2.1"],"title":"add encoding of cloudFormation url params","number":242365,"url":"https://github.com/elastic/kibana/pull/242365","mergeCommit":{"message":"add encoding of cloudFormation url params (#242365)\n\n## Summary\n\nThis PR addresses the following\n[issue](https://github.com/elastic/security-team/issues/14627).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n**Screen Recording - Fix**\n\n\nhttps://github.com/user-attachments/assets/85687888-25cf-4a26-b0fb-91a3c2c5ef46","sha":"370ec0e3298a60a778070b7b04cc2723198f9a63"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/242365","number":242365,"mergeCommit":{"message":"add encoding of cloudFormation url params (#242365)\n\n## Summary\n\nThis PR addresses the following\n[issue](https://github.com/elastic/security-team/issues/14627).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n**Screen Recording - Fix**\n\n\nhttps://github.com/user-attachments/assets/85687888-25cf-4a26-b0fb-91a3c2c5ef46","sha":"370ec0e3298a60a778070b7b04cc2723198f9a63"}},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->