### PR TITLE
[Kibana MCP Dev Server] Sanitize backslashes in `find_dependency_references`

### DIFF
--- a/src/platform/packages/shared/kbn-mcp-dev-server/src/tools/find_dependency_references.ts
+++ b/src/platform/packages/shared/kbn-mcp-dev-server/src/tools/find_dependency_references.ts
@@ -340,6 +340,7 @@ function matchPathToPattern(filePath: string, pattern: string): boolean {
 
   // Convert glob pattern to regex
   let regexPattern = normalizedPattern
+    .replace(/\\/g, '\\\\') // Escape backslashes
     .replace(/\./g, '\\.') // Escape dots
     .replace(/\*\*/g, '___DOUBLESTAR___') // Placeholder for **
     .replace(/\*/g, '[^/]*') // Single * matches anything except /


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/security/code-scanning/623

This PR adds a step to sanitize backslash characters to solve an alert.


