### PR TITLE
Update pipeline tags for Kibana release path

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml
@@ -44,4 +44,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
-        - :kibana: Kibana release path
+        - ':kibana: Kibana release path'

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml
@@ -15,7 +15,7 @@ spec:
     kind: Pipeline
     metadata:
       name: kibana / artifacts container image
-      description: Kibana container image artifact builds
+      description: Kibana serverless container image artifact builds
     spec:
       env:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-serverless-test-alerts'
@@ -44,4 +44,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
-        - kibana-serverless-release
+        - :kibana: Kibana release path

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
@@ -44,4 +44,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
-        - :kibana: Kibana release path
+        - ':kibana: Kibana release path'

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
@@ -44,3 +44,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
+        - :kibana: Kibana release path

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
@@ -44,4 +44,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
-        - :kibana: Kibana release path
+        - ':kibana: Kibana release path'

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
@@ -44,3 +44,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
+        - :kibana: Kibana release path

--- a/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
@@ -54,4 +54,4 @@ spec:
           branch: main
       tags:
         - kibana
-        - :kibana: Kibana release path
+        - ':kibana: Kibana release path'

--- a/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
@@ -54,4 +54,4 @@ spec:
           branch: main
       tags:
         - kibana
-        - kibana-serverless-release
+        - :kibana: Kibana release path

--- a/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
@@ -163,3 +163,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
+        - :kibana: Kibana release path

--- a/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
@@ -163,4 +163,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
-        - :kibana: Kibana release path
+        - ':kibana: Kibana release path'

--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
@@ -50,4 +50,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
-        - kibana-serverless-release
+        - :kibana: Kibana release path

--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
@@ -50,4 +50,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
-        - :kibana: Kibana release path
+        - ':kibana: Kibana release path'

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-emergency-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-emergency-release.yml
@@ -16,11 +16,12 @@ spec:
     kind: Pipeline
     metadata:
       name: kibana / emergency release
+      description: Start Kibana serverless emergency release
     spec:
       repository: elastic/kibana
       provider_settings:
         trigger_mode: none
-      pipeline_file: ".buildkite/pipelines/emergency_release.yml"
+      pipeline_file: .buildkite/pipelines/emergency_release.yml
       teams:
         kibana-operations:
           access_level: MANAGE_BUILD_AND_READ
@@ -30,4 +31,4 @@ spec:
           access_level: READ_ONLY
       tags:
         - kibana
-        - kibana-serverless-release
+        - :kibana: Kibana release path

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-emergency-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-emergency-release.yml
@@ -31,4 +31,4 @@ spec:
           access_level: READ_ONLY
       tags:
         - kibana
-        - :kibana: Kibana release path
+        - ':kibana: Kibana release path'

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates-emergency.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates-emergency.yml
@@ -16,7 +16,7 @@ spec:
     kind: Pipeline
     metadata:
       name: kibana-tests-emergency
-      description: Pipeline that tests the service integration in various environments
+      description: Kibana serverless emergency release quality gates
     spec:
       repository: elastic/kibana
       pipeline_file: ./.buildkite/pipelines/quality-gates/emergency/pipeline.emergency.kibana-tests.yaml
@@ -33,4 +33,4 @@ spec:
           access_level: READ_ONLY
       tags:
         - kibana
-        - kibana-serverless-release
+        - :kibana: Kibana release path

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates-emergency.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates-emergency.yml
@@ -33,4 +33,4 @@ spec:
           access_level: READ_ONLY
       tags:
         - kibana
-        - :kibana: Kibana release path
+        - ':kibana: Kibana release path'

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates.yml
@@ -16,7 +16,7 @@ spec:
     kind: Pipeline
     metadata:
       name: kibana-tests
-      description: Pipeline that tests the service integration in various environments
+      description: Kibana serverless release quality gates
     spec:
       repository: elastic/kibana
       pipeline_file: ./.buildkite/pipelines/quality-gates/pipeline.kibana-tests.yaml
@@ -33,4 +33,4 @@ spec:
           access_level: READ_ONLY
       tags:
         - kibana
-        - kibana-serverless-release
+        - :kibana: Kibana release path

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates.yml
@@ -33,4 +33,4 @@ spec:
           access_level: READ_ONLY
       tags:
         - kibana
-        - :kibana: Kibana release path
+        - ':kibana: Kibana release path'

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
@@ -45,4 +45,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
-        - kibana-serverless-release
+        - :kibana: Kibana release path

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
@@ -45,4 +45,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
-        - :kibana: Kibana release path
+        - ':kibana: Kibana release path'

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
@@ -47,4 +47,4 @@ spec:
           branch: main
       tags:
         - kibana
-        - kibana-serverless-release
+        - :kibana: Kibana release path

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
@@ -47,4 +47,4 @@ spec:
           branch: main
       tags:
         - kibana
-        - :kibana: Kibana release path
+        - ':kibana: Kibana release path'


### PR DESCRIPTION
## Summary

This PR updates the Buildkite pipeline tags for the pipelines on the Kibana release path, for serverless and stateful (replacing the existing serverless tag `kibana-serverless-release` where existent). This allows for easier filtering in Buildkite.
It also updates / adds pipeline descriptions where missing or unclear.