### PR TITLE
[9.2] [SharedUX] Add kbn-tour-queue package to avoid tour overlapping (#242640)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -595,6 +595,7 @@ src/platform/packages/shared/kbn-test-jest-helpers @elastic/kibana-operations @e
 src/platform/packages/shared/kbn-test-subj-selector @elastic/kibana-operations @elastic/appex-qa
 src/platform/packages/shared/kbn-timerange @elastic/obs-onboarding-team
 src/platform/packages/shared/kbn-tooling-log @elastic/kibana-operations
+src/platform/packages/shared/kbn-tour-queue @elastic/appex-sharedux
 src/platform/packages/shared/kbn-traced-es-client @elastic/observability-ui
 src/platform/packages/shared/kbn-tracing @elastic/kibana-core @elastic/obs-ai-assistant
 src/platform/packages/shared/kbn-tracing-config @elastic/kibana-core

--- a/package.json
+++ b/package.json
@@ -1058,6 +1058,7 @@
     "@kbn/timelion-grammar": "link:src/platform/packages/private/kbn-timelion-grammar",
     "@kbn/timerange": "link:src/platform/packages/shared/kbn-timerange",
     "@kbn/tinymath": "link:src/platform/packages/private/kbn-tinymath",
+    "@kbn/tour-queue": "link:src/platform/packages/shared/kbn-tour-queue",
     "@kbn/traced-es-client": "link:src/platform/packages/shared/kbn-traced-es-client",
     "@kbn/tracing": "link:src/platform/packages/shared/kbn-tracing",
     "@kbn/tracing-config": "link:src/platform/packages/shared/kbn-tracing-config",

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -106,7 +106,7 @@ pageLoadAssetSize:
   ml: 89000
   mockIdpPlugin: 7544
   monitoring: 28983
-  navigation: 13598
+  navigation: 14742
   newsfeed: 12371
   noDataPage: 1749
   observability: 176467

--- a/src/platform/packages/shared/kbn-tour-queue/README.md
+++ b/src/platform/packages/shared/kbn-tour-queue/README.md
@@ -1,0 +1,33 @@
+# @kbn/tour-queue
+
+# Tour Queue
+
+A global queue mechanism for managing sequential tour display across Kibana plugins.
+
+## API
+
+### useTourQueue(tourId: TourId)
+
+Hook that manages tour registration and state.
+
+**Returns:**
+- `isActive: boolean` - Whether this tour should be shown
+- `onComplete: () => void` - Callback to mark tour as completed
+
+### Tour Object Methods
+
+When you register a tour, you get a tour object with these methods:
+
+- `isActive()` - Check if this tour is currently active
+- `complete()` - Mark tour as completed
+- `skip()` - Skip all remaining tours for current page load
+- `unregister()` - Remove tour from queue (cleanup)
+
+### Tour Order
+
+| Order | Tour ID | Description |
+|----------|---------|-------------|
+| 1 | `solutionNavigationTour` | Solution navigation tour (Navigation plugin) |
+| 2 | `siemMigrationSetupTour` | Security SIEM migration setup (Security plugin) |
+
+**Note:** Lower order = shown first. If a tour is skipped, all remaining tours are skipped for the current page load only. Currently, only the navigation tour implements skip functionality.

--- a/src/platform/packages/shared/kbn-tour-queue/hooks/use_tour_queue.test.ts
+++ b/src/platform/packages/shared/kbn-tour-queue/hooks/use_tour_queue.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useTourQueue } from './use_tour_queue';
+import { getTourQueue } from '../state/registry';
+import type { TourId } from '..';
+
+describe('useTourQueue', () => {
+  const REGISTRY_KEY = '__KIBANA_TOUR_QUEUE_CTX__';
+
+  const TOUR_1 = 'tour1' as TourId;
+  const TOUR_2 = 'tour2' as TourId;
+
+  beforeEach(() => {
+    // Clean up the global registry before each test
+    if (typeof globalThis !== 'undefined') {
+      delete (globalThis as any)[REGISTRY_KEY];
+    }
+  });
+
+  it('should return isActive as true for the active tour', () => {
+    const { result } = renderHook(() => useTourQueue(TOUR_1));
+
+    expect(result.current.isActive).toBe(true);
+  });
+
+  it('should return isActive as false for a waiting tour', () => {
+    renderHook(() => useTourQueue(TOUR_1));
+    const tour2Hook = renderHook(() => useTourQueue(TOUR_2));
+
+    expect(tour2Hook.result.current.isActive).toBe(false);
+  });
+
+  it('should update isActive when the tour becomes active', () => {
+    const tour1Hook = renderHook(() => useTourQueue(TOUR_1));
+    const tour2Hook = renderHook(() => useTourQueue(TOUR_2));
+
+    expect(tour2Hook.result.current.isActive).toBe(false);
+
+    // Complete the first tour
+    act(() => {
+      tour1Hook.result.current.onComplete();
+    });
+
+    // Second tour should now be active
+    expect(tour2Hook.result.current.isActive).toBe(true);
+  });
+
+  it('should update isActive to false when tour is completed', () => {
+    const { result } = renderHook(() => useTourQueue(TOUR_1));
+
+    expect(result.current.isActive).toBe(true);
+
+    act(() => {
+      result.current.onComplete();
+    });
+
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it('should update isActive to false when queue is skipped', () => {
+    const tour1Hook = renderHook(() => useTourQueue(TOUR_1));
+    const tour2Hook = renderHook(() => useTourQueue(TOUR_2));
+    const tourQueue = getTourQueue();
+
+    // Initial state
+    expect(tour1Hook.result.current.isActive).toBe(true);
+    expect(tour2Hook.result.current.isActive).toBe(false);
+
+    // Skip all tours
+    act(() => {
+      tourQueue.skipAll();
+    });
+
+    // All tours should be false
+    expect(tour1Hook.result.current.isActive).toBe(false);
+    expect(tour2Hook.result.current.isActive).toBe(false);
+  });
+});

--- a/src/platform/packages/shared/kbn-tour-queue/hooks/use_tour_queue.ts
+++ b/src/platform/packages/shared/kbn-tour-queue/hooks/use_tour_queue.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getTourQueue } from '../state/registry';
+import type { TourId } from '..';
+import type { Tour } from '../state/tour_queue_state';
+
+/**
+ * Result object returned by useTourQueue
+ * @public
+ */
+export interface TourQueueResult {
+  /** Whether this tour is currently active and should be shown */
+  isActive: boolean;
+  /** Callback to mark this tour as completed */
+  onComplete: () => void;
+}
+
+/**
+ * Hook to manage tour queue state for a specific tour.
+ * Automatically registers the tour, subscribes to queue changes,
+ * and handles cleanup on unmount.
+ *
+ * @param tourId - The ID of the tour. Must be a valid ID from {@link TOURS}
+ * @returns Object containing isActive state and onComplete callback
+ * @public
+ */
+export const useTourQueue = (tourId: TourId): TourQueueResult => {
+  const tourQueue = getTourQueue();
+  const [isActive, setIsActive] = useState(false);
+  const tourRef = useRef<Tour | null>(null);
+
+  useEffect(() => {
+    // Register and get tour object
+    const tour = tourQueue.register(tourId);
+    tourRef.current = tour;
+    // Set initial isActive state
+    setIsActive(tour.isActive());
+    // Subscribe to state changes and get cleanup function
+    const stopListening = tourQueue.subscribe(() => {
+      setIsActive(tour.isActive());
+    });
+    return () => {
+      tourRef.current?.unregister();
+      stopListening();
+    };
+  }, [tourId, tourQueue]);
+
+  const onComplete = useCallback(() => {
+    tourRef.current?.complete();
+  }, []);
+
+  return {
+    isActive,
+    onComplete,
+  };
+};

--- a/src/platform/packages/shared/kbn-tour-queue/index.ts
+++ b/src/platform/packages/shared/kbn-tour-queue/index.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { useTourQueue } from './hooks/use_tour_queue';
+export { getTourQueue } from './state/registry';
+export type { TourQueueResult } from './hooks/use_tour_queue';
+export type { Tour } from './state/tour_queue_state';
+
+const TOUR_REGISTRY = {
+  solutionNavigationTour: 1,
+  siemMigrationSetupTour: 2,
+} as const;
+
+/**
+ * Valid tour IDs for registering tours in the queue.
+ * Tours are shown in order based on their registry value.
+ * @public
+ */
+export const TOURS = {
+  NAVIGATION: 'solutionNavigationTour',
+  SECURITY_SIEM_MIGRATION: 'siemMigrationSetupTour',
+} as const;
+
+/**
+ * Union type of all available tour IDs
+ * @public
+ */
+export type TourId = (typeof TOURS)[keyof typeof TOURS];
+
+/**
+ * Get the display order for a tour. Lower numbers are shown first.
+ * @param tourId - The tour ID
+ * @returns The numeric order value for the tour
+ * @internal
+ */
+export const getOrder = (tourId: TourId): number => {
+  return TOUR_REGISTRY[tourId];
+};

--- a/src/platform/packages/shared/kbn-tour-queue/jest.config.js
+++ b/src/platform/packages/shared/kbn-tour-queue/jest.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/src/platform/packages/shared/kbn-tour-queue'],
+};

