### PR TITLE
[Security Solution][Attacks/Alerts] Flyout: JSON tab content

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/tabs.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/tabs.tsx
@@ -11,6 +11,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { AttackDetailsPanelPaths } from '.';
 import { OVERVIEW_TAB_TEST_ID, TABLE_TAB_TEST_ID, JSON_TAB_TEST_ID } from './constants/test_ids';
 import { TableTab } from './tabs/table_tab';
+import { JsonTab } from './tabs/json_tab';
 
 export interface AttackDetailsPanelTabType {
   id: AttackDetailsPanelPaths;
@@ -52,5 +53,5 @@ export const jsonTab: AttackDetailsPanelTabType = {
       defaultMessage="JSON"
     />
   ),
-  content: <div>{`${JSON_TAB_TEST_ID}`}</div>,
+  content: <JsonTab />,
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/tabs/json_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/tabs/json_tab.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+
+import { JsonTab as SharedJsonTab } from '../../shared/components/json_tab';
+import { useAttackDetailsContext } from '../context';
+import { JSON_TAB_TEST_ID } from '../constants/test_ids';
+
+/**
+ * Json view displayed in the attack details expandable flyout
+ */
+export const JsonTab = memo(() => {
+  const { searchHit } = useAttackDetailsContext();
+
+  return (
+    <SharedJsonTab
+      value={searchHit as unknown as Record<string, unknown>}
+      showFooterOffset={false}
+      data-test-subj={JSON_TAB_TEST_ID}
+    />
+  );
+});
+
+JsonTab.displayName = 'JsonTab';


### PR DESCRIPTION
## Summary

Closes: https://github.com/elastic/kibana/issues/242330

This PR introduces the **JSON tab** inside the Attack Details Flyout.
It leverages the recently created shared component by @NicholasPeretti to ensure a consistent experience across flyouts ✅ 

### What’s included

#### JSON Tab Content:
- Added a new **JSON** tab that displays the full attack document in raw JSON form.
- Ensures formatting consistency (indentation, syntax highlighting, etc.) across flyouts.

#### Interactions:
- Added **Copy to clipboard** support using the shared component’s built-in action.

#### Tab Registration
- Registered the new JSON tab inside the attack details flyout through the existing `tabs.ts` configuration.


## 🧪 How to Test Locally

You can manually open the Attack Details Flyout with the temporary development button inside:

`x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/panel_header/primary_interactions/title/index.tsx`

```ts
import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
import { AttackDetailsRightPanelKey } from '../../../../../../../flyout/attack_details/constants/panel_keys';

const { openFlyout } = useExpandableFlyoutApi();

const handleOnAttackDetailPanelOpened = useCallback(() => {
  openFlyout({
    right: {
      id: AttackDetailsRightPanelKey,
      params: {
        attackId: attackDiscovery.id,
        indexName: '.adhoc.alerts-security.attack.discovery.alerts-default',
      },
    },
  });
}, [openFlyout, attackDiscovery.id]);

<EuiButtonIcon
  iconType="expand"
  onClick={handleOnAttackDetailPanelOpened}
  size="xs"
/>;
```

Then verify the following:

- [ ] The **JSON** tab appears in the Attack Details flyout  
- [ ] The attack document renders as properly formatted JSON  
- [ ] The **Copy to clipboard** button copies the whole JSON payload  
- [ ] Feedback appears after successfully copying  


https://github.com/user-attachments/assets/03599b8f-b890-4a3b-806a-9a0ef43b1875



