### PR TITLE
[CI] `moon.yml`s will now be owned by teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3089,7 +3089,6 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 
 # Moon related configs
 .moon         @elastic/kibana-operations
-/**/moon.yml  @elastic/kibana-operations
 
 ####
 ## These rules are always last so they take ultimate priority over everything else

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3089,6 +3089,10 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 
 # Moon related configs
 .moon         @elastic/kibana-operations
+src/platform/test/moon.yml @elastic/kibana-operations
+x-pack/platform/test/moon.yml @elastic/kibana-operations
+x-pack/solutions/observability/test/moon.yml @elastic/kibana-operations
+x-pack/solutions/security/test/moon.yml @elastic/kibana-operations
 
 ####
 ## These rules are always last so they take ultimate priority over everything else

--- a/x-pack/platform/packages/shared/kbn-evals/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-evals/moon.yml
@@ -33,6 +33,7 @@ dependsOn:
   - '@kbn/std'
   - '@kbn/test'
   - '@kbn/inference-prompt-utils'
+  - '@kbn/tracing-utils'
 tags:
   - test-helper
   - package

--- a/x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/moon.yml
+++ b/x-pack/platform/packages/shared/onechat/kbn-evals-suite-onechat/moon.yml
@@ -22,6 +22,7 @@ dependsOn:
   - '@kbn/onechat-common'
   - '@kbn/tooling-log'
   - '@kbn/core'
+  - '@kbn/scout'
 tags:
   - functional-tests
   - package


### PR DESCRIPTION
## Summary
We originally wanted to have ownership of the `moon.yml` files at Kibana Operations, so while it's still malleable, we'd have blanket approve rights for a wider-scale update. This however, adds us a required (or with some change optional) approvers. Still a lot of noise to the already over-loaded team on approvals. 

So we've decided to remove the `moon.yml` ownership from `kibana-operations` - it will be approvable by teams from now.


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->