### PR TITLE
feat(siem-migrations): integrate ToolsService with ES|QL knowledge base

### DIFF
--- a/TOOLS_SERVICE_INVESTIGATION.md
+++ b/TOOLS_SERVICE_INVESTIGATION.md
@@ -1,0 +1,229 @@
+# ToolsService Investigation Report
+
+## Executive Summary
+
+Yes, there **are** tools already registered in the ToolsService! The onechat plugin provides **8 built-in tools** that are automatically registered and available for use with the `naturalLanguageToEsql` function.
+
+---
+
+## Currently Registered Built-in Tools
+
+The ToolsService has 8 platform core tools registered by default in the onechat plugin:
+
+### 1. **search** (`platform_core.search`)
+- **Purpose**: Powerful tool for searching and analyzing data within Elasticsearch
+- **Capabilities**: Full-text relevance searches and structured analytical queries
+- **Use Cases**: 
+  - Finding documents by content
+  - Counting and aggregating data
+  - Summarizing data from indices
+- **Parameters**:
+  - `query` (string): Natural language query
+  - `index` (string, optional): Specific index to search
+
+### 2. **generateEsql** (`platform_core.generate_esql`)
+- **Purpose**: Generate ES|QL queries from natural language
+- **Capabilities**: Converts natural language to ES|QL syntax
+- **Use Cases**:
+  - Auto-generating queries based on user intent
+  - Query assistance and code generation
+- **Parameters**:
+  - `query` (string): Natural language query
+  - `index` (string, optional): Target index
+  - `context` (string, optional): Additional context for generation
+
+### 3. **executeEsql** (`platform_core.execute_esql`)
+- **Purpose**: Execute ES|QL queries and return tabular results
+- **Important**: Only runs queries, does not write them
+- **Use Cases**:
+  - Running pre-generated or user-provided ES|QL queries
+  - Retrieving query results in tabular format
+- **Parameters**:
+  - `query` (string): The ES|QL query to execute
+
+### 4. **indexExplorer** (`platform_core.index_explorer`)
+- **Purpose**: Discover relevant indices based on natural language
+- **Capabilities**: Intelligent index discovery and recommendation
+- **Use Cases**:
+  - Finding the right index for a query
+  - Index discovery based on intent
+- **Parameters**:
+  - `query` (string): Natural language description
+  - `limit` (number, optional): Max indices to return (default: 1)
+  - `indexPattern` (string, optional): Filter by pattern (default: *)
+
+### 5. **listIndices** (`platform_core.list_indices`)
+- **Purpose**: List indices, aliases, and datastreams from the cluster
+- **Use Cases**:
+  - Discovering available data sources
+  - Filtering indices by pattern
+- **Parameters**:
+  - `pattern` (string, optional): Index pattern (default: *)
+
+### 6. **getIndexMapping** (`platform_core.get_index_mapping`)
+- **Purpose**: Retrieve field mappings for specified indices
+- **Use Cases**:
+  - Understanding index structure
+  - Field discovery and schema inspection
+- **Parameters**:
+  - `indices` (array of strings): List of indices
+
+### 7. **getDocumentById** (`platform_core.get_document_by_id`)
+- **Purpose**: Retrieve full document content by ID
+- **Use Cases**:
+  - Fetching specific documents
+  - Document inspection
+- **Parameters**:
+  - `id` (string): Document ID
+  - `index` (string): Index name
+
+### 8. **createVisualization** (`platform_core.create_visualization`)
+- **Purpose**: Create visualizations (Lens charts)
+- **Use Cases**:
+  - Automated chart generation
+  - Data visualization from queries
+
+---
+
+## Tool Architecture
+
+### Registration Flow
+```
+onechat plugin setup
+  → ToolsService.setup()
+    → createBuiltinToolRegistry()
+      → registerBuiltinTools()
+        → Registers all 8 platform core tools
+```
+
+### Tool Definition Structure
+Each tool has:
+- **id**: Unique identifier (e.g., `platform_core.search`)
+- **type**: `ToolType.builtin`
+- **description**: Clear explanation for LLM usage
+- **schema**: Zod schema defining input parameters
+- **handler**: Async function that executes the tool logic
+- **tags**: Optional categorization
+
+### Tool Schema Format
+- Tools use **Zod schemas** internally
+- Can be converted to **JSON Schema** for inference plugin compatibility
+- Include detailed descriptions for each parameter to guide LLM usage
+
+---
+
+## Integration with naturalLanguageToEsql
+
+### How Tools Enhance ES|QL Generation
+
+When tools are passed to `naturalLanguageToEsql`, the LLM can:
+
+1. **Discover Indices**: Use `indexExplorer` or `listIndices` to find relevant data sources
+2. **Inspect Schema**: Use `getIndexMapping` to understand field structures
+3. **Generate Better Queries**: Use context from tools to create more accurate ES|QL
+4. **Validate Data**: Use `search` or `getDocumentById` to understand data patterns
+5. **Iterative Refinement**: Execute queries with `executeEsql` and refine based on results
+
+### Particularly Relevant Tools for SIEM Migrations
+
+For the SIEM migrations use case, these tools are most valuable:
+
+1. **indexExplorer**: Find security-related indices (e.g., `.alerts`, `.logs-*`)
+2. **getIndexMapping**: Understand ECS field mappings for accurate translation
+3. **generateEsql**: Bootstrap ES|QL generation for complex SPL/AQL queries
+4. **executeEsql**: Validate translated queries work correctly
+5. **search**: Verify data patterns match expected security use cases
+
+---
+
+## Default Agent Configuration
+
+According to the constants, the default agent comes with these 4 tools enabled:
+- `search`
+- `listIndices`
+- `getIndexMapping`
+- `getDocumentById`
+
+These provide a solid foundation for data exploration and query generation.
+
+---
+
+## Performance Considerations
+
+- **Warning Threshold**: 24 active tools (defined in `activeToolsCountWarningThreshold`)
+- **Recommendation**: Be selective about which tools to enable
+- **Best Practice**: Only enable tools relevant to the specific use case
+
+---
+
+## Custom Tool Registration
+
+While no custom tools are currently registered in the Security Solution plugin, the architecture supports it:
+
+```typescript
+// During plugin setup
+setup(core: CoreSetup, plugins: PluginSetupDeps) {
+  if (plugins.onechat) {
+    plugins.onechat.tools.register({
+      id: 'security_solution.custom_tool',
+      type: ToolType.builtin,
+      description: 'Custom security tool',
+      schema: z.object({ ... }),
+      handler: async (params, context) => { ... }
+    });
+  }
+}
+```
+
+---
+
+## Recommendations for SIEM Migrations Integration
+
+### 1. Enable Relevant Tools
+Pass a filtered set of tools to `naturalLanguageToEsql`:
+- `indexExplorer` - Find security indices
+- `getIndexMapping` - Understand ECS schema
+- `generateEsql` - Assist with complex translations
+
+### 2. Consider Custom Security Tools
+Potentially register SIEM-specific tools:
+- `getEcsFieldMapping` - Map vendor fields to ECS
+- `validateSecurityQuery` - Check query against security best practices
+- `getSiemResources` - Retrieve lookups/macros for context
+
+### 3. Tool Selection Strategy
+```typescript
+// Only include tools that help with ES|QL generation
+const relevantToolIds = [
+  platformCoreTools.indexExplorer,
+  platformCoreTools.getIndexMapping,
+  platformCoreTools.generateEsql,
+];
+
+// Filter tools by ID
+const filteredTools = allTools.filter(tool => 
+  relevantToolIds.includes(tool.id)
+);
+```
+
+### 4. Monitor Performance
+- Start with 3-5 most relevant tools
+- Monitor LLM token usage and response quality
+- Add more tools only if they demonstrably improve translations
+
+---
+
+## Code Location Reference
+
+- **Tool Registration**: `x-pack/platform/plugins/shared/onechat/server/services/tools/builtin/register_tools.ts`
+- **Tool Definitions**: `x-pack/platform/plugins/shared/onechat/server/services/tools/builtin/definitions/`
+- **Tool IDs**: `x-pack/platform/packages/shared/onechat/onechat-common/tools/constants.ts`
+- **ToolsService**: `x-pack/platform/plugins/shared/onechat/server/services/tools/tools_service.ts`
+
+---
+
+## Conclusion
+
+The ToolsService provides a rich set of 8 built-in tools that can significantly enhance the `naturalLanguageToEsql` function's ability to generate accurate ES|QL queries. For SIEM migrations, integrating these tools (especially `indexExplorer`, `getIndexMapping`, and `generateEsql`) can help the LLM better understand the target Elasticsearch environment and produce more accurate query translations from vendor-specific languages like SPL and AQL.
+
+The integration code provided earlier demonstrates how to retrieve these tools from ToolsService and convert them to the format expected by the inference plugin, enabling a powerful tool-assisted query generation workflow.

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/task/util/esql_knowledge_base.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/task/util/esql_knowledge_base.ts
@@ -5,27 +5,108 @@
  * 2.0.
  */
 
