### PR TITLE
[CI] Add tag for merged phases for instrumentation of alternate CI config

### DIFF
--- a/.buildkite/pipelines/pull_request/base_merged_phases.yml
+++ b/.buildkite/pipelines/pull_request/base_merged_phases.yml
@@ -1,3 +1,6 @@
+env:
+  KIBANA_CI_MERGED_PHASES: 'true'
+
 steps:
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution


### PR DESCRIPTION
## Summary

This adds an env variable so we can differentiate between the merged phases CI and the regular CI in clusters that ingest buildkite OTEL data.

The merged phases CI can be triggered by using the label `ci:beta-faster-pr-build`.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->