### PR TITLE
[Lens] Hide toolbar when ESQL helper is visible

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
@@ -115,11 +115,7 @@ export const FlyoutWrapper = ({
             )}
             <EuiFlexItem grow={true} />
             {toolbar && (
-              <EuiFlexItem
-                css={css({ zIndex: euiTheme.levels.menu })}
-                grow={false}
-                data-test-subj="lnsVisualizationToolbar"
-              >
+              <EuiFlexItem grow={false} data-test-subj="lnsVisualizationToolbar">
                 {toolbar}
               </EuiFlexItem>
             )}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/flyout_container.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/flyout_container.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
+import type { Interpolation, Theme } from '@emotion/react';
 import { css } from '@emotion/react';
 import {
   EuiFlyoutHeader,
@@ -51,6 +52,7 @@ export function FlyoutContainer({
   children,
   customFooter,
   isInlineEditing,
+  overrideContainerCss,
 }: {
   isOpen: boolean;
   handleClose: () => void;
@@ -61,6 +63,7 @@ export function FlyoutContainer({
   panelContainerRef?: (el: HTMLDivElement) => void;
   customFooter?: React.ReactElement;
   isInlineEditing?: boolean;
+  overrideContainerCss?: Interpolation<Theme>;
 }) {
   const [focusTrapIsEnabled, setFocusTrapIsEnabled] = useState(false);
   const euiThemeContext = useEuiTheme();
@@ -113,6 +116,7 @@ export function FlyoutContainer({
             `,
             flyoutContainerStyles(euiThemeContext),
             dimensionContainerStyles.self(euiThemeContext),
+            overrideContainerCss,
           ]}
           onAnimationEnd={() => {
             if (isOpen) {

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/flyout_toolbar.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/flyout_toolbar.tsx
@@ -76,7 +76,7 @@ export function FlyoutToolbar<S>({
     [contentMap]
   );
 
-  const flyoutContentStyles = useMemoCss(styles).flyoutContent;
+  const flyoutToolbarStyles = useMemoCss(styles);
 
   const flyoutTitle = idSelected
     ? toolbarOptions.find((toolbarOption) => toolbarOption.id === idSelected)?.label || ''
@@ -117,9 +117,10 @@ export function FlyoutToolbar<S>({
           setIdSelected('');
           setFlyoutVisible(false);
         }}
+        overrideContainerCss={flyoutToolbarStyles.dialog}
       >
         {FlyoutContent ? (
-          <div id={idSelected} css={flyoutContentStyles}>
+          <div id={idSelected} css={flyoutToolbarStyles.flyoutContent}>
             <FlyoutContent {...flyoutContentProps} />
           </div>
         ) : null}
@@ -129,6 +130,10 @@ export function FlyoutToolbar<S>({
 }
 
 const styles = {
+  dialog: ({ euiTheme }: UseEuiTheme) =>
+    css`
+      z-index: ${euiTheme.levels.menu};
+    `,
   flyoutContent: ({ euiTheme }: UseEuiTheme) =>
     css({
       padding: euiTheme.size.base,


### PR DESCRIPTION
## Summary

Updates z-index only for the styles and legend settings flyout container.

This alternative was commented [here](https://github.com/elastic/kibana/pull/241952/files#r2502446362). However, instead of directly updating the `FlyoutContainer` z-index, it is added as an optional overrideContainerCss prop, so it is only increased in the context where we have this problem. 

Closes https://github.com/elastic/kibana/issues/242702

#### Before

<img width="1271" height="627" alt="Screenshot 2025-11-11 at 16 28 53" src="https://github.com/user-attachments/assets/60a9eadb-995e-4d5e-ab54-df81fa035ead" />

#### After

The toolbar buttons are hidden.

<img width="2497" height="324" alt="Screenshot 2025-11-12 at 15 19 01" src="https://github.com/user-attachments/assets/bf6c128c-a7c2-4212-a93e-3455cb967245" />

The ES|QL editor is still not visible.

<img width="2497" height="329" alt="Screenshot 2025-11-12 at 15 19 12" src="https://github.com/user-attachments/assets/96557460-8d4a-4c26-a554-df7936cf060d" />


### Checklist
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.