### PR TITLE
[One Workflow] Merge saved execution input with current workflow schema

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_manual_form.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_manual_form.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { WorkflowYaml } from '@kbn/workflows';
+import { WorkflowExecuteManualForm } from './workflow_execute_manual_form';
+
+const baseWorkflowDefinition = {
+  version: '1',
+  name: 'test-workflow',
+  enabled: true,
+  triggers: [{ type: 'manual' }],
+  steps: [],
+} as WorkflowYaml;
+
+const renderWithProviders = (component: React.ReactElement) => {
+  return render(component, { wrapper: I18nProvider });
+};
+
+describe('WorkflowExecuteManualForm - Input Merging', () => {
+  let mockSetValue: jest.Mock;
+  let mockSetErrors: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSetValue = jest.fn();
+    mockSetErrors = jest.fn();
+  });
+
+  it('should merge saved input when schema fields are added and removed', async () => {
+    // Updated workflow schema: email removed, id added
+    const updatedDefinition: WorkflowYaml = {
+      ...baseWorkflowDefinition,
+      inputs: [
+        {
+          name: 'name',
+          type: 'string',
+        },
+        {
+          name: 'id',
+          type: 'string',
+        },
+        {
+          name: 'department',
+          type: 'string',
+        },
+        {
+          name: 'priority',
+          type: 'choice',
+          options: ['low', 'medium', 'high'],
+          default: 'low',
+        },
+      ],
+    };
+
+    // Saved input from previous schema version (has email, no id)
+    const savedInput = JSON.stringify({
+      name: 'John Doe',
+      email: 'john.doe@elastic.co',
+      department: 'Sales',
+      priority: 'low',
+    });
+
+    renderWithProviders(
+      <WorkflowExecuteManualForm
+        definition={updatedDefinition}
+        value={savedInput}
+        setValue={mockSetValue}
+        errors={null}
+        setErrors={mockSetErrors}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalled();
+      const mergedInput = JSON.parse(mockSetValue.mock.calls[0][0]);
+
+      // Preserved saved values
+      expect(mergedInput.name).toBe('John Doe');
+      expect(mergedInput.department).toBe('Sales');
+      expect(mergedInput.priority).toBe('low');
+
+      // New field added with default placeholder
+      expect(mergedInput.id).toBe('Enter a string');
+
+      // Removed field (email) should not exist
+      expect(mergedInput.email).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
When reopening the workflow execution modal, saved input values are now automatically merged with the current workflow schema structure. This ensures saved inputs adapt to schema changes (new fields added, fields removed, structure modified) while preserving user-entered values.

## Problem
Previously, saved execution inputs were loaded exactly as they were saved. If the workflow schema changed between saves, the saved input could become:
- Incomplete (missing new required fields)
- Outdated (containing fields that no longer exist)
- Incompatible with the current schema structure

## Solution
When the execution modal opens, saved input values are merged with the current workflow schema:
- Preserves the current schema structure (new fields appear with defaults)
- Updates fields with saved values where they exist
- Removes saved fields that no longer exist in the schema
- Works recursively for nested structures

## Example

https://github.com/user-attachments/assets/f69f4982-af85-4f02-abf9-91710a50926a

**Workflow Schema:**
```yaml
inputs:
  - name: name
    type: string
  - name: id
    type: string
  - name: department
    type: string
  - name: priority
    type: choice
    options: [low, medium, high]
    default: low
```

**Saved Input (from previous version):**
```json
{
  "name": "John Doe",
  "email": "john.doe@elastic.co",
  "department": "Sales",
  "priority": "low"
}
```

**Result (Merged):**
```json
{
  "name": "John Doe",
  "id": "Enter a string",
  "department": "Sales",
  "priority": "low"
}
```

The saved `name`, `department`, and `priority` values are preserved, the new `id` field appears with its default placeholder, and the outdated `email` field is removed.
