### PR TITLE
[Discover][Traces] Filter out undefined values in useGetGenerateDiscoverLink

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/hooks/use_get_generate_discover_link.test.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/hooks/use_get_generate_discover_link.test.ts
@@ -96,8 +96,14 @@ describe('useGetGenerateDiscoverLink', () => {
     });
 
     expect(mockGetRedirectUrl).toHaveBeenCalled();
-    const callArgs = mockGetRedirectUrl.mock.calls[0][0];
-    const esql = callArgs.query.esql;
+    const callArgs = mockGetRedirectUrl.mock.calls[0] as unknown as [
+      {
+        timeRange: { from: string; to: string };
+        filters: unknown[];
+        query: { language: string; esql: string };
+      }
+    ];
+    const esql = callArgs[0].query.esql;
 
     expect(esql).toBe(`FROM traces-*
   | WHERE trace.id == "abc123" AND exception.message == "Test error"`);

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/hooks/use_get_generate_discover_link.test.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/hooks/use_get_generate_discover_link.test.ts
@@ -96,14 +96,7 @@ describe('useGetGenerateDiscoverLink', () => {
     });
 
     expect(mockGetRedirectUrl).toHaveBeenCalled();
-    const callArgs = mockGetRedirectUrl.mock.calls[0] as unknown as [
-      {
-        timeRange: { from: string; to: string };
-        filters: unknown[];
-        query: { language: string; esql: string };
-      }
-    ];
-    const esql = callArgs[0].query.esql;
+    const esql = (mockGetRedirectUrl.mock.calls[0] as any)?.[0]?.query?.esql;
 
     expect(esql).toBe(`FROM traces-*
   | WHERE trace.id == "abc123" AND exception.message == "Test error"`);

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/hooks/use_get_generate_discover_link.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/hooks/use_get_generate_discover_link.ts
@@ -50,16 +50,18 @@ export function useGetGenerateDiscoverLink({
       const paramKeysMap = new Map<string, string>();
       const params: Array<Record<string, any>> = [];
 
-      Object.keys(whereClause).forEach((key) => {
-        const paramKey = toESQLParamName(key);
-        paramKeysMap.set(key, paramKey);
-        params.push({ [paramKey]: whereClause[key] });
-      });
+      Object.keys(whereClause)
+        .filter((key) => whereClause[key] !== undefined)
+        .forEach((key) => {
+          const paramKey = toESQLParamName(key);
+          paramKeysMap.set(key, paramKey);
+          params.push({ [paramKey]: whereClause[key] });
+        });
 
       esql = _from
         .pipe(
           where(
-            Object.keys(whereClause)
+            Array.from(paramKeysMap.keys())
               .map((key) => `${key} == ?${paramKeysMap.get(key)}`)
               .join(' AND '),
             params


### PR DESCRIPTION
## Summary

This PR addresses an issue with ES|QL queries generated by `useGetGenerateDiscoverLink` when they included `undefined` parameters.

We discovered this while navigating from a trace document to its related error logs, and fixing it ensures that the links now work reliably in all cases.

|Before|After|
|-|-|
|<img width="1877" height="1124" alt="Screenshot 2025-11-11 at 10 52 51" src="https://github.com/user-attachments/assets/75dc2ba4-394a-477e-9131-4ad4e2c8051f" />|<img width="1534" height="966" alt="Screenshot 2025-11-11 at 11 02 04" src="https://github.com/user-attachments/assets/aa3e45f9-3417-4ab1-9089-04e68d0b7ffa" />|






<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->