--- a/src/platform/packages/shared/kbn-tour-queue/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-tour-queue/kibana.jsonc
@@ -1,0 +1,7 @@
+{
+  "type": "shared-browser",
+  "id": "@kbn/tour-queue",
+  "owner": "@elastic/appex-sharedux",
+  "group": "platform",
+  "visibility": "shared"
+}

--- a/src/platform/packages/shared/kbn-tour-queue/package.json
+++ b/src/platform/packages/shared/kbn-tour-queue/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@kbn/tour-queue",
+  "private": true,
+  "version": "1.0.0",
+  "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
+  "sideEffects": false
+}

--- a/src/platform/packages/shared/kbn-tour-queue/state/registry.test.ts
+++ b/src/platform/packages/shared/kbn-tour-queue/state/registry.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { TourId } from '..';
+import { getTourQueue } from './registry';
+
+describe('Registry: getTourQueue', () => {
+  const REGISTRY_KEY = '__KIBANA_TOUR_QUEUE_CTX__';
+
+  const TOUR_1 = 'tour1' as TourId;
+
+  beforeEach(() => {
+    // Clean up the global registry before each test
+    if (typeof globalThis !== 'undefined') {
+      delete (globalThis as any)[REGISTRY_KEY];
+    }
+  });
+
+  it('should store the instance in globalThis registry', () => {
+    const tourQueue = getTourQueue();
+
+    expect((globalThis as any)[REGISTRY_KEY]).toBeDefined();
+    expect((globalThis as any)[REGISTRY_KEY].tourQueueStateManager).toBe(tourQueue);
+  });
+
+  it('should return the same instance on multiple calls', () => {
+    const tourQueue1 = getTourQueue();
+    const tourQueue2 = getTourQueue();
+    const tourQueue3 = getTourQueue();
+
+    expect(tourQueue2).toBe(tourQueue1);
+    expect(tourQueue3).toBe(tourQueue1);
+  });
+
+  it('should share state across multiple calls', () => {
+    const tourQueue1 = getTourQueue();
+    tourQueue1.register(TOUR_1);
+
+    const tourQueue2 = getTourQueue();
+    const tourQueue2State = tourQueue2.getState();
+
+    expect(tourQueue2State.registeredTourIds).toContain(TOUR_1);
+  });
+
+  it('should reuse existing instance from registry if already created', () => {
+    // First call creates the instance
+    const firstTourQueue = getTourQueue();
+
+    // Verify it's in the registry
+    const registryInstance = (globalThis as any)[REGISTRY_KEY]?.tourQueueStateManager;
+    expect(registryInstance).toBe(firstTourQueue);
+
+    // Second call should return the same instance
+    const secondTourQueue = getTourQueue();
+    expect(secondTourQueue).toBe(registryInstance);
+  });
+});

