### PR TITLE
[SideNav] Rewrite `isAnyPopoverOpen` logic

### DIFF
--- a/src/core/packages/chrome/navigation/src/__tests__/both_modes.test.tsx
+++ b/src/core/packages/chrome/navigation/src/__tests__/both_modes.test.tsx
@@ -404,6 +404,49 @@ describe('Both modes', () => {
         expect(overviewLink).toHaveAttribute('aria-current', 'page');
         expect(overviewLink).toHaveAttribute('data-highlighted', 'true');
       });
+
+      it('should switch popover when hovering from one item to another', async () => {
+        const customNavItems = {
+          ...basicMock.navItems,
+          primaryItems: [
+            ...basicMock.navItems.primaryItems,
+            {
+              id: 'analytics',
+              label: 'Analytics',
+              href: '/analytics',
+              iconType: 'visVisualBuilder',
+              sections: [
+                {
+                  id: 'analytics_section',
+                  label: 'Analytics Section',
+                  items: [{ id: 'analytics_sub', label: 'Sub Item', href: '/sub' }],
+                },
+              ],
+            },
+          ],
+        };
+
+        render(<TestComponent items={customNavItems} logo={basicMock.logo} />);
+
+        const appsLink = screen.getByRole('link', { name: 'Apps' });
+        const analyticsLink = screen.getByRole('link', { name: 'Analytics' });
+
+        await user.hover(appsLink);
+        flushPopoverTimers();
+
+        const appsPopover = await screen.findByRole('dialog', { name: 'Apps' });
+        expect(appsPopover).toBeInTheDocument();
+
+        await user.hover(analyticsLink);
+        flushPopoverTimers();
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog', { name: 'Apps' })).not.toBeInTheDocument();
+        });
+
+        const analyticsPopover = await screen.findByRole('dialog', { name: 'Analytics' });
+        expect(analyticsPopover).toBeInTheDocument();
+      });
     });
 
     describe('Primary menu item limit', () => {
@@ -849,6 +892,61 @@ describe('Both modes', () => {
         await waitFor(() => {
           expect(tooltip).not.toBeInTheDocument();
         });
+      });
+
+      it('should switch popover when hovering from one item to another', async () => {
+        const customNavItems = {
+          ...basicMock.navItems,
+          footerItems: [
+            {
+              id: 'footer1',
+              label: 'Footer 1',
+              href: '/footer1',
+              iconType: 'user',
+              sections: [
+                {
+                  id: 'section1',
+                  label: 'Section 1',
+                  items: [{ id: 'sub1', label: 'Sub 1', href: '/sub1' }],
+                },
+              ],
+            },
+            {
+              id: 'footer2',
+              label: 'Footer 2',
+              href: '/footer2',
+              iconType: 'gear',
+              sections: [
+                {
+                  id: 'section2',
+                  label: 'Section 2',
+                  items: [{ id: 'sub2', label: 'Sub 2', href: '/sub2' }],
+                },
+              ],
+            },
+          ],
+        };
+
+        render(<TestComponent items={customNavItems} logo={basicMock.logo} />);
+
+        const footer1Link = screen.getByRole('link', { name: 'Footer 1' });
+        const footer2Link = screen.getByRole('link', { name: 'Footer 2' });
+
+        await user.hover(footer1Link);
+        flushPopoverTimers();
+
+        const popover1 = await screen.findByRole('dialog', { name: 'Footer 1' });
+        expect(popover1).toBeInTheDocument();
+
+        await user.hover(footer2Link);
+        flushPopoverTimers();
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog', { name: 'Footer 1' })).not.toBeInTheDocument();
+        });
+
+        const popover2 = await screen.findByRole('dialog', { name: 'Footer 2' });
+        expect(popover2).toBeInTheDocument();
       });
     });
 

