### PR TITLE
[Scout] Remove Buildkite build message from reporting

### DIFF
--- a/src/platform/packages/private/kbn-scout-reporting/src/datasources/buildkite.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/datasources/buildkite.ts
@@ -57,7 +57,6 @@ export const buildkite: BuildkiteMetadata =
         branch: process.env.BUILDKITE_BRANCH,
         commit: process.env.BUILDKITE_COMMIT,
         job_id: process.env.BUILDKITE_JOB_ID,
-        message: process.env.BUILDKITE_MESSAGE,
         build: {
           id: process.env.BUILDKITE_BUILD_ID,
           number: process.env.BUILDKITE_BUILD_NUMBER,

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/component_templates.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/component_templates.ts
@@ -18,7 +18,7 @@ import {
 
 export const buildkiteMappings: ClusterPutComponentTemplateRequest = {
   name: 'scout-test-event.mappings.buildkite',
-  version: 2,
+  version: 3,
   template: {
     mappings: {
       properties: {

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/persistence/mappings.ts
@@ -18,9 +18,6 @@ export const buildkiteProperties: Record<PropertyName, MappingProperty> = {
   job_id: {
     type: 'wildcard',
   },
-  message: {
-    type: 'text',
-  },
   build: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary

The Buildkite build message can be quite wordy at times. When that happens, the size of the documents used for reporting can increase significantly.

These changes remove the field entirely from collection because we're looking to increase indexing performance and storage efficiency for data produced by the Scout event reporters.

_Note: The component templates should only be updated **after** this PR is merged and fully backported._




<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->