### PR TITLE
[Failure Store Modal] Introduce disabled option in failure store modal

### DIFF
--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/README.md
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/README.md
@@ -6,8 +6,9 @@ A reusable React component package that provides a modal interface for configuri
 
 The Failure Store Modal is a form-based modal component that allows users to:
 - Enable or disable failure store functionality
-- Configure retention periods (default or custom)
+- Configure retention periods (default, custom, or disabled)
 - Set custom retention values with various time units (days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds)
+- Disable lifecycle management for failure store retention
 - Inherit failure store configuration from parent streams or index templates
 - Validate and submit failure store configurations
 
@@ -75,6 +76,21 @@ const MyComponent = () => {
 />
 ```
 
+### With Disabled Lifecycle Management
+
+```typescript
+<FailureStoreModal
+  onCloseModal={handleClose}
+  onSaveModal={handleSave}
+  failureStoreProps={{
+    failureStoreEnabled: true,
+    defaultRetentionPeriod: '30d',
+    retentionDisabled: true
+  }}
+  canShowDisableLifecycle={true}
+/>
+```
+
 ### With Inheritance Options
 
 ```typescript
@@ -104,7 +120,8 @@ const MyComponent = () => {
 | `onSaveModal` | `(data: FailureStoreFormData) => Promise<void> \| void` | ✓ | Callback function called when the form is submitted with valid data |
 | `failureStoreProps` | `FailureStoreFormProps` | ✓ | Configuration object for the failure store settings |
 | `inheritOptions` | `InheritOptions` | ✗ | Configuration for inheritance behavior from parent stream or index template |
-| `showIlmDescription` | `boolean` | ✗ | Whether to display tier-specific messaging |
+| `showIlmDescription` | `boolean` | ✗ | Whether to display tier-specific messaging (defaults to `true`) |
+| `canShowDisableLifecycle` | `boolean` | ✗ | Whether to show the option to disable lifecycle management (defaults to `false`) |
 
 ### FailureStoreFormProps
 
@@ -113,6 +130,7 @@ const MyComponent = () => {
 | `failureStoreEnabled` | `boolean` | ✓ | Whether failure store is currently enabled |
 | `defaultRetentionPeriod` | `string` | ✗ | Default retention period (e.g., "30d", "7h") |
 | `customRetentionPeriod` | `string` | ✗ | Custom retention period if different from default |
+| `retentionDisabled` | `boolean` | ✗ | Whether lifecycle management is disabled for retention |
 
 ### InheritOptions
 
@@ -126,9 +144,10 @@ const MyComponent = () => {
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `failureStoreEnabled` | `boolean ` | Whether failure store should be enabled |
+| `failureStoreEnabled` | `boolean` | Whether failure store should be enabled |
 | `customRetentionPeriod` | `string \| undefined` | Custom retention period if specified |
-| `inherit` | `object \| undefined` | Empty object when inheritance is enabled |
+| `retentionDisabled` | `boolean \| undefined` | Whether lifecycle management is disabled |
+| `inherit` | `boolean \| undefined` | Whether to inherit configuration from parent stream or index template |
 
 ## Supported Time Units
 
@@ -153,6 +172,9 @@ The modal supports the following time units for retention periods:
 - **Inheritance Support**: Optional inheritance from parent streams or index templates
   - When inheritance is enabled, all configuration fields are disabled
   - Supports both wired (parent stream) and classic (index template) inheritance modes
+- **Lifecycle Management**: Optional ability to disable lifecycle management for failure store retention
+  - When enabled via `canShowDisableLifecycle`, users can choose to disable lifecycle management
+  - Provides flexibility for advanced retention configurations
 
 ## Development
 

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/index.ts
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { FailureStoreModal } from './src';
+export { FailureStoreModal, type FailureStoreFormData } from './src';

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/constants.ts
@@ -67,4 +67,10 @@ export const failureStorePeriodOptions = [
       defaultMessage: 'Custom period',
     }),
   },
+  {
+    id: 'disabledLifecycle',
+    label: i18n.translate('xpack.failureStoreModal.form.options.disabledPeriodLabel', {
+      defaultMessage: 'Disabled',
+    }),
+  },
 ];

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.stories.tsx
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.stories.tsx
@@ -54,3 +54,20 @@ export const InheritanceModal: Story = {
     showIlmDescription: false,
   },
 };
+
+export const InheritanceModalWithRetentionDisabled: Story = {
+  args: {
+    failureStoreProps: {
+      failureStoreEnabled: true,
+      defaultRetentionPeriod: '30d',
+      retentionDisabled: true,
+    },
+    inheritOptions: {
+      canShowInherit: true,
+      isWired: false,
+      isCurrentlyInherited: false,
+    },
+    showIlmDescription: true,
+    canShowDisableLifecycle: true,
+  },
+};

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.tsx
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.tsx
@@ -38,17 +38,20 @@ import { editFailureStoreFormSchema } from './schema';
 const PERIOD_TYPE = {
   CUSTOM: 'custom',
   DEFAULT: 'default',
+  DISABLED_LIFECYCLE: 'disabledLifecycle',
 } as const;
 
 export interface FailureStoreFormProps {
   failureStoreEnabled: boolean;
   defaultRetentionPeriod?: string;
   customRetentionPeriod?: string;
+  retentionDisabled?: boolean;
 }
 
