### PR TITLE
[Security Solution][Attacks] Populate attack_ids field

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_to_alert_documents/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_to_alert_documents/index.ts
@@ -186,7 +186,7 @@ export const transformToBaseAlertDocument = ({
     /**
      * This field is shared with security solution alerts.
      * We want both attacks and alerts to have this field so
-     * we can filter and group them in the security alerts
+     * we can filter and group them in the security attacks
      * page using both the attacks and the alerts indexes.
      *
      * @see https://github.com/elastic/kibana/issues/232341

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_to_alert_documents/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_to_alert_documents/index.ts
@@ -59,6 +59,7 @@ import {
   ALERT_ATTACK_DISCOVERY_USER_ID,
   ALERT_ATTACK_DISCOVERY_USER_NAME,
   ALERT_ATTACK_DISCOVERY_USERS,
+  ALERT_ATTACK_IDS,
   ALERT_RISK_SCORE,
 } from '../../../schedules/fields/field_names';
 import type { AttackDiscoveryAlertDocument } from '../../../schedules/types';
@@ -181,6 +182,16 @@ export const transformToBaseAlertDocument = ({
       messageContent: title,
       replacements,
     }),
+
+    /**
+     * This field is shared with security solution alerts.
+     * We want both attacks and alerts to have this field so
+     * we can filter and group them in the security alerts
+     * page using both the attacks and the alerts indexes.
+     *
+     * @see https://github.com/elastic/kibana/issues/232341
+     */
+    [ALERT_ATTACK_IDS]: [alertDocId],
   };
 
   return baseAlertDocument;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
@@ -350,6 +350,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
           'Critical Malware and Phishing Alerts on host e1cb3cf0-30f3-4f99-a9c8-518b955c6f90',
         'kibana.alert.attack_discovery.title_with_replacements':
           'Critical Malware and Phishing Alerts on host Test-Host-1',
+        'kibana.alert.attack_ids': ['fake-alert'],
       },
       context: {
         attack: {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.ts
@@ -200,7 +200,11 @@ export const attackDiscoveryScheduleExecutor = async ({
       })
     );
 
-    await updateAlertsWithAttackIds({ alertIdToAttackIdsMap: alertIdToAttackIds, esClient });
+    await updateAlertsWithAttackIds({
+      alertIdToAttackIdsMap: alertIdToAttackIds,
+      esClient,
+      spaceId,
+    });
   } catch (error) {
     logger.error(error);
     const transformedError = transformError(error);

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/updateAlertsWithAttackIds.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/updateAlertsWithAttackIds.test.ts
@@ -69,8 +69,8 @@ describe('updateAlertsWithAttackIds', () => {
       esClient.updateByQuery.mockReset();
     });
 
-    it('should throw if an empty spaceId is being used', () => {
-      expect(async () => {
+    it('should throw if an empty spaceId is being used', async () => {
+      await expect(async () => {
         await updateAlertsWithAttackIds({ esClient, alertIdToAttackIdsMap, spaceId: '' });
       }).rejects.toThrow();
     });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/updateAlertsWithAttackIds.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/updateAlertsWithAttackIds.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
+import { updateAlertsWithAttackIds } from './updateAlertsWithAttackIds';
+import { ALERT_ATTACK_IDS } from '../fields';
+
+describe('updateAlertsWithAttackIds', () => {
+  const esClient = elasticsearchClientMock.createElasticsearchClient();
+  const alertIdToAttackIdsMap = {
+    'alert-id-1': ['attack-1'],
+    'alert-id-2': ['attack-2'],
+    'alert-id-3': ['attack-1', 'attack-2'],
+  };
+
+  beforeAll(async () => {
+    await updateAlertsWithAttackIds({
+      alertIdToAttackIdsMap,
+      esClient,
+    });
+  });
+
+  it('should use the `updateByQuery` method from esClient', () => {
+    expect(esClient.updateByQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call `updateByQuery` with the expected params', () => {
+    expect(esClient.updateByQuery).toHaveBeenCalledWith({
+      index: '.alerts-security.alerts-default',
+      query: {
+        ids: {
+          values: ['alert-id-1', 'alert-id-2', 'alert-id-3'],
+        },
+      },
+      script: {
+        lang: 'painless',
+        params: {
+          alertIdToAttackIds: alertIdToAttackIdsMap,
+        },
+        source: `
+          def alertId = ctx._id;
+          def attacksToAdd = params.alertIdToAttackIds.get(alertId);
+
+          if (attacksToAdd != null) {
+            if (ctx._source['${ALERT_ATTACK_IDS}'] == null) {
+              ctx._source['${ALERT_ATTACK_IDS}'] = new ArrayList();
+            }
+
+            for (attack in attacksToAdd) {
+              if (!ctx._source['${ALERT_ATTACK_IDS}'].contains(attack)) {
+                ctx._source['${ALERT_ATTACK_IDS}'].add(attack);
+              }
+            }
+          }
+        `,
+      },
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/updateAlertsWithAttackIds.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/updateAlertsWithAttackIds.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { ALERT_ATTACK_IDS } from '../fields';
+
+export interface UpdateAlertsWithAttackIdsParams {
+  esClient: ElasticsearchClient;
+  alertIdToAttackIdsMap: Record<string, string[]>;
+}
+
+export async function updateAlertsWithAttackIds({
+  esClient,
+  alertIdToAttackIdsMap,
+}: UpdateAlertsWithAttackIdsParams) {
+  await esClient.updateByQuery({
+    index: '.alerts-security.alerts-default',
+    query: {
+      ids: {
+        values: Array.from(Object.keys(alertIdToAttackIdsMap)),
+      },
+    },
+    script: {
+      lang: 'painless',
+      params: {
+        alertIdToAttackIds: alertIdToAttackIdsMap,
+      },
+      source: `
+          def alertId = ctx._id;
+          def attacksToAdd = params.alertIdToAttackIds.get(alertId);
+
+          if (attacksToAdd != null) {
+            if (ctx._source['${ALERT_ATTACK_IDS}'] == null) {
+              ctx._source['${ALERT_ATTACK_IDS}'] = new ArrayList();
+            }
+
+            for (attack in attacksToAdd) {
+              if (!ctx._source['${ALERT_ATTACK_IDS}'].contains(attack)) {
+                ctx._source['${ALERT_ATTACK_IDS}'].add(attack);
+              }
+            }
+          }
+        `,
+    },
+  });
+}


### PR DESCRIPTION
## Summary

After adding the `attack_ids` field in both alerts and attacks mapping (in #242429) we need to populate the field when attacks are generated.

> [!warning]
> This change is intended to affect only scheduled attacks — not manual runs

### 🧭  Changes overview

- Add the `attack_ids` field to `transformToBaseAlertDocument`
  - This function creates a base-alert document from an attack-discovery object returned by the LLM
- Add the query to update all the relevant alerts
  - This is done in the new `updateAlertsWithAttackIds` function
  - Before calling it, we populate a map between alert-ids and their attack-ids
  - We then use that map in the query's script to update all the alert documents in one go
    - ⚠️ The query will not run if there are no alerts to update
    - ⚠️ `updateAlertsWithAttackIds` will throw if the passed `spaceId` is an empty string
