### PR TITLE
[Agent Builder] Create Agent errors are not surfaced on the 'tools' tab

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/agent_form.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/edit/agent_form.tsx
@@ -271,6 +271,12 @@ export const AgentForm: React.FC<AgentFormProps> = ({ editingAgentId, onDelete }
     ]
   );
 
+  const [selectedTabId, setSelectedTabId] = useState(tabs[0].id);
+
+  const onTabClick = (tab: EuiTabbedContentTab) => {
+    setSelectedTabId(tab.id);
+  };
+
   const renderSaveButton = useCallback(
     ({ size = 's' }: Pick<EuiButtonProps, 'size'> = {}) => {
       const saveButton = (
@@ -560,10 +566,20 @@ export const AgentForm: React.FC<AgentFormProps> = ({ editingAgentId, onDelete }
           <EuiForm
             id={agentFormId}
             component="form"
-            onSubmit={handleSubmit((data) => handleSave(data))}
+            onSubmit={handleSubmit(
+              (data) => handleSave(data),
+              () => {
+                // Switch to first tab (settings) when validation fails
+                setSelectedTabId('settings');
+              }
+            )}
             fullWidth
           >
-            <EuiTabbedContent tabs={tabs} initialSelectedTab={tabs[0]} />
+            <EuiTabbedContent
+              tabs={tabs}
+              selectedTab={tabs.find((tab) => tab.id === selectedTabId)}
+              onTabClick={onTabClick}
+            />
           </EuiForm>
         </FormProvider>
         <EuiSpacer


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/11871

- you cannot have errors on the 'tools' tab
- you can only have errors on the 'settings' tab

Band-aid fix is to make the tabs controlled, and programmatically redirect the user back to the 'settings' tab if onSave there are errors.

The reason I suggest a band aid fix is because once we ship 9.3, we will likely start work on the inline edit agent creation.

**Before**

https://github.com/user-attachments/assets/d7fcd636-a49f-4dd9-8bb8-8453aee8310b



**After**

https://github.com/user-attachments/assets/4a47f4fa-4e9d-4eba-b6f2-2e9753830551


