### PR TITLE
[9.2] [Search] Disable custom suggestion on embedded console (#241516)

### DIFF
--- a/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
@@ -202,6 +202,12 @@ export interface CodeEditorProps {
    */
   onFocus?: () => void;
   onBlur?: () => void;
+
+  /**
+   * Enables the suggestion widget repositioning. Enabled by default.
+   * Disabled for cases like embedded console.
+   */
+  enableSuggestWidgetRepositioning?: boolean;
 }
 
 export const CodeEditor: React.FC<CodeEditorProps> = ({
@@ -241,6 +247,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   htmlId,
   onFocus,
   onBlur,
+  enableSuggestWidgetRepositioning = true,
 }) => {
   const { euiTheme } = useEuiTheme();
   const { registerContextMenuActions, unregisterContextMenuActions } = useContextMenuUtils();
@@ -611,7 +618,10 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
           </div>
         ) : null}
         <UseBug177756ReBroadcastMouseDown>
-          <UseBug223981FixRepositionSuggestWidget editor={_editor}>
+          <UseBug223981FixRepositionSuggestWidget
+            editor={_editor}
+            enableSuggestWidgetRepositioning={enableSuggestWidgetRepositioning}
+          >
             {accessibilityOverlayEnabled && isFullScreen && renderPrompt()}
             <MonacoEditor
               theme={theme}
@@ -645,7 +655,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
                 fontSize: isFullScreen ? 16 : 12,
                 lineHeight: isFullScreen ? 24 : 21,
                 contextmenu: enableCustomContextMenu,
-                fixedOverflowWidgets: true,
+                fixedOverflowWidgets: enableSuggestWidgetRepositioning,
                 // @ts-expect-error, see https://github.com/microsoft/monaco-editor/issues/3829
                 'bracketPairColorization.enabled': false,
                 ...options,
@@ -842,8 +852,11 @@ const useFitToContent = ({
  * @description See {@link https://github.com/elastic/kibana/issues/223981} for the rationale behind this bug fix implementation
  */
 const UseBug223981FixRepositionSuggestWidget: FC<
-  PropsWithChildren<{ editor: monaco.editor.IStandaloneCodeEditor | null }>
-> = ({ children, editor }) => {
+  PropsWithChildren<{
+    editor: monaco.editor.IStandaloneCodeEditor | null;
+    enableSuggestWidgetRepositioning: boolean;
+  }>
+> = ({ children, editor, enableSuggestWidgetRepositioning }) => {
   const { euiTheme } = useEuiTheme();
   const suggestWidgetModifierClassName = 'kibanaCodeEditor__suggestWidgetModifier';
 
@@ -851,9 +864,13 @@ const UseBug223981FixRepositionSuggestWidget: FC<
     // @ts-expect-errors -- "widget" is not part of the TS interface but does exist
     const suggestionWidget = editor?.getContribution('editor.contrib.suggestController')?.widget
       ?.value;
-
     // The "onDidShow" and "onDidHide" is not documented so we guard from possible changes in the underlying lib
-    if (suggestionWidget && suggestionWidget.onDidShow && suggestionWidget.onDidHide) {
+    if (
+      suggestionWidget &&
+      suggestionWidget.onDidShow &&
+      suggestionWidget.onDidHide &&
+      enableSuggestWidgetRepositioning
+    ) {
       let $suggestWidgetNode: HTMLElement | null = null;
 
       // add a className that hides the suggestion widget by default so we might be to correctly position the suggestion widget,
@@ -879,18 +896,20 @@ const UseBug223981FixRepositionSuggestWidget: FC<
         }
       });
     }
-  }, [editor, euiTheme.size.m]);
+  }, [editor, euiTheme.size.m, enableSuggestWidgetRepositioning]);
 
   return (
     <React.Fragment>
-      <Global
-        // @ts-expect-error -- it's necessary that we apply the important modifier
-        styles={{
-          [`.${suggestWidgetModifierClassName}`]: {
-            visibility: 'hidden !important',
-          },
-        }}
-      />
+      {enableSuggestWidgetRepositioning && (
+        <Global
+          // @ts-expect-error -- it's necessary that we apply the important modifier
+          styles={{
+            [`.${suggestWidgetModifierClassName}`]: {
+              visibility: 'hidden !important',
+            },
+          }}
+        />
+      )}
       <React.Fragment>{children}</React.Fragment>
     </React.Fragment>
   );

