### PR TITLE
[Streams] Suppress toast message on data view creation type fields

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_stream_data_view_field_types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_stream_data_view_field_types.ts
@@ -28,10 +28,14 @@ export function useStreamDataViewFieldTypes(streamName: string) {
   const { value: dataView } = useAbortableAsync(
     async ({ signal }) => {
       try {
-        return await data.dataViews.create({
-          title: streamName,
-          timeFieldName: '@timestamp',
-        });
+        return await data.dataViews.create(
+          {
+            title: streamName,
+            timeFieldName: '@timestamp',
+          },
+          undefined,
+          false
+        );
       } catch (err) {
         // Silently handle errors for new streams that don't have indices yet
         return undefined;


### PR DESCRIPTION
Small fix to the data view creation for the typed icons to suppress the errors displayed by the service method