### PR TITLE
chore(dep): bump `tar` package from `7.5.1` to `7.5.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1420,7 +1420,7 @@
     "suricata-sid-db": "^1.0.2",
     "swr": "^2.3.3",
     "symbol-observable": "^4.0.0",
-    "tar": "^7.5.1",
+    "tar": "^7.5.2",
     "textarea-caret": "^3.1.0",
     "tree-dump": "^1.0.3",
     "ts-easing": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32338,10 +32338,10 @@ tar-stream@^3.0.0, tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@^7.5.1:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.1.tgz#750a8bd63b7c44c1848e7bf982260a083cf747c9"
-  integrity sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==
+tar@^7.5.2:
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.2.tgz#115c061495ec51ff3c6745ff8f6d0871c5b1dedc"
+  integrity sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
## Summary

Bump `tar` package from `7.5.1` to `7.5.2`.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->