-type FailureStoreFormData = { failureStoreEnabled: boolean } & (
+export type FailureStoreFormData = { failureStoreEnabled: boolean } & (
   | { inherit: boolean }
   | { customRetentionPeriod?: string }
+  | { retentionDisabled?: boolean }
 );
 
 interface Props {
@@ -61,14 +64,16 @@ interface Props {
     isCurrentlyInherited: boolean;
   };
   showIlmDescription?: boolean;
+  canShowDisableLifecycle?: boolean;
 }
 
 export const FailureStoreModal: FunctionComponent<Props> = ({
   onCloseModal,
   onSaveModal,
   failureStoreProps,
-  showIlmDescription = false,
+  showIlmDescription = true,
   inheritOptions,
+  canShowDisableLifecycle = false,
 }) => {
   const [isSaveInProgress, setIsSaveInProgress] = useState(false);
 
@@ -90,13 +95,23 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
         return;
       }
 
-      // The new failure store configuration has to include the enabled state and, if the custom retention type is enabled, the retention period.
-      const newFailureStoreConfig: FailureStoreFormData = {
-        failureStoreEnabled: data.failureStore,
-      };
+      // The new failure store configuration has to include the enabled state and, if the custom retention type is enabled, the retention period or disabled flag.
+      let newFailureStoreConfig: FailureStoreFormData;
 
-      if (data.failureStore && data.periodType === PERIOD_TYPE.CUSTOM) {
-        newFailureStoreConfig.customRetentionPeriod = `${data.retentionPeriodValue}${data.retentionPeriodUnit}`;
+      if (data.failureStore && data.periodType === PERIOD_TYPE.DISABLED_LIFECYCLE) {
+        newFailureStoreConfig = {
+          failureStoreEnabled: data.failureStore,
+          retentionDisabled: true,
+        };
+      } else if (data.failureStore && data.periodType === PERIOD_TYPE.CUSTOM) {
+        newFailureStoreConfig = {
+          failureStoreEnabled: data.failureStore,
+          customRetentionPeriod: `${data.retentionPeriodValue}${data.retentionPeriodUnit}`,
+        };
+      } else {
+        newFailureStoreConfig = {
+          failureStoreEnabled: data.failureStore,
+        };
       }
 
       await onSaveModal(newFailureStoreConfig);
@@ -129,12 +144,15 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
   const { form } = useForm({
     defaultValue: {
       failureStore: failureStoreProps.failureStoreEnabled ?? false,
-      periodType: failureStoreProps.customRetentionPeriod
+      periodType: failureStoreProps.retentionDisabled
+        ? PERIOD_TYPE.DISABLED_LIFECYCLE
+        : failureStoreProps.customRetentionPeriod
         ? PERIOD_TYPE.CUSTOM
         : PERIOD_TYPE.DEFAULT,
       retentionPeriodValue,
       retentionPeriodUnit,
       inherit: (inheritOptions?.isCurrentlyInherited && inheritOptions.canShowInherit) ?? false,
+      retentionDisabled: failureStoreProps.retentionDisabled ?? false,
     },
     schema: editFailureStoreFormSchema,
     id: 'editFailureStoreForm',
@@ -261,38 +279,44 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
                   defaultMessage: 'Failure store retention',
                 })}
                 euiFieldProps={{
-                  options: failureStorePeriodOptions,
+                  options: canShowDisableLifecycle
+                    ? failureStorePeriodOptions
+                    : failureStorePeriodOptions.filter((option) => option.id !== 'disabled'),
                   'data-test-subj': 'selectFailureStorePeriodType',
                   isDisabled: inherit,
                 }}
               />
 
-              <EuiFormRow fullWidth>
-                {isCustomPeriod || defaultRetentionPeriod ? (
-                  <RetentionPeriodField disabled={!isCustomPeriod || inherit} />
-                ) : (
-                  <EuiCallOut
-                    announceOnMount
-                    typeof="info"
-                    size="m"
-                    data-test-subj="defaultRetentionCallout"
-                  >
-                    <FormattedMessage
-                      id="xpack.failureStoreModal.form.defaultRetentionAvailableText"
-                      defaultMessage="This will pull the default value set at the cluster level."
-                    />
-                  </EuiCallOut>
-                )}
-              </EuiFormRow>
-              {!showIlmDescription && (
-                <EuiFormRow fullWidth>
-                  <EuiText size="s" color="subdued">
-                    <FormattedMessage
-                      id="xpack.failureStoreModal.form.retentionPeriodInfoText"
-                      defaultMessage="This retention period stores data in the hot tier for best indexing and search performance."
-                    />
-                  </EuiText>
-                </EuiFormRow>
+              {periodType !== PERIOD_TYPE.DISABLED_LIFECYCLE && (
+                <>
+                  <EuiFormRow fullWidth>
+                    {isCustomPeriod || defaultRetentionPeriod ? (
+                      <RetentionPeriodField disabled={!isCustomPeriod || inherit} />
+                    ) : (
+                      <EuiCallOut
+                        announceOnMount
+                        typeof="info"
+                        size="m"
+                        data-test-subj="defaultRetentionCallout"
+                      >
+                        <FormattedMessage
+                          id="xpack.failureStoreModal.form.defaultRetentionAvailableText"
+                          defaultMessage="This will pull the default value set at the cluster level."
+                        />
+                      </EuiCallOut>
+                    )}
+                  </EuiFormRow>
+                  {showIlmDescription && (
+                    <EuiFormRow fullWidth>
+                      <EuiText size="s" color="subdued">
+                        <FormattedMessage
+                          id="xpack.failureStoreModal.form.retentionPeriodInfoText"
+                          defaultMessage="This retention period stores data in the hot tier for best indexing and search performance."
+                        />
+                      </EuiText>
+                    </EuiFormRow>
+                  )}
+                </>
               )}
             </>
           )}

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.tsx
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/failure_store_modal.tsx
@@ -95,24 +95,18 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
         return;
       }
 
