### PR TITLE
[8.19] [CI] Cache TypeScript build artifacts (#241414)

### DIFF
--- a/.buildkite/pipelines/build_api_docs.yml
+++ b/.buildkite/pipelines/build_api_docs.yml
@@ -1,7 +1,7 @@
 env:
   PUBLISH_API_DOCS_CHANGES: 'true'
 steps:
-  - command: .buildkite/scripts/steps/check_types.sh
+  - command: .buildkite/scripts/steps/typecheck/check_types.sh
     label: 'Check types'
     key: check_types
     agents:

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -106,7 +106,7 @@ steps:
         - exit_status: '-1'
           limit: 3
 
-  - command: .buildkite/scripts/steps/check_types.sh
+  - command: .buildkite/scripts/steps/typecheck/check_types.sh
     label: 'Check Types'
     agents:
       image: family/kibana-ubuntu-2404

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -98,7 +98,7 @@ steps:
         - exit_status: '-1'
           limit: 3
 
-  - command: .buildkite/scripts/steps/check_types.sh
+  - command: .buildkite/scripts/steps/typecheck/check_types.sh
     label: 'Check Types'
     agents:
       machineType: c4-standard-4

--- a/.buildkite/scripts/common/activate_service_account.sh
+++ b/.buildkite/scripts/common/activate_service_account.sh
@@ -78,6 +78,12 @@ if [[ -z "$EMAIL" ]]; then
     "ci-artifacts.kibana.dev")
       EMAIL="kibana-ci-access-artifacts@$GCLOUD_EMAIL_POSTFIX"
       ;;
+    "ci-typescript-archives")
+      EMAIL="kibana-ci-access-ts-archives@$GCLOUD_EMAIL_POSTFIX"
+      ;;
+    "kibana-ci-access-chromium-blds")
+      EMAIL="kibana-ci-access-chromium-blds@$GCLOUD_EMAIL_POSTFIX"
+      ;;
     *)
       EMAIL="$BUCKET_NAME@$GCLOUD_EMAIL_POSTFIX"
       ;;

--- a/.buildkite/scripts/steps/typecheck/check_types.sh
+++ b/.buildkite/scripts/steps/typecheck/check_types.sh
@@ -7,4 +7,5 @@ source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
 
 echo --- Check Types
-node scripts/type_check
+set +e
+node scripts/type_check --with-archive

--- a/packages/kbn-ts-type-check-cli/run_type_check_cli.ts
+++ b/packages/kbn-ts-type-check-cli/run_type_check_cli.ts
@@ -9,19 +9,22 @@
 
 import Path from 'path';
 import Fsp from 'fs/promises';
-
 import { run } from '@kbn/dev-cli-runner';
 import { createFailError } from '@kbn/dev-cli-errors';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { asyncForEachWithLimit, asyncMapWithLimit } from '@kbn/std';
 import { SomeDevLog } from '@kbn/some-dev-log';
 import { type TsProject, TS_PROJECTS } from '@kbn/ts-projects';
+import execa from 'execa';
 
 import {
   updateRootRefsConfig,
   cleanupRootRefsConfig,
   ROOT_REFS_CONFIG_PATH,
 } from './root_refs_config';
+import { archiveTSBuildArtifacts } from './src/archive/archive_ts_build_artifacts';
+import { restoreTSBuildArtifacts } from './src/archive/restore_ts_build_artifacts';
+import { LOCAL_CACHE_ROOT } from './src/archive/constants';
 
 const rel = (from: string, to: string) => {
   const path = Path.relative(from, to);
@@ -84,21 +87,45 @@ async function createTypeCheckConfigs(log: SomeDevLog, projects: TsProject[]) {
   );
 }
 
