### PR TITLE
[8.19] [Fleet] Add in progress agent count to automatic upgrade status (#243066)

### DIFF
--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -12846,25 +12846,41 @@
                         "additionalProperties": false,
                         "properties": {
                           "agents": {
+                            "description": "Number of agents that upgraded to this version",
                             "type": "number"
                           },
                           "failedUpgradeActionIds": {
+                            "description": "List of action IDs related to failed upgrades",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
                           "failedUpgradeAgents": {
+                            "description": "Number of agents that failed to upgrade to this version",
+                            "type": "number"
+                          },
+                          "inProgressUpgradeActionIds": {
+                            "description": "List of action IDs related to in-progress upgrades",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "inProgressUpgradeAgents": {
+                            "description": "Number of agents that are upgrading to this version",
                             "type": "number"
                           },
                           "version": {
+                            "description": "Agent version",
                             "type": "string"
                           }
                         },
                         "required": [
                           "version",
                           "agents",
-                          "failedUpgradeAgents"
+                          "failedUpgradeAgents",
+                          "inProgressUpgradeAgents"
                         ],
                         "type": "object"
                       },

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -18759,19 +18759,32 @@ paths:
                       type: object
                       properties:
                         agents:
+                          description: Number of agents that upgraded to this version
                           type: number
                         failedUpgradeActionIds:
+                          description: List of action IDs related to failed upgrades
                           items:
                             type: string
                           type: array
                         failedUpgradeAgents:
+                          description: Number of agents that failed to upgrade to this version
+                          type: number
+                        inProgressUpgradeActionIds:
+                          description: List of action IDs related to in-progress upgrades
+                          items:
+                            type: string
+                          type: array
+                        inProgressUpgradeAgents:
+                          description: Number of agents that are upgrading to this version
                           type: number
                         version:
+                          description: Agent version
                           type: string
                       required:
                         - version
                         - agents
                         - failedUpgradeAgents
+                        - inProgressUpgradeAgents
                     type: array
                   totalAgents:
                     type: number

--- a/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/rest_spec/agent_policy.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { type TypeOf, schema } from '@kbn/config-schema';
+
 import type { AgentPolicy, NewAgentPolicy, FullAgentPolicy } from '../models';
 
 import type { ListResult, ListWithKuery, BulkGetResult } from './common';
@@ -31,17 +33,44 @@ export interface GetOneAgentPolicyResponse {
   item: AgentPolicy;
 }
 
-export interface CurrentVersionCount {
-  version: string;
-  agents: number;
-  failedUpgradeAgents: number;
-  failedUpgradeActionIds?: string[];
-}
+export const GetAutoUpgradeAgentsStatusResponseSchema = schema.object({
+  currentVersions: schema.arrayOf(
+    schema.object({
+      version: schema.string({
+        meta: { description: 'Agent version' },
+      }),
+      agents: schema.number({
+        meta: { description: 'Number of agents that upgraded to this version' },
+      }),
+      failedUpgradeAgents: schema.number({
+        meta: { description: 'Number of agents that failed to upgrade to this version' },
+      }),
+      failedUpgradeActionIds: schema.maybe(
+        schema.arrayOf(schema.string(), {
+          meta: { description: 'List of action IDs related to failed upgrades' },
+        })
+      ),
+      inProgressUpgradeAgents: schema.number({
+        meta: { description: 'Number of agents that are upgrading to this version' },
+      }),
+      inProgressUpgradeActionIds: schema.maybe(
+        schema.arrayOf(schema.string(), {
+          meta: { description: 'List of action IDs related to in-progress upgrades' },
+        })
+      ),
+    })
+  ),
+  totalAgents: schema.number(),
+});
 
-export interface GetAutoUpgradeAgentsStatusResponse {
-  currentVersions: CurrentVersionCount[];
-  totalAgents: number;
-}
+export type GetAutoUpgradeAgentsStatusResponse = TypeOf<
+  typeof GetAutoUpgradeAgentsStatusResponseSchema
+>;
+
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+export type CurrentVersionCount = Writeable<
+  GetAutoUpgradeAgentsStatusResponse['currentVersions'][number]
+>;
 
 export interface CreateAgentPolicyRequest {
   body: NewAgentPolicy;

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/manage_auto_upgrade_agents_modal/status_column.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/components/manage_auto_upgrade_agents_modal/status_column.tsx
@@ -33,7 +33,7 @@ export const StatusColumn: React.FunctionComponent<{
                   .join(' OR ')})`
               : ''
           }`
-        : `policy_id:"${agentPolicyId}" AND agent.version:"${version}"`;
+        : `policy_id:"${agentPolicyId}" AND (agent.version:"${version}" OR upgrade_details.target_version:"${version}") `;
       return getHref('agent_list', {
         kuery,
       });
@@ -55,6 +55,7 @@ export const StatusColumn: React.FunctionComponent<{
         version,
         agents: 0,
         failedUpgradeAgents: 0,
+        inProgressUpgradeAgents: 0,
       }
     );
   }, [autoUpgradeAgentsStatus, version]);