--- a/src/platform/packages/shared/kbn-tour-queue/state/registry.ts
+++ b/src/platform/packages/shared/kbn-tour-queue/state/registry.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { TourQueueStateManager } from './tour_queue_state';
+
+/**
+ * Global registry for ensuring single context instance across bundles
+ *
+ * This pattern is used to share a single state manager across bundles loaded from different plugins
+ * https://github.com/elastic/kibana/issues/240770
+ * @internal
+ */
+const REGISTRY_KEY = '__KIBANA_TOUR_QUEUE_CTX__';
+
+interface TourQueueRegistry {
+  tourQueueStateManager?: TourQueueStateManager;
+}
+
+const getGlobalRegistry = (): TourQueueRegistry => {
+  if (typeof globalThis === 'undefined') {
+    // Fallback for environments without globalThis
+    return {};
+  }
+  return ((globalThis as any)[REGISTRY_KEY] ??= {} as TourQueueRegistry);
+};
+
+/**
+ * Get or create the global tour queue instance.
+ * This ensures a single state manager is shared across all plugins and bundles.
+ * @internal
+ * @remarks
+ * Prefer using hook {@link useTourQueue}
+ * @returns The global tour queue state manager instance
+ */
+export const getTourQueue = (): TourQueueStateManager => {
+  const registry = getGlobalRegistry();
+  return (registry.tourQueueStateManager ??= new TourQueueStateManager());
+};

