### PR TITLE
[kbn-evals] Evaluator selection

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals/README.md
+++ b/x-pack/platform/packages/shared/kbn-evals/README.md
@@ -233,6 +233,33 @@ The helper will spin up one `local` project per available connector so results a
 node scripts/playwright test --config x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant/playwright.config.ts --project azure-gpt4o
 ```
 
+### Selecting specific evaluators
+
+To enable selective evaluator execution, wrap your evaluators with the `selectEvaluators` function:
+
+```ts
+import { selectEvaluators } from '@kbn/evals';
+
+await phoenixClient.runExperiment(
+  {
+    dataset,
+    task: myTask,
+  },
+  selectEvaluators([
+    ...createQuantitativeCorrectnessEvaluators(),
+    createQuantitativeGroundednessEvaluator(),
+  ])
+);
+```
+
+Then control which evaluators run using the `SELECTED_EVALUATORS` environment variable with a comma-separated list of evaluator names:
+
+```bash
+SELECTED_EVALUATORS="Factuality,Relevance" node scripts/playwright test --config x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/playwright.config.ts
+```
+
+If not specified, all evaluators will run by default.
+
 ### Repeated evaluations
 
 For statistical analysis and reliability testing, you can run the same evaluation examples multiple times.

--- a/x-pack/platform/packages/shared/kbn-evals/index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/index.ts
@@ -34,3 +34,5 @@ export type {
   DatasetScoreWithStats,
   EvaluatorStats,
 } from './src/utils/evaluation_stats';
+
+export { parseSelectedEvaluators, selectEvaluators } from './src/evaluators/filter';

--- a/x-pack/platform/packages/shared/kbn-evals/src/evaluators/filter.ts
+++ b/x-pack/platform/packages/shared/kbn-evals/src/evaluators/filter.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Example } from '@arizeai/phoenix-client/dist/esm/types/datasets';
+import type { TaskOutput } from '@arizeai/phoenix-client/dist/esm/types/experiments';
+import type { Evaluator } from '../types';
+
+export function parseSelectedEvaluators() {
+  return (
+    process.env.SELECTED_EVALUATORS?.split(',').map((selectedEvaluator) =>
+      selectedEvaluator.trim()
+    ) ?? []
+  );
+}
+
+export function selectEvaluators<TExample extends Example, TTaskOutput extends TaskOutput>(
+  evaluators: Evaluator<TExample, TTaskOutput>[]
+) {
+  const evaluatorsFromEnv = parseSelectedEvaluators();
+
+  if (evaluatorsFromEnv.length === 0) {
+    return evaluators;
+  }
+
+  return evaluators.filter((evaluator) => evaluatorsFromEnv.includes(evaluator.name));
+}

--- a/x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/README.md
+++ b/x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/README.md
@@ -93,6 +93,9 @@ node scripts/playwright test --config x-pack/platform/packages/shared/onechat/kb
 
 # Run with LLM-as-a-judge for consistent evaluation results
 EVALUATION_CONNECTOR_ID=llm-judge-connector-id node scripts/playwright test --config x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/playwright.config.ts
+
+# Run only selected evaluators
+SELECTED_EVALUATORS="Factuality,Relevance,Groundedness" node scripts/playwright test --config x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/playwright.config.ts
 ```
 
 ### Run Evaluation Comparisons

--- a/x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/src/evaluate_dataset.ts
+++ b/x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/src/evaluate_dataset.ts
@@ -12,6 +12,7 @@ import {
   type KibanaPhoenixClient,
   type EvaluationDataset,
   createQuantitativeGroundednessEvaluator,
+  selectEvaluators,
 } from '@kbn/evals';
 import type { ExperimentTask } from '@kbn/evals/src/types';
 import type { TaskOutput } from '@arizeai/phoenix-client/dist/esm/types/experiments';
@@ -84,14 +85,12 @@ export function createEvaluateDataset({
           metadata,
         }),
       ]);
-      const correctnessAnalysis = correctnessResult.metadata;
-      const groundednessAnalysis = groundednessResult.metadata;
 
       return {
         errors: response.errors,
         messages: response.messages,
-        correctnessAnalysis,
-        groundednessAnalysis,
+        correctnessAnalysis: correctnessResult?.metadata,
+        groundednessAnalysis: groundednessResult?.metadata,
       };
     };
 
@@ -100,7 +99,10 @@ export function createEvaluateDataset({
         dataset,
         task: callConverseAndEvaluate,
       },
-      [...createQuantitativeCorrectnessEvaluators(), createQuantitativeGroundednessEvaluator()]
+      selectEvaluators([
+        ...createQuantitativeCorrectnessEvaluators(),
+        createQuantitativeGroundednessEvaluator(),
+      ])
     );
   };
 }


### PR DESCRIPTION
Relates to: https://github.com/elastic/kibana/issues/241299

## Summary

- Add utilities to filter out the list of evaluators to use within a Phoenix experiment run
  - List of evaluators can be provided as a comma-separated string via `SELECTED_EVALUATORS` environment variable 
  - `selectEvaluators` utility function within the evaluation framework that solutions' eval suites can use to filter out evaluators prior to running a Phoenix experiment:
        
        import { selectEvaluators } from '@kbn/evals';
        
        await phoenixClient.runExperiment(
          {
            dataset,
            task: myTask,
          },
          selectEvaluators([
            ...evaluators
          ])
        );
   - Conditionally run qualitative evaluators for groundedness and correctness only when they, or their dependant quantitative evaluators, are specified by the name (avoiding added latency and token burn).
- Implemented evaluator selection for Agent Builder evaluation suites. Added documentation how other consumers can utilize this functionality.

### Testing

```bash
# Start Scout server
node scripts/scout.js start-server --stateful

# Run evals with selected evaluators
SELECTED_EVALUATORS="Factuality,Relevance,Groundedness" node scripts/playwright test --config x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/playwright.config.ts 
```
