### PR TITLE
[9.1] [Security Solution][Alert details] save selected prevalence time to local storage (#243543)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.test.tsx
@@ -14,13 +14,13 @@ import {
   PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID,
   PREVALENCE_DETAILS_TABLE_FIELD_CELL_TEST_ID,
   PREVALENCE_DETAILS_TABLE_HOST_PREVALENCE_CELL_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_PREVIEW_LINK_CELL_TEST_ID,
   PREVALENCE_DETAILS_TABLE_TEST_ID,
-  PREVALENCE_DETAILS_UPSELL_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_UPSELL_CELL_TEST_ID,
   PREVALENCE_DETAILS_TABLE_USER_PREVALENCE_CELL_TEST_ID,
   PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_PREVIEW_LINK_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_UPSELL_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID,
+  PREVALENCE_DETAILS_UPSELL_TEST_ID,
 } from './test_ids';
 import { usePrevalence } from '../../shared/hooks/use_prevalence';
 import { TestProviders } from '../../../../common/mock';
@@ -38,11 +38,13 @@ jest.mock('@kbn/expandable-flyout');
 jest.mock('../../../../common/components/user_privileges');
 
 const mockedTelemetry = createTelemetryServiceMock();
+const mockStorage = jest.fn();
 jest.mock('../../../../common/lib/kibana', () => {
   return {
     useKibana: () => ({
       services: {
         telemetry: mockedTelemetry,
+        storage: { get: mockStorage },
       },
     }),
   };
@@ -402,5 +404,27 @@ describe('PrevalenceDetails', () => {
 
     const { getByText } = renderPrevalenceDetails();
     expect(getByText(NO_DATA_MESSAGE)).toBeInTheDocument();
+  });
+
+  it('should use default interval values to fetch prevalence data', () => {
+    renderPrevalenceDetails();
+
+    expect(usePrevalence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interval: { from: 'now-30d', to: 'now' },
+      })
+    );
+  });
+
+  it('should use values from local storage to fetch prevalence data', () => {
+    mockStorage.mockReturnValue({ start: 'now-7d', end: 'now-3d' });
+
+    renderPrevalenceDetails();
+
+    expect(usePrevalence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interval: { from: 'now-7d', to: 'now-3d' },
+      })
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.tsx
@@ -22,25 +22,27 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { useKibana } from '../../../../common/lib/kibana';
+import { FLYOUT_STORAGE_KEYS } from '../../shared/constants/local_storage';
 import { FormattedCount } from '../../../../common/components/formatted_number';
 import { useLicense } from '../../../../common/hooks/use_license';
 import { InvestigateInTimelineButton } from '../../../../common/components/event_details/investigate_in_timeline_button';
 import type { PrevalenceData } from '../../shared/hooks/use_prevalence';
 import { usePrevalence } from '../../shared/hooks/use_prevalence';
 import {
-  PREVALENCE_DETAILS_TABLE_ALERT_COUNT_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_HOST_PREVALENCE_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_FIELD_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_PREVIEW_LINK_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_USER_PREVALENCE_CELL_TEST_ID,
   PREVALENCE_DETAILS_DATE_PICKER_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_TEST_ID,
-  PREVALENCE_DETAILS_UPSELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_UPSELL_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_ALERT_COUNT_CELL_TEST_ID,
   PREVALENCE_DETAILS_TABLE_COUNT_TEXT_BUTTON_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_FIELD_CELL_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_HOST_PREVALENCE_CELL_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_PREVIEW_LINK_CELL_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_UPSELL_CELL_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_USER_PREVALENCE_CELL_TEST_ID,
+  PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID,
+  PREVALENCE_DETAILS_UPSELL_TEST_ID,
 } from './test_ids';
 import { useDocumentDetailsContext } from '../../shared/context';
 import {
@@ -342,6 +344,8 @@ const columns: Array<EuiBasicTableColumn<PrevalenceDetailsRow>> = [
  * Prevalence table displayed in the document details expandable flyout left section under the Insights tab
  */
 export const PrevalenceDetails: React.FC = () => {
+  const { storage } = useKibana().services;
+
   const { dataFormattedForFieldBrowser, investigationFields, scopeId } =
     useDocumentDetailsContext();
 
@@ -351,16 +355,18 @@ export const PrevalenceDetails: React.FC = () => {
 
   const isPlatinumPlus = useLicense().isPlatinumPlus();
 
+  const timeSavedInLocalStorage = storage.get(FLYOUT_STORAGE_KEYS.PREVALENCE_TIME_RANGE);
+
   // these two are used by the usePrevalence hook to fetch the data
-  const [start, setStart] = useState(DEFAULT_FROM);
-  const [end, setEnd] = useState(DEFAULT_TO);
+  const [start, setStart] = useState(timeSavedInLocalStorage?.start || DEFAULT_FROM);
+  const [end, setEnd] = useState(timeSavedInLocalStorage?.end || DEFAULT_TO);
 
   // these two are used to pass to timeline
   const [absoluteStart, setAbsoluteStart] = useState(
-    (dateMath.parse(DEFAULT_FROM) || new Date()).toISOString()
+    (dateMath.parse(timeSavedInLocalStorage?.start || DEFAULT_FROM) || new Date()).toISOString()
   );
   const [absoluteEnd, setAbsoluteEnd] = useState(
-    (dateMath.parse(DEFAULT_TO) || new Date()).toISOString()
+    (dateMath.parse(timeSavedInLocalStorage?.end || DEFAULT_TO) || new Date()).toISOString()
   );
 
   // TODO update the logic to use a single set of start/end dates
@@ -368,6 +374,8 @@ export const PrevalenceDetails: React.FC = () => {
   //  as an AbsoluteTimeRange, which requires from/to values
   const onTimeChange = ({ start: s, end: e, isInvalid }: OnTimeChangeProps) => {
     if (isInvalid) return;
+
+    storage.set(FLYOUT_STORAGE_KEYS.PREVALENCE_TIME_RANGE, { start: s, end: e });
 
     setStart(s);
     setEnd(e);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/prevalence_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/prevalence_overview.tsx
@@ -7,8 +7,9 @@
 
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
-import { EuiBadge, EuiFlexGroup } from '@elastic/eui';
+import { EuiBadge, EuiFlexGroup, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { useKibana } from '../../../../common/lib/kibana';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import { usePrevalence } from '../../shared/hooks/use_prevalence';
 import { PREVALENCE_TEST_ID } from './test_ids';
@@ -17,11 +18,36 @@ import { LeftPanelInsightsTab } from '../../left';
 import { PREVALENCE_TAB_ID } from '../../left/components/prevalence_details';
 import { InsightsSummaryRow } from './insights_summary_row';
 import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
+import { FLYOUT_STORAGE_KEYS } from '../../shared/constants/local_storage';
 
 const UNCOMMON = (
   <FormattedMessage
     id="xpack.securitySolution.flyout.right.insights.prevalence.uncommonLabel"
     defaultMessage="Uncommon"
+  />
+);
+const DEFAULT_TIME_RANGE_LABEL = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.defaultTimeRangeApplied.badgeLabel"
+    defaultMessage="Time range applied"
+  />
+);
+const CUSTOM_TIME_RANGE_LABEL = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.customTimeRangeApplied.badgeLabel"
+    defaultMessage="Custom time range applied"
+  />
+);
+const DEFAULT_TIME_RANGE_TOOLTIP = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.custom-time-range-applied-tooltip"
+    defaultMessage="Prevalence measures how frequently data from this alert is observed across hosts or users in your environment over the last 30 days. To choose a custom time range, click the section title, then use the date time picker in the left panel."
+  />
+);
+const CUSTOM_TIME_RANGE_TOOLTIP = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.custom-time-range-applied-tooltip"
+    defaultMessage="Prevalence measures how frequently data from this alert is observed across hosts or users in your environment over the time range that you chose. To choose a different custom time range, click the section title, then use the date time picker in the left panel."
   />
 );
 
@@ -34,6 +60,9 @@ const DEFAULT_TO = 'now';
  * The component fetches the necessary data at once. The loading and error states are handled by the ExpandablePanel component.
  */
 export const PrevalenceOverview: FC = () => {
+  const { storage } = useKibana().services;
+  const timeSavedInLocalStorage = storage.get(FLYOUT_STORAGE_KEYS.PREVALENCE_TIME_RANGE);
+
   const { dataFormattedForFieldBrowser, investigationFields, isPreviewMode } =
     useDocumentDetailsContext();
 
@@ -47,8 +76,8 @@ export const PrevalenceOverview: FC = () => {
     dataFormattedForFieldBrowser,
     investigationFields,
     interval: {
-      from: DEFAULT_FROM,
-      to: DEFAULT_TO,
+      from: timeSavedInLocalStorage?.start || DEFAULT_FROM,
+      to: timeSavedInLocalStorage?.end || DEFAULT_TO,
     },
   });
 
@@ -63,6 +92,7 @@ export const PrevalenceOverview: FC = () => {
       ),
     [data]
   );
+
   const link = useMemo(
     () =>
       isLinkEnabled
@@ -90,6 +120,17 @@ export const PrevalenceOverview: FC = () => {
         ),
         link,
         iconType: !isPreviewMode ? 'arrowStart' : undefined,
+        headerContent: (
+          <EuiToolTip
+            content={
+              timeSavedInLocalStorage ? CUSTOM_TIME_RANGE_TOOLTIP : DEFAULT_TIME_RANGE_TOOLTIP
+            }
+          >
+            <EuiBadge color="hollow" iconSide="left" iconType="clock" tabIndex={0}>
+              {timeSavedInLocalStorage ? CUSTOM_TIME_RANGE_LABEL : DEFAULT_TIME_RANGE_LABEL}
+            </EuiBadge>
+          </EuiToolTip>
+        ),
       }}
       content={{ loading, error }}
       data-test-subj={PREVALENCE_TEST_ID}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
@@ -11,4 +11,5 @@ export const FLYOUT_STORAGE_KEYS = {
   RIGHT_PANEL_SELECTED_TABS: 'securitySolution.documentDetailsFlyout.rightPanel.selectedTabs.v8.14',
   TABLE_TAB_STATE: 'securitySolution.documentDetailsFlyout.tableTabState.v8.19',
   TABLE_TAB_TOUR: 'securitySolution.documentDetailsFlyout.tableTabTourState.v8.19',
+  PREVALENCE_TIME_RANGE: 'securitySolution.documentDetailsFlyout.prevalenceTimeRange',
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution][Alert details] save selected prevalence time to local storage (#243543)](https://github.com/elastic/kibana/pull/243543)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-11-21T15:27:20Z","message":"[Security Solution][Alert details] save selected prevalence time to local storage (#243543)\n\n## Summary\n\nThis PR makes a small improvement to the alert details flyout, by saving\nthe time selected by the user in the expanded section prevalence details\nto local storage.\n\n- If no value is present in local storage, we default to the value we\nhad before, which is `Last 30 days`.\n- When the user selects a new interval in the flyout expanded section\nInsights => Prevalence tab, we persist that value in local storage under\nthe `securitySolution.documentDetailsFlyout.prevalenceInterval` key. We\nsave the `start` and `end` values.\n- We apply those saved `start` and `end` values both to the prevalence\ndetails (expanded flyout tab) and prevalence overview (collapsed flyout)\ncomponents.\n\n\nhttps://github.com/user-attachments/assets/c8e3ed00-e696-45e4-b45c-f90deb285ece\n\nWe add a tooltip to let the user know that the prevalence overview (in\nthe right panel) fetches prevalence data for the interval set within the\nexpanded section\n\n| Default time range  | If time range has been saved in local storage |\n| ------------- | ------------- |\n| <img width=\"573\" height=\"805\" alt=\"Screenshot 2025-11-20 at 10 10\n37 PM\"\nsrc=\"https://github.com/user-attachments/assets/80dc5f74-31d7-4e93-a06d-8fb0a3d546b6\"\n/> | <img width=\"571\" height=\"805\" alt=\"Screenshot 2025-11-20 at 10 11\n16 PM\"\nsrc=\"https://github.com/user-attachments/assets/8cbf34b4-93ad-4a9e-9ed4-45c78310cbdd\"\n/> |\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"d417fc9c824016dd271ca98818f2f3ba1319e8bb","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Threat Hunting:Investigations","backport:version","v9.3.0","v9.0.9","v9.1.7","v8.19.8","v9.2.2"],"title":"[Security Solution][Alert details] save selected prevalence time to local storage","number":243543,"url":"https://github.com/elastic/kibana/pull/243543","mergeCommit":{"message":"[Security Solution][Alert details] save selected prevalence time to local storage (#243543)\n\n## Summary\n\nThis PR makes a small improvement to the alert details flyout, by saving\nthe time selected by the user in the expanded section prevalence details\nto local storage.\n\n- If no value is present in local storage, we default to the value we\nhad before, which is `Last 30 days`.\n- When the user selects a new interval in the flyout expanded section\nInsights => Prevalence tab, we persist that value in local storage under\nthe `securitySolution.documentDetailsFlyout.prevalenceInterval` key. We\nsave the `start` and `end` values.\n- We apply those saved `start` and `end` values both to the prevalence\ndetails (expanded flyout tab) and prevalence overview (collapsed flyout)\ncomponents.\n\n\nhttps://github.com/user-attachments/assets/c8e3ed00-e696-45e4-b45c-f90deb285ece\n\nWe add a tooltip to let the user know that the prevalence overview (in\nthe right panel) fetches prevalence data for the interval set within the\nexpanded section\n\n| Default time range  | If time range has been saved in local storage |\n| ------------- | ------------- |\n| <img width=\"573\" height=\"805\" alt=\"Screenshot 2025-11-20 at 10 10\n37 PM\"\nsrc=\"https://github.com/user-attachments/assets/80dc5f74-31d7-4e93-a06d-8fb0a3d546b6\"\n/> | <img width=\"571\" height=\"805\" alt=\"Screenshot 2025-11-20 at 10 11\n16 PM\"\nsrc=\"https://github.com/user-attachments/assets/8cbf34b4-93ad-4a9e-9ed4-45c78310cbdd\"\n/> |\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"d417fc9c824016dd271ca98818f2f3ba1319e8bb"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","9.1","8.19","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243543","number":243543,"mergeCommit":{"message":"[Security Solution][Alert details] save selected prevalence time to local storage (#243543)\n\n## Summary\n\nThis PR makes a small improvement to the alert details flyout, by saving\nthe time selected by the user in the expanded section prevalence details\nto local storage.\n\n- If no value is present in local storage, we default to the value we\nhad before, which is `Last 30 days`.\n- When the user selects a new interval in the flyout expanded section\nInsights => Prevalence tab, we persist that value in local storage under\nthe `securitySolution.documentDetailsFlyout.prevalenceInterval` key. We\nsave the `start` and `end` values.\n- We apply those saved `start` and `end` values both to the prevalence\ndetails (expanded flyout tab) and prevalence overview (collapsed flyout)\ncomponents.\n\n\nhttps://github.com/user-attachments/assets/c8e3ed00-e696-45e4-b45c-f90deb285ece\n\nWe add a tooltip to let the user know that the prevalence overview (in\nthe right panel) fetches prevalence data for the interval set within the\nexpanded section\n\n| Default time range  | If time range has been saved in local storage |\n| ------------- | ------------- |\n| <img width=\"573\" height=\"805\" alt=\"Screenshot 2025-11-20 at 10 10\n37 PM\"\nsrc=\"https://github.com/user-attachments/assets/80dc5f74-31d7-4e93-a06d-8fb0a3d546b6\"\n/> | <img width=\"571\" height=\"805\" alt=\"Screenshot 2025-11-20 at 10 11\n16 PM\"\nsrc=\"https://github.com/user-attachments/assets/8cbf34b4-93ad-4a9e-9ed4-45c78310cbdd\"\n/> |\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"d417fc9c824016dd271ca98818f2f3ba1319e8bb"}},{"branch":"9.0","label":"v9.0.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->