### PR TITLE
[9.1][Fleet] use long expiration for upgrade agents (#243443)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.test.ts
@@ -141,31 +141,12 @@ describe('sendUpgradeAgentsActions (plural)', () => {
 });
 
 describe('getRollingUpgradeOptions', () => {
-  it('should set longer expiration for 1h duration', () => {
+  it('should 1 month expiration for 1h duration', () => {
     const options = getRollingUpgradeOptions('2023-01-06T00:00:00Z', 3600);
     expect(options).toEqual({
-      expiration: '2023-01-06T02:00:00.000Z',
+      expiration: '2023-02-05T00:00:00.000Z',
       minimum_execution_duration: 3600,
       rollout_duration_seconds: 3600,
-      start_time: '2023-01-06T00:00:00Z',
-    });
-  });
-  it('should set longer expiration for 2h duration', () => {
-    const options = getRollingUpgradeOptions('2023-01-06T00:00:00Z', 7200);
-    expect(options).toEqual({
-      expiration: '2023-01-06T04:00:00.000Z',
-      minimum_execution_duration: 7200,
-      rollout_duration_seconds: 7200,
-      start_time: '2023-01-06T00:00:00Z',
-    });
-  });
-
-  it('should set normal expiration for longer duration', () => {
-    const options = getRollingUpgradeOptions('2023-01-06T00:00:00Z', 36000);
-    expect(options).toEqual({
-      expiration: '2023-01-06T10:00:00.000Z',
-      minimum_execution_duration: 7200,
-      rollout_duration_seconds: 36000,
       start_time: '2023-01-06T00:00:00Z',
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade_action_runner.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade_action_runner.ts
@@ -214,35 +214,28 @@ export const EXPIRATION_DURATION_SECONDS = 60 * 60 * 24 * 30; // 1 month
 
 export const getRollingUpgradeOptions = (startTime?: string, upgradeDurationSeconds?: number) => {
   const now = new Date().toISOString();
+  // Expiration time is set to a very long value (1 month) to allow upgrading agents staying offline for long time
+  const expiration = moment(startTime).add(EXPIRATION_DURATION_SECONDS, 'seconds').toISOString();
   // Perform a rolling upgrade
   if (upgradeDurationSeconds) {
     const minExecutionDuration = Math.min(
       MINIMUM_EXECUTION_DURATION_SECONDS,
       upgradeDurationSeconds
     );
+
     return {
       start_time: startTime ?? now,
       rollout_duration_seconds: upgradeDurationSeconds,
       minimum_execution_duration: minExecutionDuration,
-      // expiration will not be taken into account with Fleet Server version >=8.7, it is kept for BWC
-      // in the next major, expiration and minimum_execution_duration should be removed
-      expiration: moment(startTime ?? now)
-        .add(
-          upgradeDurationSeconds <= MINIMUM_EXECUTION_DURATION_SECONDS
-            ? minExecutionDuration * 2
-            : upgradeDurationSeconds,
-          'seconds'
-        )
-        .toISOString(),
+      expiration,
     };
   }
   // Schedule without rolling upgrade (Immediately after start_time)
-  // Expiration time is set to a very long value (1 month) to allow upgrading agents staying offline for long time
   if (startTime && !upgradeDurationSeconds) {
     return {
       start_time: startTime ?? now,
       minimum_execution_duration: MINIMUM_EXECUTION_DURATION_SECONDS,
-      expiration: moment(startTime).add(EXPIRATION_DURATION_SECONDS, 'seconds').toISOString(),
+      expiration,
     };
   } else {
     // Regular bulk upgrade (non scheduled, non rolling)

--- a/x-pack/platform/test/fleet_tasks/tests/automatic_upgrades.ts
+++ b/x-pack/platform/test/fleet_tasks/tests/automatic_upgrades.ts
@@ -14,9 +14,9 @@
 
 import expect from '@kbn/expect';
 
-import { FtrProviderContextWithServices } from '../ftr_provider_context';
 import { EXPIRATION_DURATION_SECONDS } from '@kbn/fleet-plugin/server/services/agents/upgrade_action_runner';
 import moment from 'moment';
+import { FtrProviderContextWithServices } from '../ftr_provider_context';
 import { cleanupAgentDocs, createAgentDoc } from '../helpers';
 
 export default function (providerContext: FtrProviderContextWithServices) {

--- a/x-pack/platform/test/fleet_tasks/tests/automatic_upgrades.ts
+++ b/x-pack/platform/test/fleet_tasks/tests/automatic_upgrades.ts
@@ -15,11 +15,14 @@
 import expect from '@kbn/expect';
 
 import { FtrProviderContextWithServices } from '../ftr_provider_context';
+import { EXPIRATION_DURATION_SECONDS } from '@kbn/fleet-plugin/server/services/agents/upgrade_action_runner';
+import moment from 'moment';
 import { cleanupAgentDocs, createAgentDoc } from '../helpers';
 
 export default function (providerContext: FtrProviderContextWithServices) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
+  const es = getService('es');
   const TASK_INTERVAL = 30000; // as set in the config
   const RETRY_DELAY = 60000; // as set in the config
   let policyId: string;
@@ -55,6 +58,12 @@ export default function (providerContext: FtrProviderContextWithServices) {
 
     afterEach(async () => {
       await cleanupAgentDocs(providerContext);
+      await es.deleteByQuery({
+        index: '.fleet-actions',
+        query: {
+          match_all: {},
+        },
+      });
     });
 
     it('should only upgrade active agents', async () => {
@@ -84,6 +93,21 @@ export default function (providerContext: FtrProviderContextWithServices) {
       res = await supertest.get('/api/fleet/agents/agent2').set('kbn-xsrf', 'xxx').expect(200);
       expect(res.body.item.upgrade_started_at).to.be(undefined);
       expect(res.body.item.upgrade_attempts).to.be(undefined);
+
+      const actionRes = await es.search({
+        index: '.fleet-actions',
+        query: {
+          term: {
+            agents: 'agent1',
+          },
+        },
+      });
+      // verify that the expiration is set to 1 month
+      const expirationDate = new Date((actionRes.hits.hits[0]?._source as any).expiration);
+      const expectedExpiration = moment(new Date())
+        .add(EXPIRATION_DURATION_SECONDS, 'seconds')
+        .toDate();
+      expect(expirationDate < expectedExpiration).to.be(true);
     });
 
     it('should take agents on target version into account', async () => {


### PR DESCRIPTION
Backport https://github.com/elastic/kibana/pull/243443 to 9.1