### PR TITLE
[8.19] Add support for flattened fields with ignore_above in mappings (#238890)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -1837,208 +1837,197 @@ describe('EPM template', () => {
     }).toThrow();
   });
 
-  it('tests priority and index pattern for data stream without dataset_is_prefix', () => {
-    const dataStreamDatasetIsPrefixUnset = {
-      type: 'metrics',
-      dataset: 'package.dataset',
-      title: 'test data stream',
-      release: 'experimental',
-      package: 'package',
-      path: 'path',
-      ingest_pipeline: 'default',
-    } as RegistryDataStream;
-    const templateIndexPatternDatasetIsPrefixUnset = 'metrics-package.dataset-*';
-    const templatePriorityDatasetIsPrefixUnset = 200;
-    const templateIndexPattern = generateTemplateIndexPattern(dataStreamDatasetIsPrefixUnset);
-    const templatePriority = getTemplatePriority(dataStreamDatasetIsPrefixUnset);
-
-    expect(templateIndexPattern).toEqual(templateIndexPatternDatasetIsPrefixUnset);
-    expect(templatePriority).toEqual(templatePriorityDatasetIsPrefixUnset);
-  });
-
-  it('tests priority and index pattern for data stream with dataset_is_prefix set to false', () => {
-    const dataStreamDatasetIsPrefixFalse = {
-      type: 'metrics',
-      dataset: 'package.dataset',
-      title: 'test data stream',
-      release: 'experimental',
-      package: 'package',
-      path: 'path',
-      ingest_pipeline: 'default',
-      dataset_is_prefix: false,
-    } as RegistryDataStream;
-    const templateIndexPatternDatasetIsPrefixFalse = 'metrics-package.dataset-*';
-    const templatePriorityDatasetIsPrefixFalse = 200;
-    const templateIndexPattern = generateTemplateIndexPattern(dataStreamDatasetIsPrefixFalse);
-    const templatePriority = getTemplatePriority(dataStreamDatasetIsPrefixFalse);
-
-    expect(templateIndexPattern).toEqual(templateIndexPatternDatasetIsPrefixFalse);
-    expect(templatePriority).toEqual(templatePriorityDatasetIsPrefixFalse);
-  });
-
-  it('tests priority and index pattern for data stream with dataset_is_prefix set to true', () => {
-    const dataStreamDatasetIsPrefixTrue = {
-      type: 'metrics',
-      dataset: 'package.dataset',
-      title: 'test data stream',
-      release: 'experimental',
-      package: 'package',
-      path: 'path',
-      ingest_pipeline: 'default',
-      dataset_is_prefix: true,
-    } as RegistryDataStream;
-    const templateIndexPatternDatasetIsPrefixTrue = 'metrics-package.dataset.*-*';
-    const templatePriorityDatasetIsPrefixTrue = 150;
-    const templateIndexPattern = generateTemplateIndexPattern(dataStreamDatasetIsPrefixTrue);
-    const templatePriority = getTemplatePriority(dataStreamDatasetIsPrefixTrue);
-
-    expect(templateIndexPattern).toEqual(templateIndexPatternDatasetIsPrefixTrue);
-    expect(templatePriority).toEqual(templatePriorityDatasetIsPrefixTrue);
-  });
-
-  describe('updateCurrentWriteIndices', () => {
-    it('update all the index matching, index template index pattern', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [{ name: 'test.prefix1-default' }],
-      } as any);
-      esClient.indices.simulateTemplate.mockResponse({
-        template: {
-          settings: { index: {} },
-          mappings: { properties: {} },
+  it('tests processing flattened field with ignore_above 1024', () => {
+    const flattenedFieldYml = `
+- name: flattenedField
+  type: flattened
+  ignore_above: 1024
+`;
+    const flattenedFieldMapping = {
+      properties: {
+        flattenedField: {
+          type: 'flattened',
+          ignore_above: 1024,
         },
-      } as any);
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(esClient, logger, [
-        {
-          templateName: 'test',
-          indexTemplate: {
-            index_patterns: ['test.*-*'],
-            template: {
-              settings: { index: {} },
-              mappings: { properties: {} },
-            },
-          } as any,
-        },
-      ]);
-      expect(esClient.indices.getDataStream).toBeCalledWith({
-        name: 'test.*-*',
-        expand_wildcards: ['open', 'hidden'],
-      });
-      const putMappingsCall = esClient.indices.putMapping.mock.calls.map(([{ index }]) => index);
-      expect(putMappingsCall).toHaveLength(1);
-      expect(putMappingsCall[0]).toBe('test.prefix1-default');
-    });
-    it('update non replicated datastream', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [
-          { name: 'test-non-replicated' },
-          { name: 'test-replicated', replicated: true },
-        ],
-      } as any);
+      },
+    };
+    const fields: Field[] = load(flattenedFieldYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(flattenedFieldMapping);
+  });
+});
 
