### PR TITLE
fix project ref removal

### DIFF
--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -48,7 +48,6 @@
     "@kbn/react-field",
     "@kbn/storage-adapter",
     "@kbn/core-i18n-browser-mocks",
-    "@kbn/stack-connectors-plugin",
     "@kbn/core-lifecycle-browser-mocks",
     "@kbn/serverless",
     "@kbn/field-types",


### PR DESCRIPTION
## Summary
https://github.com/elastic/kibana/pull/243388 started to break on main's on-merge pipeline, probably due to a merge race condition.