### PR TITLE
[Contextual Security][Serverless] Fix K8S Link

### DIFF
--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/dashboards_navigation_tree.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/dashboards_navigation_tree.ts
@@ -38,5 +38,9 @@ export const createDashboardsNavigationTree = (): NodeDefinition => ({
       id: SecurityPageName.dataQuality,
       link: securityLink(SecurityPageName.dataQuality),
     },
+    {
+      id: SecurityPageName.kubernetes,
+      link: securityLink(SecurityPageName.kubernetes),
+    },
   ],
 });


### PR DESCRIPTION
## Summary

On this previous [PR](https://github.com/elastic/kibana/pull/243431), we brought back K8S Dashboard. However there seems to be an issue when user clicks on the K8S Dashboard option in Dashboard page,

Instead of getting navigated to K8S page, user gets navigate to main page instead.

This issue only occurs on **Serverless** env.

This PR addresses this issue.

<img width="1611" height="477" alt="Screenshot 2025-11-25 at 2 03 54 PM" src="https://github.com/user-attachments/assets/d4221ac9-e1f6-4d95-9a62-8cd4d21d95fd" />




