### PR TITLE
[One Workflow] add "has" and "has_exp" filters to autocompletion

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/liquid/liquid_completions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/liquid/liquid_completions.ts
@@ -171,6 +171,21 @@ export const LIQUID_FILTERS = [
       '{{ products | group_by_exp: "item.price > 100" }} => [{"name": "true", "items": [...]}, {"name": "false", "items": [...]}]',
   },
   {
+    name: 'has',
+    description:
+      'Checks if an array of objects contains an object with a property (one param) or a specific property value (two params)',
+    insertText: 'has: "${1:property}", "${2:value}"',
+    example:
+      '{{ products | has: "type" }} => true if any product has "type" property\n{{ products | has: "type", "book" }} => true if any product has type="book"',
+  },
+  {
+    name: 'has_exp',
+    description: 'Checks if an array contains an item that matches an expression',
+    insertText: 'has_exp: "${1:itemName}", "${2:expression}"',
+    example:
+      '{{ products | has_exp: "item", "item.price > 100" }} => true if any product has price > 100',
+  },
+  {
     name: 'join',
     description: 'Combines the items in an array into a single string',
     insertText: 'join: "${1:separator}"',


### PR DESCRIPTION
- Liquid recently introduced the "has" filter.
- The filter is already included in the Liquid version we’re currently using, so validation already works.
- Add autocompletion.

[Shopify's "has" docs](https://shopify.dev/docs/api/liquid/filters/has)
[LiquidJS implementation](https://github.com/harttle/liquidjs/pull/799/files#diff-8a2c4bbee7bd5a8314e6126bd9bcf8b3a088420652911fac2f0af60e5c316299)