### PR TITLE
[9.2] [ML] Inference/AI Connector and Inference endpoint creation:  ensure deleted text in form is not sent as empty string (#244059)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/configuration/configuration_field.tsx
@@ -208,7 +208,11 @@ export const ConfigurationField: React.FC<ConfigurationFieldProps> = ({
   isPreconfigured,
 }) => {
   const validateAndSetConfigValue = (value: number | string | boolean) => {
-    setConfigValue(ensureCorrectTyping(configEntry.type, value));
+    setConfigValue(
+      configEntry.type === FieldType.STRING && value === ''
+        ? null
+        : ensureCorrectTyping(configEntry.type, value)
+    );
   };
 
   const { key, type, sensitive } = configEntry;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[ML] Inference/AI Connector and Inference endpoint creation:  ensure deleted text in form is not sent as empty string (#244059)](https://github.com/elastic/kibana/pull/244059)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Melissa Alvarez","email":"melissa.alvarez@elastic.co"},"sourceCommit":{"committedDate":"2025-11-25T19:03:52Z","message":"[ML] Inference/AI Connector and Inference endpoint creation:  ensure deleted text in form is not sent as empty string (#244059)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/242943?reload=1?reload=1\nLooks like this bug has been around so backporting the fix to the\nappropriate branches.\nThis PR sets empty string '' values for string fields in the form back\nto null when they are deleted from the form. Api will error when sending\nempty string values otherwise.\n\nBefore:\n\n<img width=\"825\" height=\"345\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/95b47dfa-dd6d-4443-a8d2-ddf5e634d752\"\n/>\n\nAfter:\n\n\n\nhttps://github.com/user-attachments/assets/ac1c7c92-1955-4dac-8a35-22d7ed54de71\n\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"be957d3167c14e5e7857a7177e7faf80d277e625","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","backport:version","Feature:Inference UI","v9.3.0","Feature: AI Infra","v8.19.8","v9.2.2","v9.1.8"],"title":"[ML] Inference/AI Connector and Inference endpoint creation:  ensure deleted text in form is not sent as empty string","number":244059,"url":"https://github.com/elastic/kibana/pull/244059","mergeCommit":{"message":"[ML] Inference/AI Connector and Inference endpoint creation:  ensure deleted text in form is not sent as empty string (#244059)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/242943?reload=1?reload=1\nLooks like this bug has been around so backporting the fix to the\nappropriate branches.\nThis PR sets empty string '' values for string fields in the form back\nto null when they are deleted from the form. Api will error when sending\nempty string values otherwise.\n\nBefore:\n\n<img width=\"825\" height=\"345\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/95b47dfa-dd6d-4443-a8d2-ddf5e634d752\"\n/>\n\nAfter:\n\n\n\nhttps://github.com/user-attachments/assets/ac1c7c92-1955-4dac-8a35-22d7ed54de71\n\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"be957d3167c14e5e7857a7177e7faf80d277e625"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.2","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/244059","number":244059,"mergeCommit":{"message":"[ML] Inference/AI Connector and Inference endpoint creation:  ensure deleted text in form is not sent as empty string (#244059)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/242943?reload=1?reload=1\nLooks like this bug has been around so backporting the fix to the\nappropriate branches.\nThis PR sets empty string '' values for string fields in the form back\nto null when they are deleted from the form. Api will error when sending\nempty string values otherwise.\n\nBefore:\n\n<img width=\"825\" height=\"345\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/95b47dfa-dd6d-4443-a8d2-ddf5e634d752\"\n/>\n\nAfter:\n\n\n\nhttps://github.com/user-attachments/assets/ac1c7c92-1955-4dac-8a35-22d7ed54de71\n\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"be957d3167c14e5e7857a7177e7faf80d277e625"}},{"branch":"8.19","label":"v8.19.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->