### PR TITLE
[Security Solution][Attacks/Alerts][Attacks discovery page] Callout updates (#232593)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/moving_attacks_callout/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/moving_attacks_callout/index.test.tsx
@@ -10,7 +10,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { TestProviders } from '../../../common/mock';
-import { CALLOUT_TEST_DATA_ID, MovingAttacksCallout } from '.';
+import { CALLOUT_TEST_DATA_ID, HIDE_BUTTON_TEST_DATA_ID, MovingAttacksCallout } from '.';
 import { useMovingAttacksCallout } from './use_moving_attacks_callout';
 import { mockUseMovingAttacksCallout } from './use_moving_attacks_callout.mock';
 
@@ -49,6 +49,12 @@ describe('MovingAttacksCallout', () => {
     expect(screen.getByTestId(CALLOUT_TEST_DATA_ID)).toBeInTheDocument();
   });
 
+  it('renders the hide callout button when isMovingAttacksCalloutVisible is true', () => {
+    renderCallout();
+
+    expect(screen.getByTestId(HIDE_BUTTON_TEST_DATA_ID)).toBeInTheDocument();
+  });
+
   it('calls hideCallout when the callout is dismissed', async () => {
     const mockHideCallout = jest.fn();
 
@@ -61,7 +67,7 @@ describe('MovingAttacksCallout', () => {
 
     renderCallout();
 
-    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    await userEvent.click(screen.getByTestId(HIDE_BUTTON_TEST_DATA_ID));
 
     await waitFor(() => {
       expect(mockHideCallout).toHaveBeenCalled();

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/moving_attacks_callout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/moving_attacks_callout/index.tsx
@@ -5,7 +5,14 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiCallOut, EuiSpacer } from '@elastic/eui';
+import { css } from '@emotion/react';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiSpacer,
+  useEuiTheme,
+  useIsWithinMaxBreakpoint,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { SecurityPageName } from '@kbn/deeplinks-security';
 import { SecuritySolutionLinkButton } from '../../../common/components/links';
@@ -18,35 +25,51 @@ export const CALLOUT_TEST_DATA_ID = 'moving-attacks-callout' as string;
  * Component to display a moving attacks callout
  */
 export const MovingAttacksCallout: React.FC = React.memo(() => {
+  const { euiTheme } = useEuiTheme();
+
   const { isMovingAttacksCalloutVisible, hideMovingAttacksCallout } = useMovingAttacksCallout();
+
+  const isSmall = useIsWithinMaxBreakpoint('m');
+  const calloutDescriptionWidth = css`
+    max-width: ${isSmall ? 'auto' : '1000px'};
+  `;
+
+  const hideButtonSpacing = css`
+    margin-left: ${euiTheme.size.s};
+  `;
 
   return isMovingAttacksCalloutVisible ? (
     <>
       <EuiCallOut
         announceOnMount
-        onDismiss={hideMovingAttacksCallout}
         title={
           <FormattedMessage
             id="xpack.securitySolution.attackDiscovery.movingAttacksCallout.title"
-            defaultMessage="Attack discovery is moving to Detections"
+            defaultMessage="Attack Discovery is moving to Detections"
           />
         }
         iconType="bolt"
         data-test-subj={CALLOUT_TEST_DATA_ID}
       >
-        <p>
+        <p css={calloutDescriptionWidth}>
           <FormattedMessage
             id="xpack.securitySolution.attackDiscovery.movingAttacksCallout.description"
-            defaultMessage="You can now schedule scans and view attacks from Detections -> Attacks. Manual scans are still available only on the legacy page. Attack discovery will move completely to the Detections section in a future release."
+            defaultMessage="You can now schedule scans and view promoted attacks from Detections -> Attacks. Manual scans are still available only here, on the legacy page. Attack Discovery will move completely to the Detections section in a future release."
           />
         </p>
+
         <SecuritySolutionLinkButton
-          deepLinkId={SecurityPageName.attacks}
           fill
+          size="s"
+          deepLinkId={SecurityPageName.attacks}
           data-test-subj="viewAttacksButton"
         >
           {i18n.VIEW_ATTACKS_BUTTON}
         </SecuritySolutionLinkButton>
+
+        <EuiButton css={hideButtonSpacing} size="s" onClick={hideMovingAttacksCallout}>
+          {i18n.HIDE_BUTTON}
+        </EuiButton>
       </EuiCallOut>
       <EuiSpacer size="l" />
     </>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/moving_attacks_callout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/moving_attacks_callout/index.tsx
@@ -20,6 +20,7 @@ import { useMovingAttacksCallout } from './use_moving_attacks_callout';
 import * as i18n from './translations';
 
 export const CALLOUT_TEST_DATA_ID = 'moving-attacks-callout' as string;
+export const HIDE_BUTTON_TEST_DATA_ID = 'hide-callout-button' as string;
 
 /**
  * Component to display a moving attacks callout
@@ -67,7 +68,12 @@ export const MovingAttacksCallout: React.FC = React.memo(() => {
           {i18n.VIEW_ATTACKS_BUTTON}
         </SecuritySolutionLinkButton>
 
-        <EuiButton css={hideButtonSpacing} size="s" onClick={hideMovingAttacksCallout}>
+        <EuiButton
+          data-test-subj={HIDE_BUTTON_TEST_DATA_ID}
+          css={hideButtonSpacing}
+          size="s"
+          onClick={hideMovingAttacksCallout}
+        >
           {i18n.HIDE_BUTTON}
         </EuiButton>
       </EuiCallOut>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/moving_attacks_callout/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/moving_attacks_callout/translations.ts
@@ -13,3 +13,10 @@ export const VIEW_ATTACKS_BUTTON = i18n.translate(
     defaultMessage: 'View Attacks',
   }
 );
+
+export const HIDE_BUTTON = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.movingAttacksCallout.hideButton',
+  {
+    defaultMessage: 'Hide',
+  }
+);


### PR DESCRIPTION
## Summary

Epic: https://github.com/elastic/kibana/issues/232569
Related to https://github.com/elastic/kibana/issues/232593

This are the followup changes to [this PR](https://github.com/elastic/kibana/pull/243272), where we added a callout about the new Attacks page that will be a new place for the Attack discovery experience.

**Updates** ([internal discussion](https://elastic.slack.com/archives/C09G1V7G34K/p1763407825167269)):
* Callout description
* Hide button instead of standard "x" dismiss button
* Improved layout for a wider screens

**NOTE**: To restore dismissed callout remove `elasticAssistantDefault.attackDiscovery.movingAttacksCallout` value in the local storage.

## Feature Flag

> [!NOTE]
> The feature is hidden behind the feature flag (in `kibana.dev.yml`):

```
feature_flags.overrides:
  securitySolution.attacksAlertsAlignment: true
```

## View recording

https://github.com/user-attachments/assets/75dc4be0-26b7-4d12-863e-e74effe460d5
