### PR TITLE
Fix FTR exit code to correctly return 1 on test failures

### DIFF
--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/cli/ftr.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/cli/ftr.ts
@@ -89,12 +89,12 @@ export function runFtrCli() {
           process.exitCode = 1;
         } else {
           await reportTime(runStartTime, 'total', {
-            success: true,
+            success: process.exitCode === 0,
             ...Object.fromEntries(flagsReader.getUsed().entries()),
           });
         }
 
-        process.exit();
+        process.exit(process.exitCode);
       };
 
       process.on('unhandledRejection', (err) =>


### PR DESCRIPTION
## Summary

Changed success reporting to check process.exitCode and changed process.exit() to process.exit(process.exitCode) so it uses the exit code that was set on line 114. Now when tests fail through normal assertions (not exceptions), the exit code will correctly be 1.


### Details

We noticed a few pipelines [like](https://buildkite.com/elastic/appex-qa-stateful-kibana-ftr-tests/builds/519) have test failures but pipeline seems successful. When running test locally Exit code was always `0` for success and failure.

### Root Cause

In `src/platform/packages/shared/kbn-test/src/functional_test_runner/cli/ftr.ts`, the `teardown()` function was calling `process.exit()` without an argument on line 97. When `process.exit()` is called without an argument, defaults to exit code `0`, ignoring any previously set `process.exitCode` value. This meant that even though the test runner correctly set `process.exitCode = 1` when tests failed, the exit code was being overridden to `0` during teardown.

Before: 
<img width="1232" height="491" alt="Screenshot 2025-11-19 at 11 25 03 AM" src="https://github.com/user-attachments/assets/8fc9edb1-dd74-4b58-8494-028087be5bb2" />

After: 
<img width="1232" height="261" alt="Screenshot 2025-11-19 at 12 25 29 PM" src="https://github.com/user-attachments/assets/90b7e574-f799-4fa9-9259-3464a5e93040" />

