### PR TITLE
[Agent Builder] Improve agents/tools navigation

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/list/agents.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/list/agents.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
-import { EuiButton, EuiLink, useEuiTheme } from '@elastic/eui';
+import { EuiButton, EuiButtonEmpty, EuiLink, EuiText, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { docLinks } from '../../../../../common/doc_links';
@@ -18,6 +18,10 @@ import { appPaths } from '../../../utils/app_paths';
 import { DeleteAgentProvider } from '../../../context/delete_agent_context';
 import { TechPreviewTitle } from '../../common/tech_preview';
 import { useUiPrivileges } from '../../../hooks/use_ui_privileges';
+
+const manageToolsLabel = i18n.translate('xpack.onechat.tools.manageToolsLabel', {
+  defaultMessage: 'Manage tools',
+});
 
 export const OnechatAgents = () => {
   const { euiTheme } = useEuiTheme();
@@ -42,6 +46,9 @@ export const OnechatAgents = () => {
         })}
       </EuiButton>
     ),
+    <EuiButtonEmpty aria-label={manageToolsLabel} href={createOnechatUrl(appPaths.tools.list)}>
+      <EuiText size="s">{manageToolsLabel}</EuiText>
+    </EuiButtonEmpty>,
   ];
   return (
     <DeleteAgentProvider>
@@ -65,15 +72,8 @@ export const OnechatAgents = () => {
           description={
             <FormattedMessage
               id="xpack.onechat.agents.description"
-              defaultMessage="Define agents with custom instructions and assign them {toolsLink} to answer questions about your data and take actions on your behalf. {learnMoreLink}"
+              defaultMessage="Define agents with custom instructions and assign them Tools to answer questions about your data and take actions on your behalf. {learnMoreLink}"
               values={{
-                toolsLink: (
-                  <EuiLink href={createOnechatUrl(appPaths.tools.list)}>
-                    {i18n.translate('xpack.onechat.agents.toolsLinkText', {
-                      defaultMessage: 'tools',
-                    })}
-                  </EuiLink>
-                ),
                 learnMoreLink: (
                   <EuiLink
                     href={docLinks.agentBuilderAgents}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/agents/list/agents.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/agents/list/agents.tsx
@@ -19,7 +19,7 @@ import { DeleteAgentProvider } from '../../../context/delete_agent_context';
 import { TechPreviewTitle } from '../../common/tech_preview';
 import { useUiPrivileges } from '../../../hooks/use_ui_privileges';
 
-const manageToolsLabel = i18n.translate('xpack.onechat.tools.manageToolsLabel', {
+const manageToolsLabel = i18n.translate('xpack.onechat.agents.manageToolsLabel', {
   defaultMessage: 'Manage tools',
 });
 
@@ -72,7 +72,7 @@ export const OnechatAgents = () => {
           description={
             <FormattedMessage
               id="xpack.onechat.agents.description"
-              defaultMessage="Define agents with custom instructions and assign them Tools to answer questions about your data and take actions on your behalf. {learnMoreLink}"
+              defaultMessage="Define agents with custom instructions and assign them tools to answer questions about your data and take actions on your behalf. {learnMoreLink}"
               values={{
                 learnMoreLink: (
                   <EuiLink

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/tools.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButton, EuiText, EuiLink, useEuiTheme } from '@elastic/eui';
+import { EuiButton, EuiText, EuiLink, useEuiTheme, EuiButtonEmpty } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { ToolType } from '@kbn/onechat-common';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
@@ -21,6 +21,11 @@ import { OnechatToolsTable } from './table/tools_table';
 import { McpConnectionButton } from './mcp_server/mcp_connection_button';
 import { TechPreviewTitle } from '../common/tech_preview';
 import { useUiPrivileges } from '../../hooks/use_ui_privileges';
+
+const manageAgentsLabel = i18n.translate('xpack.onechat.tools.manageAgentsLabel', {
+  defaultMessage: 'Manage agents',
+});
+
 export const OnechatTools = () => {
   const { euiTheme } = useEuiTheme();
   const { createTool } = useToolsActions();
@@ -35,15 +40,8 @@ export const OnechatTools = () => {
         description={
           <FormattedMessage
             id="xpack.onechat.tools.toolsDescription"
-            defaultMessage="Tools are modular, reusable Elasticsearch operations. {agentsLink} use them to search, retrieve, and analyze your data. Use our built-in tools for common operations, and create your own for custom use cases. {learnMoreLink}"
+            defaultMessage="Tools are modular, reusable Elasticsearch operations. Agents use them to search, retrieve, and analyze your data. Use our built-in tools for common operations, and create your own for custom use cases. {learnMoreLink}"
             values={{
-              agentsLink: (
-                <EuiLink href={createOnechatUrl(appPaths.agents.list)}>
-                  {i18n.translate('xpack.onechat.tools.agentsLinkText', {
-                    defaultMessage: 'Agents',
-                  })}
-                </EuiLink>
-              ),
               learnMoreLink: (
                 <EuiLink
                   href={docLinks.tools}
@@ -75,6 +73,13 @@ export const OnechatTools = () => {
               <EuiText size="s">{labels.tools.newToolButton}</EuiText>
             </EuiButton>
           ),
+          <EuiButtonEmpty
+            key="agents-button"
+            href={createOnechatUrl(appPaths.agents.list)}
+            aria-label={manageAgentsLabel}
+          >
+            <EuiText size="s">{manageAgentsLabel}</EuiText>
+          </EuiButtonEmpty>,
           <McpConnectionButton key="mcp-server-connection-button" />,
         ]}
       />


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/search-team/issues/11901 

"/agents" route
<img width="1728" height="998" alt="image" src="https://github.com/user-attachments/assets/11a3e6b8-ad24-4fdb-a854-30a940d5ead8" />

"/tools" route
<img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/920939ea-866d-4cc0-b76d-b1a552fe8df6" />


- [x] add a button to the tools page to 'manage agents'
- [x] add a button to the agents page to 'manage tools'

**Out of scope**: Changing the width of the search bar to be 50% would be a nice-to-have, but I'm not sure how possible this is with the EuiInMemoryTable - I don't think this has enough priority to spend time on this when there's other things to do. I will ship the items above.