--- a/src/platform/plugins/shared/console/public/application/containers/editor/editor.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/editor.tsx
@@ -85,228 +85,232 @@ interface Props {
   loading: boolean;
   inputEditorValue: string;
   setInputEditorValue: (value: string) => void;
+  enableSuggestWidgetRepositioning: boolean;
 }
 
-export const Editor = memo(({ loading, inputEditorValue, setInputEditorValue }: Props) => {
-  const {
-    services: { storage, objectStorageClient },
-  } = useServicesContext();
-  const styles = useStyles();
+export const Editor = memo(
+  ({ loading, inputEditorValue, setInputEditorValue, enableSuggestWidgetRepositioning }: Props) => {
+    const {
+      services: { storage, objectStorageClient },
+    } = useServicesContext();
+    const styles = useStyles();
 
-  const { currentTextObject } = useEditorReadContext();
+    const { currentTextObject } = useEditorReadContext();
 
-  const {
-    requestInFlight,
-    lastResult: { data: requestData, error: requestError },
-  } = useRequestReadContext();
+    const {
+      requestInFlight,
+      lastResult: { data: requestData, error: requestError },
+    } = useRequestReadContext();
 
-  const dispatch = useRequestActionContext();
-  const editorDispatch = useEditorActionContext();
+    const dispatch = useRequestActionContext();
+    const editorDispatch = useEditorActionContext();
 
-  const [fetchingAutocompleteEntities, setFetchingAutocompleteEntities] = useState(false);
+    const [fetchingAutocompleteEntities, setFetchingAutocompleteEntities] = useState(false);
 
-  useEffect(() => {
-    const debouncedSetFechingAutocompleteEntities = debounce(
-      setFetchingAutocompleteEntities,
-      DEBOUNCE_DELAY
+    useEffect(() => {
+      const debouncedSetFechingAutocompleteEntities = debounce(
+        setFetchingAutocompleteEntities,
+        DEBOUNCE_DELAY
+      );
+      const subscription = getAutocompleteInfo().isLoading$.subscribe(
+        debouncedSetFechingAutocompleteEntities
+      );
+
+      return () => {
+        subscription.unsubscribe();
+        debouncedSetFechingAutocompleteEntities.cancel();
+      };
+    }, []);
+
+    const [firstPanelSize, secondPanelSize] = storage.get(StorageKeys.SIZE, [
+      INITIAL_PANEL_SIZE,
+      INITIAL_PANEL_SIZE,
+    ]);
+
+    const isVerticalLayout = useIsWithinBreakpoints(['xs', 's', 'm']);
+
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+    const onPanelSizeChange = useCallback(
+      debounce((sizes) => {
+        storage.set(StorageKeys.SIZE, Object.values(sizes));
+      }, 300),
+      []
     );
-    const subscription = getAutocompleteInfo().isLoading$.subscribe(
-      debouncedSetFechingAutocompleteEntities
+
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+    const debouncedUpdateLocalStorageValue = useCallback(
+      debounce((newValue: string | undefined) => {
+        const textObject = {
+          ...currentTextObject,
+          text: newValue,
+          updatedAt: Date.now(),
+        } as TextObject;
+
+        objectStorageClient.text.update(textObject);
+
+        editorDispatch({
+          type: 'setCurrentTextObject',
+          payload: textObject,
+        });
+      }, DEBOUNCE_DELAY),
+      []
     );
 
-    return () => {
-      subscription.unsubscribe();
-      debouncedSetFechingAutocompleteEntities.cancel();
-    };
-  }, []);
+    // Always keep the localstorage value in sync with the value in the editor
+    // to avoid losing the text object when the user navigates away from the shell
+    useEffect(() => {
+      debouncedUpdateLocalStorageValue(inputEditorValue);
+    }, [debouncedUpdateLocalStorageValue, inputEditorValue]);
 
-  const [firstPanelSize, secondPanelSize] = storage.get(StorageKeys.SIZE, [
-    INITIAL_PANEL_SIZE,
-    INITIAL_PANEL_SIZE,
-  ]);
+    if (!currentTextObject) return null;
 
-  const isVerticalLayout = useIsWithinBreakpoints(['xs', 's', 'm']);
+    const data = getResponseWithMostSevereStatusCode(requestData) ?? requestError;
+    const isLoading = loading || requestInFlight;
 
-  /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  const onPanelSizeChange = useCallback(
-    debounce((sizes) => {
-      storage.set(StorageKeys.SIZE, Object.values(sizes));
-    }, 300),
-    []
-  );
-
-  /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  const debouncedUpdateLocalStorageValue = useCallback(
-    debounce((newValue: string | undefined) => {
-      const textObject = {
-        ...currentTextObject,
-        text: newValue,
-        updatedAt: Date.now(),
-      } as TextObject;
-
-      objectStorageClient.text.update(textObject);
-
-      editorDispatch({
-        type: 'setCurrentTextObject',
-        payload: textObject,
-      });
-    }, DEBOUNCE_DELAY),
-    []
-  );
-
-  // Always keep the localstorage value in sync with the value in the editor
-  // to avoid losing the text object when the user navigates away from the shell
-  useEffect(() => {
-    debouncedUpdateLocalStorageValue(inputEditorValue);
-  }, [debouncedUpdateLocalStorageValue, inputEditorValue]);
-
-  if (!currentTextObject) return null;
-
-  const data = getResponseWithMostSevereStatusCode(requestData) ?? requestError;
-  const isLoading = loading || requestInFlight;
-
-  return (
-    <>
-      {fetchingAutocompleteEntities ? (
-        <div css={styles.requestProgressBarContainer}>
-          <EuiProgress size="xs" color="accent" position="absolute" />
-        </div>
-      ) : null}
-      <EuiResizableContainer
-        css={styles.fullHeightPanel}
-        direction={isVerticalLayout ? 'vertical' : 'horizontal'}
-        onPanelWidthChange={(sizes) => onPanelSizeChange(sizes)}
-        data-test-subj="consoleEditorContainer"
-      >
-        {(EuiResizablePanel, EuiResizableButton) => (
-          <>
-            <EuiResizablePanel
-              initialSize={firstPanelSize}
-              minSize={PANEL_MIN_SIZE}
-              tabIndex={0}
-              paddingSize="none"
-            >
-              <EuiSplitPanel.Outer
-                grow={true}
-                borderRadius="none"
-                hasShadow={false}
-                css={styles.fullHeightPanel}
+    return (
+      <>
+        {fetchingAutocompleteEntities ? (
+          <div css={styles.requestProgressBarContainer}>
+            <EuiProgress size="xs" color="accent" position="absolute" />
+          </div>
+        ) : null}
+        <EuiResizableContainer
+          css={styles.fullHeightPanel}
+          direction={isVerticalLayout ? 'vertical' : 'horizontal'}
+          onPanelWidthChange={(sizes) => onPanelSizeChange(sizes)}
+          data-test-subj="consoleEditorContainer"
+        >
+          {(EuiResizablePanel, EuiResizableButton) => (
+            <>
+              <EuiResizablePanel
+                initialSize={firstPanelSize}
+                minSize={PANEL_MIN_SIZE}
+                tabIndex={0}
+                paddingSize="none"
               >
-                <EuiSplitPanel.Inner
-                  paddingSize="none"
+                <EuiSplitPanel.Outer
                   grow={true}
-                  css={[styles.consoleEditorPanel, styles.editorPanelPositioned]}
+                  borderRadius="none"
+                  hasShadow={false}
+                  css={styles.fullHeightPanel}
                 >
-                  {loading ? (
-                    <EditorContentSpinner />
-                  ) : (
-                    <MonacoEditor
-                      localStorageValue={currentTextObject.text}
-                      value={inputEditorValue}
-                      setValue={setInputEditorValue}
-                    />
-                  )}
-                </EuiSplitPanel.Inner>
-
-                {!loading && (
                   <EuiSplitPanel.Inner
-                    grow={false}
-                    paddingSize="s"
-                    color="subdued"
-                    css={styles.consoleEditorPanel}
+                    paddingSize="none"
+                    grow={true}
+                    css={[styles.consoleEditorPanel, styles.editorPanelPositioned]}
                   >
-                    <EuiButtonEmpty
-                      size="xs"
-                      color="primary"
-                      data-test-subj="clearConsoleInput"
-                      onClick={() => {
-                        setInputEditorValue('');
-                      }}
+                    {loading ? (
+                      <EditorContentSpinner />
+                    ) : (
+                      <MonacoEditor
+                        localStorageValue={currentTextObject.text}
+                        value={inputEditorValue}
+                        setValue={setInputEditorValue}
+                        enableSuggestWidgetRepositioning={enableSuggestWidgetRepositioning}
+                      />
+                    )}
+                  </EuiSplitPanel.Inner>
+
+                  {!loading && (
+                    <EuiSplitPanel.Inner
+                      grow={false}
+                      paddingSize="s"
+                      color="subdued"
+                      css={styles.consoleEditorPanel}
                     >
-                      {i18n.translate('console.editor.clearConsoleInputButton', {
-                        defaultMessage: 'Clear this input',
-                      })}
-                    </EuiButtonEmpty>
-                  </EuiSplitPanel.Inner>
-                )}
-              </EuiSplitPanel.Outer>
-            </EuiResizablePanel>
-
-            <EuiResizableButton
-              css={styles.resizerButton}
-              aria-label={i18n.translate('console.editor.adjustPanelSizeAriaLabel', {
-                defaultMessage: "Press left/right to adjust panels' sizes",
-              })}
-            />
-
-            <EuiResizablePanel
-              initialSize={secondPanelSize}
-              minSize={PANEL_MIN_SIZE}
-              tabIndex={0}
-              paddingSize="none"
-            >
-              <EuiSplitPanel.Outer
-                borderRadius="none"
-                hasShadow={false}
-                css={styles.fullHeightPanel}
-              >
-                <EuiSplitPanel.Inner
-                  paddingSize="none"
-                  css={[styles.consoleEditorPanel, styles.outputPanelCentered]}
-                >
-                  {data ? (
-                    <MonacoEditorOutput />
-                  ) : isLoading ? (
-                    <EditorContentSpinner />
-                  ) : (
-                    <OutputPanelEmptyState />
+                      <EuiButtonEmpty
+                        size="xs"
+                        color="primary"
+                        data-test-subj="clearConsoleInput"
+                        onClick={() => {
+                          setInputEditorValue('');
+                        }}
+                      >
+                        {i18n.translate('console.editor.clearConsoleInputButton', {
+                          defaultMessage: 'Clear this input',
+                        })}
+                      </EuiButtonEmpty>
+                    </EuiSplitPanel.Inner>
                   )}
-                </EuiSplitPanel.Inner>
+                </EuiSplitPanel.Outer>
+              </EuiResizablePanel>
 
-                {(data || isLoading) && (
+              <EuiResizableButton
+                css={styles.resizerButton}
+                aria-label={i18n.translate('console.editor.adjustPanelSizeAriaLabel', {
+                  defaultMessage: "Press left/right to adjust panels' sizes",
+                })}
+              />
+
+              <EuiResizablePanel
+                initialSize={secondPanelSize}
+                minSize={PANEL_MIN_SIZE}
+                tabIndex={0}
+                paddingSize="none"
+              >
+                <EuiSplitPanel.Outer
+                  borderRadius="none"
+                  hasShadow={false}
+                  css={styles.fullHeightPanel}
+                >
                   <EuiSplitPanel.Inner
-                    grow={false}
-                    paddingSize="s"
-                    css={[styles.consoleEditorPanel, styles.actionsPanelWithBackground]}
+                    paddingSize="none"
+                    css={[styles.consoleEditorPanel, styles.outputPanelCentered]}
                   >
-                    <EuiFlexGroup gutterSize="none" responsive={false}>
-                      <EuiFlexItem grow={false}>
-                        <EuiButtonEmpty
-                          size="xs"
-                          color="primary"
-                          data-test-subj="clearConsoleOutput"
-                          onClick={() => dispatch({ type: 'cleanRequest', payload: undefined })}
-                        >
-                          {i18n.translate('console.editor.clearConsoleOutputButton', {
-                            defaultMessage: 'Clear this output',
-                          })}
-                        </EuiButtonEmpty>
-                      </EuiFlexItem>
-
-                      <EuiFlexItem>
-                        <NetworkRequestStatusBar
-                          requestInProgress={requestInFlight}
-                          requestResult={
-                            data
-                              ? {
-                                  method: data.request.method.toUpperCase(),
-                                  endpoint: data.request.path,
-                                  statusCode: data.response.statusCode,
-                                  statusText: data.response.statusText,
-                                  timeElapsedMs: data.response.timeMs,
-                                }
-                              : undefined
-                          }
-                        />
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
+                    {data ? (
+                      <MonacoEditorOutput />
+                    ) : isLoading ? (
+                      <EditorContentSpinner />
+                    ) : (
+                      <OutputPanelEmptyState />
+                    )}
                   </EuiSplitPanel.Inner>
-                )}
-              </EuiSplitPanel.Outer>
-            </EuiResizablePanel>
-          </>
-        )}
-      </EuiResizableContainer>
-    </>
-  );
-});
+
+                  {(data || isLoading) && (
+                    <EuiSplitPanel.Inner
+                      grow={false}
+                      paddingSize="s"
+                      css={[styles.consoleEditorPanel, styles.actionsPanelWithBackground]}
+                    >
+                      <EuiFlexGroup gutterSize="none" responsive={false}>
+                        <EuiFlexItem grow={false}>
+                          <EuiButtonEmpty
+                            size="xs"
+                            color="primary"
+                            data-test-subj="clearConsoleOutput"
+                            onClick={() => dispatch({ type: 'cleanRequest', payload: undefined })}
+                          >
+                            {i18n.translate('console.editor.clearConsoleOutputButton', {
+                              defaultMessage: 'Clear this output',
+                            })}
+                          </EuiButtonEmpty>
+                        </EuiFlexItem>
+
+                        <EuiFlexItem>
+                          <NetworkRequestStatusBar
+                            requestInProgress={requestInFlight}
+                            requestResult={
+                              data
+                                ? {
+                                    method: data.request.method.toUpperCase(),
+                                    endpoint: data.request.path,
+                                    statusCode: data.response.statusCode,
+                                    statusText: data.response.statusText,
+                                    timeElapsedMs: data.response.timeMs,
+                                  }
+                                : undefined
+                            }
+                          />
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiSplitPanel.Inner>
+                  )}
+                </EuiSplitPanel.Outer>
+              </EuiResizablePanel>
+            </>
+          )}
+        </EuiResizableContainer>
+      </>
+    );
+  }
+);

--- a/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor.tsx
@@ -56,9 +56,15 @@ export interface EditorProps {
   localStorageValue: string | undefined;
   value: string;
   setValue: (value: string) => void;
+  enableSuggestWidgetRepositioning: boolean;
 }
 
-export const MonacoEditor = ({ localStorageValue, value, setValue }: EditorProps) => {
+export const MonacoEditor = ({
+  localStorageValue,
+  value,
+  setValue,
+  enableSuggestWidgetRepositioning,
+}: EditorProps) => {
   const context = useServicesContext();
   const {
     services: {
@@ -294,6 +300,7 @@ export const MonacoEditor = ({ localStorageValue, value, setValue }: EditorProps
         suggestionProvider={suggestionProvider}
         enableFindAction={true}
         enableCustomContextMenu={true}
+        enableSuggestWidgetRepositioning={enableSuggestWidgetRepositioning}
       />
     </div>
   );

--- a/src/platform/plugins/shared/console/public/application/containers/main/main.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/main/main.tsx
@@ -361,6 +361,7 @@ export function Main({ currentTabProp, isEmbeddable = false }: MainProps) {
               loading={!done}
               inputEditorValue={inputEditorValue}
               setInputEditorValue={setInputEditorValue}
+              enableSuggestWidgetRepositioning={!isEmbeddable}
             />
           )}
           {currentTab === HISTORY_TAB_ID && <History />}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Search] Disable custom suggestion on embedded console (#241516)](https://github.com/elastic/kibana/pull/241516)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Saarika Bhasi","email":"55930906+saarikabhasi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-11-17T15:53:06Z","message":"[Search] Disable custom suggestion on embedded console (#241516)\n\n### Summary\n**Problem**: In the embedded console, the error & suggestion widget is\nmisplaced. Currently `fixedOverflowWidgets` prop of monaco editor is set\nto `true` and the suggestion widget css is calculated to prevent widget\nbeing placed under header in Dashboard, ES|QL. In this PR, the\ncustomized css would be applied only if it's not a embeddable console.\n\n### Changes\n- create new prop within the `UseBug223981FixRepositionSuggestWidget`\ncalled `enableSuggestWidgetRepositioning`\n- default this prop to `true` except for within the embedded console\n\n### Screen recording\n**recording of error in embedded console vs standalone dev  console**\n\n\nhttps://github.com/user-attachments/assets/f88f0124-bdb2-4aaf-b66a-0c91ec1587dc\n\n**fix in embedded console vs standalone dev  console**\n\n\nhttps://github.com/user-attachments/assets/827a8ded-50cf-4f0b-b07a-3c2c2dd1741c\n\n\n\n### Testing\nopen dev console and create a empty query to generate suggestion widget\n& error message.\n\n---------\n\nCo-authored-by: Matt Wilde <matt.wilde@elastic.co>","sha":"9cd32222f7a234704f229a039c33417d10281d79","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.2.0","v9.3.0"],"title":"[Search] Disable custom suggestion on embedded console","number":241516,"url":"https://github.com/elastic/kibana/pull/241516","mergeCommit":{"message":"[Search] Disable custom suggestion on embedded console (#241516)\n\n### Summary\n**Problem**: In the embedded console, the error & suggestion widget is\nmisplaced. Currently `fixedOverflowWidgets` prop of monaco editor is set\nto `true` and the suggestion widget css is calculated to prevent widget\nbeing placed under header in Dashboard, ES|QL. In this PR, the\ncustomized css would be applied only if it's not a embeddable console.\n\n### Changes\n- create new prop within the `UseBug223981FixRepositionSuggestWidget`\ncalled `enableSuggestWidgetRepositioning`\n- default this prop to `true` except for within the embedded console\n\n### Screen recording\n**recording of error in embedded console vs standalone dev  console**\n\n\nhttps://github.com/user-attachments/assets/f88f0124-bdb2-4aaf-b66a-0c91ec1587dc\n\n**fix in embedded console vs standalone dev  console**\n\n\nhttps://github.com/user-attachments/assets/827a8ded-50cf-4f0b-b07a-3c2c2dd1741c\n\n\n\n### Testing\nopen dev console and create a empty query to generate suggestion widget\n& error message.\n\n---------\n\nCo-authored-by: Matt Wilde <matt.wilde@elastic.co>","sha":"9cd32222f7a234704f229a039c33417d10281d79"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241516","number":241516,"mergeCommit":{"message":"[Search] Disable custom suggestion on embedded console (#241516)\n\n### Summary\n**Problem**: In the embedded console, the error & suggestion widget is\nmisplaced. Currently `fixedOverflowWidgets` prop of monaco editor is set\nto `true` and the suggestion widget css is calculated to prevent widget\nbeing placed under header in Dashboard, ES|QL. In this PR, the\ncustomized css would be applied only if it's not a embeddable console.\n\n### Changes\n- create new prop within the `UseBug223981FixRepositionSuggestWidget`\ncalled `enableSuggestWidgetRepositioning`\n- default this prop to `true` except for within the embedded console\n\n### Screen recording\n**recording of error in embedded console vs standalone dev  console**\n\n\nhttps://github.com/user-attachments/assets/f88f0124-bdb2-4aaf-b66a-0c91ec1587dc\n\n**fix in embedded console vs standalone dev  console**\n\n\nhttps://github.com/user-attachments/assets/827a8ded-50cf-4f0b-b07a-3c2c2dd1741c\n\n\n\n### Testing\nopen dev console and create a empty query to generate suggestion widget\n& error message.\n\n---------\n\nCo-authored-by: Matt Wilde <matt.wilde@elastic.co>","sha":"9cd32222f7a234704f229a039c33417d10281d79"}}]}] BACKPORT-->