### PR TITLE
[Streams] Improve error messaging when expensive queries are disabled in Streams schema editor

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/index.tsx
@@ -70,7 +70,7 @@ export const SchemaEditorFlyout = ({
   }: {
     isValid: boolean;
     isIgnored: boolean;
-    isExpensiveQueriesError: boolean;
+    isExpensiveQueries: boolean;
   }) => {
     setIsIgnoredField(isIgnored);
     setValidSimulation(isValid);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/index.tsx
@@ -49,7 +49,7 @@ export const SchemaEditorFlyout = ({
   const [isValidAdvancedFieldMappings, setValidAdvancedFieldMappings] = useState(true);
   const [isValidSimulation, setValidSimulation] = useState(true);
   const [isIgnoredField, setIsIgnoredField] = useState(false);
-
+  const [isExpensiveQueriesError, setIsExpensiveQueriesError] = useState(false);
   const flyoutId = useGeneratedHtmlId({ prefix: 'streams-edit-field' });
 
   const [nextField, setNextField] = useReducer(
@@ -63,9 +63,18 @@ export const SchemaEditorFlyout = ({
 
   const hasValidFieldType = nextField.type !== undefined;
 
-  const onValidate = ({ isValid, isIgnored }: { isValid: boolean; isIgnored: boolean }) => {
+  const onValidate = ({
+    isValid,
+    isIgnored,
+    isExpensiveQueries,
+  }: {
+    isValid: boolean;
+    isIgnored: boolean;
+    isExpensiveQueriesError: boolean;
+  }) => {
     setIsIgnoredField(isIgnored);
     setValidSimulation(isValid);
+    setIsExpensiveQueriesError(isExpensiveQueries);
   };
 
   return (
@@ -128,7 +137,11 @@ export const SchemaEditorFlyout = ({
             </EuiButtonEmpty>
             <EuiButton
               data-test-subj="streamsAppSchemaEditorFieldStageButton"
-              disabled={!hasValidFieldType || !isValidAdvancedFieldMappings || !isValidSimulation}
+              disabled={
+                !hasValidFieldType ||
+                !isValidAdvancedFieldMappings ||
+                (!isValidSimulation && !isExpensiveQueriesError)
+              }
               onClick={() => {
                 onStage({
                   ...nextField,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/sample_preview_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/sample_preview_table.tsx
@@ -23,7 +23,15 @@ import { convertToFieldDefinitionConfig } from '../utils';
 interface SamplePreviewTableProps {
   stream: Streams.ingest.all.Definition;
   nextField: SchemaField;
-  onValidate?: ({ isValid, isIgnored }: { isValid: boolean; isIgnored: boolean }) => void;
+  onValidate?: ({
+    isValid,
+    isIgnored,
+    isExpensiveQueriesError,
+  }: {
+    isValid: boolean;
+    isIgnored: boolean;
+    isExpensiveQueriesError: boolean;
+  }) => void;
 }
 
 export const SamplePreviewTable = (props: SamplePreviewTableProps) => {
@@ -69,6 +77,9 @@ const SamplePreviewTableContent = ({
 
   useEffect(() => {
     if (onValidate) {
+      const isExpensiveQueriesError =
+        error && getFormattedError(error)?.message.includes('allow_expensive_queries');
+
       onValidate({
         isValid: value?.status === 'failure' || error ? false : true,
         isIgnored:
@@ -78,6 +89,7 @@ const SamplePreviewTableContent = ({
           )
             ? true
             : false,
+        isExpensiveQueriesError: isExpensiveQueriesError ?? false,
       });
     }
   }, [value, error, onValidate]);
@@ -110,6 +122,27 @@ const SamplePreviewTableContent = ({
 
   if ((value && value.status === 'failure') || error) {
     const formattedError = error && getFormattedError(error);
+
+    const isExpensiveQueriesError = formattedError?.message.includes('allow_expensive_queries');
+
+    if (isExpensiveQueriesError) {
+      return (
+        <EuiCallOut
+          announceOnMount
+          color="warning"
+          title={i18n.translate('xpack.streams.samplePreviewTable.warningTitle', {
+            defaultMessage: 'Some fields are failing when simulating ingestion.',
+          })}
+        >
+          {i18n.translate('xpack.streams.samplePreviewTable.expensiveQueriesDisabledWarning', {
+            defaultMessage:
+              'Field simulation is unavailable because expensive queries are disabled on your cluster. ' +
+              'The schema changes can still be applied, but field compatibility cannot be verified in advance. ' +
+              'Proceed with caution - incompatible field types may cause ingestion errors.',
+          })}
+        </EuiCallOut>
+      );
+    }
     return (
       <EuiCallOut
         announceOnMount

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/sample_preview_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/sample_preview_table.tsx
@@ -26,11 +26,11 @@ interface SamplePreviewTableProps {
   onValidate?: ({
     isValid,
     isIgnored,
-    isExpensiveQueriesError,
+    isExpensiveQueries,
   }: {
     isValid: boolean;
     isIgnored: boolean;
-    isExpensiveQueriesError: boolean;
+    isExpensiveQueries: boolean;
   }) => void;
 }
 
@@ -89,7 +89,7 @@ const SamplePreviewTableContent = ({
           )
             ? true
             : false,
-        isExpensiveQueriesError: isExpensiveQueriesError ?? false,
+        isExpensiveQueries: isExpensiveQueriesError ?? false,
       });
     }
   }, [value, error, onValidate]);
@@ -123,9 +123,9 @@ const SamplePreviewTableContent = ({
   if ((value && value.status === 'failure') || error) {
     const formattedError = error && getFormattedError(error);
 
-    const isExpensiveQueriesError = formattedError?.message.includes('allow_expensive_queries');
+    const isExpensiveQueries = formattedError?.message.includes('allow_expensive_queries');
 
-    if (isExpensiveQueriesError) {
+    if (isExpensiveQueries) {
       return (
         <EuiCallOut
           announceOnMount


### PR DESCRIPTION
Closes #243161 

## Summary

This PR enhances the user experience in the Streams schema editor when the Elasticsearch cluster setting `search.allow_expensive_queries` is set to false. Instead of showing a raw, technical error message, users now see a user-friendly warning that explains the situation and allows them to proceed with caution.


## Problem

When `search.allow_expensive_queries `is disabled on an Elasticsearch cluster, the Streams schema editor's field simulation fails because it relies on runtime mappings.

## Testing

On the DevTools, set the `search.allow_expensive_queries` to false

```bash
PUT /_cluster/settings
{
  "transient": { "search.allow_expensive_queries": false }
}
```

You can make sure it is set to false by querying
`GET _cluster/settings`

Or by checking the logs of the Elasticsearch cluster running
`info [o.e.c.s.ClusterSettings] [YourMachine] updating [search.allow_expensive_queries] from [true] to [false]`

Once it is set to false:

**Schema Editor**

- Navigate to Streams and open a stream (not a wired stream)
- Make schema changes (add/modify fields)
- Add field and submit changes - should see the new user-friendly warning message
- Verify the "Confirm changes" button is enabled
- Click to proceed - changes should be applied successfully

**Processing**

- Navigate to Streams and open a stream (not a wired stream)
- Create some processor that has an expensive query
- Save changes - should see the new user-friendly warning message
- Verify the "Confirm changes" button is enabled
- Click to proceed - changes should be applied successfully


## Unhandled case

For the global search we also use expensive queries, but there is no error triggered if the `search.allow_expensive_queries` is set to false. The difference here is that the wired streams will not show up on the search results, while they do appear if the `search.allow_expensive_queries` is set to true.