### PR TITLE
[Synthtrace] Wired streams: Setting documents in failure store and some boolean values

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/sample_logs.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/sample_logs.ts
@@ -84,51 +84,49 @@ const scenario: Scenario<LogDocument> = async (runOptions) => {
                 // Set up some failed documents
                 {
                   where: {
-                      field: "attributes.user.name",
-                      eq: "user1",
-                      steps: [
-                          {
-                              action: "date",
-                              where: {
-                                  always: {}
-                              },
-                              from: "attributes.user.name",
-                              formats: [
-                                  "UNIX_MS"
-                              ],
-                              ignore_failure: false,
-                              customIdentifier: "icd139630-bfc9-11f0-be91-458063de4bb2"
-                          }
-                      ]
+                    field: 'attributes.user.name',
+                    eq: 'user1',
+                    steps: [
+                      {
+                        action: 'date',
+                        where: {
+                          always: {},
+                        },
+                        from: 'attributes.user.name',
+                        formats: ['UNIX_MS'],
+                        ignore_failure: false,
+                        customIdentifier: 'icd139630-bfc9-11f0-be91-458063de4bb2',
+                      },
+                    ],
                   },
-                  customIdentifier: "ic6001030-bfc9-11f0-be91-458063de4bb2"
+                  customIdentifier: 'ic6001030-bfc9-11f0-be91-458063de4bb2',
                 },
                 // Set up some documents with boolean `false` value
                 {
-                    action: "set",
-                    where: {
-                        always: {}
-                    },
-                    to: "attributes.secure",
-                    value: "false",
-                    override: true,
-                    ignore_failure: false,
-                    customIdentifier: "i89cd8e40-c072-11f0-b0d2-fb65f5013a7f"
+                  action: 'set',
+                  where: {
+                    always: {},
+                  },
+                  to: 'attributes.secure',
+                  value: 'false',
+                  override: true,
+                  ignore_failure: false,
+                  customIdentifier: 'i89cd8e40-c072-11f0-b0d2-fb65f5013a7f',
                 },
                 // Set up some documents with boolean `true` value
                 {
-                    action: "set",
-                    where: {
-                        field: "attributes.user.name",
-                        eq: "user3"
-                    },
-                    to: "attributes.secure",
-                    value: "true",
-                    override: true,
-                    ignore_failure: false,
-                    customIdentifier: "icedf22a0-c072-11f0-b0d2-fb65f5013a7f"
-                }
-            ]
+                  action: 'set',
+                  where: {
+                    field: 'attributes.user.name',
+                    eq: 'user3',
+                  },
+                  to: 'attributes.secure',
+                  value: 'true',
+                  override: true,
+                  ignore_failure: false,
+                  customIdentifier: 'icedf22a0-c072-11f0-b0d2-fb65f5013a7f',
+                },
+              ],
             },
             wired: {
               fields: {

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/sample_logs.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/sample_logs.ts
@@ -80,11 +80,60 @@ const scenario: Scenario<LogDocument> = async (runOptions) => {
             lifecycle: { inherit: {} },
             settings: {},
             processing: {
-              steps: [],
+              steps: [
+                // Set up some failed documents
+                {
+                  where: {
+                      field: "attributes.user.name",
+                      eq: "user1",
+                      steps: [
+                          {
+                              action: "date",
+                              where: {
+                                  always: {}
+                              },
+                              from: "attributes.user.name",
+                              formats: [
+                                  "UNIX_MS"
+                              ],
+                              ignore_failure: false,
+                              customIdentifier: "icd139630-bfc9-11f0-be91-458063de4bb2"
+                          }
+                      ]
+                  },
+                  customIdentifier: "ic6001030-bfc9-11f0-be91-458063de4bb2"
+                },
+                // Set up some documents with boolean `false` value
+                {
+                    action: "set",
+                    where: {
+                        always: {}
+                    },
+                    to: "attributes.secure",
+                    value: "false",
+                    override: true,
+                    ignore_failure: false,
+                    customIdentifier: "i89cd8e40-c072-11f0-b0d2-fb65f5013a7f"
+                },
+                // Set up some documents with boolean `true` value
+                {
+                    action: "set",
+                    where: {
+                        field: "attributes.user.name",
+                        eq: "user3"
+                    },
+                    to: "attributes.secure",
+                    value: "true",
+                    override: true,
+                    ignore_failure: false,
+                    customIdentifier: "icedf22a0-c072-11f0-b0d2-fb65f5013a7f"
+                }
+            ]
             },
             wired: {
               fields: {
                 'attributes.process.name': { type: 'keyword', ignore_above: 18 },
+                'attributes.secure': { type: 'boolean' },
               },
               routing: [],
             },


### PR DESCRIPTION
With these changes now we would get by default some failed documents 
<img width="1315" height="862" alt="Screenshot 2025-11-13 at 10 40 17" src="https://github.com/user-attachments/assets/dfce40b2-6249-4a43-87ee-3bc75e68766a" />

And some documents with a `boolean` property
<img width="1727" height="864" alt="Screenshot 2025-11-13 at 10 41 22" src="https://github.com/user-attachments/assets/da0815e5-d078-4aa8-b597-4b9a95a716dc" />
