### PR TITLE
[Security Solution] Replace react router history with window history

### DIFF
--- a/x-pack/solutions/security/packages/expandable-flyout/src/hooks/use_expandable_flyout_api.ts
+++ b/x-pack/solutions/security/packages/expandable-flyout/src/hooks/use_expandable_flyout_api.ts
@@ -6,7 +6,6 @@
  */
 
 import { useCallback, useMemo } from 'react';
-import { useHistory } from 'react-router-dom';
 import { REDUX_ID_FOR_MEMORY_STORAGE } from '../constants';
 import { useExpandableFlyoutContext } from '../context';
 import {
@@ -30,7 +29,6 @@ export type { ExpandableFlyoutApi };
  */
 export const useExpandableFlyoutApi = () => {
   const dispatch = useDispatch();
-  const history = useHistory();
 
   const { urlKey } = useExpandableFlyoutContext();
   // if no urlKey is provided, we are in memory storage mode and use the reserved word 'memory'
@@ -80,9 +78,9 @@ export const useExpandableFlyoutApi = () => {
     if (id === REDUX_ID_FOR_MEMORY_STORAGE) {
       dispatch(previousPreviewPanelAction({ id }));
     } else {
-      history.goBack();
+      window.history.back();
     }
-  }, [dispatch, id, history]);
+  }, [dispatch, id]);
 
   const closePanels = useCallback(() => dispatch(closePanelsAction({ id })), [dispatch, id]);
 


### PR DESCRIPTION
## Summary

Fixes a bug where the back button in flyout preview does not navigate to the previous url upon refresh

https://github.com/user-attachments/assets/7a63d441-a10b-4e10-9554-3116e1d7a2ca

https://github.com/elastic/kibana/issues/242826