### PR TITLE
[One Workflow] fix: disable keyboard shortcuts in when executions tab is selected

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/use_register_keyboard_commands.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/use_register_keyboard_commands.ts
@@ -37,6 +37,18 @@ export function useRegisterKeyboardCommands(): UseRegisterKeyboardCommandsReturn
 
       const { editor, openActionsPopover, save, run, saveAndRun } = params;
 
+      /**
+       * Helper function to wrap action handlers with read-only check
+       */
+      const withReadOnlyCheck = <T extends unknown[]>(callback: (...args: T) => void) => {
+        return (...args: T) => {
+          if (editor.getOption(monaco.editor.EditorOption.readOnly) === true) {
+            return;
+          }
+          callback(...args);
+        };
+      };
+
       keyboardActions.current = [
         // Toggle comments action
         // This addresses keyboard layout issues where Ctrl+/ doesn't work on non-US layouts
@@ -54,9 +66,9 @@ export function useRegisterKeyboardCommands(): UseRegisterKeyboardCommandsReturn
             // eslint-disable-next-line no-bitwise
             monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Digit7, // German, Turkish, Spanish, Swiss layouts
           ],
-          run: (ed) => {
+          run: withReadOnlyCheck((ed) => {
             ed.trigger('keyboard', 'editor.action.commentLine', null);
-          },
+          }),
         }),
 
         // Open the actions popover
@@ -67,7 +79,9 @@ export function useRegisterKeyboardCommands(): UseRegisterKeyboardCommandsReturn
           }),
           // eslint-disable-next-line no-bitwise
           keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK],
-          run: openActionsPopover,
+          run: withReadOnlyCheck(() => {
+            openActionsPopover();
+          }),
         }),
 
         // Save action
@@ -78,7 +92,9 @@ export function useRegisterKeyboardCommands(): UseRegisterKeyboardCommandsReturn
           }),
           // eslint-disable-next-line no-bitwise
           keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS],
-          run: save,
+          run: withReadOnlyCheck(() => {
+            save();
+          }),
         }),
 
         // Run action
@@ -89,7 +105,9 @@ export function useRegisterKeyboardCommands(): UseRegisterKeyboardCommandsReturn
           }),
           // eslint-disable-next-line no-bitwise
           keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
-          run,
+          run: withReadOnlyCheck(() => {
+            run();
+          }),
         }),
 
         // Save and Run action
@@ -100,7 +118,9 @@ export function useRegisterKeyboardCommands(): UseRegisterKeyboardCommandsReturn
           }),
           // eslint-disable-next-line no-bitwise
           keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter],
-          run: saveAndRun,
+          run: withReadOnlyCheck(() => {
+            saveAndRun();
+          }),
         }),
       ];
     },

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/actions_menu_button.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/actions_menu_button.tsx
@@ -9,25 +9,22 @@
 
 import type { UseEuiTheme } from '@elastic/eui';
 import { EuiButtonEmpty, EuiText, EuiTextColor } from '@elastic/eui';
+import type { EuiButtonEmptyPropsForButton } from '@elastic/eui/src/components/button/button_empty/button_empty';
 import { css } from '@emotion/react';
 import React from 'react';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { isMac } from '../../../shared/utils/is_mac';
 
-export interface WorkflowYAMLEditorShortcutsProps {
-  onOpenActionsMenu: (open: boolean) => void;
-}
+type ActionsMenuButtonProps = Omit<EuiButtonEmptyPropsForButton, 'children'>;
 
