### PR TITLE
[9.1] [APM] `getTraceDocsPerPage` with builder pattern validation (#243054)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_trace_docs_per_page.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_trace_docs_per_page.ts
@@ -9,14 +9,15 @@ import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
 import type { QueryDslQueryContainer, Sort } from '@elastic/elasticsearch/lib/api/types';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { rangeQuery } from '@kbn/observability-plugin/server';
-import { omit } from 'lodash';
-import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
+import { accessKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
 import { asMutableArray } from '../../../common/utils/as_mutable_array';
 import {
   AGENT_NAME,
   CHILD_ID,
   EVENT_OUTCOME,
   FAAS_COLDSTART,
+  LINKS_SPAN_ID,
+  LINKS_TRACE_ID,
   OTEL_SPAN_LINKS_SPAN_ID,
   OTEL_SPAN_LINKS_TRACE_ID,
   PARENT_ID,
@@ -147,46 +148,46 @@ export async function getTraceDocsPerPage({
   return {
     hits: res.hits.hits.map((hit) => {
       const sort = hit.sort;
-      const fields = unflattenKnownApmEventFields(hit?.fields);
+      const fields = accessKnownApmEventFields(hit.fields).requireFields(requiredFields);
 
       const spanLinks =
-        'span' in hit._source ? hit._source.span?.links : mapOtelToSpanLink(fields.links);
+        'span' in hit._source
+          ? hit._source.span?.links
+          : mapOtelToSpanLink({
+              span_id: fields[LINKS_SPAN_ID],
+              trace_id: fields[LINKS_TRACE_ID],
+            });
 
-      if (hit.fields[PROCESSOR_EVENT]?.[0] === ProcessorEvent.span) {
-        const spanEvent = unflattenKnownApmEventFields(hit.fields, [
-          ...requiredFields,
-          ...requiredSpanFields,
-        ]);
+      if (fields[PROCESSOR_EVENT] === ProcessorEvent.span) {
+        const { child, span, processor, ...spanEvent } = fields
+          .requireFields(requiredSpanFields)
+          .unflatten();
 
         const spanWaterfallEvent: WaterfallSpan = {
-          ...omit(spanEvent, 'child'),
-          processor: {
-            event: 'span',
-          },
+          ...spanEvent,
+          processor: processor as { event: 'span' },
           span: {
-            ...spanEvent.span,
-            composite: spanEvent.span.composite
-              ? (spanEvent.span.composite as Required<WaterfallSpan['span']>['composite'])
+            ...span,
+            composite: span.composite
+              ? (span.composite as Required<WaterfallSpan['span']>['composite'])
               : undefined,
             links: spanLinks,
           },
-          ...(spanEvent.child ? { child: spanEvent.child as WaterfallSpan['child'] } : {}),
+          ...(child ? { child: child as WaterfallSpan['child'] } : undefined),
         };
 
         return { sort, hit: spanWaterfallEvent };
       }
 
-      const txEvent = unflattenKnownApmEventFields(hit.fields, [
-        ...requiredFields,
-        ...requiredTxFields,
-      ]);
+      const { span, processor, ...txEvent } = fields.requireFields(requiredTxFields).unflatten();
+
       const txWaterfallEvent: WaterfallTransaction = {
         ...txEvent,
-        processor: {
-          event: 'transaction',
+        processor: processor as {
+          event: 'transaction';
         },
         span: {
-          ...txEvent.span,
+          ...span,
           links: spanLinks,
         },
       };

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_trace_docs_per_page.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_trace_docs_per_page.ts
@@ -16,8 +16,6 @@ import {
   CHILD_ID,
   EVENT_OUTCOME,
   FAAS_COLDSTART,
-  LINKS_SPAN_ID,
-  LINKS_TRACE_ID,
   OTEL_SPAN_LINKS_SPAN_ID,
   OTEL_SPAN_LINKS_TRACE_ID,
   PARENT_ID,
@@ -154,8 +152,8 @@ export async function getTraceDocsPerPage({
         'span' in hit._source
           ? hit._source.span?.links
           : mapOtelToSpanLink({
-              span_id: fields[LINKS_SPAN_ID],
-              trace_id: fields[LINKS_TRACE_ID],
+              span_id: fields[OTEL_SPAN_LINKS_SPAN_ID],
+              trace_id: fields[OTEL_SPAN_LINKS_TRACE_ID],
             });
 
       if (fields[PROCESSOR_EVENT] === ProcessorEvent.span) {

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.ts
@@ -154,7 +154,7 @@ export async function getUnifiedTraceItems({
   return {
     traceItems: unifiedTraceItems.hits.hits
       .map((hit) => {
-        const event = accessKnownApmEventFields(hit.fields, fields);
+        const event = accessKnownApmEventFields(hit.fields).requireFields(fields);
         const apmDuration = event[SPAN_DURATION] ?? event[TRANSACTION_DURATION];
         const id = event[SPAN_ID] ?? event[TRANSACTION_ID];
         const name = event[SPAN_NAME] ?? event[TRANSACTION_NAME];

--- a/x-pack/solutions/observability/plugins/apm_data_access/server/utils/access_known_fields.ts
+++ b/x-pack/solutions/observability/plugins/apm_data_access/server/utils/access_known_fields.ts
@@ -15,6 +15,19 @@ import {
   ensureRequiredApmFields,
 } from './utility_types';
 
+/**
+ * WeakMap storing all proxied methods for `ApmDocument`. As long as the proxy
+ * object lives, the methods will be available. All the methods here are lazily
+ * evaluated/initialised so the user only "pays the cost" of the methods they use.
+ */
+const PROXIED_METHODS: WeakMap<
+  Record<string, any>,
+  {
+    requireFields?: (required: string[]) => Record<string, any>;
+    unflatten?: () => Record<string, any>;
+  }
+> = new WeakMap();
+
 type RequiredApmFields<
   T extends Partial<FlattenedApmEvent>,
   R extends keyof FlattenedApmEvent = never
@@ -31,9 +44,9 @@ type ProxiedApmEvent<
 > = Readonly<MapToSingleOrMultiValue<RequiredApmFields<T, R>>>;
 
 /**
- * Interface for exposing an `unflatten()` method on proxied APM documents.
+ * Interface for exposing the `unflatten()` and `requireFields()` methods on proxied APM documents.
  */
-interface UnflattenApmDocument<
+interface ApmDocumentMethods<
   T extends Partial<FlattenedApmEvent>,
   R extends keyof FlattenedApmEvent = never
 > {
@@ -47,6 +60,12 @@ interface UnflattenApmDocument<
    * ```
    */
   unflatten(): UnflattenedKnownFields<RequiredApmFields<T, R>>;
+  /**
+   * Evaluates the APM Event with a set of required fields, throwing an error if
+   * the event is invalid, or returning the document if valid, but now type-checked to
+   * include the provided required fields.
+   */
+  requireFields<K extends keyof FlattenedApmEvent = never>(fields: K[]): ApmDocument<T, R | K>;
 }
 
 /**
@@ -57,10 +76,10 @@ interface UnflattenApmDocument<
  * An `unflatten()` method is also exposed by this document to return an unflattened
  * version of the document.
  */
-type ApmDocument<
+export type ApmDocument<
   T extends Partial<FlattenedApmEvent>,
   R extends keyof FlattenedApmEvent = never
-> = ProxiedApmEvent<T, R> & UnflattenApmDocument<T, R>;
+> = ProxiedApmEvent<T, R> & ApmDocumentMethods<T, R>;
 
 /**
  * Validates an APM Event document, checking if it has all the required fields if provided,
@@ -71,7 +90,7 @@ type ApmDocument<
  * ## Example
  *
  * ```ts
- * const event = accessKnownApmEventFields(hit, ['service.name']);
+ * const event = accessKnownApmEventFields(hit).requireFields(['service.name']);
  *
  * // The key is strongly typed to be `keyof FlattenedApmEvent`.
  * console.log(event['service.name']) // => outputs `"node-svc"`, not `["node-svc"]` as in the original doc
@@ -80,30 +99,43 @@ type ApmDocument<
  *
  * console.log(unflattened.service.name); // => outputs "node-svc" like above
  */
-export function accessKnownApmEventFields<
-  T extends Partial<FlattenedApmEvent>,
-  R extends keyof FlattenedApmEvent = never
->(fields: T, required?: R[]): ApmDocument<T, R>;
+export function accessKnownApmEventFields<T extends Partial<FlattenedApmEvent>>(
+  fields: T
+): ApmDocument<T, never>;
 
-export function accessKnownApmEventFields(fields: Record<string, any>, required?: string[]) {
-  if (required) {
-    ensureRequiredApmFields(fields, required);
-  }
+export function accessKnownApmEventFields(fields: Record<string, any>) {
+  const proxy = new Proxy(fields, accessHandler);
 
-  return new Proxy(fields, accessHandler);
+  // Methods are lazily initialised so you only pay the "cost" of what you use.
+  PROXIED_METHODS.set(proxy, {});
+
+  return proxy;
 }
 
 const accessHandler = {
-  get(fields: Record<string, any>, key: string) {
-    if (key === 'unflatten') {
-      return () => unflattenKnownApmEventFields(fields);
+  get(fields: Record<string, any>, key: string, proxy: any) {
+    switch (key) {
+      case 'unflatten':
+        // Lazily initialise method on first access
+        return (PROXIED_METHODS.get(proxy)!.unflatten ??= () =>
+          unflattenKnownApmEventFields(fields));
+
+      case 'requireFields':
+        // Lazily initialise method on first access
+        return (PROXIED_METHODS.get(proxy)!.requireFields ??= (requiredFields: string[]) => {
+          ensureRequiredApmFields(fields, requiredFields);
+
+          return proxy;
+        });
+
+      default: {
+        const value = fields[key];
+
+        return KNOWN_SINGLE_VALUED_FIELDS_SET.has(key as KnownField) && Array.isArray(value)
+          ? value[0]
+          : value;
+      }
     }
-
-    const value = fields[key];
-
-    return KNOWN_SINGLE_VALUED_FIELDS_SET.has(key as KnownField) && Array.isArray(value)
-      ? value[0]
-      : value;
   },
 
   // Trap any setters to make the proxied object immutable.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[APM] `getTraceDocsPerPage` with builder pattern validation (#243054)](https://github.com/elastic/kibana/pull/243054)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gonçalo Rica Pais da Silva","email":"goncalo.rica@elastic.co"},"sourceCommit":{"committedDate":"2025-11-17T16:07:41Z","message":"[APM] `getTraceDocsPerPage` with builder pattern validation (#243054)\n\n## Summary\n\nThis PR provides `getTraceDocsPerPage` with the new\n`accessKnownApmEventFields` method for validating and unflattening the\nresponse for the old Traces APM Waterfall API, however the method\n`accessKnownApmEventFields` has been refactored further to take on a\nmore builder pattern approach. The reasoning is that looking at\n`getTraceDocsPerPage` showed the need to validate an object multiple\ntimes, but at deferred stages, and with a builder pattern, it is easier\nto express multiple stages of validation without imposing a heavy cost\nwith multiple unflattening steps.\n\nAs such, the API of `accessKnownApmEventFields` has been changed with\nthe mind to only initialise methods that are used during a\nvalidation/response composition. This should make\n`accessKnownApmEventFields` still fairly \"light\" to initialise at first,\nwith only the cost of initialising the methods one uses directly from\nthe proxied APM document. This will allow the API surface to increase\nwithout imposing an increasing \"cost\" to the abstraction. Pay Only For\nWhat You Use.\n\n## How to Test\n\n- Go to Discover on an Observability space, select a traces index in\neither Classic or ES|QL mode\n- Open a trace document to its overview and go to the APM page via the\n`trace.id` link.\n- Look at the APM Waterfall at the bottom. The waterfall should render\ncorrectly, with no regressions to the same document but without these\nchanges.","sha":"dec44ee314186b6c1820842ba29dcac10c099b52","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.3.0","Team:obs-exploration","v8.19.8","v9.2.2","v9.1.8"],"title":"[APM] `getTraceDocsPerPage` with builder pattern validation","number":243054,"url":"https://github.com/elastic/kibana/pull/243054","mergeCommit":{"message":"[APM] `getTraceDocsPerPage` with builder pattern validation (#243054)\n\n## Summary\n\nThis PR provides `getTraceDocsPerPage` with the new\n`accessKnownApmEventFields` method for validating and unflattening the\nresponse for the old Traces APM Waterfall API, however the method\n`accessKnownApmEventFields` has been refactored further to take on a\nmore builder pattern approach. The reasoning is that looking at\n`getTraceDocsPerPage` showed the need to validate an object multiple\ntimes, but at deferred stages, and with a builder pattern, it is easier\nto express multiple stages of validation without imposing a heavy cost\nwith multiple unflattening steps.\n\nAs such, the API of `accessKnownApmEventFields` has been changed with\nthe mind to only initialise methods that are used during a\nvalidation/response composition. This should make\n`accessKnownApmEventFields` still fairly \"light\" to initialise at first,\nwith only the cost of initialising the methods one uses directly from\nthe proxied APM document. This will allow the API surface to increase\nwithout imposing an increasing \"cost\" to the abstraction. Pay Only For\nWhat You Use.\n\n## How to Test\n\n- Go to Discover on an Observability space, select a traces index in\neither Classic or ES|QL mode\n- Open a trace document to its overview and go to the APM page via the\n`trace.id` link.\n- Look at the APM Waterfall at the bottom. The waterfall should render\ncorrectly, with no regressions to the same document but without these\nchanges.","sha":"dec44ee314186b6c1820842ba29dcac10c099b52"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243054","number":243054,"mergeCommit":{"message":"[APM] `getTraceDocsPerPage` with builder pattern validation (#243054)\n\n## Summary\n\nThis PR provides `getTraceDocsPerPage` with the new\n`accessKnownApmEventFields` method for validating and unflattening the\nresponse for the old Traces APM Waterfall API, however the method\n`accessKnownApmEventFields` has been refactored further to take on a\nmore builder pattern approach. The reasoning is that looking at\n`getTraceDocsPerPage` showed the need to validate an object multiple\ntimes, but at deferred stages, and with a builder pattern, it is easier\nto express multiple stages of validation without imposing a heavy cost\nwith multiple unflattening steps.\n\nAs such, the API of `accessKnownApmEventFields` has been changed with\nthe mind to only initialise methods that are used during a\nvalidation/response composition. This should make\n`accessKnownApmEventFields` still fairly \"light\" to initialise at first,\nwith only the cost of initialising the methods one uses directly from\nthe proxied APM document. This will allow the API surface to increase\nwithout imposing an increasing \"cost\" to the abstraction. Pay Only For\nWhat You Use.\n\n## How to Test\n\n- Go to Discover on an Observability space, select a traces index in\neither Classic or ES|QL mode\n- Open a trace document to its overview and go to the APM page via the\n`trace.id` link.\n- Look at the APM Waterfall at the bottom. The waterfall should render\ncorrectly, with no regressions to the same document but without these\nchanges.","sha":"dec44ee314186b6c1820842ba29dcac10c099b52"}},{"branch":"8.19","label":"v8.19.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/243239","number":243239,"state":"MERGED","mergeCommit":{"sha":"ece7b27778554d42f0dc9a87ade739af8041514e","message":"[9.2] [APM] `getTraceDocsPerPage` with builder pattern validation (#243054) (#243239)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[APM] `getTraceDocsPerPage` with builder pattern validation\n(#243054)](https://github.com/elastic/kibana/pull/243054)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Gonçalo Rica Pais da Silva <goncalo.rica@elastic.co>"}},{"branch":"9.1","label":"v9.1.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->