### PR TITLE
[ES|QL] Fixes inline suggestions with breaks inside a command

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/inline_suggestions/inline_suggest.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/inline_suggestions/inline_suggest.ts
@@ -35,7 +35,7 @@ function processQuery(query: string): string {
   return query
     .replace(/\/\*[^*]*(?:\*(?!\/)[^*]*)*\*\//g, '') // Remove block comments (/* */)
     .replace(/\/\/.*$/gm, '') // Remove line comments (//)
-    .replace(/[\n\r]/g, '') // Remove newlines
+    .replace(/[\n\r]/g, ' ') // Remove newlines
     .replace(/\s*\|\s*/g, ' | ') // Normalize pipe spacing
     .trim();
 }


### PR DESCRIPTION
## Summary

Sometimes users are breaking in the middle of a command, especially when they have multi filters.

My inline suggestions logic didnt take this under consideration but now it does. 

For example:

**Main**

<img width="989" height="147" alt="image" src="https://github.com/user-attachments/assets/8f72f0f8-9484-434e-84a7-3b6704264224" />



**With this PR:**

<img width="1003" height="108" alt="image" src="https://github.com/user-attachments/assets/acec65c4-8439-4ccb-98df-1f4775b8304e" />


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



