### PR TITLE
[8.19] [Console] Fix 'maximum tokenizer stack size reached' console error (#238531)

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/shared.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/shared.ts
@@ -101,7 +101,17 @@ export const matchTokensWithEOL = (
 
 const xjsonRules = { ...buildXjsonRules('json_root') };
 
+// Override the xjson brace rules to prevent stack overflow in Console
+// The default xjson uses @push/@pop which causes stack overflow with many requests
+// We replace those rules with Console-specific rules that don't use @push
+const originalJsonRoot = xjsonRules.json_root;
 xjsonRules.json_root = [
+  // Return to root when closing brace is at end of line
+  // This prevents stack accumulation across multiple HTTP requests
+  // @ts-expect-error custom rule
+  matchTokensWithEOL('paren.rparen', /}/, 'root'),
+  // Don't push for opening braces to prevent stack overflow
+  [/{/, { token: 'paren.lparen' }],
   // @ts-expect-error include comments into json
   { include: '@comments' },
   // @ts-expect-error include variables into json
@@ -114,7 +124,18 @@ xjsonRules.json_root = [
   buildEsqlStartRule(false),
   // @ts-expect-error include a rule to start esql highlighting
   buildEsqlStartRule(true),
-  ...xjsonRules.json_root,
+  // Include remaining xjson rules, filtering out the original brace rules
+  ...originalJsonRoot.filter((rule: any) => {
+    // Filter out the original @push/@pop brace rules from xjson
+    if (Array.isArray(rule) && rule.length >= 2) {
+      const regex = rule[0];
+      // Skip the original brace rules (they use @push/@pop)
+      if (regex instanceof RegExp && (regex.source === '\\{' || regex.source === '\\}')) {
+        return false;
+      }
+    }
+    return true;
+  }),
 ];
 
 const sqlRules = buildSqlRules();

--- a/src/platform/test/functional/apps/console/large_input.ts
+++ b/src/platform/test/functional/apps/console/large_input.ts
@@ -1,0 +1,299 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const LARGE_INPUT = `PUT myindex123
+
+DELETE myindex123
+
+PUT .kibana_test
+
+PUT .alert_test
+
+PUT .alerts_test
+
+PUT myindex1234
+
+PUT mytest
+
+POST _aliases
+{
+  "actions": [
+    {
+      "add": {
+        "index": "myindex1234",
+        "alias": "myindex123"
+      }
+    }
+  ]
+}
+
+
+# Versioned routes: Version 1 is deprecated
+GET kbn:/api/routing_example/d/versioned?apiVersion=1
+GET kbn:/api/routing_example/d/versioned?apiVersion=2
+
+# Non-versioned routes
+GET kbn:/api/routing_example/d/removed_route
+POST kbn:/api/routing_example/d/migrated_route
+{}
+
+GET .kibana_usage_counters/_search
+{
+    "query": {
+        "bool": {
+            "should": [
+              {"match": { "usage-counter.counterType": "deprecated_api_call:total"}},
+              {"match": { "usage-counter.counterType": "deprecated_api_call:resolved"}},
+              {"match": { "usage-counter.counterType": "deprecated_api_call:marked_as_resolved"}}
+            ]
+        }
+    }
+}
+
+PUT myindexflat
+{
+    "mappings": {
+        "properties": {
+            "flat": {
+                "type": "flattened"
+            }
+        }
+    }
+}
+
+PUT myindexflat/_doc/123
+{
+    "flat": [{"test": 1},{"test": 2},{"another": 1}]
+}
+
+POST myindexflat/_search
+{
+  "fields": ["flat.test"],
+  "_source": false
+}
+
+POST kbn:/api/endpoint/suggestions/eventFilters
+{
+  "query": "test",
+  "field": "test"
+
+}
+
+GET .lists-default/_search?filter_path=hits
+
+
+// Should contain results from hidden index
+GET my_*/_search?filter_path=hits&expand_wildcards=all,hidden
+
+// Should be empty
+GET my_*/_search?filter_path=hits
+
+
+GET .my*/_search?filter_path=hits
+GET .my_hidden_index/_search?filter_path=hits
+GET my_hidden_index/_search?filter_path=hits
+
+PUT .my_hidden_index/_doc/1
+{
+  "SHOULD_NOT_BE_HERE": true
+}
+
+GET .my_sys_index
+GET .my_hidden_index
+GET _alias/.my_hidden_index
+
+PUT /
+
+# Creates a component template for mappings
+PUT _component_template/my-mappings
+{
+  "template": {
+    "mappings": {
+      "properties": {
+        "@timestamp": {
+          "type": "date",
+          "format": "date_optional_time||epoch_millis"
+        },
+        "message": {
+          "type": "wildcard"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "description": "Mappings for @timestamp and message fields",
+    "my-custom-meta-field": "More arbitrary metadata"
+  }
+}
+
+# Creates a component template for index settings
+PUT _component_template/my-settings
+{
+  "template": {
+    "settings": {
+      "index.lifecycle.name": "my-lifecycle-policy"
+    }
+  },
+  "_meta": {
+    "description": "Settings for ILM",
+    "my-custom-meta-field": "More arbitrary metadata"
+  }
+}
+
+
+PUT _index_template/enterprise_search
+{
+  "index_patterns": ["logs-enterprise_search*", "logs-app_search.*", "logs-workplace_search.*"],
+  "data_stream": { },
+  "composed_of": [ "my-mappings", "my-settings" ],
+  "priority": 500,
+  "_meta": {
+    "description": "Template for my time series data",
+    "my-custom-meta-field": "More arbitrary metadata"
+  }
+}
+
+PUT _data_stream/logs-enterprise_search.whathaveyou
+PUT _data_stream/logs-app_search.whathaveyou
+PUT _data_stream/logs-workplace_search.whathaveyou
+
+GET _migration/deprecations
+
+POST my-data-stream/_doc
+{
+  "@timestamp": "2099-05-06T16:21:15.000Z",
+  "message": """192.0.2.42 - - [06/May/2099:16:21:15 +0000] "GET /images/bg.jpg HTTP/1.0" 200 24736""",
+  "object": {
+    "this": "might work",
+    "array": [{ "test": 1 }, { "test": 2 } ]
+  }
+}
+
+GET my-data-stream/_search
+{
+  "runtime_mappings": {
+    "object.array.test2": {
+      "type": "long",
+      "script": {
+        "source": """
+          if (params._source.object != null && params._source.object.array != null) {
+            def arr = params._source.object.array;
+            for (def entry : arr) {
+                emit(entry.test + 10)
+            }
+            return;
+          }
+        """
+      }
+    },
+    "messageV2": {
+      "type": "text",
+      "script": {
+        "source": """
+          if (params._source["messageV2"] != null) {
+            // return what we have in source if there is something
+            emit(params._source["messageV2"]);
+          } else  {
+            // return the original processed in some way
+            emit(doc['message'].value + " the original, but processed");
+          }
+        """
+      }
+    }
+  },
+  "query": {
+    "match_all": {}
+  },
+  "fields": ["messageV2", "object.array.test2"]
+}
+
+GET _index_template/my-index-template
+
+GET _data_stream/my-data-strea
+
+PUT _data_stream/my-data-stream-2
+GET _data_stream/my-data-stream
+GET _data_stream/my-data-stream-2
+
+GET _data_stream/
+
+GET .ds-my-data-stream-2025.08.13-000001/_mapping
+PUT .ds-my-data-stream-2025.08.13-000001/_mapping
+{
+"_data_stream_timestamp": {
+        "enabled": true
+      },
+      "properties": {
+        "@timestamp": {
+          "type": "date",
+          "format": "date_optional_time||epoch_millis"
+        },
+        "message": {
+          "type": "wildcard"
+        },
+        "messageV2": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "object": {
+          "properties": {
+            "array": {
+              "properties": {
+                "test": {
+                  "type": "long"
+                }
+              }
+            },
+            "this": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            }
+          }
+        },
+        "test": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        }
+      }
+    }
+
+PUT _index_template/my-index-template
+{
+    "index_patterns": [
+      "my-data-stream*"
+    ],
+    "composed_of": [
+      "my-mappings",
+      "my-settings"
+    ],
+    "priority": 500,
+    "_meta": {
+      "my-custom-meta-field": "More arbitrary metadata",
+      "description": "Template for my time series data"
+    },
+    "data_stream": {
+      "hidden": false,
+      "allow_custom_routing": false
+    }
+  }\n\n`;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Console] Fix 'maximum tokenizer stack size reached' console error (#238531)](https://github.com/elastic/kibana/pull/238531)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Stoeva","email":"59341489+ElenaStoeva@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-11-05T10:38:50Z","message":"[Console] Fix 'maximum tokenizer stack size reached' console error (#238531)\n\nFixes https://github.com/elastic/kibana/issues/237845\n\n## Summary\n\nThis PR fixes the \"maximum tokenizer stack size reached\" console error\nwhich happens when the user adds a lot of lines in the editor.\n\n<details>\n<summary>Sample input that was causing the error:</summary>\n\n```\nPUT myindex123\n\nDELETE myindex123\n\nPUT .kibana_test\n\nPUT .alert_test\n\nPUT .alerts_test\n\nPUT myindex1234\n\nPUT mytest\n\nPOST _aliases\n{\n  \"actions\": [\n    {\n      \"add\": {\n        \"index\": \"myindex1234\",\n        \"alias\": \"myindex123\"\n      }\n    }\n  ]\n}\n\n\n# Versioned routes: Version 1 is deprecated\nGET kbn:/api/routing_example/d/versioned?apiVersion=1\nGET kbn:/api/routing_example/d/versioned?apiVersion=2\n\n# Non-versioned routes\nGET kbn:/api/routing_example/d/removed_route\nPOST kbn:/api/routing_example/d/migrated_route\n{}\n\nGET .kibana_usage_counters/_search\n{\n    \"query\": {\n        \"bool\": {\n            \"should\": [\n              {\"match\": { \"usage-counter.counterType\": \"deprecated_api_call:total\"}},\n              {\"match\": { \"usage-counter.counterType\": \"deprecated_api_call:resolved\"}},\n              {\"match\": { \"usage-counter.counterType\": \"deprecated_api_call:marked_as_resolved\"}}\n            ]\n        }\n    }\n}\n\nPUT myindexflat\n{\n    \"mappings\": {\n        \"properties\": {\n            \"flat\": {\n                \"type\": \"flattened\"\n            }\n        }\n    }\n}\n\nPUT myindexflat/_doc/123\n{\n    \"flat\": [{\"test\": 1},{\"test\": 2},{\"another\": 1}]\n}\n\nPOST myindexflat/_search\n{\n  \"fields\": [\"flat.test\"],\n  \"_source\": false\n}\n\nPOST kbn:/api/endpoint/suggestions/eventFilters\n{\n  \"query\": \"test\",\n  \"field\": \"test\"\n\n}\n\nGET .lists-default/_search?filter_path=hits\n\n\n// Should contain results from hidden index\nGET my_*/_search?filter_path=hits&expand_wildcards=all,hidden\n\n// Should be empty\nGET my_*/_search?filter_path=hits\n\n\nGET .my*/_search?filter_path=hits\nGET .my_hidden_index/_search?filter_path=hits\nGET my_hidden_index/_search?filter_path=hits\n\nPUT .my_hidden_index/_doc/1\n{\n  \"SHOULD_NOT_BE_HERE\": true\n}\n\nGET .my_sys_index\nGET .my_hidden_index\nGET _alias/.my_hidden_index\n\nPUT /\n\n# Creates a component template for mappings\nPUT _component_template/my-mappings\n{\n  \"template\": {\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": {\n          \"type\": \"date\",\n          \"format\": \"date_optional_time||epoch_millis\"\n        },\n        \"message\": {\n          \"type\": \"wildcard\"\n        }\n      }\n    }\n  },\n  \"_meta\": {\n    \"description\": \"Mappings for @timestamp and message fields\",\n    \"my-custom-meta-field\": \"More arbitrary metadata\"\n  }\n}\n\n# Creates a component template for index settings\nPUT _component_template/my-settings\n{\n  \"template\": {\n    \"settings\": {\n      \"index.lifecycle.name\": \"my-lifecycle-policy\"\n    }\n  },\n  \"_meta\": {\n    \"description\": \"Settings for ILM\",\n    \"my-custom-meta-field\": \"More arbitrary metadata\"\n  }\n}\n\n\nPUT _index_template/enterprise_search\n{\n  \"index_patterns\": [\"logs-enterprise_search*\", \"logs-app_search.*\", \"logs-workplace_search.*\"],\n  \"data_stream\": { },\n  \"composed_of\": [ \"my-mappings\", \"my-settings\" ],\n  \"priority\": 500,\n  \"_meta\": {\n    \"description\": \"Template for my time series data\",\n    \"my-custom-meta-field\": \"More arbitrary metadata\"\n  }\n}\n\nPUT _data_stream/logs-enterprise_search.whathaveyou\nPUT _data_stream/logs-app_search.whathaveyou\nPUT _data_stream/logs-workplace_search.whathaveyou\n\nGET _migration/deprecations\n\nPOST my-data-stream/_doc\n{\n  \"@timestamp\": \"2099-05-06T16:21:15.000Z\",\n  \"message\": \"\"\"192.0.2.42 - - [06/May/2099:16:21:15 +0000] \"GET /images/bg.jpg HTTP/1.0\" 200 24736\"\"\",\n  \"object\": {\n    \"this\": \"might work\",\n    \"array\": [{ \"test\": 1 }, { \"test\": 2 } ]\n  }\n}\n\nGET my-data-stream/_search\n{\n  \"runtime_mappings\": {\n    \"object.array.test2\": {\n      \"type\": \"long\",\n      \"script\": {\n        \"source\": \"\"\"\n          if (params._source.object != null && params._source.object.array != null) {\n            def arr = params._source.object.array;\n            for (def entry : arr) {\n                emit(entry.test + 10)\n            }\n            return;\n          }\n        \"\"\"\n      }\n    },\n    \"messageV2\": {\n      \"type\": \"text\",\n      \"script\": {\n        \"source\": \"\"\"\n          if (params._source[\"messageV2\"] != null) {\n            // return what we have in source if there is something\n            emit(params._source[\"messageV2\"]);\n          } else  {\n            // return the original processed in some way\n            emit(doc['message'].value + \" the original, but processed\");\n          }\n        \"\"\"\n      }\n    }\n  },\n  \"query\": {\n    \"match_all\": {}\n  },\n  \"fields\": [\"messageV2\", \"object.array.test2\"]\n}\n\nGET _index_template/my-index-template\n\nGET _data_stream/my-data-strea\n\nPUT _data_stream/my-data-stream-2\nGET _data_stream/my-data-stream\nGET _data_stream/my-data-stream-2\n\nGET _data_stream/\n\nGET .ds-my-data-stream-2025.08.13-000001/_mapping\nPUT .ds-my-data-stream-2025.08.13-000001/_mapping\n{\n\"_data_stream_timestamp\": {\n        \"enabled\": true\n      },\n      \"properties\": {\n        \"@timestamp\": {\n          \"type\": \"date\",\n          \"format\": \"date_optional_time||epoch_millis\"\n        },\n        \"message\": {\n          \"type\": \"wildcard\"\n        },\n        \"messageV2\": {\n          \"type\": \"text\",\n          \"fields\": {\n            \"keyword\": {\n              \"type\": \"keyword\",\n              \"ignore_above\": 256\n            }\n          }\n        },\n        \"object\": {\n          \"properties\": {\n            \"array\": {\n              \"properties\": {\n                \"test\": {\n                  \"type\": \"long\"\n                }\n              }\n            },\n            \"this\": {\n              \"type\": \"text\",\n              \"fields\": {\n                \"keyword\": {\n                  \"type\": \"keyword\",\n                  \"ignore_above\": 256\n                }\n              }\n            }\n          }\n        },\n        \"test\": {\n          \"type\": \"text\",\n          \"fields\": {\n            \"keyword\": {\n              \"type\": \"keyword\",\n              \"ignore_above\": 256\n            }\n          }\n        }\n      }\n    }\n\nPUT _index_template/my-index-template\n{\n    \"index_patterns\": [\n      \"my-data-stream*\"\n    ],\n    \"composed_of\": [\n      \"my-mappings\",\n      \"my-settings\"\n    ],\n    \"priority\": 500,\n    \"_meta\": {\n      \"my-custom-meta-field\": \"More arbitrary metadata\",\n      \"description\": \"Template for my time series data\"\n    },\n    \"data_stream\": {\n      \"hidden\": false,\n      \"allow_custom_routing\": false\n    }\n  }\n```\n</details>\n\n**Root Cause:**\nThe xjson lexer rules inherited from `buildXjsonRules()` used Monaco's\n`@push` and `@pop` state management for\nopening/closing braces (`{` and `}`). When Console displayed multiple\nrequests sequentially (e.g., `GET\n/index`, `POST /data {...}`, `PUT /data {...}`), the tokenizer would\npush a new state for each opening brace\nbut never properly pop back to the root state between requests. This\ncaused stack accumulation,\neventually exceeding Monaco's tokenizer stack limit.\n\n**The Fix:**\nThe fix overrides the brace handling rules in `json_root` to avoid using\n`@push/@pop`:\n\n1. When a `}` appears at the end of a line, it explicitly\ntransitions back to the 'root' state, ensuring clean state boundaries\nbetween requests.\n2. The `{` token is treated as a simple token without pushing state onto\n  the stack.\n3. The original xjson brace rules (which used @push/@pop) are filtered\nout\n  before including the remaining `xjson` rules.","sha":"6f9c6766c580b72231a0de597ac5203cbe8264b6","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Team:Kibana Management","release_note:skip","backport:all-open","v9.3.0"],"title":"[Console] Fix 'maximum tokenizer stack size reached' console error","number":238531,"url":"https://github.com/elastic/kibana/pull/238531","mergeCommit":{"message":"[Console] Fix 'maximum tokenizer stack size reached' console error (#238531)\n\nFixes https://github.com/elastic/kibana/issues/237845\n\n## Summary\n\nThis PR fixes the \"maximum tokenizer stack size reached\" console error\nwhich happens when the user adds a lot of lines in the editor.\n\n<details>\n<summary>Sample input that was causing the error:</summary>\n\n```\nPUT myindex123\n\nDELETE myindex123\n\nPUT .kibana_test\n\nPUT .alert_test\n\nPUT .alerts_test\n\nPUT myindex1234\n\nPUT mytest\n\nPOST _aliases\n{\n  \"actions\": [\n    {\n      \"add\": {\n        \"index\": \"myindex1234\",\n        \"alias\": \"myindex123\"\n      }\n    }\n  ]\n}\n\n\n# Versioned routes: Version 1 is deprecated\nGET kbn:/api/routing_example/d/versioned?apiVersion=1\nGET kbn:/api/routing_example/d/versioned?apiVersion=2\n\n# Non-versioned routes\nGET kbn:/api/routing_example/d/removed_route\nPOST kbn:/api/routing_example/d/migrated_route\n{}\n\nGET .kibana_usage_counters/_search\n{\n    \"query\": {\n        \"bool\": {\n            \"should\": [\n              {\"match\": { \"usage-counter.counterType\": \"deprecated_api_call:total\"}},\n              {\"match\": { \"usage-counter.counterType\": \"deprecated_api_call:resolved\"}},\n              {\"match\": { \"usage-counter.counterType\": \"deprecated_api_call:marked_as_resolved\"}}\n            ]\n        }\n    }\n}\n\nPUT myindexflat\n{\n    \"mappings\": {\n        \"properties\": {\n            \"flat\": {\n                \"type\": \"flattened\"\n            }\n        }\n    }\n}\n\nPUT myindexflat/_doc/123\n{\n    \"flat\": [{\"test\": 1},{\"test\": 2},{\"another\": 1}]\n}\n\nPOST myindexflat/_search\n{\n  \"fields\": [\"flat.test\"],\n  \"_source\": false\n}\n\nPOST kbn:/api/endpoint/suggestions/eventFilters\n{\n  \"query\": \"test\",\n  \"field\": \"test\"\n\n}\n\nGET .lists-default/_search?filter_path=hits\n\n\n// Should contain results from hidden index\nGET my_*/_search?filter_path=hits&expand_wildcards=all,hidden\n\n// Should be empty\nGET my_*/_search?filter_path=hits\n\n\nGET .my*/_search?filter_path=hits\nGET .my_hidden_index/_search?filter_path=hits\nGET my_hidden_index/_search?filter_path=hits\n\nPUT .my_hidden_index/_doc/1\n{\n  \"SHOULD_NOT_BE_HERE\": true\n}\n\nGET .my_sys_index\nGET .my_hidden_index\nGET _alias/.my_hidden_index\n\nPUT /\n\n# Creates a component template for mappings\nPUT _component_template/my-mappings\n{\n  \"template\": {\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": {\n          \"type\": \"date\",\n          \"format\": \"date_optional_time||epoch_millis\"\n        },\n        \"message\": {\n          \"type\": \"wildcard\"\n        }\n      }\n    }\n  },\n  \"_meta\": {\n    \"description\": \"Mappings for @timestamp and message fields\",\n    \"my-custom-meta-field\": \"More arbitrary metadata\"\n  }\n}\n\n# Creates a component template for index settings\nPUT _component_template/my-settings\n{\n  \"template\": {\n    \"settings\": {\n      \"index.lifecycle.name\": \"my-lifecycle-policy\"\n    }\n  },\n  \"_meta\": {\n    \"description\": \"Settings for ILM\",\n    \"my-custom-meta-field\": \"More arbitrary metadata\"\n  }\n}\n\n\nPUT _index_template/enterprise_search\n{\n  \"index_patterns\": [\"logs-enterprise_search*\", \"logs-app_search.*\", \"logs-workplace_search.*\"],\n  \"data_stream\": { },\n  \"composed_of\": [ \"my-mappings\", \"my-settings\" ],\n  \"priority\": 500,\n  \"_meta\": {\n    \"description\": \"Template for my time series data\",\n    \"my-custom-meta-field\": \"More arbitrary metadata\"\n  }\n}\n\nPUT _data_stream/logs-enterprise_search.whathaveyou\nPUT _data_stream/logs-app_search.whathaveyou\nPUT _data_stream/logs-workplace_search.whathaveyou\n\nGET _migration/deprecations\n\nPOST my-data-stream/_doc\n{\n  \"@timestamp\": \"2099-05-06T16:21:15.000Z\",\n  \"message\": \"\"\"192.0.2.42 - - [06/May/2099:16:21:15 +0000] \"GET /images/bg.jpg HTTP/1.0\" 200 24736\"\"\",\n  \"object\": {\n    \"this\": \"might work\",\n    \"array\": [{ \"test\": 1 }, { \"test\": 2 } ]\n  }\n}\n\nGET my-data-stream/_search\n{\n  \"runtime_mappings\": {\n    \"object.array.test2\": {\n      \"type\": \"long\",\n      \"script\": {\n        \"source\": \"\"\"\n          if (params._source.object != null && params._source.object.array != null) {\n            def arr = params._source.object.array;\n            for (def entry : arr) {\n                emit(entry.test + 10)\n            }\n            return;\n          }\n        \"\"\"\n      }\n    },\n    \"messageV2\": {\n      \"type\": \"text\",\n      \"script\": {\n        \"source\": \"\"\"\n          if (params._source[\"messageV2\"] != null) {\n            // return what we have in source if there is something\n            emit(params._source[\"messageV2\"]);\n          } else  {\n            // return the original processed in some way\n            emit(doc['message'].value + \" the original, but processed\");\n          }\n        \"\"\"\n      }\n    }\n  },\n  \"query\": {\n    \"match_all\": {}\n  },\n  \"fields\": [\"messageV2\", \"object.array.test2\"]\n}\n\nGET _index_template/my-index-template\n\nGET _data_stream/my-data-strea\n\nPUT _data_stream/my-data-stream-2\nGET _data_stream/my-data-stream\nGET _data_stream/my-data-stream-2\n\nGET _data_stream/\n\nGET .ds-my-data-stream-2025.08.13-000001/_mapping\nPUT .ds-my-data-stream-2025.08.13-000001/_mapping\n{\n\"_data_stream_timestamp\": {\n        \"enabled\": true\n      },\n      \"properties\": {\n        \"@timestamp\": {\n          \"type\": \"date\",\n          \"format\": \"date_optional_time||epoch_millis\"\n        },\n        \"message\": {\n          \"type\": \"wildcard\"\n        },\n        \"messageV2\": {\n          \"type\": \"text\",\n          \"fields\": {\n            \"keyword\": {\n              \"type\": \"keyword\",\n              \"ignore_above\": 256\n            }\n          }\n        },\n        \"object\": {\n          \"properties\": {\n            \"array\": {\n              \"properties\": {\n                \"test\": {\n                  \"type\": \"long\"\n                }\n              }\n            },\n            \"this\": {\n              \"type\": \"text\",\n              \"fields\": {\n                \"keyword\": {\n                  \"type\": \"keyword\",\n                  \"ignore_above\": 256\n                }\n              }\n            }\n          }\n        },\n        \"test\": {\n          \"type\": \"text\",\n          \"fields\": {\n            \"keyword\": {\n              \"type\": \"keyword\",\n              \"ignore_above\": 256\n            }\n          }\n        }\n      }\n    }\n\nPUT _index_template/my-index-template\n{\n    \"index_patterns\": [\n      \"my-data-stream*\"\n    ],\n    \"composed_of\": [\n      \"my-mappings\",\n      \"my-settings\"\n    ],\n    \"priority\": 500,\n    \"_meta\": {\n      \"my-custom-meta-field\": \"More arbitrary metadata\",\n      \"description\": \"Template for my time series data\"\n    },\n    \"data_stream\": {\n      \"hidden\": false,\n      \"allow_custom_routing\": false\n    }\n  }\n```\n</details>\n\n**Root Cause:**\nThe xjson lexer rules inherited from `buildXjsonRules()` used Monaco's\n`@push` and `@pop` state management for\nopening/closing braces (`{` and `}`). When Console displayed multiple\nrequests sequentially (e.g., `GET\n/index`, `POST /data {...}`, `PUT /data {...}`), the tokenizer would\npush a new state for each opening brace\nbut never properly pop back to the root state between requests. This\ncaused stack accumulation,\neventually exceeding Monaco's tokenizer stack limit.\n\n**The Fix:**\nThe fix overrides the brace handling rules in `json_root` to avoid using\n`@push/@pop`:\n\n1. When a `}` appears at the end of a line, it explicitly\ntransitions back to the 'root' state, ensuring clean state boundaries\nbetween requests.\n2. The `{` token is treated as a simple token without pushing state onto\n  the stack.\n3. The original xjson brace rules (which used @push/@pop) are filtered\nout\n  before including the remaining `xjson` rules.","sha":"6f9c6766c580b72231a0de597ac5203cbe8264b6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238531","number":238531,"mergeCommit":{"message":"[Console] Fix 'maximum tokenizer stack size reached' console error (#238531)\n\nFixes https://github.com/elastic/kibana/issues/237845\n\n## Summary\n\nThis PR fixes the \"maximum tokenizer stack size reached\" console error\nwhich happens when the user adds a lot of lines in the editor.\n\n<details>\n<summary>Sample input that was causing the error:</summary>\n\n```\nPUT myindex123\n\nDELETE myindex123\n\nPUT .kibana_test\n\nPUT .alert_test\n\nPUT .alerts_test\n\nPUT myindex1234\n\nPUT mytest\n\nPOST _aliases\n{\n  \"actions\": [\n    {\n      \"add\": {\n        \"index\": \"myindex1234\",\n        \"alias\": \"myindex123\"\n      }\n    }\n  ]\n}\n\n\n# Versioned routes: Version 1 is deprecated\nGET kbn:/api/routing_example/d/versioned?apiVersion=1\nGET kbn:/api/routing_example/d/versioned?apiVersion=2\n\n# Non-versioned routes\nGET kbn:/api/routing_example/d/removed_route\nPOST kbn:/api/routing_example/d/migrated_route\n{}\n\nGET .kibana_usage_counters/_search\n{\n    \"query\": {\n        \"bool\": {\n            \"should\": [\n              {\"match\": { \"usage-counter.counterType\": \"deprecated_api_call:total\"}},\n              {\"match\": { \"usage-counter.counterType\": \"deprecated_api_call:resolved\"}},\n              {\"match\": { \"usage-counter.counterType\": \"deprecated_api_call:marked_as_resolved\"}}\n            ]\n        }\n    }\n}\n\nPUT myindexflat\n{\n    \"mappings\": {\n        \"properties\": {\n            \"flat\": {\n                \"type\": \"flattened\"\n            }\n        }\n    }\n}\n\nPUT myindexflat/_doc/123\n{\n    \"flat\": [{\"test\": 1},{\"test\": 2},{\"another\": 1}]\n}\n\nPOST myindexflat/_search\n{\n  \"fields\": [\"flat.test\"],\n  \"_source\": false\n}\n\nPOST kbn:/api/endpoint/suggestions/eventFilters\n{\n  \"query\": \"test\",\n  \"field\": \"test\"\n\n}\n\nGET .lists-default/_search?filter_path=hits\n\n\n// Should contain results from hidden index\nGET my_*/_search?filter_path=hits&expand_wildcards=all,hidden\n\n// Should be empty\nGET my_*/_search?filter_path=hits\n\n\nGET .my*/_search?filter_path=hits\nGET .my_hidden_index/_search?filter_path=hits\nGET my_hidden_index/_search?filter_path=hits\n\nPUT .my_hidden_index/_doc/1\n{\n  \"SHOULD_NOT_BE_HERE\": true\n}\n\nGET .my_sys_index\nGET .my_hidden_index\nGET _alias/.my_hidden_index\n\nPUT /\n\n# Creates a component template for mappings\nPUT _component_template/my-mappings\n{\n  \"template\": {\n    \"mappings\": {\n      \"properties\": {\n        \"@timestamp\": {\n          \"type\": \"date\",\n          \"format\": \"date_optional_time||epoch_millis\"\n        },\n        \"message\": {\n          \"type\": \"wildcard\"\n        }\n      }\n    }\n  },\n  \"_meta\": {\n    \"description\": \"Mappings for @timestamp and message fields\",\n    \"my-custom-meta-field\": \"More arbitrary metadata\"\n  }\n}\n\n# Creates a component template for index settings\nPUT _component_template/my-settings\n{\n  \"template\": {\n    \"settings\": {\n      \"index.lifecycle.name\": \"my-lifecycle-policy\"\n    }\n  },\n  \"_meta\": {\n    \"description\": \"Settings for ILM\",\n    \"my-custom-meta-field\": \"More arbitrary metadata\"\n  }\n}\n\n\nPUT _index_template/enterprise_search\n{\n  \"index_patterns\": [\"logs-enterprise_search*\", \"logs-app_search.*\", \"logs-workplace_search.*\"],\n  \"data_stream\": { },\n  \"composed_of\": [ \"my-mappings\", \"my-settings\" ],\n  \"priority\": 500,\n  \"_meta\": {\n    \"description\": \"Template for my time series data\",\n    \"my-custom-meta-field\": \"More arbitrary metadata\"\n  }\n}\n\nPUT _data_stream/logs-enterprise_search.whathaveyou\nPUT _data_stream/logs-app_search.whathaveyou\nPUT _data_stream/logs-workplace_search.whathaveyou\n\nGET _migration/deprecations\n\nPOST my-data-stream/_doc\n{\n  \"@timestamp\": \"2099-05-06T16:21:15.000Z\",\n  \"message\": \"\"\"192.0.2.42 - - [06/May/2099:16:21:15 +0000] \"GET /images/bg.jpg HTTP/1.0\" 200 24736\"\"\",\n  \"object\": {\n    \"this\": \"might work\",\n    \"array\": [{ \"test\": 1 }, { \"test\": 2 } ]\n  }\n}\n\nGET my-data-stream/_search\n{\n  \"runtime_mappings\": {\n    \"object.array.test2\": {\n      \"type\": \"long\",\n      \"script\": {\n        \"source\": \"\"\"\n          if (params._source.object != null && params._source.object.array != null) {\n            def arr = params._source.object.array;\n            for (def entry : arr) {\n                emit(entry.test + 10)\n            }\n            return;\n          }\n        \"\"\"\n      }\n    },\n    \"messageV2\": {\n      \"type\": \"text\",\n      \"script\": {\n        \"source\": \"\"\"\n          if (params._source[\"messageV2\"] != null) {\n            // return what we have in source if there is something\n            emit(params._source[\"messageV2\"]);\n          } else  {\n            // return the original processed in some way\n            emit(doc['message'].value + \" the original, but processed\");\n          }\n        \"\"\"\n      }\n    }\n  },\n  \"query\": {\n    \"match_all\": {}\n  },\n  \"fields\": [\"messageV2\", \"object.array.test2\"]\n}\n\nGET _index_template/my-index-template\n\nGET _data_stream/my-data-strea\n\nPUT _data_stream/my-data-stream-2\nGET _data_stream/my-data-stream\nGET _data_stream/my-data-stream-2\n\nGET _data_stream/\n\nGET .ds-my-data-stream-2025.08.13-000001/_mapping\nPUT .ds-my-data-stream-2025.08.13-000001/_mapping\n{\n\"_data_stream_timestamp\": {\n        \"enabled\": true\n      },\n      \"properties\": {\n        \"@timestamp\": {\n          \"type\": \"date\",\n          \"format\": \"date_optional_time||epoch_millis\"\n        },\n        \"message\": {\n          \"type\": \"wildcard\"\n        },\n        \"messageV2\": {\n          \"type\": \"text\",\n          \"fields\": {\n            \"keyword\": {\n              \"type\": \"keyword\",\n              \"ignore_above\": 256\n            }\n          }\n        },\n        \"object\": {\n          \"properties\": {\n            \"array\": {\n              \"properties\": {\n                \"test\": {\n                  \"type\": \"long\"\n                }\n              }\n            },\n            \"this\": {\n              \"type\": \"text\",\n              \"fields\": {\n                \"keyword\": {\n                  \"type\": \"keyword\",\n                  \"ignore_above\": 256\n                }\n              }\n            }\n          }\n        },\n        \"test\": {\n          \"type\": \"text\",\n          \"fields\": {\n            \"keyword\": {\n              \"type\": \"keyword\",\n              \"ignore_above\": 256\n            }\n          }\n        }\n      }\n    }\n\nPUT _index_template/my-index-template\n{\n    \"index_patterns\": [\n      \"my-data-stream*\"\n    ],\n    \"composed_of\": [\n      \"my-mappings\",\n      \"my-settings\"\n    ],\n    \"priority\": 500,\n    \"_meta\": {\n      \"my-custom-meta-field\": \"More arbitrary metadata\",\n      \"description\": \"Template for my time series data\"\n    },\n    \"data_stream\": {\n      \"hidden\": false,\n      \"allow_custom_routing\": false\n    }\n  }\n```\n</details>\n\n**Root Cause:**\nThe xjson lexer rules inherited from `buildXjsonRules()` used Monaco's\n`@push` and `@pop` state management for\nopening/closing braces (`{` and `}`). When Console displayed multiple\nrequests sequentially (e.g., `GET\n/index`, `POST /data {...}`, `PUT /data {...}`), the tokenizer would\npush a new state for each opening brace\nbut never properly pop back to the root state between requests. This\ncaused stack accumulation,\neventually exceeding Monaco's tokenizer stack limit.\n\n**The Fix:**\nThe fix overrides the brace handling rules in `json_root` to avoid using\n`@push/@pop`:\n\n1. When a `}` appears at the end of a line, it explicitly\ntransitions back to the 'root' state, ensuring clean state boundaries\nbetween requests.\n2. The `{` token is treated as a simple token without pushing state onto\n  the stack.\n3. The original xjson brace rules (which used @push/@pop) are filtered\nout\n  before including the remaining `xjson` rules.","sha":"6f9c6766c580b72231a0de597ac5203cbe8264b6"}},{"url":"https://github.com/elastic/kibana/pull/243012","number":243012,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->