### PR TITLE
[Cases][Connector] Improve IBM error message

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/resilient/resilient.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/resilient/resilient.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AxiosError } from 'axios';
-import { omitBy, isNil } from 'lodash/fp';
+import { omitBy, isNil, isObject } from 'lodash/fp';
 import type { ServiceParams } from '@kbn/actions-plugin/server';
 import { CaseConnector, getBasicAuthHeader } from '@kbn/actions-plugin/server';
 import { z } from '@kbn/zod';
@@ -75,6 +75,9 @@ export class ResilientConnector extends CaseConnector<
     }
     if (error.response.status === 401) {
       return i18n.UNAUTHORIZED_API_ERROR;
+    }
+    if (isObject(error.response?.data) && 'message' in error.response.data) {
+      return `API Error: ${error.response.data.message}`;
     }
     return `API Error: ${error.response?.statusText}`;
   }


### PR DESCRIPTION
## Summary

Addresses: https://github.com/elastic/kibana/issues/243994

Improves the error message when the connector fails:

Before:
<img width="1083" height="407" alt="Screenshot 2025-11-24 at 15 16 55" src="https://github.com/user-attachments/assets/a8efb8c7-96ce-43a1-a349-27683f31bb97" />


After:
<img width="1119" height="580" alt="Screenshot 2025-11-24 at 15 57 38" src="https://github.com/user-attachments/assets/e2b282a4-5255-4e72-9644-455416f8efaf" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->