### PR TITLE
Fix EIS Gateway ACL config and add required endpoint metadata

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/get_docker_compose_yaml.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/get_docker_compose_yaml.ts
@@ -31,6 +31,7 @@ export function getDockerComposeYaml({
           - "8051:8051"
         volumes:
           - "${config.eisGateway.mount.acl}:/app/acl/acl.yaml:ro"
+          - "${config.eisGateway.mount.endpointMetadata}:/endpoint-metadata/endpoint-metadata.yaml:ro"
           - "${config.eisGateway.mount.tls.cert}:/certs/tls/tls.crt:ro"
           - "${config.eisGateway.mount.tls.key}:/certs/tls/tls.key:ro"
           - "${config.eisGateway.mount.ca.cert}:/certs/ca/ca.crt:ro"
@@ -42,9 +43,10 @@ ${credentials
   })
   .join('\n')}
           ACL_FILE_PATH: "/app/acl/acl.yaml"
+          ENDPOINT_METADATA_FILE_PATH: "/endpoint-metadata/endpoint-metadata.yaml"
           ENTITLEMENTS_SKIP_CHECK: "true"
           TELEMETRY_EXPORTER_TYPE: "none"
-          TLS_VERIFY_CLIENT_CERTS: "false"
+          TLS_CLIENT_AUTH: "NoClientCert"
           LOGGER_LEVEL: "info"
         healthcheck:
           test: [

--- a/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/get_docker_compose_yaml.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/get_docker_compose_yaml.ts
@@ -31,7 +31,9 @@ export function getDockerComposeYaml({
           - "8051:8051"
         volumes:
           - "${config.eisGateway.mount.acl}:/app/acl/acl.yaml:ro"
-          - "${config.eisGateway.mount.endpointMetadata}:/endpoint-metadata/endpoint-metadata.yaml:ro"
+          - "${
+            config.eisGateway.mount.endpointMetadata
+          }:/endpoint-metadata/endpoint-metadata.yaml:ro"
           - "${config.eisGateway.mount.tls.cert}:/certs/tls/tls.crt:ro"
           - "${config.eisGateway.mount.tls.key}:/certs/tls/tls.key:ro"
           - "${config.eisGateway.mount.ca.cert}:/certs/ca/ca.crt:ro"

--- a/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/get_eis_gateway_config.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/get_eis_gateway_config.ts
@@ -16,6 +16,7 @@ export interface EisGatewayConfig {
   ports: [number, number];
   mount: {
     acl: string;
+    endpointMetadata: string;
     tls: {
       cert: string;
       key: string;
@@ -48,8 +49,32 @@ interface AccessControlListConfig {
         security: boolean;
       };
     };
-    task_types: string[];
   };
+}
+
+interface EndpointMetadataConfig {
+  inference_endpoints: Array<{
+    id: string;
+    model_name: string;
+    task_types: {
+      elasticsearch: string;
+      eis: string;
+    };
+    status: string;
+    properties: string[];
+    release_date: string;
+    end_of_life_date?: string;
+    configuration?: {
+      similarity?: string;
+      dimensions?: number;
+      element_type?: string;
+      chunking_settings?: {
+        strategy: string;
+        max_chunk_size: number;
+        sentence_overlap: number;
+      };
+    };
+  }>;
 }
 
 export async function getEisGatewayConfig({
@@ -84,7 +109,6 @@ export async function getEisGatewayConfig({
           security: false,
         },
       },
-      task_types: ['chat'],
     },
     elser_model_2: {
       allow_cloud_trials: true,
@@ -101,7 +125,6 @@ export async function getEisGatewayConfig({
           security: false,
         },
       },
-      task_types: ['embed/text/sparse'],
     },
     'jina-embeddings-v3': {
       allow_cloud_trials: true,
@@ -118,13 +141,77 @@ export async function getEisGatewayConfig({
           security: false,
         },
       },
-      task_types: ['embed/text/dense'],
     },
   };
 
   const aclFilePath = await writeTempfile('acl.yaml', dump(aclContents));
 
   log.debug(`Wrote ACL file to ${aclFilePath}`);
+
+  // This file is meant for LOCAL DEVELOPMENT ONLY!
+  // We have different versions of this in serverless-gitops via Helm values.
+  const endpointMetadataContents: EndpointMetadataConfig = {
+    inference_endpoints: [
+      {
+        id: `.${EIS_CHAT_MODEL_NAME}-elastic`,
+        model_name: EIS_CHAT_MODEL_NAME,
+        task_types: {
+          elasticsearch: 'chat_completion',
+          eis: 'chat',
+        },
+        status: 'ga',
+        properties: ['multilingual'],
+        release_date: '2025-06-23',
+        end_of_life_date: '2026-04-15',
+      },
+      {
+        id: '.elser-2-elastic',
+        model_name: 'elser_model_2',
+        task_types: {
+          elasticsearch: 'sparse_embedding',
+          eis: 'embed/text/sparse',
+        },
+        status: 'preview',
+        properties: ['english'],
+        release_date: '2025-10-01',
+        configuration: {
+          chunking_settings: {
+            strategy: 'sentence',
+            max_chunk_size: 250,
+            sentence_overlap: 1,
+          },
+        },
+      },
+      {
+        id: '.jina-embeddings-v3',
+        model_name: 'jina-embeddings-v3',
+        task_types: {
+          elasticsearch: 'text_embedding',
+          eis: 'embed/text/dense',
+        },
+        status: 'beta',
+        properties: ['multilingual', 'open-weights'],
+        release_date: '2025-11-30',
+        configuration: {
+          similarity: 'cosine',
+          dimensions: 1024,
+          element_type: 'float',
+          chunking_settings: {
+            strategy: 'sentence',
+            max_chunk_size: 250,
+            sentence_overlap: 1,
+          },
+        },
+      },
+    ],
+  };
+
+  const endpointMetadataFilePath = await writeTempfile(
+    'endpoint-metadata.yaml',
+    dump(endpointMetadataContents)
+  );
+
+  log.debug(`Wrote endpoint metadata file to ${endpointMetadataFilePath}`);
 
   const { tls, ca } = await generateCertificates({
     log,
@@ -139,6 +226,7 @@ export async function getEisGatewayConfig({
     },
     mount: {
       acl: aclFilePath,
+      endpointMetadata: endpointMetadataFilePath,
       tls,
       ca,
     },


### PR DESCRIPTION
## Summary

The EIS Gateway container was failing to start due to two
configuration issues:

1. The ACL configuration incorrectly included a `task_types` field, which the eis-gateway Go code does not recognize in ACL config. This field belongs only in endpoint metadata, not ACL.

2. The endpoint metadata file was missing entirely. Starting with Elasticsearch 9.3, eis-gateway requires endpoint metadata to be provided, and it validates that all models in the ACL have corresponding endpoint metadata entries.

This change removes `task_types` from the ACL configuration and adds automatic generation and mounting of the endpoint metadata file, matching the models configured in the ACL (rainbow-sprinkles, elser_model_2, and jina-embeddings-v3).

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

