### PR TITLE
Alerting rule execution inspector including search source requests

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_form/src/create_rule_form.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/create_rule_form.tsx
@@ -223,6 +223,7 @@ export const CreateRuleForm = (props: CreateRuleFormProps) => {
         onSave={onSave}
         onChangeMetaData={onChangeMetaData}
         focusTrapProps={props.focusTrapProps}
+        http={http}
       />
     </RuleFormStateProvider>
   );

--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_page/inspector_context.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_page/inspector_context.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ReactNode } from 'react';
+import React, { createContext, useMemo, useContext } from 'react';
+import { RequestAdapter } from '@kbn/inspector-plugin/public';
+
+interface IInspectorContext {
+  requestsAdapter: RequestAdapter;
+}
+
+const InspectorContext = createContext<IInspectorContext | null>(null);
+
+export const RuleFormInspectorProvider = ({ children }: { children: ReactNode }) => {
+  const requestsAdapter = useMemo(() => new RequestAdapter(), []);
+
+  const value = useMemo(
+    () => ({
+      requestsAdapter,
+    }),
+    [requestsAdapter]
+  );
+
+  return <InspectorContext.Provider value={value}>{children}</InspectorContext.Provider>;
+};
+
+export const useRuleFormInspector = (): IInspectorContext => {
+  const context = useContext(InspectorContext);
+  if (!context) {
+    throw new Error('useRuleFormInspector must be used within a RuleFormInspectorProvider');
+  }
+  return context;
+};

--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_footer.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_footer.tsx
@@ -115,12 +115,11 @@ export const RulePageFooter = (props: RulePageFooterProps) => {
                 requestParams: operation.params,
               });
             }
-          } catch (queryError: any) {
+          } catch (error: any) {
             // TODO: how to handle error
             console.log('error:', error);
             requestResponder.error({
-              body: Joperation.response.body,
-              requestParams: operation.params,
+              json: { message: error.message },
             });
           }
         });
