### PR TITLE
[9.1] [Oblt Onboarding] Replace non-POSIX `arch` command with `uname -m`

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
@@ -115,7 +115,7 @@ export const OtelLogsPanel: React.FC = () => {
       id: 'linux',
       name: 'Linux',
       firstStepTitle: HOST_COMMAND,
-      content: `arch=$(if ([[ $(arch) == "arm" || $(arch) == "aarch64" ]]); then echo "arm64"; else echo $(arch); fi)
+      content: `arch=$(if [[ $(uname -m) == "arm" || $(uname -m) == "aarch64" ]]; then echo "arm64"; else echo $(uname -m); fi)
 
 curl --output elastic-distro-${agentVersion}-linux-$arch.tar.gz --url https://${AGENT_CDN_BASE_URL}/elastic-agent-${agentVersion}-linux-$arch.tar.gz --proto '=https' --tlsv1.2 -fL && mkdir -p elastic-distro-${agentVersion}-linux-$arch && tar -xvf elastic-distro-${agentVersion}-linux-$arch.tar.gz -C "elastic-distro-${agentVersion}-linux-$arch" --strip-components=1 && cd elastic-distro-${agentVersion}-linux-$arch
 


### PR DESCRIPTION
## Summary
Backport of #243991

The `arch` utility is not part of POSIX and is not installed by default on many systems (e.g. Arch Linux). According to GNU Coreutils documentation:
https://www.gnu.org/software/coreutils/manual/coreutils.html#arch-invocation
> arch is not installed by default, so portable scripts should not
> rely on its existence.

The POSIX-standard way to get the machine hardware name is `uname -m` as specified in:
https://pubs.opengroup.org/onlinepubs/9799919799/utilities/uname.html

This change replaces all instances of `$(arch)` with `$(uname -m)` in the Linux install command builder, ensuring better portability across different Unix-like systems. The macOS case already used `uname -m` correctly.

Also fixed a minor syntax issue: changed `if ([[ ... ]]` to `if [[ ... ]]` to match standard bash syntax.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Skipping backport because https://github.com/elastic/kibana/pull/234052 is also `backport:skip`

Related to:
- https://github.com/elastic/kibana/issues/194872
- https://github.com/elastic/kibana/pull/234052