### PR TITLE
[One Workflow] refactor: Make functions sync instead of async in StepExecutionRuntime

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/enter_foreach_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/enter_foreach_node_impl.ts
@@ -25,14 +25,14 @@ export class EnterForeachNodeImpl implements NodeImplementation {
     if (!this.stepExecutionRuntime.getCurrentStepState()) {
       await this.enterForeach();
     } else {
-      await this.advanceIteration();
+      this.advanceIteration();
     }
   }
 
   private async enterForeach(): Promise<void> {
-    await this.stepExecutionRuntime.startStep();
+    this.stepExecutionRuntime.startStep();
     let foreachState = this.stepExecutionRuntime.getCurrentStepState();
-    await this.stepExecutionRuntime.setInput({
+    this.stepExecutionRuntime.setInput({
       foreach: this.node.configuration.foreach,
     });
     const evaluatedItems = this.getItems();
@@ -44,11 +44,11 @@ export class EnterForeachNodeImpl implements NodeImplementation {
           workflow: { step_id: this.node.stepId },
         }
       );
-      await this.stepExecutionRuntime.setCurrentStepState({
+      this.stepExecutionRuntime.setCurrentStepState({
         items: [],
         total: 0,
       });
-      await this.stepExecutionRuntime.finishStep();
+      this.stepExecutionRuntime.finishStep();
       this.wfExecutionRuntimeManager.navigateToNode(this.node.exitNodeId);
       return;
     }
@@ -68,14 +68,14 @@ export class EnterForeachNodeImpl implements NodeImplementation {
       total: evaluatedItems.length,
     };
 
-    await this.stepExecutionRuntime.setCurrentStepState(foreachState);
+    this.stepExecutionRuntime.setCurrentStepState(foreachState);
     // Enter a new scope for the first iteration
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.wfExecutionRuntimeManager.enterScope(foreachState.index!.toString());
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 
-  private async advanceIteration(): Promise<void> {
+  private advanceIteration(): void {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     let foreachState = this.stepExecutionRuntime.getCurrentStepState()!;
     // Update items and index if they have changed
@@ -90,7 +90,7 @@ export class EnterForeachNodeImpl implements NodeImplementation {
       total,
     };
     // Enter a new scope for the new iteration
-    await this.stepExecutionRuntime.setCurrentStepState(foreachState);
+    this.stepExecutionRuntime.setCurrentStepState(foreachState);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.wfExecutionRuntimeManager.enterScope(foreachState.index!.toString());
     this.wfExecutionRuntimeManager.navigateToNextNode();

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/exit_foreach_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/exit_foreach_node_impl.ts
@@ -33,7 +33,7 @@ export class ExitForeachNodeImpl implements NodeImplementation {
       return;
     }
 
-    await this.stepExecutionRuntime.finishStep();
+    this.stepExecutionRuntime.finishStep();
     this.workflowLogger.logDebug(
       `Exiting foreach step ${this.node.stepId} after processing all items.`,
       {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/exit_foreach_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/exit_foreach_node_impl.ts
@@ -21,7 +21,7 @@ export class ExitForeachNodeImpl implements NodeImplementation {
     private workflowLogger: IWorkflowEventLogger
   ) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     const foreachState = this.stepExecutionRuntime.getCurrentStepState();
 
     if (!foreachState) {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/tests/exit_foreach_node_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/tests/exit_foreach_node_impl.test.ts
@@ -52,8 +52,8 @@ describe('ExitForeachNodeImpl', () => {
       (stepExecutionRuntime.getCurrentStepState as jest.Mock).mockReturnValue(undefined);
     });
 
-    it('should throw an error', async () => {
-      await expect(underTest.run()).rejects.toThrow(
+    it('should throw an error', () => {
+      expect(() => underTest.run()).toThrow(
         new Error(`Foreach state for step ${node.stepId} not found`)
       );
     });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/http_step/http_step_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/http_step/http_step_impl.ts
@@ -173,7 +173,7 @@ export class HttpStepImpl extends BaseAtomicNodeImplementation<HttpStep> {
     };
   }
 
-  protected async handleFailure(input: any, error: any): Promise<RunStepResult> {
+  protected handleFailure(input: any, error: any): RunStepResult {
     let errorMessage: string;
     let isAborted = false;
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/enter_condition_branch_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/enter_condition_branch_node_impl.ts
@@ -17,7 +17,7 @@ export class EnterConditionBranchNodeImpl implements NodeImplementation {
     private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager
   ) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     if (this.node.type === 'enter-then-branch') {
       this.wfExecutionRuntimeManager.enterScope('true');
     } else {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/enter_if_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/enter_if_node_impl.ts
@@ -25,7 +25,7 @@ export class EnterIfNodeImpl implements NodeImplementation {
   ) {}
 
   public async run(): Promise<void> {
-    await this.stepExecutionRuntime.startStep();
+    this.stepExecutionRuntime.startStep();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const successors: any[] = this.workflowGraph.getDirectSuccessors(this.node.id);
 
@@ -51,7 +51,7 @@ export class EnterIfNodeImpl implements NodeImplementation {
     const renderedCondition =
       this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(thenNode.condition);
     const evaluatedConditionResult = this.evaluateCondition(renderedCondition);
-    await this.stepExecutionRuntime.setInput({
+    this.stepExecutionRuntime.setInput({
       condition: renderedCondition,
       conditionResult: evaluatedConditionResult,
     });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/exit_condition_branch_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/exit_condition_branch_node_impl.ts
@@ -18,7 +18,7 @@ export class ExitConditionBranchNodeImpl implements NodeImplementation {
     private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager
   ) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     const successors = this.workflowGraph.getDirectSuccessors(this.step.id);
 
     if (successors.length !== 1) {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/exit_if_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/exit_if_node_impl.ts
@@ -18,7 +18,7 @@ export class ExitIfNodeImpl implements NodeImplementation {
   ) {}
 
   public async run(): Promise<void> {
-    await this.stepExecutionRuntime.finishStep();
+    this.stepExecutionRuntime.finishStep();
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/exit_if_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/exit_if_node_impl.ts
@@ -17,7 +17,7 @@ export class ExitIfNodeImpl implements NodeImplementation {
     private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager
   ) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     this.stepExecutionRuntime.finishStep();
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/tests/exit_condition_branch_node_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/tests/exit_condition_branch_node_impl.test.ts
@@ -40,30 +40,30 @@ describe('ExitConditionBranchNodeImpl', () => {
     ]);
   });
 
-  it('should raise an error if there are multiple successors', async () => {
+  it('should raise an error if there are multiple successors', () => {
     workflowGraphMock.getDirectSuccessors = jest.fn().mockReturnValue([
       { id: 'exitIfNode1', type: 'exit-if' },
       { id: 'exitIfNode2', type: 'exit-if' },
     ]);
 
-    await expect(impl.run()).rejects.toThrow(
+    expect(() => impl.run()).toThrow(
       `ExitConditionBranchNode with id ${node.id} must have exactly one successor, but found 2.`
     );
   });
 
-  it('should raise an error if no successors', async () => {
+  it('should raise an error if no successors', () => {
     workflowGraphMock.getDirectSuccessors = jest.fn().mockReturnValue([]);
 
-    await expect(impl.run()).rejects.toThrow(
+    expect(() => impl.run()).toThrow(
       `ExitConditionBranchNode with id ${node.id} must have exactly one successor, but found 0.`
     );
   });
 
-  it('should raise an error if successor is not exit-if', async () => {
+  it('should raise an error if successor is not exit-if', () => {
     workflowGraphMock.getDirectSuccessors = jest
       .fn()
       .mockReturnValue([{ id: 'someOtherNode', type: 'some-other-type' }]);
-    await expect(impl.run()).rejects.toThrow(
+    expect(() => impl.run()).toThrow(
       `ExitConditionBranchNode with id ${node.id} must have an exit-if successor, but found some-other-type with id someOtherNode.`
     );
   });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
@@ -47,7 +47,9 @@ export interface MonitorableNode {
   monitor(monitoredContext: StepExecutionRuntime): Promise<void> | void;
 }
 
-export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep> implements NodeImplementation {
+export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep>
+  implements NodeImplementation
+{
   protected step: TStep;
   protected stepExecutionRuntime: StepExecutionRuntime;
   protected connectorExecutor: ConnectorExecutor;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
@@ -77,11 +77,11 @@ export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep>
 
   public async run(): Promise<void> {
     let input: any;
-    await this.stepExecutionRuntime.startStep();
+    this.stepExecutionRuntime.startStep();
 
     try {
       input = await this.getInput();
-      await this.stepExecutionRuntime.setInput(input);
+      this.stepExecutionRuntime.setInput(input);
       const result = await this._run(input);
 
       // Don't update step execution runtime if abort was initiated
@@ -90,13 +90,13 @@ export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep>
       }
 
       if (result.error) {
-        await this.stepExecutionRuntime.failStep(result.error);
+        this.stepExecutionRuntime.failStep(result.error);
       } else {
-        await this.stepExecutionRuntime.finishStep(result.output);
+        this.stepExecutionRuntime.finishStep(result.output);
       }
     } catch (error) {
       const result = await this.handleFailure(input, error);
-      await this.stepExecutionRuntime.failStep(result.error);
+      this.stepExecutionRuntime.failStep(result.error);
     }
 
     this.workflowExecutionRuntime.navigateToNextNode();

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
@@ -40,11 +40,11 @@ export interface NodeImplementation {
 }
 
 export interface NodeWithErrorCatching {
-  catchError(): Promise<void>;
+  catchError(): Promise<void> | void;
 }
 
 export interface MonitorableNode {
-  monitor(monitoredContext: StepExecutionRuntime): Promise<void>;
+  monitor(monitoredContext: StepExecutionRuntime): Promise<void> | void;
 }
 
 export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep> implements NodeImplementation {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
@@ -36,7 +36,7 @@ export interface BaseStep {
 export type StepDefinition = BaseStep;
 
 export interface NodeImplementation {
-  run(): Promise<void>;
+  run(): Promise<void> | void;
 }
 
 export interface NodeWithErrorCatching {
@@ -47,9 +47,7 @@ export interface MonitorableNode {
   monitor(monitoredContext: StepExecutionRuntime): Promise<void>;
 }
 
-export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep>
-  implements NodeImplementation
-{
+export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep> implements NodeImplementation {
   protected step: TStep;
   protected stepExecutionRuntime: StepExecutionRuntime;
   protected connectorExecutor: ConnectorExecutor;
@@ -95,7 +93,7 @@ export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep>
         this.stepExecutionRuntime.finishStep(result.output);
       }
     } catch (error) {
-      const result = await this.handleFailure(input, error);
+      const result = this.handleFailure(input, error);
       this.stepExecutionRuntime.failStep(result.error);
     }
 
@@ -106,7 +104,7 @@ export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep>
   protected abstract _run(input?: any): Promise<RunStepResult>;
 
   // Helper for handling on-failure, retries, etc.
-  protected async handleFailure(input: any, error: any): Promise<RunStepResult> {
+  protected handleFailure(input: any, error: any): RunStepResult {
     // Implement retry logic based on step['on-failure']
     // Build comprehensive error message including cause chain (messages only)
     const getErrorMessage = (err: any): string => {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/continue_step/enter_continue_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/continue_step/enter_continue_node_impl.ts
@@ -23,7 +23,7 @@ export class EnterContinueNodeImpl implements NodeImplementation, NodeWithErrorC
     this.workflowRuntime.navigateToNextNode();
   }
 
-  public async catchError(): Promise<void> {
+  public catchError(): void {
     this.workflowLogger.logDebug(`Error caught, continuing execution.`);
 
     // Continue step should always go to exit continue node to continue execution

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/continue_step/enter_continue_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/continue_step/enter_continue_node_impl.ts
@@ -19,7 +19,7 @@ export class EnterContinueNodeImpl implements NodeImplementation, NodeWithErrorC
     private workflowLogger: IWorkflowEventLogger
   ) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     this.workflowRuntime.navigateToNextNode();
   }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/continue_step/exit_continue_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/continue_step/exit_continue_node_impl.ts
@@ -13,7 +13,7 @@ import type { NodeImplementation } from '../../node_implementation';
 export class ExitContinueNodeImpl implements NodeImplementation {
   constructor(private workflowRuntime: WorkflowExecutionRuntimeManager) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     this.workflowRuntime.navigateToNextNode();
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/enter_fallback_path_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/enter_fallback_path_node_impl.ts
@@ -13,7 +13,7 @@ import type { NodeImplementation } from '../../node_implementation';
 export class EnterFallbackPathNodeImpl implements NodeImplementation {
   constructor(private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     this.wfExecutionRuntimeManager.enterScope('fallback');
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/enter_normal_path_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/enter_normal_path_node_impl.ts
@@ -13,7 +13,7 @@ import type { NodeImplementation } from '../../node_implementation';
 export class EnterNormalPathNodeImpl implements NodeImplementation {
   constructor(private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/enter_try_block_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/enter_try_block_node_impl.ts
@@ -20,7 +20,7 @@ export class EnterTryBlockNodeImpl implements NodeImplementation, NodeWithErrorC
   ) {}
 
   public async run(): Promise<void> {
-    await this.stepExecutionRuntime.startStep();
+    this.stepExecutionRuntime.startStep();
     this.wfExecutionRuntimeManager.navigateToNode(this.node.enterNormalPathNodeId);
   }
 
@@ -31,7 +31,7 @@ export class EnterTryBlockNodeImpl implements NodeImplementation, NodeWithErrorC
     const stepState = this.stepExecutionRuntime.getCurrentStepState() || {};
 
     if (!stepState.isFallbackExecuted) {
-      await this.stepExecutionRuntime.setCurrentStepState({
+      this.stepExecutionRuntime.setCurrentStepState({
         ...stepState,
         isFallbackExecuted: true,
         error: this.wfExecutionRuntimeManager.getWorkflowExecution().error, // save error to the state of the enter node

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/enter_try_block_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/enter_try_block_node_impl.ts
@@ -19,7 +19,7 @@ export class EnterTryBlockNodeImpl implements NodeImplementation, NodeWithErrorC
     private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager
   ) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     this.stepExecutionRuntime.startStep();
     this.wfExecutionRuntimeManager.navigateToNode(this.node.enterNormalPathNodeId);
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/enter_try_block_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/enter_try_block_node_impl.ts
@@ -24,7 +24,7 @@ export class EnterTryBlockNodeImpl implements NodeImplementation, NodeWithErrorC
     this.wfExecutionRuntimeManager.navigateToNode(this.node.enterNormalPathNodeId);
   }
 
-  async catchError(): Promise<void> {
+  catchError(): void {
     this.stepExecutionRuntime.stepLogger.logError(
       'Error caught by the OnFailure zone. Redirecting to the fallback path'
     );

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/exit_fallback_path_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/exit_fallback_path_node_impl.ts
@@ -17,7 +17,7 @@ export class ExitFallbackPathNodeImpl implements NodeImplementation {
     private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager
   ) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     this.wfExecutionRuntimeManager.navigateToNode(this.node.exitOnFailureZoneNodeId);
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/exit_normal_path_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/exit_normal_path_node_impl.ts
@@ -17,7 +17,7 @@ export class ExitNormalPathNodeImpl implements NodeImplementation {
     private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager
   ) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     this.wfExecutionRuntimeManager.navigateToNode(this.node.exitOnFailureZoneNodeId);
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/exit_try_block_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/fallback-step/exit_try_block_node_impl.ts
@@ -23,12 +23,12 @@ export class ExitTryBlockNodeImpl implements NodeImplementation {
     if (stepState.error) {
       // if error is in state, that means failure path was executed
       // and we have to throw error
-      await this.stepExecutionRuntime.failStep(stepState.error);
+      this.stepExecutionRuntime.failStep(stepState.error);
       this.wfExecutionRuntimeManager.setWorkflowError(stepState.error);
       return;
     }
 
-    await this.stepExecutionRuntime.finishStep();
+    this.stepExecutionRuntime.finishStep();
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/retry_step/enter_retry_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/retry_step/enter_retry_node_impl.ts
@@ -30,7 +30,7 @@ export class EnterRetryNodeImpl implements NodeImplementation, NodeWithErrorCatc
     this.advanceRetryAttempt();
   }
 
-  public async catchError(): Promise<void> {
+  public catchError(): void {
     const attempt = this.stepExecutionRuntime.getCurrentStepState()?.attempt ?? 0;
 
     if (attempt < this.node.configuration['max-attempts']) {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/retry_step/enter_retry_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/retry_step/enter_retry_node_impl.ts
@@ -27,7 +27,7 @@ export class EnterRetryNodeImpl implements NodeImplementation, NodeWithErrorCatc
       await this.initializeRetry();
       return;
     }
-    await this.advanceRetryAttempt();
+    this.advanceRetryAttempt();
   }
 
   public async catchError(): Promise<void> {
@@ -41,16 +41,16 @@ export class EnterRetryNodeImpl implements NodeImplementation, NodeWithErrorCatc
       return;
     }
 
-    await this.stepExecutionRuntime.failStep(
+    this.stepExecutionRuntime.failStep(
       new Error(`Retry step "${this.node.stepId}" has exceeded the maximum number of attempts.`)
     );
   }
 
   private async initializeRetry(): Promise<void> {
     // Enter whole retry step scope
-    await this.stepExecutionRuntime.startStep();
+    this.stepExecutionRuntime.startStep();
     // Enter first attempt scope. Since attempt is 0 based, we add 1 to it.
-    await this.stepExecutionRuntime.setCurrentStepState({
+    this.stepExecutionRuntime.setCurrentStepState({
       attempt: 0,
     });
     // Enter a new scope for the new attempt. Since attempt is 0 based, we add 1 to it.
@@ -58,7 +58,7 @@ export class EnterRetryNodeImpl implements NodeImplementation, NodeWithErrorCatc
     this.workflowRuntime.navigateToNextNode();
   }
 
-  private async advanceRetryAttempt(): Promise<void> {
+  private advanceRetryAttempt(): void {
     if (
       this.node.configuration.delay &&
       this.stepExecutionRuntime.tryEnterDelay(this.node.configuration.delay)
@@ -72,7 +72,7 @@ export class EnterRetryNodeImpl implements NodeImplementation, NodeWithErrorCatc
     const retryState = this.stepExecutionRuntime.getCurrentStepState()!;
     const attempt = retryState.attempt + 1;
     this.workflowLogger.logDebug(`Retrying "${this.node.stepId}" step. (attempt ${attempt}).`);
-    await this.stepExecutionRuntime.setCurrentStepState({ ...retryState, attempt });
+    this.stepExecutionRuntime.setCurrentStepState({ ...retryState, attempt });
     this.workflowRuntime.enterScope(`${attempt + 1}-attempt`);
     this.workflowRuntime.navigateToNextNode();
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/retry_step/exit_retry_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/retry_step/exit_retry_node_impl.ts
@@ -23,13 +23,13 @@ export class ExitRetryNodeImpl implements NodeImplementation {
 
   public async run(): Promise<void> {
     // Exit whole retry step scope
-    await this.stepExecutionRuntime.finishStep();
+    this.stepExecutionRuntime.finishStep();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const retryState = this.stepExecutionRuntime.getCurrentStepState()!;
     this.workflowLogger.logDebug(
       `Exiting retry step ${this.node.stepId} after ${retryState.attempt} attempts.`
     );
-    await this.stepExecutionRuntime.setCurrentStepState(undefined);
+    this.stepExecutionRuntime.setCurrentStepState(undefined);
     this.workflowRuntime.navigateToNextNode();
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/step-level/enter_step_timeout_zone_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/step-level/enter_step_timeout_zone_node_impl.ts
@@ -26,7 +26,7 @@ export class EnterStepTimeoutZoneNodeImpl implements NodeImplementation, Monitor
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 
-  public monitor(monitoredContext: StepExecutionRuntime): Promise<void> {
+  public monitor(monitoredContext: StepExecutionRuntime): void {
     const timeoutMs = parseDuration(this.node.timeout);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const stepExecution = this.stepExecutionRuntime.stepExecution!;
@@ -40,7 +40,5 @@ export class EnterStepTimeoutZoneNodeImpl implements NodeImplementation, Monitor
         `TimeoutError: Step execution exceeded the configured timeout of ${this.node.timeout}.`
       );
     }
-
-    return Promise.resolve();
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/step-level/enter_step_timeout_zone_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/step-level/enter_step_timeout_zone_node_impl.ts
@@ -22,7 +22,7 @@ export class EnterStepTimeoutZoneNodeImpl implements NodeImplementation, Monitor
   ) {}
 
   public async run(): Promise<void> {
-    await this.stepExecutionRuntime.startStep();
+    this.stepExecutionRuntime.startStep();
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/step-level/exit_step_timeout_zone_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/step-level/exit_step_timeout_zone_node_impl.ts
@@ -17,7 +17,7 @@ export class ExitStepTimeoutZoneNodeImpl implements NodeImplementation {
     private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager
   ) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     this.stepExecutionRuntime.finishStep();
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/step-level/exit_step_timeout_zone_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/step-level/exit_step_timeout_zone_node_impl.ts
@@ -18,7 +18,7 @@ export class ExitStepTimeoutZoneNodeImpl implements NodeImplementation {
   ) {}
 
   public async run(): Promise<void> {
-    await this.stepExecutionRuntime.finishStep();
+    this.stepExecutionRuntime.finishStep();
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/step-level/tests/enter_step_timeout_zone_node_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/step-level/tests/enter_step_timeout_zone_node_impl.test.ts
@@ -124,7 +124,7 @@ describe('EnterStepTimeoutZoneNodeImpl', () => {
       } as any as StepExecutionRuntime;
     });
 
-    it('should not throw error when within timeout limit', async () => {
+    it('should not throw error when within timeout limit', () => {
       const startTime = new Date().getTime() - 10000; // 10 seconds ago
       mockParseDuration.mockReturnValue(30000); // 30 seconds
 
@@ -133,11 +133,11 @@ describe('EnterStepTimeoutZoneNodeImpl', () => {
         startedAt: new Date(startTime).toISOString(),
       };
 
-      await expect(impl.monitor(monitoredContextMock)).resolves.not.toThrow();
+      expect(() => impl.monitor(monitoredContextMock)).not.toThrow();
       expect(monitoredContextMock.abortController.abort).not.toHaveBeenCalled();
     });
 
-    it('should throw error and abort when timeout exceeded', async () => {
+    it('should throw error and abort when timeout exceeded', () => {
       const startTime = new Date().getTime() - 40000; // 40 seconds ago (exceeds 30s timeout)
       mockParseDuration.mockReturnValue(30000); // 30 seconds
 
@@ -147,7 +147,7 @@ describe('EnterStepTimeoutZoneNodeImpl', () => {
       };
 
       try {
-        await impl.monitor(monitoredContextMock);
+        impl.monitor(monitoredContextMock);
         fail('Expected monitor to throw error');
       } catch (error: any) {
         expect(error.message).toMatch(
@@ -167,14 +167,9 @@ describe('EnterStepTimeoutZoneNodeImpl', () => {
         startedAt: new Date(startTime).toISOString(),
       };
 
-      try {
-        await impl.monitor(monitoredContextMock);
-        fail('Expected monitor to throw error');
-      } catch (error: any) {
-        expect(error.message).toMatch(
-          'TimeoutError: Step execution exceeded the configured timeout of 30s.'
-        );
-      }
+      expect(() => impl.monitor(monitoredContextMock)).toThrow(
+        'TimeoutError: Step execution exceeded the configured timeout of 30s.'
+      );
     });
 
     it('should handle different timeout formats', async () => {
@@ -188,11 +183,11 @@ describe('EnterStepTimeoutZoneNodeImpl', () => {
         startedAt: new Date(startTime).toISOString(),
       };
 
-      await expect(impl.monitor(monitoredContextMock)).resolves.not.toThrow();
+      expect(() => impl.monitor(monitoredContextMock)).not.toThrow();
       expect(monitoredContextMock.abortController.abort).not.toHaveBeenCalled();
     });
 
-    it('should use step execution from step execution runtime directly', async () => {
+    it('should use step execution from step execution runtime directly', () => {
       const startTime = new Date().getTime() - 10000;
       mockParseDuration.mockReturnValue(30000); // 30 seconds
 
@@ -201,18 +196,18 @@ describe('EnterStepTimeoutZoneNodeImpl', () => {
         startedAt: new Date(startTime).toISOString(),
       };
 
-      await impl.monitor(monitoredContextMock);
+      impl.monitor(monitoredContextMock);
 
       // The implementation uses stepExecutionRuntime.stepExecution directly
       expect(stepExecutionRuntimeMock.stepExecution).toBeDefined();
     });
 
-    it('should handle missing step execution', async () => {
+    it('should handle missing step execution', () => {
       // Remove stepExecution to simulate null/undefined
       (stepExecutionRuntimeMock as any).stepExecution = null;
 
       try {
-        await impl.monitor(monitoredContextMock);
+        impl.monitor(monitoredContextMock);
         fail('Expected monitor to throw error');
       } catch (error: any) {
         expect(error.message).toEqual("Cannot read properties of null (reading 'startedAt')");
@@ -230,14 +225,9 @@ describe('EnterStepTimeoutZoneNodeImpl', () => {
       };
 
       // Should exceed the 30s timeout and report 50 (seconds but labeled as "ms" due to bug)
-      try {
-        await impl.monitor(monitoredContextMock);
-        fail('Expected monitor to throw error');
-      } catch (error: any) {
-        expect(error.message).toBe(
-          'TimeoutError: Step execution exceeded the configured timeout of 30s.'
-        );
-      }
+      expect(() => impl.monitor(monitoredContextMock)).toThrow(
+        'TimeoutError: Step execution exceeded the configured timeout of 30s.'
+      );
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/enter_workflow_timeout_zone_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/enter_workflow_timeout_zone_node_impl.ts
@@ -25,7 +25,7 @@ export class EnterWorkflowTimeoutZoneNodeImpl implements NodeImplementation, Mon
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 
-  public async monitor(monitoredStepExecutionRuntime: StepExecutionRuntime): Promise<void> {
+  public monitor(monitoredStepExecutionRuntime: StepExecutionRuntime): void {
     const timeoutMs = parseDuration(this.node.timeout);
     const whenStepStartedTime = new Date(
       this.wfExecutionRuntimeManager.getWorkflowExecution().startedAt
@@ -59,7 +59,5 @@ export class EnterWorkflowTimeoutZoneNodeImpl implements NodeImplementation, Mon
       this.wfExecutionRuntimeManager.setWorkflowError(undefined);
       this.wfExecutionRuntimeManager.markWorkflowTimeouted();
     }
-
-    return Promise.resolve();
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/enter_workflow_timeout_zone_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/enter_workflow_timeout_zone_node_impl.ts
@@ -36,7 +36,7 @@ export class EnterWorkflowTimeoutZoneNodeImpl implements NodeImplementation, Mon
     if (currentStepDuration > timeoutMs) {
       const timeoutError = new Error('Failed due to workflow timeout');
       monitoredStepExecutionRuntime.abortController.abort();
-      await monitoredStepExecutionRuntime.failStep(timeoutError);
+      monitoredStepExecutionRuntime.failStep(timeoutError);
 
       let stack = monitoredStepExecutionRuntime.scopeStack;
 
@@ -51,7 +51,7 @@ export class EnterWorkflowTimeoutZoneNodeImpl implements NodeImplementation, Mon
           });
 
         if (scopeStepExecutionRuntime.stepExecution) {
-          await scopeStepExecutionRuntime.failStep(timeoutError);
+          scopeStepExecutionRuntime.failStep(timeoutError);
         }
       }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/exit_workflow_timeout_zone_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/exit_workflow_timeout_zone_node_impl.ts
@@ -13,7 +13,7 @@ import type { NodeImplementation } from '../../node_implementation';
 export class ExitWorkflowTimeoutZoneNodeImpl implements NodeImplementation {
   constructor(private wfExecutionRuntimeManager: WorkflowExecutionRuntimeManager) {}
 
-  public async run(): Promise<void> {
+  public run(): void {
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/tests/enter_workflow_timeout_zone_node_impl.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/timeout_zone_step/workflow-level/tests/enter_workflow_timeout_zone_node_impl.test.ts
@@ -110,7 +110,7 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
         startedAt: new Date(startTime).toISOString(),
       });
 
-      await impl.monitor(monitoredStepExecutionRuntimeMock);
+      impl.monitor(monitoredStepExecutionRuntimeMock);
 
       expect(monitoredStepExecutionRuntimeMock.abortController.abort).not.toHaveBeenCalled();
       expect(monitoredStepExecutionRuntimeMock.failStep).not.toHaveBeenCalled();
@@ -127,7 +127,7 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
       // Mock empty scope stack (no nested scopes to fail)
       (monitoredStepExecutionRuntimeMock.scopeStack.isEmpty as jest.Mock).mockReturnValue(true);
 
-      await impl.monitor(monitoredStepExecutionRuntimeMock);
+      impl.monitor(monitoredStepExecutionRuntimeMock);
 
       expect(monitoredStepExecutionRuntimeMock.abortController.abort).toHaveBeenCalledTimes(1);
       expect(monitoredStepExecutionRuntimeMock.failStep).toHaveBeenCalledWith(expect.any(Error));
@@ -190,7 +190,7 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
         .mockReturnValueOnce(scopeStepExecutionRuntime1)
         .mockReturnValueOnce(scopeStepExecutionRuntime2);
 
-      await impl.monitor(nestedMonitoredStepExecutionRuntime);
+      impl.monitor(nestedMonitoredStepExecutionRuntime);
 
       expect(monitoredStepExecutionRuntimeMock.abortController.abort).toHaveBeenCalledTimes(1);
       expect(monitoredStepExecutionRuntimeMock.failStep).toHaveBeenCalledWith(expect.any(Error));
@@ -213,7 +213,7 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
       // Mock empty scope stack (no nested scopes to fail)
       (monitoredStepExecutionRuntimeMock.scopeStack.isEmpty as jest.Mock).mockReturnValue(true);
 
-      await impl.monitor(monitoredStepExecutionRuntimeMock);
+      impl.monitor(monitoredStepExecutionRuntimeMock);
 
       expect(wfExecutionRuntimeManagerMock.setWorkflowError).toHaveBeenCalledWith(undefined);
     });
@@ -226,7 +226,7 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
         startedAt: new Date(startTime).toISOString(),
       });
 
-      await impl.monitor(monitoredStepExecutionRuntimeMock);
+      impl.monitor(monitoredStepExecutionRuntimeMock);
 
       expect(parseDuration).toHaveBeenCalledWith('2m');
       expect(monitoredStepExecutionRuntimeMock.abortController.abort).not.toHaveBeenCalled();
@@ -241,7 +241,7 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
       wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(recentStartTime).toISOString(),
       });
-      await impl.monitor(monitoredStepExecutionRuntimeMock);
+      impl.monitor(monitoredStepExecutionRuntimeMock);
       expect(parseDuration).toHaveBeenCalledWith('30s');
 
       // Test minutes
@@ -250,7 +250,7 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
       wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(recentStartTime).toISOString(),
       });
-      await impl.monitor(monitoredStepExecutionRuntimeMock);
+      impl.monitor(monitoredStepExecutionRuntimeMock);
       expect(parseDuration).toHaveBeenCalledWith('5m');
 
       // Test hours
@@ -259,7 +259,7 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
       wfExecutionRuntimeManagerMock.getWorkflowExecution = jest.fn().mockReturnValue({
         startedAt: new Date(recentStartTime).toISOString(),
       });
-      await impl.monitor(monitoredStepExecutionRuntimeMock);
+      impl.monitor(monitoredStepExecutionRuntimeMock);
       expect(parseDuration).toHaveBeenCalledWith('1h');
     });
 
@@ -273,7 +273,7 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
 
       (monitoredStepExecutionRuntimeMock.scopeStack.isEmpty as jest.Mock).mockReturnValue(true);
 
-      await impl.monitor(monitoredStepExecutionRuntimeMock);
+      impl.monitor(monitoredStepExecutionRuntimeMock);
 
       expect(monitoredStepExecutionRuntimeMock.abortController.abort).toHaveBeenCalledTimes(1);
       expect(wfExecutionRuntimeManagerMock.markWorkflowTimeouted).toHaveBeenCalledTimes(1);
@@ -286,8 +286,8 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
         startedAt: new Date(startTime).toISOString(),
       });
 
-      const result = await impl.monitor(monitoredStepExecutionRuntimeMock);
-      expect(result).toBeUndefined(); // Promise<void> resolves to undefined
+      const result = impl.monitor(monitoredStepExecutionRuntimeMock);
+      expect(result).toBeUndefined(); // void returns undefined
     });
 
     it('should handle edge case where timeout exactly equals current duration', async () => {
@@ -298,7 +298,7 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
         startedAt: new Date(startTime).toISOString(),
       });
 
-      await impl.monitor(monitoredStepExecutionRuntimeMock);
+      impl.monitor(monitoredStepExecutionRuntimeMock);
 
       // Should not timeout when duration equals timeout limit (using > comparison)
       expect(monitoredStepExecutionRuntimeMock.abortController.abort).not.toHaveBeenCalled();
@@ -314,7 +314,7 @@ describe('EnterWorkflowTimeoutZoneNodeImpl', () => {
 
       (monitoredStepExecutionRuntimeMock.scopeStack.isEmpty as jest.Mock).mockReturnValue(true);
 
-      await impl.monitor(monitoredStepExecutionRuntimeMock);
+      impl.monitor(monitoredStepExecutionRuntimeMock);
 
       expect(monitoredStepExecutionRuntimeMock.abortController.abort).toHaveBeenCalledTimes(1);
       expect(wfExecutionRuntimeManagerMock.markWorkflowTimeouted).toHaveBeenCalledTimes(1);

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/wait_step/wait_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/wait_step/wait_step.ts
@@ -28,11 +28,11 @@ export class WaitStepImpl implements NodeImplementation {
       return;
     }
 
-    await this.exitWait();
+    this.exitWait();
   }
 
-  private async exitWait(): Promise<void> {
-    await this.stepExecutionRuntime.finishStep();
+  private exitWait(): void {
+    this.stepExecutionRuntime.finishStep();
     this.workflowLogger.logDebug(
       `Finished waiting for ${this.node.configuration.with.duration} in step ${this.node.id}`
     );

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_execution_runtime.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_execution_runtime.ts
@@ -108,7 +108,7 @@ export class StepExecutionRuntime {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async setCurrentStepState(state: Record<string, any> | undefined): Promise<void> {
+  public setCurrentStepState(state: Record<string, any> | undefined): void {
     const stepId = this.node.stepId;
     this.workflowExecutionState.upsertStep({
       id: this.stepExecutionId,
@@ -117,7 +117,7 @@ export class StepExecutionRuntime {
     });
   }
 
-  public async startStep(): Promise<void> {
+  public startStep(): void {
     const stepId = this.node.stepId;
     const stepStartedAt = new Date();
 
@@ -137,7 +137,7 @@ export class StepExecutionRuntime {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async setInput(input: Record<string, any>): Promise<void> {
+  public setInput(input: Record<string, any>): void {
     this.workflowExecutionState.upsertStep({
       id: this.stepExecutionId,
       input,
@@ -145,7 +145,7 @@ export class StepExecutionRuntime {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async finishStep(stepOutput?: Record<string, any>): Promise<void> {
+  public finishStep(stepOutput?: Record<string, any>): void {
     const startedStepExecution = this.workflowExecutionState.getStepExecution(this.stepExecutionId);
     const stepExecutionUpdate = {
       id: this.stepExecutionId,
@@ -164,7 +164,7 @@ export class StepExecutionRuntime {
     this.logStepComplete(stepExecutionUpdate);
   }
 
-  public async failStep(error: Error | string): Promise<void> {
+  public failStep(error: Error | string): void {
     // if there is a last step execution, fail it
     // if not, create a new step execution with fail
     const startedStepExecution = this.workflowExecutionState.getStepExecution(this.stepExecutionId);

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/step_execution_runtime.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/step_execution_runtime.test.ts
@@ -160,8 +160,8 @@ describe('StepExecutionRuntime', () => {
       });
     });
 
-    it('should upsertStep with the fake step execution id', async () => {
-      await underTest.setCurrentStepState({});
+    it('should upsertStep with the fake step execution id', () => {
+      underTest.setCurrentStepState({});
       expect(workflowExecutionState.upsertStep).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 'fake_step_execution_id',
@@ -169,13 +169,13 @@ describe('StepExecutionRuntime', () => {
       );
     });
 
-    it('should update the step execution with the state and be able to retrieve it', async () => {
+    it('should update the step execution with the state and be able to retrieve it', () => {
       (workflowExecutionState.getLatestStepExecution as jest.Mock).mockReturnValue({
         stepId: 'node1',
         state: { success: true, data: {} },
       } as Partial<EsWorkflowStepExecution>);
       const fakeState = { success: true, data: {} };
-      await underTest.setCurrentStepState(fakeState);
+      underTest.setCurrentStepState(fakeState);
 
       expect(workflowExecutionState.upsertStep).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -212,8 +212,8 @@ describe('StepExecutionRuntime', () => {
       mockDateNow = new Date('2023-01-01T00:00:00.000Z');
     });
 
-    it('should upsertStep with the fake step execution id', async () => {
-      await underTest.startStep();
+    it('should upsertStep with the fake step execution id', () => {
+      underTest.startStep();
 
       expect(workflowExecutionState.upsertStep).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -222,8 +222,8 @@ describe('StepExecutionRuntime', () => {
       );
     });
 
-    it('should create a step execution with "RUNNING" status', async () => {
-      await underTest.startStep();
+    it('should create a step execution with "RUNNING" status', () => {
+      underTest.startStep();
 
       expect(workflowExecutionState.upsertStep).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -235,8 +235,8 @@ describe('StepExecutionRuntime', () => {
       );
     });
 
-    it('should log the start of step execution', async () => {
-      await underTest.startStep();
+    it('should log the start of step execution', () => {
+      underTest.startStep();
       expect(workflowLogger.logInfo).toHaveBeenCalledWith(`Step 'fakeStepId1' started`, {
         event: { action: 'step-start', category: ['workflow', 'step'] },
         tags: ['workflow', 'step', 'start'],
@@ -253,8 +253,8 @@ describe('StepExecutionRuntime', () => {
       });
     });
 
-    it('should save step path from the workflow execution stack', async () => {
-      await underTest.startStep();
+    it('should save step path from the workflow execution stack', () => {
+      underTest.startStep();
       expect(workflowExecutionState.upsertStep).toHaveBeenCalledWith(
         expect.objectContaining({
           scopeStack: [
@@ -265,8 +265,8 @@ describe('StepExecutionRuntime', () => {
       );
     });
 
-    it('should save step type', async () => {
-      await underTest.startStep();
+    it('should save step type', () => {
+      underTest.startStep();
       expect(workflowExecutionState.upsertStep).toHaveBeenCalledWith(
         expect.objectContaining({
           stepType: 'fakeStepType1',
@@ -298,10 +298,10 @@ describe('StepExecutionRuntime', () => {
       });
     });
 
-    it('should correctly calculate step completedAt and executionTimeMs', async () => {
+    it('should correctly calculate step completedAt and executionTimeMs', () => {
       const expectedCompletedAt = new Date('2025-08-06T00:00:02.000Z');
       mockDateNow = expectedCompletedAt;
-      await underTest.finishStep();
+      underTest.finishStep();
 
       expect(workflowExecutionState.upsertStep).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -312,7 +312,7 @@ describe('StepExecutionRuntime', () => {
     });
 
     describe('step execution succeeds', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         (workflowExecutionState.getStepExecution as jest.Mock).mockImplementation(
           (stepExecutionId) => {
             if (stepExecutionId === 'fake_step_execution_id') {
@@ -327,8 +327,8 @@ describe('StepExecutionRuntime', () => {
         );
       });
 
-      it('should upsert step with the fake step execution id', async () => {
-        await underTest.finishStep();
+      it('should upsert step with the fake step execution id', () => {
+        underTest.finishStep();
 
         expect(workflowExecutionState.upsertStep).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -337,8 +337,8 @@ describe('StepExecutionRuntime', () => {
         );
       });
 
-      it('should finish a step execution with "COMPLETED" status', async () => {
-        await underTest.finishStep();
+      it('should finish a step execution with "COMPLETED" status', () => {
+        underTest.finishStep();
 
         expect(workflowExecutionState.upsertStep).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -347,8 +347,8 @@ describe('StepExecutionRuntime', () => {
         );
       });
 
-      it('should finish a step execution executionTime', async () => {
-        await underTest.finishStep();
+      it('should finish a step execution executionTime', () => {
+        underTest.finishStep();
 
         expect(workflowExecutionState.upsertStep).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -357,8 +357,8 @@ describe('StepExecutionRuntime', () => {
         );
       });
 
-      it('should log successful step execution', async () => {
-        await underTest.finishStep();
+      it('should log successful step execution', () => {
+        underTest.finishStep();
         expect(workflowLogger.logInfo).toHaveBeenCalledWith(`Step 'fakeStepId1' completed`, {
           event: {
             action: 'step-complete',
@@ -394,9 +394,9 @@ describe('StepExecutionRuntime', () => {
       });
     });
 
-    it('should upsert step with the fake step execution id', async () => {
+    it('should upsert step with the fake step execution id', () => {
       const error = new Error('Step execution failed');
-      await underTest.failStep(error);
+      underTest.failStep(error);
 
       expect(workflowExecutionState.upsertStep).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -405,9 +405,9 @@ describe('StepExecutionRuntime', () => {
       );
     });
 
-    it('should mark the step as failed', async () => {
+    it('should mark the step as failed', () => {
       const error = new Error('Step execution failed');
-      await underTest.failStep(error);
+      underTest.failStep(error);
 
       expect(workflowExecutionState.upsertStep).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -417,9 +417,9 @@ describe('StepExecutionRuntime', () => {
       );
     });
 
-    it('should log the failure of the step', async () => {
+    it('should log the failure of the step', () => {
       const error = new Error('Step execution failed');
-      await underTest.failStep(error);
+      underTest.failStep(error);
 
       expect(workflowLogger.logError).toHaveBeenCalledWith(
         `Step 'fakeStepId1' failed: Step execution failed`,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/catch_error.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/catch_error.ts
@@ -70,7 +70,7 @@ export async function catchError(
     }
 
     if (failedStepExecutionRuntime.stepExecutionExists()) {
-      await failedStepExecutionRuntime.failStep(
+      failedStepExecutionRuntime.failStep(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         params.workflowExecutionState.getWorkflowExecution().error!
       );
@@ -112,7 +112,7 @@ export async function catchError(
 
       if (params.workflowExecutionState.getWorkflowExecution().error) {
         if (stepExecutionRuntime.stepExecutionExists()) {
-          await stepExecutionRuntime.failStep(
+          stepExecutionRuntime.failStep(
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             params.workflowExecutionState.getWorkflowExecution().error!
           );

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/catch_error.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/catch_error.ts
@@ -102,7 +102,7 @@ export async function catchError(
         const stepErrorCatcher = stepImplementation as unknown as NodeWithErrorCatching;
 
         try {
-          await stepErrorCatcher.catchError();
+          await Promise.resolve(stepErrorCatcher.catchError());
         } catch (error) {
           params.workflowExecutionState.updateWorkflowExecution({
             error,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
@@ -86,9 +86,10 @@ export async function runNode(params: WorkflowExecutionLoopParams): Promise<void
 
     // Sometimes monitoring can prevent the step from running, e.g. when the workflow is cancelled, timeout occured right before running step, etc.
     if (!monitorAbortController.signal.aborted) {
-      runStepPromise = nodeImplementation
-        .run()
-        .then(() => stepExecutionRuntime && handleExecutionDelay(params, stepExecutionRuntime));
+      const runResult = nodeImplementation.run();
+      runStepPromise = Promise.resolve(runResult).then(
+        () => stepExecutionRuntime && handleExecutionDelay(params, stepExecutionRuntime)
+      );
     }
 
     await Promise.race([runMonitorPromise, runStepPromise]);

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
@@ -86,8 +86,7 @@ export async function runNode(params: WorkflowExecutionLoopParams): Promise<void
 
     // Sometimes monitoring can prevent the step from running, e.g. when the workflow is cancelled, timeout occured right before running step, etc.
     if (!monitorAbortController.signal.aborted) {
-      const runResult = nodeImplementation.run();
-      runStepPromise = Promise.resolve(runResult).then(
+      runStepPromise = Promise.resolve(nodeImplementation.run()).then(
         () => stepExecutionRuntime && handleExecutionDelay(params, stepExecutionRuntime)
       );
     }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_stack_monitor/process_node_stack_monitoring.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_stack_monitor/process_node_stack_monitoring.ts
@@ -51,7 +51,7 @@ export async function processNodeStackMonitoring(
 
     if (typeof (nodeImplementation as unknown as MonitorableNode).monitor === 'function') {
       const monitored = nodeImplementation as unknown as MonitorableNode;
-      await monitored.monitor(monitoredStepExecutionRuntime);
+      await Promise.resolve(monitored.monitor(monitoredStepExecutionRuntime));
     }
   }
 


### PR DESCRIPTION
## Summary

relates to: https://github.com/elastic/security-team/issues/14849

This PR simplifies node interfaces and their implementations by removing unnecessary async/Promise patterns from methods that perform only synchronous operations.

### Key Changes

#### Interface Definitions

Updated three core interfaces to support both synchronous and asynchronous implementations:
- `NodeImplementation.run()`: `Promise<void>` → `Promise<void> | void`
- `NodeWithErrorCatching.catchError()`: `Promise<void>` → `Promise<void> | void`
- `MonitorableNode.monitor()`: `Promise<void>` → `Promise<void> | void`

#### Node Implementations Converted to Sync

**If Step Nodes:**
- `EnterIfNodeImpl` - Removed unnecessary `await` calls for `startStep()` and `setInput()`
- `EnterConditionBranchNodeImpl.run()` - Converted to synchronous
- `ExitConditionBranchNodeImpl.run()` - Converted to synchronous
- `ExitIfNodeImpl.run()` - Converted to synchronous

**Foreach Step Nodes:**
- `EnterForeachNodeImpl` - Converted `advanceIteration()` to sync, removed unnecessary `await` calls
- `ExitForeachNodeImpl.run()` - Converted to synchronous

**On-Failure Nodes:**
- `EnterContinueNodeImpl.run()` and `catchError()` - Converted to synchronous
- `ExitContinueNodeImpl.run()` - Converted to synchronous
- `EnterTryBlockNodeImpl.run()` and `catchError()` - Converted to synchronous
- `EnterFallbackPathNodeImpl.run()` - Converted to synchronous
- `EnterNormalPathNodeImpl.run()` - Converted to synchronous
- `ExitFallbackPathNodeImpl.run()` - Converted to synchronous
- `ExitNormalPathNodeImpl.run()` - Converted to synchronous
- `ExitTryBlockNodeImpl.run()` - Converted to synchronous (except outer method)
- `EnterRetryNodeImpl.catchError()` and `advanceRetryAttempt()` - Converted to synchronous
- `ExitRetryNodeImpl.run()` - Converted to synchronous (except outer method)

**Timeout Zone Nodes:**
- `EnterStepTimeoutZoneNodeImpl.monitor()` - Converted to synchronous
- `ExitStepTimeoutZoneNodeImpl.run()` - Converted to synchronous
- `EnterWorkflowTimeoutZoneNodeImpl.monitor()` - Converted to synchronous
- `ExitWorkflowTimeoutZoneNodeImpl.run()` - Converted to synchronous

**Wait Step:**
- `WaitStepImpl.exitWait()` - Converted to synchronous

#### Core Framework Changes

**BaseAtomicNodeImplementation:**
- `handleFailure()` - Converted from `async` to synchronous
- Removed unnecessary `await` calls for synchronous methods: `startStep()`, `setInput()`, `failStep()`, `finishStep()`

**StepExecutionRuntime:**

Converted the following methods from `async` to synchronous:
- `setCurrentStepState()`
- `startStep()`
- `setInput()`
- `finishStep()`
- `failStep()`

**Execution Loop Updates:**
- `run_node.ts` - Wrapped `nodeImplementation.run()` with `Promise.resolve()` for compatibility
- `catch_error.ts` - Wrapped `catchError()` with `Promise.resolve()`, removed unnecessary `await` calls
- `process_node_stack_monitoring.ts` - Wrapped `monitor()` with `Promise.resolve()` for compatibility

#### HttpStepImpl
- `handleFailure()` - Converted to synchronous

### Benefits

- **Improved Performance**: Eliminates unnecessary Promise overhead for synchronous operations
- **Clearer Code Intent**: Synchronous methods are immediately identifiable as non-blocking
- **Type Safety**: Interfaces now correctly represent that methods can be either sync or async
- **Maintained Compatibility**: Call sites use `Promise.resolve()` to handle both patterns seamlessly

#### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



