### PR TITLE
Skip serverless dataset quality table test suite for MKI

### DIFF
--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/dataset_quality_table.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/dataset_quality_table.ts
@@ -40,6 +40,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
 
   describe('Dataset quality table', function () {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/243760
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       // Install Integration and ingest logs for it
       await PageObjects.observabilityLogsExplorer.installPackage(pkg);


### PR DESCRIPTION
## Summary

This PR skips the serverless dataset quality table test suite for MKI runs.
Details on the failure / flakiness in #243760.



