### PR TITLE
Remove space icon in access_mode_container for serverless and default space

### DIFF
--- a/src/platform/packages/shared/content-management/access_control/access_control_public/src/components/access_mode_container.tsx
+++ b/src/platform/packages/shared/content-management/access_control/access_control_public/src/components/access_mode_container.tsx
@@ -59,8 +59,9 @@ const getSpaceIcon = (space: Space['solution']) => {
     case 'oblt':
       return 'logoObservability';
     case 'classic':
-    default:
       return 'logoElasticStack';
+    default:
+      return undefined;
   }
 };
 


### PR DESCRIPTION
## Summary

This PR changes the icon behavior to not display a solution icon for access mode container in default space and when there in serverless environment.

