### PR TITLE
[Security Solution] POC 1 for rule changes history (DRAFT FOR COMMENTING)

### DIFF
--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_create.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_create.ts
@@ -278,6 +278,26 @@ export const performBulkCreate = async <T>(
         expectedResult.rawMigratedDoc._source
       );
 
+      // Create snapshots
+      if (options.snapshot) {
+        const { _id, _source } = expectedResult.rawMigratedDoc;
+        bulkCreateParams.push(
+          {
+            create: {
+              _id: SavedObjectsUtils.generateId(),
+              _index: commonHelper.getSnapshotIndexForType(object.type),
+            },
+          },
+          {
+            '@timestamp': new Date().toISOString(),
+            'user.id': updatedBy || 'unknown',
+            message: options.reason || 'bulk create',
+            id: _id,
+            source: _source,
+          }
+        );
+      }
+
       return right(expectedResult);
     })
   );

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/common.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/helpers/common.ts
@@ -68,6 +68,21 @@ export class CommonHelper {
   }
 
   /**
+   * Returns snapshotindex specified by the given type
+   *
+   * @param type - the type
+   */
+  public getSnapshotIndexForType(type: string) {
+    return getIndexForType({
+      type,
+      defaultIndex: this.defaultIndex,
+      typeRegistry: this.registry,
+      kibanaVersion: this.kibanaVersion,
+      snapshot: true,
+    });
+  }
+
+  /**
    * Returns an array of indices as specified in `this._registry` for each of the
    * given `types`. If any of the types don't have an associated index, the
    * default index `this._index` will be included.

--- a/src/core/packages/saved-objects/api-server/src/apis/bulk_update.ts
+++ b/src/core/packages/saved-objects/api-server/src/apis/bulk_update.ts
@@ -49,6 +49,10 @@ export interface SavedObjectsBulkUpdateOptions extends SavedObjectsBaseOptions {
   refresh?: MutatingOperationRefreshSetting;
   /** {@link SavedObjectsRawDocParseOptions.migrationVersionCompatibility} */
   migrationVersionCompatibility?: 'compatible' | 'raw';
+  /** Snapshot the object after bulk update */
+  snapshot?: boolean;
+  /** Why change was made */
+  reason: string;
 }
 
 /**

--- a/src/core/packages/saved-objects/api-server/src/apis/create.ts
+++ b/src/core/packages/saved-objects/api-server/src/apis/create.ts
@@ -21,6 +21,10 @@ export interface SavedObjectsCreateOptions extends SavedObjectsBaseOptions {
   id?: string;
   /** Overwrite existing documents (defaults to false) */
   overwrite?: boolean;
+  /** Snapshot the object after creation */
+  snapshot?: boolean;
+  /** Why change was made */
+  reason?: string;
   /**
    * An opaque version number which changes on each successful write operation.
    * Can be used in conjunction with `overwrite` for implementing optimistic concurrency control.

--- a/src/core/packages/saved-objects/api-server/src/apis/update.ts
+++ b/src/core/packages/saved-objects/api-server/src/apis/update.ts
@@ -42,6 +42,10 @@ export interface SavedObjectsUpdateOptions<Attributes = unknown> extends SavedOb
    * Defaults to `true`.
    */
   mergeAttributes?: boolean;