-      esClient.indices.simulateTemplate.mockResponse({
-        template: {
-          settings: { index: {} },
-          mappings: { properties: {} },
-          lifecycle: {
-            data_retention: '7d',
+it('tests priority and index pattern for data stream without dataset_is_prefix', () => {
+  const dataStreamDatasetIsPrefixUnset = {
+    type: 'metrics',
+    dataset: 'package.dataset',
+    title: 'test data stream',
+    release: 'experimental',
+    package: 'package',
+    path: 'path',
+    ingest_pipeline: 'default',
+  } as RegistryDataStream;
+  const templateIndexPatternDatasetIsPrefixUnset = 'metrics-package.dataset-*';
+  const templatePriorityDatasetIsPrefixUnset = 200;
+  const templateIndexPattern = generateTemplateIndexPattern(dataStreamDatasetIsPrefixUnset);
+  const templatePriority = getTemplatePriority(dataStreamDatasetIsPrefixUnset);
+
+  expect(templateIndexPattern).toEqual(templateIndexPatternDatasetIsPrefixUnset);
+  expect(templatePriority).toEqual(templatePriorityDatasetIsPrefixUnset);
+});
+
+it('tests priority and index pattern for data stream with dataset_is_prefix set to false', () => {
+  const dataStreamDatasetIsPrefixFalse = {
+    type: 'metrics',
+    dataset: 'package.dataset',
+    title: 'test data stream',
+    release: 'experimental',
+    package: 'package',
+    path: 'path',
+    ingest_pipeline: 'default',
+    dataset_is_prefix: false,
+  } as RegistryDataStream;
+  const templateIndexPatternDatasetIsPrefixFalse = 'metrics-package.dataset-*';
+  const templatePriorityDatasetIsPrefixFalse = 200;
+  const templateIndexPattern = generateTemplateIndexPattern(dataStreamDatasetIsPrefixFalse);
+  const templatePriority = getTemplatePriority(dataStreamDatasetIsPrefixFalse);
+
+  expect(templateIndexPattern).toEqual(templateIndexPatternDatasetIsPrefixFalse);
+  expect(templatePriority).toEqual(templatePriorityDatasetIsPrefixFalse);
+});
+
+it('tests priority and index pattern for data stream with dataset_is_prefix set to true', () => {
+  const dataStreamDatasetIsPrefixTrue = {
+    type: 'metrics',
+    dataset: 'package.dataset',
+    title: 'test data stream',
+    release: 'experimental',
+    package: 'package',
+    path: 'path',
+    ingest_pipeline: 'default',
+    dataset_is_prefix: true,
+  } as RegistryDataStream;
+  const templateIndexPatternDatasetIsPrefixTrue = 'metrics-package.dataset.*-*';
+  const templatePriorityDatasetIsPrefixTrue = 150;
+  const templateIndexPattern = generateTemplateIndexPattern(dataStreamDatasetIsPrefixTrue);
+  const templatePriority = getTemplatePriority(dataStreamDatasetIsPrefixTrue);
+
+  expect(templateIndexPattern).toEqual(templateIndexPatternDatasetIsPrefixTrue);
+  expect(templatePriority).toEqual(templatePriorityDatasetIsPrefixTrue);
+});
+
+describe('updateCurrentWriteIndices', () => {
+  it('update all the index matching, index template index pattern', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [{ name: 'test.prefix1-default' }],
+    } as any);
+    esClient.indices.simulateTemplate.mockResponse({
+      template: {
+        settings: { index: {} },
+        mappings: { properties: {} },
+      },
+    } as any);
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(esClient, logger, [
+      {
+        templateName: 'test',
+        indexTemplate: {
+          index_patterns: ['test.*-*'],
+          template: {
+            settings: { index: {} },
+            mappings: { properties: {} },
           },
-        },
-      } as any);
+        } as any,
+      },
+    ]);
+    expect(esClient.indices.getDataStream).toBeCalledWith({
+      name: 'test.*-*',
+      expand_wildcards: ['open', 'hidden'],
+    });
+    const putMappingsCall = esClient.indices.putMapping.mock.calls.map(([{ index }]) => index);
+    expect(putMappingsCall).toHaveLength(1);
+    expect(putMappingsCall[0]).toBe('test.prefix1-default');
+  });
+  it('update non replicated datastream', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [
+        { name: 'test-non-replicated' },
+        { name: 'test-replicated', replicated: true },
+      ],
+    } as any);
 
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(esClient, logger, [
-        {
-          templateName: 'test',
-          indexTemplate: {
-            index_patterns: ['test-*'],
-            template: {
-              settings: { index: {} },
-              mappings: { properties: {} },
-            },
-          } as any,
-        },
-      ]);
-
-      const putMappingsCall = esClient.indices.putMapping.mock.calls.map(([{ index }]) => index);
-      expect(putMappingsCall).toHaveLength(1);
-      expect(putMappingsCall[0]).toBe('test-non-replicated');
-
-      const putDatastreamLifecycleCalls = esClient.transport.request.mock.calls;
-      expect(putDatastreamLifecycleCalls).toHaveLength(1);
-      expect(putDatastreamLifecycleCalls[0][0]).toEqual({
-        method: 'PUT',
-        path: '_data_stream/test-non-replicated/_lifecycle',
-        body: {
+    esClient.indices.simulateTemplate.mockResponse({
+      template: {
+        settings: { index: {} },
+        mappings: { properties: {} },
+        lifecycle: {
           data_retention: '7d',
         },
-      });
+      },
+    } as any);
+
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(esClient, logger, [
+      {
+        templateName: 'test',
+        indexTemplate: {
+          index_patterns: ['test-*'],
+          template: {
+            settings: { index: {} },
+            mappings: { properties: {} },
+          },
+        } as any,
+      },
+    ]);
+
+    const putMappingsCall = esClient.indices.putMapping.mock.calls.map(([{ index }]) => index);
+    expect(putMappingsCall).toHaveLength(1);
+    expect(putMappingsCall[0]).toBe('test-non-replicated');
+
+    const putDatastreamLifecycleCalls = esClient.transport.request.mock.calls;
+    expect(putDatastreamLifecycleCalls).toHaveLength(1);
+    expect(putDatastreamLifecycleCalls[0][0]).toEqual({
+      method: 'PUT',
+      path: '_data_stream/test-non-replicated/_lifecycle',
+      body: {
+        data_retention: '7d',
+      },
     });
+  });
 
