### PR TITLE
[SharedUX] Adjust side nav tour z-index

### DIFF
--- a/src/core/packages/chrome/navigation-tour/src/tour.tsx
+++ b/src/core/packages/chrome/navigation-tour/src/tour.tsx
@@ -72,7 +72,6 @@ function ActiveTour({ state, tourManager }: { state: TourState; tourManager: Tou
       stepsTotal={state.steps.length}
       content={currentStep.content}
       anchorPosition={'leftCenter'}
-      zIndex={10000 /* we want tour to be on top of other chrome popover */}
       panelProps={{
         'data-test-subj': `nav-tour-step-${currentStep.id}`,
       }}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/242635

## Summary

- Removed `z-index` override for the side nav tour. We will instead rely on the tour inheriting its anchor positioning: `By default, popover content inherits the z-index of the anchor component` ([docs](https://eui.elastic.co/docs/components/display/tour/#EuiTourStep-prop-zIndex))
- We had added this override (`z-index: 10000`) to avoid having the tour overlapped by the spaces selector (`z-index: 6001`) dropdown or other header components such as global search dropdown (small screens only). But this led to other positioning issues where the tour was being placed on top of EUI's overlay mask (`z-index: 6000`). Trying to find an in between number to overcome this will always result in the tour being on top of the mask. 
- What we had before was not ideal, removing it is also not the perfect answer but two components overlapping seems not as bad as the tour stealing focus from the modal on top of the mask. And the override might be hiding other overlapping issues we are not aware of. 

### Testing

| **Before** | **After** |
| ------------- | ------------- |
| <img width="1284" height="723" alt="Screenshot 2025-11-20 at 13 03 29" src="https://github.com/user-attachments/assets/903a8df4-5f2b-41ba-bfcc-14148cfe89b4" /> | <img width="1283" height="712" alt="Screenshot 2025-11-20 at 13 03 46" src="https://github.com/user-attachments/assets/24d37fed-acfd-405e-8616-843ab266d739" /> |
| <img width="1281" height="720" alt="Screenshot 2025-11-20 at 13 06 14" src="https://github.com/user-attachments/assets/59ae5564-f7a2-43fb-8553-83f74cf26c0e" /> | <img width="1281" height="723" alt="Screenshot 2025-11-20 at 13 05 49" src="https://github.com/user-attachments/assets/8e2b3b7c-470d-4265-a961-76fe0c738924" />  | 

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->