### PR TITLE
[ML] Inference/AI Connector and Inference endpoint creation:  ensures deleted text in form is not sent as empty string

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.tsx
@@ -414,7 +414,11 @@ export const ConfigurationField: React.FC<ConfigurationFieldProps> = ({
   isPreconfigured,
 }) => {
   const validateAndSetConfigValue = (value: number | string | boolean | Map) => {
-    setConfigValue(configEntry.type === FieldType.STRING && value === '' ? null : ensureCorrectTyping(configEntry.type, value));
+    setConfigValue(
+      configEntry.type === FieldType.STRING && value === ''
+        ? null
+        : ensureCorrectTyping(configEntry.type, value)
+    );
   };
 
   const { key, type, sensitive } = configEntry;

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.tsx
@@ -414,7 +414,7 @@ export const ConfigurationField: React.FC<ConfigurationFieldProps> = ({
   isPreconfigured,
 }) => {
   const validateAndSetConfigValue = (value: number | string | boolean | Map) => {
-    setConfigValue(ensureCorrectTyping(configEntry.type, value));
+    setConfigValue(configEntry.type === FieldType.STRING && value === '' ? null : ensureCorrectTyping(configEntry.type, value));
   };
 
   const { key, type, sensitive } = configEntry;


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/242943?reload=1?reload=1
Looks like this bug has been around so backporting the fix to the appropriate branches.
This PR sets empty string '' values for string fields in the form back to null when they are deleted from the form. Api will error when sending empty string values otherwise.

Before:

<img width="825" height="345" alt="image" src="https://github.com/user-attachments/assets/95b47dfa-dd6d-4443-a8d2-ddf5e634d752" />

After:


https://github.com/user-attachments/assets/ac1c7c92-1955-4dac-8a35-22d7ed54de71





### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->