### PR TITLE
Revert "[performance] optimize ES|QL async polling (#243104)"

### DIFF
--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.test.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.test.ts
@@ -22,7 +22,7 @@ import * as searchPhaseException from '../../../common/search/test_data/search_p
 import * as resourceNotFoundException from '../../../common/search/test_data/resource_not_found_exception.json';
 import { BehaviorSubject } from 'rxjs';
 import { dataPluginMock } from '../../mocks';
-import { ESQL_ASYNC_SEARCH_STRATEGY, UI_SETTINGS } from '../../../common';
+import { UI_SETTINGS } from '../../../common';
 import type { SearchServiceStartDependencies } from '../search_service';
 import type { Start as InspectorStart } from '@kbn/inspector-plugin/public';
 import { SearchTimeoutError, TimeoutErrorMode } from './timeout_error';
@@ -292,205 +292,7 @@ describe('SearchInterceptor', () => {
       expect(error).not.toHaveBeenCalled();
     });
 
-    test('should make secondary request if first call returns partial result (ES|QL)', async () => {
-      const responses = [
-        {
-          time: 10,
-          value: {
-            body: {
-              id: '1',
-              is_running: true,
-              documents_found: 0,
-              values_loaded: 0,
-              all_columns: [],
-              columns: [],
-              values: [],
-              _clusters: {},
-            },
-          },
-        },
-        {
-          time: 20,
-          value: {
-            body: {
-              id: '1',
-              is_running: false,
-              took: 8,
-              is_partial: false,
-              documents_found: 5,
-              values_loaded: 5,
-              all_columns: [
-                {
-                  name: 'results',
-                  type: 'long',
-                },
-                {
-                  name: 'timestamp',
-                  type: 'date',
-                },
-              ],
-              columns: [
-                {
-                  name: 'results',
-                  type: 'long',
-                },
-                {
-                  name: 'timestamp',
-                  type: 'date',
-                },
-              ],
-              values: [
-                [1, '2025-11-17T11:00:00.000Z'],
-                [1, '2025-11-17T09:30:00.000Z'],
-                [1, '2025-11-17T12:00:00.000Z'],
-                [1, '2025-11-17T11:30:00.000Z'],
-                [1, '2025-11-17T16:30:00.000Z'],
-              ],
-            },
-          },
-        },
-      ];
-
-      mockCoreSetup.http.post.mockImplementation(getHttpMock(responses));
-
-      const response = searchInterceptor.search(
-        {
-          params: {
-            query:
-              'FROM kibana_sample_data_logs | LIMIT 5 |EVAL DELAY(1s)\n| STATS results = COUNT(*) BY timestamp = BUCKET(@timestamp, 30 minute)',
-            locale: 'en',
-            include_execution_metadata: true,
-            filter: {
-              bool: {
-                must: [],
-                filter: [
-                  {
-                    range: {
-                      '@timestamp': {
-                        format: 'strict_date_optional_time',
-                        gte: '2025-11-17T07:00:00.000Z',
-                        lte: '2025-11-18T06:59:59.999Z',
-                      },
-                    },
-                  },
-                ],
-                should: [],
-                must_not: [],
-              },
-            },
-            dropNullColumns: true,
-          },
-        },
-        { pollInterval: 0, strategy: ESQL_ASYNC_SEARCH_STRATEGY }
-      );
-      response.subscribe({ next, error, complete });
-
-      await timeTravel(10);
-
-      expect(next).toHaveBeenCalled();
-      expect(next.mock.calls[0][0]).toMatchInlineSnapshot(`
-        Object {
-          "id": "1",
-          "isPartial": undefined,
-          "isRestored": false,
-          "isRunning": true,
-          "rawResponse": Object {
-            "_clusters": Object {},
-            "all_columns": Array [],
-            "columns": Array [],
-            "documents_found": 0,
-            "id": "1",
-            "is_running": true,
-            "values": Array [],
-            "values_loaded": 0,
-          },
-          "requestParams": Object {},
-          "warning": undefined,
-        }
-      `);
-      expect(complete).not.toHaveBeenCalled();
-      expect(error).not.toHaveBeenCalled();
-
-      await timeTravel(20);
-
-      expect(next).toHaveBeenCalledTimes(2);
-      expect(next.mock.calls[1][0]).toMatchInlineSnapshot(`
-        Object {
-          "id": "1",
-          "isPartial": false,
-          "isRestored": false,
-          "isRunning": false,
-          "rawResponse": Object {
-            "all_columns": Array [
-              Object {
-                "name": "results",
-                "type": "long",
-              },
-              Object {
-                "name": "timestamp",
-                "type": "date",
-              },
-            ],
-            "columns": Array [
-              Object {
-                "name": "results",
-                "type": "long",
-              },
-              Object {
-                "name": "timestamp",
-                "type": "date",
-              },
-            ],
-            "documents_found": 5,
-            "id": "1",
-            "is_partial": false,
-            "is_running": false,
-            "took": 8,
-            "values": Array [
-              Array [
-                1,
-                "2025-11-17T11:00:00.000Z",
-              ],
-              Array [
-                1,
-                "2025-11-17T09:30:00.000Z",
-              ],
-              Array [
-                1,
-                "2025-11-17T12:00:00.000Z",
-              ],
-              Array [
-                1,
-                "2025-11-17T11:30:00.000Z",
-              ],
-              Array [
-                1,
-                "2025-11-17T16:30:00.000Z",
-              ],
-            ],
-            "values_loaded": 5,
-          },
-          "requestParams": Object {},
-          "warning": undefined,
-        }
-      `);
-      expect(complete).toHaveBeenCalled();
-      expect(error).not.toHaveBeenCalled();
-
-      // check that the query and filter weren't included in the polling request
-      expect(mockCoreSetup.http.post).toHaveBeenCalledTimes(2);
-      const firstRequest = (
-        mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
-      )[1];
-      expect(JSON.parse(firstRequest?.body as string).params).toBeDefined();
-
-      const secondRequest = (
-        mockCoreSetup.http.post.mock.calls[1] as unknown as [string, HttpFetchOptions]
-      )[1];
-      expect(JSON.parse(secondRequest?.body as string).params).not.toBeDefined();
-    });
-
-    test('should make secondary request if first call returns partial result (DSL)', async () => {
+    test('should make secondary request if first call returns partial result', async () => {
       const responses = [
         {
           time: 10,
@@ -599,12 +401,12 @@ describe('SearchInterceptor', () => {
       const firstRequest = (
         mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
       )[1];
-      expect(JSON.parse(firstRequest?.body as string).params).toBeDefined();
+      expect(JSON.parse(firstRequest?.body as string).params.body).toBeDefined();
 
       const secondRequest = (
         mockCoreSetup.http.post.mock.calls[1] as unknown as [string, HttpFetchOptions]
       )[1];
-      expect(JSON.parse(secondRequest?.body as string).params).not.toBeDefined();
+      expect(JSON.parse(secondRequest?.body as string).params.body).not.toBeDefined();
     });
 
     test('should abort on user abort', async () => {


### PR DESCRIPTION
Checking for build failures seen in https://buildkite.com/elastic/kibana-on-merge/builds/82173.

May be unrelated, failing tests were not propagating previously - see https://github.com/elastic/kibana/pull/243499