### PR TITLE
[One workflow] Workflow input cache collision when workflows share the same name

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/use_execution_input/use_execution_input.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/use_execution_input/use_execution_input.tsx
@@ -11,9 +11,11 @@ import { useEffect, useMemo, useState } from 'react';
 
 export const useExecutionInput = ({
   workflowName,
+  workflowId,
   selectedTrigger,
 }: {
   workflowName: string;
+  workflowId?: string;
   selectedTrigger: string;
 }) => {
   const [executionInput, setExecutionInput] = useState<string>('');
@@ -22,8 +24,9 @@ export const useExecutionInput = ({
     if (!workflowName || selectedTrigger !== 'manual') {
       return null;
     }
-    return `workflow-${selectedTrigger}-input-${workflowName}`;
-  }, [workflowName, selectedTrigger]);
+    const storageIdentifier = workflowId || workflowName;
+    return `workflow-${selectedTrigger}-input-${storageIdentifier}`;
+  }, [workflowName, workflowId, selectedTrigger]);
 
   useEffect(() => {
     if (localStorageKey) {

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -50,11 +50,12 @@ function getDefaultTrigger(definition: WorkflowYaml | null): TriggerType {
 
 interface WorkflowExecuteModalProps {
   definition: WorkflowYaml | null;
+  workflowId?: string;
   onClose: () => void;
   onSubmit: (data: Record<string, unknown>) => void;
 }
 export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
-  ({ definition, onClose, onSubmit }) => {
+  ({ definition, workflowId, onClose, onSubmit }) => {
     const modalTitleId = useGeneratedHtmlId();
     const enabledTriggers = ['alert', 'index', 'manual'];
     const defaultTrigger = useMemo(() => getDefaultTrigger(definition), [definition]);
@@ -62,6 +63,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
 
     const { executionInput, setExecutionInput } = useExecutionInput({
       workflowName: definition?.name || '',
+      workflowId,
       selectedTrigger,
     });
     const [executionInputErrors, setExecutionInputErrors] = useState<string | null>(null);

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_list.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_list/ui/workflow_list.tsx
@@ -465,6 +465,7 @@ export function WorkflowList({ search, setSearch, onCreateWorkflow }: WorkflowLi
       {executeWorkflow?.definition && (
         <WorkflowExecuteModal
           definition={executeWorkflow.definition}
+          workflowId={executeWorkflow.id}
           onClose={() => setExecuteWorkflow(null)}
           onSubmit={(event) => handleRunWorkflow(executeWorkflow.id, event)}
         />

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_test_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_test_modal.tsx
@@ -13,6 +13,7 @@ import { i18n } from '@kbn/i18n';
 import {
   selectIsTestModalOpen,
   selectWorkflowDefinition,
+  selectWorkflowId,
 } from '../../../entities/workflows/store/workflow_detail/selectors';
 import { setIsTestModalOpen } from '../../../entities/workflows/store/workflow_detail/slice';
 import { testWorkflowThunk } from '../../../entities/workflows/store/workflow_detail/thunks/test_workflow_thunk';
@@ -31,6 +32,7 @@ export const WorkflowDetailTestModal = () => {
 
   const isTestModalOpen = useSelector(selectIsTestModalOpen);
   const definition = useSelector(selectWorkflowDefinition);
+  const workflowId = useSelector(selectWorkflowId);
 
   const testWorkflow = useAsyncThunk(testWorkflowThunk);
   const handleRunWorkflow = useCallback(
@@ -76,6 +78,7 @@ export const WorkflowDetailTestModal = () => {
   return (
     <WorkflowExecuteModal
       definition={definition}
+      workflowId={workflowId}
       onClose={closeModal}
       onSubmit={handleRunWorkflow}
     />


### PR DESCRIPTION
**Problem**
With the "Run again with the same value" feature, execution inputs are cached in localStorage using the workflow name as the key. This caused collisions when multiple workflows shared the same name, leading to incorrect input values being loaded.

**Solution**
- Use `workflow ID` as the cache key for saved workflows
- Fallback to workflow name for unsaved workflows (which don't have an ID)
- Updated `useExecutionInput` hook to accept optional `workflowId` parameter
- Updated `WorkflowExecuteModal` to accept and pass `workflowId` prop
- Updated modal usages in `workflow_list.tsx` and `workflow_detail_test_modal.tsx` to pass workflow ID

**Before**

https://github.com/user-attachments/assets/196ef599-b82e-42d1-b6c6-51dd72dcbc8c

**After**

https://github.com/user-attachments/assets/8dbcd51a-0e2d-4f71-9281-8d162d4ca140
