### PR TITLE
[Fleet] Report otelcol inputs with receiver id instead of type

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_integration_inputs.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_integration_inputs.test.tsx
@@ -132,4 +132,32 @@ describe('AgentDetailsIntegrationInputs', () => {
     await userEvent.click(component.container.querySelector('#endpoint')!);
     expect(component.getByText('Endpoint')).toBeInTheDocument();
   });
+
+  it('should render input type using input id for otelcol inputs', async () => {
+    packageMock.inputs.push({
+      type: 'otelcol',
+      enabled: true,
+      streams: [],
+      id: 'otelcol/my-otelcol-input',
+    });
+
+    const component = renderComponent();
+    await userEvent.click(component.container.querySelector('#agentIntegrationsInputs')!);
+    await userEvent.click(component.container.querySelector('#otelcol')!);
+    expect(component.getByText('otelcol/my-otelcol-input')).toBeInTheDocument();
+  });
+
+  it('should render input type using input type for non-otelcol inputs', async () => {
+    packageMock.inputs.push({
+      type: 'logfile',
+      enabled: true,
+      streams: [],
+      id: 'logfile/my-logfile-input',
+    });
+
+    const component = renderComponent();
+    await userEvent.click(component.container.querySelector('#agentIntegrationsInputs')!);
+    await userEvent.click(component.container.querySelector('#logfile')!);
+    expect(component.getByText('Logs')).toBeInTheDocument();
+  });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_integration_inputs.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_integration_inputs.tsx
@@ -157,7 +157,7 @@ export const AgentDetailsIntegrationInputs: React.FunctionComponent<{
                         }
                       )}
                     >
-                      {displayInputType(current.type)}
+                      {displayInputType(current.type, current?.id)}
                     </StyledEuiLink>
                   ) : (
                     <>{displayInputType(current.type)}</>

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/input_type_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/input_type_utils.ts
@@ -16,8 +16,9 @@ import {
   AGENT_DATASET_OSQUERYBEAT,
   AGENT_DATASET_HEARTBEAT,
 } from '../agent_logs/constants';
+import { OTEL_COLLECTOR_INPUT_TYPE } from '../../../../../../../../common/constants';
 
-export function displayInputType(inputType: string): string {
+export function displayInputType(inputType: string, id?: string): string {
   if (inputType === 'logfile') {
     return i18n.translate('xpack.fleet.agentDetailsIntegrations.inputTypeLogText', {
       defaultMessage: 'Logs',
@@ -32,6 +33,11 @@ export function displayInputType(inputType: string): string {
     return i18n.translate('xpack.fleet.agentDetailsIntegrations.inputTypeMetricsText', {
       defaultMessage: 'Metrics',
     });
+  }
+
+  // show the input id to differentiate multiple otelcol inputs, if present
+  if (inputType === OTEL_COLLECTOR_INPUT_TYPE && id) {
+    return id;
   }
 
   return inputType;


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/243720

## Summary
Integration input health reports otelcol inputs with `receiver id` instead of input type `otelcol`. 

Currently the input health show input name "otelcol" for any receiver, making it difficult to diagnose which input has issues in case of multiple inputs. This PR addresses it, showing the receiver id instead of the generic type. 

Note that this change is done only for "otelcol" inputs and not for any other type of inputs, they'll keep showing the type instead; the link ref stays the same, it's just the text that has been changed.


### Before
<img width="951" height="638" alt="Screenshot 2025-11-24 at 15 57 20" src="https://github.com/user-attachments/assets/9e67c70b-4e73-45c6-8bc4-ba0c5de70b91" />

### After
<img width="1771" height="996" alt="Screenshot 2025-11-24 at 15 51 36" src="https://github.com/user-attachments/assets/84a3ef3f-8895-405c-8417-dda772964d09" />

### Testing
- Locally build this package: https://github.com/elastic/integrations/pull/15739
- Install it into Fleet with 
 ```
curl -XPOST -H 'content-type: application/zip' -H 'kbn-xsrf: true' http://localhost:5601/<PATH>/api/fleet/epm/packages -u elastic:changeme --data-binary @docker_otel_input-0.2.0.zip
```
- Add it to an agent policy and enroll an agent into that policy
- Verify the input health in agent view. The input name should correspond to the receiver id and the link should correctly navigate to the logs.


### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