-    it('should fill constant keywords from previous mappings', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
+  it('should fill constant keywords from previous mappings', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
 
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [
-          {
-            name: 'test-constant.keyword-default',
-            indices: [
-              { index_name: '.ds-test-constant.keyword-default-0001' },
-              { index_name: '.ds-test-constant.keyword-default-0002' },
-            ],
-          },
-        ],
-      } as any);
-
-      esClient.indices.get.mockResponse({
-        'test-constant.keyword-default': {
-          mappings: {
-            properties: {
-              some_keyword_field: {
-                type: 'constant_keyword',
-              },
-            },
-          },
-        },
-      } as any);
-      esClient.indices.simulateTemplate.mockResponse({
-        template: {
-          settings: { index: {} },
-          mappings: {
-            properties: {
-              some_keyword_field: {
-                type: 'constant_keyword',
-                value: 'some_value',
-              },
-            },
-          },
-        },
-      } as any);
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(esClient, logger, [
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [
         {
-          templateName: 'test',
-          indexTemplate: {
-            index_patterns: ['test-constant.keyword-*'],
-            template: {
-              template: {
-                settings: { index: {} },
-                mappings: { properties: {} },
-              },
-            },
-          } as any,
+          name: 'test-constant.keyword-default',
+          indices: [
+            { index_name: '.ds-test-constant.keyword-default-0001' },
+            { index_name: '.ds-test-constant.keyword-default-0002' },
+          ],
         },
-      ]);
-      expect(esClient.indices.get).toBeCalledWith({
-        index: '.ds-test-constant.keyword-default-0002',
-      });
-      const putMappingsCalls = esClient.indices.putMapping.mock.calls;
-      expect(putMappingsCalls).toHaveLength(1);
-      expect(putMappingsCalls[0][0]).toEqual({
-        index: 'test-constant.keyword-default',
-        body: {
+      ],
+    } as any);
+
+    esClient.indices.get.mockResponse({
+      'test-constant.keyword-default': {
+        mappings: {
+          properties: {
+            some_keyword_field: {
+              type: 'constant_keyword',
+            },
+          },
+        },
+      },
+    } as any);
+    esClient.indices.simulateTemplate.mockResponse({
+      template: {
+        settings: { index: {} },
+        mappings: {
           properties: {
             some_keyword_field: {
               type: 'constant_keyword',
@@ -2046,69 +2035,329 @@ describe('EPM template', () => {
             },
           },
         },
-        write_index_only: true,
-      });
+      },
+    } as any);
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(esClient, logger, [
+      {
+        templateName: 'test',
+        indexTemplate: {
+          index_patterns: ['test-constant.keyword-*'],
+          template: {
+            template: {
+              settings: { index: {} },
+              mappings: { properties: {} },
+            },
+          },
+        } as any,
+      },
+    ]);
+    expect(esClient.indices.get).toBeCalledWith({
+      index: '.ds-test-constant.keyword-default-0002',
     });
+    const putMappingsCalls = esClient.indices.putMapping.mock.calls;
+    expect(putMappingsCalls).toHaveLength(1);
+    expect(putMappingsCalls[0][0]).toEqual({
+      index: 'test-constant.keyword-default',
+      body: {
+        properties: {
+          some_keyword_field: {
+            type: 'constant_keyword',
+            value: 'some_value',
+          },
+        },
+      },
+      write_index_only: true,
+    });
+  });
 