@@ -106,7 +107,10 @@ export const StatusColumn: React.FunctionComponent<{
 
     if (agentVersionCounts.failedUpgradeAgents > 0) {
       statusButton = failedStatus;
-    } else if (agentVersionCounts.agents === 0) {
+    } else if (
+      agentVersionCounts.agents === 0 &&
+      agentVersionCounts.inProgressUpgradeAgents === 0
+    ) {
       statusButton = notStartedStatus;
     } else {
       const currPercentage = calcPercentage(agentVersionCounts.agents);

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/auto_upgrade_agents_status.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/auto_upgrade_agents_status.test.ts
@@ -76,6 +76,27 @@ describe('getAutoUpgradeAgentsStatus', () => {
             },
           },
           total: 15,
+        })
+        .mockResolvedValueOnce({
+          aggregations: {
+            action_id_versions: {
+              buckets: [
+                {
+                  key: ['0.0.1', '1.0.0', 'action-1'],
+                  doc_count: 1,
+                },
+                {
+                  key: ['1.0.0', '1.0.0', 'action-1'],
+                  doc_count: 2,
+                },
+                {
+                  key: ['0.0.1', '1.0.0', 'action-2'],
+                  doc_count: 2,
+                },
+              ],
+            },
+          },
+          total: 5,
         }),
     } as any;
 
@@ -92,6 +113,10 @@ describe('getAutoUpgradeAgentsStatus', () => {
               "action-1",
             ],
             "failedUpgradeAgents": 10,
+            "inProgressUpgradeActionIds": Array [
+              "action-1",
+            ],
+            "inProgressUpgradeAgents": 1,
             "version": "1.0.0",
           },
         ],

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/auto_upgrade_agents_status.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/auto_upgrade_agents_status.ts
@@ -50,6 +50,7 @@ export async function getAutoUpgradeAgentsStatus(
             version: bucket.key,
             agents: bucket.doc_count,
             failedUpgradeAgents: 0,
+            inProgressUpgradeAgents: 0,
           })
       );
       total = result.total;
@@ -105,6 +106,7 @@ export async function getAutoUpgradeAgentsStatus(
                 version,
                 agents: 0,
                 failedUpgradeAgents: 0,
+                inProgressUpgradeAgents: 0,
               };
             }
 
@@ -113,6 +115,80 @@ export async function getAutoUpgradeAgentsStatus(
               currentVersionsMap[version].failedUpgradeActionIds = [];
             }
             currentVersionsMap[version].failedUpgradeActionIds!.push(actionId);
