### PR TITLE
[9.1] Add support for flattened fields with ignore_above in mappings (#238890)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -625,6 +625,12 @@ function _generateMappings(
               type: 'aggregate_metric_double',
             };
             break;
+          case 'flattened':
+            fieldProps.type = type;
+            if (field.ignore_above) {
+              fieldProps.ignore_above = field.ignore_above;
+            }
+            break;
           default:
             fieldProps.type = type;
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Add support for flattened fields with ignore_above in mappings (#238890)](https://github.com/elastic/kibana/pull/238890)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tere","email":"teresa.romero@elastic.co"},"sourceCommit":{"committedDate":"2025-10-17T08:20:07Z","message":"Add support for flattened fields with ignore_above in mappings (#238890)\n\n## Summary\n\nFix #223245 \n\nFields of type `flattened` where being mapped as default. This did not\ninclude `ignore_above` field.\nThis PR fixes the mapping and includes `ignore_above` field if exists.\nIf the field is not present, it does not use a default value.\n\nTesting done:\n\n- unit test case for `generateMappings` function\n- manual testing installing the reported integration and checking the\nfield is now being mapped.\nusing `crowdstrike` integration and adding `ignore_above` to the\n[flattened\nfield](https://github.com/elastic/integrations/blob/main/packages/crowdstrike/data_stream/falcon/fields/fields.yml#L689).\nonce installed, add the integration to an agent policy and verify the\nmapping has included the given field\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes `ignore_above` mapping for `flattened` fields\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"aa12bed49740bab72bc3466e3d8ec66198c87d9e","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:version","v9.2.0","v9.3.0"],"title":"Add support for flattened fields with ignore_above in mappings","number":238890,"url":"https://github.com/elastic/kibana/pull/238890","mergeCommit":{"message":"Add support for flattened fields with ignore_above in mappings (#238890)\n\n## Summary\n\nFix #223245 \n\nFields of type `flattened` where being mapped as default. This did not\ninclude `ignore_above` field.\nThis PR fixes the mapping and includes `ignore_above` field if exists.\nIf the field is not present, it does not use a default value.\n\nTesting done:\n\n- unit test case for `generateMappings` function\n- manual testing installing the reported integration and checking the\nfield is now being mapped.\nusing `crowdstrike` integration and adding `ignore_above` to the\n[flattened\nfield](https://github.com/elastic/integrations/blob/main/packages/crowdstrike/data_stream/falcon/fields/fields.yml#L689).\nonce installed, add the integration to an agent policy and verify the\nmapping has included the given field\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes `ignore_above` mapping for `flattened` fields\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"aa12bed49740bab72bc3466e3d8ec66198c87d9e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/239490","number":239490,"state":"MERGED","mergeCommit":{"sha":"08792efca38a2b6f8d4d9db92f9536dea9186071","message":"[9.2] Add support for flattened fields with ignore_above in mappings (#238890) (#239490)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [Add support for flattened fields with ignore_above in mappings\n(#238890)](https://github.com/elastic/kibana/pull/238890)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Tere <teresa.romero@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238890","number":238890,"mergeCommit":{"message":"Add support for flattened fields with ignore_above in mappings (#238890)\n\n## Summary\n\nFix #223245 \n\nFields of type `flattened` where being mapped as default. This did not\ninclude `ignore_above` field.\nThis PR fixes the mapping and includes `ignore_above` field if exists.\nIf the field is not present, it does not use a default value.\n\nTesting done:\n\n- unit test case for `generateMappings` function\n- manual testing installing the reported integration and checking the\nfield is now being mapped.\nusing `crowdstrike` integration and adding `ignore_above` to the\n[flattened\nfield](https://github.com/elastic/integrations/blob/main/packages/crowdstrike/data_stream/falcon/fields/fields.yml#L689).\nonce installed, add the integration to an agent policy and verify the\nmapping has included the given field\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes `ignore_above` mapping for `flattened` fields\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"aa12bed49740bab72bc3466e3d8ec66198c87d9e"}}]}] BACKPORT-->