### PR TITLE
[Agent Builder] Fix - Don't clear configuration when cloning tool

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
@@ -128,47 +128,6 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
   } = services;
 
   const currentToolId = watch('toolId');
-  const isSyncingSourceToolRef = useRef(false);
-  const hasSourceTool = mode === ToolFormMode.Create && Boolean(tool);
-
-  useEffect(() => {
-    if (hasSourceTool) {
-      isSyncingSourceToolRef.current = true;
-    }
-  }, [hasSourceTool]);
-
-  useEffect(() => {
-    if (tool) {
-      const toolTypeConfig = getToolTypeConfig(tool.type);
-      if (toolTypeConfig) {
-        const { toolToFormData } = toolTypeConfig;
-        reset(toolToFormData(tool));
-      }
-    }
-  }, [tool, reset]);
-
-  // Switching tool types clears tool-specific fields
-  useEffect(() => {
-    if (!urlToolType || mode !== ToolFormMode.Create) {
-      return;
-    }
-    if (isSyncingSourceToolRef.current) {
-      isSyncingSourceToolRef.current = false;
-      return;
-    }
-
-    const currentValues = getValues();
-    const newDefaultValues = getToolTypeDefaultValues(urlToolType);
-
-    const mergedValues: ToolFormData = {
-      ...newDefaultValues,
-      toolId: currentValues.toolId,
-      description: currentValues.description,
-      labels: currentValues.labels,
-    };
-
-    reset(mergedValues);
-  }, [urlToolType, initialToolType, mode, getValues, reset]);
 
   // Handle opening test tool flyout on navigation
   useEffect(() => {
@@ -222,6 +181,48 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
     },
     [handleSave, handleTestTool]
   );
+
+  useEffect(() => {
+    if (tool) {
+      const toolTypeConfig = getToolTypeConfig(tool.type);
+      if (toolTypeConfig) {
+        const { toolToFormData } = toolTypeConfig;
+        reset(toolToFormData(tool));
+      }
+    }
+  }, [tool, reset]);
+
+  const isSyncingSourceToolRef = useRef(false);
+  const hasSourceTool = mode === ToolFormMode.Create && Boolean(tool);
+
+  useEffect(() => {
+    if (hasSourceTool) {
+      isSyncingSourceToolRef.current = true;
+    }
+  }, [hasSourceTool]);
+
+  // Switching tool types clears tool-specific fields
+  useEffect(() => {
+    if (!urlToolType || mode !== ToolFormMode.Create) {
+      return;
+    }
+    if (isSyncingSourceToolRef.current) {
+      isSyncingSourceToolRef.current = false;
+      return;
+    }
+
+    const currentValues = getValues();
+    const newDefaultValues = getToolTypeDefaultValues(urlToolType);
+
+    const mergedValues: ToolFormData = {
+      ...newDefaultValues,
+      toolId: currentValues.toolId,
+      description: currentValues.description,
+      labels: currentValues.labels,
+    };
+
+    reset(mergedValues);
+  }, [urlToolType, initialToolType, mode, getValues, reset]);
 
   const toolFormId = useGeneratedHtmlId({
     prefix: 'toolForm',

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tool.tsx
@@ -25,7 +25,7 @@ import type { ToolDefinitionWithSchema, ToolType } from '@kbn/onechat-common';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { useUnsavedChangesPrompt } from '@kbn/unsaved-changes-prompt';
 import { defer } from 'lodash';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormProvider } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -128,6 +128,47 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
   } = services;
 
   const currentToolId = watch('toolId');
+  const isSyncingSourceToolRef = useRef(false);
+  const hasSourceTool = mode === ToolFormMode.Create && Boolean(tool);
+
+  useEffect(() => {
+    if (hasSourceTool) {
+      isSyncingSourceToolRef.current = true;
+    }
+  }, [hasSourceTool]);
+
+  useEffect(() => {
+    if (tool) {
+      const toolTypeConfig = getToolTypeConfig(tool.type);
+      if (toolTypeConfig) {
+        const { toolToFormData } = toolTypeConfig;
+        reset(toolToFormData(tool));
+      }
+    }
+  }, [tool, reset]);
+
+  // Switching tool types clears tool-specific fields
+  useEffect(() => {
+    if (!urlToolType || mode !== ToolFormMode.Create) {
+      return;
+    }
+    if (isSyncingSourceToolRef.current) {
+      isSyncingSourceToolRef.current = false;
+      return;
+    }
+
+    const currentValues = getValues();
+    const newDefaultValues = getToolTypeDefaultValues(urlToolType);
+
+    const mergedValues: ToolFormData = {
+      ...newDefaultValues,
+      toolId: currentValues.toolId,
+      description: currentValues.description,
+      labels: currentValues.labels,
+    };
+
+    reset(mergedValues);
+  }, [urlToolType, initialToolType, mode, getValues, reset]);
 
   // Handle opening test tool flyout on navigation
   useEffect(() => {
@@ -181,33 +222,6 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
     },
     [handleSave, handleTestTool]
   );
-
-  useEffect(() => {
-    if (tool) {
-      const toolTypeConfig = getToolTypeConfig(tool.type);
-      if (toolTypeConfig) {
-        const { toolToFormData } = toolTypeConfig;
-        reset(toolToFormData(tool));
-      }
-    }
-  }, [tool, reset]);
-
-  // Switching tool types clears tool-specific fields
-  useEffect(() => {
-    if (!urlToolType) return;
-    if (mode !== ToolFormMode.Create) return;
-    const currentValues = getValues();
-    const newDefaultValues = getToolTypeDefaultValues(urlToolType);
-
-    const mergedValues: ToolFormData = {
-      ...newDefaultValues,
-      toolId: currentValues.toolId,
-      description: currentValues.description,
-      labels: currentValues.labels,
-    };
-
-    reset(mergedValues);
-  }, [urlToolType, initialToolType, mode, getValues, reset]);
 
   const toolFormId = useGeneratedHtmlId({
     prefix: 'toolForm',


### PR DESCRIPTION
## Summary

Full disclosure, I don't fully understand why this fixes the issue. I just found the changes that made the issue stop happening and copied them over 🙂

Now instead of watching the tool type in the URL, we watch the form value to know when trigger the effect that resets the tool configuration. We also use `useUpdateEffect` rather than `useEffect` which just skips the first effect trigger while the component is mounting, without that there is a race condition.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



