### PR TITLE
[Security Solution][Entity Analytics][PrivMon][Tests] Fixing Privmon Test Flakiness

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_integrations_sync.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_integrations_sync.ts
@@ -16,8 +16,7 @@ export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const privMonUtils = PrivMonUtils(getService);
 
-  // Failing: See https://github.com/elastic/kibana/issues/243599
-  describe.skip('@ess @serverless @skipInServerlessMKI Entity Privilege Monitoring Engine Integrations Sync', () => {
+  describe('@ess @serverless @skipInServerlessMKI Entity Privilege Monitoring Engine Integrations Sync', () => {
     describe('integrations sync', async () => {
       beforeEach(async () => {
         await esArchiver.load(
@@ -139,12 +138,10 @@ export default ({ getService }: FtrProviderContext) => {
           nowMinus2M,
           privMonUtils.integrationsSync.OKTA_INDEX
         );
-        await privMonUtils.runSync();
-        const snapA = await privMonUtils.integrationsSync.expectUserCount(4);
+        const snapA = await privMonUtils.scheduleEngineAndWaitForUserCount(4);
 
         // PHASE 2: Re-run with no changes => no processing, marker should be default (now-1M)
-        await privMonUtils.runSync();
-        const snapB = await privMonUtils.integrationsSync.expectUserCount(4);
+        const snapB = await privMonUtils.scheduleEngineAndWaitForUserCount(4);
         expect(new Set(snapB)).toEqual(new Set(snapA));
 
         const markerAfterPhase2 = await privMonUtils.integrationsSync.getLastProcessedMarker(
@@ -160,7 +157,7 @@ export default ({ getService }: FtrProviderContext) => {
           nowMinus1w,
           privMonUtils.integrationsSync.OKTA_INDEX
         );
-        await privMonUtils.runSync();
+        await privMonUtils.scheduleEngineAndWaitForUserCount(4);
         const markerAfterPhase3 = await privMonUtils.integrationsSync.getLastProcessedMarker(
           privMonUtils.integrationsSync.OKTA_INDEX
         );
@@ -178,8 +175,7 @@ export default ({ getService }: FtrProviderContext) => {
           privMonUtils.integrationsSync.OKTA_INDEX
         );
 
-        await privMonUtils.runSync();
-        await privMonUtils.integrationsSync.expectUserCount(5);
+        await privMonUtils.scheduleEngineAndWaitForUserCount(5);
 
         const markerAfterPhase4 = await privMonUtils.integrationsSync.getLastProcessedMarker(
           privMonUtils.integrationsSync.OKTA_INDEX


### PR DESCRIPTION
## Summary

### The Problem
The original code used `runSync()` which only waits for the sync task to be **scheduled**, not **completed**. This created a race condition where:
- Sometimes the sync completed before the assertion → test passed ✅
- Sometimes the assertion ran before sync completed → test failed with wrong count ❌

### The Solution
`scheduleEngineAndWaitForUserCount()` properly waits for:
1. The sync task to be scheduled
2. The sync task to actually complete
3. The user count to stabilize at the expected value

This eliminates the race condition entirely.

## Testing Steps

1. Run the specific test multiple times to verify stability

2. Check CI/CD pipeline results after merging

3. Monitor the test over the next few days to ensure no flakiness


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
