### PR TITLE
fix: pass the kibana request so it will run as the user

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -284,7 +284,8 @@ export class WorkflowsExecutionEnginePlugin
     const executeWorkflowStep = async (
       workflow: WorkflowExecutionEngineModel,
       stepId: string,
-      contextOverride: Record<string, any>
+      contextOverride: Record<string, any>,
+      request?: any
     ): Promise<ExecuteWorkflowStepResponse> => {
       await this.initialize(coreStart);
       const workflowCreatedAt = new Date();
@@ -328,7 +329,18 @@ export class WorkflowsExecutionEnginePlugin
         enabled: true,
       };
 
-      await plugins.taskManager.schedule(taskInstance);
+      // Use Task Manager's first-class API key support by passing the request
+      // This ensures the step runs with the user's permissions, not kibana_system
+      if (request) {
+        this.logger.debug(
+          `Scheduling workflow step task with user context for workflow ${workflow.id}, step ${stepId}`
+        );
+        await plugins.taskManager.schedule(taskInstance, { request });
+      } else {
+        this.logger.debug(`Scheduling workflow step task without user context`);
+        await plugins.taskManager.schedule(taskInstance);
+      }
+
       return {
         workflowExecutionId: workflowExecution.id!,
       };

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -39,7 +39,8 @@ export interface WorkflowsExecutionEnginePluginStart {
   executeWorkflowStep(
     workflow: WorkflowExecutionEngineModel,
     stepId: string,
-    contextOverride: Record<string, any>
+    contextOverride: Record<string, any>,
+    request?: KibanaRequest
   ): Promise<ExecuteWorkflowStepResponse>;
 
   cancelWorkflowExecution(workflowExecutionId: string, spaceId: string): Promise<void>;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_api.ts
@@ -278,7 +278,8 @@ export class WorkflowsManagementApi {
         spaceId,
       },
       stepId,
-      contextOverride
+      contextOverride,
+      request
     );
     return executeResponse.workflowExecutionId;
   }


### PR DESCRIPTION
close https://github.com/elastic/security-team/issues/14689

## Summary

Updated executeWorkflowStep() to accept and pass the request parameter to Task Manager's schedule() method. Task Manager uses this request to create an API key with the user's permissions, ensuring the step executes with proper authorization.

## Changes

Added optional request parameter to executeWorkflowStep() interface and implementation
Updated caller in workflows_management_api.ts to pass the request through
Added debug logging to track when user context is available
