### PR TITLE
[Discover][Extension Points] Add actions to getChartSectionConfiguration extension point

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
@@ -17,7 +17,10 @@ import { UnifiedHistogramChart, useUnifiedHistogram } from '@kbn/unified-histogr
 import { useChartStyles } from '@kbn/unified-histogram/components/chart/hooks/use_chart_styles';
 import { useServicesBootstrap } from '@kbn/unified-histogram/hooks/use_services_bootstrap';
 import type { UnifiedMetricsGridRestorableState } from '@kbn/unified-metrics-grid';
-import { useProfileAccessor } from '../../../../context_awareness';
+import {
+  type ChartSectionConfigurationExtensionParams,
+  useProfileAccessor,
+} from '../../../../context_awareness';
 import { DiscoverCustomizationProvider } from '../../../../customizations';
 import {
   CurrentTabProvider,
@@ -138,13 +141,25 @@ type UnifiedHistogramChartProps = Pick<UnifiedHistogramGuardProps, 'panelsToggle
 };
 
 const ChartsWrapper = ({ stateContainer, panelsToggle }: UnifiedHistogramChartProps) => {
+  const dispatch = useInternalStateDispatch();
   const getChartConfigAccessor = useProfileAccessor('getChartSectionConfiguration');
+  const chartSectionConfigurationExtParams: ChartSectionConfigurationExtensionParams =
+    useMemo(() => {
+      return {
+        actions: {
+          openInNewTab: (params) =>
+            dispatch(internalStateActions.openInNewTabExtPointAction(params)),
+          updateESQLQuery: stateContainer.actions.updateESQLQuery,
+        },
+      };
+    }, [dispatch, stateContainer.actions.updateESQLQuery]);
+
   const chartSectionConfig = useMemo(
     () =>
       getChartConfigAccessor(() => ({
         replaceDefaultChart: false,
-      }))(),
-    [getChartConfigAccessor]
+      }))(chartSectionConfigurationExtParams),
+    [getChartConfigAccessor, chartSectionConfigurationExtParams]
   );
 
   useEffect(() => {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/metrics_data_source_profile/accessor/chart_section.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/metrics_data_source_profile/accessor/chart_section.tsx
@@ -15,15 +15,16 @@ import { once } from 'lodash';
 import type { ChartSectionProps } from '@kbn/unified-histogram/types';
 import type { ExpressionRendererEvent } from '@kbn/expressions-plugin/public';
 import type { DataSourceProfileProvider } from '../../../../profiles';
+import type { ChartSectionConfigurationExtensionParams } from '../../../../types';
 
 export const createChartSection = (
   metricsExperienceClient?: MetricsExperienceClient
 ): DataSourceProfileProvider['profile']['getChartSectionConfiguration'] =>
   // prevents unmounting the component when the query changes but the index pattern is still valid
-  once((prev: () => ChartSectionConfiguration) =>
-    once((): ChartSectionConfiguration => {
+  once((prev: (params: ChartSectionConfigurationExtensionParams) => ChartSectionConfiguration) =>
+    once((params: ChartSectionConfigurationExtensionParams): ChartSectionConfiguration => {
       return {
-        ...(prev ? prev() : {}),
+        ...(prev ? prev(params) : {}),
         Component: (props: ChartSectionProps) => {
           // This will prevent the filter being added to the query for multi-dimensional breakdowns when the user clicks on a data point on the series.
           const handleFilter = (event: ExpressionRendererEvent['data']) => {

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
@@ -279,6 +279,12 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
         recommendedFields: exampleRecommendedFieldNames,
       };
     },
+    getChartSectionConfiguration: (prev) => (params) => {
+      const prevConfig = prev(params);
+      return {
+        ...prevConfig,
+      };
+    },
   },
   resolve: (params) => {
     const indexPattern = extractIndexPatternFrom(params);

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/accessors/chart_session.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile/accessors/chart_session.tsx
@@ -12,16 +12,17 @@ import type { ChartSectionProps } from '@kbn/unified-histogram/types';
 import { TraceMetricsGrid, type DataSource } from '@kbn/unified-metrics-grid';
 import React from 'react';
 import { once } from 'lodash';
+import type { ChartSectionConfigurationExtensionParams } from '../../../../types';
 import type { DataSourceProfileProvider } from '../../../../profiles';
 
 export const createChartSection = (
   dataSource: DataSource
 ): DataSourceProfileProvider['profile']['getChartSectionConfiguration'] =>
   // prevents unmounting the component when the query changes but the index pattern is still valid
-  once((prev: () => ChartSectionConfiguration) =>
-    once((): ChartSectionConfiguration => {
+  once((prev: (params: ChartSectionConfigurationExtensionParams) => ChartSectionConfiguration) =>
+    once((params: ChartSectionConfigurationExtensionParams): ChartSectionConfiguration => {
       return {
-        ...(prev ? prev() : {}),
+        ...(prev ? prev(params) : {}),
         Component: (props: ChartSectionProps) => (
           <TraceMetricsGrid {...props} dataSource={dataSource} />
         ),

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -99,6 +99,23 @@ export interface AppMenuExtensionParams {
   authorizedRuleTypeIds: string[];
 }
 
+export interface ChartSectionConfigurationExtensionParams {
+  /**
+   * Available actions for the chart section configuration
+   */
+  actions: {
+    /**
+     * Opens a new tab
+     * @param params The parameters for the open in new tab action
+     */
+    openInNewTab?: (params: OpenInNewTabParams) => void;
+    /**
+     * Updates the current ES|QL query
+     */
+    updateESQLQuery?: DiscoverStateContainer['actions']['updateESQLQuery'];
+  };
+}
+
 /**
  * Supports customizing the Discover document viewer flyout
  */
@@ -400,7 +417,9 @@ export interface Profile {
    * This allows modifying the chart section with a custom component
    * @returns The custom configuration for the chart
    */
-  getChartSectionConfiguration: () => ChartSectionConfiguration;
+  getChartSectionConfiguration: (
+    params: ChartSectionConfigurationExtensionParams
+  ) => ChartSectionConfiguration;
 
   /**
    * Data grid


### PR DESCRIPTION
## Summary

This PR adds the `actions` parameter to the `getChartSectionConfiguration` extension point. It will allow the consumers to call the `openInNewTab` and `updateESQLQuery` actions which will as names suggest open the new tab on demand or update existing ES|QL query.
It closes: #239036

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
