### PR TITLE
[Data quality] Fix failure store flaky test

### DIFF
--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/dataset_quality_table.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/dataset_quality_table.ts
@@ -241,10 +241,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await testSubjects.existOrFail(editFailureStoreModal);
 
-        const saveModalButton = await testSubjects.find(failureStoreModalSaveButton);
         await testSubjects.click(enableFailureStoreToggle);
-        expect(await saveModalButton.isEnabled()).to.be(true);
-        await testSubjects.click(failureStoreModalSaveButton);
+        await testSubjects.clickWhenNotDisabled(failureStoreModalSaveButton);
         await testSubjects.missingOrFail(editFailureStoreModal);
 
         const updatedLinks = await testSubjects.findAll(enableFailureStoreFromTableButton);


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/243885

## Summary
This test is flaky and for fix that I've replaced the immediate check for the save button being enabled (which was failing due to a race condition and it doesn't make much sense in this test) with `clickWhenNotDisabled()` which automatically waits for the button to become enabled before clicking it.

The suite is also failing on MKI, but that fix has been done in this other PR https://github.com/elastic/kibana/pull/243824

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/9905