### PR TITLE
[Lens]Unsaved changes on save and return when Lens has panel filters

### DIFF
--- a/src/platform/plugins/shared/data/common/query/filters/persistable_state.ts
+++ b/src/platform/plugins/shared/data/common/query/filters/persistable_state.ts
@@ -48,7 +48,7 @@ export const inject = (filters: Filter[], references: SavedObjectReference[]) =>
       meta: {
         ...filter.meta,
         // if no reference has been found, keep the current "index" property (used for adhoc data views)
-        index: reference ? reference.id : filter.meta.index,
+        index: reference ? reference.id : filter.meta.index, // here the transformation happens
       },
     };
   });

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/app.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/app.tsx
@@ -124,6 +124,7 @@ export function App({
     visualization,
     annotationGroups,
   } = useLensSelector((state) => state.lens);
+  console.log(persistedDoc, 'persistedDoc in App component');
 
   const activeVisualization = visualization.activeId
     ? visualizationMap[visualization.activeId]
@@ -141,6 +142,7 @@ export function App({
   const currentDoc = useLensSelector((state) =>
     selectSavedObjectFormat(state, selectorDependencies)
   );
+  console.log(currentDoc, 'currentDoc in App component');
 
   // Used to show a popover that guides the user towards changing the date range when no data is available.
   const [indicateNoData, setIndicateNoData] = useState(false);

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_document_equality.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_document_equality.ts
@@ -88,6 +88,9 @@ export const isLensEqual = (
     return false;
   }
 
+  console.log(doc1.state.filters[0].meta.index, 'doc1'); // the docs have different state.filters[0].meta.index - values
+  console.log(doc2.state.filters[0].meta.index, 'doc2');
+
   const [filtersInjected1, filtersInjected2] = [doc1, doc2].map((doc) =>
     removePinnedFilters(injectDocFilterReferences(injectFilterReferences, doc))
   );

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_state_management.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_state_management.ts
@@ -62,7 +62,7 @@ export function initializeStateManagement(
     anyStateChange$: merge(internalApi.attributes$).pipe(map(() => undefined)),
     getComparators: () => {
       return {
-        attributes: initialState.savedObjectId === undefined ? 'deepEquality' : 'skip',
+        attributes: initialState.savedObjectId === undefined ? 'deepEquality' : 'skip', // here
         savedObjectId: 'skip',
       };
     },

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/lens_embeddable.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/lens_embeddable.tsx
@@ -64,7 +64,10 @@ export const createLensEmbeddableFactory = (
       );
 
       const initialRuntimeState = await deserializeState(services, initialState.rawState);
-
+      console.log(
+        initialRuntimeState?.attributes?.state?.filters[0].meta.index,
+        'initialRuntimeState"'
+      ); // this is changing before and after navigating back from lens editor to dashboard
       /**
        * Observables and functions declared here are used internally to store mutating state values
        * This is an internal API not exposed outside of the embeddable.


### PR DESCRIPTION
Investigation of #174786

The log below shows the state diff that triggers the “unsaved changes” badge, even though there are no changes in the Lens editor; the attributes differ only in the index pattern identifiers of the filters.

<img width="581" height="389" alt="Screenshot 2025-11-25 at 18 15 58" src="https://github.com/user-attachments/assets/455b78aa-683c-48ac-a070-b5f543ef309e" />

I added logs in the code in this PR at the points where the transformation of filters index occurs and where differences in the compared documents appear.

From the dashboard’s perspective, these changes in the filters index cause the “Unsaved Changes” badge to appear, even though Lens itself considers the filters equal. At the dashboard level, the comparison uses deep equality, which includes these dynamic index values.

Below the video demonstrating the issue and the logs:

https://github.com/user-attachments/assets/bd7a1039-466d-47a3-9a41-8c3bea5e6ff5

