### PR TITLE
[8.18] [Docs] Adds 2 missing genAI observability advanced settings (#243993)

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -501,6 +501,12 @@ Switch to fetch the TopN Functions from the Stacktraces API.
 [[observability-profiling-cost-per-vcpu-per-hour]]`observability:profilingCostPervCPUPerHour`::
 Default Hourly Cost per CPU Core for machines not on AWS or Azure.
 
+[[gen-ai-settings-default-ai-connector]]`genAiSettings:defaultAIConnector`::
+Sets the default AI connector to power the AI Assistant and AI-driven features in Elastic. Select a generative AI connector from your available pre-configured or custom connectors. The default value is `NO_DEFAULT_CONNECTOR`. When no connector is selected, Elastic uses the Elastic Managed LLM connector when available, or the last used custom connector.
+
+[[gen-ai-settings-default-ai-connector-only]]`genAiSettings:defaultAIConnectorOnly`::
+When enabled, only the default AI connector selected in `genAiSettings:defaultAIConnector` is shown to users of this space. This restricts users from selecting other available connectors. The default value is `false`.
+
 [float]
 [[kibana-reporting-settings]]
 ==== Reporting


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.18`:
 - [[Docs] Adds 2 missing genAI observability advanced settings (#243993)](https://github.com/elastic/kibana/pull/243993)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"florent-leborgne","email":"florent.leborgne@elastic.co"},"sourceCommit":{"committedDate":"2025-11-25T08:53:42Z","message":"[Docs] Adds 2 missing genAI observability advanced settings (#243993)\n\nThis PR adds 2 missing advanced settings from the Observability solution\nsection.\n\nCloses: https://github.com/elastic/docs-content-internal/issues/394\n\n- [x] Used AI to write description and read defaults from the codebase\n\nI'll backport this to 8.18 too","sha":"5e9b6eca47168d9dba2eb75f6fe495926082f60e","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","backport:version","v8.18.9"],"title":"[Docs] Adds 2 missing genAI observability advanced settings","number":243993,"url":"https://github.com/elastic/kibana/pull/243993","mergeCommit":{"message":"[Docs] Adds 2 missing genAI observability advanced settings (#243993)\n\nThis PR adds 2 missing advanced settings from the Observability solution\nsection.\n\nCloses: https://github.com/elastic/docs-content-internal/issues/394\n\n- [x] Used AI to write description and read defaults from the codebase\n\nI'll backport this to 8.18 too","sha":"5e9b6eca47168d9dba2eb75f6fe495926082f60e"}},"sourceBranch":"8.19","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->