### PR TITLE
[ON Week] Health dashboard when creating SLOs

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/create.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/create.ts
@@ -33,6 +33,7 @@ const createSLOParamsSchema = t.type({
       revision: t.number,
       artifacts: t.partial({
         dashboards: t.array(t.type({ id: t.string })),
+        autoCreateDashboard: t.boolean,
       }),
     }),
   ]),

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/slo_edit_form.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/slo_edit_form.tsx
@@ -94,7 +94,9 @@ export function SloEditForm({ slo, initialValues, onSave }: Props) {
               title: i18n.translate('xpack.slo.sloEdit.description.title', {
                 defaultMessage: 'Describe SLO',
               }),
-              children: showDescriptionSection ? <SloEditFormDescriptionSection /> : null,
+              children: showDescriptionSection ? (
+                <SloEditFormDescriptionSection isEditMode={isEditMode} />
+              ) : null,
               status:
                 showDescriptionSection && isDescriptionSectionValid ? 'complete' : 'incomplete',
             },

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/slo_edit_form_description_section.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/slo_edit_form_description_section.tsx
@@ -7,6 +7,7 @@
 
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
 import {
+  EuiCheckbox,
   EuiComboBox,
   EuiFieldText,
   EuiFormRow,
@@ -24,7 +25,13 @@ import type { CreateSLOForm } from '../types';
 import { OptionalText } from './common/optional_text';
 import { MAX_WIDTH } from '../constants';
 
-export function SloEditFormDescriptionSection() {
+export interface SloEditFormDescriptionSectionProps {
+  isEditMode?: boolean;
+}
+
+export function SloEditFormDescriptionSection({
+  isEditMode = false,
+}: SloEditFormDescriptionSectionProps) {
   const { control, getFieldState } = useFormContext<CreateSLOForm>();
   const sloNameId = useGeneratedHtmlId({ prefix: 'sloName' });
   const descriptionId = useGeneratedHtmlId({ prefix: 'sloDescription' });
@@ -171,6 +178,26 @@ export function SloEditFormDescriptionSection() {
           )}
         />
       </EuiFormRow>
+      {!isEditMode && (
+        <EuiFormRow fullWidth>
+          <Controller
+            name="artifacts.autoCreateDashboard"
+            control={control}
+            defaultValue={false}
+            render={({ field }) => (
+              <EuiCheckbox
+                id="autoCreateDashboardCheckbox"
+                label={i18n.translate('xpack.slo.sloEdit.autoCreateDashboard.label', {
+                  defaultMessage: 'Create and link transforms SLO dashboard',
+                })}
+                checked={field.value ?? false}
+                onChange={(e) => field.onChange(e.target.checked)}
+                data-test-subj="sloFormAutoCreateDashboardCheckbox"
+              />
+            )}
+          />
+        </EuiFormRow>
+      )}
     </EuiPanel>
   );
 }

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/helpers/process_slo_form_values.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/helpers/process_slo_form_values.ts
@@ -98,6 +98,7 @@ export function transformCreateSLOFormToCreateSLOInput(values: CreateSLOForm): C
     },
     artifacts: {
       dashboards: values.artifacts?.dashboards || [],
+      autoCreateDashboard: values.artifacts?.autoCreateDashboard,
     },
   };
 }

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/types.ts
@@ -31,5 +31,6 @@ export interface CreateSLOForm<IndicatorType = Indicator> {
   };
   artifacts?: {
     dashboards?: { id: string }[];
+    autoCreateDashboard?: boolean;
   };
 }

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/create_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/create_slo.ts
@@ -7,6 +7,7 @@
 
 import { createSLOParamsSchema } from '@kbn/slo-schema';
 import { CreateSLO } from '../../services';
+import { getHealthDashboard } from '../../services/health_dashboard/panels';
 import { createSloServerRoute } from '../create_slo_server_route';
 import { assertPlatinumLicense } from './utils/assert_platinum_license';
 
