### PR TITLE
[One Workflow] fix: manually registering and disposing of the completion provider to avoid stale data

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_workflow_yaml_completion_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_workflow_yaml_completion_provider.ts
@@ -9,19 +9,19 @@
 
 import { useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
+import type { monaco } from '@kbn/monaco';
 import type { WorkflowDetailState } from '../../../../entities/workflows/store';
 import { selectDetail } from '../../../../entities/workflows/store/workflow_detail/selectors';
 import { getCompletionItemProvider } from '../../lib/autocomplete/get_completion_item_provider';
 
-export const useCompletionProvider = () => {
+export const useWorkflowYamlCompletionProvider = (): monaco.languages.CompletionItemProvider => {
   const editorState = useSelector(selectDetail);
   const editorStateRef = useRef<WorkflowDetailState>(editorState);
   editorStateRef.current = editorState;
 
-  const completionProvider = useMemo(
-    () => getCompletionItemProvider(() => editorStateRef.current),
-    []
-  );
+  const completionProvider = useMemo(() => {
+    return getCompletionItemProvider(() => editorStateRef.current);
+  }, []);
 
   return completionProvider;
 };

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.test.tsx
@@ -331,12 +331,6 @@ steps:
   });
 
   describe('completion provider', () => {
-    let completionProvider: monaco.languages.CompletionItemProvider;
-
-    beforeEach(() => {
-      completionProvider = getCompletionItemProvider(() => createMockStore().getState().detail);
-    });
-
     it('registers the completion provider when the editor mounts', () => {
       const yamlContent = 'version: "1"\nname: "test"';
       const store = createMockStore();

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.test.tsx
@@ -12,16 +12,28 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { I18nProviderMock } from '@kbn/core-i18n-browser-mocks/src/i18n_context_mock';
+import { monaco, YAML_LANG_ID } from '@kbn/monaco';
 import type { WorkflowYAMLEditorProps } from './workflow_yaml_editor';
 import { WorkflowYAMLEditor } from './workflow_yaml_editor';
 import { setActiveTab, setExecution, setYamlString } from '../../../entities/workflows/store';
 import { createMockStore } from '../../../entities/workflows/store/__mocks__/store.mock';
+import type { YamlEditorProps } from '../../../shared/ui';
+import { getCompletionItemProvider } from '../lib/autocomplete/get_completion_item_provider';
 
 // Mock the YamlEditor component to avoid Monaco complexity in tests
 jest.mock('../../../shared/ui/yaml_editor', () => ({
-  YamlEditor: ({ value, onChange, ...props }: any) => (
+  YamlEditor: ({ value, onChange, editorDidMount, ...props }: YamlEditorProps) => (
     <div data-testid="yaml-editor">
       <textarea
+        ref={(el) => {
+          const editorMock = {
+            getModel: jest.fn(),
+            dispose: jest.fn(),
+          } as unknown as monaco.editor.IStandaloneCodeEditor;
+          if (el) {
+            editorDidMount?.(editorMock);
+          }
+        }}
         value={value || ''}
         onChange={(e: any) => onChange?.(e.target.value)}
         data-testid="yaml-textarea"
@@ -38,11 +50,6 @@ jest.mock('../../../features/validate_workflow_yaml/lib/use_yaml_validation', ()
     validateVariables: jest.fn(),
     handleMarkersChanged: jest.fn(),
   }),
-}));
-
-// Mock the completion provider
-jest.mock('./hooks/use_completion_provider', () => ({
-  useCompletionProvider: jest.fn().mockReturnValue({}),
 }));
 
 // Mock the UnsavedChangesPrompt
@@ -160,6 +167,29 @@ jest.mock(
     })),
   })
 );
+
+const mockCompletionProvider = {
+  triggerCharacters: ['@', '.', ' ', '|', '{'],
+  provideCompletionItems: jest.fn(),
+};
+
+jest.mock('../lib/autocomplete/get_completion_item_provider', () => ({
+  getCompletionItemProvider: jest.fn(() => mockCompletionProvider),
+}));
+
+jest.mock('@kbn/monaco', () => ({
+  monaco: {
+    editor: {
+      setModelMarkers: jest.fn(),
+    },
+    languages: {
+      registerCompletionItemProvider: jest.fn().mockReturnValue({
+        dispose: jest.fn(),
+      }),
+    },
+  },
+  YAML_LANG_ID: 'yaml',
+}));
 
 describe('WorkflowYAMLEditor', () => {
   const defaultProps: WorkflowYAMLEditorProps = {
@@ -297,6 +327,58 @@ steps:
         '[data-testid="yaml-textarea"]'
       ) as HTMLTextAreaElement;
       expect(textarea?.value).toBe(yamlContent);
+    });
+  });
+
+  describe('completion provider', () => {
+    let completionProvider: monaco.languages.CompletionItemProvider;
+
+    beforeEach(() => {
+      completionProvider = getCompletionItemProvider(() => createMockStore().getState().detail);
+    });
+
+    it('registers the completion provider when the editor mounts', () => {
+      const yamlContent = 'version: "1"\nname: "test"';
+      const store = createMockStore();
+      store.dispatch(setYamlString(yamlContent));
+      store.dispatch(setActiveTab('workflow'));
+
+      renderWithProviders(<WorkflowYAMLEditor {...defaultProps} />, store);
+
+      // Verify that registerCompletionItemProvider was called with the correct parameters
+      expect(monaco.languages.registerCompletionItemProvider).toHaveBeenCalledWith(
+        YAML_LANG_ID,
+        mockCompletionProvider
+      );
+
+      // Verify that getCompletionItemProvider was called
+      expect(getCompletionItemProvider).toHaveBeenCalled();
+
+      // Get the second argument passed to registerCompletionItemProvider
+      const registeredProvider = (monaco.languages.registerCompletionItemProvider as jest.Mock).mock
+        .calls[0][1];
+
+      // Verify it's the same object returned by our mock
+      expect(registeredProvider).toBe(mockCompletionProvider);
+      expect(registeredProvider).toHaveProperty('triggerCharacters', ['@', '.', ' ', '|', '{']);
+      expect(registeredProvider).toHaveProperty('provideCompletionItems');
+    });
+
+    it('should dispose the completion provider when the editor unmounts', () => {
+      const yamlContent = 'version: "1"\nname: "test"';
+      const store = createMockStore();
+      store.dispatch(setYamlString(yamlContent));
+      store.dispatch(setActiveTab('workflow'));
+
+      const { unmount } = renderWithProviders(<WorkflowYAMLEditor {...defaultProps} />, store);
+
+      const registeredProvider = (monaco.languages.registerCompletionItemProvider as jest.Mock).mock
+        .results[0].value;
+
+      unmount();
+
+      // Verify that dispose was called on the completion provider
+      expect(registeredProvider.dispose).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Close https://github.com/elastic/security-team/issues/14677

## Before

https://github.com/user-attachments/assets/33162a72-e622-4620-96cf-e55479b9e478

## After

https://github.com/user-attachments/assets/897dc84b-0825-4b1a-8191-1497af222954


