### PR TITLE
Enable skipBundleRoutesIfCdnEnabled by default

### DIFF
--- a/src/core/packages/apps/server-internal/src/core_app_config.test.ts
+++ b/src/core/packages/apps/server-internal/src/core_app_config.test.ts
@@ -15,7 +15,7 @@ describe('CoreApp Config', () => {
     expect(configValue).toMatchInlineSnapshot(`
       CoreAppConfig {
         "allowDynamicConfigOverrides": false,
-        "skipBundleRoutesIfCdnEnabled": false,
+        "skipBundleRoutesIfCdnEnabled": true,
       }
     `);
   });

--- a/src/core/packages/apps/server-internal/src/core_app_config.ts
+++ b/src/core/packages/apps/server-internal/src/core_app_config.ts
@@ -16,7 +16,10 @@ import type { ServiceConfigDescriptor } from '@kbn/core-base-server-internal';
  */
 export const configSchema = schema.object({
   allowDynamicConfigOverrides: schema.boolean({ defaultValue: false }),
-  skipBundleRoutesIfCdnEnabled: schema.boolean({ defaultValue: false }),
+  /**
+   * Do not register unused bundle routes if the CDN configuration is enabled.
+   */
+  skipBundleRoutesIfCdnEnabled: schema.boolean({ defaultValue: true }),
 });
 
 export type CoreAppConfigType = TypeOf<typeof configSchema>;


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/232928.

After confirming that this works as intended, we're happy to enable it by default.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- [x] If there's any misbehavior, it can be reverted by explicitly setting this to `false`.
- [x] If the CDN has an outage, disabling the CDN configuration solves the problem (no need to change this setting). This aligns with the current guidance.



