### PR TITLE
Fix Create GCP Credentials guide

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/gcp_credentials_form/gcp_credentials_form_agentless.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/gcp_credentials_form/gcp_credentials_form_agentless.test.tsx
@@ -294,7 +294,7 @@ describe('GcpCredentialsFormAgentless', () => {
       expect(screen.getByTestId('gcp-credentials-guide')).toBeInTheDocument();
       expect(screen.getByTestId('guide-organization-state')).toHaveTextContent('false');
       expect(screen.getByTestId('guide-command-text')).toHaveTextContent(
-        'gcloud config set project <PROJECT_ID> ./deploy_service_account.sh'
+        'gcloud config set project <PROJECT_ID> && ./deploy_service_account.sh'
       );
     });
   });
@@ -339,7 +339,7 @@ describe('GcpCredentialsFormAgentless', () => {
 
       expect(screen.getByTestId('guide-organization-state')).toHaveTextContent('true');
       expect(screen.getByTestId('guide-command-text')).toHaveTextContent(
-        'gcloud config set project <PROJECT_ID> && ORG_ID=<ORG_ID_VALUE> ./deploy_service_account.sh'
+        'gcloud config set project <PROJECT_ID> && ORG_ID=<ORG_ID_VALUE> && ./deploy_service_account.sh'
       );
     });
   });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/gcp_credentials_form/gcp_credentials_form_agentless.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/gcp_credentials_form/gcp_credentials_form_agentless.tsx
@@ -73,8 +73,8 @@ export const GcpCredentialsFormAgentless = ({
   )?.replace(TEMPLATE_URL_ACCOUNT_TYPE_ENV_VAR, accountType);
 
   const commandText = `gcloud config set project ${
-    isOrganization ? `<PROJECT_ID> && ORG_ID=<ORG_ID_VALUE>` : `<PROJECT_ID>`
-  } ./deploy_service_account.sh`;
+    isOrganization ? `<PROJECT_ID> && ORG_ID=<ORG_ID_VALUE> && ` : `<PROJECT_ID> && `
+  }./deploy_service_account.sh`;
 
   return (
     <>

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/gcp_credentials_form/gcp_credentials_guide.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/gcp_credentials_form/gcp_credentials_guide.test.tsx
@@ -17,7 +17,7 @@ const renderWithIntl = (component: React.ReactElement) => {
 
 describe('GoogleCloudShellCredentialsGuide', () => {
   const defaultProps = {
-    commandText: 'gcloud config set project <PROJECT_ID> ./deploy_service_account.sh',
+    commandText: 'gcloud config set project <PROJECT_ID> && ./deploy_service_account.sh',
     isOrganization: false,
   };
 
@@ -159,7 +159,10 @@ describe('GoogleCloudShellCredentialsGuide', () => {
       expect(screen.getByText('Trust Repo')).toBeInTheDocument();
       expect(screen.getByText('Confirm')).toBeInTheDocument();
 
-      // Step 5: Run command (text is split across elements, use matcher function)
+      // Step 5: Authorize
+      expect(screen.getByText('Authorize')).toBeInTheDocument();
+
+      // Step 6: Run command
       expect(
         screen.getByText((content, element) => {
           return (
@@ -168,7 +171,7 @@ describe('GoogleCloudShellCredentialsGuide', () => {
         })
       ).toBeInTheDocument();
 
-      // Step 6: Copy JSON
+      // Step 7: Copy JSON
       expect(screen.getByText('cat KEY_FILE.json')).toBeInTheDocument();
     });
 
@@ -176,7 +179,7 @@ describe('GoogleCloudShellCredentialsGuide', () => {
       renderWithIntl(<GoogleCloudShellCredentialsGuide {...defaultProps} />);
 
       const listItems = screen.getAllByRole('listitem');
-      expect(listItems).toHaveLength(6); // Should have 6 instruction steps
+      expect(listItems).toHaveLength(7);
     });
   });
 

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/gcp_credentials_form/gcp_credentials_guide.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/gcp_credentials_form/gcp_credentials_guide.tsx
@@ -103,6 +103,18 @@ export const GoogleCloudShellCredentialsGuide = (props: {
             <EuiSpacer size="xs" />
             <li>
               <FormattedMessage
+                id="securitySolutionPackages.cloudSecurityPosture.cloudSetup.gcp.cloudshell.guide.steps.authorize"
+                defaultMessage="Click {authorizeButton} if prompted to authorize {googleCloudShell}"
+                values={{
+                  authorizeButton: <strong>{'Authorize'}</strong>,
+                  googleCloudShell: <strong>{'Google Cloud Shell'}</strong>,
+                }}
+                ignoreTag
+              />
+            </li>
+            <EuiSpacer size="xs" />
+            <li>
+              <FormattedMessage
                 id="securitySolutionPackages.cloudSecurityPosture.cloudSetup.gcp.cloudshell.guide.steps.runCloudShellScript"
                 defaultMessage="Paste and run command in the {googleCloudShell} terminal"
                 values={{
@@ -115,7 +127,7 @@ export const GoogleCloudShellCredentialsGuide = (props: {
             <li>
               <FormattedMessage
                 id="securitySolutionPackages.cloudSecurityPosture.cloudSetup.gcp.cloudshell.guide.steps.copyJsonServiceKey"
-                defaultMessage="Run {catCommand} to view the service account key. Copy and paste Credentials JSON below"
+                defaultMessage="Run {catCommand} to view the service account key. Copy the entire output and paste into Credentials JSON below"
                 values={{
                   catCommand: <code>{'cat KEY_FILE.json'}</code>,
                 }}


### PR DESCRIPTION
## Summary

fixes:
- https://github.com/elastic/kibana/issues/214128

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




