### PR TITLE
Add comprehensive logging to debug flaky test: Entity Analytics Privilege Monitoring

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_integrations_sync.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_integrations_sync.ts
@@ -15,6 +15,88 @@ export default ({ getService }: FtrProviderContext) => {
   const kibanaServer = getService('kibanaServer');
   const esArchiver = getService('esArchiver');
   const privMonUtils = PrivMonUtils(getService);
+  const log = getService('log');
+  const es = getService('es');
+
+  // Helper function to log full index contents for debugging
+  const logIndexContents = async (indexPattern: string, phase: string) => {
+    try {
+      const searchResult = await es.search({
+        index: indexPattern,
+        size: 1000,
+        query: { match_all: {} },
+        sort: [{ '@timestamp': { order: 'asc' } }],
+      });
+      log.info(
+        `[${phase}] Index ${indexPattern} contents (${searchResult.hits.hits.length} documents):`
+      );
+      searchResult.hits.hits.forEach((hit: any, idx: number) => {
+        log.info(
+          `[${phase}] Document ${idx + 1} (ID: ${hit._id}): ${JSON.stringify(
+            {
+              '@timestamp': hit._source?.['@timestamp'],
+              'user.name': hit._source?.user?.name,
+              'user.is_privileged': hit._source?.user?.is_privileged,
+              'user.roles': hit._source?.user?.roles,
+              'user.entity.attributes.Privileged':
+                hit._source?.user?.entity?.attributes?.Privileged,
+            },
+            null,
+            2
+          )}`
+        );
+      });
+    } catch (error) {
+      log.error(`[${phase}] Error logging index contents for ${indexPattern}:`, error);
+    }
+  };
+
+  // Helper function to log all users from API
+  const logUsersFromAPI = async (phase: string) => {
+    try {
+      const { body: users } = await api.listPrivMonUsers({ query: {} });
+      log.info(`[${phase}] Users from API (count: ${users.length}):`);
+      users.forEach((user: any, idx: number) => {
+        log.info(
+          `[${phase}] User ${idx + 1}: ${JSON.stringify(
+            {
+              name: user.user?.name,
+              is_privileged: user.user?.is_privileged,
+              '@timestamp': user['@timestamp'],
+              'event.ingested': user.event?.ingested,
+              'labels.sources': user.labels?.sources,
+              'labels.source_ids': user.labels?.source_ids,
+              'entity_analytics_monitoring.labels': user.entity_analytics_monitoring?.labels,
+            },
+            null,
+            2
+          )}`
+        );
+      });
+      return users;
+    } catch (error) {
+      log.error(`[${phase}] Error logging users from API:`, error);
+      return [];
+    }
+  };
+
+  // Helper function to log sync data and last processed marker
+  const logSyncData = async (phase: string) => {
+    try {
+      const syncData = await privMonUtils.integrationsSync.getSyncData(
+        privMonUtils.integrationsSync.OKTA_INDEX
+      );
+      const lastProcessedMarker = await privMonUtils.integrationsSync.getLastProcessedMarker(
+        privMonUtils.integrationsSync.OKTA_INDEX
+      );
+      log.info(`[${phase}] Sync Data: ${JSON.stringify(syncData, null, 2)}`);
+      log.info(`[${phase}] Last Processed Marker: ${lastProcessedMarker}`);
+      return { syncData, lastProcessedMarker };
+    } catch (error) {
+      log.error(`[${phase}] Error logging sync data:`, error);
+      return { syncData: null, lastProcessedMarker: null };
+    }
+  };
 
   describe('@ess @serverless @skipInServerlessMKI Entity Privilege Monitoring Engine Integrations Sync', () => {
     describe('integrations sync', async () => {
@@ -119,6 +201,10 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should update and create users within lastProcessedMarker range during update detection ', async () => {
+        log.info(
+          '=== STARTING FLAKY TEST: should update and create users within lastProcessedMarker range ==='
+        );
+
         // --- Timestamps
         const nowMinus1M1D = await privMonUtils.integrationsSync.dateOffsetFrom({
           months: 2,
@@ -127,45 +213,121 @@ export default ({ getService }: FtrProviderContext) => {
         const nowMinus2M = await privMonUtils.integrationsSync.dateOffsetFrom({ months: 2 });
         const nowMinus1w = await privMonUtils.integrationsSync.dateOffsetFrom({ days: 7 });
         const nowMinus6d = await privMonUtils.integrationsSync.dateOffsetFrom({ days: 6 });
+
+        log.info('=== TIMESTAMP VALUES ===');
+        log.info(`nowMinus1M1D: ${nowMinus1M1D}`);
+        log.info(`nowMinus2M: ${nowMinus2M}`);
+        log.info(`nowMinus1w: ${nowMinus1w}`);
+        log.info(`nowMinus6d: ${nowMinus6d}`);
+        log.info(
+          `DEFAULT_INTEGRATIONS_RELATIVE_TIMESTAMP: ${privMonUtils.integrationsSync.DEFAULT_INTEGRATIONS_RELATIVE_TIMESTAMP}`
+        );
+
+        // Log initial state
+        log.info('=== INITIAL STATE (before PHASE 1) ===');
+        await logIndexContents(privMonUtils.integrationsSync.OKTA_INDEX, 'INITIAL');
+        await logUsersFromAPI('INITIAL');
+        await logSyncData('INITIAL');
+
         // PHASE 1: Push two users out of range, sync => expect 4 privileged remain
+        log.info('=== PHASE 1: Setting timestamps for devon and elinor ===');
+        log.info(
+          `Setting devon (${privMonUtils.integrationsSync.OKTA_USER_IDS.devon}) timestamp to: ${nowMinus1M1D}`
+        );
         await privMonUtils.integrationsSync.setTimestamp(
           privMonUtils.integrationsSync.OKTA_USER_IDS.devon,
           nowMinus1M1D,
           privMonUtils.integrationsSync.OKTA_INDEX
+        );
+        log.info(
+          `Setting elinor (${privMonUtils.integrationsSync.OKTA_USER_IDS.elinor}) timestamp to: ${nowMinus2M}`
         );
         await privMonUtils.integrationsSync.setTimestamp(
           privMonUtils.integrationsSync.OKTA_USER_IDS.elinor,
           nowMinus2M,
           privMonUtils.integrationsSync.OKTA_INDEX
         );
+
+        log.info('=== PHASE 1: After setting timestamps, before sync ===');
+        await logIndexContents(privMonUtils.integrationsSync.OKTA_INDEX, 'PHASE1_BEFORE_SYNC');
+
+        log.info('=== PHASE 1: Running sync ===');
         await privMonUtils.runSync();
+
+        log.info('=== PHASE 1: After sync ===');
+        await logIndexContents(privMonUtils.integrationsSync.OKTA_INDEX, 'PHASE1_AFTER_SYNC');
         const snapA = await privMonUtils.integrationsSync.expectUserCount(4);
+        await logUsersFromAPI('PHASE1_AFTER_SYNC');
+        await logSyncData('PHASE1_AFTER_SYNC');
+        log.info(`PHASE 1: snapA user count: ${snapA.length}`);
 
         // PHASE 2: Re-run with no changes => no processing, marker should be default (now-1M)
+        log.info('=== PHASE 2: Re-running sync with no changes ===');
+        log.info('=== PHASE 2: Before sync ===');
+        await logIndexContents(privMonUtils.integrationsSync.OKTA_INDEX, 'PHASE2_BEFORE_SYNC');
+        await logUsersFromAPI('PHASE2_BEFORE_SYNC');
+        await logSyncData('PHASE2_BEFORE_SYNC');
+
+        log.info('=== PHASE 2: Running sync ===');
         await privMonUtils.runSync();
+
+        log.info('=== PHASE 2: After sync ===');
+        await logIndexContents(privMonUtils.integrationsSync.OKTA_INDEX, 'PHASE2_AFTER_SYNC');
         const snapB = await privMonUtils.integrationsSync.expectUserCount(4);
+        await logUsersFromAPI('PHASE2_AFTER_SYNC');
+        await logSyncData('PHASE2_AFTER_SYNC');
+        log.info(`PHASE 2: snapB user count: ${snapB.length}`);
+        log.info(`PHASE 2: Comparing snapA and snapB sets...`);
+        log.info(`PHASE 2: snapA user names: ${snapA.map((u: any) => u.user?.name).join(', ')}`);
+        log.info(`PHASE 2: snapB user names: ${snapB.map((u: any) => u.user?.name).join(', ')}`);
         expect(new Set(snapB)).toEqual(new Set(snapA));
 
         const markerAfterPhase2 = await privMonUtils.integrationsSync.getLastProcessedMarker(
           privMonUtils.integrationsSync.OKTA_INDEX
+        );
+        log.info(`PHASE 2: markerAfterPhase2: ${markerAfterPhase2}`);
+        log.info(
+          `PHASE 2: Expected marker: ${privMonUtils.integrationsSync.DEFAULT_INTEGRATIONS_RELATIVE_TIMESTAMP}`
         );
         expect(markerAfterPhase2).toBe(
           privMonUtils.integrationsSync.DEFAULT_INTEGRATIONS_RELATIVE_TIMESTAMP
         );
 
         // PHASE 3: Bring one user back in-range, sync => last processed marker updates to that timestamp
+        log.info('=== PHASE 3: Bringing kaelyn back in-range ===');
+        log.info(
+          `Setting kaelyn (${privMonUtils.integrationsSync.OKTA_USER_IDS.kaelyn}) timestamp to: ${nowMinus1w}`
+        );
         await privMonUtils.integrationsSync.setTimestamp(
           privMonUtils.integrationsSync.OKTA_USER_IDS.kaelyn,
           nowMinus1w,
           privMonUtils.integrationsSync.OKTA_INDEX
         );
+
+        log.info('=== PHASE 3: After setting timestamp, before sync ===');
+        await logIndexContents(privMonUtils.integrationsSync.OKTA_INDEX, 'PHASE3_BEFORE_SYNC');
+        await logUsersFromAPI('PHASE3_BEFORE_SYNC');
+        await logSyncData('PHASE3_BEFORE_SYNC');
+
+        log.info('=== PHASE 3: Running sync ===');
         await privMonUtils.runSync();
+
+        log.info('=== PHASE 3: After sync ===');
+        await logIndexContents(privMonUtils.integrationsSync.OKTA_INDEX, 'PHASE3_AFTER_SYNC');
+        await logUsersFromAPI('PHASE3_AFTER_SYNC');
         const markerAfterPhase3 = await privMonUtils.integrationsSync.getLastProcessedMarker(
           privMonUtils.integrationsSync.OKTA_INDEX
         );
+        await logSyncData('PHASE3_AFTER_SYNC');
+        log.info(`PHASE 3: markerAfterPhase3: ${markerAfterPhase3}`);
+        log.info(`PHASE 3: Expected marker: ${nowMinus1w}`);
         expect(markerAfterPhase3).toBe(nowMinus1w);
 
         // PHASE 4: Flip a non-privileged user to privileged + in-range, sync => count 5, last processed marker updates
+        log.info('=== PHASE 4: Flipping bennett to privileged and setting timestamp ===');
+        log.info(
+          `Setting bennett (${privMonUtils.integrationsSync.OKTA_USER_IDS.bennett}) to privileged: true, timestamp: ${nowMinus6d}`
+        );
         await privMonUtils.integrationsSync.setIntegrationUserPrivilege({
           id: privMonUtils.integrationsSync.OKTA_USER_IDS.bennett,
           isPrivileged: true,
@@ -177,13 +339,27 @@ export default ({ getService }: FtrProviderContext) => {
           privMonUtils.integrationsSync.OKTA_INDEX
         );
 
-        await privMonUtils.runSync();
-        await privMonUtils.integrationsSync.expectUserCount(5);
+        log.info('=== PHASE 4: After setting privilege and timestamp, before sync ===');
+        await logIndexContents(privMonUtils.integrationsSync.OKTA_INDEX, 'PHASE4_BEFORE_SYNC');
+        await logUsersFromAPI('PHASE4_BEFORE_SYNC');
+        await logSyncData('PHASE4_BEFORE_SYNC');
 
+        log.info('=== PHASE 4: Running sync ===');
+        await privMonUtils.runSync();
+
+        log.info('=== PHASE 4: After sync ===');
+        await logIndexContents(privMonUtils.integrationsSync.OKTA_INDEX, 'PHASE4_AFTER_SYNC');
+        await privMonUtils.integrationsSync.expectUserCount(5);
+        await logUsersFromAPI('PHASE4_AFTER_SYNC');
         const markerAfterPhase4 = await privMonUtils.integrationsSync.getLastProcessedMarker(
           privMonUtils.integrationsSync.OKTA_INDEX
         );
+        await logSyncData('PHASE4_AFTER_SYNC');
+        log.info(`PHASE 4: markerAfterPhase4: ${markerAfterPhase4}`);
+        log.info(`PHASE 4: Expected marker: ${nowMinus6d}`);
         expect(markerAfterPhase4).toBe(nowMinus6d);
+
+        log.info('=== END OF FLAKY TEST ===');
       });
 
       it('deletes missing users during a full sync window', async () => {


### PR DESCRIPTION
## Summary

This PR adds comprehensive logging to help debug the flaky test: **Entity Analytics - Privilege Monitoring Engine Integrations Sync - "should update and create users within lastProcessedMarker range during update detection"**

Related to: https://github.com/elastic/kibana/issues/243599

## Changes

### Test File (`engine_integrations_sync.ts`)
- Added helper functions to log:
  - **Index contents**: All documents in the OKTA index with timestamps, privilege status, and user details
  - **Users from API**: All users retrieved from the API with their full properties
  - **Sync data**: Last processed markers and sync data at each phase
- Added phase-by-phase logging throughout the flaky test:
  - Initial state logging (before PHASE 1)
  - Before/after sync logging for each phase (PHASE 1-4)
  - Timestamp value logging with relationships
  - User count comparisons
  - Marker value logging with expected vs actual

### Utils File (`privmon_utils.ts`)
- Added detailed logging to utility functions:
  - `updateIntegrationsUserTimeStamp()`: Logs queries and verifies updates
  - `setIntegrationUserPrivilege()`: Logs privilege changes and verifies updates
  - `getLastProcessedMarker()`: Logs API responses and marker values
  - `getSyncData()`: Logs sync data retrieval
  - `runSync()`: Logs sync execution steps
  - `expectUserCount()`: Logs user counts and names

## What the Logging Captures

- ✅ **Index contents**: All documents with timestamps, privilege status, and user details
- ✅ **Elasticsearch queries**: All updateByQuery operations with full query details
- ✅ **API responses**: All listEntitySources and listPrivMonUsers responses
- ✅ **Timestamp values**: All calculated timestamps and their relationships
- ✅ **Last processed markers**: Before and after each phase
- ✅ **User counts and details**: At each phase with user names
- ✅ **Verification**: Document state after each update operation

## Testing

This is a debugging branch to help identify the root cause of the flakiness. The logging will help us understand:
- What state the index is in at each phase
- What queries are being executed
- What the API is returning
- What timestamps and markers are being set/retrieved

The branch name `MANIFEST-OF-FLAKINESS` is intentionally humorous to make it easy to identify this debugging branch.