### PR TITLE
[Discover] Move H1 tag outside of the tabs

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
@@ -415,22 +415,6 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
         `,
       ]}
     >
-      <h1
-        id="savedSearchTitle"
-        className="euiScreenReaderOnly"
-        data-test-subj="discoverSavedSearchTitle"
-      >
-        {discoverSession?.title
-          ? i18n.translate('discover.pageTitleWithSavedSearch', {
-              defaultMessage: 'Discover - {savedSearchTitle}',
-              values: {
-                savedSearchTitle: discoverSession.title,
-              },
-            })
-          : i18n.translate('discover.pageTitleWithoutSavedSearch', {
-              defaultMessage: 'Discover - Search not yet saved',
-            })}
-      </h1>
       <TopNavMemoized
         savedQuery={savedQuery}
         stateContainer={stateContainer}
@@ -440,7 +424,7 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
         isLoading={isLoading}
         onCancelClick={onCancelClick}
       />
-      <EuiPageBody aria-describedby="savedSearchTitle" css={styles.savedSearchTitle}>
+      <EuiPageBody css={styles.pageBody}>
         <div css={styles.sidebarContainer}>
           {dataViewLoading && (
             <EuiDelayRender delay={300}>
@@ -550,7 +534,7 @@ const componentStyles = {
       padding: 0,
       backgroundColor: euiTheme.colors.backgroundBasePlain,
     }),
-  savedSearchTitle: css({
+  pageBody: css({
     overflow: 'hidden',
   }),
   sidebarContainer: css({

--- a/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
@@ -44,6 +44,7 @@ import { useAlertResultsToast } from './hooks/use_alert_results_toast';
 import { setBreadcrumbs } from '../../utils/breadcrumbs';
 import { useUnsavedChanges } from './state_management/hooks/use_unsaved_changes';
 import { DiscoverTopNavMenuProvider } from './components/top_nav/discover_topnav_menu';
+import { i18n } from '@kbn/i18n';
 
 export interface MainRouteProps {
   customizationContext: DiscoverCustomizationContext;
@@ -252,11 +253,29 @@ const DiscoverMainRouteContent = (props: SingleTabViewProps) => {
     <rootProfileState.AppWrapper>
       <ChartPortalsRenderer runtimeStateManager={runtimeStateManager}>
         <DiscoverTopNavMenuProvider>
-          {tabsEnabled && customizationContext.displayMode !== 'embedded' ? (
-            <TabsView {...props} />
-          ) : (
-            <SingleTabView {...props} />
-          )}
+          <>
+            <h1
+              id="savedSearchTitle"
+              className="euiScreenReaderOnly"
+              data-test-subj="discoverSavedSearchTitle"
+            >
+              {persistedDiscoverSession?.title
+                ? i18n.translate('discover.pageTitleWithSavedSearch', {
+                    defaultMessage: 'Discover - {savedSearchTitle}',
+                    values: {
+                      savedSearchTitle: persistedDiscoverSession.title,
+                    },
+                  })
+                : i18n.translate('discover.pageTitleWithoutSavedSearch', {
+                    defaultMessage: 'Discover - Search not yet saved',
+                  })}
+            </h1>
+            {tabsEnabled && customizationContext.displayMode !== 'embedded' ? (
+              <TabsView {...props} />
+            ) : (
+              <SingleTabView {...props} />
+            )}
+          </>
         </DiscoverTopNavMenuProvider>
       </ChartPortalsRenderer>
     </rootProfileState.AppWrapper>

--- a/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
@@ -254,10 +254,7 @@ const DiscoverMainRouteContent = (props: SingleTabViewProps) => {
       <ChartPortalsRenderer runtimeStateManager={runtimeStateManager}>
         <DiscoverTopNavMenuProvider>
           <>
-            <h1
-              className="euiScreenReaderOnly"
-              data-test-subj="discoverSavedSearchTitle"
-            >
+            <h1 className="euiScreenReaderOnly" data-test-subj="discoverSavedSearchTitle">
               {persistedDiscoverSession?.title
                 ? i18n.translate('discover.pageTitleWithSavedSearch', {
                     defaultMessage: 'Discover - {savedSearchTitle}',

--- a/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
@@ -266,7 +266,7 @@ const DiscoverMainRouteContent = (props: SingleTabViewProps) => {
                     },
                   })
                 : i18n.translate('discover.pageTitleWithoutSavedSearch', {
-                    defaultMessage: 'Discover - Search not yet saved',
+                    defaultMessage: 'Discover - Session not yet saved',
                   })}
             </h1>
             {tabsEnabled && customizationContext.displayMode !== 'embedded' ? (

--- a/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
@@ -16,6 +16,7 @@ import useUnmount from 'react-use/lib/useUnmount';
 import type { AppMountParameters } from '@kbn/core/public';
 import { useExecutionContext } from '@kbn/kibana-react-plugin/public';
 import useLatest from 'react-use/lib/useLatest';
+import { i18n } from '@kbn/i18n';
 import { useDiscoverServices } from '../../hooks/use_discover_services';
 import type { CustomizationCallback, DiscoverCustomizationContext } from '../../customizations';
 import {
@@ -44,7 +45,6 @@ import { useAlertResultsToast } from './hooks/use_alert_results_toast';
 import { setBreadcrumbs } from '../../utils/breadcrumbs';
 import { useUnsavedChanges } from './state_management/hooks/use_unsaved_changes';
 import { DiscoverTopNavMenuProvider } from './components/top_nav/discover_topnav_menu';
-import { i18n } from '@kbn/i18n';
 
 export interface MainRouteProps {
   customizationContext: DiscoverCustomizationContext;

--- a/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
@@ -255,7 +255,6 @@ const DiscoverMainRouteContent = (props: SingleTabViewProps) => {
         <DiscoverTopNavMenuProvider>
           <>
             <h1
-              id="savedSearchTitle"
               className="euiScreenReaderOnly"
               data-test-subj="discoverSavedSearchTitle"
             >


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/231961

## Summary

Before: H1 tag with the discover session title was located inside a tab content.
After: H1 tag is located above of all tabs in DOM tree.


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->