### PR TITLE
[Chrome Grid] Improvements for fleet 

### DIFF
--- a/src/core/packages/chrome/layout/core-chrome-layout/layouts/grid/grid_global_app_style.tsx
+++ b/src/core/packages/chrome/layout/core-chrome-layout/layouts/grid/grid_global_app_style.tsx
@@ -118,10 +118,14 @@ const globalTempHackStyles = (euiTheme: UseEuiTheme['euiTheme']) => css`
     ${logicalCSS('padding-right', `var(--euiPushFlyoutOffsetInlineEnd, 0px)`)};
     ${logicalCSS('padding-left', `var(--euiPushFlyoutOffsetInlineStart, 0px)`)};
   }
-  // this is a temporary hack to override EUI's body padding with push flyout
   .kbnBody {
+    // this is a temporary hack to override EUI's body padding with push flyout
     ${logicalCSS('padding-right', `0px !important`)};
     ${logicalCSS('padding-left', `0px !important`)};
+    // this is a temporary hack to override EUI's body padding with euibottom bar
+    ${logicalCSS('padding-bottom', `0px !important`)};
+    // just for consistency with other sides
+    ${logicalCSS('padding-top', `0px !important`)};
   }
 `;
 

--- a/x-pack/platform/plugins/shared/fleet/public/layouts/without_header.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/layouts/without_header.tsx
@@ -13,7 +13,7 @@ export const Wrapper = styled.div`
   background-color: ${(props) => props.theme.eui.euiColorEmptyShade};
 
   // Set the min height to the viewport size minus the height of any global Kibana headers
-  min-height: calc(100vh - var(--euiFixedHeadersOffset, 0));
+  min-height: var(--kbn-application--content-height);
 `;
 
 export const Page = styled(EuiPage)`


### PR DESCRIPTION
## Summary

Partially address https://github.com/elastic/kibana/issues/240441#issuecomment-3521475713

- adjust min-page height 
- make sure there is no unnecessary scroll when EuiBottomBar is shown. (note: we don't apply padding anymore so the content is too close, I will have to follow up on EUI side to set padding to main app container similar like we do with push flyout as part of https://github.com/elastic/kibana/issues/242893) 