+async function detectLocalChanges(): Promise<boolean> {
+  const { stdout } = await execa('git', ['status', '--porcelain'], {
+    cwd: REPO_ROOT,
+  });
+
+  return stdout.trim().length > 0;
+}
+
 run(
   async ({ log, flagsReader, procRunner }) => {
-    if (flagsReader.boolean('clean-cache')) {
+    const shouldCleanCache = flagsReader.boolean('clean-cache');
+    const shouldUseArchive = flagsReader.boolean('with-archive');
+
+    if (shouldCleanCache) {
       await asyncForEachWithLimit(TS_PROJECTS, 10, async (proj) => {
         await Fsp.rm(Path.resolve(proj.directory, 'target/types'), {
           force: true,
           recursive: true,
         });
       });
-      log.warning('Deleted all typescript caches');
+      await Fsp.rm(LOCAL_CACHE_ROOT, {
+        force: true,
+        recursive: true,
+      });
+      log.warning('Deleted all TypeScript caches');
+      return;
     }
 
     // if the tsconfig.refs.json file is not self-managed then make sure it has
     // a reference to every composite project in the repo
     await updateRootRefsConfig(log);
+
+    if (shouldUseArchive && !shouldCleanCache) {
+      await restoreTSBuildArtifacts(log);
+    } else if (shouldCleanCache && shouldUseArchive) {
+      log.info('Skipping TypeScript cache restore because --clean-cache was provided.');
+    } else {
+      log.verbose('Skipping TypeScript cache restore because --with-archive was not provided.');
+    }
 
     const projectFilter = flagsReader.path('project');
 
@@ -108,7 +135,7 @@ run(
 
     const created = await createTypeCheckConfigs(log, projects);
 
-    let pluginBuildResult;
+    let didTypeCheckFail = false;
     try {
       log.info(
         `Building TypeScript projects to check types (For visible, though excessive, progress info you can pass --verbose)`
@@ -126,6 +153,7 @@ run(
           relative,
           '--pretty',
           ...(flagsReader.boolean('verbose') ? ['--verbose'] : []),
+          ...(flagsReader.boolean('extended-diagnostics') ? ['--extendedDiagnostics'] : []),
         ],
         env: {
           NODE_OPTIONS: '--max-old-space-size=10240',
@@ -133,10 +161,20 @@ run(
         cwd: REPO_ROOT,
         wait: true,
       });
-
-      pluginBuildResult = { failed: false };
     } catch (error) {
-      pluginBuildResult = { failed: true };
+      didTypeCheckFail = true;
+    }
+
+    const hasLocalChanges = shouldUseArchive ? await detectLocalChanges() : false;
+
+    if (shouldUseArchive) {
+      if (hasLocalChanges) {
+        log.info('Skipping TypeScript cache archive because uncommitted changes were detected.');
+      } else {
+        await archiveTSBuildArtifacts(log);
+      }
+    } else {
+      log.verbose('Skipping TypeScript cache archive because --with-archive was not provided.');
     }
 
     // cleanup if requested
@@ -149,7 +187,7 @@ run(
       });
     }
 
-    if (pluginBuildResult.failed) {
+    if (didTypeCheckFail) {
       throw createFailError('Unable to build TS project refs');
     }
   },
@@ -166,7 +204,7 @@ run(
     `,
     flags: {
       string: ['project'],
-      boolean: ['clean-cache', 'cleanup'],
+      boolean: ['clean-cache', 'cleanup', 'extended-diagnostics', 'with-archive'],
       help: `
         --project [path]        Path to a tsconfig.json file determines the project to check
         --help                  Show this message
@@ -175,6 +213,8 @@ run(
                                   files in place makes subsequent executions faster because ts can
                                   identify that none of the imports have changed (it uses creation/update
                                   times) but cleaning them prevents leaving garbage around the repo.
+        --extended-diagnostics  Turn on extended diagnostics in the TypeScript compiler
+        --with-archive          Restore cached artifacts before running and archive results afterwards
       `,
     },
   }

--- a/packages/kbn-ts-type-check-cli/src/archive/archive_ts_build_artifacts.test.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/archive_ts_build_artifacts.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SomeDevLog } from '@kbn/some-dev-log';
+import globby from 'globby';
+import { archiveTSBuildArtifacts } from './archive_ts_build_artifacts';
+import { LocalFileSystem } from './file_system/local_file_system';
+import { getPullRequestNumber, isCiEnvironment, resolveCurrentCommitSha } from './utils';
+
+jest.mock('globby', () => jest.fn());
+
+jest.mock('./utils', () => ({
+  getPullRequestNumber: jest.fn(),
+  isCiEnvironment: jest.fn(),
+  resolveCurrentCommitSha: jest.fn(),
+  withGcsAuth: jest.fn((_, action: () => Promise<unknown>) => action()),
+}));
+
+jest.mock('./file_system/gcs_file_system', () => ({
+  GcsFileSystem: jest.fn().mockImplementation(() => ({
+    updateArchive: jest.fn(),
+  })),
+}));
+
+const mockedGlobby = globby as jest.MockedFunction<typeof globby>;
+const mockedGetPullRequestNumber = getPullRequestNumber as jest.MockedFunction<
+  typeof getPullRequestNumber
+>;
+const mockedIsCiEnvironment = isCiEnvironment as jest.MockedFunction<typeof isCiEnvironment>;
+const mockedResolveCurrentCommitSha = resolveCurrentCommitSha as jest.MockedFunction<
+  typeof resolveCurrentCommitSha
+>;
+
+const createLog = (): SomeDevLog => {
+  return {
+    info: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as SomeDevLog;
+};
+
+describe('archiveTSBuildArtifacts', () => {
+  let updateSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedIsCiEnvironment.mockReturnValue(false);
+    mockedGetPullRequestNumber.mockReturnValue(undefined);
+    mockedResolveCurrentCommitSha.mockResolvedValue('');
+    mockedGlobby.mockResolvedValue([]);
+    updateSpy = jest
+      .spyOn(LocalFileSystem.prototype, 'updateArchive')
+      .mockResolvedValue(Promise.resolve() as unknown as void);
+  });
+
+  afterEach(() => {
+    updateSpy.mockRestore();
+  });
+
+  it('logs when no build artifacts are present', async () => {
+    const log = createLog();
+
+    mockedGlobby.mockResolvedValueOnce([]);
+
+    await archiveTSBuildArtifacts(log);
+
+    expect(log.info).toHaveBeenCalledWith('No TypeScript build artifacts found to archive.');
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns when the commit SHA cannot be determined', async () => {
+    const log = createLog();
+
+    mockedGlobby.mockResolvedValueOnce(['a']);
+    mockedResolveCurrentCommitSha.mockResolvedValueOnce(undefined);
+
+    await archiveTSBuildArtifacts(log);
+
+    expect(log.warning).toHaveBeenCalledWith(
+      'Unable to determine commit SHA for TypeScript cache archive.'
+    );
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses the LocalFileSystem to archive matching artifacts', async () => {
+    const log = createLog();
+    const files = ['target/types/foo.d.ts', 'tsconfig.type_check.json'];
+
+    mockedGlobby.mockResolvedValueOnce(files);
+    mockedResolveCurrentCommitSha.mockResolvedValueOnce('abc123');
+    mockedGetPullRequestNumber.mockReturnValueOnce('789');
+
+    await archiveTSBuildArtifacts(log);
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledWith({
+      files,
+      prNumber: '789',
+      sha: 'abc123',
+    });
+  });
+});

--- a/packages/kbn-ts-type-check-cli/src/archive/archive_ts_build_artifacts.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/archive_ts_build_artifacts.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { REPO_ROOT } from '@kbn/repo-info';
+import type { SomeDevLog } from '@kbn/some-dev-log';
+import globby from 'globby';
+import { CACHE_IGNORE_GLOBS, CACHE_MATCH_GLOBS } from './constants';
+import { GcsFileSystem } from './file_system/gcs_file_system';
+import { LocalFileSystem } from './file_system/local_file_system';
+import {
+  getPullRequestNumber,
+  isCiEnvironment,
+  resolveCurrentCommitSha,
+  withGcsAuth,
+} from './utils';
+
+/**
+ * Archives .tsbuildinfo, type_check.tsconfig.json, and declaration files
+ * in a GCS bucket for cached type checks.
+ */
+export async function archiveTSBuildArtifacts(log: SomeDevLog) {
+  try {
+    const matches = await globby(CACHE_MATCH_GLOBS, {
+      cwd: REPO_ROOT,
+      dot: true,
+      followSymbolicLinks: false,
+      ignore: CACHE_IGNORE_GLOBS,
+    });
+
+    if (matches.length === 0) {
+      log.info('No TypeScript build artifacts found to archive.');
+      return;
+    }
+
+    const commitSha = await resolveCurrentCommitSha();
+
+    if (!commitSha) {
+      log.warning('Unable to determine commit SHA for TypeScript cache archive.');
+      return;
+    }
+
+    const prNumber = getPullRequestNumber();
+
+    const options = { files: matches, sha: commitSha, prNumber };
+
+    if (isCiEnvironment()) {
+      await withGcsAuth(log, () => new GcsFileSystem(log).updateArchive(options));
+    } else {
+      await new LocalFileSystem(log).updateArchive(options);
+    }
+  } catch (error) {
+    const archiveErrorDetails = error instanceof Error ? error.message : String(error);
+    log.warning(`Failed to archive TypeScript build artifacts: ${archiveErrorDetails}`);
+  }
+}

--- a/packages/kbn-ts-type-check-cli/src/archive/constants.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/constants.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Path from 'path';
+import { REPO_ROOT } from '@kbn/repo-info';
+import Os from 'os';
+
+/**
+ * globs for the archive
+ */
+export const CACHE_MATCH_GLOBS = ['**/target/types/**', '**/tsconfig*.type_check.json'];
+export const CACHE_IGNORE_GLOBS = [
+  '**/node_modules/**',
+  '**/.git/**',
+  '.moon/cache/**',
+  '.es/**',
+  '.es-data/**',
+  'data/**',
+  '.ftr/**',
+  'build/**',
+];
+
+export const ARCHIVE_FILE_NAME = 'ts-build-artifacts.tar.gz';
+export const ARCHIVE_METADATA_FILE_NAME = 'ts-build-artifacts.meta.json';
+
+export const GCS_BUCKET_NAME = 'ci-typescript-archives';
+
+export const GCS_BUCKET_PATH = 'ts_type_check';
+
+export const GCS_BUCKET_URI = `gs://${GCS_BUCKET_NAME}/${GCS_BUCKET_PATH}`;
+
+export const COMMITS_PATH = `commits`;
+export const PULL_REQUESTS_PATH = `prs`;
+export const GCS_COMMITS_PREFIX = `${GCS_BUCKET_URI}/${COMMITS_PATH}`;
+export const GCS_PULL_REQUESTS_PREFIX = `${GCS_BUCKET_URI}/${PULL_REQUESTS_PATH}`;
+
+export const GCLOUD_ACTIVATE_SCRIPT = Path.resolve(
+  REPO_ROOT,
+  '.buildkite/scripts/common/activate_service_account.sh'
+);
+
+const BASE_DIR = Path.resolve(Os.tmpdir(), 'kibana-ts-type-check-cache');
+
+export const TMP_DIR = Path.join(BASE_DIR, 'tmp');
+export const LOCAL_CACHE_ROOT = Path.join(BASE_DIR, 'archives');
+
+export const MAX_COMMITS_TO_CHECK = 50;
+
+export const TYPES_DIRECTORY_GLOB = '**/target/types';
+export const TYPE_CHECK_CONFIG_GLOB = '**/tsconfig*.type_check.json';

--- a/packages/kbn-ts-type-check-cli/src/archive/file_system/abstract_file_system.test.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/file_system/abstract_file_system.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Fs from 'fs';
+import type { SomeDevLog } from '@kbn/some-dev-log';
+import { TMP_DIR } from '../constants';
+import type { ArchiveMetadata } from './types';
+import { AbstractFileSystem } from './abstract_file_system';
+
+jest.mock('../utils', () => ({
+  cleanTypeCheckArtifacts: jest.fn(),
+}));
+
+const { cleanTypeCheckArtifacts } = jest.requireMock('../utils') as {
+  cleanTypeCheckArtifacts: jest.MockedFunction<(log: SomeDevLog) => Promise<void>>;
+};
+
+class TestFileSystem extends AbstractFileSystem {
+  public readonly archiveCalls: Array<{ archivePath: string; fileListPath: string }> = [];
+  public readonly extractCalls: string[] = [];
+  public readonly metadata = new Map<string, ArchiveMetadata>();
+  public readonly availableArchives = new Set<string>();
+
+  protected getPath(archiveId: string): string {
+    return archiveId;
+  }
+
+  protected async readMetadata(metadataPath: string): Promise<ArchiveMetadata | undefined> {
+    return this.metadata.get(metadataPath);
+  }
+
+  protected async writeMetadata(metadataPath: string, data: ArchiveMetadata): Promise<void> {
+    this.metadata.set(metadataPath, data);
+  }
+
+  protected async hasArchive(archivePath: string): Promise<boolean> {
+    return this.availableArchives.has(archivePath);
+  }
+
+  protected async extract(archivePath: string): Promise<void> {
+    this.extractCalls.push(archivePath);
+  }
+
+  protected async archive(archivePath: string, fileListPath: string): Promise<void> {
+    this.archiveCalls.push({ archivePath, fileListPath });
+  }
+
+  public async clean(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+const createLog = (): SomeDevLog => {
+  return {
+    info: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as SomeDevLog;
+};
+
+describe('AbstractFileSystem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cleanTypeCheckArtifacts.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await Fs.promises.rm(TMP_DIR, { recursive: true, force: true });
+  });
+
+  describe('updateArchive', () => {
+    it('writes a null-delimited file list and metadata for commit archives', async () => {
+      const log = createLog();
+      const fs = new TestFileSystem(log);
+
+      await fs.updateArchive({ files: ['foo', 'bar'], sha: 'abcd1234' });
+
+      expect(fs.archiveCalls).toHaveLength(1);
+      const [{ archivePath, fileListPath }] = fs.archiveCalls;
+      expect(archivePath).toBe('commits/abcd1234/archive.tar.gz');
+
+      const fileListContent = await Fs.promises.readFile(fileListPath, 'utf8');
+      expect(fileListContent).toBe('foo\u0000bar\u0000');
+
+      expect(fs.metadata.get('commits/abcd1234/metadata.json')).toEqual({
+        commitSha: 'abcd1234',
+        prNumber: undefined,
+      });
+    });
+
+    it('stores metadata including PR number for pull request archives', async () => {
+      const log = createLog();
+      const fs = new TestFileSystem(log);
+
+      await fs.updateArchive({ files: ['one'], sha: 'commitsha', prNumber: '42' });
+
+      expect(fs.archiveCalls).toHaveLength(1);
+      const [{ archivePath }] = fs.archiveCalls;
+      expect(archivePath).toBe('prs/42/archive.tar.gz');
+
+      expect(fs.metadata.get('prs/42/metadata.json')).toEqual({
+        commitSha: 'commitsha',
+        prNumber: '42',
+      });
+    });
+  });
+
+  describe('restoreArchive', () => {
+    it('extracts the first matching archive and cleans existing artifacts', async () => {
+      const log = createLog();
+      const fs = new TestFileSystem(log);
+      fs.availableArchives.add('commits/sha2/archive.tar.gz');
+
+      await fs.restoreArchive({ shas: ['sha1', 'sha2', 'sha3'] });
+
+      expect(cleanTypeCheckArtifacts).toHaveBeenCalledTimes(1);
+      expect(cleanTypeCheckArtifacts).toHaveBeenCalledWith(log);
+      expect(fs.extractCalls).toEqual(['commits/sha2/archive.tar.gz']);
+    });
+
+    it('prefers the pull request archive when metadata matches the candidate SHA', async () => {
+      const log = createLog();
+      const fs = new TestFileSystem(log);
+      fs.metadata.set('prs/123/metadata.json', { commitSha: 'sha-pr', prNumber: '123' });
+      fs.availableArchives.add('prs/123/archive.tar.gz');
+
+      await fs.restoreArchive({ shas: ['sha-pr', 'sha-other'], prNumber: '123' });
+
+      expect(cleanTypeCheckArtifacts).toHaveBeenCalledTimes(1);
+      expect(fs.extractCalls).toEqual(['prs/123/archive.tar.gz']);
+    });
+
+    it('logs when no archive could be restored', async () => {
+      const log = createLog();
+      const fs = new TestFileSystem(log);
+
+      await fs.restoreArchive({ shas: ['missing-one'] });
+
+      expect(fs.extractCalls).toHaveLength(0);
+      expect(cleanTypeCheckArtifacts).not.toHaveBeenCalled();
+      expect((log.info as jest.Mock).mock.calls).toContainEqual([
+        'No cached TypeScript build artifacts available to restore.',
+      ]);
+    });
+  });
+});

--- a/packages/kbn-ts-type-check-cli/src/archive/file_system/abstract_file_system.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/file_system/abstract_file_system.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import Path from 'path';
+import Fs from 'fs';
+import type { SomeDevLog } from '@kbn/some-dev-log';
+import type { ArchiveMetadata } from './types';
+import { COMMITS_PATH, PULL_REQUESTS_PATH, TMP_DIR } from '../constants';
+import { join } from './utils';
+import { cleanTypeCheckArtifacts } from '../utils';
+
+export abstract class AbstractFileSystem {
+  constructor(protected readonly log: SomeDevLog) {}
+
+  protected abstract getPath(archiveId: string): string;
+
+  protected abstract readMetadata(metadataPath: string): Promise<ArchiveMetadata | undefined>;
+  protected abstract writeMetadata(metadataPath: string, data: ArchiveMetadata): Promise<void>;
+
+  protected abstract hasArchive(archivePath: string): Promise<boolean>;
+
+  protected abstract extract(archivePath: string): Promise<void>;
+  protected abstract archive(archivePath: string, fileListPath: string): Promise<void>;
+
+  public abstract clean(): Promise<void>;
+
+  protected getArchivePath(archiveId: string) {
+    return join(this.getPath(archiveId), `archive.tar.gz`);
+  }
+
+  protected getMetadataPath(archiveId: string) {
+    return join(this.getPath(archiveId), `metadata.json`);
+  }
+
+  private async writeFileList(files: string[]): Promise<string> {
+    // Build a null-delimited file list so tar avoids path escaping and can scan names quickly.
+    // Example: find . -print0 | tar --null -T - --create …
+    const fileListPath = Path.join(TMP_DIR, 'ts-artifacts.list');
+    const nullDelimiter = '\0';
+
+    const archiveEntries = files;
+    const fileListContent = Buffer.from(
+      `${archiveEntries.join(nullDelimiter)}${nullDelimiter}`,
+      'utf8'
+    );
+
+    await Fs.promises.mkdir(TMP_DIR, { recursive: true });
+
+    await Fs.promises.writeFile(fileListPath, fileListContent);
+
+    return fileListPath;
+  }
+
+  public async restoreArchive(options: { shas: string[]; prNumber?: string }) {
+    const prArchiveId = options.prNumber ? join(PULL_REQUESTS_PATH, options.prNumber) : undefined;
+
+    const prArchiveMetadata = prArchiveId
+      ? await this.readMetadata(this.getMetadataPath(prArchiveId))
+      : undefined;
+
+    const prSha = prArchiveMetadata?.commitSha;
+
+    for (const sha of options.shas) {
+      const archiveId = prSha && sha === prSha ? prArchiveId! : join(COMMITS_PATH, sha);
+
+      const archivePath = this.getArchivePath(archiveId);
+
+      if (await this.hasArchive(archivePath)) {
+        await cleanTypeCheckArtifacts(this.log);
+        this.log.info(`Extracting archive for ${sha}`);
+        return await this.extract(archivePath);
+      }
+    }
+
+    this.log.info('No cached TypeScript build artifacts available to restore.');
+
+    return undefined;
+  }
+
+  public async updateArchive(options: { files: string[]; sha: string; prNumber?: string }) {
+    const archiveId = options.prNumber
+      ? join(PULL_REQUESTS_PATH, options.prNumber.toString())
+      : join(COMMITS_PATH, options.sha);
+
+    const metadata: ArchiveMetadata = {
+      commitSha: options.sha,
+      prNumber: options.prNumber,
+    };
+
+    const fileListPath = await this.writeFileList(options.files);
+
+    const archivePath = this.getArchivePath(archiveId);
+
+    this.log.info(`Writing archive to ${archivePath}`);
+
+    await this.archive(archivePath, fileListPath);
+
+    await this.writeMetadata(this.getMetadataPath(archiveId), metadata);
+  }
+}

--- a/packages/kbn-ts-type-check-cli/src/archive/file_system/gcs_file_system.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/file_system/gcs_file_system.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import Fs from 'fs';
+import Os from 'os';
+import Path from 'path';
+import { REPO_ROOT } from '@kbn/repo-info';
+import type { SomeDevLog } from '@kbn/some-dev-log';
+import execa from 'execa';
+import { GCS_BUCKET_URI } from '../constants';
+import { getTarCreateArgs, getTarPlatformOptions, resolveTarEnvironment } from './utils';
+import { AbstractFileSystem } from './abstract_file_system';
+import type { ArchiveMetadata } from './types';
+import { join } from './utils';
+
+export class GcsFileSystem extends AbstractFileSystem {
+  constructor(log: SomeDevLog) {
+    super(log);
+  }
+
+  protected getPath(archiveId: string): string {
+    return join(GCS_BUCKET_URI, archiveId);
+  }
+
+  protected async archive(archivePath: string, fileListPath: string): Promise<void> {
+    const tarProcess = execa('tar', getTarCreateArgs('-', fileListPath), {
+      cwd: REPO_ROOT,
+      stdout: 'pipe',
+      stderr: 'inherit',
+      env: resolveTarEnvironment(),
+      buffer: false,
+    });
+
+    const uploadProcess = execa('gcloud', ['storage', 'cp', '-', archivePath], {
+      cwd: REPO_ROOT,
+      stdin: 'pipe',
+      stdout: 'inherit',
+      stderr: 'inherit',
+    });
+
+    if (!tarProcess.stdout || !uploadProcess.stdin) {
+      tarProcess.kill();
+      uploadProcess.kill();
+      throw new Error('Failed to stream TypeScript cache archive to GCS.');
+    }
+
+    tarProcess.stdout.pipe(uploadProcess.stdin);
+
+    await Promise.all([tarProcess, uploadProcess]);
+  }
+
+  protected async extract(archivePath: string): Promise<void> {
+    this.log.info(`Streaming TypeScript build artifacts from ${archivePath}`);
+
+    const extractBaseArgs = ['--directory', REPO_ROOT, ...getTarPlatformOptions()];
+
+    const tarArgs = ['--extract', '--file', '-', '--gzip', ...extractBaseArgs];
+
+    const tarProcess = execa('tar', tarArgs, {
+      cwd: REPO_ROOT,
+      stdin: 'pipe',
+      stdout: 'ignore',
+      stderr: 'inherit',
+      env: resolveTarEnvironment(),
+      buffer: false,
+    });
+
+    const catProcess = execa('gcloud', ['storage', 'cat', archivePath], {
+      cwd: REPO_ROOT,
+      stdout: 'pipe',
+      stderr: 'inherit',
+      buffer: false,
+    });
+
+    if (!catProcess.stdout || !tarProcess.stdin) {
+      tarProcess.kill();
+      catProcess.kill();
+      throw new Error('Failed to establish stream between gcloud and tar.');
+    }
+
+    catProcess.stdout.pipe(tarProcess.stdin);
+
+    await Promise.all([catProcess, tarProcess]);
+  }
+
+  protected async hasArchive(archivePath: string): Promise<boolean> {
+    const commands: Array<[cmd: string, args: string[]]> = [
+      ['gcloud', ['storage', 'ls', '--uri', archivePath]],
+      ['gsutil', ['-q', 'ls', archivePath]],
+    ];
+
+    for (const [cmd, args] of commands) {
+      try {
+        await execa(cmd, args, {
+          cwd: REPO_ROOT,
+          stdio: 'ignore',
+        });
+        return true;
+      } catch (error) {
+        continue;
+      }
+    }
+
+    return false;
+  }
+
+  protected async readMetadata(metadataPath: string): Promise<ArchiveMetadata | undefined> {
+    const commands: Array<[cmd: string, args: string[]]> = [
+      ['gcloud', ['storage', 'cat', metadataPath]],
+      ['gsutil', ['cat', metadataPath]],
+    ];
+
+    for (const [cmd, args] of commands) {
+      try {
+        const { stdout } = await execa(cmd, args, {
+          cwd: REPO_ROOT,
+          stderr: 'ignore',
+        });
+        return JSON.parse(stdout) as ArchiveMetadata;
+      } catch (error) {
+        continue;
+      }
+    }
+
+    return undefined;
+  }
+
+  protected async writeMetadata(metadataPath: string, data: ArchiveMetadata): Promise<void> {
+    const tempDir = await Fs.promises.mkdtemp(Path.join(Os.tmpdir(), 'kbn-ts-metadata-'));
+    const tempFilePath = Path.join(tempDir, 'metadata.json');
+
+    try {
+      await Fs.promises.writeFile(tempFilePath, JSON.stringify(data), 'utf8');
+
+      await execa('gcloud', ['storage', 'cp', tempFilePath, metadataPath], {
+        cwd: REPO_ROOT,
+        stdout: 'inherit',
+        stderr: 'inherit',
+      });
+    } finally {
+      await Fs.promises.rm(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  async clean(): Promise<void> {
+    // do nothing
+  }
+}

--- a/packages/kbn-ts-type-check-cli/src/archive/file_system/local_file_system.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/file_system/local_file_system.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { REPO_ROOT } from '@kbn/repo-info';
+import type { SomeDevLog } from '@kbn/some-dev-log';
+import execa from 'execa';
+import Fs from 'fs';
+import Path from 'path';
+import { getTarCreateArgs, getTarPlatformOptions, resolveTarEnvironment } from './utils';
+import { AbstractFileSystem } from './abstract_file_system';
+import type { ArchiveMetadata } from './types';
+import { join } from './utils';
+import { LOCAL_CACHE_ROOT } from '../constants';
+
+export class LocalFileSystem extends AbstractFileSystem {
+  private readonly basePath = LOCAL_CACHE_ROOT;
+  constructor(log: SomeDevLog) {
+    super(log);
+  }
+
+  protected getPath(archiveId: string): string {
+    return join(this.basePath, archiveId);
+  }
+
+  protected async ensureArchiveDir(path: string): Promise<void> {
+    await Fs.promises.mkdir(Path.dirname(path), { recursive: true });
+  }
+
+  protected async archive(archivePath: string, fileListPath: string): Promise<void> {
+    await this.ensureArchiveDir(archivePath);
+
+    const tarArgs = getTarCreateArgs(archivePath, fileListPath);
+
+    await execa('tar', tarArgs, {
+      cwd: REPO_ROOT,
+      stdout: 'inherit',
+      stderr: 'inherit',
+      env: resolveTarEnvironment(),
+      buffer: false,
+    });
+  }
+
+  protected async extract(archivePath: string): Promise<void> {
+    const extractBaseArgs = ['--directory', REPO_ROOT, ...getTarPlatformOptions()];
+
+    const tarArgs = ['--extract', '--file', archivePath, '--gzip', ...extractBaseArgs];
+
+    await execa('tar', tarArgs, {
+      cwd: REPO_ROOT,
+      stdout: 'ignore',
+      stderr: 'inherit',
+      env: resolveTarEnvironment(),
+      buffer: false,
+    });
+  }
+
+  protected async readMetadata(metadataPath: string): Promise<ArchiveMetadata | undefined> {
+    try {
+      const contents = await Fs.promises.readFile(metadataPath, 'utf8');
+      return JSON.parse(contents) as ArchiveMetadata;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  protected async writeMetadata(metadataPath: string, data: ArchiveMetadata): Promise<void> {
+    await this.ensureArchiveDir(metadataPath);
+
+    await Fs.promises.writeFile(metadataPath, JSON.stringify(data), 'utf8');
+  }
+
+  protected async hasArchive(archivePath: string): Promise<boolean> {
+    try {
+      const stat = await Fs.promises.stat(archivePath);
+      return stat.isFile();
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+      return false;
+    }
+  }
+
+  async clean(): Promise<void> {
+    await Fs.promises.rm(this.basePath, { recursive: true, force: true });
+  }
+}

--- a/packages/kbn-ts-type-check-cli/src/archive/file_system/types.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/file_system/types.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export type WritableData = string | NodeJS.ArrayBufferView;
+
+export interface ArchiveMetadata {
+  commitSha: string;
+  prNumber?: string | null;
+}
+
+export interface PullRequestArchiveMetadata {
+  prNumber: string;
+  commits: ArchiveMetadata[];
+  updatedAt: string;
+}

--- a/packages/kbn-ts-type-check-cli/src/archive/file_system/utils.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/file_system/utils.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Path from 'path';
+import { REPO_ROOT } from '@kbn/repo-info';
+
+export function parseSerializedContent<T>(rawContent: string): T | undefined {
+  try {
+    return JSON.parse(rawContent) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function joinUri(base: string, targetPath: string) {
+  const cleanBase = base.replace(/\/+$/, '');
+  const cleanTarget = targetPath.replace(/^\/+/, '');
+  return `${cleanBase}/${cleanTarget}`;
+}
+
+export function join(left: string, ...rights: string[]) {
+  const isUri = left.includes('://');
+  if (isUri) {
+    return rights.reduce((prev, current) => {
+      return joinUri(prev, current);
+    }, left);
+  }
+  return Path.join(left, ...rights);
+}
+
+const TAR_PLATFORM_OPTIONS =
+  process.platform === 'linux'
+    ? ['--no-same-owner', '--no-same-permissions', '--numeric-owner', '--delay-directory-restore']
+    : [];
+
+export const getTarPlatformOptions = () => TAR_PLATFORM_OPTIONS;
+
+export const getTarCreateArgs = (fileArg: string, fileListPath: string): string[] => [
+  '--create',
+  '--file',
+  fileArg,
+  '--gzip',
+  '--directory',
+  REPO_ROOT,
+  '--null',
+  '--files-from',
+  fileListPath,
+];
+
+export const resolveTarEnvironment = (): NodeJS.ProcessEnv => {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    // these should speed up archiving on MacOS
+    COPYFILE_DISABLE: '1',
+    COPY_EXTENDED_ATTRIBUTES_DISABLE: '1',
+  };
+
+  return env;
+};

--- a/packages/kbn-ts-type-check-cli/src/archive/restore_ts_build_artifacts.test.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/restore_ts_build_artifacts.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SomeDevLog } from '@kbn/some-dev-log';
+import { restoreTSBuildArtifacts } from './restore_ts_build_artifacts';
+import { LocalFileSystem } from './file_system/local_file_system';
+import {
+  buildCandidateShaList,
+  getPullRequestNumber,
+  isCiEnvironment,
+  readRecentCommitShas,
+  resolveCurrentCommitSha,
+} from './utils';
+
+jest.mock('./utils', () => ({
+  buildCandidateShaList: jest.fn(),
+  getPullRequestNumber: jest.fn(),
+  isCiEnvironment: jest.fn(),
+  readRecentCommitShas: jest.fn(),
+  resolveCurrentCommitSha: jest.fn(),
+  withGcsAuth: jest.fn((_, action: () => Promise<unknown>) => action()),
+}));
+
+jest.mock('./file_system/gcs_file_system', () => ({
+  GcsFileSystem: jest.fn().mockImplementation(() => ({
+    restoreArchive: jest.fn(),
+  })),
+}));
+
+const mockedBuildCandidateShaList = buildCandidateShaList as jest.MockedFunction<
+  typeof buildCandidateShaList
+>;
+const mockedGetPullRequestNumber = getPullRequestNumber as jest.MockedFunction<
+  typeof getPullRequestNumber
+>;
+const mockedIsCiEnvironment = isCiEnvironment as jest.MockedFunction<typeof isCiEnvironment>;
+const mockedReadRecentCommitShas = readRecentCommitShas as jest.MockedFunction<
+  typeof readRecentCommitShas
+>;
+const mockedResolveCurrentCommitSha = resolveCurrentCommitSha as jest.MockedFunction<
+  typeof resolveCurrentCommitSha
+>;
+
+const createLog = (): SomeDevLog => {
+  return {
+    info: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as SomeDevLog;
+};
+
+describe('restoreTSBuildArtifacts', () => {
+  let restoreSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedIsCiEnvironment.mockReturnValue(false);
+    mockedGetPullRequestNumber.mockReturnValue(undefined);
+    mockedResolveCurrentCommitSha.mockResolvedValue('');
+    mockedReadRecentCommitShas.mockResolvedValue([]);
+    mockedBuildCandidateShaList.mockReturnValue([]);
+    restoreSpy = jest
+      .spyOn(LocalFileSystem.prototype, 'restoreArchive')
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    restoreSpy.mockRestore();
+  });
+
+  it('logs when there is no commit history to restore', async () => {
+    const log = createLog();
+
+    mockedBuildCandidateShaList.mockReturnValueOnce([]);
+
+    await restoreTSBuildArtifacts(log);
+
+    expect(log.info).toHaveBeenCalledWith(
+      'No commit history available for TypeScript cache restore.'
+    );
+    expect(restoreSpy).not.toHaveBeenCalled();
+  });
+
+  it('restores artifacts using the LocalFileSystem when candidates exist', async () => {
+    const log = createLog();
+
+    const candidateShas = ['sha-current', 'sha-parent'];
+    mockedResolveCurrentCommitSha.mockResolvedValueOnce('sha-current');
+    mockedReadRecentCommitShas.mockResolvedValueOnce(['sha-parent']);
+    mockedBuildCandidateShaList.mockReturnValueOnce(candidateShas);
+    mockedGetPullRequestNumber.mockReturnValueOnce('456');
+
+    await restoreTSBuildArtifacts(log);
+
+    expect(restoreSpy).toHaveBeenCalledTimes(1);
+    expect(restoreSpy).toHaveBeenCalledWith({
+      prNumber: '456',
+      shas: candidateShas,
+    });
+  });
+
+  it('logs a warning when restoration throws', async () => {
+    const log = createLog();
+
+    mockedResolveCurrentCommitSha.mockResolvedValueOnce('shaX');
+    mockedReadRecentCommitShas.mockResolvedValueOnce(['shaY']);
+    mockedBuildCandidateShaList.mockReturnValueOnce(['shaX']);
+
+    restoreSpy.mockRejectedValueOnce(new Error('boom')); // ensure throw
+
+    await restoreTSBuildArtifacts(log);
+
+    expect(log.warning).toHaveBeenCalledWith('Failed to restore TypeScript build artifacts: boom');
+  });
+});

--- a/packages/kbn-ts-type-check-cli/src/archive/restore_ts_build_artifacts.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/restore_ts_build_artifacts.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SomeDevLog } from '@kbn/some-dev-log';
+import { MAX_COMMITS_TO_CHECK } from './constants';
+import { GcsFileSystem } from './file_system/gcs_file_system';
+import { LocalFileSystem } from './file_system/local_file_system';
+import {
+  buildCandidateShaList,
+  getPullRequestNumber,
+  isCiEnvironment,
+  readRecentCommitShas,
+  resolveCurrentCommitSha,
+  withGcsAuth,
+} from './utils';
+
+export async function restoreTSBuildArtifacts(log: SomeDevLog) {
+  try {
+    log.info(`Restoring TypeScript build artifacts`);
+    const currentSha = await resolveCurrentCommitSha();
+    const history = await readRecentCommitShas(MAX_COMMITS_TO_CHECK);
+    const candidateShas = buildCandidateShaList(currentSha, history);
+
+    if (candidateShas.length === 0) {
+      log.info('No commit history available for TypeScript cache restore.');
+      return;
+    }
+
+    const prNumber = getPullRequestNumber();
+
+    if (isCiEnvironment()) {
+      await withGcsAuth(log, async () => {
+        await new GcsFileSystem(log).restoreArchive({ shas: candidateShas, prNumber });
+      });
+    } else {
+      await new LocalFileSystem(log).restoreArchive({ shas: candidateShas, prNumber });
+    }
+  } catch (error) {
+    const restoreErrorDetails = error instanceof Error ? error.message : String(error);
+    log.warning(`Failed to restore TypeScript build artifacts: ${restoreErrorDetails}`);
+  }
+}

--- a/packages/kbn-ts-type-check-cli/src/archive/utils.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/utils.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import Fs from 'fs';
+import execa from 'execa';
+import { REPO_ROOT } from '@kbn/repo-info';
+import type { SomeDevLog } from '@kbn/some-dev-log';
+import globby from 'globby';
+import { asyncForEachWithLimit } from '@kbn/std';
+import {
+  CACHE_IGNORE_GLOBS,
+  GCLOUD_ACTIVATE_SCRIPT,
+  GCS_BUCKET_NAME,
+  LOCAL_CACHE_ROOT,
+  TYPES_DIRECTORY_GLOB,
+  TYPE_CHECK_CONFIG_GLOB,
+} from './constants';
+export type { ArchiveMetadata, PullRequestArchiveMetadata } from './file_system/types';
+
+export const getPullRequestNumber = (): string | undefined => {
+  const value = process.env.BUILDKITE_PULL_REQUEST ?? '';
+  if (value.length === 0 || value === 'false') {
+    return undefined;
+  }
+
+  return value;
+};
+
+export async function resolveCurrentCommitSha(): Promise<string | undefined> {
+  if (process.env.BUILDKITE_COMMIT) {
+    return process.env.BUILDKITE_COMMIT;
+  }
+
+  const { stdout } = await execa('git', ['rev-parse', 'HEAD'], { cwd: REPO_ROOT });
+  const sha = stdout.trim();
+  return sha.length > 0 ? sha : undefined;
+}
+
+export async function readRecentCommitShas(limit: number): Promise<string[]> {
+  const { stdout } = await execa('git', ['rev-list', '--max-count', String(limit), 'HEAD'], {
+    cwd: REPO_ROOT,
+  });
+  return stdout
+    .split('\n')
+    .map((sha: string) => sha.trim())
+    .filter((sha: string) => sha.length > 0);
+}
+
+export function isCiEnvironment() {
+  return (process.env.CI ?? '').toLowerCase() === 'true';
+}
+
+export async function withGcsAuth<TReturn>(
+  log: SomeDevLog,
+  action: () => Promise<TReturn>
+): Promise<TReturn> {
+  await execa(GCLOUD_ACTIVATE_SCRIPT, [GCS_BUCKET_NAME], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+  });
+
+  try {
+    return await action();
+  } finally {
+    try {
+      await execa(GCLOUD_ACTIVATE_SCRIPT, ['--unset-impersonation'], {
+        cwd: REPO_ROOT,
+        stdio: 'inherit',
+      });
+    } catch (unsetError) {
+      const unsetErrorDetails =
+        unsetError instanceof Error ? unsetError.message : String(unsetError);
+      log.warning(`Failed to unset GCP impersonation: ${unsetErrorDetails}`);
+    }
+  }
+}
+
+export async function ensureLocalCacheRoot() {
+  await Fs.promises.mkdir(LOCAL_CACHE_ROOT, { recursive: true });
+}
+
+export function buildCandidateShaList(currentSha: string | undefined, history: string[]): string[] {
+  const uniqueShas = new Set<string>();
+
+  if (currentSha) {
+    uniqueShas.add(currentSha);
+  }
+
+  for (const sha of history) {
+    if (sha) {
+      uniqueShas.add(sha);
+    }
+  }
+
+  return Array.from(uniqueShas);
+}
+
+export async function cleanTypeCheckArtifacts(log: SomeDevLog) {
+  const directoryMatches = await globby(TYPES_DIRECTORY_GLOB, {
+    cwd: REPO_ROOT,
+    absolute: true,
+    onlyDirectories: true,
+    followSymbolicLinks: false,
+    ignore: CACHE_IGNORE_GLOBS,
+  });
+  const directoryPaths: string[] = Array.from(new Set<string>(directoryMatches));
+
+  const configMatches = await globby(TYPE_CHECK_CONFIG_GLOB, {
+    cwd: REPO_ROOT,
+    absolute: true,
+    onlyFiles: true,
+    followSymbolicLinks: false,
+    ignore: CACHE_IGNORE_GLOBS,
+  });
+  const configPaths: string[] = Array.from(new Set<string>(configMatches));
+
+  await asyncForEachWithLimit(directoryPaths, 10, async (directoryPath) => {
+    await Fs.promises.rm(directoryPath, { recursive: true, force: true });
+  });
+
+  await asyncForEachWithLimit(configPaths, 25, async (configPath) => {
+    await Fs.promises.rm(configPath, { force: true });
+  });
+
+  if (directoryPaths.length > 0 || configPaths.length > 0) {
+    log.info(
+      `Cleared ${directoryPaths.length} type cache directories and ${configPaths.length} config files before restore.`
+    );
+  }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] Cache TypeScript build artifacts (#241414)](https://github.com/elastic/kibana/pull/241414)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dario Gieselaar","email":"dario.gieselaar@elastic.co"},"sourceCommit":{"committedDate":"2025-11-11T14:31:10Z","message":"[CI] Cache TypeScript build artifacts (#241414)\n\nImplements a GCS-backed cache of TypeScript builds, which ensures only\ninvalidated projects need to be re-checked, which can speed up CI checks\nfrom 25-30m to 3m in many cases.\n\nWhen restoring an archive, we use the most recent commit for which there\nis an archive. Archives are stored either by commit sha (for the\non-merge pipeline) or PR number (for the pull-request pipeline).\n\nStoring & restoring takes about 20s each. A fully-cached type check is\nabout 50s.\n\nBased on https://github.com/elastic/kibana/pull/240981 from @delanni.\n\n---------\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"659c01aa5fec2699c1c4a264742a29b3a5c80086","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.3.0"],"title":"[CI] Cache TypeScript build artifacts","number":241414,"url":"https://github.com/elastic/kibana/pull/241414","mergeCommit":{"message":"[CI] Cache TypeScript build artifacts (#241414)\n\nImplements a GCS-backed cache of TypeScript builds, which ensures only\ninvalidated projects need to be re-checked, which can speed up CI checks\nfrom 25-30m to 3m in many cases.\n\nWhen restoring an archive, we use the most recent commit for which there\nis an archive. Archives are stored either by commit sha (for the\non-merge pipeline) or PR number (for the pull-request pipeline).\n\nStoring & restoring takes about 20s each. A fully-cached type check is\nabout 50s.\n\nBased on https://github.com/elastic/kibana/pull/240981 from @delanni.\n\n---------\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"659c01aa5fec2699c1c4a264742a29b3a5c80086"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241414","number":241414,"mergeCommit":{"message":"[CI] Cache TypeScript build artifacts (#241414)\n\nImplements a GCS-backed cache of TypeScript builds, which ensures only\ninvalidated projects need to be re-checked, which can speed up CI checks\nfrom 25-30m to 3m in many cases.\n\nWhen restoring an archive, we use the most recent commit for which there\nis an archive. Archives are stored either by commit sha (for the\non-merge pipeline) or PR number (for the pull-request pipeline).\n\nStoring & restoring takes about 20s each. A fully-cached type check is\nabout 50s.\n\nBased on https://github.com/elastic/kibana/pull/240981 from @delanni.\n\n---------\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"659c01aa5fec2699c1c4a264742a29b3a5c80086"}}]}] BACKPORT-->