### PR TITLE
[ci] enable scout tests for ES serverless image verification pipeline

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -611,6 +611,12 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
   const bk = new BuildkiteClient();
   const envFromlabels: Record<string, string> = collectEnvFromLabels();
 
+  // Collect environment variables to pass through to test execution steps
+  const scoutExtraEnv: Record<string, string> = {};
+  if (process.env.SERVERLESS_TESTS_ONLY) {
+    scoutExtraEnv.SERVERLESS_TESTS_ONLY = process.env.SERVERLESS_TESTS_ONLY;
+  }
+
   if (!Fs.existsSync(scoutConfigsPath)) {
     throw new Error(`Scout configs file not found at ${scoutConfigsPath}`);
   }
@@ -650,6 +656,7 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
               SCOUT_CONFIG_GROUP_KEY: key,
               SCOUT_CONFIG_GROUP_TYPE: group,
               ...envFromlabels,
+              ...scoutExtraEnv,
             },
             retry: {
               automatic: [

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -62,6 +62,26 @@ steps:
             - exit_status: '*'
               limit: 1
 
+      - command: .buildkite/scripts/steps/test/scout_test_run_builder.sh
+        label: 'Scout Test Run Builder'
+        agents:
+          image: family/kibana-ubuntu-2404
+          imageProject: elastic-images-prod
+          provider: gcp
+          machineType: n2-standard-4
+          diskSizeGb: 115
+        key: build_scout_tests
+        timeout_in_minutes: 15
+        depends_on:
+          - build
+        env:
+          SERVERLESS_TESTS_ONLY: 'true'
+          SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'
+        retry:
+          automatic:
+            - exit_status: '*'
+              limit: 1
+
       - command: .buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
         label: 'Serverless Entity Analytics - Security Solution Cypress Tests'
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"

--- a/.buildkite/scripts/steps/test/scout_configs.sh
+++ b/.buildkite/scripts/steps/test/scout_configs.sh
@@ -66,8 +66,20 @@ RUN_MODES["observability"]="--stateful --serverless=oblt --serverless=oblt-logs-
 RUN_MODES["search"]="--stateful --serverless=es"
 RUN_MODES["security"]="--stateful --serverless=security"
 
+# Define serverless-only run modes based on group
+declare -A RUN_MODES_SERVERLESS_ONLY
+RUN_MODES_SERVERLESS_ONLY["platform"]="--serverless=es --serverless=oblt --serverless=security"
+RUN_MODES_SERVERLESS_ONLY["observability"]="--serverless=oblt --serverless=oblt-logs-essentials"
+RUN_MODES_SERVERLESS_ONLY["search"]="--serverless=es"
+RUN_MODES_SERVERLESS_ONLY["security"]="--serverless=security"
+
 # Determine valid run modes for the group
-RUN_MODE_LIST=${RUN_MODES[$group]}
+if [[ -n "${SERVERLESS_TESTS_ONLY:-}" ]]; then
+  echo "--- Using serverless-only test modes (SERVERLESS_TESTS_ONLY is set)"
+  RUN_MODE_LIST=${RUN_MODES_SERVERLESS_ONLY[$group]}
+else
+  RUN_MODE_LIST=${RUN_MODES[$group]}
+fi
 
 if [[ -z "$RUN_MODE_LIST" ]]; then
   echo "Unknown group: $group"


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/appex-qa-team/issues/538

This PR adds `SERVERLESS_TESTS_ONLY` variable to limit scope of Scout test to **serverless only** and extends `verify_es_serverless_image.yml` pipeline o run those tests.


