### PR TITLE
[Unified Data Table] Improve failing test speed

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/__snapshots__/data_table_columns.test.tsx.snap
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/__snapshots__/data_table_columns.test.tsx.snap
@@ -33,6 +33,7 @@ Array [
         },
       ],
       "showHide": Object {
+        "data-test-subj": "unifiedDataTableRemoveColumn",
         "iconType": "cross",
         "label": "Remove column",
       },
@@ -89,6 +90,7 @@ Array [
         },
       ],
       "showHide": Object {
+        "data-test-subj": "unifiedDataTableRemoveColumn",
         "iconType": "cross",
         "label": "Remove column",
       },
@@ -143,6 +145,7 @@ Array [
         },
       ],
       "showHide": Object {
+        "data-test-subj": "unifiedDataTableRemoveColumn",
         "iconType": "cross",
         "label": "Remove column",
       },
@@ -434,6 +437,7 @@ Array [
         },
       ],
       "showHide": Object {
+        "data-test-subj": "unifiedDataTableRemoveColumn",
         "iconType": "cross",
         "label": "Remove column",
       },
@@ -569,6 +573,7 @@ Array [
         },
       ],
       "showHide": Object {
+        "data-test-subj": "unifiedDataTableRemoveColumn",
         "iconType": "cross",
         "label": "Remove column",
       },
@@ -707,6 +712,7 @@ Array [
         },
       ],
       "showHide": Object {
+        "data-test-subj": "unifiedDataTableRemoveColumn",
         "iconType": "cross",
         "label": "Remove column",
       },
@@ -853,6 +859,7 @@ Array [
         },
       ],
       "showHide": Object {
+        "data-test-subj": "unifiedDataTableRemoveColumn",
         "iconType": "cross",
         "label": "Remove column",
       },
@@ -1410,6 +1417,7 @@ Array [
         },
       ],
       "showHide": Object {
+        "data-test-subj": "unifiedDataTableRemoveColumn",
         "iconType": "cross",
         "label": "Remove column",
       },
@@ -1544,6 +1552,7 @@ Array [
         },
       ],
       "showHide": Object {
+        "data-test-subj": "unifiedDataTableRemoveColumn",
         "iconType": "cross",
         "label": "Remove column",
       },
@@ -1832,6 +1841,7 @@ Array [
         },
       ],
       "showHide": Object {
+        "data-test-subj": "unifiedDataTableRemoveColumn",
         "iconType": "cross",
         "label": "Remove column",
       },