--- a/src/core/packages/chrome/navigation/src/components/navigation.tsx
+++ b/src/core/packages/chrome/navigation/src/components/navigation.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { type ReactNode, useState } from 'react';
+import React, { useState, type ReactNode } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -92,14 +92,14 @@ export const Navigation = ({
     openerNode,
   } = useNavigation(isCollapsed, items, logo.id, activeItemId);
 
+  const [isAnyPopoverLocked, setIsAnyPopoverLocked] = useState(false);
+
   const { overflowMenuItems, primaryMenuRef, visibleMenuItems } = useResponsiveMenu(
     isCollapsed,
     items.primaryItems
   );
 
   useLayoutWidth({ isCollapsed, isSidePanelOpen, setWidth });
-
-  const [isAnyPopoverOpen, setAnyPopoverOpen] = useState(false);
 
   return (
     <div
@@ -123,10 +123,9 @@ export const Navigation = ({
               <SideNav.Popover
                 key={item.id}
                 hasContent={getHasSubmenu(item)}
-                isAnyPopoverOpen={isAnyPopoverOpen}
                 isSidePanelOpen={!isCollapsed && item.id === openerNode?.id}
+                isAnyPopoverLocked={isAnyPopoverLocked}
                 label={item.label}
-                setAnyPopoverOpen={setAnyPopoverOpen}
                 trigger={
                   <SideNav.PrimaryMenu.Item
                     hasContent={getHasSubmenu(item)}
@@ -172,13 +171,13 @@ export const Navigation = ({
           {overflowMenuItems.length > 0 && (
             <SideNav.Popover
               hasContent
-              isAnyPopoverOpen={isAnyPopoverOpen}
               isSidePanelOpen={false}
+              isAnyPopoverLocked={isAnyPopoverLocked}
+              setIsLocked={setIsAnyPopoverLocked}
               label={i18n.translate('core.ui.chrome.sideNavigation.moreMenuLabel', {
                 defaultMessage: 'More',
               })}
               persistent
-              setAnyPopoverOpen={setAnyPopoverOpen}
               trigger={
                 <SideNav.PrimaryMenu.Item
                   data-test-subj={moreMenuTriggerTestSubj}
@@ -268,11 +267,10 @@ export const Navigation = ({
               <SideNav.Popover
                 key={item.id}
                 hasContent={getHasSubmenu(item)}
-                isAnyPopoverOpen={isAnyPopoverOpen}
                 isSidePanelOpen={!isCollapsed && item.id === openerNode?.id}
+                isAnyPopoverLocked={isAnyPopoverLocked}
                 label={item.label}
                 persistent={false}
-                setAnyPopoverOpen={setAnyPopoverOpen}
                 trigger={
                   <SideNav.Footer.Item
                     isHighlighted={item.id === visuallyActivePageId}

--- a/src/core/packages/chrome/navigation/src/components/side_nav/popover.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/popover.tsx
@@ -41,11 +41,11 @@ export interface PopoverProps {
   children?: ReactNode | ((closePopover: () => void) => ReactNode);
   container?: HTMLElement;
   hasContent: boolean;
-  isAnyPopoverOpen: boolean;
   isSidePanelOpen: boolean;
+  isAnyPopoverLocked?: boolean;
+  setIsLocked?: (isLocked: boolean) => void;
   label: string;
   persistent?: boolean;
-  setAnyPopoverOpen: (isOpen: boolean) => void;
   trigger: ReactElement<{
     ref?: Ref<HTMLElement>;
     onClick?: (e: MouseEvent) => void;
@@ -68,11 +68,11 @@ export const Popover = ({
   children,
   container,
   hasContent,
-  isAnyPopoverOpen,
   isSidePanelOpen,
+  isAnyPopoverLocked = false,
+  setIsLocked = () => {},
   label,
   persistent = false,
-  setAnyPopoverOpen,
   trigger,
 }: PopoverProps): JSX.Element => {
   const { euiTheme } = useEuiTheme();
@@ -85,52 +85,48 @@ export const Popover = ({
   const [isOpen, setIsOpen] = useState(false);
   const [shouldFocusOnOpen, setShouldFocusOnOpen] = useState(false);
 
+  useEffect(() => {
+    if (persistent) {
+      setIsLocked(isOpenedByClick && isOpen);
+    }
+  }, [persistent, isOpenedByClick, isOpen, setIsLocked]);
+
   const setOpenedByClick = useCallback(() => setIsOpenedByClick(true), []);
 
   const clearOpenedByClick = useCallback(() => setIsOpenedByClick(false), []);
 
   const open = useCallback(() => {
     setIsOpen(true);
-    setAnyPopoverOpen(true);
-  }, [setAnyPopoverOpen]);
+  }, []);
 
   const close = useCallback(() => {
     setIsOpen(false);
     clearOpenedByClick();
     clearHoverTimeout();
     setShouldFocusOnOpen(false);
-    setAnyPopoverOpen(false);
-  }, [clearOpenedByClick, clearHoverTimeout, setAnyPopoverOpen]);
+  }, [clearOpenedByClick, clearHoverTimeout]);
 
   const handleClose = useCallback(() => {
     clearHoverTimeout();
     close();
   }, [clearHoverTimeout, close]);
 
-  const tryOpen = useCallback(() => {
-    if (!isSidePanelOpen && !isAnyPopoverOpen) {
-      open();
-    }
-  }, [isAnyPopoverOpen, isSidePanelOpen, open]);
-
   const handleMouseEnter = useCallback(() => {
-    if (!persistent || !isOpenedByClick) {
+    if ((!persistent || !isOpenedByClick) && (!isAnyPopoverLocked || isOpen)) {
       clearHoverTimeout();
-      if (isAnyPopoverOpen) {
-        setHoverTimeout(tryOpen, POPOVER_HOVER_DELAY);
-      } else if (!isSidePanelOpen) {
+      if (!isSidePanelOpen) {
         setHoverTimeout(open, POPOVER_HOVER_DELAY);
       }
     }
   }, [
     persistent,
     isOpenedByClick,
-    isAnyPopoverOpen,
+    isAnyPopoverLocked,
+    isOpen,
     isSidePanelOpen,
     clearHoverTimeout,
     open,
     setHoverTimeout,
-    tryOpen,
   ]);
 
   const handleMouseLeave = useCallback(() => {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/243488

### Problem

`isAnyPopoverOpen` is needed for when "More" menu is persistent (click on the trigger) and we don't want to open other popovers when hovering over their triggers.

The issue with popovers not showing is that on the refactor PR: https://github.com/elastic/kibana/pull/242302/commits/d19b1d199a3ab25b4b6639087a6c88c461f8b89c I rewrote the global flag `isAnyPopoverOpen` to React state. That introduced a stale closure because:

1. When we hovered over a menu item (say A), it scheduled a function to run after a delay to open the popover.
2. The scheduled function used the `isAnyPopoverOpen` prop at the moment the hover started.
3. We hovered over an item B, the item A was still open. Item B captured `isAnyPopoverOpen = true`.
4. Item A closed and React state updated to `false`.
5. The timed out function for item B was already created and it was holding onto the `true` value.
6. When the timeout finished and the function ran, it asked "is any popover open?", it received a stale value of `true` instead of the actual `false` so it didn't open item B.

### Solution

The idea is to move the check from the end of the timer to the start of the interaction. I also renamed `isAnyPopoverOpen` to `isAnyPopoverLocked` which is now closer to the intention.

### Mouse interaction

https://github.com/user-attachments/assets/694e6983-77df-48eb-b7ad-cff2fb2f913a

### Keyboard navigation

https://github.com/user-attachments/assets/2af7810f-82d1-47b1-9b2a-94e52493afe6

### Checklist

- [ ] run the branch locally and verify the popover hover works as expected
    - [ ] for primary menu
    - [ ] for footer menu
    - [ ] moving on a diagonal