### PR TITLE
[Security Solution][Attacks/Alerts][Attacks page][Header Section] Schedule button (#233450)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/schedule/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/schedule/index.tsx
@@ -12,7 +12,7 @@ import { SCHEDULE_TAB_ID } from '../../settings_flyout/constants';
 import * as i18n from './translations';
 
 interface Props {
-  isLoading: boolean;
+  isLoading?: boolean;
   openFlyout: (tabId: string) => void;
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/content.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/content.test.tsx
@@ -28,4 +28,16 @@ describe('AttacksPageContent', () => {
       expect(screen.getByTestId('header-page-title')).toHaveTextContent('Attacks');
     });
   });
+
+  it('should render `Schedule` button', async () => {
+    render(
+      <TestProviders>
+        <AttacksPageContent dataView={dataView} />
+      </TestProviders>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule')).toBeInTheDocument();
+    });
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/content.tsx
@@ -5,17 +5,20 @@
  * 2.0.
  */
 
+import React, { useCallback, useRef, useState } from 'react';
 import { EuiHorizontalRule, EuiSpacer, EuiWindowEvent } from '@elastic/eui';
 import styled from '@emotion/styled';
 import { noop } from 'lodash/fp';
-import React, { useRef } from 'react';
 import type { DataView } from '@kbn/data-views-plugin/common';
+
+import { Schedule } from '../../../attack_discovery/pages/header/schedule';
 import { PAGE_TITLE } from '../../pages/attacks/translations';
 import { HeaderPage } from '../../../common/components/header_page';
 import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
 import { useGlobalFullScreen } from '../../../common/containers/use_full_screen';
 import { Display } from '../../../explore/hosts/pages/display';
 import { SearchBarSection } from './search_bar/search_bar_section';
+import { SchedulesFlyout } from './schedule_flyout';
 
 export const CONTENT_TEST_ID = 'attacks-page-content';
 export const SECURITY_SOLUTION_PAGE_WRAPPER_TEST_ID = 'attacks-page-security-solution-page-wrapper';
@@ -44,6 +47,13 @@ export const AttacksPageContent = React.memo(({ dataView }: AttacksPageContentPr
 
   const { globalFullScreen } = useGlobalFullScreen();
 
+  // showing / hiding the flyout:
+  const [showFlyout, setShowFlyout] = useState<boolean>(false);
+  const openFlyout = useCallback(() => {
+    setShowFlyout(true);
+  }, []);
+  const onClose = useCallback(() => setShowFlyout(false), []);
+
   return (
     <StyledFullHeightContainer data-test-subj={CONTENT_TEST_ID} ref={containerElement}>
       <EuiWindowEvent event="resize" handler={noop} />
@@ -53,10 +63,14 @@ export const AttacksPageContent = React.memo(({ dataView }: AttacksPageContentPr
         data-test-subj={SECURITY_SOLUTION_PAGE_WRAPPER_TEST_ID}
       >
         <Display show={!globalFullScreen}>
-          <HeaderPage title={PAGE_TITLE} />
+          <HeaderPage title={PAGE_TITLE}>
+            <Schedule openFlyout={openFlyout} />
+          </HeaderPage>
           <EuiHorizontalRule margin="none" />
           <EuiSpacer size="l" />
         </Display>
+
+        {showFlyout && <SchedulesFlyout onClose={onClose} />}
       </SecuritySolutionPageWrapper>
     </StyledFullHeightContainer>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/schedule_flyout/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/schedule_flyout/index.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SchedulesFlyout } from '.';
+import { useKibana } from '../../../../common/lib/kibana';
+import { TestProviders } from '../../../../common/mock';
+import { useSourcererDataView } from '../../../../sourcerer/containers';
+import {
+  ATTACK_DISCOVERY_SCHEDULE,
+  ATTACK_DISCOVERY_SETTINGS,
+} from '../../../../attack_discovery/pages/settings_flyout/translations';
+
+jest.mock('../../../../common/hooks/use_experimental_features');
+jest.mock('../../../../common/lib/kibana');
+jest.mock('../../../../sourcerer/containers');
+jest.mock('react-router-dom', () => ({
+  matchPath: jest.fn(),
+  useLocation: jest.fn().mockReturnValue({
+    search: '',
+  }),
+  withRouter: jest.fn(),
+}));
+
+const mockUseKibanaFeatureFlags = jest
+  .fn()
+  .mockReturnValue({ attackDiscoveryPublicApiEnabled: false });
+jest.mock('../../../../attack_discovery/pages/use_kibana_feature_flags', () => ({
+  useKibanaFeatureFlags: () => mockUseKibanaFeatureFlags(),
+}));
+
+const defaultProps = {
+  onClose: jest.fn(),
+};
+
+const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
+const mockUseSourcererDataView = useSourcererDataView as jest.MockedFunction<
+  typeof useSourcererDataView
+>;
+
+const setupMocks = () => {
+  mockUseKibana.mockReturnValue({
+    services: {
+      lens: {
+        EmbeddableComponent: () => <div data-test-subj="mockEmbeddableComponent" />,
+      },
+      uiSettings: {
+        get: jest.fn(),
+      },
+      unifiedSearch: {
+        ui: {
+          SearchBar: () => <div data-test-subj="mockSearchBar" />,
+        },
+      },
+    },
+  } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+
+  mockUseSourcererDataView.mockReturnValue({
+    sourcererDataView: {},
+    loading: false,
+  } as unknown as jest.Mocked<ReturnType<typeof useSourcererDataView>>);
+};
+
+const renderComponent = (props = defaultProps) => {
+  return render(
+    <TestProviders>
+      <SchedulesFlyout {...props} />
+    </TestProviders>
+  );
+};
+
+const clickButton = (testId: string) => {
+  const button = screen.getByTestId(testId);
+  fireEvent.click(button);
+};
+
+describe('SchedulesFlyout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMocks();
+  });
+
+  it('does not render the settings tab', () => {
+    renderComponent();
+
+    expect(
+      screen.queryByRole('heading', { name: ATTACK_DISCOVERY_SETTINGS })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the schedule tab', async () => {
+    renderComponent();
+
+    expect(screen.getByRole('heading', { name: ATTACK_DISCOVERY_SCHEDULE })).toBeInTheDocument();
+  });
+
+  it('invokes onClose when the close button is clicked', () => {
+    renderComponent();
+
+    clickButton('euiFlyoutCloseButton');
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/schedule_flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/schedule_flyout/index.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { noop } from 'lodash/fp';
+
+import { SettingsFlyout } from '../../../../attack_discovery/pages/settings_flyout';
+import { SCHEDULE_TAB_ID } from '../../../../attack_discovery/pages/settings_flyout/constants';
+
+export interface SchedulesFlyoutProps {
+  /**
+   * Handles the flyout `onClose` callback
+   */
+  onClose: () => void;
+}
+
+/**
+ * The wrapper around attack discovery schedules flyout
+ * NOTE: Added to hide internal implementation and bunch of not used fields
+ */
+export const SchedulesFlyout = React.memo(({ onClose }: SchedulesFlyoutProps) => {
+  return (
+    <SettingsFlyout
+      connectorId={undefined}
+      defaultSelectedTabId={SCHEDULE_TAB_ID}
+      end={undefined}
+      filters={undefined}
+      onClose={onClose}
+      onConnectorIdSelected={noop}
+      onGenerate={() => Promise.resolve()}
+      query={undefined}
+      setEnd={noop}
+      setFilters={noop}
+      setQuery={noop}
+      setStart={noop}
+      start={undefined}
+      localStorageAttackDiscoveryMaxAlerts={undefined}
+      setLocalStorageAttackDiscoveryMaxAlerts={noop}
+    />
+  );
+});
+SchedulesFlyout.displayName = 'SchedulesFlyout';


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/233450

These changes add `Schedule` button to the Attacks page. The button is reused from the Attack discovery page.

## Feature Flag

> [!NOTE]
> The feature is hidden behind the feature flag (in `kibana.dev.yml`):

```
feature_flags.overrides:
  securitySolution.attacksAlertsAlignment: true
```

## Testing

1. Enabled feature flag
2. Navigate to Detections > Attacks page

**Expected**: There should be a `Schedule` button in the header section of the page. The button should behave the same as the one on the Attack discovery page.

## Video recording

https://github.com/user-attachments/assets/0fd15115-21cc-4544-93d6-0e8f00134728