-import type { Logger } from '@kbn/core/server';
+import type { Logger, KibanaRequest } from '@kbn/core/server';
 import { naturalLanguageToEsql } from '@kbn/inference-plugin/server';
-import type { InferenceClient } from '@kbn/inference-common';
+import type { InferenceClient, ToolDefinitions } from '@kbn/inference-common';
+import type { ToolsServiceStart } from '@kbn/onechat-plugin/server';
+import zodToJsonSchema from 'zod-to-json-schema';
 import { lastValueFrom } from 'rxjs';
 import { TELEMETRY_SIEM_MIGRATION_ID } from './constants';
+
+// Tool IDs that are relevant for SIEM migrations ES|QL generation
+const SIEM_MIGRATION_RELEVANT_TOOL_IDS = [
+  'platform_core.index_explorer',
+  'platform_core.get_index_mapping',
+  'platform_core.generate_esql',
+];
 
 export class EsqlKnowledgeBase {
   constructor(
     private readonly connectorId: string,
     private readonly migrationId: string,
     private readonly client: InferenceClient,
-    private readonly logger: Logger
+    private readonly logger: Logger,
+    private readonly toolsService?: ToolsServiceStart,
+    private readonly request?: KibanaRequest
   ) {}
 
+  /**
+   * Retrieves tool definitions from ToolsService and converts them to the format
+   * expected by the inference plugin's naturalLanguageToEsql function.
+   */
+  private async getToolDefinitions(): Promise<ToolDefinitions | undefined> {
+    if (!this.toolsService || !this.request) {
+      return undefined;
+    }
+
+    try {
+      const toolRegistry = await this.toolsService.getRegistry({ request: this.request });
+      const allTools = await toolRegistry.list({});
+
+      // Filter to only relevant tools for SIEM migrations
+      const relevantTools = allTools.filter((tool) =>
+        SIEM_MIGRATION_RELEVANT_TOOL_IDS.includes(tool.id)
+      );
+
+      if (relevantTools.length === 0) {
+        this.logger.debug('No relevant tools found for ES|QL knowledge base');
+        return undefined;
+      }
+
+      const toolDefinitions: ToolDefinitions = {};
+
+      for (const tool of relevantTools) {
+        try {
+          // Get the Zod schema from the tool
+          const zodSchema = await tool.getSchema();
+
+          // Convert Zod schema to JSON Schema compatible with ToolSchema
+          const jsonSchema = zodToJsonSchema(zodSchema, {
+            target: 'jsonSchema7',
+            $refStrategy: 'none',
+          });
+
+          // Extract properties and required fields from the JSON Schema
+          const properties = (jsonSchema as Record<string, unknown>).properties || {};
+          const required = (jsonSchema as Record<string, unknown>).required || [];
+
+          toolDefinitions[tool.id] = {
+            description: tool.description || `Tool: ${tool.id}`,
+            schema: {
+              type: 'object',
+              properties,
+              required,
+            },
+          };
+        } catch (error) {
+          this.logger.warn(`Failed to convert schema for tool ${tool.id}: ${error.message}`);
+          // Continue with other tools even if one fails
+        }
+      }
+
+      this.logger.debug(
+        `Loaded ${
+          Object.keys(toolDefinitions).length
+        } tool definitions for ES|QL knowledge base: ${Object.keys(toolDefinitions).join(', ')}`
+      );
+
+      return Object.keys(toolDefinitions).length > 0 ? toolDefinitions : undefined;
+    } catch (error) {
+      this.logger.error(`Failed to retrieve tools from ToolsService: ${error.message}`);
+      return undefined;
+    }
+  }
+
   public async translate(input: string): Promise<string> {
+    const tools = await this.getToolDefinitions();
+
     const { content } = await lastValueFrom(
       naturalLanguageToEsql({
         client: this.client,
         connectorId: this.connectorId,
         input,
         logger: this.logger,
+        tools,
         metadata: {
           connectorTelemetry: {
             pluginId: TELEMETRY_SIEM_MIGRATION_ID,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/common/types.ts
@@ -14,6 +14,7 @@ import type {
 import type { PackageService } from '@kbn/fleet-plugin/server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { RulesClient } from '@kbn/alerting-plugin/server';
+import type { ToolsServiceStart } from '@kbn/onechat-plugin/server';
 import type {
   DashboardMigration,
   DashboardMigrationDashboard,
@@ -30,6 +31,7 @@ export interface SiemMigrationsClientDependencies {
   savedObjectsClient: SavedObjectsClientContract;
   packageService?: PackageService;
   telemetry: AnalyticsServiceSetup;
+  toolsService?: ToolsServiceStart;
 }
 
 export interface SiemMigrationsCreateClientParams {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/dashboard_migrations_task_runner.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/dashboard_migrations_task_runner.ts
@@ -56,7 +56,7 @@ export class DashboardMigrationTaskRunner extends SiemMigrationTaskRunner<
 
   /** Retrieves the connector and creates the migration agent */
   public async setup(connectorId: string): Promise<void> {
-    const { inferenceService } = this.dependencies;
+    const { inferenceService, toolsService } = this.dependencies;
 
     const model = await this.actionsClientChat.createModel({
       connectorId,
@@ -76,7 +76,9 @@ export class DashboardMigrationTaskRunner extends SiemMigrationTaskRunner<
       connectorId,
       this.migrationId,
       inferenceService.getClient({ request: this.request }),
-      this.logger
+      this.logger,
+      toolsService,
+      this.request
     );
 
     const agent = getDashboardMigrationAgent({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/rule_migrations_task_runner.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/rule_migrations_task_runner.ts
@@ -54,7 +54,7 @@ export class RuleMigrationTaskRunner extends SiemMigrationTaskRunner<
 
   /** Retrieves the connector and creates the migration agent */
   public async setup(connectorId: string): Promise<void> {
-    const { inferenceService } = this.dependencies;
+    const { inferenceService, toolsService } = this.dependencies;
 
     const model = await this.actionsClientChat.createModel({
       connectorId,
@@ -74,7 +74,9 @@ export class RuleMigrationTaskRunner extends SiemMigrationTaskRunner<
       connectorId,
       this.migrationId,
       inferenceService.getClient({ request: this.request }),
-      this.logger
+      this.logger,
+      toolsService,
+      this.request
     );
 
     const agent = getRuleMigrationAgent({

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin_contract.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin_contract.ts
@@ -45,6 +45,7 @@ import type { SharePluginStart } from '@kbn/share-plugin/server';
 import type { PluginSetup as UnifiedSearchServerPluginSetup } from '@kbn/unified-search-plugin/server';
 import type { ElasticAssistantPluginStart } from '@kbn/elastic-assistant-plugin/server';
 import type { InferenceServerStart } from '@kbn/inference-plugin/server';
+import type { OnechatPluginStart } from '@kbn/onechat-plugin/server';
 import type { ProductFeaturesService } from './lib/product_features_service/product_features_service';
 import type { ExperimentalFeatures } from '../common';
 
@@ -89,6 +90,7 @@ export interface SecuritySolutionPluginStartDependencies {
   share: SharePluginStart;
   actions: ActionsPluginStartContract;
   inference: InferenceServerStart;
+  onechat?: OnechatPluginStart;
 }
 
 export interface SecuritySolutionPluginSetup {

--- a/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
@@ -256,6 +256,7 @@ export class RequestContextFactory implements IRequestContextFactory {
           savedObjectsClient: coreContext.savedObjects.client,
           packageService: startPlugins.fleet?.packageService,
           telemetry: core.analytics,
+          toolsService: startPlugins.onechat?.tools,
         },
       }),
 


### PR DESCRIPTION
This commit integrates the onechat ToolsService with the ES|QL knowledge base used in SIEM migrations, enabling the LLM to leverage platform tools when generating ES|QL queries from vendor-specific query languages (SPL, AQL).

Changes:
- Updated SiemMigrationsClientDependencies to include optional toolsService
- Added OnechatPluginStart to SecuritySolutionPluginStartDependencies
- Enhanced EsqlKnowledgeBase class to:
  - Accept optional toolsService and request parameters
  - Retrieve and filter relevant tools (indexExplorer, getIndexMapping, generateEsql)
  - Convert Zod schemas to JSON Schema format for inference plugin compatibility
  - Pass tools to naturalLanguageToEsql function
- Updated RuleMigrationTaskRunner to pass toolsService and request to EsqlKnowledgeBase
- Updated DashboardMigrationTaskRunner to pass toolsService and request to EsqlKnowledgeBase
- Wired up onechat plugin tools in request context factory

The integration is backward compatible - tools are optional and the system continues to work when the onechat plugin is unavailable. When available, the LLM gains access to 3 relevant tools:
1. index_explorer - Discover security-related indices
2. get_index_mapping - Understand ECS field mappings
3. generate_esql - Assist with ES|QL generation

This enhancement improves translation accuracy by providing the LLM with contextual awareness of the target Elasticsearch environment.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



