### PR TITLE
[CI] Bump disk to 115

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -507,7 +507,7 @@ export async function pickTestGroupRunOrder() {
             key: 'jest',
             agents: {
               ...expandAgentQueue('n2-4-spot'),
-              diskSizeGb: 100,
+              diskSizeGb: 115,
             },
             env: {
               SCOUT_TARGET_TYPE: 'local',

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -10,7 +10,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-      diskSizeGb: 100
+      diskSizeGb: 115
     retry:
       automatic:
         - exit_status: '*'
@@ -54,7 +54,7 @@ steps:
       provider: gcp
       machineType: n2-highcpu-8
       preemptible: true
-      diskSizeGb: 100
+      diskSizeGb: 115
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -69,7 +69,7 @@ steps:
       provider: gcp
       machineType: n2-standard-2
       preemptible: true
-      diskSizeGb: 100
+      diskSizeGb: 115
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -84,7 +84,7 @@ steps:
       provider: gcp
       machineType: n2-standard-16
       preemptible: true
-      diskSizeGb: 100
+      diskSizeGb: 115
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -99,7 +99,7 @@ steps:
       provider: gcp
       machineType: n2-standard-32
       preemptible: true
-      diskSizeGb: 100
+      diskSizeGb: 115
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -116,7 +116,7 @@ steps:
       diskType: 'hyperdisk-balanced'
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c
-      diskSizeGb: 100
+      diskSizeGb: 115
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -148,7 +148,7 @@ steps:
       provider: gcp
       machineType: n2-highmem-4
       preemptible: true
-      diskSizeGb: 100
+      diskSizeGb: 115
     timeout_in_minutes: 80
     retry:
       automatic:
@@ -164,7 +164,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-      diskSizeGb: 100
+      diskSizeGb: 115
     timeout_in_minutes: 10
     depends_on:
       - build
@@ -181,7 +181,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-      diskSizeGb: 100
+      diskSizeGb: 115
     timeout_in_minutes: 10
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
@@ -199,7 +199,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 100
+      diskSizeGb: 115
     key: build_scout_tests
     timeout_in_minutes: 15
     depends_on:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -5,7 +5,7 @@ steps:
     id: pre_build
     agents:
       machineType: n2-standard-2
-      diskSizeGb: 100
+      diskSizeGb: 115
 
   - wait
 
@@ -39,7 +39,7 @@ steps:
     agents:
       machineType: n2-highcpu-8
       preemptible: true
-      diskSizeGb: 100
+      diskSizeGb: 115
     key: quick_checks
     timeout_in_minutes: 60
     retry:
@@ -53,7 +53,7 @@ steps:
     agents:
       machineType: n2-standard-2
       preemptible: true
-      diskSizeGb: 100
+      diskSizeGb: 115
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -65,7 +65,7 @@ steps:
     agents:
       machineType: n2-standard-16
       preemptible: true
-      diskSizeGb: 100
+      diskSizeGb: 115
     key: linting
     timeout_in_minutes: 60
     retry:
@@ -78,7 +78,7 @@ steps:
     agents:
       machineType: n2-standard-32
       preemptible: true
-      diskSizeGb: 100
+      diskSizeGb: 115
     key: linting_with_types
     timeout_in_minutes: 60
     retry:
@@ -105,7 +105,7 @@ steps:
       diskType: 'hyperdisk-balanced'
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c
-      diskSizeGb: 100
+      diskSizeGb: 115
     key: check_types
     timeout_in_minutes: 60
     retry:
@@ -119,7 +119,7 @@ steps:
     label: Mark CI Stats as ready
     agents:
       machineType: n2-standard-2
-      diskSizeGb: 100
+      diskSizeGb: 115
     timeout_in_minutes: 10
     depends_on:
       - build
@@ -134,7 +134,7 @@ steps:
     agents:
       machineType: n2-highmem-4
       preemptible: true
-      diskSizeGb: 100
+      diskSizeGb: 115
     key: build_api_docs
     timeout_in_minutes: 90
     retry:

--- a/.buildkite/pipelines/pull_request/pick_test_groups.yml
+++ b/.buildkite/pipelines/pull_request/pick_test_groups.yml
@@ -3,7 +3,7 @@ steps:
     label: 'Pick Test Group Run Order'
     agents:
       machineType: n2-standard-2
-      diskSizeGb: 100
+      diskSizeGb: 115
     timeout_in_minutes: 10
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'

--- a/.buildkite/pipelines/pull_request/prompt_changes.yml
+++ b/.buildkite/pipelines/pull_request/prompt_changes.yml
@@ -4,7 +4,7 @@ steps:
     agents:
       machineType: n2-standard-2
       preemptible: true
-      diskSizeGb: 100
+      diskSizeGb: 115
     timeout_in_minutes: 10
     retry:
       automatic:


### PR DESCRIPTION
## Summary

Starting to see wide spread issues of running out of disk pulling package registry: https://buildkite.com/elastic/kibana-on-merge/builds/81771#019a7b75-ea5f-4f50-9ba7-1184fdc1463e/7-5103

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->