### PR TITLE
[SideNav] Include popover in flyout trap focus

### DIFF
--- a/src/core/packages/chrome/navigation/src/components/side_nav/popover.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/popover.tsx
@@ -202,9 +202,8 @@ export const Popover = ({
         Boolean(
           triggerRef.current?.contains(nextFocused) || popoverRef.current?.contains(nextFocused)
         );
-      const isTrappedByFlyout = (nextFocused as HTMLElement)?.classList.contains('euiFlyout');
 
-      if (isStayingInComponent === false && isTrappedByFlyout === false) {
+      if (isStayingInComponent === false) {
         handleClose();
       }
     },

--- a/src/core/packages/chrome/navigation/src/components/side_nav/popover.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/popover.tsx
@@ -19,6 +19,7 @@ import type {
 } from 'react';
 import { EuiPopover, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { euiIncludeSelectorInFocusTrap } from '@kbn/core-chrome-layout-constants';
 
 import {
   BOTTOM_POPOVER_GAP,
@@ -272,6 +273,10 @@ export const Popover = ({
         ownFocus={false}
         panelPaddingSize="none"
         repositionOnScroll
+        panelProps={{
+          ...euiIncludeSelectorInFocusTrap.prop,
+          'data-test-subj': `side-nav-popover-${label}`,
+        }}
       >
         <div
           ref={(ref) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/page_overlay/page_overlay.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/page_overlay/page_overlay.tsx
@@ -305,7 +305,7 @@ export const PageOverlay = memo<PageOverlayProps>(
 
     const focusTrapShards = useMemo(() => {
       return new Proxy([], {
-        get(target, prop) {
+        get(_, prop) {
           const elements = Array.from(
             document.querySelectorAll(euiIncludeSelectorInFocusTrap.selector)
           );


### PR DESCRIPTION
## Summary

### Flyout

See https://github.com/elastic/kibana/pull/239500 for details.

I'm adding a proper selector to the popover panel so that it's included in flyout focus trap shards and can be navigable with a keyboard when a flyout is rendered.

Removed the flyout check workaround in `handleBlur` added on https://github.com/elastic/kibana/pull/238230.

https://github.com/user-attachments/assets/3f01d80a-94f9-44be-8814-c35801906bd7

Entering a popover with a keyboard and clicking on a popover item with a mouse both work as expected normally and when a flyout is rendered on the screen.

### Console overlay

Resolves https://github.com/elastic/security-team/issues/14810

To fix it on EUI side for flyouts, we opted for a singleton that works with one EUI instance. 

Because Security overlay (`x-pack/solutions/security/plugins/security_solution/public/management/components/page_overlay/page_overlay.tsx`) uses `EuiFocusTrap` directly, and adding a global Kibana singleton seems like an overkill, I went for a Proxy array method. It's slightly more reactive but keeps the change scoped to `PageOverlay` in Security solution. Whenever the underlying library `react-focus-on` accesses `shards` value, we query the elements by `euiIncludeSelectorInFocusTrap.selector` (that on the same PR is applied to the popovers ☝🏻).

#### Before

https://github.com/user-attachments/assets/a609598a-ddc0-425c-8590-dc3f6507b18b

#### After

https://github.com/user-attachments/assets/5bd2c783-e6bf-483d-8489-aff5b884f509

## QA

### Flyouts

Any flyout in Kibana will do. Exemplary steps to reproduce:

1. Access any solution view.
2. Go to Discover.
3. In the toolbar, to the right, click on the folder icon - "Open session".
4. Try navigating the side nav:
- [ ] press <kbd>Enter</kbd> to move focus to the popover
- [ ] use Up and Down arrow keys to navigate the list
- [ ] press <kbd>Escape</kbd> to move focus back to the popover trigger
5. Test mouse interaction:
- [ ] hover over a menu item with a submenu to trigger the popover
- [ ] click on any menu item, it should redirect
- [ ] go back and test the nested "More" menu

### Security

Steps to reproduce are outlined in the [issue](https://github.com/elastic/security-team/issues/14810).

Run ES with: `yarn es snapshot --license trial -E xpack.security.authc.api_key.enabled=true -E http.host=0.0.0.0`

Follow similar steps as above ☝🏻 