### PR TITLE
[Agent Builder] use `getAgentDescription` from attachment types - reloaded

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/default/prompts.ts
@@ -254,10 +254,10 @@ const renderAttachmentTypeInstructions = (attachmentTypes: ProcessedAttachmentTy
     return '';
   }
 
-  const perTypeInstructions = attachmentTypes.map(({ type, agentDescription }) => {
+  const perTypeInstructions = attachmentTypes.map(({ type, description }) => {
     return `### ${type} attachments
 
-${agentDescription ?? 'No instructions available.'}
+${description ?? 'No instructions available.'}
 `;
   });
 

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/prepare_conversation.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/prepare_conversation.ts
@@ -19,7 +19,7 @@ export interface ProcessedAttachment {
 
 export interface ProcessedAttachmentType {
   type: string;
-  agentDescription?: string;
+  description?: string;
 }
 
 export interface ProcessedRoundInput {


### PR DESCRIPTION
## Summary

Follow-up of https://github.com/elastic/kibana/pull/243541.... 

Should be good this time