### PR TITLE
[Discover][APM] Remove EuiAccordion temporarily from Attributes tab

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/attributes_accordion.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/attributes_accordion.tsx
@@ -7,7 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import React from 'react';
-import { EuiAccordion, EuiText, EuiNotificationBadge, EuiIconTip, useEuiTheme } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiNotificationBadge,
+  EuiIconTip,
+  useEuiTheme,
+} from '@elastic/eui';
 import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
@@ -48,48 +55,53 @@ export const AttributesAccordion = ({
   isEsqlMode = false,
 }: AttributesAccordionProps) => {
   const { euiTheme } = useEuiTheme();
+
+  // TODO: Re-add EuiAccordion once the buggy interaction between it and EuiDataGrid is
+  // resolved.
   return (
-    <EuiAccordion
-      id={id}
-      buttonContent={
-        <EuiText size="s">
-          <strong css={{ marginRight: euiTheme.size.xs }}>{title}</strong>
-          <EuiIconTip
-            aria-label={tooltipMessage}
-            type="question"
-            color="subdued"
-            size="s"
-            content={tooltipMessage}
-            iconProps={{
-              className: 'eui-alignTop',
-            }}
+    <EuiFlexGroup id={id} direction="column">
+      <EuiFlexItem grow={0}>
+        <EuiFlexGroup>
+          <EuiFlexItem paddingSize="m">
+            <EuiText size="s">
+              <strong css={{ marginRight: euiTheme.size.xs }}>{title}</strong>
+              <EuiIconTip
+                aria-label={tooltipMessage}
+                type="question"
+                color="subdued"
+                size="s"
+                content={tooltipMessage}
+                iconProps={{
+                  className: 'eui-alignTop',
+                }}
+              />
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={0} paddingSize="m">
+            <EuiNotificationBadge size="m" color="subdued">
+              {fields.length}
+            </EuiNotificationBadge>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem paddingSize="m">
+        {fields.length === 0 ? (
+          <AttributesEmptyPrompt />
+        ) : (
+          <AttributesTable
+            hit={hit}
+            dataView={dataView}
+            columns={columns}
+            columnsMeta={columnsMeta}
+            fields={fields}
+            searchTerm={searchTerm}
+            onAddColumn={onAddColumn}
+            onRemoveColumn={onRemoveColumn}
+            filter={filter}
+            isEsqlMode={isEsqlMode}
           />
-        </EuiText>
-      }
-      initialIsOpen={fields.length > 0}
-      extraAction={
-        <EuiNotificationBadge size="m" color="subdued">
-          {fields.length}
-        </EuiNotificationBadge>
-      }
-      paddingSize="m"
-    >
-      {fields.length === 0 ? (
-        <AttributesEmptyPrompt />
-      ) : (
-        <AttributesTable
-          hit={hit}
-          dataView={dataView}
-          columns={columns}
-          columnsMeta={columnsMeta}
-          fields={fields}
-          searchTerm={searchTerm}
-          onAddColumn={onAddColumn}
-          onRemoveColumn={onRemoveColumn}
-          filter={filter}
-          isEsqlMode={isEsqlMode}
-        />
-      )}
-    </EuiAccordion>
+        )}
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/attributes_accordion.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/attributes_accordion.tsx
@@ -57,7 +57,7 @@ export const AttributesAccordion = ({
   const { euiTheme } = useEuiTheme();
 
   // TODO: Re-add EuiAccordion once the buggy interaction between it and EuiDataGrid is
-  // resolved.
+  // resolved. https://github.com/elastic/kibana/issues/242652
   return (
     <EuiFlexGroup id={id} direction="column">
       <EuiFlexItem grow={0}>


### PR DESCRIPTION
## Summary

Due to an unfortunate interaction between `EuiAccordion` and `EuiDataGrid`, in Chrome, the Attributes tab experiences an infinite loop in certain circumstances which trigger a continuous flicker with the scrollbar for an attribute section (See #226986). To fix this requires changes upstream in EUI, but since that is a while off, the temporary solution is to remove `EuiAccordion` for the moment so to avoid this buggy interaction.

<img width="489" height="477" alt="image" src="https://github.com/user-attachments/assets/a08017d0-a49b-461f-a930-befe536f9fdc" />

## How to test

- Ensure you are on the Chrome browser (bug did not appear whilst on Firefox).
- Go to Discover whilst in an Observability space, select an OTEL trace index in either classic or ES|QL mode.
- Select various trace documents and open them in the doc viewer, switching to the Attributes tab.
- No trace document's Attribute tab should have any attribute group/section exhibit flickering behaviour.


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->