### PR TITLE
[SLO]: Introduce hierarchy view in SLO overview page

### DIFF
--- a/scripts/slo_demo_data_generator.js
+++ b/scripts/slo_demo_data_generator.js
@@ -1,0 +1,268 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// @ts-nocheck
+/* eslint-disable @kbn/eslint/require-license-header, no-restricted-syntax */
+
+/**
+ * SLO Demo Data Generator
+ *
+ * Creates sample SLOs organized hierarchically for the ING Bank demo
+ *
+ * Usage:
+ *   node scripts/slo_demo_data_generator.js --kibanaUrl http://localhost:5601
+ */
+
+require('../src/setup_node_env');
+
+const { run } = require('@kbn/dev-cli-runner');
+const axios = require('axios');
+
+class DemoDataGenerator {
+  constructor(kibanaUrl, log, auth) {
+    this.log = log;
+
+    this.client = axios.create({
+      baseURL: kibanaUrl,
+      ...(auth && { auth }),
+      headers: {
+        'kbn-xsrf': 'true',
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  async createSLO(slo) {
+    try {
+      const response = await this.client.post('/api/observability/slos', slo);
+      this.log.success(`✓ Created SLO: ${slo.name}`);
+      return response.data;
+    } catch (error) {
+      this.log.error(`✗ Failed to create SLO ${slo.name}: ${error.message}`);
+      // Don't throw - continue with other SLOs
+      return null;
+    }
+  }
+
+  async generateDemoData() {
+    this.log.info('\n🏦 Generating ING Bank Demo SLOs...\n');
+
+    const slos = this.buildDemoSLOs();
+
+    this.log.info(`Creating ${slos.length} SLOs across 3 value streams...\n`);
+
+    let created = 0;
+    let failed = 0;
+
+    for (const slo of slos) {
+      const result = await this.createSLO(slo);
+      if (result) {
+        created++;
+      } else {
+        failed++;
+      }
+      // Small delay to avoid overwhelming the server
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    this.log.info('\n📊 Demo Data Generation Summary:');
+    this.log.success(`✓ Successfully created: ${created} SLOs`);
+    if (failed > 0) {
+      this.log.error(`✗ Failed: ${failed} SLOs`);
+    }
+
+    this.log.info('\n💡 Next Steps:');
+    this.log.info('1. Navigate to Observability → SLOs');
+    this.log.info('2. Switch to "Hierarchical View" to see the organization');
+    this.log.info('3. Explore value streams → business components → services');
+    this.log.info('4. Use the Executive Report for leadership overview\n');
+  }
+
+  buildDemoSLOs() {
+    const slos = [];
+
+    // Value Stream 1: Customer Onboarding
+    slos.push(
+      ...this.buildValueStream('customer-onboarding', [
+        {
+          businessComponent: 'identity-verification',
+          services: [
+            { name: 'id-scanner-api', target: 0.985, description: 'Document scanning service' },
+            {
+              name: 'document-validator',
+              target: 0.882,
+              description: 'AI-powered document validation',
+            },
+            {
+              name: 'fraud-check-service',
+              target: 0.961,
+              description: 'Real-time fraud detection',
+            },
+          ],
+        },
+        {
+          businessComponent: 'account-creation',
+          services: [
+            { name: 'account-api', target: 0.991, description: 'Account management API' },
+            { name: 'database-service', target: 0.982, description: 'Core database operations' },
+            { name: 'email-service', target: 0.961, description: 'Email notification service' },
+          ],
+        },
+        {
+          businessComponent: 'funding',
+          services: [
+            { name: 'payment-gateway', target: 0.992, description: 'Payment processing gateway' },
+            {
+              name: 'bank-integration',
+              target: 0.97,
+              description: 'External bank integration',
+            },
+          ],
+        },
+      ])
+    );
+
+    // Value Stream 2: Digital Banking
+    slos.push(
+      ...this.buildValueStream('digital-banking', [
+        {
+          businessComponent: 'transaction-processing',
+          services: [
+            { name: 'transaction-api', target: 0.995, description: 'Transaction processing API' },
+            { name: 'ledger-service', target: 0.988, description: 'Ledger management' },
+            {
+              name: 'notification-service',
+              target: 0.955,
+              description: 'Transaction notifications',
+            },
+          ],
+        },
+        {
+          businessComponent: 'account-management',
+          services: [
+            { name: 'balance-service', target: 0.998, description: 'Real-time balance queries' },
+            { name: 'statement-generator', target: 0.945, description: 'Statement generation' },
+          ],
+        },
+      ])
+    );
+
+    // Value Stream 3: Lending Platform
+    slos.push(
+      ...this.buildValueStream('lending-platform', [
+        {
+          businessComponent: 'loan-origination',
+          services: [
+            { name: 'application-api', target: 0.99, description: 'Loan application API' },
+            {
+              name: 'credit-scoring-engine',
+              target: 0.92,
+              description: 'ML credit scoring',
+            },
+            {
+              name: 'decision-engine',
+              target: 0.965,
+              description: 'Automated decision making',
+            },
+          ],
+        },
+        {
+          businessComponent: 'loan-servicing',
+          services: [
+            { name: 'repayment-service', target: 0.992, description: 'Payment processing' },
+            { name: 'interest-calculator', target: 0.978, description: 'Interest calculations' },
+          ],
+        },
+      ])
+    );
+
+    return slos;
+  }
+
+  buildValueStream(valueStreamName, businessComponents) {
+    const slos = [];
+
+    businessComponents.forEach(({ businessComponent, services }) => {
+      services.forEach(({ name, target, description }) => {
+        slos.push({
+          name: `${valueStreamName}-${businessComponent}-${name}`,
+          description,
+          indicator: {
+            type: 'sli.kql.custom',
+            params: {
+              index: 'kbn-data-forge-fake_stack.admin-console-*',
+              good: 'http.response.status_code < 500',
+              total: 'http.response.status_code: *',
+              timestampField: '@timestamp',
+            },
+          },
+          timeWindow: {
+            duration: '30d',
+            type: 'rolling',
+          },
+          budgetingMethod: 'occurrences',
+          objective: {
+            target,
+          },
+          tags: [
+            `value-stream:${valueStreamName}`,
+            `business-component:${businessComponent}`,
+            `service:${name}`,
+            'demo',
+            'production',
+            'ing-bank-demo',
+          ],
+        });
+      });
+    });
+
+    return slos;
+  }
+}
+
+run(
+  async ({ flags, log }) => {
+    const kibanaUrl = flags.kibanaUrl || 'http://localhost:5601';
+    const username = flags.username;
+    const password = flags.password;
+
+    log.info('SLO Demo Data Generator');
+    log.info('=======================\n');
+    log.info(`Kibana URL: ${kibanaUrl}\n`);
+
+    const auth = username && password ? { username, password } : undefined;
+    const generator = new DemoDataGenerator(kibanaUrl, log, auth);
+
+    await generator.generateDemoData();
+
+    log.success('\n✅ Demo data generation completed!');
+    log.info('\n🎯 You can now view the hierarchical SLO organization in Kibana\n');
+  },
+  {
+    description: `
+      Generate demo SLO data for ING Bank hierarchy demonstration
+      
+      Creates sample SLOs organized by:
+      - Value Streams (Customer Onboarding, Digital Banking, Lending)
+      - Business Components (Identity Verification, Transaction Processing, etc.)
+      - Services (APIs, databases, integrations)
+    `,
+    flags: {
+      string: ['kibanaUrl', 'username', 'password'],
+      default: {
+        kibanaUrl: 'http://localhost:5601',
+      },
+      help: `
+        --kibanaUrl    Kibana URL (default: http://localhost:5601)
+        --username     Username for authentication
+        --password     Password for authentication
+      `,
+    },
+  }
+);

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/hierarchy_view/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/hierarchy_view/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { SloHierarchyView } from './slo_hierarchy_view';
+export { SloHierarchyTree } from './slo_hierarchy_tree';

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/hierarchy_view/slo_hierarchy_tree.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/hierarchy_view/slo_hierarchy_tree.tsx
@@ -1,0 +1,471 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiIcon,
+  EuiBadge,
+  EuiButtonIcon,
+  EuiSpacer,
+  EuiLoadingSpinner,
+  EuiEmptyPrompt,
+  EuiHealth,
+  EuiToolTip,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { SLOWithSummaryResponse } from '@kbn/slo-schema';
+import { useKibana } from '../../../../hooks/use_kibana';
+import { paths } from '../../../../../common/locators/paths';
+
+interface HierarchyNode {
+  id: string;
+  name: string;
+  type: 'value-stream' | 'business-component' | 'service';
+  slo?: SLOWithSummaryResponse;
+  children: HierarchyNode[];
+  // Aggregated metrics for parent nodes
+  aggregatedSliValue?: number;
+  aggregatedStatus?: string;
+  aggregatedErrorBudget?: number;
+  sloCount?: number;
+}
+
+interface Props {
+  sloList: SLOWithSummaryResponse[];
+  loading?: boolean;
+}
+
+/**
+ * Builds a hierarchical tree structure from flat SLO list based on tags
+ *
+ * Tag convention:
+ * - value-stream:customer-onboarding
+ * - business-component:identity-verification
+ * - service:id-scanner-api
+ */
+export function SloHierarchyTree({ sloList, loading }: Props) {
+  const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set(['root']));
+
+  const hierarchyTree = useMemo(() => buildHierarchyFromTags(sloList), [sloList]);
+
+  const toggleNode = (nodeId: string) => {
+    const newExpanded = new Set(expandedNodes);
+    if (newExpanded.has(nodeId)) {
+      newExpanded.delete(nodeId);
+    } else {
+      newExpanded.add(nodeId);
+    }
+    setExpandedNodes(newExpanded);
+  };
+
+  if (loading) {
+    return (
+      <EuiPanel>
+        <EuiFlexGroup justifyContent="center" alignItems="center">
+          <EuiLoadingSpinner size="xl" />
+        </EuiFlexGroup>
+      </EuiPanel>
+    );
+  }
+
+  if (hierarchyTree.length === 0) {
+    return (
+      <EuiEmptyPrompt
+        iconType="search"
+        title={
+          <h2>
+            {i18n.translate('xpack.slo.hierarchyView.noDataTitle', {
+              defaultMessage: 'No hierarchical SLOs found',
+            })}
+          </h2>
+        }
+        body={
+          <p>
+            {i18n.translate('xpack.slo.hierarchyView.noDataBody', {
+              defaultMessage:
+                'Tag your SLOs with value-stream, business-component, and service tags to see the hierarchy.',
+            })}
+          </p>
+        }
+      />
+    );
+  }
+
+  return (
+    <EuiPanel hasBorder>
+      {hierarchyTree.map((node) => (
+        <HierarchyNodeComponent
+          key={node.id}
+          node={node}
+          level={0}
+          expandedNodes={expandedNodes}
+          onToggle={toggleNode}
+        />
+      ))}
+    </EuiPanel>
+  );
+}
+
+interface NodeProps {
+  node: HierarchyNode;
+  level: number;
+  expandedNodes: Set<string>;
+  onToggle: (nodeId: string) => void;
+}
+
+function HierarchyNodeComponent({ node, level, expandedNodes, onToggle }: NodeProps) {
+  const {
+    application: { navigateToUrl },
+    http: { basePath },
+  } = useKibana().services;
+
+  const isExpanded = expandedNodes.has(node.id);
+  const hasChildren = node.children.length > 0;
+  const paddingLeft = level * 24;
+
+  const statusColor = getStatusColor(node.aggregatedStatus || node.slo?.summary.status);
+  const sliValue = node.aggregatedSliValue ?? node.slo?.summary.sliValue;
+  const formattedSli = sliValue ? `${(sliValue * 100).toFixed(2)}%` : 'N/A';
+
+  // Determine which child is causing the most impact
+  const worstChild = node.children.length > 0 ? getWorstPerformingChild(node.children) : null;
+
+  // Handle click for service nodes (navigate to SLO details)
+  const handleClick = () => {
+    if (hasChildren) {
+      onToggle(node.id);
+    } else if (node.slo) {
+      // Navigate to SLO details page
+      const sloDetailsUrl = basePath.prepend(
+        paths.sloDetails(node.slo.id, node.slo.instanceId, node.slo.remote?.remoteName)
+      );
+      navigateToUrl(sloDetailsUrl);
+    }
+  };
+
+  // Determine cursor style
+  const cursorStyle = hasChildren ? 'pointer' : node.slo ? 'pointer' : 'default';
+
+  return (
+    <div>
+      <EuiPanel
+        paddingSize="s"
+        hasShadow={false}
+        hasBorder={false}
+        style={{ paddingLeft, cursor: cursorStyle }}
+        onClick={handleClick}
+        color={node.slo ? 'subdued' : 'plain'}
+        data-test-subj={node.slo ? 'sloHierarchyServiceNode' : 'sloHierarchyParentNode'}
+      >
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          {/* Expand/Collapse Icon */}
+          <EuiFlexItem grow={false}>
+            {hasChildren ? (
+              <EuiButtonIcon
+                iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
+                size="s"
+                aria-label={isExpanded ? 'Collapse' : 'Expand'}
+                data-test-subj="sloHierarchyNodeToggle"
+                onClick={(e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  onToggle(node.id);
+                }}
+              />
+            ) : (
+              <div style={{ width: 24 }} />
+            )}
+          </EuiFlexItem>
+
+          {/* Node Type Icon */}
+          <EuiFlexItem grow={false}>
+            <EuiIcon type={getNodeIcon(node.type)} size="m" />
+          </EuiFlexItem>
+
+          {/* Node Name */}
+          <EuiFlexItem grow={true}>
+            <EuiText size="s">
+              <strong>{node.name}</strong>
+              {node.sloCount && node.sloCount > 1 && (
+                <EuiBadge color="hollow" style={{ marginLeft: 8 }}>
+                  {i18n.translate('xpack.slo.hierarchyView.sloCount', {
+                    defaultMessage: '{count} SLOs',
+                    values: { count: node.sloCount },
+                  })}
+                </EuiBadge>
+              )}
+            </EuiText>
+          </EuiFlexItem>
+
+          {/* SLI Value */}
+          <EuiFlexItem grow={false} style={{ minWidth: 100 }}>
+            <EuiHealth color={statusColor}>
+              <strong>{formattedSli}</strong>
+            </EuiHealth>
+          </EuiFlexItem>
+
+          {/* Status Badge */}
+          <EuiFlexItem grow={false}>
+            <EuiBadge color={statusColor}>
+              {node.aggregatedStatus || node.slo?.summary.status || 'N/A'}
+            </EuiBadge>
+          </EuiFlexItem>
+
+          {/* Error Budget */}
+          {(node.slo?.summary.errorBudget || node.aggregatedErrorBudget !== undefined) && (
+            <EuiFlexItem grow={false} style={{ minWidth: 100 }}>
+              <EuiToolTip
+                content={i18n.translate('xpack.slo.hierarchyView.errorBudgetTooltip', {
+                  defaultMessage:
+                    node.aggregatedErrorBudget !== undefined
+                      ? 'Average error budget remaining'
+                      : 'Error budget remaining',
+                })}
+              >
+                <EuiText size="xs" color="subdued">
+                  {i18n.translate('xpack.slo.hierarchyView.budgetLabel', {
+                    defaultMessage: 'Budget: {value}',
+                    values: {
+                      value:
+                        node.slo?.summary.errorBudget?.remaining !== undefined
+                          ? `${(node.slo.summary.errorBudget.remaining * 100).toFixed(1)}%`
+                          : node.aggregatedErrorBudget !== undefined
+                          ? `${(node.aggregatedErrorBudget * 100).toFixed(1)}%`
+                          : i18n.translate('xpack.slo.hierarchyView.notAvailable', {
+                              defaultMessage: 'N/A',
+                            }),
+                    },
+                  })}
+                </EuiText>
+              </EuiToolTip>
+            </EuiFlexItem>
+          )}
+
+          {/* Impact indicator */}
+          {worstChild && (
+            <EuiFlexItem grow={false}>
+              <EuiIcon
+                type="alert"
+                color="danger"
+                title={i18n.translate('xpack.slo.hierarchyView.impactTooltip', {
+                  defaultMessage: 'Worst performing: {childName}',
+                  values: { childName: worstChild.name },
+                })}
+              />
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      </EuiPanel>
+
+      {/* Render children if expanded */}
+      {isExpanded && hasChildren && (
+        <div>
+          {node.children.map((child) => (
+            <HierarchyNodeComponent
+              key={child.id}
+              node={child}
+              level={level + 1}
+              expandedNodes={expandedNodes}
+              onToggle={onToggle}
+            />
+          ))}
+        </div>
+      )}
+
+      {level === 0 && <EuiSpacer size="m" />}
+    </div>
+  );
+}
+
+/**
+ * Builds hierarchy from SLO tags
+ * Expected tag format: "value-stream:name", "business-component:name", "service:name"
+ */
+function buildHierarchyFromTags(sloList: SLOWithSummaryResponse[]): HierarchyNode[] {
+  const valueStreamMap = new Map<string, HierarchyNode>();
+
+  sloList.forEach((slo) => {
+    const tags = slo.tags || [];
+
+    // Extract hierarchy tags
+    const valueStreamTag = tags.find((t) => t.startsWith('value-stream:'));
+    const businessComponentTag = tags.find((t) => t.startsWith('business-component:'));
+    const serviceTag = tags.find((t) => t.startsWith('service:'));
+
+    if (!valueStreamTag && !businessComponentTag && !serviceTag) {
+      return; // Skip SLOs without hierarchy tags
+    }
+
+    const valueStreamName = valueStreamTag?.split(':')[1] || 'Unassigned';
+    const businessComponentName = businessComponentTag?.split(':')[1];
+    const serviceName = serviceTag?.split(':')[1] || slo.name;
+
+    // Get or create value stream node
+    let valueStream = valueStreamMap.get(valueStreamName);
+    if (!valueStream) {
+      valueStream = {
+        id: `vs-${valueStreamName}`,
+        name: formatName(valueStreamName),
+        type: 'value-stream',
+        children: [],
+      };
+      valueStreamMap.set(valueStreamName, valueStream);
+    }
+
+    if (businessComponentName) {
+      // Get or create business component node
+      let businessComponent = valueStream.children.find(
+        (c) => c.id === `bc-${businessComponentName}`
+      );
+      if (!businessComponent) {
+        businessComponent = {
+          id: `bc-${businessComponentName}`,
+          name: formatName(businessComponentName),
+          type: 'business-component',
+          children: [],
+        };
+        valueStream.children.push(businessComponent);
+      }
+
+      // Add service node
+      const serviceNode: HierarchyNode = {
+        id: `svc-${slo.id}`,
+        name: formatName(serviceName),
+        type: 'service',
+        slo,
+        children: [],
+      };
+      businessComponent.children.push(serviceNode);
+    } else {
+      // No business component, add service directly to value stream
+      const serviceNode: HierarchyNode = {
+        id: `svc-${slo.id}`,
+        name: formatName(serviceName),
+        type: 'service',
+        slo,
+        children: [],
+      };
+      valueStream.children.push(serviceNode);
+    }
+  });
+
+  // Calculate aggregated metrics for parent nodes
+  const hierarchy = Array.from(valueStreamMap.values());
+  hierarchy.forEach((valueStream) => calculateAggregatedMetrics(valueStream));
+
+  return hierarchy;
+}
+
+/**
+ * Calculate aggregated metrics for parent nodes (recursive)
+ */
+function calculateAggregatedMetrics(node: HierarchyNode): void {
+  if (node.children.length === 0) {
+    // Leaf node, use SLO data directly
+    return;
+  }
+
+  // First, calculate metrics for all children
+  node.children.forEach((child) => calculateAggregatedMetrics(child));
+
+  // Collect all leaf SLOs under this node
+  const leafSLOs = collectLeafSLOs(node);
+
+  if (leafSLOs.length === 0) {
+    return;
+  }
+
+  // Calculate weighted average SLI (could also use min/worst-case)
+  const totalWeight = leafSLOs.length;
+  const sumSliValues = leafSLOs.reduce((sum, slo) => {
+    return sum + (slo.summary.sliValue ?? 0);
+  }, 0);
+
+  node.aggregatedSliValue = sumSliValues / totalWeight;
+  node.sloCount = leafSLOs.length;
+
+  // Calculate average error budget remaining
+  const slosWithBudget = leafSLOs.filter((slo) => slo.summary.errorBudget?.remaining != null);
+  if (slosWithBudget.length > 0) {
+    const sumBudget = slosWithBudget.reduce((sum, slo) => {
+      return sum + (slo.summary.errorBudget.remaining ?? 0);
+    }, 0);
+    node.aggregatedErrorBudget = sumBudget / slosWithBudget.length;
+  }
+
+  // Determine aggregated status based on worst child
+  const statuses = leafSLOs.map((slo) => slo.summary.status);
+  if (statuses.includes('VIOLATED')) {
+    node.aggregatedStatus = 'VIOLATED';
+  } else if (statuses.includes('DEGRADING')) {
+    node.aggregatedStatus = 'DEGRADING';
+  } else if (statuses.includes('HEALTHY')) {
+    node.aggregatedStatus = 'HEALTHY';
+  } else {
+    node.aggregatedStatus = 'NO_DATA';
+  }
+}
+
+/**
+ * Collect all leaf SLOs under a node (recursive)
+ */
+function collectLeafSLOs(node: HierarchyNode): SLOWithSummaryResponse[] {
+  if (node.slo) {
+    return [node.slo];
+  }
+
+  return node.children.flatMap((child) => collectLeafSLOs(child));
+}
+
+/**
+ * Find the worst performing child node
+ */
+function getWorstPerformingChild(children: HierarchyNode[]): HierarchyNode | null {
+  if (children.length === 0) return null;
+
+  return children.reduce((worst, child) => {
+    const worstSli = worst.aggregatedSliValue ?? worst.slo?.summary.sliValue ?? 1;
+    const childSli = child.aggregatedSliValue ?? child.slo?.summary.sliValue ?? 1;
+    return childSli < worstSli ? child : worst;
+  });
+}
+
+function getStatusColor(status?: string): string {
+  switch (status) {
+    case 'VIOLATED':
+      return 'danger';
+    case 'DEGRADING':
+      return 'warning';
+    case 'HEALTHY':
+      return 'success';
+    default:
+      return 'subdued';
+  }
+}
+
+function getNodeIcon(type: HierarchyNode['type']): string {
+  switch (type) {
+    case 'value-stream':
+      return 'branch';
+    case 'business-component':
+      return 'package';
+    case 'service':
+      return 'compute';
+    default:
+      return 'dot';
+  }
+}
+
+function formatName(name: string): string {
+  return name
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/hierarchy_view/slo_hierarchy_view.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/hierarchy_view/slo_hierarchy_view.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTitle,
+  EuiText,
+  EuiSpacer,
+  EuiCallOut,
+  EuiPanel,
+  EuiButton,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { SloHierarchyTree } from './slo_hierarchy_tree';
+import { useFetchSloList } from '../../../../hooks/use_fetch_slo_list';
+
+interface Props {
+  onSwitchToStandardView?: () => void;
+}
+
+export function SloHierarchyView({ onSwitchToStandardView }: Props) {
+  // Fetch all SLOs - in production, you might want pagination or filtering
+  const {
+    data: sloList,
+    isLoading,
+    isError,
+  } = useFetchSloList({
+    perPage: 1000, // Fetch more SLOs for hierarchy view
+  });
+
+  return (
+    <div>
+      <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="m">
+            <h2>
+              {i18n.translate('xpack.slo.hierarchyView.title', {
+                defaultMessage: 'Hierarchical SLO View',
+              })}
+            </h2>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiText size="s" color="subdued">
+            {i18n.translate('xpack.slo.hierarchyView.subtitle', {
+              defaultMessage:
+                'View SLOs organized by value stream, business component, and service. Drill down to identify bottlenecks.',
+            })}
+          </EuiText>
+        </EuiFlexItem>
+        {onSwitchToStandardView && (
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              data-test-subj="sloSloHierarchyViewSwitchToListViewButton"
+              onClick={onSwitchToStandardView}
+              iconType="list"
+            >
+              {i18n.translate('xpack.slo.hierarchyView.switchToStandardView', {
+                defaultMessage: 'Switch to list view',
+              })}
+            </EuiButton>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+
+      <EuiSpacer size="l" />
+
+      <EuiCallOut
+        title={i18n.translate('xpack.slo.hierarchyView.calloutTitle', {
+          defaultMessage: 'How to use hierarchical view',
+        })}
+        color="primary"
+        iconType="iInCircle"
+        size="s"
+      >
+        <p>
+          {i18n.translate('xpack.slo.hierarchyView.calloutDescription', {
+            defaultMessage:
+              'Tag your SLOs with "value-stream:", "business-component:", and "service:" tags to organize them hierarchically. Example: value-stream:customer-onboarding, business-component:identity-verification, service:id-scanner-api',
+          })}
+        </p>
+      </EuiCallOut>
+
+      <EuiSpacer size="l" />
+
+      {isError && (
+        <>
+          <EuiCallOut
+            announceOnMount
+            title={i18n.translate('xpack.slo.hierarchyView.errorTitle', {
+              defaultMessage: 'Error loading SLOs',
+            })}
+            color="danger"
+            iconType="alert"
+          >
+            <p>
+              {i18n.translate('xpack.slo.hierarchyView.errorMessage', {
+                defaultMessage: 'Unable to fetch SLO data. Please try again.',
+              })}
+            </p>
+          </EuiCallOut>
+          <EuiSpacer size="l" />
+        </>
+      )}
+
+      <SloHierarchyTree sloList={sloList?.results || []} loading={isLoading} />
+
+      <EuiSpacer size="l" />
+
+      {/* Statistics Panel */}
+      {sloList && sloList.results.length > 0 && (
+        <EuiPanel hasBorder>
+          <EuiText size="s">
+            <strong>
+              {i18n.translate('xpack.slo.hierarchyView.stats', {
+                defaultMessage: 'Total SLOs: {total}',
+                values: { total: sloList.total },
+              })}
+            </strong>
+          </EuiText>
+        </EuiPanel>
+      )}
+    </div>
+  );
+}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list.tsx
@@ -18,6 +18,7 @@ import { useUrlSearchState } from '../hooks/use_url_search_state';
 import { GroupView } from './grouped_slos/group_view';
 import { ToggleSLOView } from './toggle_slo_view';
 import { UngroupedView } from './ungrouped_slos/ungrouped_view';
+import { SloHierarchyView } from './hierarchy_view';
 
 export function SloList() {
   const { observabilityAIAssistant } = useKibana().services;
@@ -103,23 +104,29 @@ export function SloList() {
           loading={isLoading || isDeletingSlo}
         />
       </EuiFlexItem>
-      {groupBy === 'ungrouped' && (
-        <UngroupedView
-          sloList={sloList}
-          loading={isLoading || isRefetching}
-          error={isError}
-          view={view}
-        />
-      )}
-      {groupBy !== 'ungrouped' && (
-        <GroupView
-          view={view}
-          groupBy={groupBy}
-          kqlQuery={kqlQuery}
-          sort={state.sort.by}
-          direction={state.sort.direction}
-          filters={filters}
-        />
+      {view === 'hierarchyView' ? (
+        <SloHierarchyView onSwitchToStandardView={() => onStateChange({ view: 'cardView' })} />
+      ) : (
+        <>
+          {groupBy === 'ungrouped' && (
+            <UngroupedView
+              sloList={sloList}
+              loading={isLoading || isRefetching}
+              error={isError}
+              view={view}
+            />
+          )}
+          {groupBy !== 'ungrouped' && (
+            <GroupView
+              view={view}
+              groupBy={groupBy}
+              kqlQuery={kqlQuery}
+              sort={state.sort.by}
+              direction={state.sort.direction}
+              filters={filters}
+            />
+          )}
+        </>
       )}
     </EuiFlexGroup>
   );

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/toggle_slo_view.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/toggle_slo_view.tsx
@@ -44,6 +44,14 @@ const toggleButtonsIcons = [
       defaultMessage: 'Compact view',
     }),
   },
+  {
+    iconType: 'aggregate',
+    id: 'hierarchyView',
+    label: i18n.translate('xpack.slo.listView.hierarchyViewLabel', {
+      defaultMessage: 'Hierarchy view',
+    }),
+    'data-test-subj': 'sloHierarchyViewButton',
+  },
 ];
 
 export function ToggleSLOView({
@@ -64,7 +72,7 @@ export function ToggleSLOView({
   return (
     <EuiFlexGroup alignItems="center">
       <EuiFlexItem grow={true}>
-        {(!state.groupBy || state.groupBy === 'ungrouped') && (
+        {(!state.groupBy || state.groupBy === 'ungrouped') && view !== 'hierarchyView' && (
           <EuiText size="s">
             <FormattedMessage
               id="xpack.slo.overview.pagination.description"
@@ -82,12 +90,16 @@ export function ToggleSLOView({
           </EuiText>
         )}
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <SLOSortBy state={state} onStateChange={onStateChange} loading={loading} />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <SloGroupBy state={state} onStateChange={onStateChange} loading={loading} />
-      </EuiFlexItem>
+      {view !== 'hierarchyView' && (
+        <>
+          <EuiFlexItem grow={false}>
+            <SLOSortBy state={state} onStateChange={onStateChange} loading={loading} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <SloGroupBy state={state} onStateChange={onStateChange} loading={loading} />
+          </EuiFlexItem>
+        </>
+      )}
       <EuiFlexItem grow={false}>
         <EuiButtonGroup
           buttonSize="compressed"

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export type ViewType = 'cardView' | 'listView' | 'compactView';
+export type ViewType = 'cardView' | 'listView' | 'compactView' | 'hierarchyView';
 export type GroupByField =
   | 'ungrouped'
   | 'slo.tags'


### PR DESCRIPTION
## Summary

- Hierarchical SLO view as a 4th view option (card, list, compact, hierarchy)
- Aggregated error budget calculation for parent nodes
- Clickable service nodes that navigate to SLO details
- Demo script that creates 18 SLOs organized by value streams → business components → services