-    it('should not error when previous mappings are not found', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [{ name: 'test-constant.keyword-default' }],
-      } as any);
-      esClient.indices.get.mockResponse({
-        'test-constant.keyword-default': {
-          mappings: {
-            properties: {
-              some_keyword_field: {
-                type: 'constant_keyword',
-              },
+  it('should not error when previous mappings are not found', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [{ name: 'test-constant.keyword-default' }],
+    } as any);
+    esClient.indices.get.mockResponse({
+      'test-constant.keyword-default': {
+        mappings: {
+          properties: {
+            some_keyword_field: {
+              type: 'constant_keyword',
             },
           },
         },
+      },
+    } as any);
+    esClient.indices.simulateTemplate.mockResponse({
+      template: {},
+    } as any);
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(esClient, logger, [
+      {
+        templateName: 'test',
+        indexTemplate: {
+          index_patterns: ['test-constant.keyword-*'],
+          template: {
+            template: {
+              settings: { index: {} },
+              mappings: { properties: {} },
+            },
+          },
+        } as any,
+      },
+    ]);
+    const putMappingsCalls = esClient.indices.putMapping.mock.calls;
+    expect(putMappingsCalls).toHaveLength(1);
+    expect(putMappingsCalls[0][0]).toEqual({
+      index: 'test-constant.keyword-default',
+      body: {},
+      write_index_only: true,
+    });
+  });
+
+  it('should rollover on expected error', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [{ name: 'test.prefix1-default' }],
+    } as any);
+    esClient.indices.simulateTemplate.mockImplementation(() => {
+      throw new errors.ResponseError({
+        statusCode: 400,
+        body: {
+          error: {
+            type: 'illegal_argument_exception',
+          },
+        },
       } as any);
-      esClient.indices.simulateTemplate.mockResponse({
-        template: {},
+    });
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(esClient, logger, [
+      {
+        templateName: 'test',
+        indexTemplate: {
+          index_patterns: ['test.*-*'],
+          template: {
+            settings: { index: {} },
+            mappings: { properties: {} },
+          },
+        } as any,
+      },
+    ]);
+
+    expect(esClient.transport.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/test.prefix1-default/_rollover',
+        querystring: {
+          lazy: true,
+        },
+      })
+    );
+  });
+
+  it('should rollover on expected error when field subobjects in mappings changed', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [{ name: 'test.prefix1-default' }],
+    } as any);
+    esClient.indices.get.mockResponse({
+      'test.prefix1-default': {
+        mappings: {},
+      },
+    } as any);
+    esClient.indices.simulateTemplate.mockResponse({
+      template: {
+        settings: { index: {} },
+        mappings: { subobjects: false },
+      },
+    } as any);
+    esClient.indices.putMapping.mockImplementation(() => {
+      throw new errors.ResponseError({
+        body: {
+          error: {
+            message:
+              'mapper_exception\n' +
+              '\tRoot causes:\n' +
+              "\t\tmapper_exception: the [subobjects] parameter can't be updated for the object mapping [_doc]",
+          },
+        },
       } as any);
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(esClient, logger, [
+    });
+
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(esClient, logger, [
+      {
+        templateName: 'test',
+        indexTemplate: {
+          index_patterns: ['test.*-*'],
+          template: {
+            settings: { index: {} },
+            mappings: {},
+          },
+        } as any,
+      },
+    ]);
+
+    expect(esClient.transport.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/test.prefix1-default/_rollover',
+        querystring: {
+          lazy: true,
+        },
+      })
+    );
+  });
+  it('should rollover on mapper exception with subobjects in reason', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [{ name: 'test.prefix1-default' }],
+    } as any);
+    esClient.indices.get.mockResponse({
+      'test.prefix1-default': {
+        mappings: {},
+      },
+    } as any);
+    esClient.indices.simulateTemplate.mockResponse({
+      template: {
+        settings: { index: {} },
+        mappings: {},
+      },
+    } as any);
+    esClient.indices.putMapping.mockImplementation(() => {
+      throw new errors.ResponseError({
+        body: {
+          error: {
+            type: 'mapper_exception',
+            reason:
+              "the [subobjects] parameter can't be updated for the object mapping [okta.debug_context.debug_data]",
+          },
+        },
+      } as any);
+    });
+
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(esClient, logger, [
+      {
+        templateName: 'test',
+        indexTemplate: {
+          index_patterns: ['test.*-*'],
+          template: {
+            settings: { index: {} },
+            mappings: {},
+          },
+        } as any,
+      },
+    ]);
+
+    expect(esClient.transport.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/test.prefix1-default/_rollover',
+        querystring: {
+          lazy: true,
+        },
+      })
+    );
+  });
+
+  it('should rollover on mapper exception that change enabled object mappings', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [{ name: 'test.prefix1-default' }],
+    } as any);
+    esClient.indices.get.mockResponse({
+      'test.prefix1-default': {
+        mappings: {},
+      },
+    } as any);
+    esClient.indices.simulateTemplate.mockResponse({
+      template: {
+        settings: { index: {} },
+        mappings: {},
+      },
+    } as any);
+    esClient.indices.putMapping.mockImplementation(() => {
+      throw new errors.ResponseError({
+        body: {
+          error: {
+            type: 'mapper_exception',
+            reason: `Mappings update for logs-cisco_ise.log-default failed due to ResponseError: mapper_exception
+ 	Root causes:
+		mapper_exception: the [enabled] parameter can't be updated for the object mapping [cisco_ise.log.cisco_av_pair]`,
+          },
+        },
+      } as any);
+    });
+
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(esClient, logger, [
+      {
+        templateName: 'test',
+        indexTemplate: {
+          index_patterns: ['test.*-*'],
+          template: {
+            settings: { index: {} },
+            mappings: {},
+          },
+        } as any,
+      },
+    ]);
+
+    expect(esClient.transport.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/test.prefix1-default/_rollover',
+        querystring: {
+          lazy: true,
+        },
+      })
+    );
+  });
+
+  it('should skip rollover on expected error when flag is on', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [{ name: 'test.prefix1-default' }],
+    } as any);
+    esClient.indices.simulateTemplate.mockImplementation(() => {
+      throw new errors.ResponseError({
+        statusCode: 400,
+        body: {
+          error: {
+            type: 'illegal_argument_exception',
+          },
+        },
+      } as any);
+    });
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(
+      esClient,
+      logger,
+      [
         {
           templateName: 'test',
           indexTemplate: {
-            index_patterns: ['test-constant.keyword-*'],
+            index_patterns: ['test.*-*'],
             template: {
-              template: {
-                settings: { index: {} },
-                mappings: { properties: {} },
-              },
+              settings: { index: {} },
+              mappings: { properties: {} },
             },
           } as any,
         },
-      ]);
-      const putMappingsCalls = esClient.indices.putMapping.mock.calls;
-      expect(putMappingsCalls).toHaveLength(1);
-      expect(putMappingsCalls[0][0]).toEqual({
-        index: 'test-constant.keyword-default',
-        body: {},
-        write_index_only: true,
-      });
-    });
+      ],
+      {
+        skipDataStreamRollover: true,
+      }
+    );
 
