### PR TITLE
Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group3.x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/rule·ts - Alerting builtin alertTypes es_query rule runs correctly: threshold on ungrouped agg metric < > for searchSource search type

### DIFF
--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/rule.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/rule.ts
@@ -42,7 +42,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
     getAllAADDocs,
   } = getRuleServices(getService);
 
-  describe('testtest rule', () => {
+  describe('rule', () => {
     let endDate: string;
     let connectorId: string;
     const objectRemover = new ObjectRemover(supertest);

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/rule.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/rule.ts
@@ -231,7 +231,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
             name: 'always fire',
             size: 100,
             thresholdComparator: '>',
-            threshold: [0],
+            threshold: [-1],
             searchType: 'searchSource',
             searchConfiguration: {
               query: {
@@ -253,7 +253,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
         await initData();
 
         const messagePattern =
-          /Document count is \d+.?\d* in the last 30s in kibana-alerting-test-data (?:index|data view). Alert when greater than 0./;
+          /Document count is \d+.?\d* in the last 30s in kibana-alerting-test-data (?:index|data view). Alert when greater than -1./;
 
         const docs = await waitForDocs(2);
         for (let i = 0; i < docs.length; i++) {
@@ -284,7 +284,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
           'Number of matching documents where avg of testedValue is greater than -1'
         );
         const value = parseInt(alertDoc['kibana.alert.evaluation.value'], 10);
-        expect(value).greaterThan(0);
+        expect(value >= 0).to.be(true);
         expect(alertDoc[ALERT_URL]).to.contain('/s/space1/app/');
         expect(alertDoc['host.name'][0]).to.be('host-1');
         expect(alertDoc['host.hostname'][0]).to.be('host-1');

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/rule.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/rule.ts
@@ -42,8 +42,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
     getAllAADDocs,
   } = getRuleServices(getService);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/241403
-  describe.skip('rule', () => {
+  describe('testtest rule', () => {
     let endDate: string;
     let connectorId: string;
     const objectRemover = new ObjectRemover(supertest);
@@ -232,7 +231,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
             name: 'always fire',
             size: 100,
             thresholdComparator: '>',
-            threshold: [-1],
+            threshold: [0],
             searchType: 'searchSource',
             searchConfiguration: {
               query: {
@@ -254,7 +253,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
         await initData();
 
         const messagePattern =
-          /Document count is \d+.?\d* in the last 30s in kibana-alerting-test-data (?:index|data view). Alert when greater than -1./;
+          /Document count is \d+.?\d* in the last 30s in kibana-alerting-test-data (?:index|data view). Alert when greater than 0./;
 
         const docs = await waitForDocs(2);
         for (let i = 0; i < docs.length; i++) {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/241403

## Summary

Same issue as this other flaky test: https://github.com/elastic/kibana/pull/215604

The rule is configured to generate an alert if the threshold condition is `> -1`. This is configured specifically because we've had bugs in the past where we were not matching on value === 0. This means that the alert value could be `0` (which is greater than -1) but the test for the alert document is only looking for > 0. Fixing to allow >= 0 in the alert evaluation value.