### PR TITLE
[ES|QL] First section of inline documentation has extra space

### DIFF
--- a/src/platform/packages/private/kbn-language-documentation/src/components/shared/documentation_content.tsx
+++ b/src/platform/packages/private/kbn-language-documentation/src/components/shared/documentation_content.tsx
@@ -98,9 +98,11 @@ function DocumentationContent({
               <section
                 key={helpGroup.label}
                 css={css`
-                  border-top: ${theme.euiTheme.border.thin};
-                  padding-top: ${theme.euiTheme.size.xxl};
-                  margin-top: ${theme.euiTheme.size.xxl};
+                  &:not(:first-of-type) {
+                    border-top: ${theme.euiTheme.border.thin};
+                    padding-top: ${theme.euiTheme.size.xxl};
+                    margin-top: ${theme.euiTheme.size.xxl};
+                  }
                 `}
                 ref={(el) => {
                   if (el) {


### PR DESCRIPTION
## Summary

fixes https://github.com/elastic/kibana/issues/243939

The inline documentation had extra space at the beginning of every section tag, to separate between them, but this was also applied to the first one where the extra space was not really necessary.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
