### PR TITLE
[FTR] re-enable `accessibility/apps/group3/upgrade_assistant.ts` tests

### DIFF
--- a/x-pack/platform/test/accessibility/apps/group3/config.ts
+++ b/x-pack/platform/test/accessibility/apps/group3/config.ts
@@ -22,6 +22,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       serverArgs: [
         ...functionalConfig.get('kbnTestServer.serverArgs'),
         '--data.search.sessions.enabled=true',
+        '--xpack.upgrade_assistant.ui.enabled=true',
       ],
     },
 


### PR DESCRIPTION
**Summary:** 
Re-enable the accessibility tests for `accessibility/apps/group3/upgrade_assistant.ts` which were previously skipped. 

**Important node:**
Since we can’t guarantee the stability of the mock that triggers the `ES deprecation`, and I wasn’t able to find anything for version `9.0+ `that triggers the ES deprecation, I think it makes sense to keep the check only for the initial load.  
That will make tests stable between versions. 

In that PR I've removed `translogSettingsIndexDeprecation` and `multiFieldsIndexDeprecation`. It's not a valid syntax now.

Flaky tests have passed ✅