@@ -25,6 +26,7 @@ export const createSLORoute = createSloServerRoute({
     const {
       scopedClusterClient,
       internalSoClient,
+      soClient,
       spaceId,
       repository,
       transformManager,
@@ -47,6 +49,39 @@ export const createSLORoute = createSloServerRoute({
       userId
     );
 
-    return await createSLO.execute(params.body);
+    // Create the SLO first to get its ID
+    const sloResult = await createSLO.execute(params.body);
+
+    // Create dashboard with error budget visualization if requested
+    if (params.body.artifacts?.autoCreateDashboard) {
+      try {
+        const dashboard = await getHealthDashboard({
+          sloId: sloResult.id,
+          sloParams: params.body,
+          soClient,
+          logger,
+        });
+
+        // Fetch the full SLO from repository to get all its properties
+        const fullSlo = await repository.findById(sloResult.id);
+
+        // Update the SLO to link it to the dashboard
+        const updatedSlo = {
+          ...fullSlo,
+          artifacts: {
+            ...fullSlo.artifacts,
+            dashboards: [{ id: dashboard.id }],
+          },
+        };
+
+        await repository.update(updatedSlo);
+        logger.info(`Linked dashboard ${dashboard.id} to SLO ${sloResult.id}`);
+      } catch (error) {
+        logger.error(`Failed to create dashboard for SLO ${sloResult.id}: ${error}`);
+        // Continue execution even if dashboard creation fails
+      }
+    }
+
+    return sloResult;
   },
 });

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_dashboard/create_esql_panel.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_dashboard/create_esql_panel.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { v4 as uuidv4 } from 'uuid';
+import type { DashboardPanel } from '@kbn/dashboard-plugin/server';
+import type { DataViewSpec } from '@kbn/data-views-plugin/common';
+import type { AggregateQuery } from '@kbn/es-query';
+
+/**
+ * Column definition for ESQL panels
+ */
+interface ESQLColumn {
+  columnId: string;
+  fieldName: string;
+  label?: string;
+  customLabel?: boolean;
+  meta: {
+    type: string;
+    esType?: string;
+    sourceParams?: {
+      indexPattern: string;
+      sourceField: string;
+    };
+    params?: {
+      id: string;
+    };
+  };
+  inMetricDimension?: boolean;
+}
+
+/**
+ * Configuration for creating an ESQL dashboard panel
+ */
+export interface ESQLPanelConfig {
+  esqlQuery: string;
+  title: string;
+  description: string;
+  indexPattern: string;
+  gridPosition: {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  };
+  visualizationType: 'lnsXY' | 'lnsDatatable' | 'lnsMetric';
+  columns: ESQLColumn[];
+  visualizationConfig: {
+    // For lnsXY (line/bar charts)
+    xAccessor?: string;
+    accessors?: string[];
+    seriesType?: 'line' | 'bar' | 'bar_stacked' | 'area';
+    // For lnsDatatable
+    tableColumns?: Array<{
+      columnId: string;
+      isTransposed?: boolean;
+      width?: number;
+    }>;
+    // For lnsMetric
+    metricAccessor?: string;
+  };
+  timeField?: string;
+  includeTimeFieldInLayer?: boolean;
+}
+
+/**
+ * Utility function to create an ESQL-based Lens dashboard panel
+ */
+export function createESQLPanel(config: ESQLPanelConfig): DashboardPanel {
+  const layerId = uuidv4();
+  const adHocDataViewId = uuidv4();
+  const timeField = config.timeField ?? '@timestamp';
+  const includeTimeField = config.includeTimeFieldInLayer !== false;
+  const isMetric = config.visualizationType === 'lnsMetric';
+  const esqlQuery: AggregateQuery = { esql: config.esqlQuery };
+
+  // Build visualization config based on type using a map for cleaner code
+  const visualization = buildVisualizationConfig(
+    config.visualizationType,
+    config.visualizationConfig,
+    layerId
+  );
+
+  // Build layer config with conditional properties
+  const layerConfig = {
+    index: adHocDataViewId,
+    query: esqlQuery,
+    columns: config.columns,
+    ...(includeTimeField && { timeField }),
+  };
+
+  // Build index pattern ref with conditional properties
+  const indexPatternRef = {
+    id: adHocDataViewId,
+    title: config.indexPattern,
+    ...(includeTimeField && { timeField }),
+  };
+
+  // Build ad hoc data view with conditional properties
+  const adHocDataView: DataViewSpec = {
+    id: adHocDataViewId,
+    title: config.indexPattern,
+    name: config.indexPattern,
+    ...(isMetric
+      ? {
+          sourceFilters: [],
+          fieldFormats: {},
+          runtimeFieldMap: {},
+          allowNoIndex: false,
+          allowHidden: false,
+        }
+      : { timeFieldName: timeField }),
+  };
+
+  // Build common lens attributes structure
+  const lensAttributes = {
+    title: config.title,
+    description: config.description,
+    visualizationType: config.visualizationType,
+    references: [],
+    state: {
+      query: esqlQuery,
+      filters: [],
+      datasourceStates: {
+        textBased: {
+          layers: {
+            [layerId]: layerConfig,
+          },
+          indexPatternRefs: [indexPatternRef],
+        },
+      },
+      visualization,
+      adHocDataViews: {
+        [adHocDataViewId]: adHocDataView,
+      },
+    },
+    ...(isMetric && { version: 1, type: 'lens' }),
+  };
+
+  // Return panel with conditional config wrapper for metrics
+  return {
+    type: 'lens',
+    grid: config.gridPosition,
+    config: isMetric
+      ? {
+          enhancements: {
+            dynamicActions: {
+              events: [],
+            },
+          },
+          syncColors: false,
+          syncCursor: true,
+          syncTooltips: false,
+          filters: [],
+          query: esqlQuery,
+          attributes: lensAttributes,
+        }
+      : { attributes: lensAttributes },
+  };
+}
+
+/**
+ * Builds the visualization configuration based on the visualization type
+ */
+function buildVisualizationConfig(
+  visualizationType: ESQLPanelConfig['visualizationType'],
+  visualizationConfig: ESQLPanelConfig['visualizationConfig'],
+  layerId: string
+): Record<string, unknown> {
+  const visualizationBuilders = {
+    lnsXY: () => ({
+      legend: {
+        isVisible: true,
+        position: 'right',
+      },
+      valueLabels: 'hide',
+      fittingFunction: 'Linear',
+      axisTitlesVisibilitySettings: {
+        x: true,
+        yLeft: true,
+        yRight: true,
+      },
+      tickLabelsVisibilitySettings: {
+        x: true,
+        yLeft: true,
+        yRight: true,
+      },
+      labelsOrientation: {
+        x: 0,
+        yLeft: 0,
+        yRight: 0,
+      },
+      gridlinesVisibilitySettings: {
+        x: true,
+        yLeft: true,
+        yRight: true,
+      },
+      preferredSeriesType: visualizationConfig.seriesType ?? 'line',
+      layers: [
+        {
+          layerId,
+          seriesType: visualizationConfig.seriesType ?? 'line',
+          xAccessor: visualizationConfig.xAccessor,
+          accessors: visualizationConfig.accessors,
+          layerType: 'data',
+        },
+      ],
+    }),
+    lnsDatatable: () => ({
+      layerId,
+      layerType: 'data',
+      columns: visualizationConfig.tableColumns ?? [],
+    }),
+    lnsMetric: () => ({
+      layerId,
+      layerType: 'data',
+      metricAccessor: visualizationConfig.metricAccessor,
+    }),
+  } as const;
+
+  const builder = visualizationBuilders[visualizationType];
+  return builder ? builder() : {};
+}

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_dashboard/good_vs_bad_events_panel.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_dashboard/good_vs_bad_events_panel.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CreateSLOParams } from '@kbn/slo-schema';
+import type { DashboardPanel } from '@kbn/dashboard-plugin/server';
+import { createESQLPanel } from './create_esql_panel';
+
+/**
+ * Extracts the KQL query string from either a string or KQL query object
+ */
+function extractKqlString(
+  kql: string | { kqlQuery: string; filters: unknown[] } | undefined
+): string | undefined {
+  if (!kql) {
+    return undefined;
+  }
+  if (typeof kql === 'string') {
+    return kql;
+  }
+  return kql.kqlQuery;
+}
+
+/**
+ * Converts a simple KQL query to ESQL WHERE clause
+ * Handles basic field:value patterns and comparison operators
+ */
+function kqlToEsqlWhere(kql: string): string {
+  // Remove leading/trailing whitespace
+  kql = kql.trim();
+
+  // Pattern: field : "value" or field : value (equality)
+  const simpleMatch = kql.match(/^(\w+(?:\.\w+)*)\s*:\s*"([^"]+)"$/);
+  if (simpleMatch) {
+    return `${simpleMatch[1]} == "${simpleMatch[2]}"`;
+  }
+
+  const simpleMatchNoQuotes = kql.match(/^(\w+(?:\.\w+)*)\s*:\s*(\w+)$/);
+  if (simpleMatchNoQuotes) {
+    return `${simpleMatchNoQuotes[1]} == "${simpleMatchNoQuotes[2]}"`;
+  }
+
+  // Pattern: field < value, field > value, field <= value, field >= value, field != value
+  const comparisonMatch = kql.match(/^(\w+(?:\.\w+)*)\s*(<=?|>=?|!=)\s*(\d+(?:\.\d+)?)$/);
+  if (comparisonMatch) {
+    return `${comparisonMatch[1]} ${comparisonMatch[2]} ${comparisonMatch[3]}`;
+  }
+
+  // Pattern: field < "value", field > "value", etc. with quoted values
+  const comparisonMatchQuoted = kql.match(/^(\w+(?:\.\w+)*)\s*(<=?|>=?|!=)\s*"([^"]+)"$/);
+  if (comparisonMatchQuoted) {
+    return `${comparisonMatchQuoted[1]} ${comparisonMatchQuoted[2]} "${comparisonMatchQuoted[3]}"`;
+  }
+
+  // Return as comment if we can't convert
+  return `/* KQL: ${kql} - Complex KQL not converted */`;
+}
+
+/**
+ * Generates an ESQL query for good vs bad events from source data
+ * Only works for custom KQL indicator type
+ */
+function generateGoodBadEventsQuery(sloParams: CreateSLOParams): string | null {
+  const indicator = sloParams.indicator;
+
+  // Only support custom KQL indicators
+  if (indicator.type !== 'sli.kql.custom') {
+    return null;
+  }
+
+  // Extract index pattern and timestamp field
+  if (!('params' in indicator) || !indicator.params) {
+    return null;
+  }
+
+  const params = indicator.params;
+  const indexPattern = params.index;
+  const timestampField = params.timestampField || '@timestamp';
+
+  // Extract KQL strings from potentially complex objects
+  const globalFilterKql = extractKqlString(params.filter);
+  const goodKql = extractKqlString(params.good);
+  const totalKql = extractKqlString(params.total);
+
+  if (!indexPattern || !goodKql) {
+    return null;
+  }
+
+  // Convert KQL to ESQL WHERE clauses
+  const goodWhere = kqlToEsqlWhere(goodKql);
+  // If totalKql is empty or not provided, consider all documents (always true)
+  const totalWhere = totalKql && totalKql.trim() !== '' ? kqlToEsqlWhere(totalKql) : 'true';
+
+  // Build query
+  let query = `FROM ${indexPattern}\n`;
+
+  if (globalFilterKql && globalFilterKql.trim() !== '') {
+    query += `| WHERE ${kqlToEsqlWhere(globalFilterKql)}\n`;
+  }
+
+  query += `| EVAL is_good = CASE(
+    ${goodWhere}, 1,
+    0
+  )
+  | EVAL is_total = CASE(
+    ${totalWhere}, 1,
+    0
+  )
+  | STATS 
+      good_events = SUM(is_good),
+      total_events = SUM(is_total)
+    BY time_bucket = BUCKET(${timestampField}, 1 minute)
+  | EVAL bad_events = total_events - good_events
+  | EVAL time_bucket = TO_DATETIME(time_bucket)
+  | SORT time_bucket DESC
+  | LIMIT 100`;
+
+  return query;
+}
+
+/**
+ * Generates a Lens panel showing good vs bad events from source data
+ * Only works for custom KQL indicator type
+ * Returns null for other indicator types
+ */
+export function generateSourceDataPanel(sloParams: CreateSLOParams): DashboardPanel | null {
+  const indicator = sloParams.indicator;
+
+  // Only support custom KQL indicators
+  if (indicator.type !== 'sli.kql.custom') {
+    return null;
+  }
+
+  const esqlQuery = generateGoodBadEventsQuery(sloParams);
+
+  if (!esqlQuery) {
+    return null;
+  }
+
+  // At this point, TypeScript knows indicator.type is 'sli.kql.custom'
+  // so indicator.params is properly typed
+  const params = indicator.params;
+  const indexPattern = params.index;
+  const timestampField = params.timestampField || '@timestamp';
+
+  return createESQLPanel({
+    esqlQuery,
+    title: 'Good vs Bad Events (Source Data)',
+    description: 'Good and bad events from source index (independent of transforms)',
+    indexPattern,
+    gridPosition: { x: 0, y: 0, w: 24, h: 12 },
+    visualizationType: 'lnsXY',
+    columns: [
+      {
+        columnId: 'time_bucket',
+        fieldName: 'time_bucket',
+        meta: {
+          type: 'date',
+          esType: 'date',
+        },
+      },
+      {
+        columnId: 'good_events',
+        fieldName: 'good_events',
+        meta: {
+          type: 'number',
+          esType: 'long',
+        },
+        inMetricDimension: true,
+      },
+      {
+        columnId: 'bad_events',
+        fieldName: 'bad_events',
+        meta: {
+          type: 'number',
+          esType: 'long',
+        },
+        inMetricDimension: true,
+      },
+    ],
+    visualizationConfig: {
+      xAccessor: 'time_bucket',
+      accessors: ['good_events', 'bad_events'],
+      seriesType: 'bar_stacked',
+    },
+    timeField: timestampField,
+  });
+}

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_dashboard/panels.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_dashboard/panels.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CreateSLOParams } from '@kbn/slo-schema';
+import type { DashboardState } from '@kbn/dashboard-plugin/server/content_management/latest';
+import { transformDashboardIn } from '@kbn/dashboard-plugin/server/content_management/latest';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+import { DASHBOARD_SAVED_OBJECT_TYPE } from '@kbn/deeplinks-analytics/constants';
+import { generateTransformHealthPanel } from './rollup_events_panel';
+import { generateSummaryUpdatePanel } from './summary_update_panel';
+import { generateSourceDataPanel } from './good_vs_bad_events_panel';
+
+export const getHealthDashboard = async ({
+  sloId,
+  sloParams,
+  soClient,
+  logger,
+}: {
+  sloId: string;
+  sloParams: CreateSLOParams;
+  soClient: SavedObjectsClientContract;
+  logger: Logger;
+}) => {
+  const transformHealthPanel = generateTransformHealthPanel(sloId);
+  const summaryUpdatePanel = generateSummaryUpdatePanel(sloId);
+  const sourceDataPanel = generateSourceDataPanel(sloParams);
+  const panels = [transformHealthPanel, summaryUpdatePanel];
+  if (sourceDataPanel) {
+    panels.push(sourceDataPanel);
+  }
+
+  const dashboardState: DashboardState = {
+    title: `${sloParams.name}`,
+    panels,
+    tags: sloParams.tags || [],
+  };
+
+  // Transform dashboard state to saved object format
+  const {
+    attributes,
+    references,
+    error: transformError,
+  } = transformDashboardIn({
+    dashboardState,
+    incomingReferences: [],
+  });
+
+  if (transformError) {
+    throw new Error(`Failed to transform dashboard: ${transformError.message}`);
+  }
+
+  // Create the dashboard using the saved objects client
+  const dashboard = await soClient.create(DASHBOARD_SAVED_OBJECT_TYPE, attributes, {
+    references,
+  });
+
+  logger.info(`Created dashboard ${dashboard.id} for SLO ${sloId}`);
+
+  return dashboard;
+};

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_dashboard/rollup_events_panel.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_dashboard/rollup_events_panel.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DashboardPanel } from '@kbn/dashboard-plugin/server';
+import { createESQLPanel } from './create_esql_panel';
+
+/**
+ * Generates an ESQL query for rollup transform monitoring
+ * Shows good vs bad events written by the rollup transform over time
+ */
+function generateTransformHealthQuery(sloId: string): string {
+  return `FROM .slo-observability.sli-v3*
+| WHERE slo.id == "${sloId}"
+| STATS 
+    good_events = SUM(slo.numerator),
+    total_events = SUM(slo.denominator)
+  BY time_bucket = BUCKET(@timestamp, 1 minute)
+| EVAL bad_events = total_events - good_events
+| EVAL time_bucket = TO_DATETIME(time_bucket)
+| SORT time_bucket DESC
+| LIMIT 100`;
+}
+
+/**
+ * Generates a Lens panel for monitoring rollup transform output
+ * Shows good vs bad events written by the rollup transform per minute
+ */
+export function generateTransformHealthPanel(sloId: string): DashboardPanel {
+  return createESQLPanel({
+    esqlQuery: generateTransformHealthQuery(sloId),
+    title: 'Good vs Bad Events (Rollup Transform Output)',
+    description: 'Good and bad events from the rollup transform output',
+    indexPattern: '.slo-observability.sli-v3*',
+    gridPosition: { x: 0, y: 12, w: 24, h: 12 },
+    visualizationType: 'lnsXY',
+    columns: [
+      {
+        columnId: 'time_bucket',
+        fieldName: 'time_bucket',
+        meta: {
+          type: 'date',
+          esType: 'date',
+        },
+      },
+      {
+        columnId: 'good_events',
+        fieldName: 'good_events',
+        meta: {
+          type: 'number',
+          esType: 'long',
+        },
+        inMetricDimension: true,
+      },
+      {
+        columnId: 'bad_events',
+        fieldName: 'bad_events',
+        meta: {
+          type: 'number',
+          esType: 'long',
+        },
+        inMetricDimension: true,
+      },
+    ],
+    visualizationConfig: {
+      xAccessor: 'time_bucket',
+      accessors: ['good_events', 'bad_events'],
+      seriesType: 'bar_stacked',
+    },
+  });
+}

