### PR TITLE
[Fleet] fix docker image in Add agent k8s manifest

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -23,7 +23,7 @@ import {
   packagePolicyService,
   licenseService,
 } from '../../services';
-import { type AgentClient, getLatestAvailableAgentVersion } from '../../services/agents';
+import { type AgentClient } from '../../services/agents';
 import {
   AGENTS_PREFIX,
   MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_10,
@@ -73,6 +73,7 @@ import { FLEET_API_PRIVILEGES } from '../../constants/api_privileges';
 import { getAutoUpgradeAgentsStatus } from '../../services/agents';
 
 import { createPackagePolicyHandler } from '../package_policy/handlers';
+import { getLatestAgentAvailableDockerImageVersion } from '../../services/agents';
 
 export async function populateAssignedAgentsCount(
   agentClient: AgentClient,
@@ -684,7 +685,7 @@ export const getFullAgentPolicy: FleetRequestHandler<
 
   if (request.query.kubernetes === true) {
     const agentVersion =
-      await fleetContext.agentClient.asInternalUser.getLatestAgentAvailableVersion();
+      await fleetContext.agentClient.asInternalUser.getLatestAgentAvailableDockerImageVersion();
     const fullAgentConfigMap = await agentPolicyService.getFullAgentConfigMap(
       soClient,
       request.params.agentPolicyId,
@@ -740,7 +741,7 @@ export const downloadFullAgentPolicy: FleetRequestHandler<
 
   if (request.query.kubernetes === true) {
     const agentVersion =
-      await fleetContext.agentClient.asInternalUser.getLatestAgentAvailableVersion();
+      await fleetContext.agentClient.asInternalUser.getLatestAgentAvailableDockerImageVersion();
     const fullAgentConfigMap = await agentPolicyService.getFullAgentConfigMap(
       soClient,
       request.params.agentPolicyId,
@@ -793,7 +794,7 @@ export const getK8sManifest: FleetRequestHandler<
   const fleetServer = request.query.fleetServer ?? '';
   const token = request.query.enrolToken ?? '';
 
-  const agentVersion = await getLatestAvailableAgentVersion();
+  const agentVersion = await getLatestAgentAvailableDockerImageVersion();
 
   const fullAgentManifest = await agentPolicyService.getFullAgentManifest(
     fleetServer,
@@ -821,7 +822,7 @@ export const downloadK8sManifest: FleetRequestHandler<
 > = async (context, request, response) => {
   const fleetServer = request.query.fleetServer ?? '';
   const token = request.query.enrolToken ?? '';
-  const agentVersion = await getLatestAvailableAgentVersion();
+  const agentVersion = await getLatestAgentAvailableDockerImageVersion();
   const fullAgentManifest = await agentPolicyService.getFullAgentManifest(
     fleetServer,
     token,

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/index.test.ts
@@ -69,7 +69,7 @@ jest.mock('../../services', () => ({
 }));
 
 jest.mock('../../services/agents', () => ({
-  getLatestAvailableAgentVersion: jest.fn().mockResolvedValue('1.0.0'),
+  getLatestAgentAvailableDockerImageVersion: jest.fn().mockResolvedValue('1.0.0'),
 }));
 
 describe('schema validation', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/index.ts
@@ -21,5 +21,9 @@ export { getAgentUploads, getAgentUploadFile, deleteAgentUploadFile } from './up
 export { AgentServiceImpl } from './agent_service';
 export type { AgentClient, AgentService } from './agent_service';
 export { BulkActionsResolver } from './bulk_actions_resolver';
-export { getAvailableVersions, getLatestAvailableAgentVersion } from './versions';
+export {
+  getAvailableVersions,
+  getLatestAvailableAgentVersion,
+  getLatestAgentAvailableDockerImageVersion,
+} from './versions';
 export { getAutoUpgradeAgentsStatus } from './auto_upgrade_agents_status';

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.test.ts
@@ -12,7 +12,11 @@ import type { DeepPartial } from 'utility-types';
 
 import type { FleetConfigType } from '../../../public/plugin';
 
-import { getAvailableVersions, getLatestAvailableAgentVersion } from './versions';
+import {
+  getAvailableVersions,
+  getLatestAgentAvailableDockerImageVersion,
+  getLatestAvailableAgentVersion,
+} from './versions';
 
 let mockKibanaVersion = '300.0.0';
 let mockConfig: DeepPartial<FleetConfigType> = {};
@@ -157,6 +161,44 @@ describe('getLatestAvailableAgentVersion', () => {
     const res = await getLatestAvailableAgentVersion({ ignoreCache: true });
 
     expect(res).toEqual('8.12.2+build20240501');
+  });
+});
+
+describe('getLatestAgentAvailableDockerImageVersion', () => {
+  it('should return latest available docker image version with + replaced by .', async () => {
+    mockKibanaVersion = '8.12.2';
+    mockedReadFile.mockResolvedValue(
+      `["8.13.0", "8.12.2+build20240501", "8.12.2+build20240501", "8.12.2",  "8.12.1", "8.12.0"]`
+    );
+    mockedFetch.mockResolvedValueOnce({
+      status: 200,
+      text: jest.fn().mockResolvedValue(
+        JSON.stringify([
+          [
+            {
+              title: 'Elastic Agent 8.13.0',
+              version_number: '8.13.0',
+            },
+            {
+              title: 'Elastic Agent 8.12.2',
+              version_number: '8.12.2',
+            },
+            {
+              title: 'Elastic Agent 8.12.1',
+              version_number: '8.12.1',
+            },
+            {
+              title: 'Elastic Agent 8.12.0',
+              version_number: '8.12.0',
+            },
+          ],
+        ])
+      ),
+    } as any);
+
+    const res = await getLatestAgentAvailableDockerImageVersion({ ignoreCache: true });
+
+    expect(res).toEqual('8.12.2.build20240501');
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.ts
@@ -68,6 +68,17 @@ export const getLatestAvailableAgentVersion = async ({
   return latestCompatibleVersion;
 };
 
+export const getLatestAgentAvailableDockerImageVersion = async ({
+  includeCurrentVersion = false,
+  ignoreCache = false,
+}: {
+  includeCurrentVersion?: boolean;
+  ignoreCache?: boolean;
+} = {}): Promise<string> => {
+  const fullVersion = await getLatestAvailableAgentVersion({ includeCurrentVersion, ignoreCache });
+  return fullVersion.replace('+', '.');
+};
+
 export const getAvailableVersions = async ({
   includeCurrentVersion,
   ignoreCache = false, // This is only here to allow us to ignore the cache in tests


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/242560

Replace `+` with `.` in kubernetes manifest in Add agent instructions.

<img width="879" height="1063" alt="image" src="https://github.com/user-attachments/assets/c9954936-2bd6-46ea-a4ce-a26edfea3a4c" />

```
docker pull docker.elastic.co/elastic-agent/elastic-agent:9.2.0.build202510300150
9.2.0.build202510300150: Pulling from elastic-agent/elastic-agent
5445572ec352: Already exists 
885bf482c68d: Pull complete 
```


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->