### PR TITLE
[One Workflow] Completion provider updates with debounced changes

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/middleware.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/middleware.ts
@@ -13,7 +13,7 @@ import { _clearComputedData, _setComputedDataInternal, setYamlString } from './s
 import { performComputation } from './utils/computation';
 import type { RootState } from '../types';
 
-const COMPUTATION_DEBOUNCE_MS = 500;
+const COMPUTATION_DEBOUNCE_MS = 300;
 
 const compute = (yamlString: string, store: MiddlewareAPI<Dispatch<AnyAction>, RootState>) => {
   try {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_workflow_yaml_completion_provider.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_workflow_yaml_completion_provider.test.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { monaco, YAML_LANG_ID } from '@kbn/monaco';
+import { useWorkflowYamlCompletionProvider } from './use_workflow_yaml_completion_provider';
+import { createMockStore } from '../../../../entities/workflows/store/__mocks__/store.mock';
+import {
+  _setComputedDataInternal,
+  setActiveTab,
+  setYamlString,
+} from '../../../../entities/workflows/store/workflow_detail/slice';
+import type { ComputedData } from '../../../../entities/workflows/store/workflow_detail/types';
+import { getCompletionItemProvider } from '../../lib/autocomplete/get_completion_item_provider';
+
+// Mock the completion provider
+const mockCompletionProvider = {
+  triggerCharacters: ['@', '.', ' ', '|', '{'],
+  provideCompletionItems: jest.fn(),
+};
+
+jest.mock('../../lib/autocomplete/get_completion_item_provider', () => ({
+  getCompletionItemProvider: jest.fn(() => mockCompletionProvider),
+}));
+
+// Mock Monaco
+jest.mock('@kbn/monaco', () => {
+  const mockDisposableValue = {
+    dispose: jest.fn(),
+  };
+  const mockRegisterCompletionItemProvider = jest.fn().mockReturnValue(mockDisposableValue);
+  return {
+    monaco: {
+      languages: {
+        registerCompletionItemProvider: mockRegisterCompletionItemProvider,
+      },
+    },
+    YAML_LANG_ID: 'yaml',
+  };
+});
+
+// Helper function to create a mock editor
+const createMockEditor = (): monaco.editor.IStandaloneCodeEditor => {
+  return {
+    getModel: jest.fn(),
+    dispose: jest.fn(),
+  } as unknown as monaco.editor.IStandaloneCodeEditor;
+};
+
+// Helper function to create mock computed data
+const createMockComputedData = (overrides: Partial<ComputedData> = {}): ComputedData => ({
+  yamlDocument: undefined,
+  yamlLineCounter: undefined,
+  workflowLookup: undefined,
+  workflowGraph: undefined,
+  workflowDefinition: undefined,
+  ...overrides,
+});
+
+// Helper to render hook with Redux provider
+const renderHookWithProviders = (
+  editor: monaco.editor.IStandaloneCodeEditor | null,
+  initialComputed?: ComputedData
+) => {
+  const store = createMockStore();
+
+  // Set initial YAML
+  store.dispatch(setYamlString('version: "1"\nname: test'));
+  store.dispatch(setActiveTab('workflow'));
+
+  // Set computed data if provided
+  if (initialComputed) {
+    store.dispatch(_setComputedDataInternal(initialComputed));
+  }
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => {
+    return React.createElement(Provider, { store }, children);
+  };
+
+  return {
+    ...renderHook(
+      (currentEditor: monaco.editor.IStandaloneCodeEditor | null) =>
+        useWorkflowYamlCompletionProvider(currentEditor),
+      {
+        wrapper,
+        initialProps: editor,
+      }
+    ),
+    store,
+  };
+};
+
+describe('useWorkflowYamlCompletionProvider', () => {
+  // Get the mock disposable from a specific call index
+  const getMockDisposable = (callIndex: number = 0) => {
+    const results = (monaco.languages.registerCompletionItemProvider as jest.Mock).mock.results;
+    if (results.length === 0) return null;
+    return results[callIndex]?.value ?? null;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should register completion provider when editor and computed are provided', () => {
+    const editor = createMockEditor();
+    const computed = createMockComputedData();
+    renderHookWithProviders(editor, computed);
+
+    expect(getCompletionItemProvider).toHaveBeenCalledTimes(1);
+    expect(monaco.languages.registerCompletionItemProvider).toHaveBeenCalledWith(
+      YAML_LANG_ID,
+      mockCompletionProvider
+    );
+  });
+
+  it('should pass a function to getCompletionItemProvider that returns current state', () => {
+    const editor = createMockEditor();
+    const computed = createMockComputedData();
+    const { store } = renderHookWithProviders(editor, computed);
+
+    const getStateFn = (getCompletionItemProvider as jest.Mock).mock.calls[0][0];
+    const state = getStateFn();
+
+    expect(state).toEqual(store.getState().detail);
+  });
+
+  it('should use latest state via ref when provider is called', () => {
+    const editor = createMockEditor();
+    const computed = createMockComputedData();
+    const { store } = renderHookWithProviders(editor, computed);
+
+    const getStateFn = (getCompletionItemProvider as jest.Mock).mock.calls[0][0];
+
+    act(() => {
+      store.dispatch(setYamlString('version: "1"\nname: updated'));
+    });
+
+    const currentState = getStateFn();
+    expect(currentState.yamlString).toBe('version: "1"\nname: updated');
+  });
+
+  it('should dispose completion provider when component unmounts', () => {
+    const editor = createMockEditor();
+    const computed = createMockComputedData();
+    const { unmount } = renderHookWithProviders(editor, computed);
+
+    expect(monaco.languages.registerCompletionItemProvider).toHaveBeenCalledTimes(1);
+    const disposable = getMockDisposable(0);
+    expect(disposable?.dispose).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(disposable?.dispose).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_workflow_yaml_completion_provider.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_workflow_yaml_completion_provider.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { monaco, YAML_LANG_ID } from '@kbn/monaco';
@@ -162,4 +162,3 @@ describe('useWorkflowYamlCompletionProvider', () => {
     expect(disposable?.dispose).toHaveBeenCalledTimes(1);
   });
 });
-

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_workflow_yaml_completion_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_workflow_yaml_completion_provider.ts
@@ -7,21 +7,58 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
-import type { monaco } from '@kbn/monaco';
+import { monaco, YAML_LANG_ID } from '@kbn/monaco';
 import type { WorkflowDetailState } from '../../../../entities/workflows/store';
-import { selectDetail } from '../../../../entities/workflows/store/workflow_detail/selectors';
+import {
+  selectDetail,
+  selectEditorComputed,
+} from '../../../../entities/workflows/store/workflow_detail/selectors';
 import { getCompletionItemProvider } from '../../lib/autocomplete/get_completion_item_provider';
 
-export const useWorkflowYamlCompletionProvider = (): monaco.languages.CompletionItemProvider => {
+export const useWorkflowYamlCompletionProvider = (
+  editor: monaco.editor.IStandaloneCodeEditor | null
+): void => {
   const editorState = useSelector(selectDetail);
   const editorStateRef = useRef<WorkflowDetailState>(editorState);
   editorStateRef.current = editorState;
 
-  const completionProvider = useMemo(() => {
-    return getCompletionItemProvider(() => editorStateRef.current);
-  }, []);
+  const computed = useSelector(selectEditorComputed);
 
-  return completionProvider;
+  // Create a new completion provider when the computed data changes to ensure we get the latest data
+  // Computed data is calculations are debounced so we need to force an update when the computed data changes
+  const completionProvider = useMemo(() => {
+    if (!computed) {
+      return undefined; // only happens on the initial state
+    }
+    return getCompletionItemProvider(() => editorStateRef.current);
+  }, [computed]);
+
+  // Register/unregister completion provider when completionProvider data changes
+  const completionProviderDisposableRef = useRef<monaco.IDisposable | null>(null);
+  useEffect(() => {
+    if (!editor || !completionProvider) {
+      return;
+    }
+
+    // Dispose previous registration if it exists
+    if (completionProviderDisposableRef.current) {
+      completionProviderDisposableRef.current.dispose();
+      completionProviderDisposableRef.current = null;
+    }
+
+    const disposable = monaco.languages.registerCompletionItemProvider(
+      YAML_LANG_ID,
+      completionProvider
+    );
+    completionProviderDisposableRef.current = disposable;
+
+    return () => {
+      if (completionProviderDisposableRef.current) {
+        completionProviderDisposableRef.current.dispose();
+        completionProviderDisposableRef.current = null;
+      }
+    };
+  }, [completionProvider, editor]);
 };

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_workflow_yaml_completion_provider.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/hooks/use_workflow_yaml_completion_provider.ts
@@ -29,16 +29,13 @@ export const useWorkflowYamlCompletionProvider = (
   // Create a new completion provider when the computed data changes to ensure we get the latest data
   // Computed data is calculations are debounced so we need to force an update when the computed data changes
   const completionProvider = useMemo(() => {
-    if (!computed) {
-      return undefined; // only happens on the initial state
-    }
     return getCompletionItemProvider(() => editorStateRef.current);
-  }, [computed]);
+  }, []);
 
   // Register/unregister completion provider when completionProvider data changes
   const completionProviderDisposableRef = useRef<monaco.IDisposable | null>(null);
   useEffect(() => {
-    if (!editor || !completionProvider) {
+    if (!editor || !completionProvider || !computed) {
       return;
     }
 
@@ -60,5 +57,5 @@ export const useWorkflowYamlCompletionProvider = (
         completionProviderDisposableRef.current = null;
       }
     };
-  }, [completionProvider, editor]);
+  }, [completionProvider, editor, computed]);
 };

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -17,7 +17,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
 import type YAML from 'yaml';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { monaco, YAML_LANG_ID } from '@kbn/monaco';
