### PR TITLE
[Security Solution] separate SearchBar sourcererDataView prop in two separate props

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/search_bar/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/search_bar/index.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { createMockStore, mockGlobalState, TestProviders } from '../../mock';
-import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { SearchBarComponent } from '.';
 import type { SavedQuery } from '@kbn/data-plugin/public';
 import { FilterManager } from '@kbn/data-plugin/public';
@@ -16,6 +16,8 @@ import { inputsActions } from '../../store/inputs';
 import { InputsModelId } from '../../store/inputs/constants';
 import { useKibana } from '../../lib/kibana';
 import { useKibana as mockUseKibana } from '../../lib/kibana/__mocks__';
+import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 
 const mockSetAppFilters = jest.fn();
 const mockFilterManager = new FilterManager(coreMock.createStart().uiSettings);
@@ -26,6 +28,9 @@ const mockUpdateUrlParam = jest.fn();
 jest.mock('../../utils/global_query_string', () => ({
   useUpdateUrlParam: () => mockUpdateUrlParam,
 }));
+
+const dataView: DataView = createStubDataView({ spec: {} });
+const dataViewSpec: DataViewSpec = dataView.toSpec();
 
 const original = mockUseKibana();
 const useKibanaMock = {
@@ -60,7 +65,8 @@ describe('SearchBarComponent', () => {
       fields: [],
       title: '',
     },
-    sourcererDataView: {},
+    dataView,
+    sourcererDataViewSpec: dataViewSpec,
     updateSearch: jest.fn(),
     setSavedQuery: jest.fn(),
     setSearchBarFilter: jest.fn(),

--- a/x-pack/solutions/security/plugins/security_solution/public/dashboards/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/dashboards/pages/details/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import type { DashboardCapabilities } from '@kbn/dashboard-plugin/common/types';
 import { useParams } from 'react-router-dom';
@@ -31,7 +31,6 @@ import { DashboardToolBar } from '../../components/dashboard_tool_bar';
 
 import { useDashboardRenderer } from '../../hooks/use_dashboard_renderer';
 import { DashboardTitle } from '../../components/dashboard_title';
-import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 
 const dashboardViewFlexGroupStyle = { minHeight: `calc(100vh - 140px)` };
 
@@ -53,7 +52,7 @@ const DashboardViewComponent: React.FC<DashboardViewProps> = ({
   );
   const query = useDeepEqualSelector(getGlobalQuerySelector);
   const filters = useDeepEqualSelector(getGlobalFiltersQuerySelector);
-  const { sourcererDataView: oldSourcererDataView } = useSourcererDataView();
+  const { sourcererDataView: oldSourcererDataViewSpec } = useSourcererDataView();
 
   const { show: canReadDashboard } = useCapabilities<DashboardCapabilities>('dashboard_v2');
   const errorState = useMemo(
@@ -68,15 +67,15 @@ const DashboardViewComponent: React.FC<DashboardViewProps> = ({
   const onDashboardToolBarLoad = useCallback((mode: ViewMode) => {
     setViewMode(mode);
   }, []);
-  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
   const { dataView: experimentalDataView } = useDataView();
 
   return (
     <>
       <FiltersGlobal>
         <SiemSearchBar
+          dataView={experimentalDataView}
           id={InputsModelId.global}
-          sourcererDataView={newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataView}
+          sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
         />
       </FiltersGlobal>
       <SecuritySolutionPageWrapper>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -643,11 +643,10 @@ export const RuleDetailsPage = connector(
           <EuiWindowEvent event="resize" handler={noop} />
           <FiltersGlobal>
             <SiemSearchBar
-              id={InputsModelId.global}
+              dataView={experimentalDataView}
               pollForSignalIndex={pollForSignalIndex}
-              sourcererDataView={
-                newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataViewSpec
-              }
+              id={InputsModelId.global}
+              sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
             />
           </FiltersGlobal>
           <RuleDetailsContextProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/search_bar/search_bar_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/search_bar/search_bar_section.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useMemo } from 'react';
+import React, { memo } from 'react';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import type { PackageListItem } from '@kbn/fleet-plugin/common';
@@ -35,8 +35,6 @@ export interface SearchBarSectionProps {
 export const SearchBarSection = memo(({ dataView, packages }: SearchBarSectionProps) => {
   const { integrations } = useIntegrations({ packages });
 
-  const dataViewSpec = useMemo(() => dataView.toSpec(), [dataView]);
-
   return (
     <EuiFlexGroup gutterSize="none" alignItems="center">
       <EuiFlexItem grow={false}>
@@ -45,10 +43,10 @@ export const SearchBarSection = memo(({ dataView, packages }: SearchBarSectionPr
       <EuiFlexItem>
         <SiemSearchBar
           dataTestSubj={SEARCH_BAR_TEST_ID}
+          dataView={dataView}
           hideFilterBar
           hideQueryMenu
           id={InputsModelId.global}
-          sourcererDataView={dataViewSpec}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/content.tsx
@@ -120,9 +120,7 @@ export const AlertsPageContent = memo(
         ref={containerElement}
       >
         <EuiWindowEvent event="resize" handler={noop} />
-        <SearchBarSection
-          dataView={newDataViewPickerEnabled ? dataView : oldSourcererDataViewSpec}
-        />
+        <SearchBarSection dataView={dataView} sourcererDataViewSpec={oldSourcererDataViewSpec} />
         <SecuritySolutionPageWrapper
           noPadding={globalFullScreen}
           data-test-subj={SECURITY_SOLUTION_PAGE_WRAPPER_TEST_ID}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/search_bar/search_bar_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/search_bar/search_bar_section.test.tsx
@@ -10,7 +10,7 @@ import { render } from '@testing-library/react';
 import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 import { TestProviders } from '../../../../common/mock';
 import { SEARCH_BAR_TEST_ID, SearchBarSection } from './search_bar_section';
-import type { DataViewSpec } from '@kbn/data-views-plugin/common';
+import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
 
 jest.mock('../../../../common/components/filters_global', () => ({
   FiltersGlobal: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -20,13 +20,14 @@ jest.mock('../../../../common/components/search_bar', () => ({
   SiemSearchBar: () => <div data-test-subj={'alerts-page-search-bar'} />,
 }));
 
-const dataViewSpec: DataViewSpec = createStubDataView({ spec: {} }).toSpec();
+const dataView: DataView = createStubDataView({ spec: {} });
+const dataViewSpec: DataViewSpec = dataView.toSpec();
 
 describe('<ChartsSection />', () => {
   it('should render correctly', () => {
     const { getByTestId } = render(
       <TestProviders>
-        <SearchBarSection dataView={dataViewSpec} />
+        <SearchBarSection dataView={dataView} sourcererDataViewSpec={dataViewSpec} />
       </TestProviders>
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/search_bar/search_bar_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts/search_bar/search_bar_section.tsx
@@ -18,25 +18,32 @@ export interface SearchBarSectionProps {
   /**
    * DataView object to pass to the SiemSearchBar component.
    */
-  dataView: DataViewSpec | DataView; // TODO clean types when we remove the newDataViewPickerEnabled feature flag
+  dataView: DataView;
+  /**
+   * Old sourcerer dataView object to pass to the SiemSearchBar component.
+   */
+  sourcererDataViewSpec: DataViewSpec; // TODO remove when we remove the newDataViewPickerEnabled feature flag
 }
 
 /**
  * UI section of the alerts page that renders the global search bar.
  */
-export const SearchBarSection = memo(({ dataView }: SearchBarSectionProps) => {
-  const { pollForSignalIndex } = useSignalHelpers();
+export const SearchBarSection = memo(
+  ({ dataView, sourcererDataViewSpec }: SearchBarSectionProps) => {
+    const { pollForSignalIndex } = useSignalHelpers();
 
-  return (
-    <FiltersGlobal>
-      <SiemSearchBar
-        dataTestSubj={SEARCH_BAR_TEST_ID}
-        id={InputsModelId.global}
-        pollForSignalIndex={pollForSignalIndex}
-        sourcererDataView={dataView}
-      />
-    </FiltersGlobal>
-  );
-});
+    return (
+      <FiltersGlobal>
+        <SiemSearchBar
+          dataTestSubj={SEARCH_BAR_TEST_ID}
+          dataView={dataView}
+          id={InputsModelId.global}
+          pollForSignalIndex={pollForSignalIndex}
+          sourcererDataViewSpec={sourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
+        />
+      </FiltersGlobal>
+    );
+  }
+);
 
 SearchBarSection.displayName = 'SearchBarSection';

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_dashboard.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_dashboard.tsx
@@ -64,8 +64,9 @@ const EntityAnalyticsComponent = () => {
         <>
           <FiltersGlobal>
             <SiemSearchBar
+              dataView={dataView}
               id={InputsModelId.global}
-              sourcererDataView={newDataViewPickerEnabled ? dataView : oldSourcererDataViewSpec}
+              sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
             />
           </FiltersGlobal>
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_privileged_user_monitoring_page.tsx
@@ -18,9 +18,9 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import {
+  type InitMonitoringEngineResponse,
   PrivilegeMonitoringEngineStatusEnum,
   type PrivMonHealthResponse,
-  type InitMonitoringEngineResponse,
 } from '../../../common/api/entity_analytics';
 import { SecurityPageName } from '../../app/types';
 import { SecuritySolutionPageWrapper } from '../../common/components/page_wrapper';
@@ -207,8 +207,9 @@ export const EntityAnalyticsPrivilegedUserMonitoringPage = () => {
       {state.type === 'dashboard' && (
         <FiltersGlobal>
           <SiemSearchBar
+            dataView={dataView}
             id={InputsModelId.global}
-            sourcererDataView={newDataViewPickerEnabled ? dataView : oldSourcererDataViewSpec}
+            sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
           />
         </FiltersGlobal>
       )}

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/details/index.tsx
@@ -234,10 +234,9 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
           <EuiWindowEvent event="resize" handler={noop} />
           <FiltersGlobal>
             <SiemSearchBar
+              dataView={experimentalDataView}
               id={InputsModelId.global}
-              sourcererDataView={
-                newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataView
-              }
+              sourcererDataViewSpec={oldSourcererDataView} // TODO remove when we remove the newDataViewPickerEnabled feature flag
             />
           </FiltersGlobal>
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/hosts.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/pages/hosts.tsx
@@ -106,7 +106,7 @@ const HostsComponent = () => {
   const {
     indicesExist: oldIndicesExist,
     selectedPatterns: oldSelectedPatterns,
-    sourcererDataView: oldSourcererDataView,
+    sourcererDataView: oldSourcererDataViewSpec,
   } = useSourcererDataView();
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
@@ -125,23 +125,23 @@ const HostsComponent = () => {
     () =>
       convertToBuildEsQuery({
         config: getEsQueryConfig(uiSettings),
-        dataViewSpec: oldSourcererDataView,
+        dataViewSpec: oldSourcererDataViewSpec,
         dataView: experimentalDataView,
         queries: [query],
         filters: globalFilters,
       }),
-    [uiSettings, oldSourcererDataView, experimentalDataView, query, globalFilters]
+    [uiSettings, oldSourcererDataViewSpec, experimentalDataView, query, globalFilters]
   );
   const [tabsFilterQuery] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: getEsQueryConfig(uiSettings),
-        dataViewSpec: oldSourcererDataView,
+        dataViewSpec: oldSourcererDataViewSpec,
         dataView: experimentalDataView,
         queries: [query],
         filters: tabsFilters,
       }),
-    [uiSettings, oldSourcererDataView, experimentalDataView, query, tabsFilters]
+    [uiSettings, oldSourcererDataViewSpec, experimentalDataView, query, tabsFilters]
   );
 
   useInvalidFilterQuery({
@@ -189,12 +189,10 @@ const HostsComponent = () => {
         <StyledFullHeightContainer onKeyDown={onKeyDown} ref={containerElement}>
           <EuiWindowEvent event="resize" handler={noop} />
           <FiltersGlobal>
-            {/* TODO: newDataViewPicker - Can be removed after migration to new dataview picker */}
             <SiemSearchBar
+              dataView={experimentalDataView}
               id={InputsModelId.global}
-              sourcererDataView={
-                newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataView
-              }
+              sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
             />
           </FiltersGlobal>
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/details/index.tsx
@@ -20,8 +20,8 @@ import { AlertsByStatus } from '../../../../overview/components/detection_respon
 import { useSignalIndex } from '../../../../detections/containers/detection_engine/alerts/use_signal_index';
 import { InputsModelId } from '../../../../common/store/inputs/constants';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
-import { LastEventIndexKey } from '../../../../../common/search_strategy';
 import type { FlowTargetSourceDest } from '../../../../../common/search_strategy';
+import { LastEventIndexKey } from '../../../../../common/search_strategy';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { FiltersGlobal } from '../../../../common/components/filters_global';
 import { HeaderPage } from '../../../../common/components/header_page';
@@ -36,7 +36,7 @@ import { IpOverview } from '../../components/details';
 import { SiemSearchBar } from '../../../../common/components/search_bar';
 import { PageLoader } from '../../../../common/components/page_loader';
 import { SecuritySolutionPageWrapper } from '../../../../common/components/page_wrapper';
-import { useNetworkDetails, ID } from '../../containers/details';
+import { ID, useNetworkDetails } from '../../containers/details';
 import { useKibana } from '../../../../common/lib/kibana';
 import { decodeIpv6 } from '../../../../common/lib/helpers';
 import { inputsSelectors } from '../../../../common/store';
@@ -58,8 +58,8 @@ import { navTabsNetworkDetails } from './nav_tabs';
 import { NetworkDetailsTabs } from './details_tabs';
 import { useInstalledSecurityJobNameById } from '../../../../common/components/ml/hooks/use_installed_security_jobs';
 import {
-  SecurityCellActions,
   CellActionsMode,
+  SecurityCellActions,
   SecurityCellActionsTrigger,
 } from '../../../../common/components/cell_actions';
 import { SourcererScopeName } from '../../../../sourcerer/store/model';
@@ -114,7 +114,7 @@ const NetworkDetailsComponent: React.FC = () => {
   const {
     indicesExist: oldIndicesExist,
     selectedPatterns: oldSelectedPatterns,
-    sourcererDataView: oldSourcererDataView,
+    sourcererDataView: oldSourcererDataViewSpec,
   } = useSourcererDataView();
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
@@ -138,7 +138,7 @@ const NetworkDetailsComponent: React.FC = () => {
         buildEsQuery(
           newDataViewPickerEnabled
             ? experimentalDataView
-            : dataViewSpecToViewBase(oldSourcererDataView),
+            : dataViewSpecToViewBase(oldSourcererDataViewSpec),
           [query],
           [...networkDetailsFilter, ...globalFilters],
           getEsQueryConfig(uiSettings)
@@ -152,7 +152,7 @@ const NetworkDetailsComponent: React.FC = () => {
     globalFilters,
     networkDetailsFilter,
     newDataViewPickerEnabled,
-    oldSourcererDataView,
+    oldSourcererDataViewSpec,
     query,
     uiSettings,
   ]);
@@ -201,8 +201,8 @@ const NetworkDetailsComponent: React.FC = () => {
   const indexPattern = useMemo(() => {
     return newDataViewPickerEnabled
       ? experimentalDataView || { title: '', fields: [] }
-      : dataViewSpecToViewBase(oldSourcererDataView);
-  }, [experimentalDataView, newDataViewPickerEnabled, oldSourcererDataView]);
+      : dataViewSpecToViewBase(oldSourcererDataViewSpec);
+  }, [experimentalDataView, newDataViewPickerEnabled, oldSourcererDataViewSpec]);
 
   if (newDataViewPickerEnabled && status === 'pristine') {
     return <PageLoader />;
@@ -214,10 +214,9 @@ const NetworkDetailsComponent: React.FC = () => {
         <>
           <FiltersGlobal>
             <SiemSearchBar
-              sourcererDataView={
-                newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataView
-              }
+              dataView={experimentalDataView}
               id={InputsModelId.global}
+              sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
             />
           </FiltersGlobal>
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/network.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/pages/network.tsx
@@ -90,7 +90,7 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
     const {
       indicesExist: oldIndicesExist,
       selectedPatterns: oldSelectedPatterns,
-      sourcererDataView: oldSourcererDataView,
+      sourcererDataView: oldSourcererDataViewSpec,
     } = useSourcererDataView();
 
     const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
@@ -131,24 +131,24 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
       () =>
         convertToBuildEsQuery({
           config: getEsQueryConfig(uiSettings),
-          dataViewSpec: oldSourcererDataView,
+          dataViewSpec: oldSourcererDataViewSpec,
           dataView,
           queries: [query],
           filters: globalFilters,
         }),
-      [uiSettings, oldSourcererDataView, dataView, query, globalFilters]
+      [uiSettings, oldSourcererDataViewSpec, dataView, query, globalFilters]
     );
 
     const [tabsFilterQuery] = useMemo(
       () =>
         convertToBuildEsQuery({
           config: getEsQueryConfig(uiSettings),
-          dataViewSpec: oldSourcererDataView,
+          dataViewSpec: oldSourcererDataViewSpec,
           dataView,
           queries: [query],
           filters: tabsFilters,
         }),
-      [uiSettings, oldSourcererDataView, dataView, query, tabsFilters]
+      [uiSettings, oldSourcererDataViewSpec, dataView, query, tabsFilters]
     );
 
     useInvalidFilterQuery({ id: ID, filterQuery, kqlError, query, startDate: from, endDate: to });
@@ -164,8 +164,9 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
             <EuiWindowEvent event="resize" handler={noop} />
             <FiltersGlobal>
               <SiemSearchBar
+                dataView={dataView}
                 id={InputsModelId.global}
-                sourcererDataView={newDataViewPickerEnabled ? dataView : oldSourcererDataView}
+                sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
               />
             </FiltersGlobal>
 
@@ -204,7 +205,7 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
                 <NetworkKpiComponent from={from} to={to} />
               </Display>
 
-              {capabilitiesFetched && !isInitializing && oldSourcererDataView ? (
+              {capabilitiesFetched && !isInitializing && oldSourcererDataViewSpec ? (
                 <>
                   <Display show={!globalFullScreen}>
                     <EuiSpacer />

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/details/index.tsx
@@ -113,7 +113,7 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
   const {
     indicesExist: oldIndicesExist,
     selectedPatterns: oldSelectedPatterns,
-    sourcererDataView: oldSourcererDataView,
+    sourcererDataView: oldSourcererDataViewSpec,
   } = useSourcererDataView();
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
@@ -134,7 +134,7 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
         buildEsQuery(
           newDataViewPickerEnabled
             ? experimentalDataView
-            : dataViewSpecToViewBase(oldSourcererDataView),
+            : dataViewSpecToViewBase(oldSourcererDataViewSpec),
           [query],
           [...usersDetailsPageFilters, ...globalFilters],
           getEsQueryConfig(uiSettings)
@@ -147,7 +147,7 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
     experimentalDataView,
     globalFilters,
     newDataViewPickerEnabled,
-    oldSourcererDataView,
+    oldSourcererDataViewSpec,
     query,
     uiSettings,
     usersDetailsPageFilters,
@@ -233,10 +233,9 @@ const UsersDetailsComponent: React.FC<UsersDetailsProps> = ({
           <EuiWindowEvent event="resize" handler={noop} />
           <FiltersGlobal>
             <SiemSearchBar
-              sourcererDataView={
-                newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataView
-              } // TODO: newDataViewPicker - Can be removed after migration to new dataview picker
+              dataView={experimentalDataView}
               id={InputsModelId.global}
+              sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
             />
           </FiltersGlobal>
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/users.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/users/pages/users.tsx
@@ -107,7 +107,7 @@ const UsersComponent = () => {
   const {
     indicesExist: oldIndicesExist,
     selectedPatterns: oldSelectedPatterns,
-    sourcererDataView: oldSourcererDataView,
+    sourcererDataView: oldSourcererDataViewSpec,
   } = useSourcererDataView();
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
@@ -126,23 +126,23 @@ const UsersComponent = () => {
     () =>
       convertToBuildEsQuery({
         config: getEsQueryConfig(uiSettings),
-        dataViewSpec: oldSourcererDataView,
+        dataViewSpec: oldSourcererDataViewSpec,
         dataView: experimentalDataView,
         queries: [query],
         filters: globalFilters,
       }),
-    [uiSettings, oldSourcererDataView, experimentalDataView, query, globalFilters]
+    [uiSettings, oldSourcererDataViewSpec, experimentalDataView, query, globalFilters]
   );
   const [tabsFilterQuery] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: getEsQueryConfig(uiSettings),
-        dataViewSpec: oldSourcererDataView,
+        dataViewSpec: oldSourcererDataViewSpec,
         dataView: experimentalDataView,
         queries: [query],
         filters: tabsFilters,
       }),
-    [experimentalDataView, oldSourcererDataView, query, tabsFilters, uiSettings]
+    [experimentalDataView, oldSourcererDataViewSpec, query, tabsFilters, uiSettings]
   );
 
   useInvalidFilterQuery({
@@ -192,10 +192,9 @@ const UsersComponent = () => {
           <EuiWindowEvent event="resize" handler={noop} />
           <FiltersGlobal>
             <SiemSearchBar
-              sourcererDataView={
-                newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataView
-              }
+              dataView={experimentalDataView}
               id={InputsModelId.global}
+              sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
             />
           </FiltersGlobal>
 

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/pages/detection_response.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/pages/detection_response.tsx
@@ -42,7 +42,7 @@ const DetectionResponseComponent = () => {
   const {
     indicesExist: oldIndicesExist,
     loading: oldIsSourcererLoading,
-    sourcererDataView: oldSourcererDataView,
+    sourcererDataView: oldSourcererDataViewSpec,
   } = useSourcererDataView();
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
@@ -75,10 +75,9 @@ const DetectionResponseComponent = () => {
         <>
           <FiltersGlobal>
             <SiemSearchBar
+              dataView={experimentalDataView}
               id={InputsModelId.global}
-              sourcererDataView={
-                newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataView
-              }
+              sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
             />
           </FiltersGlobal>
           <SecuritySolutionPageWrapper data-test-subj="detectionResponsePage">

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/pages/overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/pages/overview.tsx
@@ -8,11 +8,11 @@
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSpacer,
-  EuiShowFor,
   EuiScreenReaderOnly,
+  EuiShowFor,
+  EuiSpacer,
 } from '@elastic/eui';
-import React, { useCallback, useState, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { OVERVIEW } from '../../app/translations';
 import { InputsModelId } from '../../common/store/inputs/constants';
@@ -56,7 +56,7 @@ const OverviewComponent = () => {
   const { from, deleteQuery, setQuery, to } = useGlobalTime();
   const {
     indicesExist: oldIndicesExist,
-    sourcererDataView: oldSourcererDataView,
+    sourcererDataView: oldSourcererDataViewSpec,
     selectedPatterns: oldSelectedPatterns,
   } = useSourcererDataView();
 
@@ -107,10 +107,9 @@ const OverviewComponent = () => {
         <>
           <FiltersGlobal>
             <SiemSearchBar
+              dataView={experimentalDataView}
               id={InputsModelId.global}
-              sourcererDataView={
-                newDataViewPickerEnabled ? experimentalDataView : oldSourcererDataView
-              }
+              sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
             />
           </FiltersGlobal>
 
@@ -142,7 +141,7 @@ const OverviewComponent = () => {
                       deleteQuery={deleteQuery}
                       filters={filters}
                       from={from}
-                      dataViewSpec={oldSourcererDataView}
+                      dataViewSpec={oldSourcererDataViewSpec}
                       dataView={experimentalDataView}
                       query={query}
                       queryType="overview"
@@ -155,7 +154,7 @@ const OverviewComponent = () => {
                       filters={filters}
                       from={from}
                       indexNames={selectedPatterns}
-                      dataViewSpec={oldSourcererDataView}
+                      dataViewSpec={oldSourcererDataViewSpec}
                       dataView={experimentalDataView}
                       query={query}
                       setQuery={setQuery}

--- a/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/pages/indicators.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/threat_intelligence/modules/indicators/pages/indicators.tsx
@@ -7,6 +7,7 @@
 
 import type { FC, PropsWithChildren } from 'react';
 import React from 'react';
+import { DataView } from '@kbn/data-views-plugin/common';
 import { InputsModelId } from '../../../../common/store/inputs/constants';
 import { SiemSearchBar } from '../../../../common/components/search_bar';
 import { FiltersGlobal } from '../../../../common/components/filters_global';
@@ -26,6 +27,7 @@ import { useColumnSettings } from '../hooks/use_column_settings';
 import { IndicatorsFilters } from '../containers/filters';
 import { UpdateStatus } from '../../../components/update_status';
 import { ScreenReaderAnnouncementsProvider } from '../containers/screen_reader_a11y';
+import { useKibana } from '../../../../common/lib/kibana';
 
 const IndicatorsPageProviders: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <ScreenReaderAnnouncementsProvider>
@@ -42,7 +44,10 @@ const IndicatorsPageProviders: FC<PropsWithChildren<unknown>> = ({ children }) =
 const IndicatorsPageContent: FC = () => {
   const { blockListIndicatorValue } = useBlockListContext();
 
-  const { sourcererDataView, browserFields } = useTIDataView();
+  const { sourcererDataView: sourcererDataViewSpec, browserFields } = useTIDataView();
+
+  const { fieldFormats } = useKibana().services;
+  const dataView = new DataView({ spec: sourcererDataViewSpec, fieldFormats });
 
   const columnSettings = useColumnSettings();
 
@@ -84,7 +89,11 @@ const IndicatorsPageContent: FC = () => {
         subHeader={<UpdateStatus isUpdating={isFetchingIndicators} updatedAt={dataUpdatedAt} />}
       >
         <FiltersGlobal>
-          <SiemSearchBar id={InputsModelId.global} sourcererDataView={sourcererDataView} />
+          <SiemSearchBar
+            dataView={dataView}
+            id={InputsModelId.global}
+            sourcererDataViewSpec={sourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
+          />
         </FiltersGlobal>
 
         <IndicatorsBarChartWrapper


### PR DESCRIPTION
## Summary

This PR makes a small change to the SearchBar component used in many pages in Security Solution. 

### Context

In the previous version of the code, we were passing the dataView to the component via the `sourcererDataView` prop. There was also some internal logic to fetch the dataView using the `useDataView` hook, as well as some logic to switch between the `sourcererDataView` and the new `dataView` using the `dataViewPickerEnabled` feature flag.
The problem is this was not clear, as almost every page using the SearchBar component was also fetching the `experimentalDataView` and the `oldSourcererDataView` and pass only the correct one depending on the value of the `dataViewPickerEnabled` feature flag.

That logic was done in so many places, it was very confusing.

Also, something that the previous code was not allowing us to do was to pass a dataView for a specific scope. The `useDataView` hook within the `SearchBar` component was using the default scope.
For the Attacks page we're currently creating (see skeleton PR [here](https://github.com/elastic/kibana/pull/242384)), we need to select the attacks data view (created in [this previous PR](https://github.com/elastic/kibana/pull/238750)).

### Changes

This PR makes the following small changes:
- separate the previous `sourcererDataView` prop into 2 new ones:
  - `dataView` for the dataView used when the `dataViewPickerEnabled` is `true`
  - `sourcererDataViewSpec` for the dataView used when the `dataViewPickerEnabled` is `false`
- rename `oldSourcererDataView` to `oldSourcererDataViewSpec` to better reflect the type of the variable (`DataViewSpec`)
- added TODOs everywhere as we will be removing all the old sourcerer related code soon (most likely January, PR in draft [here](https://github.com/elastic/kibana/pull/238549)).

> [!NOTE]
> This PR should not introduce any behavior or UI changes. A good sign is other than name changes, none of the existing unit tests have been changed 😄 
> You'll also notice that the changes are very repetitive between all the files.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
