### PR TITLE
[triggers_actions_ui] Expose rule row non-editable state in data-test-subj

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.test.tsx
@@ -1323,7 +1323,7 @@ describe('rules_list with show only capability', () => {
       await waitForElementToBeRemoved(() => screen.queryByTestId('centerJustifiedSpinner'));
 
       expect(await screen.findAllByTestId('rulesList')).toHaveLength(1);
-      expect(await screen.findAllByTestId('rule-row')).toHaveLength(2);
+      expect(await screen.findAllByTestId('rule-row-isNotEditable')).toHaveLength(2);
       expect(screen.queryByTestId('deleteActionHoverButton')).not.toBeInTheDocument();
 
       hasAllPrivilege.mockReturnValue(true);

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_table.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_table.tsx
@@ -907,7 +907,7 @@ export const RulesListTable = (props: RulesListTableProps) => {
     (rule: RuleTableItem) => {
       const selectedClass = isRowSelected(rule) ? 'euiTableRow-isSelected' : '';
       return {
-        'data-test-subj': 'rule-row',
+        'data-test-subj': `rule-row${rule.isEditable ? '' : '-isNotEditable'}`,
         className: !ruleTypesState.data.get(rule.ruleTypeId)?.enabledInLicense
           ? `actRulesList__tableRowDisabled ${selectedClass}`
           : selectedClass,


### PR DESCRIPTION
## Summary

closes #241640 

1. Expose the "non editable" nature of each rule row in the `RulesTable`, following the guidelines suggested in [Repeated EAH25 Talk Break the Flake.mp4](https://drive.google.com/file/d/1s7lj2uYnl5BTOVo14vWYnVklU2cwwuwO/view?usp=sharing). If the rule is **not** editable, the `-isNotEditable` string is appended to the `data-test-subj`, this is done this way so we can keep backward compatibility with the existing tests as much as possible. This is part of a bigger effort to start migrating some of the observability FTR tests to scout.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



