### PR TITLE
🌊 Streams: Fix field simulation

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping.spec.ts
@@ -11,8 +11,7 @@ import { expect } from '@kbn/scout';
 import { test } from '../../fixtures';
 import { generateLogsData } from '../../fixtures/generators';
 
-// Failing: See https://github.com/elastic/kibana/issues/242994
-test.describe.skip('Stream data mapping - schema editor', { tag: ['@ess', '@svlOblt'] }, () => {
+test.describe('Stream data mapping - schema editor', { tag: ['@ess', '@svlOblt'] }, () => {
   test.beforeAll(async ({ apiServices, logsSynthtraceEsClient }) => {
     await apiServices.streams.enable();
     // Clear existing rules


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/242994

With https://github.com/elastic/elasticsearch/pull/137992, the approach we used to do field simulation for wired streams doesn't work anymore. This PR fixes this by switching to a similar strategy we use for the processing simulation: Overwrite the root logs pipeline to reroute the doc, then overwrite the current stream pipeline with a noop.

For classic streams we keep the existing behavior.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->