### PR TITLE
[Discover][Traces] Update chart area height for RED metrics

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/accessors/chart_session.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/accessors/chart_session.tsx
@@ -26,7 +26,7 @@ export const createChartSection = (
           <TraceMetricsGrid {...props} dataSource={dataSource} />
         ),
         replaceDefaultChart: true,
-        defaultTopPanelHeight: 'max-content',
+        defaultTopPanelHeight: 300,
       };
     })
   );


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/pull/236635

Recently, we noticed that the chart area height was set with too much unused space, so in this PR we’ve updated it.

|Before|After|
|-|-|
|<img width="1279" height="938" alt="Screenshot 2025-11-17 at 17 09 26" src="https://github.com/user-attachments/assets/c6e74a1c-94e8-4288-8467-016987ead41c" />|<img width="1271" height="937" alt="Screenshot 2025-11-17 at 17 09 47" src="https://github.com/user-attachments/assets/11099b8a-f489-4f83-b4d7-4e073c1d9065" />|


This is controlled via the `defaultTopPanelHeight` attribute in the chart section of the profile. 
There are three different options available, and we chose the one that provides a fixed height, as it best suits displaying the charts clearly.

|`max-content`❌ |unset ⚠️ |`300` ✅ |
|-|-|-|
|![max-content](https://github.com/user-attachments/assets/212c69fc-ebea-4afc-95bd-faf6fa2d0e55)|![unset](https://github.com/user-attachments/assets/22e251ed-ba72-4387-83e5-cbb3ef3beba8)|![set_300](https://github.com/user-attachments/assets/fd16c7ab-d781-497a-966f-032d6699bf78)|

It’s important to mention that if a user manually adjusts the height of the chart section, which is stored in localStorage, this attribute will be ignored. User settings take priority over the default configuration.
