### PR TITLE
[Infra][Hosts] Charts not filtering by host.name fix

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/chart.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/chart.tsx
@@ -20,7 +20,7 @@ import { useAfterLoadedState } from '../../../hooks/use_after_loaded_state';
 
 export type ChartProps = LensConfig & {
   id: string;
-  dataView?: DataView;
+  dataView: DataView | undefined;
 };
 
 export const Chart = ({ id, dataView, ...chartProps }: ChartProps) => {

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/metrics_grid.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/metrics_grid.tsx
@@ -43,7 +43,7 @@ export const MetricsGrid = () => {
       <EuiFlexGrid columns={2} gutterSize="s" data-test-subj="hostsView-metricChart">
         {charts.map((chartProp, index) => (
           <EuiFlexItem key={index} grow={false}>
-            <Chart {...chartProp} />
+            <Chart {...chartProp} dataView={metricsView?.dataViewReference} />
           </EuiFlexItem>
         ))}
       </EuiFlexGrid>


### PR DESCRIPTION
fixes https://github.com/elastic/kibana/issues/242665

## Summary

This PR fixes a regression caused by https://github.com/elastic/kibana/pull/238872, which made the chart component not build the filter by host name.


![host_fix](https://github.com/user-attachments/assets/c733559b-2c1b-4482-9e2f-ac3f2b0ec300)


### How to test

- Start Kibana pointing to an oblt cluster 
- Navigate to Hosts
- Filter by anything that will return at least 1 host. All the charts in the grid should only show data for the hosts in the table





<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2"]} ONMERGE-->