### PR TITLE
[ES|QL Histogram] Discard previous vertical axis customization before applying a breakdown

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
@@ -27,6 +27,7 @@ import type {
   Suggestion,
   TermsIndexPatternColumn,
   TypedLensByValueInput,
+  XYState,
 } from '@kbn/lens-plugin/public';
 import type { AggregateQuery, TimeRange } from '@kbn/es-query';
 import { getAggregateQueryMode, isOfAggregateQueryType } from '@kbn/es-query';
@@ -496,7 +497,7 @@ export class LensVisService {
   private getHistogramSuggestionForESQL = ({
     queryParams,
     breakdownField,
-    preferredVisAttributes,
+    preferredVisAttributes: originalPreferredVisAttributes,
   }: {
     queryParams: QueryParams;
     breakdownField?: DataViewField;
@@ -506,6 +507,20 @@ export class LensVisService {
     const breakdownColumn = breakdownField?.name
       ? columns?.find((column) => column.name === breakdownField.name)
       : undefined;
+    let preferredVisAttributes = originalPreferredVisAttributes;
+
+    if (preferredVisAttributes && breakdownColumn) {
+      const visualization = preferredVisAttributes?.state?.visualization as XYState | undefined;
+      const layers = Array.isArray(visualization?.layers) ? visualization.layers : [];
+      if (
+        !layers.some(
+          (layer) => 'splitAccessor' in layer && layer.splitAccessor === breakdownColumn.name
+        )
+      ) {
+        // the preferred vis attributes don't contain the breakdown column, so we discard it to avoid issues
+        preferredVisAttributes = undefined;
+      }
+    }
 
     if (
       dataView.isTimeBased() &&

--- a/src/platform/test/functional/apps/discover/group10/_lens_vis.ts
+++ b/src/platform/test/functional/apps/discover/group10/_lens_vis.ts
@@ -228,6 +228,40 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(await discover.getVisContextSuggestionType()).to.be('histogramForESQL');
     });
 
+    it('should be able to customize ESQL histogram and then choose a breakdown field', async () => {
+      await discover.selectTextBaseLang();
+
+      await monacoEditor.setCodeEditorValue('from logstash-* | sort @timestamp desc | limit 100');
+      await testSubjects.click('querySubmitButton');
+      await discover.waitUntilTabIsLoaded();
+
+      await discover.changeVisShape('Line');
+
+      await checkESQLHistogramVis(
+        'Sep 19, 2015 @ 06:31:44.000 - Sep 23, 2015 @ 18:31:44.000',
+        '100'
+      );
+
+      expect(await discover.getCurrentVisTitle()).to.be('Line');
+      expect(await discover.getVisContextSuggestionType()).to.be('histogramForESQL');
+
+      await discover.chooseBreakdownField('extension');
+      await discover.waitUntilTabIsLoaded();
+
+      await retry.try(async () => {
+        expect(await discover.getCurrentVisTitle()).to.be('Bar');
+      });
+
+      expect(await discover.getVisContextSuggestionType()).to.be('histogramForESQL');
+      const list = await discover.getHistogramLegendList();
+      expect(list).to.eql(['css', 'gif', 'jpg', 'php', 'png']);
+
+      await checkESQLHistogramVis(
+        'Sep 19, 2015 @ 06:31:44.000 - Sep 23, 2015 @ 18:31:44.000',
+        '100'
+      );
+    });
+
     it('should be able to load a saved search with custom histogram vis, edit vis and revert changes', async () => {
       await discover.loadSavedSearch('testCustomESQLHistogram');
 


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/242549

## Summary

This PR discards the previously applied vertical axis customization when user goes from having 'No breakdown' to selecting a breakdown field. 


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->