--- a/src/platform/packages/shared/kbn-tour-queue/state/tour_queue_state.test.ts
+++ b/src/platform/packages/shared/kbn-tour-queue/state/tour_queue_state.test.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { TourQueueStateManager } from './tour_queue_state';
+import type { TourId } from '..';
+
+const TOUR_1 = 'tour1' as TourId;
+const TOUR_2 = 'tour2' as TourId;
+
+// Mock getOrder to return mocked TOUR_REGISTRY orders
+jest.mock('..', () => {
+  const actual = jest.requireActual('..');
+  return {
+    ...actual,
+    getOrder: jest.fn((tourId: TourId) => {
+      const TOUR_REGISTRY = {
+        [TOUR_1]: 1,
+        [TOUR_2]: 2,
+      } as const;
+      return TOUR_REGISTRY[tourId as string];
+    }),
+  };
+});
+
+describe('TourQueueStateManager', () => {
+  let tourQueue: TourQueueStateManager;
+  let subscriber: jest.Mock;
+
+  beforeEach(() => {
+    tourQueue = new TourQueueStateManager();
+    subscriber = jest.fn();
+  });
+
+  describe('register', () => {
+    it('should register tours with provided ids and in order', () => {
+      tourQueue.register(TOUR_2); // order 2
+      tourQueue.register(TOUR_1); // order 1
+
+      const state = tourQueue.getState();
+      expect(state.registeredTourIds[0]).toBe(TOUR_1);
+      expect(state.registeredTourIds[1]).toBe(TOUR_2);
+    });
+
+    it('should not register the same tour twice and return relevant tour object', () => {
+      const tour = tourQueue.register(TOUR_1);
+      const duplicatedTour = tourQueue.register(TOUR_1);
+
+      const state = tourQueue.getState();
+      expect(state.registeredTourIds.filter((id) => id === TOUR_1)).toHaveLength(1);
+      expect(tour.isActive()).toBe(true);
+      expect(duplicatedTour.isActive()).toBe(true);
+    });
+
+    it('should notify subscribers when a tour is registered', () => {
+      tourQueue.subscribe(subscriber);
+
+      tourQueue.register(TOUR_1);
+      tourQueue.register(TOUR_2);
+
+      expect(subscriber).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getActive', () => {
+    it('should return the first in order order registered tour', () => {
+      tourQueue.register(TOUR_2);
+      tourQueue.register(TOUR_1);
+
+      expect(tourQueue.getActive()).toBe(TOUR_1);
+    });
+
+    it('should return the next tour after the first is completed', () => {
+      const tour1 = tourQueue.register(TOUR_1);
+      tourQueue.register(TOUR_2);
+
+      tour1.complete();
+
+      expect(tourQueue.getActive()).toBe(TOUR_2);
+    });
+
+    it('should return null when all tours are completed', () => {
+      const tour1 = tourQueue.register(TOUR_1);
+      const tour2 = tourQueue.register(TOUR_2);
+
+      tour1.complete();
+      tour2.complete();
+
+      expect(tourQueue.getActive()).toBeNull();
+    });
+
+    it('should return null when queue is skipped', () => {
+      const tour = tourQueue.register(TOUR_1);
+      tour.skip();
+
+      expect(tourQueue.getActive()).toBeNull();
+    });
+  });
+
+  describe('Tour object', () => {
+    describe('isActive', () => {
+      it('should return true for the active tour and false for a waiting tour', () => {
+        const tour1 = tourQueue.register(TOUR_1);
+        const tour2 = tourQueue.register(TOUR_2);
+
+        expect(tour1.isActive()).toBe(true);
+        expect(tour2.isActive()).toBe(false);
+      });
+
+      it('should return false for a completed tour', () => {
+        const tour = tourQueue.register(TOUR_1);
+        tour.complete();
+
+        expect(tour.isActive()).toBe(false);
+      });
+
+      it('should return false when queue is skipped', () => {
+        const tour = tourQueue.register(TOUR_1);
+        tour.skip();
+
+        expect(tour.isActive()).toBe(false);
+      });
+    });
+    describe('complete', () => {
+      it('should mark the tour as completed', () => {
+        const tour = tourQueue.register(TOUR_1);
+
+        expect(tourQueue.getState().registeredTourIds).toContain(TOUR_1);
+        expect(tourQueue.getState().completedTourIds.has(TOUR_1)).toBe(false);
+
+        tour.complete();
+
+        expect(tourQueue.getState().completedTourIds.has(TOUR_1)).toBe(true);
+      });
+
+      it('should notify subscribers when completed', () => {
+        const tour = tourQueue.register(TOUR_1);
+        tourQueue.subscribe(subscriber);
+
+        tour.complete();
+
+        expect(subscriber).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('skip', () => {
+      it('should skip all tours in the queue', () => {
+        const tour1 = tourQueue.register(TOUR_1);
+        tourQueue.register(TOUR_2);
+
+        expect(tourQueue.getActive()).toBe(TOUR_1);
+
+        tour1.skip();
+
+        expect(tourQueue.getState().isQueueSkipped).toBe(true);
+        expect(tourQueue.getActive()).toBeNull();
+      });
+
+      it('should notify subscribers when skipped', () => {
+        const tour = tourQueue.register(TOUR_1);
+        tourQueue.subscribe(subscriber);
+
+        tour.skip();
+
+        expect(subscriber).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('unregister', () => {
+      it('should remove tour from registered list', () => {
+        const tour = tourQueue.register(TOUR_1);
+
+        expect(tourQueue.getState().registeredTourIds).toContain(TOUR_1);
+
+        tour.unregister();
+
+        expect(tourQueue.getState().registeredTourIds).not.toContain(TOUR_1);
+      });
+
+      it('should notify subscribers', () => {
+        const tour = tourQueue.register(TOUR_1);
+        tourQueue.subscribe(subscriber);
+
+        tour.unregister();
+
+        expect(subscriber).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-tour-queue/state/tour_queue_state.ts
+++ b/src/platform/packages/shared/kbn-tour-queue/state/tour_queue_state.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getOrder, type TourId } from '..';
+
+/**
+ * Tour object returned by the queue when registering a tour.
+ * Provides methods to control the tour's lifecycle.
+ * @public
+ */
+export interface Tour {
+  /** Check if this tour is currently active in the queue */
+  isActive: () => boolean;
+  /** Skip all tours in the queue for the current page load only */
+  skip: () => void;
+  /** Mark this tour as completed */
+  complete: () => void;
+  /** Unregister this tour from the queue */
+  unregister: () => void;
+}
+
+export interface TourQueueState {
+  registeredTourIds: TourId[];
+  completedTourIds: Set<TourId>;
+  isQueueSkipped: boolean;
+}
+
+export class TourQueueStateManager {
+  private registeredTourIds: TourId[] = [];
+  private completedTourIds: Set<TourId> = new Set();
+  private isQueueSkipped: boolean = false;
+  private subscribers: Set<() => void> = new Set();
+
+  constructor() {}
+
+  register(tourId: TourId): Tour {
+    const exists = this.registeredTourIds.includes(tourId);
+
+    if (!exists) {
+      this.registeredTourIds = [...this.registeredTourIds, tourId].sort(
+        (a, b) => getOrder(a) - getOrder(b)
+      );
+      this.notifySubscribers();
+    }
+
+    return {
+      isActive: () => this.isActive(tourId),
+      skip: () => {
+        this.skipAll();
+      },
+      complete: () => {
+        this.complete(tourId);
+      },
+      unregister: () => {
+        this.unregister(tourId);
+      },
+    };
+  }
+
+  getActive(): TourId | null {
+    if (this.isQueueSkipped) {
+      return null;
+    }
+
+    // Find the first tour that hasn't been completed
+    const activeTour = this.registeredTourIds.find(
+      (registeredTourId) => !this.completedTourIds.has(registeredTourId)
+    );
+
+    return activeTour ?? null;
+  }
+
+  isActive(tourId: TourId): boolean {
+    return this.getActive() === tourId;
+  }
+
+  unregister(tourId: TourId): void {
+    this.registeredTourIds = this.registeredTourIds.filter(
+      (registeredTourId) => registeredTourId !== tourId
+    );
+    this.notifySubscribers();
+  }
+
+  complete(tourId: TourId): void {
+    this.completedTourIds.add(tourId);
+    this.notifySubscribers();
+  }
+
+  skipAll(): void {
+    this.isQueueSkipped = true;
+    this.notifySubscribers();
+  }
+
+  getState(): TourQueueState {
+    return {
+      registeredTourIds: [...this.registeredTourIds],
+      completedTourIds: new Set(this.completedTourIds),
+      isQueueSkipped: this.isQueueSkipped,
+    };
+  }
+
+  subscribe(callback: () => void): () => void {
+    this.subscribers.add(callback);
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  private notifySubscribers(): void {
+    this.subscribers.forEach((callback) => callback());
+  }
+}

--- a/src/platform/packages/shared/kbn-tour-queue/tsconfig.json
+++ b/src/platform/packages/shared/kbn-tour-queue/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": []
+}

--- a/src/platform/packages/shared/kbn-tour-queue/tsconfig.json
+++ b/src/platform/packages/shared/kbn-tour-queue/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "extends": "../../../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "target/types",
   },

--- a/src/platform/plugins/shared/navigation/public/solution_tour/solution_tour.ts
+++ b/src/platform/plugins/shared/navigation/public/solution_tour/solution_tour.ts
@@ -13,12 +13,14 @@ import type { UserProfileServiceStart } from '@kbn/core-user-profile-browser';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { FeatureFlagsStart } from '@kbn/core-feature-flags-browser';
 import { getSideNavVersion } from '@kbn/core-chrome-layout-feature-flags';
+import { getTourQueue } from '@kbn/tour-queue';
 
 /**
  * This tour combines the spaces solution view tour and new navigation tour into a single
  * multi-step tour.
  */
 export class SolutionNavigationTourManager {
+  private tourQueue = getTourQueue();
   constructor(
     private deps: {
       navigationTourManager: NavigationTourManager;
@@ -30,21 +32,44 @@ export class SolutionNavigationTourManager {
   ) {}
 
   async startTour(): Promise<void> {
-    // first start the spaces tour (if applicable)
-    const spacesTour = await this.deps.spacesSolutionViewTourManager.startTour();
-    if (spacesTour.result === 'started') {
-      await this.deps.spacesSolutionViewTourManager.waitForTourEnd();
+    // Register and get tour object
+    const tour = this.tourQueue.register('solutionNavigationTour');
+    // This will only work as long as solutionNavigationTour is the first tour in the queue
+    // Will be removed as part of tour cleanup https://github.com/elastic/kibana/issues/239313
+    if (!tour.isActive()) {
+      tour.unregister();
+      return;
     }
 
-    // when completes, maybe start the navigation tour (if applicable)
-    if (getSideNavVersion(this.deps.featureFlags) !== 'v2') return;
-    const hasCompletedTour = await checkTourCompletion(this.deps.userProfile);
-    if (hasCompletedTour) return;
+    try {
+      // first start the spaces tour (if applicable)
+      if (this.deps.spacesSolutionViewTourManager) {
+        const spacesTour = await this.deps.spacesSolutionViewTourManager.startTour();
+        if (spacesTour.result === 'started') {
+          await this.deps.spacesSolutionViewTourManager.waitForTourEnd();
+        }
+      }
 
-    this.deps.navigationTourManager.startTour();
-    await this.deps.navigationTourManager.waitForTourEnd();
+      if (getSideNavVersion(this.deps.featureFlags) !== 'v2') return;
 
-    await preserveTourCompletion(this.deps.userProfile);
+      // when completes, maybe start the navigation tour (if applicable)
+      const hasCompletedTour = await checkTourCompletion(this.deps.userProfile);
+      if (hasCompletedTour) {
+        tour.complete();
+        return;
+      }
+      this.deps.navigationTourManager.startTour();
+      const navigationTourResult = await this.deps.navigationTourManager.waitForTourEnd();
+
+      // If skipped, notify queue to skip all remaining tours for the current page load only
+      if (navigationTourResult === 'skipped') {
+        tour.skip();
+      }
+      await preserveTourCompletion(this.deps.userProfile);
+      tour.complete();
+    } finally {
+      tour.unregister();
+    }
   }
 }
 

--- a/src/platform/plugins/shared/navigation/tsconfig.json
+++ b/src/platform/plugins/shared/navigation/tsconfig.json
@@ -33,6 +33,7 @@
     "@kbn/core-feature-flags-browser",
     "@kbn/core-chrome-layout-feature-flags",
     "@kbn/core-chrome-navigation-tour",
+    "@kbn/tour-queue"
   ],
   "exclude": [
     "target/**/*",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2204,6 +2204,8 @@
       "@kbn/tinymath/*": ["src/platform/packages/private/kbn-tinymath/*"],
       "@kbn/tooling-log": ["src/platform/packages/shared/kbn-tooling-log"],
       "@kbn/tooling-log/*": ["src/platform/packages/shared/kbn-tooling-log/*"],
+      "@kbn/tour-queue": ["src/platform/packages/shared/kbn-tour-queue"],
+      "@kbn/tour-queue/*": ["src/platform/packages/shared/kbn-tour-queue/*"],
       "@kbn/traced-es-client": ["src/platform/packages/shared/kbn-traced-es-client"],
       "@kbn/traced-es-client/*": ["src/platform/packages/shared/kbn-traced-es-client/*"],
       "@kbn/tracing": ["src/platform/packages/shared/kbn-tracing"],

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/tours/setup_guide/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/tours/setup_guide/index.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { EuiButtonEmpty, EuiTourStep } from '@elastic/eui';
+import { TOURS, useTourQueue } from '@kbn/tour-queue';
 import { NEW_FEATURES_TOUR_STORAGE_KEYS } from '../../../../../../common/constants';
 import { useKibana } from '../../../../../common/lib/kibana';
 import * as i18n from './translations';
@@ -32,12 +33,15 @@ export const SiemMigrationSetupTour: React.FC<SetupTourProps> = React.memo(({ ch
     return tourConfig;
   });
 
+  const { isActive: isActiveInQueue, onComplete } = useTourQueue(TOURS.SECURITY_SIEM_MIGRATION);
+
   const onTourFinished = useCallback(() => {
     setTourState({
       ...tourState,
       isTourActive: false,
     });
-  }, [tourState]);
+    onComplete();
+  }, [tourState, onComplete]);
 
   useEffect(() => {
     storage.set(NEW_FEATURES_TOUR_STORAGE_KEYS.SIEM_MAIN_LANDING_PAGE, tourState);
@@ -52,8 +56,13 @@ export const SiemMigrationSetupTour: React.FC<SetupTourProps> = React.memo(({ ch
   }, []);
 
   const showTour = useMemo(() => {
-    return siemMigrations.rules.isAvailable() && tourState.isTourActive && tourDelayElapsed;
-  }, [siemMigrations.rules, tourDelayElapsed, tourState.isTourActive]);
+    return (
+      siemMigrations.rules.isAvailable() &&
+      tourState.isTourActive &&
+      tourDelayElapsed &&
+      isActiveInQueue
+    );
+  }, [siemMigrations.rules, tourDelayElapsed, tourState.isTourActive, isActiveInQueue]);
 
   return (
     <EuiTourStep

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -258,5 +258,6 @@
     "@kbn/core-analytics-server-mocks",
     "@kbn/object-utils",
     "@kbn/react-query",
+    "@kbn/tour-queue"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8717,6 +8717,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/tour-queue@link:src/platform/packages/shared/kbn-tour-queue":
+  version "0.0.0"
+  uid ""
+
 "@kbn/traced-es-client@link:src/platform/packages/shared/kbn-traced-es-client":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[SharedUX] Add kbn-tour-queue package to avoid tour overlapping (#242640)](https://github.com/elastic/kibana/pull/242640)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ángeles Martínez Barrio","email":"angeles.martinezbarrio@elastic.co"},"sourceCommit":{"committedDate":"2025-11-20T16:30:43Z","message":"[SharedUX] Add kbn-tour-queue package to avoid tour overlapping (#242640)\n\nCloses https://github.com/elastic/kibana-team/issues/2146\n\n## Summary\n\n- This PR introduces a new package to orchestrate tours to avoid\noverlapping. Currently, Side Nav Tour and Security tour are overlapping\nin this way:\n\n<img width=\"675\" height=\"391\" alt=\"Screenshot 2025-11-12 at 10 32 34\"\nsrc=\"https://github.com/user-attachments/assets/27a3ba52-2c69-4fe0-bf62-18d649354de5\"\n/>\n\n- Package `kbn-tour-queue` uses `globalThis` to share state across\nplugins and to ensure only one single instance of the state manager is\nused. This approach is based on @Dosant `kbn-developer-toolbar` [state\nimplementation](https://github.com/elastic/kibana/blob/7518eebd9acaf352f02241901cbeb7129e0a1f32/src/platform/packages/shared/kbn-developer-toolbar/src/hooks/use_toolbar_state.tsx#L14-L40).\n- If any of the tours in the queue are skipped, the remaining tours are\nalso skipped (currently only Side Nav tour handles skip behaviour).\nSkipped status is not persisted for now, it is only honored until page\nreload.\n- Side Nav and Security tours were updated to use the new tour queue\nsystem.\n\n### Testing\n\nTour completion (Spaces + SideNav + Security):\n\n\nhttps://github.com/user-attachments/assets/139847ac-48ea-41e6-8eba-cf5c4981ed96\n\nTour skipping (Spaces + SideNav):\n\n\nhttps://github.com/user-attachments/assets/e75f7aa0-6cb4-4c43-9117-172f88f1fe8b","sha":"60952a0bbdeb09c931eaf4469c01f21931836651","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:SharedUX","backport:version","v9.3.0","v9.2.2"],"title":"[SharedUX] Add kbn-tour-queue package to avoid tour overlapping","number":242640,"url":"https://github.com/elastic/kibana/pull/242640","mergeCommit":{"message":"[SharedUX] Add kbn-tour-queue package to avoid tour overlapping (#242640)\n\nCloses https://github.com/elastic/kibana-team/issues/2146\n\n## Summary\n\n- This PR introduces a new package to orchestrate tours to avoid\noverlapping. Currently, Side Nav Tour and Security tour are overlapping\nin this way:\n\n<img width=\"675\" height=\"391\" alt=\"Screenshot 2025-11-12 at 10 32 34\"\nsrc=\"https://github.com/user-attachments/assets/27a3ba52-2c69-4fe0-bf62-18d649354de5\"\n/>\n\n- Package `kbn-tour-queue` uses `globalThis` to share state across\nplugins and to ensure only one single instance of the state manager is\nused. This approach is based on @Dosant `kbn-developer-toolbar` [state\nimplementation](https://github.com/elastic/kibana/blob/7518eebd9acaf352f02241901cbeb7129e0a1f32/src/platform/packages/shared/kbn-developer-toolbar/src/hooks/use_toolbar_state.tsx#L14-L40).\n- If any of the tours in the queue are skipped, the remaining tours are\nalso skipped (currently only Side Nav tour handles skip behaviour).\nSkipped status is not persisted for now, it is only honored until page\nreload.\n- Side Nav and Security tours were updated to use the new tour queue\nsystem.\n\n### Testing\n\nTour completion (Spaces + SideNav + Security):\n\n\nhttps://github.com/user-attachments/assets/139847ac-48ea-41e6-8eba-cf5c4981ed96\n\nTour skipping (Spaces + SideNav):\n\n\nhttps://github.com/user-attachments/assets/e75f7aa0-6cb4-4c43-9117-172f88f1fe8b","sha":"60952a0bbdeb09c931eaf4469c01f21931836651"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/242640","number":242640,"mergeCommit":{"message":"[SharedUX] Add kbn-tour-queue package to avoid tour overlapping (#242640)\n\nCloses https://github.com/elastic/kibana-team/issues/2146\n\n## Summary\n\n- This PR introduces a new package to orchestrate tours to avoid\noverlapping. Currently, Side Nav Tour and Security tour are overlapping\nin this way:\n\n<img width=\"675\" height=\"391\" alt=\"Screenshot 2025-11-12 at 10 32 34\"\nsrc=\"https://github.com/user-attachments/assets/27a3ba52-2c69-4fe0-bf62-18d649354de5\"\n/>\n\n- Package `kbn-tour-queue` uses `globalThis` to share state across\nplugins and to ensure only one single instance of the state manager is\nused. This approach is based on @Dosant `kbn-developer-toolbar` [state\nimplementation](https://github.com/elastic/kibana/blob/7518eebd9acaf352f02241901cbeb7129e0a1f32/src/platform/packages/shared/kbn-developer-toolbar/src/hooks/use_toolbar_state.tsx#L14-L40).\n- If any of the tours in the queue are skipped, the remaining tours are\nalso skipped (currently only Side Nav tour handles skip behaviour).\nSkipped status is not persisted for now, it is only honored until page\nreload.\n- Side Nav and Security tours were updated to use the new tour queue\nsystem.\n\n### Testing\n\nTour completion (Spaces + SideNav + Security):\n\n\nhttps://github.com/user-attachments/assets/139847ac-48ea-41e6-8eba-cf5c4981ed96\n\nTour skipping (Spaces + SideNav):\n\n\nhttps://github.com/user-attachments/assets/e75f7aa0-6cb4-4c43-9117-172f88f1fe8b","sha":"60952a0bbdeb09c931eaf4469c01f21931836651"}},{"branch":"9.2","label":"v9.2.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->