### PR TITLE
[ES|QL] Fix perf issue in highlighting feature

### DIFF
--- a/src/platform/packages/private/kbn-language-documentation/src/utils/highlight_matches.tsx
+++ b/src/platform/packages/private/kbn-language-documentation/src/utils/highlight_matches.tsx
@@ -72,7 +72,9 @@ const findProtectedRanges = memoize((text: string): ProtectedRange[] => {
   }
 
   // Find markdown links ([text](url))
-  const linkRegex = /\[([^\]]*)\]\([^)]*\)/g;
+  // Use a limited length match to prevent ReDoS - links shouldn't be extremely long
+  // This matches up to 500 chars in brackets and parentheses (should be enough for any link)
+  const linkRegex = /\[(?:[^\]]){0,500}?\]\((?:[^)]){0,500}?\)/g;
   while ((match = linkRegex.exec(text)) !== null) {
     ranges.push({ start: match.index, end: match.index + match[0].length });
   }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-team/issues/2306
## Summary
Fix Polynomial regular expression used on uncontrolled data, on a regex used for highlighting.

The fix adds a limit to the regex for looking characters within `()` and `[]`, staying that no more than 500 characters
 can be placed in each of those sections.