### PR TITLE
[Renovate] disable p-map and p-retry

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3416,7 +3416,7 @@
         "blocked"
       ],
       "minimumReleaseAge": "14 days",
-      "enabled": true
+      "enabled": false
     },
     {
       "groupName": "p-retry - ESM Required",
@@ -3438,7 +3438,7 @@
         "effort:low"
       ],
       "minimumReleaseAge": "14 days",
-      "enabled": true
+      "enabled": false
     },
     {
       "groupName": "redux-actions",


### PR DESCRIPTION
## Summary

disable p-map and p-retry, since we can't upgrade these due to some babel issue 

<img width="1583" height="632" alt="image" src="https://github.com/user-attachments/assets/d097d547-a995-42cc-ace4-064b6887bd0c" />

