### PR TITLE
Catch connector errors but do not interrupt the case creation flow

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/create/form_context.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/form_context.tsx
@@ -90,10 +90,18 @@ export const FormContext: React.FC<Props> = ({
         }
 
         if (theCase?.id && data.connector.id !== 'none') {
-          await pushCaseToExternalService({
-            caseId: theCase.id,
-            connector: data.connector,
-          });
+          try {
+            await pushCaseToExternalService({
+              caseId: theCase.id,
+              connector: data.connector,
+            });
+          } catch (error) {
+            // Catch the error but do not interrupt the flow.
+            // The case has been created successfully at this point.
+            // The only thing that failed was pushing to the external service.
+            // Changes to the connector fields can be made later on by the user.
+            // They will be notified about the connector failure.
+          }
         }
 
         if (onSuccess && theCase) {

--- a/x-pack/solutions/security/test/moon.yml
+++ b/x-pack/solutions/security/test/moon.yml
@@ -53,6 +53,7 @@ dependsOn:
   - '@kbn/management-settings-ids'
   - '@kbn/connector-schemas'
   - '@kbn/cloud-security-posture-graph'
+  - '@kbn/securitysolution-list-constants'
 tags:
   - test-helper
   - package


### PR DESCRIPTION
## Summary

Addresses: https://github.com/elastic/kibana/issues/243852

During case creation, when the case connector failed to push, the case creation form would get stuck in a loading state. To the user that looked like the case had not been created and they'd lost their work. However, the case had been created but only the connector failed to push. 

Since the case connector issues can be resolved from the case page, we can redirect users to the case page even when the connector fails to push. On top, a message is show to the user with details about the connector failure.

<!--ONMERGE {"backportTargets":["9.0","9.1","9.2"]} ONMERGE-->