### PR TITLE
[ci] Moon project gen shoulnd't break main

### DIFF
--- a/.buildkite/scripts/steps/checks/verify_moon_projects.sh
+++ b/.buildkite/scripts/steps/checks/verify_moon_projects.sh
@@ -10,6 +10,8 @@ if is_pr && ! is_auto_commit_disabled && [[ "$BUILDKITE_PULL_REQUEST_BASE_BRANCH
   node scripts/regenerate_moon_projects.js --update
   check_for_changed_files "node scripts/regenerate_moon_projects.js --update" true
 else
-  node scripts/regenerate_moon_projects.js --update
-  check_for_changed_files "node scripts/regenerate_moon_projects.js --update"
+  # Do not break on main yet, we can wait until pending PRs get merged in the non-offending version.
+#  node scripts/regenerate_moon_projects.js --update
+#  check_for_changed_files "node scripts/regenerate_moon_projects.js --update"
+  echo "Skipping Moon project verification on non-PR or non-main base branch."
 fi

--- a/src/platform/plugins/shared/workflows_management/moon.yml
+++ b/src/platform/plugins/shared/workflows_management/moon.yml
@@ -76,6 +76,7 @@ dependsOn:
   - '@kbn/core-http-server-mocks'
   - '@kbn/core-elasticsearch-server'
   - '@kbn/safer-lodash-set'
+  - '@kbn/connector-specs'
 tags:
   - plugin
   - prod


### PR DESCRIPTION
## Summary
The check breaking on main was alive a bit too early, there were probably a handful of PRs that got verified in the world where the quick-check didn't update the moon.yml configs.