### PR TITLE
[SideNav][SharedUX] Fix beta badge color in dark mode

### DIFF
--- a/src/core/packages/chrome/navigation/src/components/beta_badge/index.tsx
+++ b/src/core/packages/chrome/navigation/src/components/beta_badge/index.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { EuiBetaBadge, EuiThemeProvider, useIsDarkMode } from '@elastic/eui';
+import { EuiBetaBadge, EuiThemeProvider } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 
@@ -25,7 +25,6 @@ interface BetaBadgeProps {
  * It can be aligned to the middle or bottom of the text.
  */
 export const BetaBadge = ({ type, isInverted, alignment = 'bottom' }: BetaBadgeProps) => {
-  const isDarkMode = useIsDarkMode();
   const betaBadgeStyles = css`
     vertical-align: ${alignment === 'text-bottom' ? 'text-bottom' : 'bottom'};
   `;
@@ -47,7 +46,7 @@ export const BetaBadge = ({ type, isInverted, alignment = 'bottom' }: BetaBadgeP
 
   return (
     <EuiThemeProvider
-      colorMode={isInverted && !isDarkMode ? 'inverse' : undefined}
+      colorMode={isInverted ? 'dark' : undefined}
       wrapperProps={{ cloneElement: true }}
     >
       <EuiBetaBadge

--- a/src/core/packages/chrome/navigation/src/components/beta_badge/index.tsx
+++ b/src/core/packages/chrome/navigation/src/components/beta_badge/index.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { EuiBetaBadge, EuiThemeProvider } from '@elastic/eui';
+import { EuiBetaBadge, EuiThemeProvider, useIsDarkMode } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 
@@ -25,6 +25,7 @@ interface BetaBadgeProps {
  * It can be aligned to the middle or bottom of the text.
  */
 export const BetaBadge = ({ type, isInverted, alignment = 'bottom' }: BetaBadgeProps) => {
+  const isDarkMode = useIsDarkMode();
   const betaBadgeStyles = css`
     vertical-align: ${alignment === 'text-bottom' ? 'text-bottom' : 'bottom'};
   `;
@@ -46,7 +47,7 @@ export const BetaBadge = ({ type, isInverted, alignment = 'bottom' }: BetaBadgeP
 
   return (
     <EuiThemeProvider
-      colorMode={isInverted ? 'inverse' : undefined}
+      colorMode={isInverted && !isDarkMode ? 'inverse' : undefined}
       wrapperProps={{ cloneElement: true }}
     >
       <EuiBetaBadge


### PR DESCRIPTION
## Summary

- Fixed beta badge color for dark mode: we were inverting the badge color inside tooltip (always dark backgrounds). But for dark mode, that meant inverting what was already inverted.
- Added a check to invert only when we are not on dark mode.

### Testing

| Before | After |
|-----------------|-----------------|
|  <img width="241" height="360" alt="Screenshot 2025-11-21 at 13 13 53" src="https://github.com/user-attachments/assets/3c0af219-8187-4f31-940a-496e2eeefadc" />  |  <img width="270" height="362" alt="Screenshot 2025-11-21 at 13 12 45" src="https://github.com/user-attachments/assets/1a5b474a-0f30-463c-8777-ed3556bd18b0" />  |
|  <img width="257" height="369" alt="Screenshot 2025-11-21 at 13 13 17" src="https://github.com/user-attachments/assets/4fe8ecb7-6513-4efa-b1ae-0f1341b05663" />  |  No changes |


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->