### PR TITLE
[Search] Fix FTRs to expect agents in classic side nav

### DIFF
--- a/x-pack/solutions/search/test/functional_search/tests/classic_navigation.basic.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/classic_navigation.basic.ts
@@ -43,6 +43,7 @@ export default function searchClassicNavigationTests({
         { id: 'Indices', label: 'Index Management' },
         { id: 'Playground', label: 'Playground' },
         { id: 'SearchApplications', label: 'Search applications' },
+        { id: 'Agents', label: 'Agents' },
         { id: 'Relevance', label: 'Relevance' },
         { id: 'Synonyms', label: 'Synonyms' },
         { id: 'QueryRules', label: 'Query rules' },

--- a/x-pack/solutions/search/test/functional_search/tests/classic_navigation.ts
+++ b/x-pack/solutions/search/test/functional_search/tests/classic_navigation.ts
@@ -41,6 +41,7 @@ export default function searchSolutionNavigation({
         { id: 'Indices', label: 'Index Management' },
         { id: 'Playground', label: 'Playground' },
         { id: 'SearchApplications', label: 'Search applications' },
+        { id: 'Agents', label: 'Agents' },
         { id: 'Relevance', label: 'Relevance' },
         { id: 'Synonyms', label: 'Synonyms' },
         { id: 'QueryRules', label: 'Query rules' },


### PR DESCRIPTION
## Summary

Updated classic nav tests to expect `Agents` to display by default.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.