### PR TITLE
[Fleet] Disable update of namespace for managed policies via API

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
@@ -1211,6 +1211,59 @@ describe('Agent policy', () => {
       );
     });
 
+    it('should throw a HostedAgentPolicyRestrictionRelatedError if user tries to update namespace for a managed policy', async () => {
+      const soClient = createSavedObjectClientMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            attributes: { is_managed: true },
+            id: 'mocked',
+            type: 'mocked',
+            references: [],
+          },
+        ],
+      });
+
+      await expect(
+        agentPolicyService.update(soClient, esClient, 'test-id', {
+          namespace: 'test-namespace',
+        })
+      ).rejects.toThrowError(
+        new HostedAgentPolicyRestrictionRelatedError('Cannot update namespace')
+      );
+    });
+    it('should not throw if user tries to update namespace for a managed policy with option force', async () => {
+      const soClient = createSavedObjectClientMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            attributes: { is_managed: true },
+            id: 'mocked',
+            type: 'mocked',
+            references: [],
+          },
+        ],
+      });
+
+      await expect(
+        agentPolicyService.update(
+          soClient,
+          esClient,
+          'test-id',
+          {
+            namespace: 'test-namespace',
+          },
+          { force: true }
+        )
+      ).resolves.not.toThrowError(
+        new HostedAgentPolicyRestrictionRelatedError('Cannot update namespace')
+      );
+    });
+
     it('should call audit logger', async () => {
       const soClient = createSavedObjectClientMock();
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -136,8 +136,6 @@ import { isSpaceAwarenessEnabled } from './spaces/helpers';
 import { agentlessAgentService } from './agents/agentless_agent';
 import { scheduleDeployAgentPoliciesTask } from './agent_policies/deploy_agent_policies_task';
 
-const KEY_EDITABLE_FOR_MANAGED_POLICIES = ['namespace'];
-
 function normalizeKuery(savedObjectType: string, kuery: string) {
   if (savedObjectType === LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE) {
     return _normalizeKuery(
@@ -1013,13 +1011,11 @@ class AgentPolicyService {
     }
 
     if (existingAgentPolicy.is_managed && !options?.force) {
-      Object.entries(agentPolicy)
-        .filter(([key]) => !KEY_EDITABLE_FOR_MANAGED_POLICIES.includes(key))
-        .forEach(([key, val]) => {
-          if (!isEqual(existingAgentPolicy[key as keyof AgentPolicy], val)) {
-            throw new HostedAgentPolicyRestrictionRelatedError(`Cannot update ${key}`);
-          }
-        });
+      Object.entries(agentPolicy).forEach(([key, val]) => {
+        if (!isEqual(existingAgentPolicy[key as keyof AgentPolicy], val)) {
+          throw new HostedAgentPolicyRestrictionRelatedError(`Cannot update ${key}`);
+        }
+      });
     }
     const { monitoring_enabled: monitoringEnabled } = agentPolicy;
     const packagesToInstall = [];


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/issues/227793


## Summary

 Disable update of namespace for managed policies via API. The update from the UI from prevented with https://github.com/elastic/kibana/pull/244204 but the endpoint was still allowing it. 

### Testing steps
- Create a managed policy and try to update the namespace. Example with the cloud policy:
```
PUT kbn:/api/fleet/agent_policies/policy-elastic-agent-on-cloud
{
    "name": "Elastic Cloud agent policy",
    "description": "Default agent policy for agents hosted on Elastic Cloud",
    "namespace": "new"
}
```

It should throw with `Cannot update namespace in Fleet because the agent policy is managed by an external orchestration solution, such as Elastic Cloud, Kubernetes, etc. Please make changes using your orchestration solution.`
- Updating with `force` option will still work - as it's the case with all other fields.


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
