### PR TITLE
[Agent Builder] use ESQL syntax highlight for ESQL code blocks

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/chat_message_text.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/chat_message_text.tsx
@@ -87,7 +87,9 @@ export function ChatMessageText({ content, steps: stepsFromCurrentRound }: Props
       esql: (props) => {
         return (
           <>
-            <EuiCodeBlock>{props.value}</EuiCodeBlock>
+            <EuiCodeBlock language="esql" isCopyable>
+              {props.value}
+            </EuiCodeBlock>
             <EuiSpacer size="m" />
           </>
         );

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/query_result_step.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/query_result_step.tsx
@@ -26,7 +26,7 @@ export const QueryResultStep: React.FC<QueryResultStepProps> = ({ result: { data
   return (
     <EuiFlexGroup direction="column" gutterSize="s">
       <EuiFlexItem>
-        <EuiCodeBlock css={codeBlockStyles} language="sql" isCopyable paddingSize="m">
+        <EuiCodeBlock css={codeBlockStyles} language="esql" isCopyable paddingSize="m">
           {data.esql}
         </EuiCodeBlock>
       </EuiFlexItem>


### PR DESCRIPTION
## Summary

### Before

<img width="871" height="554" alt="Screenshot 2025-11-11 at 16 36 18" src="https://github.com/user-attachments/assets/53a04db9-630f-4bbf-9bb6-1366938c7b5b" />


### After

<img width="795" height="521" alt="Screenshot 2025-11-11 at 16 08 07" src="https://github.com/user-attachments/assets/d22cff3f-5e8e-4c1e-99ac-41f729274a01" />

