### PR TITLE
[Agent Builder] Remove resizable container around conversation elements

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.styles.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.styles.ts
@@ -7,6 +7,17 @@
 
 import { css } from '@emotion/react';
 
-export const maxConversationWidthStyles = css`
+const maxConversationWidthStyles = css`
   max-width: 800px;
+`;
+
+// Ensures the conversation element is always 100% of it's parent or 800px, whichever is smaller.
+export const conversationElementWidthStyles = css`
+  width: 100%;
+  ${maxConversationWidthStyles}
+`;
+
+export const fullWidthAndHeightStyles = css`
+  width: 100%;
+  height: 100%;
 `;

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, useEuiTheme, EuiButtonIcon } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, useEuiTheme, useEuiScrollBar } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useEffect, useRef } from 'react';
 import { useHasActiveConversation } from '../../hooks/use_conversation';
@@ -18,12 +18,8 @@ import { useSendMessage } from '../../context/send_message/send_message_context'
 import { useConversationScrollActions } from '../../hooks/use_conversation_scroll_actions';
 import { useConversationStatus } from '../../hooks/use_conversation';
 import { useSendPredefinedInitialMessage } from '../../hooks/use_initial_message';
-import { maxConversationWidthStyles } from './conversation.styles';
-
-const scrollContainerWrapperStyles = css`
-  position: relative;
-  min-height: 0;
-`;
+import { conversationElementWidthStyles, fullWidthAndHeightStyles } from './conversation.styles';
+import { ScrollButton } from './scroll_button';
 
 export const Conversation: React.FC<{}> = () => {
   const conversationId = useConversationId();
@@ -58,24 +54,21 @@ export const Conversation: React.FC<{}> = () => {
     }
   }, [stickToBottom, isFetched, conversationId, shouldStickToBottom]);
 
-  const conversationContainerStyles = css`
-    width: 100%;
-    ${maxConversationWidthStyles}
-    height: 100%;
+  const containerStyles = css`
+    ${fullWidthAndHeightStyles}
     padding-bottom: ${euiTheme.size.l};
   `;
 
-  const scrollContainerStyles = css`
-    overflow-y: auto;
-    height: 100%;
+  // Necessary to position the scroll button absolute to the container.
+  const scrollWrapperStyles = css`
+    ${fullWidthAndHeightStyles}
+    position: relative;
+    min-height: 0;
   `;
 
-  const scrollDownButtonStyles = css`
-    position: absolute;
-    bottom: ${euiTheme.size.s};
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 1;
+  const scrollableStyles = css`
+    ${useEuiScrollBar()}
+    overflow-y: auto;
   `;
 
   if (!hasActiveConversation) {
@@ -83,24 +76,21 @@ export const Conversation: React.FC<{}> = () => {
   }
 
   return (
-    <EuiFlexGroup direction="column" css={conversationContainerStyles}>
-      <EuiFlexItem grow={true} css={scrollContainerWrapperStyles}>
-        <div ref={scrollContainerRef} css={scrollContainerStyles}>
-          <ConversationRounds scrollContainerHeight={scrollContainerHeight} />
-        </div>
-        {showScrollButton && (
-          <EuiButtonIcon
-            display="base"
-            size="s"
-            color="text"
-            css={scrollDownButtonStyles}
-            iconType="sortDown"
-            aria-label="Scroll down"
-            onClick={scrollToMostRecentRoundBottom}
-          />
-        )}
+    <EuiFlexGroup direction="column" alignItems="center" css={containerStyles}>
+      <EuiFlexItem grow={true} css={scrollWrapperStyles}>
+        <EuiFlexGroup
+          direction="column"
+          alignItems="center"
+          ref={scrollContainerRef}
+          css={scrollableStyles}
+        >
+          <EuiFlexItem css={conversationElementWidthStyles}>
+            <ConversationRounds scrollContainerHeight={scrollContainerHeight} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        {showScrollButton && <ScrollButton onClick={scrollToMostRecentRoundBottom} />}
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem css={conversationElementWidthStyles} grow={false}>
         <ConversationInputForm onSubmit={scrollToMostRecentRoundTop} />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation.tsx
@@ -5,13 +5,7 @@
  * 2.0.
  */
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  useEuiTheme,
-  EuiButtonIcon,
-  useEuiOverflowScroll,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, useEuiTheme, EuiButtonIcon } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useEffect, useRef } from 'react';
 import { useHasActiveConversation } from '../../hooks/use_conversation';
@@ -74,9 +68,6 @@ export const Conversation: React.FC<{}> = () => {
   const scrollContainerStyles = css`
     overflow-y: auto;
     height: 100%;
-    ${useEuiOverflowScroll('y', true)} // applies a mask (blur) to the overflow content
-    // Padding ensures content isn't too close to the edges where the mask (blur) is applied.
-    padding: ${euiTheme.size.s} 0;
   `;
 
   const scrollDownButtonStyles = css`

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/new_conversation_prompt.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/new_conversation_prompt.tsx
@@ -23,7 +23,7 @@ import { ConversationInputForm } from './conversation_input/conversation_input_f
 import { docLinks } from '../../../../common/doc_links';
 import { WelcomeText } from '../common/welcome_text';
 import { useUiPrivileges } from '../../hooks/use_ui_privileges';
-import { maxConversationWidthStyles } from './conversation.styles';
+import { conversationElementWidthStyles } from './conversation.styles';
 
 interface QuickNavigationCard {
   key: string;
@@ -166,7 +166,7 @@ export const NewConversationPrompt: React.FC<{}> = () => {
   const { euiTheme } = useEuiTheme();
 
   const containerStyles = css`
-    ${maxConversationWidthStyles}
+    ${conversationElementWidthStyles}
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/scroll_button.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/scroll_button.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiButtonIcon, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+interface ScrollButtonProps {
+  onClick: () => void;
+}
+
+export const ScrollButton: React.FC<ScrollButtonProps> = ({ onClick }) => {
+  const { euiTheme } = useEuiTheme();
+
+  const scrollDownButtonStyles = css`
+    position: absolute;
+    bottom: ${euiTheme.size.s};
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1;
+  `;
+
+  return (
+    <EuiButtonIcon
+      display="base"
+      size="s"
+      color="text"
+      css={scrollDownButtonStyles}
+      iconType="sortDown"
+      aria-label="Scroll down"
+      onClick={onClick}
+    />
+  );
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/shared/styles.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/esql/shared/styles.ts
@@ -26,7 +26,7 @@ export const actionsContainer = (euiTheme: UseEuiTheme['euiTheme']) =>
   css({
     position: 'absolute',
     top: `-${euiTheme.size.xs}`,
-    right: `-${euiTheme.size.xs}`,
+    right: 0,
     zIndex: 2,
     opacity: 0,
     pointerEvents: 'none',


### PR DESCRIPTION
## Summary

relates to https://github.com/elastic/search-team/issues/11783

Soon, we will have an input (content-editable div) that resizes to match the size of the input text that's added (up to a set height), in preparation for that, this PR removes the resizable container logic.

https://github.com/user-attachments/assets/f67e07df-87c2-4319-a556-27bc6b7e8410


