### PR TITLE
[Metrics][Discover] Fix broken "Values" dropdown on smaller screens

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart_section_template.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart_section_template.tsx
@@ -65,13 +65,13 @@ export const ChartSectionTemplate = ({
                 flex-basis: 100%;
                 order: 3;
 
-                .euiFlexGroup {
+                > .euiFlexGroup {
                   flex-wrap: wrap;
-                }
 
-                .euiFlexItem {
-                  flex-grow: 1;
-                  flex-basis: 100%;
+                  > .euiFlexItem {
+                    flex-grow: 1;
+                    flex-basis: 100%;
+                  }
                 }
               }
               [data-toolbar-section='right'] {


### PR DESCRIPTION
## Summary

Closes #242684

This PR fixes broken "Values" dropdown on smaller screens.

Before:
<img width="839" height="969" alt="Screenshot 2025-11-12 at 13 29 26" src="https://github.com/user-attachments/assets/ecd61423-67c1-45d1-ad17-e2f3ee0907fd" />


After:
<img width="836" height="963" alt="Screenshot 2025-11-12 at 13 27 39" src="https://github.com/user-attachments/assets/bb05dde2-e2b4-42a7-9296-e111593a14d7" />




