### PR TITLE
[Discover] Show a warning about unsaved changes in the sharing modal

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
@@ -135,7 +135,7 @@ export const getShareAppMenuItem = ({
             },
           },
           link: {
-            draftModeCallOut: true,
+            draftModeCallOut: tabsEnabled,
           },
         },
       },

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
@@ -134,6 +134,9 @@ export const getShareAppMenuItem = ({
               },
             },
           },
+          link: {
+            draftModeCallOut: true,
+          },
         },
       },
       sharingData: {


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/238408

## Summary

<img width="1225" height="797" alt="Screenshot 2025-11-13 at 13 10 32" src="https://github.com/user-attachments/assets/e7aaa099-a0a8-42ce-8f63-495a7b08d4b1" />

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

