### PR TITLE
[9.2][SideNav] Fix Security PageOverlay trap focus making side nav items not interactive

### DIFF
--- a/src/core/packages/chrome/navigation/src/components/popover/index.tsx
+++ b/src/core/packages/chrome/navigation/src/components/popover/index.tsx
@@ -194,8 +194,15 @@ export const SideNavPopover = ({
           triggerRef.current?.contains(nextFocused) || popoverRef.current?.contains(nextFocused)
         );
       const isTrappedByFlyout = (nextFocused as HTMLElement)?.classList.contains('euiFlyout');
+      const isTrappedByPageOverlay = !!(nextFocused as HTMLElement)?.closest(
+        '.securitySolution-pageOverlay'
+      );
 
-      if (isStayingInComponent === false && isTrappedByFlyout === false) {
+      if (
+        isStayingInComponent === false &&
+        isTrappedByFlyout === false &&
+        isTrappedByPageOverlay === false
+      ) {
         handleClose();
       }
     },


### PR DESCRIPTION
## Summary

There is a meaningful fix already on: https://github.com/elastic/kibana/pull/243612

It's going into 9.3 and cannot be backported because it relies on latest EUI updates ([v109.1.0](https://github.com/elastic/eui/releases/tag/v109.1.0)), specifically:

> Fixed an issue where portalled components like EuiPopover were not included in EuiFlyout's focus trap through includeSelectorInFocusTrap, making them inaccessible to keyboard users (https://github.com/elastic/eui/pull/9103)

## QA

### Flyouts

https://github.com/user-attachments/assets/3957c82e-c5ed-4113-bd3d-5a8a3ffa5bd6

### Security PageOverlay

https://github.com/user-attachments/assets/9a491ba0-51b3-44d6-8d39-63aea538f2e6

### Keyboard navigation

https://github.com/user-attachments/assets/f1d8677c-5825-4ace-aa13-3b17b6b8b4e5