### PR TITLE
[Controls Anywhere] Add telemetry

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/usage/dashboard_telemetry.ts
+++ b/src/platform/plugins/shared/dashboard/server/usage/dashboard_telemetry.ts
@@ -18,8 +18,36 @@ import type {
 import { TASK_ID } from './dashboard_telemetry_collection_task';
 import { emptyState, type LatestTaskStateSchema } from './task_state';
 
-type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> };
-export type DashboardCollectorData = DeepWriteable<LatestTaskStateSchema['telemetry']>;
+// TODO: Merge with LatestTaskStateSchema. Requires a refactor of collectPanelsByType() because
+// LatestTaskStateSchema doesn't allow mutations (uses ReadOnly<..>).
+export interface DashboardCollectorData {
+  panels: {
+    total: number;
+    by_reference: number;
+    by_value: number;
+    by_type: {
+      [key: string]: {
+        total: number;
+        by_reference: number;
+        by_value: number;
+        details: {
+          [key: string]: number;
+        };
+      };
+    };
+  };
+  controls: {
+    total: number;
+    by_type: {
+      [key: string]: {
+        total: number;
+      };
+    };
+  };
+  sections: {
+    total: number;
+  };
+}
 
 export const getEmptyDashboardData = (): DashboardCollectorData => ({
   panels: {

--- a/src/platform/plugins/shared/dashboard/server/usage/dashboard_telemetry.ts
+++ b/src/platform/plugins/shared/dashboard/server/usage/dashboard_telemetry.ts
@@ -21,7 +21,21 @@ import { emptyState, type LatestTaskStateSchema } from './task_state';
 type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> };
 export type DashboardCollectorData = DeepWriteable<LatestTaskStateSchema['telemetry']>;
 
-export const getEmptyDashboardData = (): DashboardCollectorData => emptyState.telemetry;
+export const getEmptyDashboardData = (): DashboardCollectorData => ({
+  panels: {
+    total: 0,
+    by_reference: 0,
+    by_value: 0,
+    by_type: {},
+  },
+  controls: {
+    total: 0,
+    by_type: {},
+  },
+  sections: {
+    total: 0,
+  },
+});
 
 export const getEmptyPanelTypeData = () => ({
   total: 0,

--- a/src/platform/plugins/shared/dashboard/server/usage/dashboard_telemetry.ts
+++ b/src/platform/plugins/shared/dashboard/server/usage/dashboard_telemetry.ts
@@ -13,50 +13,25 @@ import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type {
   DashboardSavedObjectAttributes,
   SavedDashboardPanel,
+  StoredControlGroupInput,
 } from '../dashboard_saved_object';
 import { TASK_ID } from './dashboard_telemetry_collection_task';
 import { emptyState, type LatestTaskStateSchema } from './task_state';
 
-// TODO: Merge with LatestTaskStateSchema. Requires a refactor of collectPanelsByType() because
-// LatestTaskStateSchema doesn't allow mutations (uses ReadOnly<..>).
-export interface DashboardCollectorData {
-  panels: {
-    total: number;
-    by_reference: number;
-    by_value: number;
-    by_type: {
-      [key: string]: {
-        total: number;
-        by_reference: number;
-        by_value: number;
-        details: {
-          [key: string]: number;
-        };
-      };
-    };
-  };
-  sections: {
-    total: number;
-  };
-}
+type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> };
+export type DashboardCollectorData = DeepWriteable<LatestTaskStateSchema['telemetry']>;
 
-export const getEmptyDashboardData = (): DashboardCollectorData => ({
-  panels: {
-    total: 0,
-    by_reference: 0,
-    by_value: 0,
-    by_type: {},
-  },
-  sections: {
-    total: 0,
-  },
-});
+export const getEmptyDashboardData = (): DashboardCollectorData => emptyState.telemetry;
 
 export const getEmptyPanelTypeData = () => ({
   total: 0,
   by_reference: 0,
   by_value: 0,
   details: {},
+});
+
+export const getEmptyControlTypeData = () => ({
+  total: 0,
 });
 
 export const collectPanelsByType = (
@@ -98,6 +73,23 @@ export const collectDashboardSections = (
 ) => {
   collectorData.sections.total += attributes.sections?.length ?? 0;
   return collectorData;
+};
+
+export const collectStickyControls = (
+  controls: StoredControlGroupInput['panels'],
+  collectorData: DashboardCollectorData,
+  embeddableService: EmbeddablePersistableStateService
+) => {
+  const controlValues = Object.values(controls);
+  collectorData.controls.total += controlValues.length;
+
+  for (const control of controlValues) {
+    const type = control.type;
+    if (!collectorData.controls.by_type[type]) {
+      collectorData.controls.by_type[type] = getEmptyControlTypeData();
+    }
+    collectorData.controls.by_type[type].total += 1;
+  }
 };
 
 async function getLatestTaskState(taskManager: TaskManagerStartContract) {

--- a/src/platform/plugins/shared/dashboard/server/usage/dashboard_telemetry_collection_task.ts
+++ b/src/platform/plugins/shared/dashboard/server/usage/dashboard_telemetry_collection_task.ts
@@ -113,8 +113,6 @@ export function dashboardTaskRunner(logger: Logger, core: CoreSetup, embeddable:
               const controls = JSON.parse(
                 dashboard.attributes.controlGroupInput?.panelsJSON as string
               ) as unknown as StoredControlGroupInput['panels'];
-
-              console.log({ controls });
               collectStickyControls(controls, dashboardData, embeddable);
             } catch (e) {
               logger.warn('Unable to parse panelsJSON for telemetry collection');

--- a/src/platform/plugins/shared/dashboard/server/usage/dashboard_telemetry_collection_task.ts
+++ b/src/platform/plugins/shared/dashboard/server/usage/dashboard_telemetry_collection_task.ts
@@ -19,14 +19,15 @@ import type { CoreSetup, Logger, SavedObjectReference } from '@kbn/core/server';
 import { stateSchemaByVersion, emptyState, type LatestTaskStateSchema } from './task_state';
 
 import {
-  // controlsCollectorFactory,
   collectPanelsByType,
   getEmptyDashboardData,
   collectDashboardSections,
+  collectStickyControls,
 } from './dashboard_telemetry';
 import type {
   DashboardSavedObjectAttributes,
   SavedDashboardPanel,
+  StoredControlGroupInput,
 } from '../dashboard_saved_object';
 
 interface DashboardSavedObjectAttributesAndReferences {
@@ -94,7 +95,6 @@ export function dashboardTaskRunner(logger: Logger, core: CoreSetup, embeddable:
     return {
       async run() {
         let dashboardData = getEmptyDashboardData();
-        // const controlsCollector = controlsCollectorFactory(embeddable);
         const processDashboards = (dashboards: DashboardSavedObjectAttributesAndReferences[]) => {
           for (const dashboard of dashboards) {
             // TODO is this injecting references really necessary?
@@ -102,15 +102,20 @@ export function dashboardTaskRunner(logger: Logger, core: CoreSetup, embeddable:
             //   embeddablePersistableStateService: embeddable,
             // });
 
-            // dashboardData = controlsCollector(dashboard.attributes, dashboardData);
             dashboardData = collectDashboardSections(dashboard.attributes, dashboardData);
 
             try {
               const panels = JSON.parse(
                 dashboard.attributes.panelsJSON as string
               ) as unknown as SavedDashboardPanel[];
-
               collectPanelsByType(panels, dashboardData, embeddable);
+
+              const controls = JSON.parse(
+                dashboard.attributes.controlGroupInput?.panelsJSON as string
+              ) as unknown as StoredControlGroupInput['panels'];
+
+              console.log({ controls });
+              collectStickyControls(controls, dashboardData, embeddable);
             } catch (e) {
               logger.warn('Unable to parse panelsJSON for telemetry collection');
             }

--- a/src/platform/plugins/shared/dashboard/server/usage/register_collector.ts
+++ b/src/platform/plugins/shared/dashboard/server/usage/register_collector.ts
@@ -63,56 +63,19 @@ export function registerDashboardUsageCollector(
           },
         },
       },
-      // TODO https://github.com/elastic/kibana/issues/242763
-      // controls: {
-      //   total: { type: 'long' },
-      //   by_type: {
-      //     DYNAMIC_KEY: {
-      //       total: {
-      //         type: 'long',
-      //         _meta: {
-      //           description: 'The number of this type of control in all Control Groups',
-      //         },
-      //       },
-      //       details: {
-      //         DYNAMIC_KEY: {
-      //           type: 'long',
-      //           _meta: {
-      //             description:
-      //               'Collection of telemetry metrics that embeddable service reports. Will be used for details which are specific to the current control type',
-      //           },
-      //         },
-      //       },
-      //     },
-      //   },
-      //   ignore_settings: {
-      //     DYNAMIC_KEY: {
-      //       type: 'long',
-      //       _meta: {
-      //         description:
-      //           'Collection of telemetry metrics that count the number of control groups which have this ignore setting turned on',
-      //       },
-      //     },
-      //   },
-      //   chaining_system: {
-      //     DYNAMIC_KEY: {
-      //       type: 'long',
-      //       _meta: {
-      //         description:
-      //           'Collection of telemetry metrics that count the number of control groups which are using this chaining system',
-      //       },
-      //     },
-      //   },
-      //   label_position: {
-      //     DYNAMIC_KEY: {
-      //       type: 'long',
-      //       _meta: {
-      //         description:
-      //           'Collection of telemetry metrics that count the number of control groups which have their labels in this position',
-      //       },
-      //     },
-      //   },
-      // },
+      controls: {
+        total: { type: 'long' },
+        by_type: {
+          DYNAMIC_KEY: {
+            total: {
+              type: 'long',
+              _meta: {
+                description: 'The number of this type of control in all Control Groups',
+              },
+            },
+          },
+        },
+      },
       sections: {
         total: {
           type: 'long',

--- a/src/platform/plugins/shared/dashboard/server/usage/register_collector.ts
+++ b/src/platform/plugins/shared/dashboard/server/usage/register_collector.ts
@@ -64,13 +64,18 @@ export function registerDashboardUsageCollector(
         },
       },
       controls: {
-        total: { type: 'long' },
+        total: {
+          type: 'long',
+          _meta: {
+            description: 'The total number of pinned controls',
+          },
+        },
         by_type: {
           DYNAMIC_KEY: {
             total: {
               type: 'long',
               _meta: {
-                description: 'The number of this type of control in all Control Groups',
+                description: 'The number of pinned controls of this specific type',
               },
             },
           },

--- a/src/platform/plugins/shared/dashboard/server/usage/task_state.test.ts
+++ b/src/platform/plugins/shared/dashboard/server/usage/task_state.test.ts
@@ -21,9 +21,6 @@ describe('telemetry task state', () => {
           "telemetry": Object {
             "controls": Object {
               "by_type": Object {},
-              "chaining_system": Object {},
-              "ignore_settings": Object {},
-              "label_position": Object {},
               "total": 0,
             },
             "panels": Object {
@@ -51,9 +48,6 @@ describe('telemetry task state', () => {
           },
           controls: {
             total: 6,
-            chaining_system: { foo: 7 },
-            label_position: { foo: 8 },
-            ignore_settings: { foo: 9 },
             by_type: { foo: 10 },
           },
         },
@@ -70,9 +64,6 @@ describe('telemetry task state', () => {
           "telemetry": Object {
             "controls": Object {
               "by_type": Object {},
-              "chaining_system": Object {},
-              "ignore_settings": Object {},
-              "label_position": Object {},
               "total": 0,
             },
             "panels": Object {

--- a/src/platform/plugins/shared/dashboard/server/usage/task_state.ts
+++ b/src/platform/plugins/shared/dashboard/server/usage/task_state.ts
@@ -48,6 +48,15 @@ export const stateSchemaByVersion = {
             })
           ),
         }),
+        controls: schema.object({
+          total: schema.number(),
+          by_type: schema.recordOf(
+            schema.string(),
+            schema.object({
+              total: schema.number(),
+            })
+          ),
+        }),
         sections: schema.object({ total: schema.number() }),
       }),
     }),
@@ -64,6 +73,10 @@ export const emptyState: LatestTaskStateSchema = {
       total: 0,
       by_reference: 0,
       by_value: 0,
+      by_type: {},
+    },
+    controls: {
+      total: 0,
       by_type: {},
     },
     sections: {

--- a/src/platform/plugins/shared/dashboard/server/usage/task_state.ts
+++ b/src/platform/plugins/shared/dashboard/server/usage/task_state.ts
@@ -29,6 +29,10 @@ export const stateSchemaByVersion = {
           by_value: state.telemetry?.panels?.by_value || 0,
           by_type: state.telemetry?.panels?.by_type || {},
         },
+        controls: {
+          total: state.telemetry?.controls?.total || 0,
+          by_type: state.telemetry?.controls?.by_type || {},
+        },
       },
     }),
     schema: schema.object({

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -11032,7 +11032,7 @@
         "observability:streamsEnableGroupStreams": {
           "type": "boolean",
           "_meta": {
-            "description": "Enable Group streams in Streams"`
+            "description": "Enable Group streams in Streams"
           }
         },
           "observability:streamsEnableAttachments": {

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -9512,7 +9512,10 @@
         "controls": {
           "properties": {
             "total": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "The total number of pinned controls"
+              }
             },
             "by_type": {
               "properties": {
@@ -9521,7 +9524,7 @@
                     "total": {
                       "type": "long",
                       "_meta": {
-                        "description": "The number of this type of control in all Control Groups"
+                        "description": "The number of pinned controls of this specific type"
                       }
                     }
                   }

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -9509,6 +9509,27 @@
             }
           }
         },
+        "controls": {
+          "properties": {
+            "total": {
+              "type": "long"
+            },
+            "by_type": {
+              "properties": {
+                "DYNAMIC_KEY": {
+                  "properties": {
+                    "total": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "The number of this type of control in all Control Groups"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "sections": {
           "properties": {
             "total": {
@@ -11011,7 +11032,7 @@
             "description": "Enable Group streams in Streams"
           }
         },
-          "observability:streamsEnableAttachments": {
+        "observability:streamsEnableAttachments": {
           "type": "boolean",
           "_meta": {
             "description": "Enable Streams attachments tab."

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -11032,10 +11032,10 @@
         "observability:streamsEnableGroupStreams": {
           "type": "boolean",
           "_meta": {
-            "description": "Enable Group streams in Streams"
+            "description": "Enable Group streams in Streams"`
           }
         },
-        "observability:streamsEnableAttachments": {
+          "observability:streamsEnableAttachments": {
           "type": "boolean",
           "_meta": {
             "description": "Enable Streams attachments tab."


### PR DESCRIPTION
> [!WARNING]
> **_This work is being merged into a feature branch, not main!_**
> Because of this, we only need a review from @elastic/kibana-presentation for now.


Closes https://github.com/elastic/kibana/issues/242763

## Summary

This PR ensures that telemetry continues to be gathered for pinned controls. I kept the telemetry bare-bones - since we moved many control group settings to be individual control panel settings + dashboard settings, I decided not to implement these for now. Instead, we are just gathering the counts of each control type in the sticky section. Note that control **panels** will be gathered under the normal `"panel"` telemetry - and they also only contain counts of each panel type with no additional tracking of panel settings.

**Before**

```json
"controls": {
  "total": 9,
  "chaining_system": {
    "HIERARCHICAL": 4
  },
  "ignore_settings": {},
  "label_position": {
    "oneLine": 4
  },
  "by_type": {
    "optionsListControl": {
      "total": 6,
      "details": {}
    },
    "rangeSliderControl": {
      "total": 3,
      "details": {}
    }
  }
},
```

**After**

```json
"controls": {
  "total": 18,
  "by_type": {
    "optionsListControl": {
      "total": 12
    },
    "rangeSliderControl": {
      "total": 6
    }
  }
},
```