### PR TITLE
[Kbn grid layout] Use max_value instead of infinity

### DIFF
--- a/src/platform/packages/private/kbn-grid-layout/grid/use_grid_layout_events/panel/utils.test.ts
+++ b/src/platform/packages/private/kbn-grid-layout/grid/use_grid_layout_events/panel/utils.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { RuntimeGridSettings } from '../../types';
+import { getRowCountInPixels } from './utils';
+
+const runtimeSettings: RuntimeGridSettings = {
+  gutterSize: 0,
+  rowHeight: 10,
+  columnCount: 48,
+  keyboardDragTopLimit: 0,
+  columnPixelWidth: 12,
+};
+
+describe('getRowCountInPixels', () => {
+  describe('with no gutter', () => {
+    it('should return Infinity when given infinite rows', () => {
+      const result = getRowCountInPixels({
+        rowCount: Infinity,
+        runtimeSettings,
+      });
+      expect(result).toBe(Infinity);
+    });
+
+    it('should return a number when given a number of rows', () => {
+      const result = getRowCountInPixels({
+        rowCount: 10,
+        runtimeSettings,
+      });
+      expect(result).toBe(100);
+    });
+  });
+
+  describe('with a gutter', () => {
+    it('should return Infinity when given Infinite rows', () => {
+      const result = getRowCountInPixels({
+        rowCount: Infinity,
+        runtimeSettings: { ...runtimeSettings, gutterSize: 8 },
+      });
+      expect(result).toBe(Infinity);
+    });
+
+    it('should return a number when given a number of rows', () => {
+      const result = getRowCountInPixels({
+        rowCount: 10,
+        runtimeSettings: { ...runtimeSettings, gutterSize: 8 },
+      });
+      expect(result).toBe(172);
+    });
+  });
+});

--- a/src/platform/packages/private/kbn-grid-layout/grid/use_grid_layout_events/panel/utils.ts
+++ b/src/platform/packages/private/kbn-grid-layout/grid/use_grid_layout_events/panel/utils.ts
@@ -33,13 +33,16 @@ const getColumnCountInPixels = ({
 }) =>
   columnCount * runtimeSettings.columnPixelWidth + (columnCount - 1) * runtimeSettings.gutterSize;
 
-const getRowCountInPixels = ({
+export const getRowCountInPixels = ({
   rowCount,
   runtimeSettings,
 }: {
   rowCount: number;
   runtimeSettings: RuntimeGridSettings;
-}) => rowCount * runtimeSettings.rowHeight + (rowCount - 1) * runtimeSettings.gutterSize;
+}) => {
+  const safeRowCount = Math.min(rowCount, Number.MAX_VALUE); // Infinity * 0 = Nan which can cause problems.
+  return safeRowCount * runtimeSettings.rowHeight + (safeRowCount - 1) * runtimeSettings.gutterSize;
+};
 
 // Calculates the preview rect coordinates for a resized panel
 export const getResizePreviewRect = ({

--- a/src/platform/packages/private/kbn-grid-layout/grid/use_grid_layout_events/panel/utils.ts
+++ b/src/platform/packages/private/kbn-grid-layout/grid/use_grid_layout_events/panel/utils.ts
@@ -21,7 +21,7 @@ export const getDefaultResizeOptions = (runtimeSettings: RuntimeGridSettings) =>
   minWidth: 1,
   maxWidth: runtimeSettings.columnCount,
   minHeight: 1,
-  maxHeight: Infinity,
+  maxHeight: Number.MAX_VALUE,
 });
 
 const getColumnCountInPixels = ({


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/243364 by using `Number.MAX_VALUE` instead of `Infinity` for the default maximum height of a panel.

## Explanation
The tab crash was caused by the dragged panel on the Dashboard attempting to resize their height to NaN. The NaN came from the `getRowCountInPixels` function when attempting to calculate max pixel height of the panel to calculate the bottom of the preview rect:

### Working case (main)
``` typescript
const rowCount = Infinity;
const rowHeight = 30;
const gutterSize = 8;

// ( Infinity * 30 = Infinity) + ( Infinity * 8 = Infinity  )  = Infinity
return rowCount * rowHeight + (rowCount - 1) * gutterSize
```

### Broken case (main)
``` typescript
const rowCount = Infinity;
const rowHeight = 30;
const gutterSize = 0;

// ( Infinity * 30 = Infinity) + ( Infinity * 0 = NaN  )  = NaN
return rowCount * rowHeight + (rowCount - 1) * gutterSize
```
### Fixed case (This PR)
``` typescript
const rowCount = MAX_VALUE;
const rowHeight = 30;
const gutterSize = 0;

// ( MAX_VALUE * 30 = Infinity) + ( MAX_VALUE * 0 = 0  )  = Infinity
return rowCount * rowHeight + (rowCount - 1) * gutterSize
```


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->