-      // The new failure store configuration has to include the enabled state and, if the custom retention type is enabled, the retention period or disabled flag.
-      let newFailureStoreConfig: FailureStoreFormData;
-
-      if (data.failureStore && data.periodType === PERIOD_TYPE.DISABLED_LIFECYCLE) {
-        newFailureStoreConfig = {
-          failureStoreEnabled: data.failureStore,
-          retentionDisabled: true,
-        };
-      } else if (data.failureStore && data.periodType === PERIOD_TYPE.CUSTOM) {
-        newFailureStoreConfig = {
-          failureStoreEnabled: data.failureStore,
-          customRetentionPeriod: `${data.retentionPeriodValue}${data.retentionPeriodUnit}`,
-        };
-      } else {
-        newFailureStoreConfig = {
-          failureStoreEnabled: data.failureStore,
-        };
-      }
+      // The failure store configuration has to include the enabled state and, if the custom retention type is enabled, the retention period or disabled flag.
+      const newFailureStoreConfig: FailureStoreFormData = {
+        failureStoreEnabled: data.failureStore,
+        ...(data.failureStore &&
+          data.periodType === PERIOD_TYPE.DISABLED_LIFECYCLE && {
+            retentionDisabled: true,
+          }),
+        ...(data.failureStore &&
+          data.periodType === PERIOD_TYPE.CUSTOM && {
+            customRetentionPeriod: `${data.retentionPeriodValue}${data.retentionPeriodUnit}`,
+          }),
+      };
 
       await onSaveModal(newFailureStoreConfig);
     } finally {
@@ -281,7 +275,9 @@ export const FailureStoreModal: FunctionComponent<Props> = ({
                 euiFieldProps={{
                   options: canShowDisableLifecycle
                     ? failureStorePeriodOptions
-                    : failureStorePeriodOptions.filter((option) => option.id !== 'disabled'),
+                    : failureStorePeriodOptions.filter(
+                        (option) => option.id !== PERIOD_TYPE.DISABLED_LIFECYCLE
+                      ),
                   'data-test-subj': 'selectFailureStorePeriodType',
                   isDisabled: inherit,
                 }}

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/index.ts
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/failure_store_modal/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { FailureStoreModal } from './failure_store_modal';
+export { FailureStoreModal, type FailureStoreFormData } from './failure_store_modal';

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/index.ts
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/components/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { FailureStoreModal } from './failure_store_modal';
+export { FailureStoreModal, type FailureStoreFormData } from './failure_store_modal';

--- a/x-pack/platform/packages/shared/kbn-failure-store-modal/src/index.ts
+++ b/x-pack/platform/packages/shared/kbn-failure-store-modal/src/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { FailureStoreModal } from './components';
+export { FailureStoreModal, type FailureStoreFormData } from './components';


### PR DESCRIPTION
## Summary
This PR introduces another option in the fault store modal: the ability to disable the fault store lifecycle. This way, data will be retained forever instead of for a specified period of time. This option is not mandatory and must be determined by the client.
<img width="544" height="325" alt="Screenshot 2025-11-20 at 15 16 42" src="https://github.com/user-attachments/assets/cfd8651c-e3f3-47c0-8e01-10d99fb79280" />


### How to test
run `yarn storybook failure_store_modal` to test the storybook.

