### PR TITLE
[Lens] Increase timeout for some FTR helpers due to MKI flakyness

### DIFF
--- a/x-pack/platform/test/functional/page_objects/lens_page.ts
+++ b/x-pack/platform/test/functional/page_objects/lens_page.ts
@@ -779,7 +779,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       });
 
       await testSubjects.click('confirmSaveSavedObjectButton');
-      await retry.waitForWithTimeout('Save modal to disappear', 2000, () =>
+      await retry.waitForWithTimeout('Save modal to disappear', 5000, () =>
         testSubjects
           .missingOrFail('confirmSaveSavedObjectButton')
           .then(() => true)
@@ -970,7 +970,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       await retry.try(async () => {
         const allChartSwitches = await testSubjects.findAll('lnsChartSwitchPopover');
         await allChartSwitches[layerIndex].click();
-        await testSubjects.existOrFail('lnsChartSwitchList', { timeout: 2000 });
+        await testSubjects.existOrFail('lnsChartSwitchList', { timeout: 5000 });
       });
     },
 


### PR DESCRIPTION
## Summary

Increase timeout for save modal and chart switch popover to 5s.
