### PR TITLE
fix typo: secutity -> security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1219,7 +1219,7 @@ x-pack/solutions/security/plugins/security_solution_serverless @elastic/security
 x-pack/solutions/security/plugins/session_view @elastic/contextual-security-apps
 x-pack/solutions/security/test
 x-pack/solutions/security/test/plugin_functional/plugins/resolver_test @elastic/security-solution
-x-pack/solutions/security/test/security_solution_api_integration @elastic/secutity-detection-engine
+x-pack/solutions/security/test/security_solution_api_integration @elastic/security-detection-engine
 x-pack/solutions/security/test/security_solution_api_integration/config/services/detections_response @elastic/security-detection-engine
 x-pack/solutions/security/test/security_solution_endpoint @elastic/security-defend-workflows
 x-pack/solutions/workplaceai/packages/kbn-workplaceai-api-keys-components @elastic/search-kibana @elastic/workchat-eng

--- a/x-pack/solutions/security/test/security_solution_api_integration/kibana.jsonc
+++ b/x-pack/solutions/security/test/security_solution_api_integration/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "functional-tests",
   "id": "@kbn/test-suites-security-solution-apis",
-  "owner": "@elastic/secutity-detection-engine",
+  "owner": "@elastic/security-detection-engine",
   "group": "security",
   "visibility": "private",
   "devOnly": true

--- a/x-pack/solutions/security/test/security_solution_api_integration/moon.yml
+++ b/x-pack/solutions/security/test/security_solution_api_integration/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/test-suites-security-solution-apis'
 type: unknown
 owners:
-  defaultOwner: '@elastic/secutity-detection-engine'
+  defaultOwner: '@elastic/security-detection-engine'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/test-suites-security-solution-apis'
   description: Moon project for @kbn/test-suites-security-solution-apis
   channel: ''
-  owner: '@elastic/secutity-detection-engine'
+  owner: '@elastic/security-detection-engine'
   metadata:
     sourceRoot: x-pack/solutions/security/test/security_solution_api_integration
 dependsOn:


### PR DESCRIPTION
## Summary
Fixes silly codeowners typo

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->