### PR TITLE
[9.1] Fix kbn fs tsconfig

### DIFF
--- a/x-pack/platform/packages/shared/kbn-fs/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-fs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../../../tsconfig.base.json",
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
   "compilerOptions": {
     "outDir": "target/types",
     "types": [


### PR DESCRIPTION
## Summary
Fixes currently breaking on-merge's quick-checks. It's broken because the check was checked/merged parallel to the `kbn-fs` backport. 