-export function WorkflowYAMLEditorShortcuts({
-  onOpenActionsMenu,
-}: WorkflowYAMLEditorShortcutsProps) {
+export function ActionsMenuButton(props: ActionsMenuButtonProps) {
   const styles = useMemoCss(componentStyles);
 
   const commandKey = isMac() ? '⌘' : 'Ctrl';
 
   return (
-    <EuiButtonEmpty onClick={() => onOpenActionsMenu(true)} size="s">
+    <EuiButtonEmpty size="s" {...props}>
       <EuiText css={{ display: 'flex', alignItems: 'center', gap: '6px' }} size="xs">
         <b>
           <FormattedMessage

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.test.tsx
@@ -51,8 +51,8 @@ jest.mock('../../../shared/ui/unsaved_changes_prompt', () => ({
 }));
 
 // Mock the validation errors component
-jest.mock('./workflow_yaml_validation_errors', () => ({
-  WorkflowYAMLValidationErrors: () => null,
+jest.mock('./workflow_yaml_validation_accordion', () => ({
+  WorkflowYamlValidationAccordion: () => null,
 }));
 
 // Mock the useAvailableConnectors hook
@@ -106,8 +106,8 @@ jest.mock('./step_actions', () => ({
   StepActions: () => null,
 }));
 
-jest.mock('./workflow_yaml_editor_shortcuts', () => ({
-  WorkflowYAMLEditorShortcuts: () => null,
+jest.mock('./actions_menu_button', () => ({
+  ActionsMenuButton: () => null,
 }));
 
 jest.mock('./decorations', () => ({

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -21,6 +21,7 @@ import { monaco } from '@kbn/monaco';
 import { isTriggerType } from '@kbn/workflows';
 import type { WorkflowStepExecutionDto } from '@kbn/workflows/types/v1';
 import type { z } from '@kbn/zod';
+import { ActionsMenuButton } from './actions_menu_button';
 import {
   useAlertTriggerDecorations,
   useConnectorTypeDecorations,
@@ -31,8 +32,7 @@ import {
 } from './decorations';
 import { useCompletionProvider } from './hooks/use_completion_provider';
 import { StepActions } from './step_actions';
-import { WorkflowYAMLEditorShortcuts } from './workflow_yaml_editor_shortcuts';
-import { WorkflowYAMLValidationErrors } from './workflow_yaml_validation_errors';
+import { WorkflowYamlValidationAccordion } from './workflow_yaml_validation_accordion';
 import { useAvailableConnectors } from '../../../entities/connectors/model/use_available_connectors';
 import { useSaveYaml } from '../../../entities/workflows/model/use_save_yaml';
 import type { StepInfo } from '../../../entities/workflows/store';
@@ -531,13 +531,16 @@ export const WorkflowYAMLEditor = ({
         />
       </div>
       <div css={styles.validationErrorsContainer}>
-        <WorkflowYAMLValidationErrors
+        <WorkflowYamlValidationAccordion
           isMounted={isEditorMounted}
           isLoading={isLoadingValidation}
           error={errorValidating}
           validationErrors={validationErrors}
           onErrorClick={handleErrorClick}
-          rightSide={<WorkflowYAMLEditorShortcuts onOpenActionsMenu={setActionsPopoverOpen} />}
+          extraAction={
+            // Only show the shortcuts in edit mode
+            !isExecutionYaml ? <ActionsMenuButton onClick={openActionsPopover} /> : null
+          }
         />
       </div>
     </div>

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_validation_accordion.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_validation_accordion.tsx
@@ -31,23 +31,23 @@ import type {
 
 const severityOrder = ['error', 'warning', 'info'];
 
-interface WorkflowYAMLValidationErrorsProps {
+interface WorkflowYamlValidationAccordionProps {
   isMounted: boolean;
   isLoading: boolean;
   error: Error | null;
   validationErrors: YamlValidationResult[] | null;
   onErrorClick?: (error: YamlValidationResult) => void;
-  rightSide?: React.ReactNode;
+  extraAction?: React.ReactNode;
 }
 
-export function WorkflowYAMLValidationErrors({
+export function WorkflowYamlValidationAccordion({
   isMounted,
   isLoading,
   error: errorValidating,
   validationErrors,
   onErrorClick,
-  rightSide,
-}: WorkflowYAMLValidationErrorsProps) {
+  extraAction,
+}: WorkflowYamlValidationAccordionProps) {
   const styles = useMemoCss(componentStyles);
   const { euiTheme } = useEuiTheme();
   const accordionId = useGeneratedHtmlId({ prefix: 'wf-yaml-editor-validation-errors' });
@@ -158,9 +158,6 @@ export function WorkflowYAMLValidationErrors({
           <EuiFlexItem css={styles.buttonContentText} className="button-content-text">
             {buttonContent}
           </EuiFlexItem>
-          <EuiFlexItem css={styles.buttonContentRightSide} grow={false}>
-            {rightSide}
-          </EuiFlexItem>
         </EuiFlexGroup>
       }
       arrowDisplay={
@@ -169,6 +166,7 @@ export function WorkflowYAMLValidationErrors({
       initialIsOpen={allValidationErrors !== null && allValidationErrors.length > 0}
       isDisabled={allValidationErrors == null || allValidationErrors.length === 0}
       css={styles.accordion}
+      extraAction={extraAction}
     >
       <div css={styles.separator} />
       <div css={styles.accordionContent} className="eui-yScrollWithShadows">
@@ -240,7 +238,6 @@ export function WorkflowYAMLValidationErrors({
 const componentStyles = {
   accordion: ({ euiTheme }: UseEuiTheme) =>
     css({
-      height: '100%',
       padding: `0 ${euiTheme.size.m}`,
       borderTop: `1px solid ${euiTheme.colors.borderBasePlain}`,
       backgroundColor: euiTheme.colors.backgroundBasePlain,
@@ -259,6 +256,8 @@ const componentStyles = {
     }),
   buttonContent: ({ euiTheme }: UseEuiTheme) => css`
     width: 100%;
+    // using min-height to avoid jumping when right side is present/absent
+    min-height: 48px;
     padding: ${euiTheme.size.s} 0;
     color: ${euiTheme.colors.textParagraph};
     flex-wrap: nowrap !important;
@@ -268,9 +267,6 @@ const componentStyles = {
       ...euiFontSize(euiThemeContext, 'xs'),
       whiteSpace: 'nowrap',
     }),
-  buttonContentRightSide: css({
-    justifySelf: 'flex-end',
-  }),
   accordionContent: ({ euiTheme }: UseEuiTheme) =>
     css({
       maxHeight: '200px',


### PR DESCRIPTION
Close https://github.com/elastic/security-team/issues/14683
Close https://github.com/elastic/security-team/issues/14682

## Before

Even in the "Executions" tab, user could open actions menu via hotkey or click and it will modify workflow in read-only mode. Also, save/run/saveAndRun commands were available in the readonly editor, which is confusing.

https://github.com/user-attachments/assets/008c94ee-011d-4fc3-9f53-2df654a81851

## After

When we are on "Executions" tab, "Actions menu" button is hidden, and keyboard command is not working, if we go back to "Workflow" tab it will appear and work again.

Bonus: annoying dom nesting error fixed by using `extraAction` prop of the `EuiAccordion` instead of manually managing it with `rightSide` prop. 


https://github.com/user-attachments/assets/7c5345ad-4fea-48ab-a562-19057cf6ba0d

