### PR TITLE
[Obs AI Assistant] Update system prompt title for generic deployments

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/prompts/system_prompt.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/prompts/system_prompt.ts
@@ -59,7 +59,7 @@ export function getSystemPrompt({
     // Section One: Core Introduction
     promptSections.push(
       dedent(`
-        # System Prompt: Elastic Observability Assistant
+        # System Prompt: Elastic ${isObservabilityDeployment ? 'Observability ' : ''}Assistant
 
         <RoleAndGoal>
 

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/prompts/tests/__snapshots__/system_prompt.generic_kb_not_ready_serverless.test.ts.snap
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/prompts/tests/__snapshots__/system_prompt.generic_kb_not_ready_serverless.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getSystemPrompt - Serverless | Generic Deployment | KB NOT ready | No ProductDoc matches snapshot 1`] = `
-"# System Prompt: Elastic Observability Assistant
+"# System Prompt: Elastic Assistant
 
 <RoleAndGoal>
 

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/prompts/tests/__snapshots__/system_prompt.generic_kb_ready_ech.test.ts.snap
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/prompts/tests/__snapshots__/system_prompt.generic_kb_ready_ech.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getSystemPrompt - ECH | Generic Deployment | KB ready | No ProductDoc matches snapshot 1`] = `
-"# System Prompt: Elastic Observability Assistant
+"# System Prompt: Elastic Assistant
 
 <RoleAndGoal>
 

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/prompts/tests/__snapshots__/system_prompt.generic_kb_ready_serverless.test.ts.snap
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/prompts/tests/__snapshots__/system_prompt.generic_kb_ready_serverless.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getSystemPrompt - Serverless | Generic Deployment | KB ready | No ProductDoc matches snapshot 1`] = `
-"# System Prompt: Elastic Observability Assistant
+"# System Prompt: Elastic Assistant
 
 <RoleAndGoal>
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/243268

## Summary

The system prompt title refers to `Observability` for generic deployments. 
This PR updates the title to be `# System Prompt: Elastic Assistant` for generic deployments and keeps the title `# System Prompt: Elastic Observability Assistant` for Observability specific deployments.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->