@@ -129,9 +128,8 @@ export const RulePageFooter = (props: RulePageFooterProps) => {
     } catch (error: any) {
       // TODO: how to handle error
       console.log('error:', error);
-      requestsAdapter.reset();
-      requestsAdapter.start('Rule execution query', {
-        id: uuidv4(),
+      requestResponder.error({
+        json: { message: error.message },
       });
       inspector.open({ requests: requestsAdapter });
     }

--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_footer.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_page/rule_page_footer.tsx
@@ -9,33 +9,50 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiButton, EuiButtonEmpty } from '@elastic/eui';
+import { v4 as uuidv4 } from 'uuid';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import {
   RULE_PAGE_FOOTER_CANCEL_TEXT,
   RULE_PAGE_FOOTER_SHOW_REQUEST_TEXT,
   RULE_PAGE_FOOTER_CREATE_TEXT,
   RULE_PAGE_FOOTER_SAVE_TEXT,
+  RULE_PAGE_FOOTER_PREVIEW_TEXT,
 } from '../translations';
 import { useRuleFormScreenContext, useRuleFormState } from '../hooks';
 import { hasRuleErrors } from '../validation';
 import { ConfirmCreateRule } from '../components';
+import { useRuleFormInspector } from './inspector_context';
 
 export interface RulePageFooterProps {
   isEdit?: boolean;
   isSaving?: boolean;
+  isRunningPreview?: boolean;
   onCancel: () => void;
   onSave: () => void;
+  onPreview: (formData: any) => Promise<any>;
 }
 
 export const RulePageFooter = (props: RulePageFooterProps) => {
   const [showCreateConfirmation, setShowCreateConfirmation] = useState<boolean>(false);
+  const {
+    services: { inspector },
+  } = useKibana();
+  const { requestsAdapter } = useRuleFormInspector();
 
   const { setIsShowRequestScreenVisible } = useRuleFormScreenContext();
 
-  const { isEdit = false, isSaving = false, onCancel, onSave } = props;
+  const {
+    isEdit = false,
+    isSaving = false,
+    isRunningPreview = false,
+    onCancel,
+    onSave,
+    onPreview,
+  } = props;
 
   const {
     plugins: { application },
-    formData: { actions },
+    formData,
     connectors,
     baseErrors = {},
     paramsErrors = {},
@@ -44,7 +61,7 @@ export const RulePageFooter = (props: RulePageFooterProps) => {
   } = useRuleFormState();
 
   const hasErrors = useMemo(() => {
-    const hasBrokenConnectors = actions.some((action) => {
+    const hasBrokenConnectors = formData.actions.some((action) => {
       return !connectors.find((connector) => connector.id === action.id);
     });
 
@@ -58,7 +75,7 @@ export const RulePageFooter = (props: RulePageFooterProps) => {
       actionsErrors,
       actionsParamsErrors,
     });
-  }, [actions, connectors, baseErrors, paramsErrors, actionsErrors, actionsParamsErrors]);
+  }, [formData.actions, connectors, baseErrors, paramsErrors, actionsErrors, actionsParamsErrors]);
 
   const saveButtonText = useMemo(() => {
     if (isEdit) {
@@ -71,16 +88,65 @@ export const RulePageFooter = (props: RulePageFooterProps) => {
     setIsShowRequestScreenVisible(true);
   }, [setIsShowRequestScreenVisible]);
 
+  const onPreviewClick = useCallback(async () => {
+    requestsAdapter.reset();
+
+    try {
+      const response = await onPreview(formData);
+      if (response._inspect && response._inspect.esQueries) {
+        response._inspect.esQueries.forEach((operation: any, index) => {
+          const requestResponder = requestsAdapter.start(`Rule execution Query ${index}`, {
+            id: uuidv4(),
+          });
+
+          try {
+            requestResponder.json(JSON.parse(operation.params.body));
+            if (operation.response.statusCode < 400) {
+              // Mark this specific operation as successful.
+              requestResponder.ok({
+                json: {
+                  rawResponse: operation.response.body,
+                  requestParams: operation.params,
+                },
+              });
+            } else {
+              requestResponder.error({
+                body: operation.response.body,
+                requestParams: operation.params,
+              });
+            }
+          } catch (queryError: any) {
+            // TODO: how to handle error
+            console.log('error:', error);
+            requestResponder.error({
+              body: Joperation.response.body,
+              requestParams: operation.params,
+            });
+          }
+        });
+      }
+      inspector.open({ requests: requestsAdapter });
+    } catch (error: any) {
+      // TODO: how to handle error
+      console.log('error:', error);
+      requestsAdapter.reset();
+      requestsAdapter.start('Rule execution query', {
+        id: uuidv4(),
+      });
+      inspector.open({ requests: requestsAdapter });
+    }
+  }, [formData, onPreview, inspector, requestsAdapter]);
+
   const onSaveClick = useCallback(() => {
     if (isEdit) {
       return onSave();
     }
     const canReadConnectors = !!application.capabilities.actions?.show;
-    if (actions.length === 0 && canReadConnectors) {
+    if (formData.actions.length === 0 && canReadConnectors) {
       return setShowCreateConfirmation(true);
     }
     onSave();
-  }, [actions, isEdit, application, onSave]);
+  }, [formData.actions, isEdit, application, onSave]);
 
   const onCreateConfirmClick = useCallback(() => {
     setShowCreateConfirmation(false);
@@ -115,6 +181,16 @@ export const RulePageFooter = (props: RulePageFooterProps) => {
               >
                 {RULE_PAGE_FOOTER_SHOW_REQUEST_TEXT}
               </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                data-test-subj="rulePageFooterPreviewButton"
+                onClick={onPreviewClick}
+                disabled={isSaving || hasErrors || isRunningPreview}
+                isLoading={isRunningPreview}
+              >
+                {RULE_PAGE_FOOTER_PREVIEW_TEXT}
+              </EuiButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiButton

--- a/src/platform/packages/shared/response-ops/rule_form/src/translations.ts
+++ b/src/platform/packages/shared/response-ops/rule_form/src/translations.ts
@@ -368,6 +368,13 @@ export const RULE_PAGE_FOOTER_SAVE_TEXT = i18n.translate(
   }
 );
 
+export const RULE_PAGE_FOOTER_PREVIEW_TEXT = i18n.translate(
+  'responseOpsRuleForm.ruleForm.rulePageFooter.previewText',
+  {
+    defaultMessage: 'preview',
+  }
+);
+
 export const RULE_FLYOUT_HEADER_CREATE_TITLE = i18n.translate(
   'responseOpsRuleForm.ruleForm.ruleFlyoutHeader.createTitle',
   {

--- a/x-pack/platform/plugins/shared/alerting/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/plugin.ts
@@ -172,6 +172,7 @@ export interface AlertingServerSetup {
 }
 
 export interface AlertingServerStart {
+  logger: Logger;
   listTypes: RuleTypeRegistry['list'];
   getAllTypes: RuleTypeRegistry['getAllTypes'];
   getType: RuleTypeRegistry['get'];
@@ -739,6 +740,7 @@ export class AlertingPlugin {
     scheduleMaintenanceWindowEventsGenerator(this.logger, plugins.taskManager).catch(() => {});
 
     return {
+      logger: this.logger,
       listTypes: ruleTypeRegistry!.list.bind(this.ruleTypeRegistry!),
       getType: ruleTypeRegistry!.get.bind(this.ruleTypeRegistry),
       getAllTypes: ruleTypeRegistry!.getAllTypes.bind(this.ruleTypeRegistry!),

--- a/x-pack/platform/plugins/shared/alerting/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/plugin.ts
@@ -779,6 +779,7 @@ export class AlertingPlugin {
           return maintenanceWindowClientFactory.createWithAuthorization(request);
         },
         listTypes: ruleTypeRegistry!.list.bind(ruleTypeRegistry!),
+        getType: ruleTypeRegistry!.get.bind(ruleTypeRegistry!),
         getFrameworkHealth: async () =>
           await getHealth(savedObjects.createInternalRepository([RULE_SAVED_OBJECT_TYPE])),
         areApiKeysEnabled: async () => {

--- a/x-pack/platform/plugins/shared/alerting/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/index.ts
@@ -14,6 +14,8 @@ import type { AlertingConfig } from '../config';
 import type { GetAlertIndicesAlias, ILicenseState } from '../lib';
 import type { AlertingRequestHandlerContext } from '../types';
 import { createRuleRoute } from './rule/apis/create';
+import { executeRuleRoute } from './rule/apis/execute/execute_rule_route';
+
 import { getRuleRoute, getInternalRuleRoute } from './rule/apis/get/get_rule_route';
 import { updateRuleRoute } from './rule/apis/update/update_rule_route';
 import { deleteRuleRoute } from './rule/apis/delete/delete_rule_route';
@@ -121,6 +123,8 @@ export function defineRoutes(opts: RouteOptions) {
   } = opts;
 
   createRuleRoute(opts);
+  executeRuleRoute(opts);
+
   getRuleRoute(router, licenseState);
   getInternalRuleTemplateRoute(router, licenseState);
   getInternalRuleRoute(router, licenseState);

--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/execute/es_client_meta_wrapper.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/execute/es_client_meta_wrapper.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IScopedClusterClient } from '@kbn/core/server';
+import type { TransportRequestOptions } from '@elastic/elasticsearch/lib/api/types';
+
+export function createEsClientWithMeta(
+  esClient: IScopedClusterClient,
+  esQueries: any[]
+): IScopedClusterClient {
+  return new Proxy(esClient, {
+    get(target, prop, receiver) {
+      const original = Reflect.get(target, prop, receiver);
+      if (
+        typeof original !== 'function' ||
+        !['search', 'msearch', 'count'].includes(prop as string)
+      ) {
+        return original;
+      }
+
+      return async (...args: any[]) => {
+        const [params, options] = args as [any, TransportRequestOptions | undefined];
+
+        // The original caller might expect the body directly, or the full ApiResponse.
+        // This depends on whether `meta: true` was in the original options.
+        // TODO: Check if this is needed
+        const callerExpectsApiResponse = options?.meta === true;
+
+        const response = await original.apply(target, [params, { ...options, meta: true }]);
+
+        if (response && response.meta) {
+          esQueries.push({
+            params: response.meta.request.params,
+            response: {
+              body: response.body,
+              statusCode: response.statusCode,
+            },
+            duration: response.meta.duration,
+          });
+        }
+
+        if (callerExpectsApiResponse) {
+          return response;
+        }
+
+        // When meta is not requested, the client returns the body directly.
+        // We need to replicate that behavior.
+        return response.body;
+      };
+    },
+  });
+}

--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/execute/execute_rule_route.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/execute/execute_rule_route.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { v4 as uuidv4 } from 'uuid';
+import type { RouteOptions } from '../../..';
+import { createBodySchemaV1 } from '../../../../../common/routes/rule/apis/create';
+import type {
+  RuleExecutorOptions,
+  RuleExecutorServices,
+  AsyncSearchParams,
+  AsyncSearchStrategies,
+} from '../../../../types';
+import { BASE_ALERTING_API_PATH, DISABLE_FLAPPING_SETTINGS } from '../../../../types';
+import { DEFAULT_ALERTING_ROUTE_SECURITY } from '../../../constants';
+import { verifyAccessAndContext } from '../../../lib';
+import { createEsClientWithMeta } from './es_client_meta_wrapper';
+
+export const executeRuleRoute = ({ router, licenseState, core }: RouteOptions) => {
+  router.post(
+    {
+      path: `${BASE_ALERTING_API_PATH}/rule/_execute`,
+      security: DEFAULT_ALERTING_ROUTE_SECURITY,
+      options: {
+        access: 'public',
+        summary: `Executes a rule on-demand`,
+        tags: ['oas-tag:alerting'],
+      },
+      validate: {
+        request: {
+          body: createBodySchemaV1,
+        },
+        response: {
+          200: {
+            body: () => schema.object({}, { unknowns: 'allow' }),
+            description: 'Indicates a successful call.',
+          },
+          400: {
+            description: 'Indicates an invalid schema or parameters.',
+          },
+          403: {
+            description: 'Indicates that this call is forbidden.',
+          },
+        },
+      },
+    },
+    router.handleLegacyErrors(
+      verifyAccessAndContext(licenseState, async function (context, req, res) {
+        try {
+          const coreContext = await context.core;
+          const [, { data, dataViews, share }] = await core.getStartServices();
+          const alertingContext = await context.alerting;
+          const rulesClient = await alertingContext.getRulesClient();
+          const requestParams = req.body;
+          const ruleType = alertingContext.getType(requestParams.rule_type_id);
+
+          if (!ruleType) {
+            return res.badRequest({
+              body: `Rule type '${requestParams.rule_type_id}' is not registered.`,
+            });
+          }
+
+          const esQueries: any[] = [];
+          const asCurrentUserWithMeta = createEsClientWithMeta(
+            coreContext.elasticsearch.client.asCurrentUser,
+            esQueries
+          );
+
+          const savedObjectsClient = coreContext.savedObjects.client;
+          const dataViewsService = await dataViews.dataViewsServiceFactory(
+            savedObjectsClient,
+            coreContext.elasticsearch.client.asInternalUser
+          );
+          const searchSourceClient = await data.search.searchSource.asScoped(req);
+
+          const services: RuleExecutorServices = {
+            alertsClient: {
+              isTrackedAlert: () => false,
+              getAlertLimitValue: () => 1000,
+              setAlertLimitReached: () => {},
+              getRecoveredAlerts: () => [],
+              report: () => {},
+            },
+            getDataViews: async () => dataViewsService,
+            getMaintenanceWindowIds: async () => [],
+            getSearchSourceClient: async () => searchSourceClient,
+            savedObjectsClient: coreContext.savedObjects.client,
+            scopedClusterClient: {
+              asCurrentUser: asCurrentUserWithMeta,
+            },
+            share,
+            shouldStopExecution: () => false,
+            shouldWriteAlerts: () => false,
+            uiSettingsClient: coreContext.uiSettings.client,
+            getAsyncSearchClient: <T extends AsyncSearchParams>(
+              strategy: AsyncSearchStrategies
+            ) => {
+              throw new Error('Not implemented');
+            },
+          };
+
+          const rule = {
+            id: uuidv4(),
+            ...requestParams,
+            actions: requestParams.actions || [],
+            schedule: requestParams.schedule || { interval: '1m' },
+            enabled: requestParams.enabled === undefined ? true : requestParams.enabled,
+            name: requestParams.name || 'On-demand execution',
+            tags: requestParams.tags || [],
+            throttle: requestParams.throttle || null,
+            createdBy: 'elastic',
+            updatedBy: 'elastic',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            apiKeyOwner: 'elastic',
+            notifyWhen: 'onActionGroup',
+            consumer: requestParams.consumer,
+            rule_type_id: requestParams.rule_type_id,
+            params: requestParams.params,
+          };
+
+          const options: RuleExecutorOptions = {
+            executionId: uuidv4(),
+            logger: context.logger,
+            params: requestParams.params,
+            previousStartedAt: null,
+            rule,
+            services,
+            spaceId: rulesClient.getSpaceId(),
+            startedAt: new Date(),
+            startedAtOverridden: false,
+            state: {},
+            namespace: rulesClient.getSpaceId(),
+            flappingSettings: DISABLE_FLAPPING_SETTINGS,
+            getTimeRange: () => ({ from: 'now-5m', to: 'now' }),
+            isServerless: false,
+          };
+
+          await ruleType.executor(options);
+
+          return res.ok({ body: { _inspect: { esQueries } } });
+        } catch (error) {
+          console.error(error);
+        }
+      })
+    )
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/execute/search_source_interceptor.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/rule/apis/execute/search_source_interceptor.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ISearchSource, ISearchStartSearchSource } from '@kbn/data-plugin/common';
+
+/**
+ * Recursively creates a proxy for a SearchSource instance to intercept `fetch` and `createChild` calls.
+ * @param searchSource The SearchSource instance to wrap.
+ * @param interactions The array to store captured data in.
+ * @returns A proxied ISearchSource instance.
+ */
+function createSearchSourceProxy(
+  searchSource: ISearchSource,
+  interactions: Array<any> // Using 'any' for now to match the flexible structure
+): ISearchSource {
+  return new Proxy(searchSource, {
+    get(target, prop, receiver) {
+      const originalMethod = Reflect.get(target, prop, receiver);
+
+      // Intercept the 'fetch' method to capture request and response
+      if (prop === 'fetch' && typeof originalMethod === 'function') {
+        return async (...fetchArgs: any[]) => {
+          const requestBody = target.getSearchRequestBody(); // Get the Elasticsearch query body
+
+          // Execute the original fetch to get the parsed ISearchResponse
+          const searchResponse = await originalMethod.apply(target, fetchArgs);
+
+          // Construct the object to match the desired structure as closely as possible
+          const formattedInteraction = {
+            // 'params' in the user's example likely refers to the full Elasticsearch client request object.
+            // From searchSource.fetch(), we primarily get the request body.
+            // We'll make assumptions for method and path, as they are not directly exposed here.
+            params: {
+              body: JSON.stringify(requestBody),
+              method: 'POST', // SearchSource.fetch() typically performs a POST request
+              path: '_search', // SearchSource.fetch() typically targets the _search endpoint
+              // Other parameters like index, type, etc., would be part of the 'body'
+            },
+            response: {
+              body: searchResponse,
+              statusCode: 200,
+            },
+            // response: {
+            //   body: searchResponse.rawResponse, // ISearchResponse contains the raw Elasticsearch response body
+            //   // The HTTP status code is not directly available from ISearchResponse
+            //   statusCode: undefined, // Cannot be retrieved at this abstraction level
+            // },
+          };
+
+          interactions.push(formattedInteraction);
+
+          // Return the original response to not break the execution flow
+          return searchResponse;
+        };
+      }
+
+      // Intercept 'createChild' to ensure the child is also proxied
+      if (prop === 'createChild' && typeof originalMethod === 'function') {
+        return (...childArgs: any[]) => {
+          const realChild = originalMethod.apply(target, childArgs);
+          // Recursive call to wrap the child in the same proxy logic
+          return createSearchSourceProxy(realChild, interactions);
+        };
+      }
+
+      return originalMethod;
+    },
+  });
+}
+
+/**
+ * Wraps an ISearchStartSearchSource factory to intercept calls to SearchSource instances it creates.
+ * This allows capturing the request and response from `searchSource.fetch()` calls, including on child search sources.
+ *
+ * @param searchSourceClient The original ISearchStartSearchSource factory from the Data plugin.
+ * @param interactions An array where the captured { request, response } pairs will be stored.
+ * @returns A proxied ISearchStartSearchSource factory.
+ */
+export function searchSourceInspector(
+  searchSourceClient: ISearchStartSearchSource,
+  interactions: Array<any> // Using 'any' for now to match the flexible structure
+): ISearchStartSearchSource {
+  return new Proxy(searchSourceClient, {
+    get(factoryTarget, factoryProp, factoryReceiver) {
+      const originalFactoryMethod = Reflect.get(factoryTarget, factoryProp, factoryReceiver);
+
+      // Intercept methods that create the initial SearchSource instance
+      if (
+        (factoryProp === 'create' || factoryProp === 'createLazy') &&
+        typeof originalFactoryMethod === 'function'
+      ) {
+        return async (...args: any[]) => {
+          const realSearchSource = await originalFactoryMethod.apply(factoryTarget, args);
+          // Apply the recursive proxy to the first SearchSource instance
+          return createSearchSourceProxy(realSearchSource, interactions);
+        };
+      }
+      return originalFactoryMethod;
+    },
+  });
+}

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/preview.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/preview.ts
@@ -6,6 +6,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
+import { searchSourceInspector } from '../../routes/rule/apis/execute/search_source_interceptor';
 import { createEsClientWithMeta } from '../../routes/rule/apis/execute/es_client_meta_wrapper';
 import type {
   AsyncSearchParams,
@@ -35,6 +36,7 @@ export async function preview(
     // const [, { data, dataViews, share }] = await core.getStartServices();
     const esQueries: any[] = [];
     const asCurrentUserWithMeta = createEsClientWithMeta(esClient, esQueries);
+    const inspectedSearchSourceClient = searchSourceInspector(searchSourceClient, esQueries);
 
     const services: RuleExecutorServices = {
       alertsClient: {
@@ -51,7 +53,7 @@ export async function preview(
       },
       getDataViews: async () => dataViewsService,
       getMaintenanceWindowIds: async () => [],
-      getSearchSourceClient: async () => searchSourceClient,
+      getSearchSourceClient: async () => inspectedSearchSourceClient,
       savedObjectsClient,
       scopedClusterClient: {
         asCurrentUser: asCurrentUserWithMeta,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/preview.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/preview.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { createEsClientWithMeta } from '../../routes/rule/apis/execute/es_client_meta_wrapper';
+import type {
+  AsyncSearchParams,
+  AsyncSearchStrategies,
+  RuleExecutorOptions,
+  RuleExecutorServices,
+} from '../../types';
+import { ruleAuditEvent, RuleAuditAction } from '../common/audit_events';
+import type { RulesClientContext } from '../types';
+import { DISABLE_FLAPPING_SETTINGS } from '../../types';
+
+export async function preview(
+  context: RulesClientContext,
+  {
+    esClient,
+    requestParams,
+    ruleType,
+    savedObjectsClient,
+    dataViewsService,
+    searchSourceClient,
+    getSpaceId,
+    share,
+    uiSettingsClient,
+  }: any
+) {
+  try {
+    // const [, { data, dataViews, share }] = await core.getStartServices();
+    const esQueries: any[] = [];
+    const asCurrentUserWithMeta = createEsClientWithMeta(esClient, esQueries);
+
+    const services: RuleExecutorServices = {
+      alertsClient: {
+        isTrackedAlert: () => false,
+        getAlertLimitValue: () => 1000,
+        setAlertLimitReached: () => {},
+        getRecoveredAlerts: () => [],
+        setAlertData: () => {},
+        report: () => {
+          return {
+            uuid: uuidv4(),
+          };
+        },
+      },
+      getDataViews: async () => dataViewsService,
+      getMaintenanceWindowIds: async () => [],
+      getSearchSourceClient: async () => searchSourceClient,
+      savedObjectsClient,
+      scopedClusterClient: {
+        asCurrentUser: asCurrentUserWithMeta,
+      },
+      share,
+      shouldStopExecution: () => false,
+      shouldWriteAlerts: () => false,
+      uiSettingsClient,
+      getAsyncSearchClient: <T extends AsyncSearchParams>(strategy: AsyncSearchStrategies) => {
+        throw new Error('Not implemented');
+      },
+    };
+
+    const rule = {
+      id: uuidv4(),
+      ...requestParams,
+      actions: requestParams.actions || [],
+      schedule: requestParams.schedule || { interval: '1m' },
+      enabled: requestParams.enabled === undefined ? true : requestParams.enabled,
+      name: requestParams.name || 'On-demand execution',
+      tags: requestParams.tags || [],
+      throttle: requestParams.throttle || null,
+      createdBy: 'elastic',
+      updatedBy: 'elastic',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      apiKeyOwner: 'elastic',
+      notifyWhen: 'onActionGroup',
+      consumer: requestParams.consumer,
+      rule_type_id: requestParams.rule_type_id,
+      params: requestParams.params,
+    };
+
+    const options: RuleExecutorOptions = {
+      executionId: uuidv4(),
+      logger: context.logger,
+      params: requestParams.params,
+      previousStartedAt: null,
+      rule,
+      services,
+      spaceId: getSpaceId,
+      startedAt: new Date(),
+      startedAtOverridden: false,
+      state: {},
+      namespace: getSpaceId,
+      flappingSettings: DISABLE_FLAPPING_SETTINGS,
+      // TODO: Fix look back window
+      getTimeRange: () => ({ from: 'now-5m', to: 'now' }),
+      // TODO: Fix serverless
+      isServerless: false,
+    };
+
+    await ruleType.executor(options);
+
+    return esQueries;
+  } catch (error) {
+    console.log('error', error);
+    context.auditLogger?.log(
+      ruleAuditEvent({
+        action: RuleAuditAction.RUN_SOON,
+        // savedObject: { type: RULE_SAVED_OBJECT_TYPE, rule.id, name: attributes.name },
+        error,
+      })
+    );
+    throw error;
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/rules_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/rules_client.ts
@@ -68,6 +68,7 @@ import { unmuteAll } from '../application/rule/methods/unmute_all';
 import { muteAll } from '../application/rule/methods/mute_all';
 import { unmuteInstance } from '../application/rule/methods/unmute_alert/unmute_instance';
 import { runSoon } from './methods/run_soon';
+import { preview } from './methods/preview';
 import { listRuleTypes } from '../application/rule/methods/rule_types/rule_types';
 import { getScheduleFrequency } from '../application/rule/methods/get_schedule_frequency/get_schedule_frequency';
 import type { BulkUntrackBody } from '../application/rule/methods/bulk_untrack/bulk_untrack_alerts';
@@ -211,6 +212,8 @@ export class RulesClient {
   public bulkUntrackAlerts = (options: BulkUntrackBody) => bulkUntrackAlerts(this.context, options);
 
   public runSoon = (options: { id: string }) => runSoon(this.context, options);
+
+  public preview = (options: any) => preview(this.context, options);
 
   public listRuleTypes = () => listRuleTypes(this.context);
 

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -91,6 +91,7 @@ export interface AlertingApiRequestHandlerContext {
   getRulesSettingsClient: (withoutAuth?: boolean) => RulesSettingsClient;
   getMaintenanceWindowClient: () => MaintenanceWindowClient;
   listTypes: RuleTypeRegistry['list'];
+  getType: RuleTypeRegistry['get'];
   getFrameworkHealth: () => Promise<AlertsHealth>;
   areApiKeysEnabled: () => Promise<boolean>;
 }

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/kibana.jsonc
@@ -13,6 +13,7 @@
       "management",
       "charts",
       "data",
+      "inspector",
       "kibanaReact",
       "kibanaUtils",
       "unifiedSearch",

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/rules_app.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/rules_app.tsx
@@ -42,6 +42,7 @@ import type { CloudSetup } from '@kbn/cloud-plugin/public';
 import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { ContentManagementPublicStart } from '@kbn/content-management-plugin/public';
+import type { Start as InspectorPluginStart } from '@kbn/inspector-plugin/public';
 import { suspendedComponentWithProps } from './lib/suspended_component_with_props';
 import type { ActionTypeRegistryContract, RuleTypeRegistryContract } from '../types';
 import type { Section } from './constants';
@@ -70,6 +71,7 @@ export interface TriggersAndActionsUiServices extends CoreStart {
   spaces?: SpacesPluginStart;
   storage?: Storage;
   isCloud: boolean;
+  inspector: InspectorPluginStart;
   setBreadcrumbs: (crumbs: ChromeBreadcrumb[]) => void;
   actionTypeRegistry: ActionTypeRegistryContract;
   ruleTypeRegistry: RuleTypeRegistryContract;

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/plugin.ts
@@ -21,6 +21,7 @@ import type { ActionsPublicPluginSetup } from '@kbn/actions-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { DataViewEditorStart } from '@kbn/data-view-editor-plugin/public';
+import type { Start as InspectorPluginStart } from '@kbn/inspector-plugin/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
@@ -161,6 +162,7 @@ interface PluginsStart {
   dataViewEditor: DataViewEditorStart;
   charts: ChartsPluginStart;
   alerting?: AlertingStart;
+  inspector: InspectorPluginStart;
   spaces?: SpacesPluginStart;
   navigateToApp: CoreStart['application']['navigateToApp'];
   features: FeaturesPluginStart;
@@ -311,6 +313,7 @@ export class Plugin
             actionTypeRegistry,
             ruleTypeRegistry,
             kibanaFeatures,
+            inspector: pluginsStart.inspector,
             licensing: pluginsStart.licensing,
             expressions: pluginsStart.expressions,
             isServerless: !!pluginsStart.serverless,


### PR DESCRIPTION
## Summary

Similar logic to https://github.com/elastic/kibana/pull/242886, only added an additional interceptor for ES requests executed using searchSource instead of esClient (such as in ES Query rule).



Uploading Screen Recording 2025-11-14 at 13.01.26.mov…