-    it('should rollover on expected error', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [{ name: 'test.prefix1-default' }],
-      } as any);
-      esClient.indices.simulateTemplate.mockImplementation(() => {
-        throw new errors.ResponseError({
-          statusCode: 400,
-          body: {
-            error: {
-              type: 'illegal_argument_exception',
-            },
-          },
-        } as any);
-      });
-      const logger = loggerMock.create();
+    expect(esClient.indices.rollover).not.toHaveBeenCalled();
+  });
+  it('should not rollover on unexpected error', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [{ name: 'test.prefix1-default' }],
+    } as any);
+    esClient.indices.simulateTemplate.mockImplementation(() => {
+      throw new Error();
+    });
+    const logger = loggerMock.create();
+    try {
       await updateCurrentWriteIndices(esClient, logger, [
         {
           templateName: 'test',
@@ -2121,418 +2370,189 @@ describe('EPM template', () => {
           } as any,
         },
       ]);
+      fail('expected updateCurrentWriteIndices to throw error');
+    } catch (err) {
+      // noop
+    }
 
-      expect(esClient.transport.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: '/test.prefix1-default/_rollover',
-          querystring: {
-            lazy: true,
-          },
-        })
-      );
+    expect(esClient.indices.rollover).not.toHaveBeenCalled();
+  });
+  it('should not throw on unexpected error when flag is on', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [{ name: 'test.prefix1-default' }],
+    } as any);
+    esClient.indices.simulateTemplate.mockImplementation(() => {
+      throw new Error();
     });
