### PR TITLE
[9.2] [Metrics][Discover] Fix fields dropdown by casting dimension fields to string (#242432)

### DIFF
--- a/src/platform/packages/shared/kbn-traced-es-client/src/create_traced_es_client.ts
+++ b/src/platform/packages/shared/kbn-traced-es-client/src/create_traced_es_client.ts
@@ -165,30 +165,26 @@ export function createTracedEsClient({
           .query(
             { ...parameters },
             {
-              querystring: {
-                drop_null_columns: true,
-              },
+              querystring: { drop_null_columns: true },
+              ...requestOpts,
             }
           )
           .then((response) => {
-            const esqlResponse = response as unknown as UnparsedEsqlResponseOf<EsqlOutput>;
-
             const transform = options?.transform ?? 'none';
 
             if (transform === 'none') {
-              return esqlResponse;
+              return response;
             }
 
-            const parsedResponse = { hits: esqlResultToPlainObjects(esqlResponse) };
+            const rawEsqlResponse = response.body as unknown as UnparsedEsqlResponseOf<EsqlOutput>;
+            const hits = esqlResultToPlainObjects(rawEsqlResponse);
 
             if (transform === 'plain') {
-              return parsedResponse;
+              return { ...response, body: { hits } };
             }
 
-            return {
-              hits: parsedResponse.hits.map((hit) => unflattenObject(hit)),
-            };
-          }) as Promise<InferEsqlResponseOf<EsqlOutput, EsqlOptions>>;
+            return { ...response, body: { hits: hits.map((hit) => unflattenObject(hit)) } };
+          }) as Promise<{ body: InferEsqlResponseOf<EsqlOutput, EsqlOptions> }>;
       });
     },
     search<TDocument = unknown, TSearchRequest extends SearchRequest = SearchRequest>(

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.test.ts
@@ -91,7 +91,7 @@ TS metrics-*
     expect(query).toBe(
       `
 TS metrics-*
-  | WHERE \`host.ip\` IS NOT NULL AND \`host.name\` IS NOT NULL
+  | WHERE \`host.ip\`::STRING IS NOT NULL AND \`host.name\` IS NOT NULL
   | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend), \`host.ip\`, \`host.name\`
   | EVAL ${DIMENSIONS_COLUMN} = CONCAT(\`host.ip\`::STRING, " › ", \`host.name\`)
   | DROP \`host.ip\`, \`host.name\`
@@ -107,7 +107,7 @@ TS metrics-*
     expect(query).toBe(
       `
 TS metrics-*
-  | WHERE \`cpu.cores\` IS NOT NULL AND \`host.name\` IS NOT NULL
+  | WHERE \`cpu.cores\`::STRING IS NOT NULL AND \`host.name\` IS NOT NULL
   | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend), \`cpu.cores\`, \`host.name\`
   | EVAL ${DIMENSIONS_COLUMN} = CONCAT(\`cpu.cores\`::STRING, " › ", \`host.name\`)
   | DROP \`cpu.cores\`, \`host.name\`
@@ -123,7 +123,7 @@ TS metrics-*
     expect(query).toBe(
       `
 TS metrics-*
-  | WHERE \`host.ip\` IS NOT NULL AND \`host.name\` IS NOT NULL AND \`cpu.cores\` IS NOT NULL
+  | WHERE \`host.ip\`::STRING IS NOT NULL AND \`host.name\` IS NOT NULL AND \`cpu.cores\`::STRING IS NOT NULL
   | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend), \`host.ip\`, \`host.name\`, \`cpu.cores\`
   | EVAL ${DIMENSIONS_COLUMN} = CONCAT(\`host.ip\`::STRING, " › ", \`host.name\`, " › ", \`cpu.cores\`::STRING)
   | DROP \`host.ip\`, \`host.name\`, \`cpu.cores\`
@@ -271,7 +271,7 @@ TS metrics-*
       expect(query).toBe(
         `
 TS metrics-*
-  | WHERE \`host-ip\` IS NOT NULL AND \`service-name\` IS NOT NULL
+  | WHERE \`host-ip\`::STRING IS NOT NULL AND \`service-name\` IS NOT NULL
   | STATS AVG(cpu.usage) BY BUCKET(@timestamp, 100, ?_tstart, ?_tend), \`host-ip\`, \`service-name\`
   | EVAL ${DIMENSIONS_COLUMN} = CONCAT(\`host-ip\`::STRING, " › ", \`service-name\`)
   | DROP \`host-ip\`, \`service-name\`

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/common/utils/esql/create_esql_query.ts
@@ -53,6 +53,8 @@ export function createESQLQuery({ metric, dimensions = [], filters }: CreateESQL
 
   const whereConditions: QueryOperator[] = [];
   const valuesByField = new Map<string, Set<string>>();
+  const dimensionTypeMap = new Map(metricDimensions?.map((dim) => [dim.name, dim.type]));
+
   if (filters && filters.length) {
     for (const filter of filters) {
       const currentValues = valuesByField.get(filter.field);
@@ -64,23 +66,31 @@ export function createESQLQuery({ metric, dimensions = [], filters }: CreateESQL
     }
 
     valuesByField.forEach((value, key) => {
+      const dimType = dimensionTypeMap.get(key);
+      const escapedKey = sanitazeESQLInput(key);
+      const castedKey =
+        dimType && needsStringCasting(dimType) ? `${escapedKey}::STRING` : escapedKey;
+
       whereConditions.push(
-        where(
-          `${sanitazeESQLInput(key)} IN (${new Array(value.size).fill('?').join(', ')})`,
-          Array.from(value)
-        )
+        where(`${castedKey} IN (${new Array(value.size).fill('?').join(', ')})`, Array.from(value))
       );
     });
   }
-
-  const dimensionTypeMap = new Map(metricDimensions?.map((dim) => [dim.name, dim.type]));
 
   const unfilteredDimensions = (dimensions ?? []).filter((dim) => !valuesByField.has(dim));
   const queryPipeline = source.pipe(
     ...whereConditions,
     unfilteredDimensions.length > 0
       ? where(
-          unfilteredDimensions.map((dim) => `${sanitazeESQLInput(dim)} IS NOT NULL`).join(' AND ')
+          unfilteredDimensions
+            .map((dim) => {
+              const dimType = dimensionTypeMap.get(dim);
+              const escapedDim = sanitazeESQLInput(dim);
+              const castedDim =
+                dimType && needsStringCasting(dimType) ? `${escapedDim}::STRING` : escapedDim;
+              return `${castedDim} IS NOT NULL`;
+            })
+            .join(' AND ')
         )
       : (query) => query,
     stats(

--- a/src/platform/plugins/shared/metrics_experience/server/routes/dimensions/route.ts
+++ b/src/platform/plugins/shared/metrics_experience/server/routes/dimensions/route.ts
@@ -12,7 +12,7 @@ import { createTracedEsClient } from '@kbn/traced-es-client';
 import { isoToEpoch } from '@kbn/zod-helpers';
 import { parse as dateMathParse } from '@kbn/datemath';
 import { createRoute } from '../create_route';
-import { getDimensions } from './get_dimentions';
+import { getDimensions } from './get_dimensions';
 import { throwNotFoundIfMetricsExperienceDisabled } from '../../lib/utils';
 
 export const getDimensionsRoute = createRoute({

--- a/src/platform/plugins/shared/metrics_experience/tsconfig.json
+++ b/src/platform/plugins/shared/metrics_experience/tsconfig.json
@@ -20,5 +20,7 @@
     "@kbn/otel-semantic-conventions",
     "@kbn/i18n",
     "@kbn/core-chrome-browser",
+    "@kbn/data-plugin",
+    "@kbn/esql-composer"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Metrics][Discover] Fix fields dropdown by casting dimension fields to string (#242432)](https://github.com/elastic/kibana/pull/242432)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miriam","email":"31922082+MiriamAparicio@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-11-13T09:36:05Z","message":"[Metrics][Discover] Fix fields dropdown by casting dimension fields to string (#242432)\n\nCloses https://github.com/elastic/kibana/issues/239952\n\n### Summary\nThis PR resolves the data inconsistency between metric charts and the\n\"Filter by value\" dropdown, where values visible in charts were missing\nfrom the filter list.\n\n#### Problem\n\nThe root cause was that the same dimension field (e.g.,\n`attributes.cpu`) could have different data types across different\nindices:\n- `long` in one index\n- `keyword` in another index\n\nElasticsearch aggregations and ES|QL queries fail when trying to process\nfields with inconsistent types, resulting in incomplete dimension values\nin the dropdown.\n\n#### Solution\n\n**1. Updated `get_dimentions.ts`:**\n- Migrated from Elasticsearch `_search` API with `terms` aggregations to\nES|QL\n- Added explicit type casting to string using `::STRING` syntax\n- Increased dimension value limit from 20 to 1000\n- Simplified response mapping logic\n\n**2. Updated `create_esql_query.ts`:**\n- Added type casting logic for dimensions in `WHERE` clauses\n- Applied the same `needsStringCasting()` check used in `CONCAT`\noperations\n- Ensures consistent string type handling for null checks\n\nBEFORE\n<img width=\"2304\" height=\"560\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e74c73af-838e-4282-b6f7-9778f03e562d\"\n/>\n\nAFTER\n<img width=\"1043\" height=\"292\" alt=\"Screenshot 2025-11-10 at 14 37 35\"\nsrc=\"https://github.com/user-attachments/assets/ade48ce5-1290-4fc7-afb4-57adcf3ebaf3\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Carlos Crespo <carloshenrique.leonelcrespo@elastic.co>","sha":"08460f645c06344b0b102b9f640dd3b876c1e7c1","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.2.0","v9.3.0","v9.2.1","Team:obs-exploration"],"title":"[Metrics][Discover] Fix fields dropdown by casting dimension fields to string","number":242432,"url":"https://github.com/elastic/kibana/pull/242432","mergeCommit":{"message":"[Metrics][Discover] Fix fields dropdown by casting dimension fields to string (#242432)\n\nCloses https://github.com/elastic/kibana/issues/239952\n\n### Summary\nThis PR resolves the data inconsistency between metric charts and the\n\"Filter by value\" dropdown, where values visible in charts were missing\nfrom the filter list.\n\n#### Problem\n\nThe root cause was that the same dimension field (e.g.,\n`attributes.cpu`) could have different data types across different\nindices:\n- `long` in one index\n- `keyword` in another index\n\nElasticsearch aggregations and ES|QL queries fail when trying to process\nfields with inconsistent types, resulting in incomplete dimension values\nin the dropdown.\n\n#### Solution\n\n**1. Updated `get_dimentions.ts`:**\n- Migrated from Elasticsearch `_search` API with `terms` aggregations to\nES|QL\n- Added explicit type casting to string using `::STRING` syntax\n- Increased dimension value limit from 20 to 1000\n- Simplified response mapping logic\n\n**2. Updated `create_esql_query.ts`:**\n- Added type casting logic for dimensions in `WHERE` clauses\n- Applied the same `needsStringCasting()` check used in `CONCAT`\noperations\n- Ensures consistent string type handling for null checks\n\nBEFORE\n<img width=\"2304\" height=\"560\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e74c73af-838e-4282-b6f7-9778f03e562d\"\n/>\n\nAFTER\n<img width=\"1043\" height=\"292\" alt=\"Screenshot 2025-11-10 at 14 37 35\"\nsrc=\"https://github.com/user-attachments/assets/ade48ce5-1290-4fc7-afb4-57adcf3ebaf3\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Carlos Crespo <carloshenrique.leonelcrespo@elastic.co>","sha":"08460f645c06344b0b102b9f640dd3b876c1e7c1"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/242432","number":242432,"mergeCommit":{"message":"[Metrics][Discover] Fix fields dropdown by casting dimension fields to string (#242432)\n\nCloses https://github.com/elastic/kibana/issues/239952\n\n### Summary\nThis PR resolves the data inconsistency between metric charts and the\n\"Filter by value\" dropdown, where values visible in charts were missing\nfrom the filter list.\n\n#### Problem\n\nThe root cause was that the same dimension field (e.g.,\n`attributes.cpu`) could have different data types across different\nindices:\n- `long` in one index\n- `keyword` in another index\n\nElasticsearch aggregations and ES|QL queries fail when trying to process\nfields with inconsistent types, resulting in incomplete dimension values\nin the dropdown.\n\n#### Solution\n\n**1. Updated `get_dimentions.ts`:**\n- Migrated from Elasticsearch `_search` API with `terms` aggregations to\nES|QL\n- Added explicit type casting to string using `::STRING` syntax\n- Increased dimension value limit from 20 to 1000\n- Simplified response mapping logic\n\n**2. Updated `create_esql_query.ts`:**\n- Added type casting logic for dimensions in `WHERE` clauses\n- Applied the same `needsStringCasting()` check used in `CONCAT`\noperations\n- Ensures consistent string type handling for null checks\n\nBEFORE\n<img width=\"2304\" height=\"560\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e74c73af-838e-4282-b6f7-9778f03e562d\"\n/>\n\nAFTER\n<img width=\"1043\" height=\"292\" alt=\"Screenshot 2025-11-10 at 14 37 35\"\nsrc=\"https://github.com/user-attachments/assets/ade48ce5-1290-4fc7-afb4-57adcf3ebaf3\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Carlos Crespo <carloshenrique.leonelcrespo@elastic.co>","sha":"08460f645c06344b0b102b9f640dd3b876c1e7c1"}}]}] BACKPORT-->