@@ -1981,6 +1991,7 @@ Array [
         },
       ],
       "showHide": Object {
+        "data-test-subj": "unifiedDataTableRemoveColumn",
         "iconType": "cross",
         "label": "Remove column",
       },

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -1307,18 +1307,13 @@ describe('UnifiedDataTable', () => {
   describe('columns', () => {
     // Default column width in EUI is hardcoded to 100px for Jest envs
     const EUI_DEFAULT_COLUMN_WIDTH = '100px';
-    const getColumnHeader = (name: string) => screen.getByRole('columnheader', { name });
-    const queryColumnHeader = (name: string) => screen.queryByRole('columnheader', { name });
+    const getColumnHeader = (name: string) => screen.getByTestId(`dataGridHeaderCell-${name}`);
+    const queryColumnHeader = (name: string) => screen.queryByTestId(`dataGridHeaderCell-${name}`);
     const openColumnActions = async (name: string) => {
       const actionsButton = screen.getByTestId(`dataGridHeaderCellActionButton-${name}`);
       await userEvent.click(actionsButton);
       await waitForEuiPopoverOpen();
     };
-    const clickColumnAction = async (name: string) => {
-      const action = screen.getByRole('button', { name });
-      await userEvent.click(action);
-    };
-    const queryButton = (name: string) => screen.queryByRole('button', { name });
 
     it(
       'should reset the last column to auto width if only absolute width columns remain',
@@ -1336,7 +1331,7 @@ describe('UnifiedDataTable', () => {
         expect(getColumnHeader('extension')).toHaveStyle({ width: '50px' });
         expect(getColumnHeader('bytes')).toHaveStyle({ width: '50px' });
         await openColumnActions('message');
-        await clickColumnAction('Remove column');
+        await userEvent.click(screen.getByTestId('unifiedDataTableRemoveColumn'));
         await waitFor(() => {
           expect(queryColumnHeader('message')).not.toBeInTheDocument();
         });
@@ -1361,7 +1356,7 @@ describe('UnifiedDataTable', () => {
         expect(getColumnHeader('extension')).toHaveStyle({ width: EUI_DEFAULT_COLUMN_WIDTH });
         expect(getColumnHeader('bytes')).toHaveStyle({ width: '50px' });
         await openColumnActions('message');
-        await clickColumnAction('Remove column');
+        await userEvent.click(screen.getByTestId('unifiedDataTableRemoveColumn'));
         await waitFor(() => {
           expect(queryColumnHeader('message')).not.toBeInTheDocument();
         });
@@ -1384,24 +1379,21 @@ describe('UnifiedDataTable', () => {
           },
         });
         expect(getColumnHeader('@timestamp')).toHaveStyle({ width: '50px' });
+
         await openColumnActions('@timestamp');
-        await clickColumnAction('Reset width');
-        await waitFor(() => {
-          expect(getColumnHeader('@timestamp')).toHaveStyle({
-            width: `${defaultTimeColumnWidth}px`,
-          });
+        await userEvent.click(screen.getByTestId('unifiedDataTableResetColumnWidth'));
+        expect(getColumnHeader('@timestamp')).toHaveStyle({
+          width: `${defaultTimeColumnWidth}px`,
         });
+
         expect(getColumnHeader('message')).toHaveStyle({ width: EUI_DEFAULT_COLUMN_WIDTH });
         await openColumnActions('message');
-        expect(queryButton('Reset width')).not.toBeInTheDocument();
-        await waitFor(() => {
-          expect(getColumnHeader('extension')).toHaveStyle({ width: '50px' });
-        });
+        expect(screen.queryByTestId('unifiedDataTableResetColumnWidth')).not.toBeInTheDocument();
+
+        expect(getColumnHeader('extension')).toHaveStyle({ width: '50px' });
         await openColumnActions('extension');
-        await clickColumnAction('Reset width');
-        await waitFor(() => {
-          expect(getColumnHeader('extension')).toHaveStyle({ width: EUI_DEFAULT_COLUMN_WIDTH });
-        });
+        await userEvent.click(screen.getByTestId('unifiedDataTableResetColumnWidth'));
+        expect(getColumnHeader('extension')).toHaveStyle({ width: EUI_DEFAULT_COLUMN_WIDTH });
       },
       EXTENDED_JEST_TIMEOUT
     );

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_columns.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_columns.tsx
@@ -244,6 +244,7 @@ function buildEuiGridColumn({
                 defaultMessage: 'Remove column',
               }),
               iconType: 'cross',
+              'data-test-subj': 'unifiedDataTableRemoveColumn',
             },
       showMoveLeft: !defaultColumns,
       showMoveRight: !defaultColumns,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/234829
Closes https://github.com/elastic/kibana/issues/240905
Closes https://github.com/elastic/kibana/issues/240904

All 3 tests were timing out so lets try to improve how fast they run - for this this PR changes from `get/queryByRole` to `get/queryByTestId` as it speeds up the tests significantly.

Times measured isolating the tests using `it.only` and using the mean time of 10 runs + mean time of 10 runs of the whole file.

> [!NOTE]
> Both scripts to measure the test times were generated by ChatGPT

Individual tests where measured with this script + `it.only`: [run-tests.sh](https://github.com/user-attachments/files/23580522/run-tests.sh)
The whole test file was measured using this script: [all-tests.sh](https://github.com/user-attachments/files/23580737/all-tests.sh)

| Test | Before | After |
|--|--------|------|
| should show the reset width button only for absolute width columns, and allow resetting to default width | 1268ms | 637ms |
| should not reset the last column to auto width when there are remaining auto width columns | 894ms | 346ms |
| should reset the last column to auto width if only absolute width columns remain | 893ms | 359ms |
| All tests | 21.069s | 17.338s |


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->