-
-    it('should rollover on expected error when field subobjects in mappings changed', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [{ name: 'test.prefix1-default' }],
-      } as any);
-      esClient.indices.get.mockResponse({
-        'test.prefix1-default': {
-          mappings: {},
-        },
-      } as any);
-      esClient.indices.simulateTemplate.mockResponse({
-        template: {
-          settings: { index: {} },
-          mappings: { subobjects: false },
-        },
-      } as any);
-      esClient.indices.putMapping.mockImplementation(() => {
-        throw new errors.ResponseError({
-          body: {
-            error: {
-              message:
-                'mapper_exception\n' +
-                '\tRoot causes:\n' +
-                "\t\tmapper_exception: the [subobjects] parameter can't be updated for the object mapping [_doc]",
-            },
-          },
-        } as any);
-      });
-
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(esClient, logger, [
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(
+      esClient,
+      logger,
+      [
         {
           templateName: 'test',
           indexTemplate: {
             index_patterns: ['test.*-*'],
             template: {
               settings: { index: {} },
-              mappings: {},
+              mappings: { properties: {} },
             },
           } as any,
         },
-      ]);
-
-      expect(esClient.transport.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: '/test.prefix1-default/_rollover',
-          querystring: {
-            lazy: true,
-          },
-        })
-      );
-    });
-    it('should rollover on mapper exception with subobjects in reason', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [{ name: 'test.prefix1-default' }],
-      } as any);
-      esClient.indices.get.mockResponse({
-        'test.prefix1-default': {
-          mappings: {},
-        },
-      } as any);
-      esClient.indices.simulateTemplate.mockResponse({
-        template: {
-          settings: { index: {} },
-          mappings: {},
-        },
-      } as any);
-      esClient.indices.putMapping.mockImplementation(() => {
-        throw new errors.ResponseError({
-          body: {
-            error: {
-              type: 'mapper_exception',
-              reason:
-                "the [subobjects] parameter can't be updated for the object mapping [okta.debug_context.debug_data]",
-            },
-          },
-        } as any);
-      });
-
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(esClient, logger, [
-        {
-          templateName: 'test',
-          indexTemplate: {
-            index_patterns: ['test.*-*'],
-            template: {
-              settings: { index: {} },
-              mappings: {},
-            },
-          } as any,
-        },
-      ]);
-
-      expect(esClient.transport.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: '/test.prefix1-default/_rollover',
-          querystring: {
-            lazy: true,
-          },
-        })
-      );
-    });
-
-    it('should rollover on mapper exception that change enabled object mappings', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [{ name: 'test.prefix1-default' }],
-      } as any);
-      esClient.indices.get.mockResponse({
-        'test.prefix1-default': {
-          mappings: {},
-        },
-      } as any);
-      esClient.indices.simulateTemplate.mockResponse({
-        template: {
-          settings: { index: {} },
-          mappings: {},
-        },
-      } as any);
-      esClient.indices.putMapping.mockImplementation(() => {
-        throw new errors.ResponseError({
-          body: {
-            error: {
-              type: 'mapper_exception',
-              reason: `Mappings update for logs-cisco_ise.log-default failed due to ResponseError: mapper_exception
- 	Root causes:
-		mapper_exception: the [enabled] parameter can't be updated for the object mapping [cisco_ise.log.cisco_av_pair]`,
-            },
-          },
-        } as any);
-      });
-
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(esClient, logger, [
-        {
-          templateName: 'test',
-          indexTemplate: {
-            index_patterns: ['test.*-*'],
-            template: {
-              settings: { index: {} },
-              mappings: {},
-            },
-          } as any,
-        },
-      ]);
-
-      expect(esClient.transport.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: '/test.prefix1-default/_rollover',
-          querystring: {
-            lazy: true,
-          },
-        })
-      );
-    });
-
-    it('should skip rollover on expected error when flag is on', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [{ name: 'test.prefix1-default' }],
-      } as any);
-      esClient.indices.simulateTemplate.mockImplementation(() => {
-        throw new errors.ResponseError({
-          statusCode: 400,
-          body: {
-            error: {
-              type: 'illegal_argument_exception',
-            },
-          },
-        } as any);
-      });
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(
-        esClient,
-        logger,
-        [
-          {
-            templateName: 'test',
-            indexTemplate: {
-              index_patterns: ['test.*-*'],
-              template: {
-                settings: { index: {} },
-                mappings: { properties: {} },
-              },
-            } as any,
-          },
-        ],
-        {
-          skipDataStreamRollover: true,
-        }
-      );
-
-      expect(esClient.indices.rollover).not.toHaveBeenCalled();
-    });
-    it('should not rollover on unexpected error', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [{ name: 'test.prefix1-default' }],
-      } as any);
-      esClient.indices.simulateTemplate.mockImplementation(() => {
-        throw new Error();
-      });
-      const logger = loggerMock.create();
-      try {
-        await updateCurrentWriteIndices(esClient, logger, [
-          {
-            templateName: 'test',
-            indexTemplate: {
-              index_patterns: ['test.*-*'],
-              template: {
-                settings: { index: {} },
-                mappings: { properties: {} },
-              },
-            } as any,
-          },
-        ]);
-        fail('expected updateCurrentWriteIndices to throw error');
-      } catch (err) {
-        // noop
+      ],
+      {
+        ignoreMappingUpdateErrors: true,
       }
+    );
 
-      expect(esClient.indices.rollover).not.toHaveBeenCalled();
-    });
-    it('should not throw on unexpected error when flag is on', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [{ name: 'test.prefix1-default' }],
-      } as any);
-      esClient.indices.simulateTemplate.mockImplementation(() => {
-        throw new Error();
-      });
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(
-        esClient,
-        logger,
-        [
-          {
-            templateName: 'test',
-            indexTemplate: {
-              index_patterns: ['test.*-*'],
-              template: {
-                settings: { index: {} },
-                mappings: { properties: {} },
-              },
-            } as any,
-          },
-        ],
-        {
-          ignoreMappingUpdateErrors: true,
-        }
-      );
+    expect(esClient.indices.rollover).not.toHaveBeenCalled();
+  });
 
