### PR TITLE
[9.1] [Security Solution][Alert details] save selected threat intelligence time to local storage (#243571)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/prevalence_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/prevalence_overview.tsx
@@ -40,13 +40,13 @@ const CUSTOM_TIME_RANGE_LABEL = (
 );
 const DEFAULT_TIME_RANGE_TOOLTIP = (
   <FormattedMessage
-    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.custom-time-range-applied-tooltip"
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.defaultTimeRangeApplied.tooltipLabel"
     defaultMessage="Prevalence measures how frequently data from this alert is observed across hosts or users in your environment over the last 30 days. To choose a custom time range, click the section title, then use the date time picker in the left panel."
   />
 );
 const CUSTOM_TIME_RANGE_TOOLTIP = (
   <FormattedMessage
-    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.custom-time-range-applied-tooltip"
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.customTimeRangeApplied.tooltipLabel"
     defaultMessage="Prevalence measures how frequently data from this alert is observed across hosts or users in your environment over the time range that you chose. To choose a different custom time range, click the section title, then use the date time picker in the left panel."
   />
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.test.tsx
@@ -19,6 +19,7 @@ import {
   SUMMARY_ROW_TEXT_TEST_ID,
 } from './test_ids';
 import {
+  EXPANDABLE_PANEL_HEADER_RIGHT_SECTION_TEST_ID,
   EXPANDABLE_PANEL_HEADER_TITLE_ICON_TEST_ID,
   EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID,
   EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID,
@@ -26,9 +27,11 @@ import {
   EXPANDABLE_PANEL_TOGGLE_ICON_TEST_ID,
 } from '../../../shared/components/test_ids';
 import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
+import { useKibana } from '../../../../common/lib/kibana';
 
 jest.mock('../../shared/context');
 jest.mock('../hooks/use_fetch_threat_intelligence');
+jest.mock('../../../../common/lib/kibana');
 
 const mockNavigateToLeftPanel = jest.fn();
 jest.mock('../../shared/hooks/use_navigate_to_left_panel');
@@ -43,6 +46,9 @@ const TITLE_ICON_TEST_ID = EXPANDABLE_PANEL_HEADER_TITLE_ICON_TEST_ID(
   INSIGHTS_THREAT_INTELLIGENCE_TEST_ID
 );
 const TITLE_TEXT_TEST_ID = EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(
+  INSIGHTS_THREAT_INTELLIGENCE_TEST_ID
+);
+const RIGHT_SECTION_TEXT_TEST_ID = EXPANDABLE_PANEL_HEADER_RIGHT_SECTION_TEST_ID(
   INSIGHTS_THREAT_INTELLIGENCE_TEST_ID
 );
 const LOADING_TEST_ID = EXPANDABLE_PANEL_LOADING_TEST_ID(INSIGHTS_THREAT_INTELLIGENCE_TEST_ID);
@@ -82,6 +88,13 @@ describe('<ThreatIntelligenceOverview />', () => {
       navigateToLeftPanel: mockNavigateToLeftPanel,
       isEnabled: true,
     });
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        storage: {
+          get: () => undefined,
+        },
+      },
+    });
   });
 
   it('should render wrapper component', () => {
@@ -91,6 +104,26 @@ describe('<ThreatIntelligenceOverview />', () => {
     expect(getByTestId(TITLE_ICON_TEST_ID)).toBeInTheDocument();
     expect(getByTestId(TITLE_LINK_TEST_ID)).toBeInTheDocument();
     expect(queryByTestId(TITLE_TEXT_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('should show default time range badge', () => {
+    const { getByTestId } = renderThreatIntelligenceOverview();
+
+    expect(getByTestId(RIGHT_SECTION_TEXT_TEST_ID)).toHaveTextContent('Time range applied');
+  });
+
+  it('should show custom time range badge', () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        storage: {
+          get: () => ({ from: 'now-7d', to: 'now-3d' }),
+        },
+      },
+    });
+
+    const { getByTestId } = renderThreatIntelligenceOverview();
+
+    expect(getByTestId(RIGHT_SECTION_TEXT_TEST_ID)).toHaveTextContent('Custom time range applied');
   });
 
   it('should render link without icon if in preview mode', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.tsx
@@ -7,8 +7,10 @@
 
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
-import { EuiFlexGroup } from '@elastic/eui';
+import { EuiBadge, EuiFlexGroup, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { FLYOUT_STORAGE_KEYS } from '../../shared/constants/local_storage';
+import { useKibana } from '../../../../common/lib/kibana';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import { useFetchThreatIntelligence } from '../hooks/use_fetch_threat_intelligence';
 import { InsightsSummaryRow } from './insights_summary_row';
@@ -22,16 +24,40 @@ import { LeftPanelInsightsTab } from '../../left';
 import { THREAT_INTELLIGENCE_TAB_ID } from '../../left/components/threat_intelligence_details';
 import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
-const TITLE = (
+const HEADER_TITLE = (
   <FormattedMessage
     id="xpack.securitySolution.flyout.right.insights.threatIntelligence.threatIntelligenceTitle"
     defaultMessage="Threat intelligence"
   />
 );
-const TOOLTIP = (
+const HEADER_TOOLTIP = (
   <FormattedMessage
     id="xpack.securitySolution.flyout.right.insights.threatIntelligence.threatIntelligenceTooltip"
     defaultMessage="Show all threat intelligence"
+  />
+);
+const DEFAULT_TIME_RANGE_LABEL = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.defaultTimeRangeApplied.badgeLabel"
+    defaultMessage="Time range applied"
+  />
+);
+const CUSTOM_TIME_RANGE_LABEL = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.customTimeRangeApplied.badgeLabel"
+    defaultMessage="Custom time range applied"
+  />
+);
+const DEFAULT_TIME_RANGE_TOOLTIP = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.defaultTimeRangeAppliedTooltipLabel"
+    defaultMessage="Threat intelligence helps you to find current and emerging threats in your environment over the last 30 days. To choose a custom time range, click the section title, then use the date time picker in the left panel."
+  />
+);
+const CUSTOM_TIME_RANGE_TOOLTIP = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.insights.threatIntelligence.customTimeRangeAppliedTooltipLabel"
+    defaultMessage="Threat intelligence helps you to find current and emerging threats in your environment during the time range that you chose. To choose a different custom time range, click the section title, then use the date time picker in the left panel."
   />
 );
 
@@ -42,6 +68,9 @@ const TOOLTIP = (
  */
 export const ThreatIntelligenceOverview: FC = () => {
   const { dataFormattedForFieldBrowser, isPreviewMode } = useDocumentDetailsContext();
+
+  const { storage } = useKibana().services;
+  const timeSavedInLocalStorage = storage.get(FLYOUT_STORAGE_KEYS.THREAT_INTELLIGENCE_TIME_RANGE);
 
   const { navigateToLeftPanel: goToThreatIntelligenceTab, isEnabled: isLinkEnabled } =
     useNavigateToLeftPanel({
@@ -58,7 +87,7 @@ export const ThreatIntelligenceOverview: FC = () => {
       isLinkEnabled
         ? {
             callback: goToThreatIntelligenceTab,
-            tooltip: TOOLTIP,
+            tooltip: HEADER_TOOLTIP,
           }
         : undefined,
     [goToThreatIntelligenceTab, isLinkEnabled]
@@ -89,9 +118,20 @@ export const ThreatIntelligenceOverview: FC = () => {
   return (
     <ExpandablePanel
       header={{
-        title: TITLE,
+        title: HEADER_TITLE,
         link,
         iconType: !isPreviewMode ? 'arrowStart' : undefined,
+        headerContent: (
+          <EuiToolTip
+            content={
+              timeSavedInLocalStorage ? CUSTOM_TIME_RANGE_TOOLTIP : DEFAULT_TIME_RANGE_TOOLTIP
+            }
+          >
+            <EuiBadge color="hollow" iconSide="left" iconType="clock" tabIndex={0}>
+              {timeSavedInLocalStorage ? CUSTOM_TIME_RANGE_LABEL : DEFAULT_TIME_RANGE_LABEL}
+            </EuiBadge>
+          </EuiToolTip>
+        ),
       }}
       data-test-subj={INSIGHTS_THREAT_INTELLIGENCE_TEST_ID}
       content={{ loading }}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
@@ -12,4 +12,6 @@ export const FLYOUT_STORAGE_KEYS = {
   TABLE_TAB_STATE: 'securitySolution.documentDetailsFlyout.tableTabState.v8.19',
   TABLE_TAB_TOUR: 'securitySolution.documentDetailsFlyout.tableTabTourState.v8.19',
   PREVALENCE_TIME_RANGE: 'securitySolution.documentDetailsFlyout.prevalenceTimeRange',
+  THREAT_INTELLIGENCE_TIME_RANGE:
+    'securitySolution.documentDetailsFlyout.threatIntelligenceTimeRange',
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution][Alert details] save selected threat intelligence time to local storage (#243571)](https://github.com/elastic/kibana/pull/243571)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-11-21T18:09:32Z","message":"[Security Solution][Alert details] save selected threat intelligence time to local storage (#243571)\n\n## Summary\n\nThis PR makes a small improvement to the alert details flyout, by saving\nthe time selected by the user in the expanded section threat\nintelligence details to local storage.\n\n- If no value is present in local storage, we default to the value we\nhad before.\n- When the user selects a new interval in the flyout expanded section\nInsights => Threat intelligence tab, we persist that value in local\nstorage under the\n`securitySolution.documentDetailsFlyout.threatIntelligenceInterval` key.\nWe save the `start` and `end` values.\n- We apply those saved `start` and `end` values both to the threat\nintelligence details (expanded flyout tab) and threat intelligence\noverview (collapsed flyout) components.\n\n\nhttps://github.com/user-attachments/assets/30d3bba9-5f3b-46c4-82d8-2048c576aa7d\n\nWe add a tooltip to let the user know that the threat intelligence\noverview (in the right panel) fetches threat intelligence data for the\ninterval set within the expanded section\n\n| Default time range  | If time range has been saved in local storage |\n| ------------- | ------------- |\n| <img width=\"569\" height=\"806\" alt=\"Screenshot 2025-11-20 at 9 49\n19 PM\"\nsrc=\"https://github.com/user-attachments/assets/4a2b8473-add3-4c70-80fe-f5c81bffc834\"\n/> | <img width=\"572\" height=\"805\" alt=\"Screenshot 2025-11-20 at 10 01\n02 PM\"\nsrc=\"https://github.com/user-attachments/assets/6057d829-2e10-4041-854b-f6ec79e104ee\"\n/> |\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"d138e210b7c6c30f9bf1d78ed19fade8c45ef957","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Threat Hunting:Investigations","backport:version","v9.3.0","v9.0.9","v8.19.8","v9.2.2","v9.1.8"],"title":"[Security Solution][Alert details] save selected threat intelligence time to local storage","number":243571,"url":"https://github.com/elastic/kibana/pull/243571","mergeCommit":{"message":"[Security Solution][Alert details] save selected threat intelligence time to local storage (#243571)\n\n## Summary\n\nThis PR makes a small improvement to the alert details flyout, by saving\nthe time selected by the user in the expanded section threat\nintelligence details to local storage.\n\n- If no value is present in local storage, we default to the value we\nhad before.\n- When the user selects a new interval in the flyout expanded section\nInsights => Threat intelligence tab, we persist that value in local\nstorage under the\n`securitySolution.documentDetailsFlyout.threatIntelligenceInterval` key.\nWe save the `start` and `end` values.\n- We apply those saved `start` and `end` values both to the threat\nintelligence details (expanded flyout tab) and threat intelligence\noverview (collapsed flyout) components.\n\n\nhttps://github.com/user-attachments/assets/30d3bba9-5f3b-46c4-82d8-2048c576aa7d\n\nWe add a tooltip to let the user know that the threat intelligence\noverview (in the right panel) fetches threat intelligence data for the\ninterval set within the expanded section\n\n| Default time range  | If time range has been saved in local storage |\n| ------------- | ------------- |\n| <img width=\"569\" height=\"806\" alt=\"Screenshot 2025-11-20 at 9 49\n19 PM\"\nsrc=\"https://github.com/user-attachments/assets/4a2b8473-add3-4c70-80fe-f5c81bffc834\"\n/> | <img width=\"572\" height=\"805\" alt=\"Screenshot 2025-11-20 at 10 01\n02 PM\"\nsrc=\"https://github.com/user-attachments/assets/6057d829-2e10-4041-854b-f6ec79e104ee\"\n/> |\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"d138e210b7c6c30f9bf1d78ed19fade8c45ef957"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.19","9.2","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243571","number":243571,"mergeCommit":{"message":"[Security Solution][Alert details] save selected threat intelligence time to local storage (#243571)\n\n## Summary\n\nThis PR makes a small improvement to the alert details flyout, by saving\nthe time selected by the user in the expanded section threat\nintelligence details to local storage.\n\n- If no value is present in local storage, we default to the value we\nhad before.\n- When the user selects a new interval in the flyout expanded section\nInsights => Threat intelligence tab, we persist that value in local\nstorage under the\n`securitySolution.documentDetailsFlyout.threatIntelligenceInterval` key.\nWe save the `start` and `end` values.\n- We apply those saved `start` and `end` values both to the threat\nintelligence details (expanded flyout tab) and threat intelligence\noverview (collapsed flyout) components.\n\n\nhttps://github.com/user-attachments/assets/30d3bba9-5f3b-46c4-82d8-2048c576aa7d\n\nWe add a tooltip to let the user know that the threat intelligence\noverview (in the right panel) fetches threat intelligence data for the\ninterval set within the expanded section\n\n| Default time range  | If time range has been saved in local storage |\n| ------------- | ------------- |\n| <img width=\"569\" height=\"806\" alt=\"Screenshot 2025-11-20 at 9 49\n19 PM\"\nsrc=\"https://github.com/user-attachments/assets/4a2b8473-add3-4c70-80fe-f5c81bffc834\"\n/> | <img width=\"572\" height=\"805\" alt=\"Screenshot 2025-11-20 at 10 01\n02 PM\"\nsrc=\"https://github.com/user-attachments/assets/6057d829-2e10-4041-854b-f6ec79e104ee\"\n/> |\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"d138e210b7c6c30f9bf1d78ed19fade8c45ef957"}},{"branch":"9.0","label":"v9.0.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->