### PR TITLE
[8.19] [Discover][APM] Remove EuiAccordion temporarily from Attributes tab (#242544)

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/attributes_accordion.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes/doc_viewer_attributes_overview/attributes_accordion.tsx
@@ -7,10 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import React from 'react';
-import { EuiAccordion, EuiText, EuiNotificationBadge, EuiIconTip, useEuiTheme } from '@elastic/eui';
-import { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils';
-import { DataView } from '@kbn/data-views-plugin/common';
-import { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiNotificationBadge,
+  EuiIconTip,
+  useEuiTheme,
+} from '@elastic/eui';
+import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import { AttributesTable } from './attributes_table';
 import { AttributesEmptyPrompt } from './attributes_empty_prompt';
 import { AttributeField } from './attributes_overview';
@@ -48,48 +55,53 @@ export const AttributesAccordion = ({
   isEsqlMode = false,
 }: AttributesAccordionProps) => {
   const { euiTheme } = useEuiTheme();
+
+  // TODO: Re-add EuiAccordion once the buggy interaction between it and EuiDataGrid is
+  // resolved. https://github.com/elastic/kibana/issues/242652
   return (
-    <EuiAccordion
-      id={id}
-      buttonContent={
-        <EuiText size="s">
-          <strong css={{ marginRight: euiTheme.size.xs }}>{title}</strong>
-          <EuiIconTip
-            aria-label={tooltipMessage}
-            type="questionInCircle"
-            color="subdued"
-            size="s"
-            content={tooltipMessage}
-            iconProps={{
-              className: 'eui-alignTop',
-            }}
+    <EuiFlexGroup id={id} direction="column">
+      <EuiFlexItem grow={0}>
+        <EuiFlexGroup>
+          <EuiFlexItem paddingSize="m">
+            <EuiText size="s">
+              <strong css={{ marginRight: euiTheme.size.xs }}>{title}</strong>
+              <EuiIconTip
+                aria-label={tooltipMessage}
+                type="questionInCircle"
+                color="subdued"
+                size="s"
+                content={tooltipMessage}
+                iconProps={{
+                  className: 'eui-alignTop',
+                }}
+              />
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={0} paddingSize="m">
+            <EuiNotificationBadge size="m" color="subdued">
+              {fields.length}
+            </EuiNotificationBadge>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem paddingSize="m">
+        {fields.length === 0 ? (
+          <AttributesEmptyPrompt />
+        ) : (
+          <AttributesTable
+            hit={hit}
+            dataView={dataView}
+            columns={columns}
+            columnsMeta={columnsMeta}
+            fields={fields}
+            searchTerm={searchTerm}
+            onAddColumn={onAddColumn}
+            onRemoveColumn={onRemoveColumn}
+            filter={filter}
+            isEsqlMode={isEsqlMode}
           />
-        </EuiText>
-      }
-      initialIsOpen={fields.length > 0}
-      extraAction={
-        <EuiNotificationBadge size="m" color="subdued">
-          {fields.length}
-        </EuiNotificationBadge>
-      }
-      paddingSize="m"
-    >
-      {fields.length === 0 ? (
-        <AttributesEmptyPrompt />
-      ) : (
-        <AttributesTable
-          hit={hit}
-          dataView={dataView}
-          columns={columns}
-          columnsMeta={columnsMeta}
-          fields={fields}
-          searchTerm={searchTerm}
-          onAddColumn={onAddColumn}
-          onRemoveColumn={onRemoveColumn}
-          filter={filter}
-          isEsqlMode={isEsqlMode}
-        />
-      )}
-    </EuiAccordion>
+        )}
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover][APM] Remove EuiAccordion temporarily from Attributes tab (#242544)](https://github.com/elastic/kibana/pull/242544)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gonçalo Rica Pais da Silva","email":"goncalo.rica@elastic.co"},"sourceCommit":{"committedDate":"2025-11-12T12:25:44Z","message":"[Discover][APM] Remove EuiAccordion temporarily from Attributes tab (#242544)\n\n## Summary\n\nDue to an unfortunate interaction between `EuiAccordion` and\n`EuiDataGrid`, in Chrome, the Attributes tab experiences an infinite\nloop in certain circumstances which trigger a continuous flicker with\nthe scrollbar for an attribute section (See #226986). To fix this\nrequires changes upstream in EUI, but since that is a while off, the\ntemporary solution is to remove `EuiAccordion` for the moment so to\navoid this buggy interaction.\n\n<img width=\"489\" height=\"477\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/a08017d0-a49b-461f-a930-befe536f9fdc\"\n/>\n\n## How to test\n\n- Ensure you are on the Chrome browser (bug did not appear whilst on\nFirefox).\n- Go to Discover whilst in an Observability space, select an OTEL trace\nindex in either classic or ES|QL mode.\n- Select various trace documents and open them in the doc viewer,\nswitching to the Attributes tab.\n- No trace document's Attribute tab should have any attribute\ngroup/section exhibit flickering behaviour.","sha":"1b12f1911d97a6b21ff395895aff4a7e9efb6d87","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.3.0","Team:obs-exploration","v8.19.8","v9.2.2","v9.1.8"],"title":"[Discover][APM] Remove EuiAccordion temporarily from Attributes tab","number":242544,"url":"https://github.com/elastic/kibana/pull/242544","mergeCommit":{"message":"[Discover][APM] Remove EuiAccordion temporarily from Attributes tab (#242544)\n\n## Summary\n\nDue to an unfortunate interaction between `EuiAccordion` and\n`EuiDataGrid`, in Chrome, the Attributes tab experiences an infinite\nloop in certain circumstances which trigger a continuous flicker with\nthe scrollbar for an attribute section (See #226986). To fix this\nrequires changes upstream in EUI, but since that is a while off, the\ntemporary solution is to remove `EuiAccordion` for the moment so to\navoid this buggy interaction.\n\n<img width=\"489\" height=\"477\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/a08017d0-a49b-461f-a930-befe536f9fdc\"\n/>\n\n## How to test\n\n- Ensure you are on the Chrome browser (bug did not appear whilst on\nFirefox).\n- Go to Discover whilst in an Observability space, select an OTEL trace\nindex in either classic or ES|QL mode.\n- Select various trace documents and open them in the doc viewer,\nswitching to the Attributes tab.\n- No trace document's Attribute tab should have any attribute\ngroup/section exhibit flickering behaviour.","sha":"1b12f1911d97a6b21ff395895aff4a7e9efb6d87"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/242544","number":242544,"mergeCommit":{"message":"[Discover][APM] Remove EuiAccordion temporarily from Attributes tab (#242544)\n\n## Summary\n\nDue to an unfortunate interaction between `EuiAccordion` and\n`EuiDataGrid`, in Chrome, the Attributes tab experiences an infinite\nloop in certain circumstances which trigger a continuous flicker with\nthe scrollbar for an attribute section (See #226986). To fix this\nrequires changes upstream in EUI, but since that is a while off, the\ntemporary solution is to remove `EuiAccordion` for the moment so to\navoid this buggy interaction.\n\n<img width=\"489\" height=\"477\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/a08017d0-a49b-461f-a930-befe536f9fdc\"\n/>\n\n## How to test\n\n- Ensure you are on the Chrome browser (bug did not appear whilst on\nFirefox).\n- Go to Discover whilst in an Observability space, select an OTEL trace\nindex in either classic or ES|QL mode.\n- Select various trace documents and open them in the doc viewer,\nswitching to the Attributes tab.\n- No trace document's Attribute tab should have any attribute\ngroup/section exhibit flickering behaviour.","sha":"1b12f1911d97a6b21ff395895aff4a7e9efb6d87"}},{"branch":"8.19","label":"v8.19.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/242681","number":242681,"state":"OPEN"},{"branch":"9.1","label":"v9.1.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->