### PR TITLE
[CI] Disable test rerun optimization for flaky tests

### DIFF
--- a/.buildkite/scripts/steps/test/ftr_configs.sh
+++ b/.buildkite/scripts/steps/test/ftr_configs.sh
@@ -56,8 +56,9 @@ while read -r config; do
 
   CONFIG_EXECUTION_KEY="${config}_executed"
   IS_CONFIG_EXECUTION=$(buildkite-agent meta-data get "$CONFIG_EXECUTION_KEY" --default "false" --log-level error)
+  IS_FLAKY_TEST_RUN="${KIBANA_FLAKY_TEST_RUNNER_CONFIG:-false}" # we don't want this optimization for flaky test runs
 
-  if [[ "${IS_CONFIG_EXECUTION}" == "true" ]]; then
+  if [[ "$IS_CONFIG_EXECUTION" == "true" && "$IS_FLAKY_TEST_RUN" == "false" ]]; then
     echo "--- [ already-tested ] $FULL_COMMAND"
     continue
   else

--- a/.buildkite/scripts/steps/test/ftr_configs.sh
+++ b/.buildkite/scripts/steps/test/ftr_configs.sh
@@ -54,9 +54,11 @@ while read -r config; do
 
   FULL_COMMAND="node scripts/functional_tests --bail --config $config $EXTRA_ARGS"
 
+  # see if this config has already been executed successfully
   CONFIG_EXECUTION_KEY="${config}_executed"
   IS_CONFIG_EXECUTION=$(buildkite-agent meta-data get "$CONFIG_EXECUTION_KEY" --default "false" --log-level error)
-  IS_FLAKY_TEST_RUN="${KIBANA_FLAKY_TEST_RUNNER_CONFIG:-false}" # we don't want this optimization for flaky test runs
+  # we don't want this optimization for flaky test runs
+  IS_FLAKY_TEST_RUN=$(test -z "${KIBANA_FLAKY_TEST_RUNNER_CONFIG:-}" && echo "false" || echo "true")
 
   if [[ "$IS_CONFIG_EXECUTION" == "true" && "$IS_FLAKY_TEST_RUN" == "false" ]]; then
     echo "--- [ already-tested ] $FULL_COMMAND"


### PR DESCRIPTION
## Summary
After https://github.com/elastic/kibana/pull/237705 - it seems flaky test runs have been optimizing and skipping already successfully tested runs - this is not a desired behavior, so let's skip this optimization for flaky test runs.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->