+  /** Snapshot the object after update */
+  snapshot?: boolean;
+  /** Why change was made */
+  reason?: string;
 }
 
 /**

--- a/src/core/packages/saved-objects/base-server-internal/src/utils/get_index_for_type.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/utils/get_index_for_type.ts
@@ -24,5 +24,5 @@ export const getIndexForType = ({
   kibanaVersion,
   snapshot = false,
 }: GetIndexForTypeOptions): string => {
-  return `${typeRegistry.getIndex(type) || defaultIndex}${snapshot ? '_snapshot' : kibanaVersion}`;
+  return `${typeRegistry.getIndex(type) || defaultIndex}_${snapshot ? 'snapshots' : kibanaVersion}`;
 };

--- a/src/core/packages/saved-objects/base-server-internal/src/utils/get_index_for_type.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/utils/get_index_for_type.ts
@@ -14,6 +14,7 @@ interface GetIndexForTypeOptions {
   typeRegistry: ISavedObjectTypeRegistry;
   kibanaVersion: string;
   defaultIndex: string;
+  snapshot?: boolean;
 }
 
 export const getIndexForType = ({
@@ -21,6 +22,7 @@ export const getIndexForType = ({
   typeRegistry,
   defaultIndex,
   kibanaVersion,
+  snapshot = false,
 }: GetIndexForTypeOptions): string => {
-  return `${typeRegistry.getIndex(type) || defaultIndex}_${kibanaVersion}`;
+  return `${typeRegistry.getIndex(type) || defaultIndex}${snapshot ? '_snapshot' : kibanaVersion}`;
 };

--- a/src/core/packages/saved-objects/server/src/saved_objects_type.ts
+++ b/src/core/packages/saved-objects/server/src/saved_objects_type.ts
@@ -50,6 +50,11 @@ export interface SavedObjectsType<Attributes = any> {
    */
   hidden: boolean;
   /**
+   * Is the type snapshottable.
+   * If true, a snapshot index will be created alongside the main index.
+   */
+  snapshots?: boolean;
+  /**
    * Is the type hidden from the http APIs. If `hiddenFromHttpApis:true`, repositories will have access to the type but the type is not exposed via the HTTP APIs.
    * It is recommended to hide types registered with 'hidden=false' from the httpApis for backward compatibility in the HTTP layer.
    *

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/update/update_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/update/update_rule.ts
@@ -377,6 +377,8 @@ async function updateRuleAttributes<Params extends RuleParams = never>({
         id,
         version,
         overwrite: true,
+        snapshot: true,
+        reason: 'rule updated by user',
         references: extractedReferences,
       },
     });

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/common/bulk_edit/bulk_edit_rules_occ.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/common/bulk_edit/bulk_edit_rules_occ.ts
@@ -183,7 +183,11 @@ async function saveBulkUpdatedRules({
     result = await bulkCreateRulesSo({
       savedObjectsClient: context.unsecuredSavedObjectsClient,
       bulkCreateRuleAttributes: rules as Array<SavedObjectsBulkCreateObject<RawRule>>,
-      savedObjectsBulkCreateOptions: { overwrite: true },
+      savedObjectsBulkCreateOptions: {
+        overwrite: true,
+        snapshot: true,
+        reason: 'rule bulk updated by user',
+      },
     });
   } catch (e) {
     // avoid unused newly generated API keys

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/create_rule_saved_object.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/create_rule_saved_object.ts
@@ -71,6 +71,8 @@ export async function createRuleSavedObject<Params extends RuleTypeParams = neve
           savedObjectsCreateOptions: {
             ...options,
             references,
+            snapshot: true,
+            reason: 'rule installed by user',
             id: ruleId,
           },
         })

--- a/x-pack/platform/plugins/shared/alerting/server/saved_objects/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/saved_objects/index.ts
@@ -111,6 +111,8 @@ export function setupSavedObjects(
   savedObjects.registerType({
     name: RULE_SAVED_OBJECT_TYPE,
     indexPattern: ALERTING_CASES_SAVED_OBJECT_INDEX,
+    // Create the snapshot index for this type.
+    snapshots: true,
     hidden: true,
     namespaceType: 'multiple-isolated',
     convertToMultiNamespaceTypeVersion: '8.0.0',


### PR DESCRIPTION
Addresses: https://github.com/elastic/security-team/issues/12367
Addresses: https://github.com/elastic/kibana-team/issues/2282
Addresses: [RFC: Saved Object Changes in Audit Logs](https://docs.google.com/document/d/1w2uQZSiOJfXLGPImhhxa6GbVyg_yqrI8dgGaDIaN2m0/edit?tab=t.0#heading=h.gsls1roeb9l6)
Addresses: [RFC: Saved Objects versioning capability](https://docs.google.com/document/d/1PcNowDCJQVK9kPvSYOPNK--4rAVuj3B_DHhPnmC0GBQ/edit?tab=t.0#heading=h.85jeclqcerrh)

## POC 1: The "carbon-copy" approach (duplicate as you write).

This is a draft POC for commenting purposes / discovery on Draft RFC for Saved Objects versioning.

Part of a wider investigation on _what can be done_. To stimulate discussion.

**See also:**

- [POC 2: The "compare on save" approach](https://github.com/elastic/kibana/pull/243221)
- [POC 2.5: The "compare on save" approach (+ "masking" 🔒 encrypted fields)](https://github.com/elastic/kibana/pull/246920)
- [MVP: The "alerting framework" approach](https://github.com/elastic/kibana/pull/251471)


### Summary

1. Whenever SO client writes to ES, we send a **duplicate copy at the same time** to a `_snapshot` index.
2. Calling plugins tell the SO client when they want snapshots, by **adding a `snapshot: true` during update** calls in `options` payload .
3. SO service creates **`{type}_snapshot`** index during `start()` phase.


<img width="600" alt="image" src="https://github.com/user-attachments/assets/4a6f459c-276c-47f1-9ce0-6f2ca18fb859" />

or

<img width="700" alt="image" src="https://github.com/user-attachments/assets/8c4ac2d1-adbe-4379-ba13-40cfb6aaff31" />



### Pros / Features / Key functionality

- Exact copies of payload.
- Simple to understand and implement.
- Calling plugins retain control of whether snapshots are created _per call_ (ie which fields cause a new version).
- Centrally managed index (inside saved objects migration flow).
- No logic/processing. Just creates extra copies of data sent via ES client.
- Reduced chance for 'mid-flight' race conditions (no loading records from db before extra write)
- `create`/`bulkCreate` calls use same payload
- `update`/`bulkUpdate` rely on `_reindex` (by id), as not all data is available.

### Cons / Risks / Missing functionality

- A bit basic. No diffing algo (maybe something we can add as post processing).
- Heavy. Keeping all the snapshots will add up a lot of space over time.
- No transaction isolation: `_snapshot` index can go out of sync with SO if either fails to write
- OOM. Bulk calls with thousands of SOs will double memory footprint (2x the JSON/payload size). Though this can be bypassed by using `_reindex` instead of duplicating payloads.


### Screenshots 

https://github.com/user-attachments/assets/11d34791-4bfc-44c1-8cfb-21b6290b67e2

