### PR TITLE
[One Workflow] Use proper icon color in completions

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_step_icon_base64.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_step_icon_base64.ts
@@ -10,8 +10,8 @@
 import { type IconType } from '@elastic/eui';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { HardcodedIcons } from './hardcoded_icons';
 import { ElasticsearchLogo } from './icons/elasticsearch.svg';
-import { HARDCODED_ICONS } from './icons/hardcoded_icons';
 import { KibanaLogo } from './icons/kibana.svg';
 
 export interface GetStepIconBase64Params {
@@ -85,7 +85,7 @@ export async function getStepIconBase64(connector: GetStepIconBase64Params): Pro
       return getDataUrlFromReactComponent(KibanaLogo);
     }
 
-    const hardcodedIcon = HARDCODED_ICONS[connector.actionTypeId];
+    const hardcodedIcon = HardcodedIcons[connector.actionTypeId];
     if (hardcodedIcon) {
       if (hardcodedIcon.startsWith('data:')) {
         return hardcodedIcon;

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/hardcoded_icons.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/hardcoded_icons.ts
@@ -7,21 +7,21 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import branch from './branch.svg';
-import clock from './clock.svg';
-import console from './console.svg';
-import email from './email.svg';
-import globe from './globe.svg';
-import elasticsearchLogoSvg from './logo_elasticsearch.svg';
-import kibanaLogoSvg from './logo_kibana.svg';
-import slackLogoSvg from './logo_slack.svg';
-import plugs from './plugs.svg';
-import refresh from './refresh.svg';
-import sparkles from './sparkles.svg';
-import user from './user.svg';
-import warning from './warning.svg';
+import branch from './icons/branch.svg';
+import clock from './icons/clock.svg';
+import console from './icons/console.svg';
+import email from './icons/email.svg';
+import globe from './icons/globe.svg';
+import elasticsearchLogoSvg from './icons/logo_elasticsearch.svg';
+import kibanaLogoSvg from './icons/logo_kibana.svg';
+import slackLogoSvg from './icons/logo_slack.svg';
+import plugs from './icons/plugs.svg';
+import refresh from './icons/refresh.svg';
+import sparkles from './icons/sparkles.svg';
+import user from './icons/user.svg';
+import warning from './icons/warning.svg';
 
-export const HARDCODED_ICONS: Record<string, string> = {
+export const HardcodedIcons: Record<string, string> = {
   '.slack': slackLogoSvg,
   '.slack_api': slackLogoSvg,
   '.email': email,

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/monochrome_icons.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/monochrome_icons.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const MonochromeIcons = new Set([
+  'manual',
+  'alert',
+  'scheduled',
+  'http',
+  'console',
+  'if',
+  'foreach',
+  'parallel',
+  'merge',
+  'wait',
+  // connector icons, which are monochrome and should be colored with currentColor
+  '.inference',
+  '.email',
+  '.gen-ai',
+  '.bedrock',
+]);

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/use_dynamic_type_icons.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/use_dynamic_type_icons.ts
@@ -12,6 +12,7 @@ import { useEffect } from 'react';
 import type { ConnectorsResponse } from '../../../entities/connectors/model/types';
 import { useKibana } from '../../../hooks/use_kibana';
 import { getStepIconBase64 } from '../../../shared/ui/step_icons/get_step_icon_base64';
+import { MonochromeIcons } from '../../../shared/ui/step_icons/monochrome_icons';
 
 export interface ConnectorTypeInfoMinimal {
   actionTypeId: string;
@@ -118,41 +119,46 @@ async function injectDynamicConnectorIcons(connectorTypes: ConnectorTypeInfoMini
 
     const displayName = connector.displayName;
 
-    try {
-      // Generate CSS rule for this connector
-      const iconBase64 = await getStepIconBase64(connector);
+    // Generate CSS rule for this connector
+    const iconBase64 = await getStepIconBase64(connector);
 
-      // Only inject CSS if we successfully generated an icon
-      if (iconBase64) {
-        let selector = `.monaco-list .monaco-list-row[aria-label^="${connectorType},"] .suggest-icon:before,
-          .monaco-list .monaco-list-row[aria-label$=", ${connectorType}"] .suggest-icon:before,
-          .monaco-list .monaco-list-row[aria-label*=", ${connectorType},"] .suggest-icon:before,
-          .monaco-list .monaco-list-row[aria-label="${connectorType}"] .suggest-icon:before,
-          .monaco-list .monaco-list-row[aria-label*="${displayName}"] .suggest-icon:before`;
-        if (connectorType === 'elasticsearch') {
-          selector = '.codicon-symbol-struct:before';
-        } else if (connectorType === 'kibana') {
-          selector = '.codicon-symbol-module:before';
-        } else if (connectorType === 'console') {
-          selector = '.codicon-symbol-variable:before';
-        }
-        cssToInject += `
-          /* Target by aria-label content */
-          ${selector} {
-            background-image: url("${iconBase64}") !important;
-            background-size: 12px 12px !important;
-            background-repeat: no-repeat !important;
-            background-position: center !important;
-            content: " " !important;
-            width: 16px !important;
-            height: 16px !important;
-            display: block !important;
-          }
-        `;
-      }
-    } catch (error) {
-      // Silently skip if icon generation fails
+    let selector = `.monaco-list .monaco-list-row[aria-label^="${connectorType},"] .suggest-icon:before,
+      .monaco-list .monaco-list-row[aria-label$=", ${connectorType}"] .suggest-icon:before,
+      .monaco-list .monaco-list-row[aria-label*=", ${connectorType},"] .suggest-icon:before,
+      .monaco-list .monaco-list-row[aria-label="${connectorType}"] .suggest-icon:before,
+      .monaco-list .monaco-list-row[aria-label*="${displayName}"] .suggest-icon:before`;
+    if (connectorType === 'elasticsearch') {
+      selector = '.codicon-symbol-struct:before';
+    } else if (connectorType === 'kibana') {
+      selector = '.codicon-symbol-module:before';
+    } else if (connectorType === 'console') {
+      selector = '.codicon-symbol-variable:before';
     }
+
+    let cssProperties = '';
+    if (MonochromeIcons.has(connector.actionTypeId)) {
+      cssProperties = `
+        mask-image: url("${iconBase64}");
+        mask-size: contain;
+        background-color: currentColor;
+      `;
+    } else {
+      cssProperties = `background-image: url("${iconBase64}") !important;`;
+    }
+
+    cssToInject += `
+      /* Target by aria-label content */
+      ${selector} {
+        ${cssProperties}
+        background-size: 12px 12px !important;
+        background-repeat: no-repeat !important;
+        background-position: center !important;
+        content: " " !important;
+        width: 16px !important;
+        height: 16px !important;
+        display: block !important;
+      }
+    `;
   }
 
   // Inject the CSS
@@ -181,45 +187,52 @@ async function injectDynamicShadowIcons(connectorTypes: ConnectorTypeInfoMinimal
   let cssToInject = '';
 
   for (const connector of connectorTypes) {
-    const connectorType = connector.actionTypeId;
-    try {
-      // Generate CSS rule for this connector shadow icon
-      const iconBase64 = await getStepIconBase64(connector);
+    // Generate CSS rule for this connector
+    const iconBase64 = await getStepIconBase64(connector);
 
-      // Only inject CSS if we successfully generated an icon
-      if (iconBase64) {
-        // Get the class name for this connector
-        let className = connectorType;
-        if (connectorType.startsWith('elasticsearch.')) {
-          className = 'elasticsearch';
-        } else if (connectorType.startsWith('kibana.')) {
-          className = 'kibana';
-        } else {
-          // Handle connectors with dot notation properly
-          if (connectorType.startsWith('.')) {
-            // For connectors like ".jira", remove the leading dot
-            className = connectorType.substring(1);
-          } else if (connectorType.includes('.')) {
-            // For connectors like "thehive.createAlert", use base name
-            className = connectorType.split('.')[0];
-          } else {
-            // For simple connectors like "slack", use as-is
-            className = connectorType;
-          }
-        }
+    // Only inject CSS if we successfully generated an icon
+    const connectorType = connector.actionTypeId.startsWith('.')
+      ? connector.actionTypeId.slice(1)
+      : connector.actionTypeId;
 
-        cssToInject += `
-          .type-inline-highlight.type-${className}::after {
-            background-image: url("${iconBase64}");
-            background-size: contain;
-            background-repeat: no-repeat;
-          }
-        `;
+    // Get the class name for this connector
+    let className = connectorType;
+    if (connectorType.startsWith('elasticsearch.')) {
+      className = 'elasticsearch';
+    } else if (connectorType.startsWith('kibana.')) {
+      className = 'kibana';
+    } else {
+      // Handle connectors with dot notation properly
+      if (connectorType.startsWith('.')) {
+        // For connectors like ".jira", remove the leading dot
+        className = connectorType.substring(1);
+      } else if (connectorType.includes('.')) {
+        // For connectors like "thehive.createAlert", use base name
+        className = connectorType.split('.')[0];
+      } else {
+        // For simple connectors like "slack", use as-is
+        className = connectorType;
       }
-    } catch (error) {
-      // console.log('error getting connector icon base64', error);
-      // Silently skip if icon generation fails
     }
+
+    let cssProperties = '';
+    if (MonochromeIcons.has(connector.actionTypeId)) {
+      cssProperties = `
+        mask-image: url("${iconBase64}");
+        mask-size: contain;
+        background-color: currentColor;
+      `;
+    } else {
+      cssProperties = `background-image: url("${iconBase64}");`;
+    }
+
+    cssToInject += `
+      .type-inline-highlight.type-${className}::after {
+        ${cssProperties}
+        background-size: contain;
+        background-repeat: no-repeat;
+      }
+    `;
   }
 
   // Inject the CSS


### PR DESCRIPTION
## Summary

Fixes the completion provider icons in dark mode:

### Before
<img width="575" height="190" alt="Captura de pantalla 2025-11-21 a les 10 37 55" src="https://github.com/user-attachments/assets/d26e33b4-6be7-4bf0-86ca-248d302a96b4" />

<img width="580" height="305" alt="Captura de pantalla 2025-11-21 a les 10 37 33" src="https://github.com/user-attachments/assets/fbd653b1-d2aa-400d-b9de-b21204326cf6" />

<img width="580" height="305" alt="Captura de pantalla 2025-11-21 a les 10 37 39" src="https://github.com/user-attachments/assets/596b78c9-bfea-4b2c-99bb-e93814a2d5c5" />

### After

<img width="575" height="188" alt="Captura de pantalla 2025-11-21 a les 10 39 38" src="https://github.com/user-attachments/assets/b811f84a-0730-40a9-8971-b0ada9dd73e3" />
<img width="575" height="258" alt="Captura de pantalla 2025-11-21 a les 10 39 33" src="https://github.com/user-attachments/assets/6da17805-7764-4e63-9fb8-40fb2f5bd6dc" />
<img width="575" height="258" alt="Captura de pantalla 2025-11-21 a les 10 39 29" src="https://github.com/user-attachments/assets/be66453d-2b02-4e6c-8a15-e0992cf73a18" />