+          }
+        },
+        { concurrency: MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_20 }
+      );
+    });
+
+  await agentClient
+    .listAgents({
+      showInactive: false,
+      perPage: 0,
+      kuery: `${AgentStatusKueryHelper.buildKueryForActiveAgents()} AND ${AGENTS_PREFIX}.policy_id:"${agentPolicyId}" AND ${AGENTS_PREFIX}.upgrade_details.state:* AND not ${AGENTS_PREFIX}.upgrade_details.state:"UPG_FAILED"`,
+      aggregations: {
+        action_id_versions: {
+          multi_terms: {
+            terms: [
+              {
+                field: 'agent.version',
+              },
+              {
+                field: 'upgrade_details.target_version.keyword',
+              },
+              {
+                field: 'upgrade_details.action_id',
+              },
+            ],
+            size: 1000,
+          },
+        },
+      },
+    })
+    .then(async (result) => {
+      if (!result.aggregations?.action_id_versions) {
+        return;
+      }
+
+      const actionCacheIsAutomatic = new Map<string, boolean>();
+
+      await pMap(
+        (result.aggregations.action_id_versions as any)?.buckets ?? [],
+        async (bucket: { key: string[]; doc_count: number }) => {
+          const agentVersion = bucket.key[0];
+          const targetVersion = bucket.key[1];
+          const actionId = bucket.key[2];
+
+          // Count as success
+          if (agentVersion === targetVersion) {
+            return;
+          }
+
+          let isAutomatic = actionCacheIsAutomatic.get(actionId);
+          if (isAutomatic === undefined) {
+            const actions = await getAgentActions(
+              appContextService.getInternalUserESClient(),
+              actionId
+            );
+            isAutomatic = actions?.some((action) => action.is_automatic) ?? false;
+            actionCacheIsAutomatic.set(actionId, isAutomatic);
+          }
+
+          if (isAutomatic) {
+            if (!currentVersionsMap[targetVersion]) {
+              currentVersionsMap[targetVersion] = {
+                version: targetVersion,
+                agents: 0,
+                failedUpgradeAgents: 0,
+                inProgressUpgradeAgents: 0,
+              };
+            }
+
+            currentVersionsMap[targetVersion].inProgressUpgradeAgents += bucket.doc_count;
+            if (!currentVersionsMap[targetVersion].inProgressUpgradeActionIds) {
+              currentVersionsMap[targetVersion].inProgressUpgradeActionIds = [];
+            }
+            currentVersionsMap[targetVersion].inProgressUpgradeActionIds!.push(actionId);
           }
         },
         { concurrency: MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS_20 }

--- a/x-pack/platform/plugins/shared/fleet/server/types/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/index.ts
@@ -116,11 +116,15 @@ export interface BulkActionResult {
   error?: Error;
 }
 
-import type { PackageVerificationStatus } from '../../common/types';
+import { type PackageVerificationStatus } from '../../common/types';
+
 export interface PackageVerificationResult {
   verificationKeyId?: string;
   verificationStatus: PackageVerificationStatus;
 }
+
+import { GetAutoUpgradeAgentsStatusResponseSchema } from '../../common/types/rest_spec/agent_policy';
+export { GetAutoUpgradeAgentsStatusResponseSchema };
 
 export * from './models';
 export * from './rest_spec';

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
@@ -235,15 +235,3 @@ export const AgentPolicySchema = schema.object({
   updated_at: schema.string(),
   updated_by: schema.string(),
 });
-
-export const GetAutoUpgradeAgentsStatusResponseSchema = schema.object({
-  currentVersions: schema.arrayOf(
-    schema.object({
-      version: schema.string(),
-      agents: schema.number(),
-      failedUpgradeAgents: schema.number(),
-      failedUpgradeActionIds: schema.maybe(schema.arrayOf(schema.string())),
-    })
-  ),
-  totalAgents: schema.number(),
-});

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -9,7 +9,9 @@ import expect from '@kbn/expect';
 import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
 import { FLEET_AGENT_POLICIES_SCHEMA_VERSION } from '@kbn/fleet-plugin/server/constants';
 import { skipIfNoDockerRegistry, generateAgent } from '../../helpers';
-import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+
+import type { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { cleanFleetIndices } from '../space_awareness/helpers';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -1959,6 +1961,17 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     describe('GET /api/fleet/agent_policies/{id}/auto_upgrade_agents_status', () => {
+      before(async () => {
+        await cleanFleetIndices(es);
+        await kibanaServer.savedObjects.cleanStandardList();
+        await fleetAndAgents.setup();
+      });
+
+      after(async () => {
+        await cleanFleetIndices(es);
+        await kibanaServer.savedObjects.cleanStandardList();
+      });
+
       it('should get auto upgrade agents status', async () => {
         const {
           body: { item: policyWithAgents },
@@ -1976,15 +1989,19 @@ export default function (providerContext: FtrProviderContext) {
           target_version: '8.16.3',
           action_id: 'test-action-automatic',
         });
-
-        await generateAgent(providerContext, 'inactive', 'agent-3', policyWithAgents.id, '8.16.1');
+        await generateAgent(providerContext, 'healthy', 'agent-3', policyWithAgents.id, '8.16.1', {
+          state: 'UPG_DOWNLOADING',
+          target_version: '8.16.3',
+          action_id: 'test-action-automatic',
+        });
+        await generateAgent(providerContext, 'inactive', 'agent-4', policyWithAgents.id, '8.16.1');
         await es.index({
           index: '.fleet-actions',
           refresh: 'wait_for',
           body: {
             '@timestamp': new Date().toISOString(),
             expiration: new Date().toISOString(),
-            agents: ['agent-2'],
+            agents: ['agent-2', 'agent-3'],
             action_id: 'test-action-automatic',
             data: {},
             is_automatic: true,
@@ -2000,18 +2017,21 @@ export default function (providerContext: FtrProviderContext) {
         expect(body).to.eql({
           currentVersions: [
             {
-              agents: 2,
+              agents: 3,
               failedUpgradeAgents: 0,
+              inProgressUpgradeAgents: 0,
               version: '8.16.1',
             },
             {
               agents: 0,
-              failedUpgradeAgents: 1,
               version: '8.16.3',
+              failedUpgradeAgents: 1,
               failedUpgradeActionIds: ['test-action-automatic'],
+              inProgressUpgradeAgents: 1,
+              inProgressUpgradeActionIds: ['test-action-automatic'],
             },
           ],
-          totalAgents: 2,
+          totalAgents: 3,
         });
 
         await supertest.delete(`/api/fleet/agents/agent-1`).set('kbn-xsrf', 'xx').expect(200);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Fleet] Add in progress agent count to automatic upgrade status (#243066)](https://github.com/elastic/kibana/pull/243066)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2025-11-17T17:20:59Z","message":"[Fleet] Add in progress agent count to automatic upgrade status (#243066)","sha":"08e6c9dbbe9eed37c061599e2c5d0086b6ad957b","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Fleet","v9.3.0"],"title":"[Fleet] Add in progress agent count to automatic upgrade status","number":243066,"url":"https://github.com/elastic/kibana/pull/243066","mergeCommit":{"message":"[Fleet] Add in progress agent count to automatic upgrade status (#243066)","sha":"08e6c9dbbe9eed37c061599e2c5d0086b6ad957b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243066","number":243066,"mergeCommit":{"message":"[Fleet] Add in progress agent count to automatic upgrade status (#243066)","sha":"08e6c9dbbe9eed37c061599e2c5d0086b6ad957b"}}]}] BACKPORT-->