### PR TITLE
[9.1] [Fleet] Fix fetch package from ES to not corrupt cache (#243700)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/storage.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/storage.test.ts
@@ -6,20 +6,17 @@
  */
 
 import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 
-import { getAsset } from './storage';
-
-jest.mock('../../app_context', () => {
-  return {
-    appContextService: {
-      getLogger: jest.fn().mockReturnValue({
-        warn: jest.fn(),
-      }),
-    },
-  };
-});
+import { getAsset, getEsPackage } from './storage';
+import { appContextService } from '../../app_context';
+import { createAppContextStartContractMock } from '../../../mocks';
+import { filterAssetPathForParseAndVerifyArchive } from './parse';
 
 describe('getAsset', () => {
+  beforeEach(() => {
+    appContextService.start(createAppContextStartContractMock());
+  });
   it('should not throw error if saved object not found', async () => {
     const soClientMock = {
       get: jest.fn().mockRejectedValue(SavedObjectsErrorHelpers.createGenericNotFoundError()),
@@ -29,5 +26,124 @@ describe('getAsset', () => {
       path: 'path',
     });
     expect(result).toBeUndefined();
+  });
+});
+
+describe('getEsPackage', () => {
+  beforeEach(() => {
+    appContextService.start(createAppContextStartContractMock());
+  });
+  const PACKAGE_ASSETS: Array<[string, string]> = [
+    ['test-1.0.0/LICENSE.txt', ''],
+    ['test-1.0.0/changelog.yml', ''],
+    ['test-1.0.0/manifest.yml', 'name: test\nversion: 1.0.0\ntitle: Test\nowner: Elastic\n'],
+    ['test-1.0.0/docs/README.md', ''],
+    ['test-1.0.0/data_stream/ds1/manifest.yml', 'type: logs\ntitle: DS1\n'],
+    ['test-1.0.0/data_stream/ds1/elasticsearch/ingest_pipeline/default.yml', ''],
+  ];
+
+  it('should allow to fetch a package from ES', async () => {
+    const soClient = savedObjectsClientMock.create();
+
+    soClient.bulkGet.mockResolvedValueOnce({
+      saved_objects: PACKAGE_ASSETS.map(([path, content]) => ({
+        id: `epm-packages-assets:${path}`,
+        type: 'epm-packages-assets',
+        attributes: {
+          package_name: 'test',
+          package_version: '1.0.0',
+          install_source: 'registry',
+          asset_path: path,
+          media_type: 'text/plain',
+          data_utf8: content,
+          data_base64: '',
+        },
+        references: [],
+        version: 'WzEwLDFd',
+      })),
+    });
+
+    const test = await getEsPackage(
+      'test',
+      '1.0.0',
+      PACKAGE_ASSETS.map(([path]) => ({
+        id: `epm-packages-assets:${path}`,
+        path,
+        type: 'epm-packages-assets',
+      })),
+      soClient
+    );
+
+    expect(test?.paths).toEqual(PACKAGE_ASSETS.map(([path]) => path));
+  });
+
+  it('should return all paths even when filtering assets to fetch', async () => {
+    const soClient = savedObjectsClientMock.create();
+
+    soClient.bulkGet.mockResolvedValueOnce({
+      saved_objects: PACKAGE_ASSETS.map(([path, content]) => ({
+        id: `epm-packages-assets:${path}`,
+        type: 'epm-packages-assets',
+        attributes: {
+          package_name: 'test',
+          package_version: '1.0.0',
+          install_source: 'registry',
+          asset_path: path,
+          media_type: 'text/plain',
+          data_utf8: content,
+          data_base64: '',
+        },
+        references: [],
+        version: 'WzEwLDFd',
+      })),
+    });
+
+    const test = await getEsPackage(
+      'test',
+      '1.0.0',
+      PACKAGE_ASSETS.map(([path]) => ({
+        id: `epm-packages-assets:${path}`,
+        path,
+        type: 'epm-packages-assets',
+      })),
+      soClient,
+      {
+        shouldFetchBuffer: (reference) => {
+          return reference.path ? filterAssetPathForParseAndVerifyArchive(reference.path) : true;
+        },
+      }
+    );
+
+    expect(test?.paths).toEqual(PACKAGE_ASSETS.map(([path]) => path));
+
+    const onlyPathAssets = soClient.bulkGet.mock.calls[0][0]
+      .filter(({ fields }) => fields?.length === 1 && fields[0] === 'asset_path')
+      .map(({ id }) => id);
+
+    expect(onlyPathAssets).toMatchInlineSnapshot(`
+      Array [
+        "epm-packages-assets:test-1.0.0/LICENSE.txt",
+        "epm-packages-assets:test-1.0.0/changelog.yml",
+        "epm-packages-assets:test-1.0.0/docs/README.md",
+        "epm-packages-assets:test-1.0.0/data_stream/ds1/elasticsearch/ingest_pipeline/default.yml",
+      ]
+    `);
+
+    const withDataAssets = soClient.bulkGet.mock.calls[0][0]
+      .filter(
+        ({ fields }) =>
+          fields?.length === 3 &&
+          fields.includes('asset_path') &&
+          fields.includes('data_utf8') &&
+          fields.includes('data_base64')
+      )
+      .map(({ id }) => id);
+
+    expect(withDataAssets).toMatchInlineSnapshot(`
+      Array [
+        "epm-packages-assets:test-1.0.0/manifest.yml",
+        "epm-packages-assets:test-1.0.0/data_stream/ds1/manifest.yml",
+      ]
+    `);
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get.ts
@@ -71,6 +71,10 @@ import { auditLoggingService } from '../../audit_logging';
 import { getFilteredSearchPackages } from '../filtered_packages';
 import { filterAssetPathForParseAndVerifyArchive } from '../archive/parse';
 import { airGappedUtils } from '../airgapped';
+import type {
+  PackageAssetReference,
+  RegistryPolicyTemplate,
+} from '../../../../common/types/models/epm';
 
 import { createInstallableFrom } from '.';
 import {
@@ -749,18 +753,20 @@ export async function getInstalledPackageWithAssets(options: {
   if (!installation) {
     return;
   }
-  const assetsReference =
-    (typeof options.assetsFilter !== 'undefined'
-      ? installation.package_assets?.filter(({ path }) =>
-          typeof path !== 'undefined' ? options.assetsFilter!(path) : true
-        )
-      : installation.package_assets) ?? [];
 
   const esPackage = await getEsPackage(
     installation.name,
     installation.version,
-    assetsReference,
-    options.savedObjectsClient
+    installation.package_assets ?? [],
+    options.savedObjectsClient,
+    {
+      shouldFetchBuffer: (reference: PackageAssetReference) => {
+        if (typeof options.assetsFilter === 'undefined' || typeof reference.path === 'undefined') {
+          return true;
+        }
+        return options.assetsFilter(reference.path);
+      },
+    }
   );
 
   if (!esPackage) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get.ts
@@ -71,10 +71,7 @@ import { auditLoggingService } from '../../audit_logging';
 import { getFilteredSearchPackages } from '../filtered_packages';
 import { filterAssetPathForParseAndVerifyArchive } from '../archive/parse';
 import { airGappedUtils } from '../airgapped';
-import type {
-  PackageAssetReference,
-  RegistryPolicyTemplate,
-} from '../../../../common/types/models/epm';
+import type { PackageAssetReference } from '../../../../common/types/models/epm';
 
 import { createInstallableFrom } from '.';
 import {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Fleet] Fix fetch package from ES to not corrupt cache (#243700)](https://github.com/elastic/kibana/pull/243700)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2025-11-24T20:09:43Z","message":"[Fleet] Fix fetch package from ES to not corrupt cache (#243700)","sha":"d6856142379ead4a3e1c78d975b7bad146e9ad1d","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.3.0","v9.2.2","v9.1.8"],"title":"[Fleet] Fix fetch package from ES to not corrupt cache","number":243700,"url":"https://github.com/elastic/kibana/pull/243700","mergeCommit":{"message":"[Fleet] Fix fetch package from ES to not corrupt cache (#243700)","sha":"d6856142379ead4a3e1c78d975b7bad146e9ad1d"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243700","number":243700,"mergeCommit":{"message":"[Fleet] Fix fetch package from ES to not corrupt cache (#243700)","sha":"d6856142379ead4a3e1c78d975b7bad146e9ad1d"}},{"branch":"9.2","label":"v9.2.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/244062","number":244062,"state":"OPEN"},{"branch":"9.1","label":"v9.1.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->