### PR TITLE
[Controls Anywhere] Fix ES|QL editor in Discover

### DIFF
--- a/examples/portable_dashboards_example/kibana.jsonc
+++ b/examples/portable_dashboards_example/kibana.jsonc
@@ -20,7 +20,8 @@
       "navigation",
       "unifiedSearch",
       "developerExamples",
-      "uiActions"
+      "uiActions",
+      "kibanaReact"
     ]
   }
 }

--- a/src/platform/packages/shared/controls/control-group-renderer/src/use_children_api.tsx
+++ b/src/platform/packages/shared/controls/control-group-renderer/src/use_children_api.tsx
@@ -18,6 +18,7 @@ import type { Filter } from '@kbn/es-query';
 import {
   apiPublishesESQLVariable,
   type ESQLControlVariable,
+  type ESQLVariableType,
   type PublishesESQLVariable,
 } from '@kbn/esql-types';
 import {
@@ -47,6 +48,7 @@ export const useChildrenApi = (
   const lastSavedChildState$Ref = useRef(
     new BehaviorSubject<{ [id: string]: SerializedPanelState }>({}) // derived from lastSavedState$Ref
   );
+  const cleanupCallbackRef = useRef<() => void | undefined>();
 
   useEffect(() => {
     /** Derive `lastSavedChildState$Ref` from `lastSavedState$Ref` */
@@ -87,6 +89,58 @@ export const useChildrenApi = (
   const childrenApi = useMemo(() => {
     if (!state) return; // don't return children API until state is initialized
 
+    /**
+     * Define behaviour subjects that will rely on compatible children API observables
+     */
+    const esqlVariables$ = new BehaviorSubject<ESQLVariableType[]>([]);
+    const esqlVariablesSubscription = combineCompatibleChildrenApis<
+      PublishesESQLVariable,
+      ESQLControlVariable[]
+    >({ children$: children$Ref.current }, 'esqlVariable$', apiPublishesESQLVariable, [])
+      .pipe(distinctUntilChanged(deepEqual))
+      .subscribe((variables) => {
+        esqlVariables$.next(variables);
+      });
+
+    const appliedFilters$ = new BehaviorSubject<Filter | undefined>(undefined);
+    const appliedFiltersSubscription = combineCompatibleChildrenApis<
+      AppliesFilters,
+      Filter[] | undefined
+    >({ children$: children$Ref.current }, 'appliedFilters$', apiAppliesFilters, [], (values) => {
+      const allOutputFilters = values.filter(
+        (childOutputFilters) => childOutputFilters && childOutputFilters.length > 0
+      ) as Filter[][];
+      return allOutputFilters && allOutputFilters.length > 0 ? allOutputFilters.flat() : [];
+    })
+      .pipe(distinctUntilChanged(deepEqual))
+      .subscribe((filters) => {
+        appliedFilters$.next(filters);
+      });
+
+    const appliedTimeslice$ = new BehaviorSubject<TimeSlice | undefined>(undefined);
+    const appliedTimesliceSubscription = combineCompatibleChildrenApis<
+      AppliesTimeslice,
+      TimeSlice | undefined
+    >(
+      { children$: children$Ref.current },
+      'appliedTimeslice$',
+      apiAppliesTimeslice,
+      undefined, // flatten method is unnecessary since there is only ever one timeslice
+      (values) => {
+        return values.length === 0 ? undefined : values[values.length - 1];
+      }
+    )
+      .pipe(distinctUntilChanged(deepEqual))
+      .subscribe((timeSlice) => {
+        appliedTimeslice$.next(timeSlice);
+      });
+
+    cleanupCallbackRef.current = () => {
+      esqlVariablesSubscription.unsubscribe();
+      appliedFiltersSubscription.unsubscribe();
+      appliedTimesliceSubscription.unsubscribe();
+    };
+
     return {
       children$: children$Ref.current,
       registerChildApi: (child: DefaultEmbeddableApi) => {
@@ -126,35 +180,20 @@ export const useChildrenApi = (
         return lastSavedChildState$Ref.current.pipe(map((lastSavedState) => lastSavedState[id]));
       },
       getLastSavedStateForChild: (id: string) => lastSavedChildState$Ref.current.getValue()[id],
-      appliedFilters$: combineCompatibleChildrenApis<AppliesFilters, Filter[] | undefined>(
-        { children$: children$Ref.current },
-        'appliedFilters$',
-        apiAppliesFilters,
-        [],
-        (values) => {
-          const allOutputFilters = values.filter(
-            (childOutputFilters) => childOutputFilters && childOutputFilters.length > 0
-          ) as Filter[][];
-          return allOutputFilters && allOutputFilters.length > 0 ? allOutputFilters.flat() : [];
-        }
-      ).pipe(distinctUntilChanged(deepEqual)),
-      esqlVariables$: combineCompatibleChildrenApis<PublishesESQLVariable, ESQLControlVariable[]>(
-        { children$: children$Ref.current },
-        'esqlVariable$',
-        apiPublishesESQLVariable,
-        []
-      ).pipe(distinctUntilChanged(deepEqual)),
-      appliedTimeslice$: combineCompatibleChildrenApis<AppliesTimeslice, TimeSlice | undefined>(
-        { children$: children$Ref.current },
-        'appliedTimeslice$',
-        apiAppliesTimeslice,
-        undefined, // flatten method is unnecessary since there is only ever one timeslice
-        (values) => {
-          return values.length === 0 ? undefined : values[values.length - 1];
-        }
-      ).pipe(distinctUntilChanged(deepEqual)),
+      appliedFilters$,
+      esqlVariables$,
+      appliedTimeslice$,
     };
   }, [state, lastSavedChildState$Ref]);
+
+  useEffect(() => {
+    // run cleanup on dismount
+    return () => {
+      if (cleanupCallbackRef.current) {
+        cleanupCallbackRef.current();
+      }
+    };
+  }, []);
 
   return { childrenApi, currentChildState$Ref };
 };

--- a/src/platform/packages/shared/controls/control-group-renderer/tsconfig.json
+++ b/src/platform/packages/shared/controls/control-group-renderer/tsconfig.json
@@ -20,6 +20,7 @@
     "@kbn/std",
     "@kbn/embeddable-plugin",
     "@kbn/shared-ux-utility",
-    "@kbn/presentation-containers"
+    "@kbn/presentation-containers",
+    "@kbn/kibana-react-plugin"
   ]
 }


### PR DESCRIPTION
> [!WARNING]
> **_This work is being merged into a feature branch, not main!_**
> Because of this, we only need a review from @elastic/kibana-presentation for now.

Closes https://github.com/elastic/kibana/issues/243087

## Summary

This PR fixes the typing of `appliedFilters$`, `appliedTimeslice$`, and `esqlVariables$` in the control group renderer API so that they are a behaviour subject (with access to `getValue`) rather than an observable. 

**Before**

https://github.com/user-attachments/assets/201a71f5-b7bf-4873-b434-6a95a4673f84


**After**

https://github.com/user-attachments/assets/f88a0479-78b0-4c33-bf03-26b228c54846

