### PR TITLE
[ES|QL] Avoid fuse false positive validation when context is not provided

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/fuse/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/fuse/validate.test.ts
@@ -55,5 +55,18 @@ describe('FUSE Validation', () => {
         ]
       );
     });
+
+    test('do not return validation errors if columns context is not provided', () => {
+      const context = { columns: new Map() };
+      fuseExpectErrors(
+        `FROM index
+                    | FORK
+                      (WHERE keywordField != "" | LIMIT 100)
+                      (SORT doubleField ASC NULLS LAST)
+                    | FUSE`,
+        [],
+        context
+      );
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/fuse/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/fuse/validate.test.ts
@@ -29,6 +29,15 @@ describe('FUSE Validation', () => {
                     | FUSE`,
         []
       );
+
+      fuseExpectErrors(
+        `TS index METADATA _id, _score, _index
+                    | FORK
+                      (WHERE keywordField != "" | LIMIT 100)
+                      (SORT doubleField ASC NULLS LAST)
+                    | FUSE`,
+        []
+      );
     });
 
     test('requires _id, _index and _score metadata to be selected in the FROM command', () => {
@@ -38,11 +47,18 @@ describe('FUSE Validation', () => {
                       (WHERE keywordField != "" | LIMIT 100)
                       (SORT doubleField ASC NULLS LAST)
                     | FUSE`,
-        [
-          '[FUSE] The FROM command is missing the _id METADATA field.',
-          '[FUSE] The FROM command is missing the _index METADATA field.',
-          '[FUSE] The FROM command is missing the _score METADATA field.',
-        ]
+        ['[FUSE] The FROM command is missing the _id, _index, _score METADATA field.']
+      );
+    });
+
+    test('requires _id metadata to be selected in the FROM command', () => {
+      fuseExpectErrors(
+        `FROM index METADATA _score, _index
+                    | FORK
+                      (WHERE keywordField != "" | LIMIT 100)
+                      (SORT doubleField ASC NULLS LAST)
+                    | FUSE`,
+        ['[FUSE] The FROM command is missing the _id METADATA field.']
       );
     });
   });

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/fuse/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/fuse/validate.test.ts
@@ -6,7 +6,6 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { METADATA_FIELDS } from '../../../..';
 import { mockContext } from '../../../__tests__/context_fixtures';
 import { expectErrors } from '../../../__tests__/validation';
 import { validate } from './validate';
@@ -22,22 +21,13 @@ describe('FUSE Validation', () => {
 
   describe('FUSE', () => {
     test('no errors for valid command', () => {
-      const newColumns = new Map(mockContext.columns);
-      METADATA_FIELDS.forEach((fieldName) => {
-        newColumns.set(fieldName, { name: fieldName, type: 'keyword', userDefined: false });
-      });
-      const context = {
-        ...mockContext,
-        columns: newColumns,
-      };
       fuseExpectErrors(
         `FROM index METADATA _id, _score, _index
                     | FORK
                       (WHERE keywordField != "" | LIMIT 100)
                       (SORT doubleField ASC NULLS LAST)
                     | FUSE`,
-        [],
-        context
+        []
       );
     });
 
@@ -53,19 +43,6 @@ describe('FUSE Validation', () => {
           '[FUSE] The FROM command is missing the _index METADATA field.',
           '[FUSE] The FROM command is missing the _score METADATA field.',
         ]
-      );
-    });
-
-    test('do not return validation errors if columns context is not provided', () => {
-      const context = { columns: new Map() };
-      fuseExpectErrors(
-        `FROM index
-                    | FORK
-                      (WHERE keywordField != "" | LIMIT 100)
-                      (SORT doubleField ASC NULLS LAST)
-                    | FUSE`,
-        [],
-        context
       );
     });
   });

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/fuse/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/fuse/validate.ts
@@ -28,7 +28,9 @@ export const validate = (
     walk(fromCommand, {
       visitCommandOption: (node) => {
         if (node.name.toLocaleLowerCase() === 'metadata') {
-          const metadataFields = node.args.map((arg) => (arg as ESQLSingleAstItem).name);
+          const metadataFields = node.args.map((arg) =>
+            (arg as ESQLSingleAstItem)?.name?.toLocaleLowerCase()
+          );
           if (metadataFields.includes('_id')) {
             hasIdMetadata = true;
           }

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/fuse/validate.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/fuse/validate.ts
@@ -17,6 +17,11 @@ export const validate = (
 ): ESQLMessage[] => {
   const messages: ESQLMessage[] = [];
 
+  // If no columns are provided don't perform the client side validation, to avoid false positives.
+  if (context?.columns?.size === 0) {
+    return messages;
+  }
+
   if (!context?.columns.get('_id')) {
     messages.push(buildMissingMetadataMessage(command, '_id'));
   }


### PR DESCRIPTION
## Summary
If columns context was not provided, FUSE was having false positive validations.

### Solution
Use AST instead of columns context to check for metadata fields.