--- a/x-pack/solutions/observability/plugins/slo/server/services/health_dashboard/summary_update_panel.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/health_dashboard/summary_update_panel.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DashboardPanel } from '@kbn/dashboard-plugin/server';
+import { createESQLPanel } from './create_esql_panel';
+
+/**
+ * Generates an ESQL query for summary transform monitoring
+ * Shows how many seconds ago the summary was last updated
+ */
+function generateSummaryUpdateQuery(sloId: string): string {
+  return `FROM .slo-observability.summary-v3*
+  | WHERE slo.id == "${sloId}" AND isTempDoc == false
+  | STATS last_summary_update = MAX(summaryUpdatedAt)
+  | EVAL seconds_ago = TO_INTEGER(DATE_DIFF("second", TO_DATETIME(last_summary_update), NOW()))
+  | KEEP seconds_ago`;
+}
+
+/**
+ * Generates a Lens panel showing how many seconds ago the summary was updated
+ */
+export function generateSummaryUpdatePanel(sloId: string): DashboardPanel {
+  const indexPattern = '.slo-observability.summary-v3*';
+
+  return createESQLPanel({
+    esqlQuery: generateSummaryUpdateQuery(sloId),
+    title: 'Last Summary Update (seconds ago)',
+    description: 'Seconds ago the summary transform last updated',
+    indexPattern,
+    gridPosition: { x: 0, y: 24, w: 12, h: 10 },
+    visualizationType: 'lnsMetric',
+    columns: [
+      {
+        columnId: 'seconds_ago',
+        fieldName: 'seconds_ago',
+        label: 'seconds_ago',
+        customLabel: false,
+        meta: {
+          type: 'number',
+          esType: 'integer',
+          sourceParams: {
+            indexPattern,
+            sourceField: 'seconds_ago',
+          },
+          params: {
+            id: 'number',
+          },
+        },
+        inMetricDimension: true,
+      },
+    ],
+    visualizationConfig: {
+      metricAccessor: 'seconds_ago',
+    },
+    includeTimeFieldInLayer: false,
+  });
+}


### PR DESCRIPTION
## Auto-generated SLO Health Dashboard

### Summary
Implemented automatic dashboard creation when creating an SLO. When the `artifacts.autoCreateDashboard` flag is set, a dashboard with three ES|QL-powered visualizations is automatically created and linked to the SLO.
This dashboard provides visibility into the SLO transform pipeline architecture, making it easy to understand and monitor how data flows from the source index through the rollup transform and summary transform.

### Visualizations

**1. Good vs Bad Events (Source Data)**
- Shows data directly from the source index
- Stacked bar chart with 1-minute buckets
- Only available for custom KQL SLO type

**2. Good vs Bad Events (Rollup Index)**  
- Shows data from the rollup transform output (`.slo-observability.sli-v3*`)
- Stacked bar chart with 1-minute buckets

**3. Last Summary Update**
- Shows how many seconds ago the summary was last updated
- Metric visualization querying `.slo-observability.summary-v3*`
- Helps identify summary transform lag

https://github.com/user-attachments/assets/05f486e3-c215-4b6a-af80-3395c9cf7281