### PR TITLE
[Obs AI Assistant] kibana tool: Add auth header to request

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.test.ts
@@ -114,6 +114,26 @@ describe('kibana tool', () => {
     );
   });
 
+  it('forwards authorization header', async () => {
+    const { handler } = registerFunction({
+      headers: {
+        authorization: 'Basic dGVzdA==',
+        'x-forwarded-user': 'should-be-stripped',
+      },
+    });
+
+    await handler({
+      arguments: {
+        method: 'GET',
+        pathname: '/api/status',
+      },
+    });
+
+    const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
+    expect(forwardedRequest.headers?.authorization).toBe('Basic dGVzdA==');
+    expect(forwardedRequest.headers).not.toHaveProperty('x-forwarded-user');
+  });
+
   it('throws when server.publicBaseUrl is not configured', async () => {
     const { handler, coreStart } = registerFunction({});
     coreStart.http.basePath.publicBaseUrl = undefined as any;

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.ts
@@ -90,6 +90,7 @@ export function registerKibanaFunction({
         'accept-encoding',
         'accept-language',
         'accept',
+        'authorization',
         'content-type',
         'cookie',
         'kbn-build-number',


### PR DESCRIPTION
Follow-up to https://github.com/elastic/kibana/pull/236653

## Problem
Calls made through the "kibana" tool drops the `Authorization` header when replaying the request. Any deployment where access to Kibana goes through a proxy that enforces basic auth therefore receives `401 Unauthorized`.

## Reproduce

1. Put a proxy in front of Kibana
2. Start Kibana with `server.publicBaseUrl=http://localhost:3000`.
3. Trigger the tool, via API using basic auth:

   ```bash
   curl -X POST "http://localhost:5601/internal/observability_ai_assistant/chat/complete" \
     -H "Content-Type: application/json" \
     -H "kbn-version: 9.3.0" \
     -H "x-elastic-internal-origin: kibana" \
     -u elastic:changeme \
     -d '{
       "messages": [{
         "message": {
           "role": "user",
           "content": "Please use the \"kibana\" tool to call the Kibana API for retrieving saved objects. Use the following parameters:\n\nMethod: GET\nPathname: /api/saved_objects/_find\ntype: dashboard"
         },
         "@timestamp": "'$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")'"
       }],
       "connectorId": "<valid-connector-id>",
       "persist": false,
       "screenContexts": [],
       "scopes": ["observability"]
     }'
   ```

  The tool fails with

   ```
   Error calling Kibana API: GET http://localhost:3000/api/saved_objects/_find?type=dashboard. Failed with AxiosError: Request failed with status code 401
   ```

See https://github.com/elastic/kibana/issues/240349 for a minimal proxy for local repro

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->