### PR TITLE
[9.2] [Metrics][Discover] Fields API to consider both data streams and indices (#242164)

### DIFF
--- a/src/platform/plugins/shared/metrics_experience/server/lib/fields/enrich_metric_fields.test.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/lib/fields/enrich_metric_fields.test.ts
@@ -9,7 +9,7 @@
 
 import { enrichMetricFields } from './enrich_metric_fields';
 import type { TracedElasticsearchClient } from '@kbn/traced-es-client';
-import type { DataStreamFieldCapsMap, EpochTimeRange } from '../../types';
+import type { IndexFieldCapsMap, EpochTimeRange } from '../../types';
 import type { MetricField } from '../../../common/types';
 import { extractDimensions } from '../dimensions/extract_dimensions';
 import type { Logger } from '@kbn/core/server';
@@ -28,7 +28,7 @@ const timeRangeFixture: EpochTimeRange = { from: Date.now() - 300_000, to: Date.
 
 describe('enrichMetricFields', () => {
   let logger: Logger;
-  let dataStreamFieldCapsMap: DataStreamFieldCapsMap;
+  let indexFieldCapsMap: IndexFieldCapsMap;
 
   const TEST_METRIC_NAME = 'system.cpu.utilization';
   const TEST_INDEX = 'metrics-*';
@@ -79,7 +79,7 @@ describe('enrichMetricFields', () => {
       debug: jest.fn(),
     } as unknown as Logger;
 
-    dataStreamFieldCapsMap = new Map();
+    indexFieldCapsMap = new Map();
     extractDimensionsMock.mockImplementation(
       (_caps, names) => names?.map((name) => ({ name, type: ES_FIELD_TYPES.KEYWORD })) ?? []
     );
@@ -90,7 +90,7 @@ describe('enrichMetricFields', () => {
       const result = await enrichMetricFields({
         esClient: esClientMock,
         metricFields: [],
-        dataStreamFieldCapsMap,
+        indexFieldCapsMap,
         logger,
         timerange: timeRangeFixture,
       });
@@ -130,13 +130,13 @@ describe('enrichMetricFields', () => {
         msearchMock.mockResolvedValue(mockResponse);
 
         if (setupFieldCaps) {
-          dataStreamFieldCapsMap.set(TEST_INDEX, createFieldCaps());
+          indexFieldCapsMap.set(TEST_INDEX, createFieldCaps());
         }
 
         const result = await enrichMetricFields({
           esClient: esClientMock,
           metricFields,
-          dataStreamFieldCapsMap,
+          indexFieldCapsMap,
           logger,
           timerange: timeRangeFixture,
         });
@@ -155,13 +155,13 @@ describe('enrichMetricFields', () => {
         createMsearchResponse({ [TEST_HOST_FIELD]: [TEST_HOST_VALUE] })
       );
 
-      dataStreamFieldCapsMap.set(TEST_INDEX, createFieldCaps());
-      dataStreamFieldCapsMap.set(NO_DATA_INDEX, createFieldCaps());
+      indexFieldCapsMap.set(TEST_INDEX, createFieldCaps());
+      indexFieldCapsMap.set(NO_DATA_INDEX, createFieldCaps());
 
       const result = await enrichMetricFields({
         esClient: esClientMock,
         metricFields,
-        dataStreamFieldCapsMap,
+        indexFieldCapsMap,
         logger,
         timerange: timeRangeFixture,
       });
@@ -198,12 +198,12 @@ describe('enrichMetricFields', () => {
       msearchMock.mockResolvedValue(
         createMsearchResponse({ [TEST_HOST_FIELD]: [TEST_HOST_VALUE], unit: ['1'] })
       );
-      dataStreamFieldCapsMap.set(TEST_INDEX, createFieldCaps());
+      indexFieldCapsMap.set(TEST_INDEX, createFieldCaps());
 
       const result = await enrichMetricFields({
         esClient: esClientMock,
         metricFields,
-        dataStreamFieldCapsMap,
+        indexFieldCapsMap,
         logger,
         timerange: timeRangeFixture,
       });
@@ -228,12 +228,12 @@ describe('enrichMetricFields', () => {
       msearchMock.mockResolvedValue(
         createMsearchResponse({ [TEST_HOST_FIELD]: [TEST_HOST_VALUE] })
       );
-      dataStreamFieldCapsMap.set(TEST_INDEX, createFieldCaps());
+      indexFieldCapsMap.set(TEST_INDEX, createFieldCaps());
 
       const result = await enrichMetricFields({
         esClient: esClientMock,
         metricFields,
-        dataStreamFieldCapsMap,
+        indexFieldCapsMap,
         logger,
         timerange: timeRangeFixture,
       });

--- a/src/platform/plugins/shared/metrics_experience/server/lib/fields/enrich_metric_fields.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/lib/fields/enrich_metric_fields.ts
@@ -14,7 +14,7 @@ import type { estypes } from '@elastic/elasticsearch';
 import type { InferSearchResponseOf } from '@kbn/es-types';
 import { semconvFlat } from '@kbn/otel-semantic-conventions';
 import { dateRangeQuery } from '@kbn/es-query';
-import type { DataStreamFieldCapsMap, EpochTimeRange } from '../../types';
+import type { IndexFieldCapsMap, EpochTimeRange } from '../../types';
 import type { Dimension, MetricField } from '../../../common/types';
 import { extractDimensions } from '../dimensions/extract_dimensions';
 import { normalizeUnit } from './normalize_unit';
@@ -149,13 +149,13 @@ export async function sampleMetricMetadata({
 export async function enrichMetricFields({
   esClient,
   metricFields,
-  dataStreamFieldCapsMap,
+  indexFieldCapsMap,
   logger,
   timerange,
 }: {
   esClient: TracedElasticsearchClient;
   metricFields: MetricField[];
-  dataStreamFieldCapsMap: DataStreamFieldCapsMap;
+  indexFieldCapsMap: IndexFieldCapsMap;
   logger: Logger;
   timerange: EpochTimeRange;
 }) {
@@ -175,7 +175,7 @@ export async function enrichMetricFields({
   return metricFields.map((field) => {
     const { dimensions, unitFromSample } =
       metricMetadataMap.get(generateMapKey(field.index, field.name)) || {};
-    const fieldCaps = dataStreamFieldCapsMap.get(field.index);
+    const fieldCaps = indexFieldCapsMap.get(field.index);
 
     if (!dimensions || dimensions.length === 0) {
       return { ...field, dimensions: [], noData: true };

--- a/src/platform/plugins/shared/metrics_experience/server/lib/fields/retrieve_fieldcaps.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/lib/fields/retrieve_fieldcaps.ts
@@ -24,42 +24,38 @@ export async function retrieveFieldCaps({
   fields?: Fields;
   timerange: EpochTimeRange;
 }) {
-  const dataStreamFieldCapsMap = new Map<
+  const indexFieldCapsMap = new Map<
     string,
     Record<string, Record<string, FieldCapsFieldCapability>>
   >();
 
-  // First, resolve the index pattern to get data streams
+  // First, resolve the index pattern to get data streams or indices
   const resolveResponse = await esClient.indices.resolveIndex({
     name: indexPattern,
     expand_wildcards: 'open',
   });
 
-  // Extract data stream names
-  const dataStreams = resolveResponse.data_streams || [];
-
-  if (dataStreams.length === 0) {
-    return dataStreamFieldCapsMap;
-  }
+  // Extract resolved indices (data streams and regular indices)
+  const resolvedIndices = [...resolveResponse.data_streams, ...resolveResponse.indices];
 
   const uniqueFieldTypes = new Set([...NUMERIC_TYPES, ...DIMENSION_TYPES]);
 
-  // Call field caps in parallel for each data stream
-  const fieldCapsPromises = dataStreams.map(async (dataStream) => {
+  // Call field caps in parallel for each index
+  const fieldCapsPromises = resolvedIndices.map(async (index) => {
     const fieldCaps = await esClient.fieldCaps({
-      index: dataStream.name,
+      index: index.name,
       fields,
       include_unmapped: false,
       index_filter: dateRangeQuery(from, to)[0],
       types: [...uniqueFieldTypes],
     });
 
-    dataStreamFieldCapsMap.set(dataStream.name, fieldCaps.fields);
+    indexFieldCapsMap.set(index.name, fieldCaps.fields);
   });
 
   // Wait for all field caps requests to complete
   await Promise.all(fieldCapsPromises);
 
-  // Return the datastream field caps map.
-  return dataStreamFieldCapsMap;
+  // Return the index field caps map
+  return indexFieldCapsMap;
 }

--- a/src/platform/plugins/shared/metrics_experience/server/routes/fields/get_metric_fields.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/routes/fields/get_metric_fields.ts
@@ -40,7 +40,7 @@ export async function getMetricFields({
 }): Promise<MetricFieldsResponse> {
   if (!indexPattern) return { fields: [], total: 0 };
 
-  const dataStreamFieldCapsMap = await retrieveFieldCaps({
+  const indexFieldCapsMap = await retrieveFieldCaps({
     esClient: esClient.client,
     indexPattern,
     fields,
@@ -48,8 +48,8 @@ export async function getMetricFields({
   });
 
   const allMetricFields: MetricField[] = [];
-  for (const [dataStreamName, fieldCaps] of dataStreamFieldCapsMap.entries()) {
-    if (isNumber(dataStreamName) || fieldCaps == null) continue;
+  for (const [indexName, fieldCaps] of indexFieldCapsMap.entries()) {
+    if (isNumber(indexName) || fieldCaps == null) continue;
     if (Object.keys(fieldCaps).length === 0) continue;
 
     const metricFields = extractMetricFields(fieldCaps);
@@ -59,7 +59,7 @@ export async function getMetricFields({
     const initialFields = metricFields.map(({ fieldName, type, typeInfo }) =>
       buildMetricField({
         name: fieldName,
-        index: dataStreamName,
+        index: indexName,
         dimensions: allDimensions,
         type,
         typeInfo,
@@ -77,7 +77,7 @@ export async function getMetricFields({
   const enrichedMetricFields = await enrichMetricFields({
     esClient,
     metricFields: applyPagination({ metricFields: allMetricFields, page, size }),
-    dataStreamFieldCapsMap,
+    indexFieldCapsMap,
     logger,
     timerange,
   });

--- a/src/platform/plugins/shared/metrics_experience/server/types.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/types.ts
@@ -9,7 +9,7 @@
 
 import type { FieldCapsFieldCapability } from '@elastic/elasticsearch/lib/api/types';
 
-export type DataStreamFieldCapsMap = Map<
+export type IndexFieldCapsMap = Map<
   string,
   Record<string, Record<string, FieldCapsFieldCapability>>
 >;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Metrics][Discover] Fields API to consider both data streams and indices (#242164)](https://github.com/elastic/kibana/pull/242164)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-11-10T13:57:31Z","message":"[Metrics][Discover] Fields API to consider both data streams and indices (#242164)\n\ncloses [#242162](https://github.com/elastic/kibana/issues/242162)\n\n## Summary\n\nThis PR changes the `/fields` API to consider `indices` to the\ncompatibility check\n\n<img width=\"1726\" height=\"867\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/da4cb855-2a9c-41fe-9a28-9d353b756cfe\"\n/>\n\n\n## How to test\n- Start a local Kibana instance and point it to an oblt cluster\n```yml\nfeature_flags.overrides:\n  metricsExperienceEnabled: true\n ```\n- Install the `Sample web logs (TSDB)` sample data\n- run `TS kibana_sample_data_logstsdb` and check if the grid shows metrics\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"c83fa06fc8f57f4f0b77e29feeb26dfcef88b693","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.2.0","v9.3.0","Team:obs-exploration"],"title":"[Metrics][Discover] Fields API to consider both data streams and indices","number":242164,"url":"https://github.com/elastic/kibana/pull/242164","mergeCommit":{"message":"[Metrics][Discover] Fields API to consider both data streams and indices (#242164)\n\ncloses [#242162](https://github.com/elastic/kibana/issues/242162)\n\n## Summary\n\nThis PR changes the `/fields` API to consider `indices` to the\ncompatibility check\n\n<img width=\"1726\" height=\"867\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/da4cb855-2a9c-41fe-9a28-9d353b756cfe\"\n/>\n\n\n## How to test\n- Start a local Kibana instance and point it to an oblt cluster\n```yml\nfeature_flags.overrides:\n  metricsExperienceEnabled: true\n ```\n- Install the `Sample web logs (TSDB)` sample data\n- run `TS kibana_sample_data_logstsdb` and check if the grid shows metrics\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"c83fa06fc8f57f4f0b77e29feeb26dfcef88b693"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/242164","number":242164,"mergeCommit":{"message":"[Metrics][Discover] Fields API to consider both data streams and indices (#242164)\n\ncloses [#242162](https://github.com/elastic/kibana/issues/242162)\n\n## Summary\n\nThis PR changes the `/fields` API to consider `indices` to the\ncompatibility check\n\n<img width=\"1726\" height=\"867\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/da4cb855-2a9c-41fe-9a28-9d353b756cfe\"\n/>\n\n\n## How to test\n- Start a local Kibana instance and point it to an oblt cluster\n```yml\nfeature_flags.overrides:\n  metricsExperienceEnabled: true\n ```\n- Install the `Sample web logs (TSDB)` sample data\n- run `TS kibana_sample_data_logstsdb` and check if the grid shows metrics\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"c83fa06fc8f57f4f0b77e29feeb26dfcef88b693"}}]}] BACKPORT-->