### PR TITLE
[Fleet] Add readTrustedDevices privilege to package policy routes

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/security/route_required_authz.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/security/route_required_authz.ts
@@ -63,6 +63,9 @@ const ROUTE_AUTHZ_REQUIREMENTS = deepFreeze<Record<string, FleetRouteRequiredAut
             readBlocklist: {
               executePackageAction: true,
             },
+            readTrustedDevices: {
+              executePackageAction: true,
+            },
           },
         },
       },
@@ -93,6 +96,9 @@ const ROUTE_AUTHZ_REQUIREMENTS = deepFreeze<Record<string, FleetRouteRequiredAut
             readBlocklist: {
               executePackageAction: true,
             },
+            readTrustedDevices: {
+              executePackageAction: true,
+            },
           },
         },
       },
@@ -121,6 +127,9 @@ const ROUTE_AUTHZ_REQUIREMENTS = deepFreeze<Record<string, FleetRouteRequiredAut
               executePackageAction: true,
             },
             readBlocklist: {
+              executePackageAction: true,
+            },
+            readTrustedDevices: {
               executePackageAction: true,
             },
           },

--- a/x-pack/solutions/security/test/fleet_api_integration/apis/test_users.ts
+++ b/x-pack/solutions/security/test/fleet_api_integration/apis/test_users.ts
@@ -187,6 +187,7 @@ export const testUsers: {
           'blocklist_read',
           'event_filters_read',
           'policy_management_read',
+          'trusted_devices_read',
         ],
         securitySolutionNotes: ['all'],
         securitySolutionTimeline: ['all'],


### PR DESCRIPTION
Adds the `readTrustedDevices` privilege to Fleet package policy GET routes (info, bulk get, and list). This allows users with only `trusted_devices_all` privilege to fetch policies when assigning trusted devices to policies, matching the existing pattern for other endpoint artifact privileges like `readTrustedApplications`, `readEventFilters`, `readHostIsolationExceptions`, and `readBlocklist`.

Also updates the `endpoint_integr_read_policy` test user to include `trusted_devices_read` for test coverage.


https://github.com/user-attachments/assets/08d64146-c459-4ddb-9ca5-da0bdb2b18d9



Closes https://github.com/elastic/security-team/issues/14764

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->