### PR TITLE
[9.1] [Discover][APM] Use `accessKnownApmEventFields` in Trace Error API calls (#242727)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_apm_trace_error_query.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_apm_trace_error_query.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
+import { asMutableArray } from '../../../common/utils/as_mutable_array';
+import type { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
+import { ApmDocumentType } from '../../../common/document_type';
+import { RollupInterval } from '../../../common/rollup';
+
+import {
+  ERROR_CULPRIT,
+  ERROR_EXC_HANDLED,
+  ERROR_EXC_MESSAGE,
+  ERROR_EXC_TYPE,
+  ERROR_GROUP_ID,
+  ERROR_ID,
+  ERROR_LOG_LEVEL,
+  ERROR_LOG_MESSAGE,
+  PARENT_ID,
+  PROCESSOR_EVENT,
+  SERVICE_NAME,
+  SPAN_DESTINATION_SERVICE_RESOURCE,
+  SPAN_ID,
+  TIMESTAMP_US,
+  TRACE_ID,
+  TRANSACTION_ID,
+} from '../../../common/es_fields/apm';
+
+export const requiredFields = asMutableArray([
+  TIMESTAMP_US,
+  TRACE_ID,
+  SERVICE_NAME,
+  ERROR_ID,
+  ERROR_GROUP_ID,
+  PROCESSOR_EVENT,
+] as const);
+
+export const optionalFields = asMutableArray([
+  PARENT_ID,
+  TRANSACTION_ID,
+  SPAN_ID,
+  SPAN_DESTINATION_SERVICE_RESOURCE,
+  ERROR_CULPRIT,
+  ERROR_LOG_MESSAGE,
+  ERROR_EXC_MESSAGE,
+  ERROR_EXC_HANDLED,
+  ERROR_EXC_TYPE,
+] as const);
+
+const excludedLogLevels = ['debug', 'info', 'warning'];
+
+export function getApmTraceErrorQuery({
+  apmEventClient,
+  traceId,
+  docId,
+  start,
+  end,
+}: {
+  apmEventClient: APMEventClient;
+  traceId: string;
+  docId?: string;
+  start: number;
+  end: number;
+}) {
+  return apmEventClient.search('get_errors_docs', {
+    apm: {
+      sources: [
+        {
+          documentType: ApmDocumentType.ErrorEvent,
+          rollupInterval: RollupInterval.None,
+        },
+      ],
+    },
+    track_total_hits: false,
+    size: 1000,
+    query: {
+      bool: {
+        filter: [
+          ...termQuery(TRACE_ID, traceId),
+          ...termQuery(SPAN_ID, docId),
+          ...rangeQuery(start, end),
+        ],
+        must_not: { terms: { [ERROR_LOG_LEVEL]: excludedLogLevels } },
+      },
+    },
+    fields: [...requiredFields, ...optionalFields],
+    _source: [ERROR_LOG_MESSAGE, ERROR_EXC_MESSAGE, ERROR_EXC_HANDLED, ERROR_EXC_TYPE],
+  });
+}

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_trace_items.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_trace_items.ts
@@ -7,29 +7,9 @@
 
 import type { Logger } from '@kbn/logging';
 import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
-import { rangeQuery } from '@kbn/observability-plugin/server';
 import { last } from 'lodash';
-import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
-import { asMutableArray } from '../../../common/utils/as_mutable_array';
+import { accessKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
 import type { APMConfig } from '../..';
-import {
-  ERROR_CULPRIT,
-  ERROR_EXC_HANDLED,
-  ERROR_EXC_MESSAGE,
-  ERROR_EXC_TYPE,
-  ERROR_GROUP_ID,
-  ERROR_ID,
-  ERROR_LOG_LEVEL,
-  ERROR_LOG_MESSAGE,
-  PARENT_ID,
-  PROCESSOR_EVENT,
-  SERVICE_NAME,
-  SPAN_DESTINATION_SERVICE_RESOURCE,
-  SPAN_ID,
-  TIMESTAMP_US,
-  TRACE_ID,
-  TRANSACTION_ID,
-} from '../../../common/es_fields/apm';
 import type {
   WaterfallError,
   WaterfallSpan,
@@ -37,9 +17,9 @@ import type {
 } from '../../../common/waterfall/typings';
 import type { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 import { getSpanLinksCountById } from '../span_links/get_linked_children';
-import { ApmDocumentType } from '../../../common/document_type';
-import { RollupInterval } from '../../../common/rollup';
 import { getTraceDocsPerPage } from './get_trace_docs_per_page';
+import { getApmTraceErrorQuery, requiredFields } from './get_apm_trace_error_query';
+import { compactMap } from '../../utils/compact_map';
 
 export type TraceDoc = WaterfallTransaction | WaterfallSpan;
 
@@ -51,27 +31,6 @@ export interface TraceItems {
   traceDocsTotal: number;
   maxTraceItems: number;
 }
-
-export const requiredFields = asMutableArray([
-  TIMESTAMP_US,
-  TRACE_ID,
-  SERVICE_NAME,
-  ERROR_ID,
-  ERROR_GROUP_ID,
-  PROCESSOR_EVENT,
-] as const);
-
-export const optionalFields = asMutableArray([
-  PARENT_ID,
-  TRANSACTION_ID,
-  SPAN_ID,
-  SPAN_DESTINATION_SERVICE_RESOURCE,
-  ERROR_CULPRIT,
-  ERROR_LOG_MESSAGE,
-  ERROR_EXC_MESSAGE,
-  ERROR_EXC_HANDLED,
-  ERROR_EXC_TYPE,
-] as const);
 
 export async function getTraceItems({
   traceId,
@@ -130,57 +89,38 @@ export async function getTraceItems({
 }
 
 export const MAX_ITEMS_PER_PAGE = 10000; // 10000 is the max allowed by ES
-const excludedLogLevels = ['debug', 'info', 'warning'];
 
-export async function getApmTraceError({
-  apmEventClient,
-  traceId,
-  start,
-  end,
-}: {
+export async function getApmTraceError(params: {
   apmEventClient: APMEventClient;
   traceId: string;
   start: number;
   end: number;
 }) {
-  const response = await apmEventClient.search('get_errors_docs', {
-    apm: {
-      sources: [
-        {
-          documentType: ApmDocumentType.ErrorEvent,
-          rollupInterval: RollupInterval.None,
-        },
-      ],
-    },
-    track_total_hits: false,
-    size: 1000,
-    query: {
-      bool: {
-        filter: [{ term: { [TRACE_ID]: traceId } }, ...rangeQuery(start, end)],
-        must_not: { terms: { [ERROR_LOG_LEVEL]: excludedLogLevels } },
-      },
-    },
-    fields: [...requiredFields, ...optionalFields],
-    _source: [ERROR_LOG_MESSAGE, ERROR_EXC_MESSAGE, ERROR_EXC_HANDLED, ERROR_EXC_TYPE],
-  });
+  const response = await getApmTraceErrorQuery(params);
 
-  return response.hits.hits.map((hit) => {
+  return compactMap(response.hits.hits, (hit) => {
     const errorSource = 'error' in hit._source ? hit._source : undefined;
+    const event = hit.fields
+      ? accessKnownApmEventFields(hit.fields).requireFields(requiredFields)
+      : undefined;
 
-    const event = unflattenKnownApmEventFields(hit.fields, requiredFields);
+    if (!event) {
+      return undefined;
+    }
+
+    const { parent, error, ...unflattened } = event.unflatten();
 
     const waterfallErrorEvent: WaterfallError = {
-      ...event,
+      ...unflattened,
       parent: {
-        ...event?.parent,
-        id: event?.parent?.id ?? event?.span?.id,
+        id: parent?.id ?? unflattened.span?.id,
       },
       error: {
-        ...(event.error ?? {}),
+        ...error,
         exception:
           (errorSource?.error.exception?.length ?? 0) > 0
             ? errorSource?.error.exception
-            : event?.error.exception && [event.error.exception],
+            : error.exception && [error.exception],
         log: errorSource?.error.log,
       },
     };

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_errors.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_errors.ts
@@ -65,10 +65,7 @@ export async function getUnifiedTraceErrors({
 }
 
 export const requiredOtelFields = asMutableArray([SPAN_ID] as const);
-export const optionalOtelFields = asMutableArray([
-  EXCEPTION_TYPE,
-  EXCEPTION_MESSAGE,
-] as const);
+export const optionalOtelFields = asMutableArray([EXCEPTION_TYPE, EXCEPTION_MESSAGE] as const);
 
 export interface UnifiedError {
   id: string;

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.test.ts
@@ -12,10 +12,10 @@ describe('getErrorCountByDocId', () => {
   it('counts errors grouped by doc id from apmErrors and unprocessedOtelErrors', () => {
     const unifiedTraceErrors = {
       apmErrors: [
-        { parent: { id: 'a' } },
-        { parent: { id: 'a' } },
-        { parent: { id: 'b' } },
-        { parent: { id: undefined } },
+        { parentId: 'a' },
+        { parentId: 'a' },
+        { parentId: 'b' },
+        { parentId: undefined },
       ],
       unprocessedOtelErrors: [{ id: 'a' }, { id: 'c' }, { id: undefined }],
       totalErrors: 5,
@@ -42,7 +42,7 @@ describe('getErrorCountByDocId', () => {
 
   it('ignores errors with undefined ids', () => {
     const unifiedTraceErrors = {
-      apmErrors: [{ parent: { id: undefined } }],
+      apmErrors: [{ parentId: undefined }],
       unprocessedOtelErrors: [{ id: undefined }],
       totalErrors: 0,
     } as unknown as UnifiedTraceErrors;

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.test.ts
@@ -11,12 +11,7 @@ import { getErrorCountByDocId } from './get_unified_trace_items';
 describe('getErrorCountByDocId', () => {
   it('counts errors grouped by doc id from apmErrors and unprocessedOtelErrors', () => {
     const unifiedTraceErrors = {
-      apmErrors: [
-        { parentId: 'a' },
-        { parentId: 'a' },
-        { parentId: 'b' },
-        { parentId: undefined },
-      ],
+      apmErrors: [{ parentId: 'a' }, { parentId: 'a' }, { parentId: 'b' }, { parentId: undefined }],
       unprocessedOtelErrors: [{ id: 'a' }, { id: 'c' }, { id: undefined }],
       totalErrors: 5,
     } as UnifiedTraceErrors;

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_unified_trace_items.ts
@@ -58,12 +58,16 @@ export function getErrorCountByDocId(unifiedTraceErrors: UnifiedTraceErrors) {
     groupedErrorCountByDocId[id] += 1;
   }
 
-  unifiedTraceErrors.apmErrors.forEach((doc) =>
-    doc.parent?.id ? incrementErrorCount(doc.parent.id) : undefined
-  );
-  unifiedTraceErrors.unprocessedOtelErrors.forEach((doc) =>
-    doc.id ? incrementErrorCount(doc.id) : undefined
-  );
+  unifiedTraceErrors.apmErrors.forEach((errorDoc) => {
+    if (errorDoc.parentId) {
+      incrementErrorCount(errorDoc.parentId);
+    }
+  });
+  unifiedTraceErrors.unprocessedOtelErrors.forEach((errorDoc) => {
+    if (errorDoc.id) {
+      incrementErrorCount(errorDoc.id);
+    }
+  });
 
   return groupedErrorCountByDocId;
 }

--- a/x-pack/solutions/observability/plugins/apm/server/utils/compact_map.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/utils/compact_map.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { compactMap } from './compact_map';
+
+describe('compactMap', () => {
+  it('maps to a new array containing no undefined or null slots', () => {
+    const values = [0, 1, 2, 3, 4, 5];
+
+    expect(compactMap(values, (value) => (value % 2 === 0 ? `${value}` : undefined))).toEqual([
+      '0',
+      '2',
+      '4',
+    ]);
+
+    expect(compactMap(values, (value) => (value % 2 === 1 ? `${value}` : null))).toEqual([
+      '1',
+      '3',
+      '5',
+    ]);
+  });
+
+  it('removes nullish values, not falsey values', () => {
+    const values = [0, null, '', false, undefined, {}];
+
+    expect(compactMap(values, (value) => value)).toEqual([0, '', false, {}]);
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/server/utils/compact_map.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/utils/compact_map.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Takes an input array and a map function, outputting a new mapped array that removes
+ * all `null` or `undefined` slots.
+ */
+export function compactMap<T, U>(array: T[], mapFn: (val: T) => U | undefined | null): U[] {
+  const mapped: U[] = [];
+
+  for (const item of array) {
+    const value = mapFn(item);
+
+    if (value != null) {
+      mapped.push(value);
+    }
+  }
+
+  return mapped;
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Discover][APM] Use `accessKnownApmEventFields` in Trace Error API calls (#242727)](https://github.com/elastic/kibana/pull/242727)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gonçalo Rica Pais da Silva","email":"goncalo.rica@elastic.co"},"sourceCommit":{"committedDate":"2025-11-21T14:49:30Z","message":"[Discover][APM] Use `accessKnownApmEventFields` in Trace Error API calls (#242727)\n\n## Summary\n\nCloses #242716\n\nThis PR updates the Trace Errors API calls for APM, and splits the\n`getApmTraceError` call from the Unified Trace APIs to have a new\n`getUnifiedApmTraceError` call, which allows to unify the return\nresponse for the Unified Trace APIs, while maintaining backwards\ncompatibility with the old APM APIs. Both Error methods now make use of\n`accessKnownApmEventFields`, with `getApmTraceError` better handling the\nunflattening and response construction, and `getUnifiedApmTraceError`\nquerying for less fields and avoiding the use of unflattening entirely.\nThis now has the Unified Trace APIs no longer using any unflattening in\ntheir call stack, and standardises the error interface between APM and\nOTEL errors.\n\n## How to test\n\n- Go to Discover on an Observability space, select a traces index (APM\nand/or OTEL) in either Classic or ES|QL.\n- Select a trace with either an `event.outcome` as `failure` or\n`status.code` as `Error`. On spans/transactions with an error attached\nto it, it should show on both the focused and full trace waterfall\nwithout any issue.\n- Going through to the APM page via the `trace.id` link, the APM trace\nwaterfall should also show the same errors with no issue.","sha":"505fe7bdc31dce781125e25b261f1adaa34b3d11","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.3.0","Team:obs-exploration","ci:beta-faster-pr-build","v8.19.8","v9.2.2","v9.1.8"],"title":"[Discover][APM] Use `accessKnownApmEventFields` in Trace Error API calls","number":242727,"url":"https://github.com/elastic/kibana/pull/242727","mergeCommit":{"message":"[Discover][APM] Use `accessKnownApmEventFields` in Trace Error API calls (#242727)\n\n## Summary\n\nCloses #242716\n\nThis PR updates the Trace Errors API calls for APM, and splits the\n`getApmTraceError` call from the Unified Trace APIs to have a new\n`getUnifiedApmTraceError` call, which allows to unify the return\nresponse for the Unified Trace APIs, while maintaining backwards\ncompatibility with the old APM APIs. Both Error methods now make use of\n`accessKnownApmEventFields`, with `getApmTraceError` better handling the\nunflattening and response construction, and `getUnifiedApmTraceError`\nquerying for less fields and avoiding the use of unflattening entirely.\nThis now has the Unified Trace APIs no longer using any unflattening in\ntheir call stack, and standardises the error interface between APM and\nOTEL errors.\n\n## How to test\n\n- Go to Discover on an Observability space, select a traces index (APM\nand/or OTEL) in either Classic or ES|QL.\n- Select a trace with either an `event.outcome` as `failure` or\n`status.code` as `Error`. On spans/transactions with an error attached\nto it, it should show on both the focused and full trace waterfall\nwithout any issue.\n- Going through to the APM page via the `trace.id` link, the APM trace\nwaterfall should also show the same errors with no issue.","sha":"505fe7bdc31dce781125e25b261f1adaa34b3d11"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/242727","number":242727,"mergeCommit":{"message":"[Discover][APM] Use `accessKnownApmEventFields` in Trace Error API calls (#242727)\n\n## Summary\n\nCloses #242716\n\nThis PR updates the Trace Errors API calls for APM, and splits the\n`getApmTraceError` call from the Unified Trace APIs to have a new\n`getUnifiedApmTraceError` call, which allows to unify the return\nresponse for the Unified Trace APIs, while maintaining backwards\ncompatibility with the old APM APIs. Both Error methods now make use of\n`accessKnownApmEventFields`, with `getApmTraceError` better handling the\nunflattening and response construction, and `getUnifiedApmTraceError`\nquerying for less fields and avoiding the use of unflattening entirely.\nThis now has the Unified Trace APIs no longer using any unflattening in\ntheir call stack, and standardises the error interface between APM and\nOTEL errors.\n\n## How to test\n\n- Go to Discover on an Observability space, select a traces index (APM\nand/or OTEL) in either Classic or ES|QL.\n- Select a trace with either an `event.outcome` as `failure` or\n`status.code` as `Error`. On spans/transactions with an error attached\nto it, it should show on both the focused and full trace waterfall\nwithout any issue.\n- Going through to the APM page via the `trace.id` link, the APM trace\nwaterfall should also show the same errors with no issue.","sha":"505fe7bdc31dce781125e25b261f1adaa34b3d11"}},{"branch":"8.19","label":"v8.19.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/243849","number":243849,"state":"OPEN"},{"branch":"9.1","label":"v9.1.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->