### PR TITLE
Fixing embeddable alerts tests and skipping suite for FIPS

### DIFF
--- a/x-pack/platform/test/functional_with_es_ssl/apps/embeddable_alerts_table/embeddable_alerts_table.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/embeddable_alerts_table/embeddable_alerts_table.ts
@@ -46,7 +46,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const sampleData = getService('sampleData');
   const rules = getService('rules');
 
-  describe('Embeddable alerts panel', () => {
+  describe('Embeddable alerts panel', function () {
+    this.tags('skipFIPS');
     before(async () => {
       await sampleData.testResources.installAllKibanaSampleData();
 
@@ -103,7 +104,6 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
     for (const solution of ['stack', 'observability', 'security']) {
       describe(`with ${solution} role`, function () {
-        this.tags('skipFIPS');
         const ruleName = `${solution}-rule`;
 
         before(async () => {
@@ -186,31 +186,28 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       expect(features.every((f) => f.toLowerCase().includes('security'))).to.equal(true);
     });
 
-    describe('when user doesnt have access', function () {
-      this.tags('skipFIPS');
-      it("should show a missing authz prompt when the user doesn't have access to a panel's rule types", async () => {
-        // User with o11y-only access should see a missing authz prompt in the security panel
-        await security.testUser.setRoles([`observability_alerting`]);
-        let panels = await find.allByCssSelector(`[data-test-subj=${DASHBOARD_PANEL_TEST_SUBJ}]`);
-        expect(
-          await testSubjects.descendantExists(NO_AUTHORIZED_RULE_TYPE_PROMPT_SUBJ, panels[0])
-        ).to.equal(false);
-        expect(
-          await testSubjects.descendantExists(NO_AUTHORIZED_RULE_TYPE_PROMPT_SUBJ, panels[1])
-        ).to.equal(true);
+    it("should show a missing authz prompt when the user doesn't have access to a panel's rule types", async () => {
+      // User with o11y-only access should see a missing authz prompt in the security panel
+      await security.testUser.setRoles([`observability_alerting`]);
+      let panels = await find.allByCssSelector(`[data-test-subj=${DASHBOARD_PANEL_TEST_SUBJ}]`);
+      expect(
+        await testSubjects.descendantExists(NO_AUTHORIZED_RULE_TYPE_PROMPT_SUBJ, panels[0])
+      ).to.equal(false);
+      expect(
+        await testSubjects.descendantExists(NO_AUTHORIZED_RULE_TYPE_PROMPT_SUBJ, panels[1])
+      ).to.equal(true);
 
-        // User with security-only access should see a missing authz prompt in the o11y panel
-        await security.testUser.setRoles([`security_alerting`]);
-        panels = await find.allByCssSelector(`[data-test-subj=${DASHBOARD_PANEL_TEST_SUBJ}]`);
-        expect(
-          await testSubjects.descendantExists(NO_AUTHORIZED_RULE_TYPE_PROMPT_SUBJ, panels[0])
-        ).to.equal(true);
-        expect(
-          await testSubjects.descendantExists(NO_AUTHORIZED_RULE_TYPE_PROMPT_SUBJ, panels[1])
-        ).to.equal(false);
+      // User with security-only access should see a missing authz prompt in the o11y panel
+      await security.testUser.setRoles([`security_alerting`]);
+      panels = await find.allByCssSelector(`[data-test-subj=${DASHBOARD_PANEL_TEST_SUBJ}]`);
+      expect(
+        await testSubjects.descendantExists(NO_AUTHORIZED_RULE_TYPE_PROMPT_SUBJ, panels[0])
+      ).to.equal(true);
+      expect(
+        await testSubjects.descendantExists(NO_AUTHORIZED_RULE_TYPE_PROMPT_SUBJ, panels[1])
+      ).to.equal(false);
 
-        await security.testUser.restoreDefaults();
-      });
+      await security.testUser.restoreDefaults();
     });
 
     it('should apply the global time filter to alert panels by default', async () => {


### PR DESCRIPTION
## Summary

Reverts https://github.com/elastic/kibana/pull/242422

Moves skipFIPS to top of suite to minimize test file changes

<!--ONMERGE {"backportTargets":["8.19","9.1"]} ONMERGE-->