-      expect(esClient.indices.rollover).not.toHaveBeenCalled();
-    });
-
-    it('should rollover on dynamic dimension mappings changed', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [{ name: 'test.prefix1-default' }],
-      } as any);
-      esClient.indices.get.mockResponse({
-        'test.prefix1-default': {
-          mappings: {},
+  it('should rollover on dynamic dimension mappings changed', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [{ name: 'test.prefix1-default' }],
+    } as any);
+    esClient.indices.get.mockResponse({
+      'test.prefix1-default': {
+        mappings: {},
+      },
+    } as any);
+    esClient.indices.simulateTemplate.mockResponse({
+      template: {
+        settings: { index: {} },
+        mappings: {
+          dynamic_templates: [
+            { 'prometheus.labels.*': { mapping: { time_series_dimension: true } } },
+          ],
         },
-      } as any);
-      esClient.indices.simulateTemplate.mockResponse({
-        template: {
-          settings: { index: {} },
-          mappings: {
-            dynamic_templates: [
-              { 'prometheus.labels.*': { mapping: { time_series_dimension: true } } },
-            ],
+      },
+    } as any);
+
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(esClient, logger, [
+      {
+        templateName: 'test',
+        indexTemplate: {
+          index_patterns: ['test.*-*'],
+          template: {
+            settings: { index: {} },
+            mappings: {},
           },
-        },
-      } as any);
+        } as any,
+      },
+    ]);
 
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(esClient, logger, [
-        {
-          templateName: 'test',
-          indexTemplate: {
-            index_patterns: ['test.*-*'],
-            template: {
-              settings: { index: {} },
-              mappings: {},
-            },
-          } as any,
+    expect(esClient.transport.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/test.prefix1-default/_rollover',
+        querystring: {
+          lazy: true,
         },
-      ]);
+      })
+    );
+  });
 
-      expect(esClient.transport.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: '/test.prefix1-default/_rollover',
-          querystring: {
-            lazy: true,
+  it('should not rollover on dynamic dimension mappings not changed', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [{ name: 'test.prefix1-default' }],
+    } as any);
+    esClient.indices.get.mockResponse({
+      'test.prefix1-default': {
+        mappings: {
+          dynamic_templates: [
+            { 'prometheus.labels.*': { mapping: { time_series_dimension: true } } },
+            { 'prometheus.test.*': { mapping: { time_series_dimension: true } } },
+          ],
+        },
+      },
+    } as any);
+    esClient.indices.simulateTemplate.mockResponse({
+      template: {
+        settings: { index: {} },
+        mappings: {
+          dynamic_templates: [
+            { 'prometheus.test.*': { mapping: { time_series_dimension: true } } },
+            { 'prometheus.labels.*': { mapping: { time_series_dimension: true } } },
+          ],
+        },
+      },
+    } as any);
+
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(esClient, logger, [
+      {
+        templateName: 'test',
+        indexTemplate: {
+          index_patterns: ['test.*-*'],
+          template: {
+            settings: { index: {} },
+            mappings: {},
           },
-        })
-      );
-    });
+        } as any,
+      },
+    ]);
 
