### PR TITLE
[Security Solution][Alert details] save selected threat intelligence time to local storage

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/prevalence_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/prevalence_overview.tsx
@@ -40,13 +40,13 @@ const CUSTOM_TIME_RANGE_LABEL = (
 );
 const DEFAULT_TIME_RANGE_TOOLTIP = (
   <FormattedMessage
-    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.custom-time-range-applied-tooltip"
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.defaultTimeRangeApplied.tooltipLabel"
     defaultMessage="Prevalence measures how frequently data from this alert is observed across hosts or users in your environment over the last 30 days. To choose a custom time range, click the section title, then use the date time picker in the left panel."
   />
 );
 const CUSTOM_TIME_RANGE_TOOLTIP = (
   <FormattedMessage
-    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.custom-time-range-applied-tooltip"
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.customTimeRangeApplied.tooltipLabel"
     defaultMessage="Prevalence measures how frequently data from this alert is observed across hosts or users in your environment over the time range that you chose. To choose a different custom time range, click the section title, then use the date time picker in the left panel."
   />
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.test.tsx
@@ -19,6 +19,7 @@ import {
   SUMMARY_ROW_TEXT_TEST_ID,
 } from './test_ids';
 import {
+  EXPANDABLE_PANEL_HEADER_RIGHT_SECTION_TEST_ID,
   EXPANDABLE_PANEL_HEADER_TITLE_ICON_TEST_ID,
   EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID,
   EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID,
@@ -26,9 +27,11 @@ import {
   EXPANDABLE_PANEL_TOGGLE_ICON_TEST_ID,
 } from '../../../shared/components/test_ids';
 import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
+import { useKibana } from '../../../../common/lib/kibana';
 
 jest.mock('../../shared/context');
 jest.mock('../hooks/use_fetch_threat_intelligence');
+jest.mock('../../../../common/lib/kibana');
 
 const mockNavigateToLeftPanel = jest.fn();
 jest.mock('../../shared/hooks/use_navigate_to_left_panel');
@@ -43,6 +46,9 @@ const TITLE_ICON_TEST_ID = EXPANDABLE_PANEL_HEADER_TITLE_ICON_TEST_ID(
   INSIGHTS_THREAT_INTELLIGENCE_TEST_ID
 );
 const TITLE_TEXT_TEST_ID = EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(
+  INSIGHTS_THREAT_INTELLIGENCE_TEST_ID
+);
+const RIGHT_SECTION_TEXT_TEST_ID = EXPANDABLE_PANEL_HEADER_RIGHT_SECTION_TEST_ID(
   INSIGHTS_THREAT_INTELLIGENCE_TEST_ID
 );
 const LOADING_TEST_ID = EXPANDABLE_PANEL_LOADING_TEST_ID(INSIGHTS_THREAT_INTELLIGENCE_TEST_ID);
@@ -79,6 +85,13 @@ describe('<ThreatIntelligenceOverview />', () => {
       loading: false,
     });
     (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        storage: {
+          get: () => undefined,
+        },
+      },
+    });
   });
 
   it('should render wrapper component', () => {
@@ -88,6 +101,26 @@ describe('<ThreatIntelligenceOverview />', () => {
     expect(getByTestId(TITLE_ICON_TEST_ID)).toBeInTheDocument();
     expect(getByTestId(TITLE_LINK_TEST_ID)).toBeInTheDocument();
     expect(queryByTestId(TITLE_TEXT_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('should show default time range badge', () => {
+    const { getByTestId } = renderThreatIntelligenceOverview();
+
+    expect(getByTestId(RIGHT_SECTION_TEXT_TEST_ID)).toHaveTextContent('Time range applied');
+  });
+
+  it('should show custom time range badge', () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        storage: {
+          get: () => ({ from: 'now-7d', to: 'now-3d' }),
+        },
+      },
+    });
+
+    const { getByTestId } = renderThreatIntelligenceOverview();
+
+    expect(getByTestId(RIGHT_SECTION_TEXT_TEST_ID)).toHaveTextContent('Custom time range applied');
   });
 
   it('should render link without icon if in preview mode', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.tsx
@@ -9,6 +9,8 @@ import type { FC } from 'react';
 import React, { useMemo } from 'react';
 import { EuiBadge, EuiFlexGroup, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { FLYOUT_STORAGE_KEYS } from '../../shared/constants/local_storage';
+import { useKibana } from '../../../../common/lib/kibana';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import { useFetchThreatIntelligence } from '../hooks/use_fetch_threat_intelligence';
 import { InsightsSummaryRow } from './insights_summary_row';
@@ -22,16 +24,40 @@ import { LeftPanelInsightsTab } from '../../left';
 import { THREAT_INTELLIGENCE_TAB_ID } from '../../left/components/threat_intelligence_details';
 import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
-const TITLE = (
+const HEADER_TITLE = (
   <FormattedMessage
     id="xpack.securitySolution.flyout.right.insights.threatIntelligence.threatIntelligenceTitle"
     defaultMessage="Threat intelligence"
   />
 );
-const TOOLTIP = (
+const HEADER_TOOLTIP = (
   <FormattedMessage
     id="xpack.securitySolution.flyout.right.insights.threatIntelligence.threatIntelligenceTooltip"
     defaultMessage="Show all threat intelligence"
+  />
+);
+const DEFAULT_TIME_RANGE_LABEL = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.defaultTimeRangeApplied.badgeLabel"
+    defaultMessage="Time range applied"
+  />
+);
+const CUSTOM_TIME_RANGE_LABEL = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.customTimeRangeApplied.badgeLabel"
+    defaultMessage="Custom time range applied"
+  />
+);
+const DEFAULT_TIME_RANGE_TOOLTIP = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.defaultTimeRangeAppliedTooltipLabel"
+    defaultMessage="Threat intelligence helps you to find current and emerging threats in your environment over the last 30 days. To choose a custom time range, click the section title, then use the date time picker in the left panel."
+  />
+);
+const CUSTOM_TIME_RANGE_TOOLTIP = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.customTimeRangeAppliedTooltipLabel"
+    defaultMessage="Threat intelligence helps you to find current and emerging threats in your environment during the time range that you chose. To choose a different custom time range, click the section title, then use the date time picker in the left panel."
   />
 );
 
@@ -42,6 +68,9 @@ const TOOLTIP = (
  */
 export const ThreatIntelligenceOverview: FC = () => {
   const { dataFormattedForFieldBrowser, isPreviewMode } = useDocumentDetailsContext();
+
+  const { storage } = useKibana().services;
+  const timeSavedInLocalStorage = storage.get(FLYOUT_STORAGE_KEYS.THREAT_INTELLIGENCE_TIME_RANGE);
 
   const goToThreatIntelligenceTab = useNavigateToLeftPanel({
     tab: LeftPanelInsightsTab,
@@ -55,7 +84,7 @@ export const ThreatIntelligenceOverview: FC = () => {
   const link = useMemo(
     () => ({
       callback: goToThreatIntelligenceTab,
-      tooltip: TOOLTIP,
+      tooltip: HEADER_TOOLTIP,
     }),
     [goToThreatIntelligenceTab]
   );
@@ -85,23 +114,17 @@ export const ThreatIntelligenceOverview: FC = () => {
   return (
     <ExpandablePanel
       header={{
-        title: TITLE,
+        title: HEADER_TITLE,
         link,
         iconType: !isPreviewMode ? 'arrowStart' : undefined,
         headerContent: (
           <EuiToolTip
             content={
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.right.insights.threatIntelligence.custom-time-range-applied-tooltip"
-                defaultMessage="The threat intelligence is calculated from a specific time range. To change it, click on the Threat intelligence title (to the left) and use the date picker."
-              />
+              timeSavedInLocalStorage ? CUSTOM_TIME_RANGE_TOOLTIP : DEFAULT_TIME_RANGE_TOOLTIP
             }
           >
             <EuiBadge color="hollow" iconSide="left" iconType="clock" tabIndex={0}>
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.right.insights.threatIntelligence.custom-time-range-applied-badge-label"
-                defaultMessage="Time range applied"
-              />
+              {timeSavedInLocalStorage ? CUSTOM_TIME_RANGE_LABEL : DEFAULT_TIME_RANGE_LABEL}
             </EuiBadge>
           </EuiToolTip>
         ),

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.tsx
@@ -7,7 +7,7 @@
 
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
-import { EuiFlexGroup, EuiIconTip } from '@elastic/eui';
+import { EuiBadge, EuiFlexGroup, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import { useFetchThreatIntelligence } from '../hooks/use_fetch_threat_intelligence';
@@ -89,15 +89,21 @@ export const ThreatIntelligenceOverview: FC = () => {
         link,
         iconType: !isPreviewMode ? 'arrowStart' : undefined,
         headerContent: (
-          <EuiIconTip
+          <EuiToolTip
             content={
               <FormattedMessage
-                id="xpack.securitySolution.flyout.right.threatintelligence.time"
-                defaultMessage="The threat intelligence is calculated from a specific time interval. To change that interval, go to the Threat intelligence tab in the flyout expanded view and use the date picker."
+                id="xpack.securitySolution.flyout.right.insights.threatIntelligence.custom-time-range-applied-tooltip"
+                defaultMessage="The threat intelligence is calculated from a specific time range. To change it, click on the Threat intelligence title (to the left) and use the date picker."
               />
             }
-            type="info"
-          />
+          >
+            <EuiBadge color="hollow" iconSide="left" iconType="clock" tabIndex={0}>
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.right.insights.threatIntelligence.custom-time-range-applied-badge-label"
+                defaultMessage="Time range applied"
+              />
+            </EuiBadge>
+          </EuiToolTip>
         ),
       }}
       data-test-subj={INSIGHTS_THREAT_INTELLIGENCE_TEST_ID}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.tsx
@@ -7,7 +7,7 @@
 
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
-import { EuiFlexGroup } from '@elastic/eui';
+import { EuiFlexGroup, EuiIconTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import { useFetchThreatIntelligence } from '../hooks/use_fetch_threat_intelligence';
@@ -88,6 +88,17 @@ export const ThreatIntelligenceOverview: FC = () => {
         title: TITLE,
         link,
         iconType: !isPreviewMode ? 'arrowStart' : undefined,
+        headerContent: (
+          <EuiIconTip
+            content={
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.right.threatintelligence.time"
+                defaultMessage="The threat intelligence is calculated from a specific time interval. To change that interval, go to the Threat intelligence tab in the flyout expanded view and use the date picker."
+              />
+            }
+            type="info"
+          />
+        ),
       }}
       data-test-subj={INSIGHTS_THREAT_INTELLIGENCE_TEST_ID}
       content={{ loading }}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
@@ -12,4 +12,5 @@ export const FLYOUT_STORAGE_KEYS = {
   TABLE_TAB_STATE: 'securitySolution.documentDetailsFlyout.tableTabState.v8.19',
   TABLE_TAB_TOUR: 'securitySolution.documentDetailsFlyout.tableTabTourState.v8.19',
   PREVALENCE_TIME_RANGE: 'securitySolution.documentDetailsFlyout.prevalenceTimeRange',
+  THREAT_INTELLIGENCE_INTERVAL: 'securitySolution.documentDetailsFlyout.threatIntelligenceInterval',
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
@@ -12,5 +12,6 @@ export const FLYOUT_STORAGE_KEYS = {
   TABLE_TAB_STATE: 'securitySolution.documentDetailsFlyout.tableTabState.v8.19',
   TABLE_TAB_TOUR: 'securitySolution.documentDetailsFlyout.tableTabTourState.v8.19',
   PREVALENCE_TIME_RANGE: 'securitySolution.documentDetailsFlyout.prevalenceTimeRange',
-  THREAT_INTELLIGENCE_INTERVAL: 'securitySolution.documentDetailsFlyout.threatIntelligenceInterval',
+  THREAT_INTELLIGENCE_TIME_RANGE:
+    'securitySolution.documentDetailsFlyout.threatIntelligenceTimeRange',
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_investigation_enrichment.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_investigation_enrichment.ts
@@ -75,7 +75,7 @@ export const useInvestigationTimeEnrichment = ({
   const { data, storage, uiSettings } = useKibana().services;
   const defaultThreatIndices = uiSettings.get<string[]>(DEFAULT_THREAT_INDEX_KEY);
 
-  const timeSavedInLocalStorage = storage.get(FLYOUT_STORAGE_KEYS.THREAT_INTELLIGENCE_INTERVAL);
+  const timeSavedInLocalStorage = storage.get(FLYOUT_STORAGE_KEYS.THREAT_INTELLIGENCE_TIME_RANGE);
 
   const dispatch = useDispatch();
 
@@ -87,7 +87,7 @@ export const useInvestigationTimeEnrichment = ({
   const setRange = useCallback(
     (rge: { from: string; to: string }) => {
       setCustomRange(rge);
-      storage.set(FLYOUT_STORAGE_KEYS.THREAT_INTELLIGENCE_INTERVAL, {
+      storage.set(FLYOUT_STORAGE_KEYS.THREAT_INTELLIGENCE_TIME_RANGE, {
         start: rge.from,
         end: rge.to,
       });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_investigation_enrichment.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_investigation_enrichment.ts
@@ -24,6 +24,7 @@ import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useKibana } from '../../../../common/lib/kibana';
 import { inputsActions } from '../../../../common/store/actions';
 import { DEFAULT_THREAT_INDEX_KEY } from '../../../../../common/constants';
+import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
 
 const INVESTIGATION_ENRICHMENT_REQUEST_ERROR = i18n.translate(
   'xpack.securitySolution.flyout.threatIntelligence.requestError',
@@ -71,15 +72,28 @@ export const useInvestigationTimeEnrichment = ({
   eventFields,
 }: UseInvestigationTimeEnrichmentProps): UseInvestigationTimeEnrichmentResult => {
   const { addError } = useAppToasts();
-  const { data, uiSettings } = useKibana().services;
+  const { data, storage, uiSettings } = useKibana().services;
   const defaultThreatIndices = uiSettings.get<string[]>(DEFAULT_THREAT_INDEX_KEY);
+
+  const timeSavedInLocalStorage = storage.get(FLYOUT_STORAGE_KEYS.THREAT_INTELLIGENCE_INTERVAL);
 
   const dispatch = useDispatch();
 
-  const [range, setRange] = useState({
-    from: DEFAULT_EVENT_ENRICHMENT_FROM,
-    to: DEFAULT_EVENT_ENRICHMENT_TO,
+  const [range, setCustomRange] = useState({
+    from: timeSavedInLocalStorage?.start || DEFAULT_EVENT_ENRICHMENT_FROM,
+    to: timeSavedInLocalStorage?.end || DEFAULT_EVENT_ENRICHMENT_TO,
   });
+
+  const setRange = useCallback(
+    (rge: { from: string; to: string }) => {
+      setCustomRange(rge);
+      storage.set(FLYOUT_STORAGE_KEYS.THREAT_INTELLIGENCE_INTERVAL, {
+        start: rge.from,
+        end: rge.to,
+      });
+    },
+    [storage]
+  );
 
   const { error, loading, result, start } = useEventEnrichmentComplete();
 


### PR DESCRIPTION
## Summary

This PR makes a small improvement to the alert details flyout, by saving the time selected by the user in the expanded section threat intelligence details to local storage.

- If no value is present in local storage, we default to the value we had before.
- When the user selects a new interval in the flyout expanded section Insights => Threat intelligence tab, we persist that value in local storage under the `securitySolution.documentDetailsFlyout.threatIntelligenceInterval` key. We save the `start` and `end` values.
- We apply those saved `start` and `end` values both to the threat intelligence details (expanded flyout tab) and threat intelligence overview (collapsed flyout) components.

https://github.com/user-attachments/assets/30d3bba9-5f3b-46c4-82d8-2048c576aa7d

We add a tooltip to let the user know that the threat intelligence overview (in the right panel) fetches threat intelligence data for the interval set within the expanded section

| Default time range  | If time range has been saved in local storage |
| ------------- | ------------- |
| <img width="569" height="806" alt="Screenshot 2025-11-20 at 9 49 19 PM" src="https://github.com/user-attachments/assets/4a2b8473-add3-4c70-80fe-f5c81bffc834" /> | <img width="572" height="805" alt="Screenshot 2025-11-20 at 10 01 02 PM" src="https://github.com/user-attachments/assets/6057d829-2e10-4041-854b-f6ec79e104ee" /> |

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.19","9.0","9.1","9.2"]} ONMERGE-->