### PR TITLE
[FTR] Parse logs to detect whether docker log output is an actual error

### DIFF
--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/docker_servers/container_logs.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/docker_servers/container_logs.ts
@@ -27,8 +27,41 @@ export function observeContainerLogs(name: string, containerId: string, log: Too
 
   Rx.merge(
     observeLines(logsProc.stdout!).pipe(tap((line) => log.info(`[docker:${name}] ${line}`))), // TypeScript note: As long as the proc stdio[1] is 'pipe', then stdout will not be null
-    observeLines(logsProc.stderr!).pipe(tap((line) => log.error(`[docker:${name}] ${line}`))) // TypeScript note: As long as the proc stdio[2] is 'pipe', then stderr will not be null
+    observeLines(logsProc.stderr!).pipe(
+      tap((line) => {
+        // Check if this is actually an error or just info/debug written to stderr
+        if (isActualError(line)) {
+          log.error(`[docker:${name}] ${line}`);
+        } else {
+          log.info(`[docker:${name}] ${line}`);
+        }
+      })
+    ) // TypeScript note: As long as the proc stdio[2] is 'pipe', then stderr will not be null
   ).subscribe(logLine$);
 
   return logLine$.asObservable();
+}
+
+/**
+ * Check if a log line from stderr is actually an error or just info/debug written to stderr
+ */
+function isActualError(line: string): boolean {
+  try {
+    const parsed = JSON.parse(line);
+    // If it's JSON with a log.level field, check if it's an error/warning level
+    if (parsed['log.level']) {
+      const level = parsed['log.level'].toLowerCase();
+      return level === 'error' || level === 'fatal' || level === 'severe';
+    }
+    // If it has a level field (alternative format)
+    if (parsed.level) {
+      const level = parsed.level.toLowerCase();
+      return level === 'error' || level === 'fatal' || level === 'severe';
+    }
+  } catch (e) {
+    // Not JSON, treat as potential error since it's on stderr
+    return true;
+  }
+  // JSON but no log level field, treat as info
+  return false;
 }

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/docker_servers/container_logs.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/docker_servers/container_logs.ts
@@ -45,7 +45,7 @@ export function observeContainerLogs(name: string, containerId: string, log: Too
 /**
  * Check if a log line from stderr is actually an error or just info/debug written to stderr
  */
-function isActualError(line: string): boolean {
+export function isActualError(line: string): boolean {
   try {
     const parsed = JSON.parse(line);
     // If it's JSON with a log.level field, check if it's an error/warning level

--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/helpers/docker_registry_helper.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/helpers/docker_registry_helper.ts
@@ -87,7 +87,6 @@ export function useDockerRegistry() {
       await firstWithTimeout(
         childProcessToLogLine(dockerProcess, logger).pipe(
           filter((line) => {
-            process.stdout.write(line);
             return waitForLogLine.test(line);
           })
         ),


### PR DESCRIPTION
## Summary

FTR tests using a Docker container output all logs from the Docker process as `ERROR`, even when the logs are not in error.

## Changes
- This parses the logs and logs the correct log type to the output.
- This removes duplicate Docker logs that were written to stdout as they were already being written by the logger


**Old output:**

<img width="1177" height="919" alt="Screenshot 2025-11-14 at 11 28 02" src="https://github.com/user-attachments/assets/1ac7c15f-2841-4313-86f8-a0639996a1c7" />


**New output:**

<img width="1732" height="1184" alt="Screenshot 2025-11-14 at 15 38 23" src="https://github.com/user-attachments/assets/ddb28236-8f50-498f-88e9-2a6b4cff7d2f" />

