### PR TITLE
[index management] Make create index data-test-subj values unique

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/components/no_match/no_match.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/no_match/no_match.tsx
@@ -65,7 +65,13 @@ export const NoMatch = ({
 
   if (extensionsService.emptyListContent) {
     return extensionsService.emptyListContent.renderContent({
-      createIndexButton: <CreateIndexButton loadIndices={loadIndices} share={share} />,
+      createIndexButton: (
+        <CreateIndexButton
+          loadIndices={loadIndices}
+          share={share}
+          dataTestSubj="createIndexButtonEmptyList"
+        />
+      ),
     });
   }
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_button.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_button.tsx
@@ -17,9 +17,10 @@ import { useAppContext } from '../../../../app_context';
 export interface CreateIndexButtonProps {
   loadIndices: () => void;
   share?: SharePluginStart;
+  dataTestSubj?: string;
 }
 
-export const CreateIndexButton = ({ loadIndices, share }: CreateIndexButtonProps) => {
+export const CreateIndexButton = ({ loadIndices, share, dataTestSubj }: CreateIndexButtonProps) => {
   const [createIndexModalOpen, setCreateIndexModalOpen] = useState<boolean>(false);
   const createIndexUrl = share?.url.locators.get('SEARCH_CREATE_INDEX')?.useUrl({});
 
@@ -40,7 +41,7 @@ export const CreateIndexButton = ({ loadIndices, share }: CreateIndexButtonProps
         fill
         iconType="plusInCircleFilled"
         key="createIndexButton"
-        data-test-subj="createIndexButton"
+        data-test-subj={dataTestSubj || 'createIndexButton'}
         data-telemetry-id="idxMgmt-indexList-createIndexButton"
         {...actionProp}
       >


### PR DESCRIPTION
## Summary

Scout doesn't like non-unique data-test-subj values so I'm making them unique. In its own PR for a simpler change set. 

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->