### PR TITLE
[Storage Adapter] Allow array of strings for keyword

### DIFF
--- a/src/platform/packages/shared/kbn-storage-adapter/types.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/types.ts
@@ -82,7 +82,7 @@ type PrimitiveOf<TProperty extends StorageMappingProperty> = {
     ? TEnums extends Array<infer TEnum>
       ? TEnum
       : never
-    : string;
+    : string | string[];
   match_only_text: string;
   text: string;
   boolean: boolean;

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/persisted/client/storage.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/persisted/client/storage.ts
@@ -55,7 +55,6 @@ export interface AgentConfigurationProperties {
 
 export type AgentProfileStorageSettings = typeof storageSettings;
 
-// @ts-expect-error type mismatch for labels type
 export type AgentProfileStorage = StorageIndexAdapter<AgentProfileStorageSettings, AgentProperties>;
 
 export const createStorage = ({
@@ -65,7 +64,6 @@ export const createStorage = ({
   logger: Logger;
   esClient: ElasticsearchClient;
 }): AgentProfileStorage => {
-  // @ts-expect-error type mismatch for labels type
   return new StorageIndexAdapter<AgentProfileStorageSettings, AgentProperties>(
     esClient,
     logger,

--- a/x-pack/platform/plugins/shared/onechat/server/services/tools/persisted/client/storage.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/tools/persisted/client/storage.ts
@@ -45,7 +45,6 @@ export interface ToolProperties<TConfig extends object = Record<string, unknown>
 
 export type ToolStorageSettings = typeof storageSettings;
 
-// @ts-expect-error type mismatch for tags type
 export type ToolStorage = StorageIndexAdapter<ToolStorageSettings, ToolProperties>;
 
 export const createStorage = ({
@@ -55,7 +54,6 @@ export const createStorage = ({
   logger: Logger;
   esClient: ElasticsearchClient;
 }): ToolStorage => {
-  // @ts-expect-error type mismatch for tags type
   return new StorageIndexAdapter<ToolStorageSettings, ToolProperties>(
     esClient,
     logger,


### PR DESCRIPTION
## Summary

Fixes a type issue in the storage adapter to properly support keyword fields that contain arrays of strings.

## Changes

- Updated the `PrimitiveOf` type for `keyword` fields in `kbn-storage-adapter` to accept both `string` and `string[]` types
- Removed `@ts-expect-error` suppressions from agent and tool storage implementations that were previously needed to work around this type mismatch

## Background

The storage adapter's type definition for `keyword` fields was too restrictive, only allowing `string` values. However, some properties like `labels` in agent profiles and `tags` in tool profiles need to store arrays of strings. This required using `@ts-expect-error` comments to suppress the type errors.

This PR fixes the root cause by allowing keyword fields to accept both single strings and arrays of strings, making the type system accurately reflect the actual Elasticsearch mapping capabilities.