### PR TITLE
[OTel] Fixed metric name for login duration

### DIFF
--- a/x-pack/platform/plugins/shared/security/server/otel/instrumentation.ts
+++ b/x-pack/platform/plugins/shared/security/server/otel/instrumentation.ts
@@ -40,7 +40,7 @@ class SecurityTelemetry {
   private readonly privilegeRegistrationDuration: Histogram<Attributes>;
 
   constructor() {
-    this.loginDuration = this.meter.createHistogram('auth.saml.login.duration', {
+    this.loginDuration = this.meter.createHistogram('auth.login.duration', {
       description: 'Duration of login attempts',
       unit: 'ms',
       valueType: ValueType.DOUBLE,


### PR DESCRIPTION
## Summary

Fixed metric name for login duration.


### Checklist
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

__Fixes: https://github.com/elastic/kibana/issues/243273__


