### PR TITLE
[8.19] chore(dep): bump `js-yaml` package from `4.1.0` to `4.1.1` (#243075)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1207,7 +1207,7 @@
     "jquery": "^3.7.1",
     "js-search": "^1.4.3",
     "js-sha256": "^0.11.1",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.1.1",
     "json-schema-to-ts": "^2.9.1",
     "json-stable-stringify": "^1.0.1",
     "json-stringify-pretty-compact": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23436,7 +23436,7 @@ js-tiktoken@^1.0.12:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0, js-yaml@^4.1.0:
+js-yaml@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -23450,6 +23450,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0, js-yaml@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@1.1.0:
   version "1.1.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(dep): bump `js-yaml` package from `4.1.0` to `4.1.1` (#243075)](https://github.com/elastic/kibana/pull/243075)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2025-11-14T21:21:51Z","message":"chore(dep): bump `js-yaml` package from `4.1.0` to `4.1.1` (#243075)\n\n## Summary\n\nBump `js-yaml` package from `4.1.0` to `4.1.1`.","sha":"6e0be3e139e9bca1cf48e72a2789cda94c8d515d","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","dependencies","backport:all-open","v9.3.0"],"title":"chore(dep): bump `js-yaml` package from `4.1.0` to `4.1.1`","number":243075,"url":"https://github.com/elastic/kibana/pull/243075","mergeCommit":{"message":"chore(dep): bump `js-yaml` package from `4.1.0` to `4.1.1` (#243075)\n\n## Summary\n\nBump `js-yaml` package from `4.1.0` to `4.1.1`.","sha":"6e0be3e139e9bca1cf48e72a2789cda94c8d515d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243075","number":243075,"mergeCommit":{"message":"chore(dep): bump `js-yaml` package from `4.1.0` to `4.1.1` (#243075)\n\n## Summary\n\nBump `js-yaml` package from `4.1.0` to `4.1.1`.","sha":"6e0be3e139e9bca1cf48e72a2789cda94c8d515d"}},{"url":"https://github.com/elastic/kibana/pull/243100","number":243100,"branch":"9.1","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/243101","number":243101,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->