### PR TITLE
[9.1] [ResponseOps][Alerts] Fix alerts table pagination resetting when lastReloadRequestTime is used (#242275)

### DIFF
--- a/src/platform/packages/shared/response-ops/alerts-table/components/alerts_table.test.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-table/components/alerts_table.test.tsx
@@ -337,6 +337,7 @@ describe('AlertsTable', () => {
   let onToggleColumn: AlertsDataGridProps['onToggleColumn'];
   let onResetColumns: AlertsDataGridProps['onResetColumns'];
   let refresh: RenderContext<AdditionalContext>['refresh'];
+  let refreshSpy: jest.SpyInstance<void, []>;
 
   mockAlertsDataGrid.mockImplementation((props) => {
     const { AlertsDataGrid: ActualAlertsDataGrid } = jest.requireActual('./alerts_data_grid');
@@ -344,6 +345,7 @@ describe('AlertsTable', () => {
     onToggleColumn = props.onToggleColumn;
     onResetColumns = props.onResetColumns;
     refresh = props.renderContext.refresh;
+    refreshSpy = jest.spyOn(props.renderContext, 'refresh');
     return <ActualAlertsDataGrid {...props} />;
   });
 
@@ -1209,6 +1211,18 @@ describe('AlertsTable', () => {
         refresh();
       });
       expect(mockSearchAlerts).toHaveBeenLastCalledWith(expect.objectContaining({ pageIndex: 0 }));
+    });
+
+    it("doesn't call `refresh` when paginating and using `lastReloadRequestTime`", async () => {
+      render(<AlertsTable {...tableProps} lastReloadRequestTime={Date.now()} />);
+
+      await waitFor(() => expect(onChangePageIndex).not.toBeUndefined());
+
+      act(() => {
+        onChangePageIndex(1);
+      });
+
+      expect(refreshSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/platform/packages/shared/response-ops/alerts-table/components/alerts_table.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-table/components/alerts_table.tsx
@@ -434,7 +434,9 @@ const AlertsTableContent = typedForwardRef(
       if (lastReloadRequestTime) {
         refresh();
       }
-    }, [lastReloadRequestTime, refresh]);
+      // Purposefully not including `refresh` to avoid refreshing when it changes
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [lastReloadRequestTime]);
 
     useImperativeHandle(ref, () => ({
       refresh,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ResponseOps][Alerts] Fix alerts table pagination resetting when lastReloadRequestTime is used (#242275)](https://github.com/elastic/kibana/pull/242275)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Umberto Pepato","email":"umbopepato@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-11-11T11:44:29Z","message":"[ResponseOps][Alerts] Fix alerts table pagination resetting when lastReloadRequestTime is used (#242275)\n\n## 📄 Summary\n\nRemoves the `refresh` callback from the `lastReloadRequestTime` effect\ndependencies to avoid triggering a refresh when the refresh callback\nitself changes (like it happened\n[here](https://github.com/elastic/kibana/issues/241593)).\n\n<details>\n<summary>\n\n## 🧪 Verification steps\n\n</summary>\n\n1. Create a rule that fires many alerts (i.e. Security query rule)\n2. Wait for the alerts to be generated\n3. Navigate to the rule page from Stack Management > Rules\n4. Check that the pagination in the alerts table at the bottom of the\npage works correctly\n\n</details>\n\n## ⏪ Backport rationale\n\nBackporting to all open versions since this is a bug fix\n\n## Release Notes\n\nFixes a bug that caused the alerts tables pagination to be stuck in the\nRule pages\n\n## 🔗 References\n\nFixes #241593\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- [ ]\n~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- [ ] ~~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- [ ] ~~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"722c33eb42562a86412be79e745ea4702f36a6d7","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","backport:version","v9.3.0","v8.19.7","v9.1.7","v9.2.1"],"title":"[ResponseOps][Alerts] Fix alerts table pagination resetting when lastReloadRequestTime is used","number":242275,"url":"https://github.com/elastic/kibana/pull/242275","mergeCommit":{"message":"[ResponseOps][Alerts] Fix alerts table pagination resetting when lastReloadRequestTime is used (#242275)\n\n## 📄 Summary\n\nRemoves the `refresh` callback from the `lastReloadRequestTime` effect\ndependencies to avoid triggering a refresh when the refresh callback\nitself changes (like it happened\n[here](https://github.com/elastic/kibana/issues/241593)).\n\n<details>\n<summary>\n\n## 🧪 Verification steps\n\n</summary>\n\n1. Create a rule that fires many alerts (i.e. Security query rule)\n2. Wait for the alerts to be generated\n3. Navigate to the rule page from Stack Management > Rules\n4. Check that the pagination in the alerts table at the bottom of the\npage works correctly\n\n</details>\n\n## ⏪ Backport rationale\n\nBackporting to all open versions since this is a bug fix\n\n## Release Notes\n\nFixes a bug that caused the alerts tables pagination to be stuck in the\nRule pages\n\n## 🔗 References\n\nFixes #241593\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- [ ]\n~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- [ ] ~~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- [ ] ~~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"722c33eb42562a86412be79e745ea4702f36a6d7"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/242275","number":242275,"mergeCommit":{"message":"[ResponseOps][Alerts] Fix alerts table pagination resetting when lastReloadRequestTime is used (#242275)\n\n## 📄 Summary\n\nRemoves the `refresh` callback from the `lastReloadRequestTime` effect\ndependencies to avoid triggering a refresh when the refresh callback\nitself changes (like it happened\n[here](https://github.com/elastic/kibana/issues/241593)).\n\n<details>\n<summary>\n\n## 🧪 Verification steps\n\n</summary>\n\n1. Create a rule that fires many alerts (i.e. Security query rule)\n2. Wait for the alerts to be generated\n3. Navigate to the rule page from Stack Management > Rules\n4. Check that the pagination in the alerts table at the bottom of the\npage works correctly\n\n</details>\n\n## ⏪ Backport rationale\n\nBackporting to all open versions since this is a bug fix\n\n## Release Notes\n\nFixes a bug that caused the alerts tables pagination to be stuck in the\nRule pages\n\n## 🔗 References\n\nFixes #241593\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- [ ]\n~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- [ ] ~~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- [ ] ~~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"722c33eb42562a86412be79e745ea4702f36a6d7"}},{"branch":"8.19","label":"v8.19.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/242527","number":242527,"state":"MERGED","mergeCommit":{"sha":"11cbc3a21cad0cf26355a31a92e02343a0ca76e0","message":"[9.2] [ResponseOps][Alerts] Fix alerts table pagination resetting when lastReloadRequestTime is used (#242275) (#242527)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[ResponseOps][Alerts] Fix alerts table pagination resetting when\nlastReloadRequestTime is used\n(#242275)](https://github.com/elastic/kibana/pull/242275)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Umberto Pepato <umbopepato@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}}]}] BACKPORT-->