### PR TITLE
[Streams] Remove failing test suite on disabled stream features

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/streams/classic.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/streams/classic.ts
@@ -7,13 +7,12 @@
 
 import expect from '@kbn/expect';
 import { Streams } from '@kbn/streams-schema';
-import { isNotFoundError } from '@kbn/es-errors';
 import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 import {
   StreamsSupertestRepositoryClient,
   createStreamsRepositoryAdminClient,
 } from './helpers/repository_client';
-import { fetchDocument, indexDocument, putStream } from './helpers/requests';
+import { fetchDocument, indexDocument } from './helpers/requests';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   const roleScopedSupertest = getService('roleScopedSupertest');
@@ -221,167 +220,6 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         (stream) => stream.name === TEST_STREAM_NAME
       );
       expect(classicStream).to.eql(undefined);
-    });
-
-    // Failing test on ES Promotion: https://github.com/elastic/kibana/issues/235001
-    describe.skip('Classic streams sharing template/pipeline', () => {
-      const TEMPLATE_NAME = 'my-shared-template';
-      const FIRST_STREAM_NAME = 'mytest-first';
-      const SECOND_STREAM_NAME = 'mytest-second';
-
-      before(async () => {
-        await esClient.indices.putIndexTemplate({
-          name: TEMPLATE_NAME,
-          index_patterns: ['mytest*'],
-          priority: 1000,
-          template: {},
-          data_stream: {
-            allow_custom_routing: false,
-            hidden: false,
-          },
-        });
-      });
-
-      after(async () => {
-        // First, ensure all data streams are deleted to avoid template deletion conflicts
-        try {
-          await esClient.indices.deleteDataStream({
-            name: [FIRST_STREAM_NAME, SECOND_STREAM_NAME],
-          });
-        } catch (error) {
-          // Ignore if already deleted
-        }
-
-        // Then delete the template
-        await esClient.indices.deleteIndexTemplate({
-          name: TEMPLATE_NAME,
-        });
-      });
-
-      it('creates an ingest pipeline and updates the template when the first stream is created', async () => {
-        await esClient.indices.createDataStream({
-          name: FIRST_STREAM_NAME,
-        });
-
-        await putStream(apiClient, FIRST_STREAM_NAME, {
-          dashboards: [],
-          queries: [],
-          stream: {
-            description: '',
-            ingest: {
-              lifecycle: { inherit: {} },
-              processing: [
-                {
-                  grok: {
-                    if: { always: {} },
-                    field: 'message',
-                    patterns: [
-                      '%{TIMESTAMP_ISO8601:inner_timestamp} %{LOGLEVEL:log.level} %{GREEDYDATA:message2}',
-                    ],
-                  },
-                },
-              ],
-              unwired: {},
-            },
-          },
-        });
-
-        const templateResponse = await esClient.indices.getIndexTemplate({
-          name: TEMPLATE_NAME,
-        });
-        const template = templateResponse.index_templates[0];
-        expect(template.index_template.template?.settings?.index?.default_pipeline).to.equal(
-          'my-shared-template-pipeline'
-        );
-
-        const pipelineResponse = await esClient.ingest.getPipeline({
-          id: `${TEMPLATE_NAME}-pipeline`,
-        });
-        const pipeline = pipelineResponse[`${TEMPLATE_NAME}-pipeline`];
-        expect(pipeline._meta?.managed_by).to.eql('streams');
-        expect(pipeline.processors?.[0].pipeline?.name).to.eql('mytest-first@stream.processing');
-      });
-
-      it('updates the ingest pipeline when the second stream is created', async () => {
-        await esClient.indices.createDataStream({
-          name: SECOND_STREAM_NAME,
-        });
-
-        await putStream(apiClient, SECOND_STREAM_NAME, {
-          dashboards: [],
-          queries: [],
-          stream: {
-            description: '',
-            ingest: {
-              lifecycle: { inherit: {} },
-              processing: [
-                {
-                  grok: {
-                    if: { always: {} },
-                    field: 'message',
-                    patterns: [
-                      '%{TIMESTAMP_ISO8601:inner_timestamp} %{LOGLEVEL:log.level} %{GREEDYDATA:message2}',
-                    ],
-                  },
-                },
-              ],
-              unwired: {},
-            },
-          },
-        });
-
-        const pipelineResponse = await esClient.ingest.getPipeline({
-          id: `${TEMPLATE_NAME}-pipeline`,
-        });
-        const pipeline = pipelineResponse[`${TEMPLATE_NAME}-pipeline`];
-        expect(pipeline.processors?.map((processor) => processor.pipeline?.name)).to.eql([
-          'mytest-first@stream.processing',
-          'mytest-second@stream.processing',
-        ]);
-      });
-
-      it('updates the ingest pipeline when one of the streams is deleted', async () => {
-        await apiClient.fetch('DELETE /api/streams/{name} 2023-10-31', {
-          params: {
-            path: {
-              name: FIRST_STREAM_NAME,
-            },
-          },
-        });
-
-        const pipelineResponse = await esClient.ingest.getPipeline({
-          id: `${TEMPLATE_NAME}-pipeline`,
-        });
-        const pipeline = pipelineResponse[`${TEMPLATE_NAME}-pipeline`];
-        expect(pipeline.processors?.[0].pipeline?.name).to.eql('mytest-second@stream.processing');
-      });
-
-      it('deletes the ingest pipeline and restores the template when both streams are deleted', async () => {
-        await apiClient.fetch('DELETE /api/streams/{name} 2023-10-31', {
-          params: {
-            path: {
-              name: SECOND_STREAM_NAME,
-            },
-          },
-        });
-
-        const templateResponse = await esClient.indices.getIndexTemplate({
-          name: TEMPLATE_NAME,
-        });
-        const template = templateResponse.index_templates[0];
-        expect(template.index_template.template?.settings?.index?.default_pipeline).to.equal(
-          undefined
-        );
-
-        try {
-          await esClient.ingest.getPipeline({
-            id: `${TEMPLATE_NAME}-pipeline`,
-          });
-          throw new Error('Expected to throw due to missing pipeline');
-        } catch (error) {
-          expect(isNotFoundError(error)).to.eql(true);
-        }
-      });
     });
 
     describe('Classic stream without pipeline', () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/streams/classic.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/streams/classic.ts
@@ -223,7 +223,8 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       expect(classicStream).to.eql(undefined);
     });
 
-    describe('Classic streams sharing template/pipeline', () => {
+    // Failing test on ES Promotion: https://github.com/elastic/kibana/issues/235001
+    describe.skip('Classic streams sharing template/pipeline', () => {
       const TEMPLATE_NAME = 'my-shared-template';
       const FIRST_STREAM_NAME = 'mytest-first';
       const SECOND_STREAM_NAME = 'mytest-second';

--- a/x-pack/solutions/observability/test/tsconfig.json
+++ b/x-pack/solutions/observability/test/tsconfig.json
@@ -96,7 +96,6 @@
     "@kbn/cypress-test-helper",
     "@kbn/streams-schema",
     "@kbn/streams-plugin",
-    "@kbn/es-errors",
     "@kbn/content-packs-schema",
     "@kbn/server-route-repository-utils",
     "@kbn/guided-onboarding-plugin",


### PR DESCRIPTION
## 📓 Summary

Related to https://github.com/elastic/kibana/issues/235001

Removing this test suite, which consistently causes failure on the forward compatibility tests pipeline, as the feature is not even enabled in 8.19.