### PR TITLE
[One Workflow] Do not use faked request in executeWorkflow

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -355,7 +355,7 @@ export class WorkflowsExecutionEnginePlugin
 
       // Use Task Manager's first-class API key support by passing the request
       // Task Manager will automatically create and manage the API key
-      if (request) {
+      if (request && !request.isFakeRequest) {
         // Debug: Log the user info from the original request
         this.logger.debug(`Scheduling workflow task with user context for workflow ${workflow.id}`);
         await plugins.taskManager.schedule(taskInstance, { request });


### PR DESCRIPTION
closes: https://github.com/elastic/security-team/issues/14761