+import { monaco } from '@kbn/monaco';
 import { isTriggerType } from '@kbn/workflows';
 import type { WorkflowStepExecutionDto } from '@kbn/workflows/types/v1';
 import type { z } from '@kbn/zod';
@@ -267,8 +267,6 @@ export const WorkflowYAMLEditor = ({
     []
   );
 
-  const completionProvider = useWorkflowYamlCompletionProvider();
-
   const handleEditorDidMount = useCallback(
     (editor: monaco.editor.IStandaloneCodeEditor) => {
       editorRef.current = editor;
@@ -278,14 +276,6 @@ export const WorkflowYAMLEditor = ({
         openActionsPopover,
         ...keyboardHandlers,
       });
-
-      if (completionProvider) {
-        const disposable = monaco.languages.registerCompletionItemProvider(
-          YAML_LANG_ID,
-          completionProvider
-        );
-        disposablesRef.current.push(disposable);
-      }
 
       // Listen to content changes to detect typing
       const model = editor.getModel();
@@ -355,6 +345,9 @@ export const WorkflowYAMLEditor = ({
       editor?.dispose();
     };
   }, []);
+
+  // Completion provider
+  useWorkflowYamlCompletionProvider(editorRef.current);
 
   // Decorations
   useTriggerTypeDecorations({


### PR DESCRIPTION
## Summary

closes: https://github.com/elastic/security-team/issues/14602

follow-up of: https://github.com/elastic/kibana/pull/243159

The completion provider is re-registered when the `computed` (debounced) data updates. The completion provider is not created again, the same instance is reused, it is simply disposed of and then registered again.

### Demo

Sometimes it takes some time for the suggestions to refresh (the debounce time), but they always end up showing the right thing:

https://github.com/user-attachments/assets/e1144d20-268f-425d-800e-28f4cff9687b

