### PR TITLE
[One Workflow] fix: weird quoting of insert text for autocompletions in plain scalar

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/context/autocomplete.types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/context/autocomplete.types.ts
@@ -12,30 +12,43 @@ import type { monaco } from '@kbn/monaco';
 import type { ConnectorTypeInfo } from '@kbn/workflows';
 import type { z } from '@kbn/zod';
 import type { LineParseResult } from './parse_line_for_completion';
-import type { StepInfo } from '../../../../../entities/workflows/store/workflow_detail/utils/build_workflow_lookup';
+import type {
+  StepInfo,
+  StepPropInfo,
+} from '../../../../../entities/workflows/store/workflow_detail/utils/build_workflow_lookup';
 
 // TODO: see if we can reduce the number of properties in this interface and group them into smaller interfaces
 export interface AutocompleteContext {
+  // what triggered the completion
   triggerCharacter: string | null;
   triggerKind: monaco.languages.CompletionTriggerKind | null;
-  range: monaco.IRange;
+
+  // content
   line: string;
   lineUpToCursor: string;
   lineParseResult: LineParseResult | null;
+
+  // position of the cursor
+  path: (string | number)[];
+  range: monaco.IRange;
+  absoluteOffset: number;
+  focusedStepInfo: StepInfo | null;
+  focusedYamlPair: StepPropInfo | null;
+
+  // context
   contextSchema: z.ZodType;
   contextScopedToPath: string | null;
-  focusedStepInfo: StepInfo | null;
   yamlDocument: Document;
   scalarType: Scalar.Type | null;
-  path: (string | number)[];
-  absoluteOffset: number;
-  dynamicConnectorTypes: Record<string, ConnectorTypeInfo> | null;
+
+  // kind of ast info
   isInLiquidBlock: boolean;
   isInTriggersContext: boolean;
   isInScheduledTriggerWithBlock: boolean;
   isInStepsContext: boolean;
-  shouldUseCurlyBraces: boolean;
-  shouldBeQuoted: boolean;
+
+  // dynamic connector types
+  dynamicConnectorTypes: Record<string, ConnectorTypeInfo> | null;
 }
 
 // we don't want to pass model and position, but currently it's used in getWithBlockSuggestions

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/context/build_autocomplete_context.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/context/build_autocomplete_context.ts
@@ -62,12 +62,6 @@ export function buildAutocompleteContext({
     return null;
   }
 
-  // variables
-  let shouldUseCurlyBraces = true;
-  if (completionContext.triggerCharacter === '@' && focusedYamlPair) {
-    shouldUseCurlyBraces = focusedYamlPair.keyNode.value !== 'foreach';
-  }
-
   let range: monaco.IRange;
   if (completionContext.triggerCharacter === ' ') {
     // When triggered by space, set range to start at current position
@@ -91,7 +85,6 @@ export function buildAutocompleteContext({
   const path = getPathAtOffset(yamlDocument, absoluteOffset);
   const yamlNode = yamlDocument.getIn(path, true);
   const scalarType = isScalar(yamlNode) ? yamlNode.type ?? null : null;
-  const shouldBeQuoted = scalarType === null || scalarType === 'PLAIN';
 
   let contextSchema: z.ZodType = DynamicStepContextSchema;
   let contextScopedToPath: string | null = null;
@@ -131,19 +124,19 @@ export function buildAutocompleteContext({
     lineUpToCursor,
     lineParseResult: parseResult,
 
+    // position of the cursor
+    path,
+    range,
+    absoluteOffset,
+    focusedStepInfo,
+    focusedYamlPair,
+    // TODO: add currentTriggerInfo
+
     // context
     contextSchema,
     contextScopedToPath,
     yamlDocument,
     scalarType,
-
-    // position of the cursor
-    path,
-    range,
-    absoluteOffset,
-    // currentStepInfo
-    focusedStepInfo,
-    // TODO: add currentTriggerInfo
 
     // kind of ast info
     isInLiquidBlock,
@@ -153,9 +146,5 @@ export function buildAutocompleteContext({
 
     // dynamic connector types
     dynamicConnectorTypes: currentDynamicConnectorTypes ?? null,
-
-    // formatting
-    shouldUseCurlyBraces,
-    shouldBeQuoted,
   };
 }

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/get_variable_suggestions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/get_variable_suggestions.ts
@@ -20,15 +20,24 @@ export function getVariableSuggestions(autocompleteContext: AutocompleteContext)
     range,
     contextSchema,
     contextScopedToPath,
+    focusedYamlPair,
     scalarType,
-    shouldBeQuoted,
-    shouldUseCurlyBraces,
     lineParseResult,
   } = autocompleteContext;
 
   if (!lineParseResult || !isVariableLineParseResult(lineParseResult)) {
     return [];
   }
+
+  // variables
+  let shouldUseCurlyBraces = true;
+  if (triggerCharacter === '@' && focusedYamlPair) {
+    shouldUseCurlyBraces = focusedYamlPair.keyNode.value !== 'foreach';
+  }
+
+  // We only add quotes if there's nothing other than the full key in the value node
+  const shouldBeQuoted =
+    (scalarType === null || scalarType === 'PLAIN') && focusedYamlPair?.valueNode.value === '@';
 
   const suggestions: monaco.languages.CompletionItem[] = [];
   const currentSchema: z.ZodType | null = contextSchema;

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/get_variable_suggestions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/get_variable_suggestions.ts
@@ -28,16 +28,19 @@ export function getVariableSuggestions(autocompleteContext: AutocompleteContext)
   if (!lineParseResult || !isVariableLineParseResult(lineParseResult)) {
     return [];
   }
-
-  // variables
-  let shouldUseCurlyBraces = true;
-  if (triggerCharacter === '@' && focusedYamlPair) {
-    shouldUseCurlyBraces = focusedYamlPair.keyNode.value !== 'foreach';
-  }
-
   // We only add quotes if there's nothing other than the full key in the value node
+  const wholePairValue =
+    typeof focusedYamlPair?.valueNode.value === 'string' ? focusedYamlPair?.valueNode.value : '';
   const shouldBeQuoted =
-    (scalarType === null || scalarType === 'PLAIN') && focusedYamlPair?.valueNode.value === '@';
+    (scalarType === null || scalarType === 'PLAIN') &&
+    (wholePairValue.startsWith('@') || wholePairValue.startsWith('{{') || wholePairValue === '');
+
+  // Do not wrap in curly braces if
+  // 1) we're in a foreach block
+  // 2) we're completing an existing variable
+  // 3) we're completing an @ trigger
+  const shouldUseCurlyBraces =
+    focusedYamlPair?.keyNode.value !== 'foreach' && lineParseResult.matchType === 'at';
 
   const suggestions: monaco.languages.CompletionItem[] = [];
   const currentSchema: z.ZodType | null = contextSchema;

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/wrap_as_monaco_suggestion.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/variable/wrap_as_monaco_suggestion.ts
@@ -11,7 +11,6 @@ import type { Scalar } from 'yaml';
 import { monaco } from '@kbn/monaco';
 import { PROPERTY_PATH_REGEX } from '../../../../../../../common/lib/regex';
 
-// TODO: extract the formatting logic, which is related only to the variable completions
 export function wrapAsMonacoSuggestion(
   key: string,
   triggerCharacter: string | null,
@@ -36,6 +35,7 @@ export function wrapAsMonacoSuggestion(
   let insertText = keyToInsert;
   let insertTextRules = monaco.languages.CompletionItemInsertTextRule.None;
   if (isAt) {
+    // $0 is the cursor position
     insertText = `${key}$0`;
     if (useCurlyBraces) {
       insertText = `{{ ${insertText} }}`;
@@ -46,7 +46,6 @@ export function wrapAsMonacoSuggestion(
   if (shouldBeQuoted) {
     insertText = `"${insertText}"`;
   }
-  // $0 is the cursor position
   return {
     label: key,
     kind: monaco.languages.CompletionItemKind.Field,


### PR DESCRIPTION
Close https://github.com/elastic/security-team/issues/14676

## Before

https://github.com/user-attachments/assets/94227fcd-e9f6-4e16-9b9f-e10589196890

## After

https://github.com/user-attachments/assets/fb86db40-5880-45d4-b0ef-c8bd8a0175bb

