### PR TITLE
[inference] Add support for gemini-3-pro

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/gemini/gemini_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/gemini/gemini_adapter.ts
@@ -15,6 +15,7 @@ import { eventSourceStreamIntoObservable } from '../../../util/event_source_stre
 import { processVertexStream } from './process_vertex_stream';
 import type { GenerateContentResponseChunk, GeminiMessage, GeminiToolConfig } from './types';
 import { getTemperatureIfValid } from '../../utils/get_temperature';
+import { mustUseThoughtSignature } from './utils';
 
 export const geminiAdapter: InferenceConnectorAdapter = {
   chatComplete: ({
@@ -29,11 +30,15 @@ export const geminiAdapter: InferenceConnectorAdapter = {
     metadata,
   }) => {
     const connector = executor.getConnector();
+    const useThoughtSignature = mustUseThoughtSignature(
+      modelName ?? connector.config?.defaultModel
+    );
+
     return defer(() => {
       return executor.invoke({
         subAction: 'invokeStream',
         subActionParams: {
-          messages: messagesToGemini({ messages }),
+          messages: messagesToGemini({ messages, useThoughtSignature }),
           systemInstruction: system,
           tools: toolsToGemini(tools),
           toolConfig: toolChoiceToConfig(toolChoice),
@@ -163,8 +168,16 @@ function toolSchemaToGemini({ schema }: { schema: ToolSchema }): Gemini.Function
   };
 }
 
-function messagesToGemini({ messages }: { messages: Message[] }): GeminiMessage[] {
-  return messages.map(messageToGeminiMapper()).reduce<GeminiMessage[]>((output, message) => {
+const skipThoughtSignatureHash = 'skip_thought_signature_validator';
+
+function messagesToGemini({
+  messages,
+  useThoughtSignature,
+}: {
+  messages: Message[];
+  useThoughtSignature: boolean;
+}): GeminiMessage[] {
+  let mapped = messages.map(messageToGeminiMapper()).reduce<GeminiMessage[]>((output, message) => {
     // merging consecutive messages from the same user, as Gemini requires multi-turn messages
     const previousMessage = output.length ? output[output.length - 1] : undefined;
     if (previousMessage?.role === message.role) {
@@ -174,7 +187,28 @@ function messagesToGemini({ messages }: { messages: Message[] }): GeminiMessage[
     }
     return output;
   }, []);
+
+  if (useThoughtSignature) {
+    mapped = mapped.map((message, index, array) => {
+      if (index < array.length - 1) {
+        addThoughtSignatureToFirstFunctionCall(message);
+      }
+      return message;
+    });
+  }
+
+  return mapped;
 }
+
+const addThoughtSignatureToFirstFunctionCall = (message: GeminiMessage) => {
+  for (const part of message.parts) {
+    if (part.functionCall) {
+      // @ts-expect-error - Gemini types are not up to date, this is a valid property
+      part.thoughtSignature = skipThoughtSignatureHash;
+      break;
+    }
+  }
+};
 
 function messageToGeminiMapper() {
   return (message: Message): GeminiMessage => {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/gemini/utils.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/gemini/utils.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Checks if the specified model must provide thought signatures for
+ */
+export const mustUseThoughtSignature = (modelName: string | undefined): boolean => {
+  // if we couldn't resolve the model name, we can't know if it must use thought signatures
+  if (modelName === undefined) {
+    return false;
+  }
+  return isGemini3Pro(modelName);
+};
+
+const isGemini3Pro = (modelName: string) => modelName.toLowerCase().includes('gemini-3-pro');


### PR DESCRIPTION
## Summary

On Gemini 3-pro, [thought signature](https://ai.google.dev/gemini-api/docs/thought-signatures) is mandatory. 

There is still an escape hatch, 


> While injecting custom function call blocks into the request is strongly discouraged, in cases where it can't be avoided, e.g. providing information to the model on function calls and responses that were executed deterministically by the client, or transferring a trace from a different model that does not include thought signatures, you can set the following dummy signatures of either "context_engineering_is_the_way_to_go" or "skip_thought_signature_validator" in the thought signature field to skip validation.

Which we are going to use for now because keeping track of a provider-specific hash in our higher level code is a lot of work, and because it's not going to work for all use cases anyway.
