### PR TITLE
[Security Solution] Skip flaky e2e tests for rule execution log in MKI

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/execution_log.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/execution_log.cy.ts
@@ -22,10 +22,11 @@ import { getCustomQueryRuleParams } from '../../../../objects/rule';
 import { EXECUTION_SHOWING } from '../../../../screens/rule_details';
 import { manualRuleRun } from '../../../../tasks/api_calls/backfill';
 
+// TODO: https://github.com/elastic/kibana/issues/244006
 describe(
   'Event log',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
   },
   function () {
     before(() => {


### PR DESCRIPTION
**Related to:** https://github.com/elastic/kibana/issues/244006

## Summary

The `Event log should display the execution log` e2e Cypress test is flaky in MKI pipelines (periodic, monitoring, 2nd quality gate) and fails there once in a few weeks. At the same time, this test is 100% stable in CI pipelines, including the simulated serverless env.

Error message: `Expected to find element: 'a[data-test-subj="navigation-execution_results"]', but never found it`. Full error looks like this:

```
1) Event log
        should display the execution log:
    AssertionError: Timed out retrying after 300000ms: Expected to find element: `a[data-test-subj="navigation-execution_results"]`, but never found it.
    at goToExecutionLogTab (webpack:///./tasks/rule_details.ts:135:5)
    at Context.eval (webpack:///./e2e/detection_response/rule_management/rule_details/execution_log.cy.ts:49:26)
```

We're skipping the test in MKI with the plan to investigate the failures and unskip it later. This effort will be tracked in https://github.com/elastic/kibana/issues/244006.

## Builds

Example builds where this test failed:

- https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/3714
- https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/3664
- https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/3478


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->