### PR TITLE
[Chrome Grid] Adjust nav zIndex for better backward compatibility

### DIFF
--- a/src/core/packages/chrome/layout/core-chrome-layout-constants/src/levels.ts
+++ b/src/core/packages/chrome/layout/core-chrome-layout-constants/src/levels.ts
@@ -16,9 +16,11 @@ export const layoutLevels = {
   header: 100,
   footer: 100,
 
+  // 999 is chosen to be the same as old EuiCollapsibleNavBeta for backwards compatibility
+  navigation: 999,
+
   // Interactive layout components that need higher priority than euiFlyout (1000)
   sidebar: 1050,
-  navigation: 1050,
   banner: 1050,
 
   // Application-level bars that appear within main content


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/242872


https://github.com/user-attachments/assets/47c2f6bb-b137-40d6-8b8b-201deb131620