-    it('should not rollover on dynamic dimension mappings not changed', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [{ name: 'test.prefix1-default' }],
-      } as any);
-      esClient.indices.get.mockResponse({
-        'test.prefix1-default': {
-          mappings: {
-            dynamic_templates: [
-              { 'prometheus.labels.*': { mapping: { time_series_dimension: true } } },
-              { 'prometheus.test.*': { mapping: { time_series_dimension: true } } },
-            ],
-          },
+    expect(esClient.transport.request).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/test.prefix1-default/_rollover',
+        querystring: {
+          lazy: true,
         },
-      } as any);
-      esClient.indices.simulateTemplate.mockResponse({
-        template: {
-          settings: { index: {} },
-          mappings: {
-            dynamic_templates: [
-              { 'prometheus.test.*': { mapping: { time_series_dimension: true } } },
-              { 'prometheus.labels.*': { mapping: { time_series_dimension: true } } },
-            ],
-          },
-        },
-      } as any);
+      })
+    );
+  });
 
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(esClient, logger, [
-        {
-          templateName: 'test',
-          indexTemplate: {
-            index_patterns: ['test.*-*'],
-            template: {
-              settings: { index: {} },
-              mappings: {},
-            },
-          } as any,
-        },
-      ]);
-
-      expect(esClient.transport.request).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: '/test.prefix1-default/_rollover',
-          querystring: {
-            lazy: true,
-          },
-        })
-      );
-    });
-
-    it('should not rollover when package do not define index mode and defaut source mode is logsdb', async () => {
-      const esClient = elasticsearchServiceMock.createElasticsearchClient();
-      esClient.indices.getDataStream.mockResponse({
-        data_streams: [{ name: 'logs.prefix1-default' }],
-      } as any);
-      esClient.indices.get.mockResponse({
-        'logs.prefix1-default': {
-          mappings: {},
-          settings: {
-            index: {
-              mode: 'logsdb',
-              mapping: {
-                source: {
-                  mode: 'STORED',
-                },
+  it('should not rollover when package do not define index mode and defaut source mode is logsdb', async () => {
+    const esClient = elasticsearchServiceMock.createElasticsearchClient();
+    esClient.indices.getDataStream.mockResponse({
+      data_streams: [{ name: 'logs.prefix1-default' }],
+    } as any);
+    esClient.indices.get.mockResponse({
+      'logs.prefix1-default': {
+        mappings: {},
+        settings: {
+          index: {
+            mode: 'logsdb',
+            mapping: {
+              source: {
+                mode: 'STORED',
               },
             },
           },
         },
-      } as any);
-      esClient.indices.simulateTemplate.mockResponse({
-        template: {
-          settings: { index: {} },
-          mappings: {},
-        },
-      } as any);
+      },
+    } as any);
+    esClient.indices.simulateTemplate.mockResponse({
+      template: {
+        settings: { index: {} },
+        mappings: {},
+      },
+    } as any);
 
-      const logger = loggerMock.create();
-      await updateCurrentWriteIndices(esClient, logger, [
-        {
-          templateName: 'logs.prefix1',
-          indexTemplate: {
-            index_patterns: ['logs.prefix1-*'],
-            template: {
-              settings: { index: {} },
-              mappings: {},
-            },
-          } as any,
-        },
-      ]);
-
-      expect(esClient.transport.request).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: '/test.prefix1-default/_rollover',
-          querystring: {
-            lazy: true,
+    const logger = loggerMock.create();
+    await updateCurrentWriteIndices(esClient, logger, [
+      {
+        templateName: 'logs.prefix1',
+        indexTemplate: {
+          index_patterns: ['logs.prefix1-*'],
+          template: {
+            settings: { index: {} },
+            mappings: {},
           },
-        })
-      );
-    });
+        } as any,
+      },
+    ]);
+
+    expect(esClient.transport.request).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/test.prefix1-default/_rollover',
+        querystring: {
+          lazy: true,
+        },
+      })
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -614,6 +614,12 @@ function _generateMappings(
               type: 'aggregate_metric_double',
             };
             break;
+          case 'flattened':
+            fieldProps.type = type;
+            if (field.ignore_above) {
+              fieldProps.ignore_above = field.ignore_above;
+            }
+            break;
           default:
             fieldProps.type = type;
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add support for flattened fields with ignore_above in mappings (#238890)](https://github.com/elastic/kibana/pull/238890)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tere","email":"teresa.romero@elastic.co"},"sourceCommit":{"committedDate":"2025-10-17T08:20:07Z","message":"Add support for flattened fields with ignore_above in mappings (#238890)\n\n## Summary\n\nFix #223245 \n\nFields of type `flattened` where being mapped as default. This did not\ninclude `ignore_above` field.\nThis PR fixes the mapping and includes `ignore_above` field if exists.\nIf the field is not present, it does not use a default value.\n\nTesting done:\n\n- unit test case for `generateMappings` function\n- manual testing installing the reported integration and checking the\nfield is now being mapped.\nusing `crowdstrike` integration and adding `ignore_above` to the\n[flattened\nfield](https://github.com/elastic/integrations/blob/main/packages/crowdstrike/data_stream/falcon/fields/fields.yml#L689).\nonce installed, add the integration to an agent policy and verify the\nmapping has included the given field\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes `ignore_above` mapping for `flattened` fields\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"aa12bed49740bab72bc3466e3d8ec66198c87d9e","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:version","v9.2.0","v9.3.0"],"title":"Add support for flattened fields with ignore_above in mappings","number":238890,"url":"https://github.com/elastic/kibana/pull/238890","mergeCommit":{"message":"Add support for flattened fields with ignore_above in mappings (#238890)\n\n## Summary\n\nFix #223245 \n\nFields of type `flattened` where being mapped as default. This did not\ninclude `ignore_above` field.\nThis PR fixes the mapping and includes `ignore_above` field if exists.\nIf the field is not present, it does not use a default value.\n\nTesting done:\n\n- unit test case for `generateMappings` function\n- manual testing installing the reported integration and checking the\nfield is now being mapped.\nusing `crowdstrike` integration and adding `ignore_above` to the\n[flattened\nfield](https://github.com/elastic/integrations/blob/main/packages/crowdstrike/data_stream/falcon/fields/fields.yml#L689).\nonce installed, add the integration to an agent policy and verify the\nmapping has included the given field\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes `ignore_above` mapping for `flattened` fields\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"aa12bed49740bab72bc3466e3d8ec66198c87d9e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/239490","number":239490,"state":"MERGED","mergeCommit":{"sha":"08792efca38a2b6f8d4d9db92f9536dea9186071","message":"[9.2] Add support for flattened fields with ignore_above in mappings (#238890) (#239490)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [Add support for flattened fields with ignore_above in mappings\n(#238890)](https://github.com/elastic/kibana/pull/238890)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Tere <teresa.romero@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/238890","number":238890,"mergeCommit":{"message":"Add support for flattened fields with ignore_above in mappings (#238890)\n\n## Summary\n\nFix #223245 \n\nFields of type `flattened` where being mapped as default. This did not\ninclude `ignore_above` field.\nThis PR fixes the mapping and includes `ignore_above` field if exists.\nIf the field is not present, it does not use a default value.\n\nTesting done:\n\n- unit test case for `generateMappings` function\n- manual testing installing the reported integration and checking the\nfield is now being mapped.\nusing `crowdstrike` integration and adding `ignore_above` to the\n[flattened\nfield](https://github.com/elastic/integrations/blob/main/packages/crowdstrike/data_stream/falcon/fields/fields.yml#L689).\nonce installed, add the integration to an agent policy and verify the\nmapping has included the given field\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Release note\n\nFixes `ignore_above` mapping for `flattened` fields\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"aa12bed49740bab72bc3466e3d8ec66198c87d9e"}}]}] BACKPORT-->