### PR TITLE
[Docs] Adds 2 missing genAI observability advanced settings

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -466,6 +466,12 @@ If you have an Azure Enterprise Agreement with Microsoft, enter your discount ra
 [[observability-profiling-cost-per-vcpu-per-hour]]`observability:profilingCostPervCPUPerHour`::
 Default Hourly Cost per CPU Core for machines not on AWS or Azure.
 
+[[gen-ai-settings-default-ai-connector]]`genAiSettings:defaultAIConnector`::
+Sets the default AI connector to power the AI Assistant and AI-driven features in Elastic. Select a generative AI connector from your available pre-configured or custom connectors. The default value is `NO_DEFAULT_CONNECTOR`. When no connector is selected, Elastic uses the Elastic Managed LLM connector when available, or the last used custom connector.
+
+[[gen-ai-settings-default-ai-connector-only]]`genAiSettings:defaultAIConnectorOnly`::
+When enabled, only the default AI connector selected in `genAiSettings:defaultAIConnector` is shown to users of this space. This restricts users from selecting other available connectors. The default value is `false`.
+
 [float]
 [[kibana-reporting-settings]]
 ==== Reporting


### PR DESCRIPTION
This PR adds 2 missing advanced settings from the Observability solution section.

Closes: https://github.com/elastic/docs-content-internal/issues/394

- [x] Used AI to write description and read defaults from the codebase

I'll backport this to 8.18 too