### PR TITLE
[Entity Analytics][Risk Score] UI for displaying privileged user contributions in Risk Summary and Inputs 

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
@@ -286,10 +286,16 @@ const ContextsSection = <T extends EntityType>({
       field: (
         <FormattedMessage
           id="xpack.securitySolution.flyout.entityDetails.riskInputs.privmonField"
-          defaultMessage="Privileged user status"
+          defaultMessage="Privileged user"
         />
       ),
-      value: <span>{String(privmon.isPrivileged ?? false)}</span>,
+      value: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.entityDetails.riskInputs.privmonValue"
+          defaultMessage="{value}"
+          values={{ value: privmon.isPrivileged ? 'Yes' : 'No' }}
+        />
+      ),
       contribution: formatContribution(privmon.contribution || 0),
     });
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
@@ -12,6 +12,7 @@ import React, { useMemo, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 import { get } from 'lodash/fp';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { AlertPreviewButton } from '../../../../../flyout/shared/components/alert_preview_button';
 import { useGlobalTime } from '../../../../../common/containers/use_global_time';
 import { useQueryInspector } from '../../../../../common/components/page/manage_query';
@@ -239,19 +240,58 @@ const ContextsSection = <T extends EntityType>({
   loading,
   entityType,
 }: ContextsSectionProps<T>) => {
-  const criticality = useMemo(() => {
+  const isPrivmonEnabled = useIsExperimentalFeatureEnabled('enableRiskScorePrivmonModifier');
+  const contributions = useMemo(() => {
     if (!riskScore) {
       return undefined;
     }
 
     return {
-      level: riskScore[entityType].risk.criticality_level,
-      contribution: riskScore[entityType].risk.category_2_score,
+      criticality: {
+        level: riskScore[entityType].risk.criticality_level,
+        contribution: riskScore[entityType].risk.category_2_score,
+      },
+      privmon: {
+        isPrivileged: riskScore[entityType].risk.is_privileged_user,
+        contribution: riskScore[entityType].risk.category_3_score,
+      },
     };
   }, [entityType, riskScore]);
 
-  if (loading || criticality === undefined) {
+  if (loading || contributions === undefined) {
     return null;
+  }
+  const { criticality, privmon } = contributions;
+
+  const items = [
+    {
+      field: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.entityDetails.riskInputs.assetCriticalityField"
+          defaultMessage="Asset Criticality Level"
+        />
+      ),
+      value: (
+        <AssetCriticalityBadge
+          criticalityLevel={criticality.level}
+          dataTestSubj="risk-inputs-asset-criticality-badge"
+        />
+      ),
+      contribution: formatContribution(criticality.contribution || 0),
+    },
+  ];
+
+  if (isPrivmonEnabled) {
+    items.push({
+      field: (
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.entityDetails.riskInputs.privmonField"
+          defaultMessage="Privileged user status"
+        />
+      ),
+      value: <span>{String(privmon.isPrivileged ?? false)}</span>,
+      contribution: formatContribution(privmon.contribution || 0),
+    });
   }
 
   return (
@@ -270,23 +310,7 @@ const ContextsSection = <T extends EntityType>({
         loading={loading}
         data-test-subj="risk-input-contexts-table"
         columns={contextColumns}
-        items={[
-          {
-            field: (
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.entityDetails.riskInputs.assetCriticalityField"
-                defaultMessage="Asset Criticality Level"
-              />
-            ),
-            value: (
-              <AssetCriticalityBadge
-                criticalityLevel={criticality.level}
-                dataTestSubj="risk-inputs-asset-criticality-badge"
-              />
-            ),
-            contribution: formatContribution(criticality.contribution || 0),
-          },
-        ]}
+        items={items}
       />
     </>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/common.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/common.tsx
@@ -84,8 +84,11 @@ export const columnsArray: Array<EuiBasicTableColumn<TableItem>> = [
   },
 ];
 
-export const getItems: (entityData: EntityData | undefined) => TableItem[] = (entityData) => {
-  return [
+export const getItems: (
+  entityData: EntityData | undefined,
+  isPrivmonEnabled: boolean
+) => TableItem[] = (entityData, isPrivmonEnabled) => {
+  const items = [
     {
       category: i18n.translate('xpack.securitySolution.flyout.entityDetails.alertsGroupLabel', {
         defaultMessage: 'Alerts',
@@ -105,6 +108,21 @@ export const getItems: (entityData: EntityData | undefined) => TableItem[] = (en
       count: undefined,
     },
   ];
+
+  if (isPrivmonEnabled) {
+    items.push({
+      category: i18n.translate(
+        'xpack.securitySolution.flyout.entityDetails.privilegedUserGroupLabel',
+        {
+          defaultMessage: 'Privileged User',
+        }
+      ),
+      score: entityData?.risk.category_3_score ?? 0,
+      count: undefined,
+    });
+  }
+
+  return items;
 };
 
 export const getEntityData = <T extends EntityType>(

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/risk_summary.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/risk_summary.tsx
@@ -21,6 +21,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import dateMath from '@kbn/datemath';
 import { i18n } from '@kbn/i18n';
 import { capitalize } from 'lodash/fp';
+import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import type { EntityType } from '../../../../common/entity_analytics/types';
 import { EntityTypeToIdentifierField } from '../../../../common/entity_analytics/types';
 import { useKibana } from '../../../common/lib/kibana/kibana_react';
@@ -80,8 +81,15 @@ const FlyoutRiskSummaryComponent = <T extends EntityType>({
       riskEntity: entityType,
     });
   }, [entityData?.name, entityData?.risk?.calculated_level, entityType, spaceId]);
+
   const xsFontSize = useEuiFontSize('xxs').fontSize;
-  const rows = useMemo(() => getItems(entityData), [entityData]);
+  const isPrivmonModifierEnabled = useIsExperimentalFeatureEnabled(
+    'enableRiskScorePrivmonModifier'
+  );
+  const rows = useMemo(
+    () => getItems(entityData, isPrivmonModifierEnabled),
+    [entityData, isPrivmonModifierEnabled]
+  );
 
   const onToggle = useCallback(
     (isOpen: boolean) => {


### PR DESCRIPTION
## Summary

This PR adds the UI for explaining the privmon contribution to risk scores.

<img width="1834" height="958" alt="Screenshot 2025-11-26 at 14 09 35" src="https://github.com/user-attachments/assets/7e16dd50-1e8f-4261-b7a8-868b9bfc74e0" />

### How to test

1. Make sure you enable the `enableRiskScorePrivmonModifier` Feature Flag.
2. Ingest some data via security documents generator with `yarn start quickmon`
3. Go to the privmon page and find a user with alerts open
4. Open the flyout for that user
5. Check that the privmon shows up in the risk summary and the contributions expanded tab (example screenshot above)

