### PR TITLE
[Dataset Quality] Unskip Dataset quality tests - Skipped due to ES `9.3.0` missing `maximum_timestamp` Error

### DIFF
--- a/x-pack/solutions/observability/test/functional/apps/dataset_quality/dataset_quality_table.ts
+++ b/x-pack/solutions/observability/test/functional/apps/dataset_quality/dataset_quality_table.ts
@@ -40,8 +40,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
   const failedDatasetName = datasetNames[1];
 
-  // Failing: See https://github.com/elastic/kibana/issues/240734
-  describe.skip('Dataset quality table', function () {
+  describe('Dataset quality table', function () {
     // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
     // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
     // and running these tests will result in an "unknown index privilege [read_failure_store]" error.


### PR DESCRIPTION
Fixes #240734
Fixes #239999
Fixes #240931
Fixes #240003

## Summary

Now that https://github.com/elastic/elasticsearch/pull/138158 is merged, we should have Dataset Quality forward compatibility tests unblocked now which were failing due to missing `maximum_timestamp` in ES `9.3.0` Snapshot.