### PR TITLE
[ObsUX][Infra] Improve link name in Hosts Flyout

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/overview/services.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/overview/services.tsx
@@ -128,6 +128,10 @@ export const ServicesContent = ({
             values={{
               apmTutorialLink: (
                 <EuiLink
+                  aria-label={i18n.translate(
+                    'xpack.infra.servicesContent.euiLink.apmTutorialLinkLabel',
+                    { defaultMessage: 'APM Instrumentation Tutorial' }
+                  )}
                   data-test-subj="assetDetailsTooltipAPMTutorialLink"
                   href={isServerlessEnv ? serverlessLinkProps.href : linkProps.href}
                 >


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/194962


This PR improves the link name in hosts flyout.

| Before | After |
|--------|--------|
| <img width="4596" height="1172" alt="image" src="https://github.com/user-attachments/assets/854a75a4-bd8d-4aa9-8079-ad08206f2bb3" /> | <img width="645" height="266" alt="image" src="https://github.com/user-attachments/assets/9bdded1e-d45f-44fd-8cc5-6355e60ee2ee" /> | 







<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->