### PR TITLE
[Agent Builder] Add support for transient tool progression events

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/chat/conversation.ts
@@ -67,6 +67,10 @@ export interface ToolCallProgress {
    * The full text message
    */
   message: string;
+  /**
+   * if true, will not be displayed in the thinking panel, only used as "current thinking"
+   **/
+  transient?: boolean;
 }
 
 /**

--- a/x-pack/platform/packages/shared/onechat/onechat-common/chat/events.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-common/chat/events.ts
@@ -65,6 +65,8 @@ export const isBrowserToolCallEvent = (
 export interface ToolProgressEventData {
   tool_call_id: string;
   message: string;
+  /** if true, will not be persisted or displayed in the thinking panel, only as "current thinking" **/
+  transient?: boolean;
 }
 
 export type ToolProgressEvent = ChatEventBase<ChatEventType.toolProgress, ToolProgressEventData>;

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/graph.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/graph.ts
@@ -57,7 +57,7 @@ export const createSearchToolGraph = ({
   const relevanceTool = createRelevanceSearchTool({ model, esClient, events });
 
   const selectAndValidateIndex = async (state: StateType) => {
-    events?.reportProgress(progressMessages.selectingTarget());
+    events?.reportProgress(progressMessages.selectingTarget(), { transient: true });
 
     const explorerRes = await indexExplorer({
       nlQuery: state.nlQuery,
@@ -70,6 +70,9 @@ export const createSearchToolGraph = ({
 
     if (explorerRes.resources.length > 0) {
       const selectedResource = explorerRes.resources[0];
+
+      events?.reportProgress(progressMessages.selectedTarget(selectedResource));
+
       return {
         indexIsValid: true,
         searchTarget: { type: selectedResource.type, name: selectedResource.name },
@@ -87,11 +90,7 @@ export const createSearchToolGraph = ({
   };
 
   const callSearchAgent = async (state: StateType) => {
-    events?.reportProgress(
-      progressMessages.resolvingSearchStrategy({
-        target: state.searchTarget.name,
-      })
-    );
+    events?.reportProgress(progressMessages.resolvingSearchStrategy());
 
     const nlSearchTool = createNaturalLanguageSearchTool({
       model,

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/i18n.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/search/i18n.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import type { RelevantResource } from '../index_explorer';
 
 export const progressMessages = {
   selectingTarget: () => {
@@ -13,12 +14,17 @@ export const progressMessages = {
       defaultMessage: 'Identifying the most relevant data source',
     });
   },
-  resolvingSearchStrategy: ({ target }: { target: string }) => {
-    return i18n.translate('xpack.onechat.tools.search.progress.searchStrategy', {
-      defaultMessage: 'Analyzing strategy to search against "{target}"',
+  selectedTarget: (resource: RelevantResource) => {
+    return i18n.translate('xpack.onechat.tools.search.progress.selectingTarget', {
+      defaultMessage: 'Selecting "{target}" as the search target',
       values: {
-        target,
+        target: resource.name,
       },
+    });
+  },
+  resolvingSearchStrategy: () => {
+    return i18n.translate('xpack.onechat.tools.search.progress.searchStrategy', {
+      defaultMessage: 'Analyzing search strategy',
     });
   },
   performingRelevanceSearch: ({ term }: { term: string }) => {

--- a/x-pack/platform/packages/shared/onechat/onechat-server/runner/events.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-server/runner/events.ts
@@ -24,7 +24,10 @@ export type ToolEventHandlerFn = (event: OnechatToolEvent) => void;
 /**
  * Progress event reporter, sending a tool progress event based on the provided progress info
  */
-export type ToolProgressEmitterFn = (progressMessage: string) => void;
+export type ToolProgressEmitterFn = (
+  progressMessage: string,
+  opts?: { transient?: boolean }
+) => void;
 
 /**
  * Tool event emitter, exposed to tool handlers

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/round_steps.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/round_steps.tsx
@@ -161,12 +161,14 @@ const labels = {
 
 const getProgressionItems = ({ step, stepIndex }: { step: ToolCallStep; stepIndex: number }) => {
   return (
-    step.progression?.map((progress, index) => (
-      <ToolProgressDisplay
-        key={`step-${stepIndex}-${step.tool_id}-progress-${index}`}
-        progress={progress}
-      />
-    )) ?? []
+    step.progression
+      ?.filter((progress) => progress.transient !== true)
+      .map((progress, index) => (
+        <ToolProgressDisplay
+          key={`step-${stepIndex}-${step.tool_id}-progress-${index}`}
+          progress={progress}
+        />
+      )) ?? []
   );
 };
 

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/send_message/use_subscribe_to_chat_events.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/send_message/use_subscribe_to_chat_events.ts
@@ -51,7 +51,7 @@ export const useSubscribeToChatEvents = ({
             });
           } else if (isToolProgressEvent(event)) {
             conversationActions.setToolCallProgress({
-              progress: { message: event.data.message },
+              progress: { message: event.data.message, transient: event.data.transient },
               toolCallId: event.data.tool_call_id,
             });
             // Individual tool progression message should also be displayed as reasoning

--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/add_round_complete_event.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/add_round_complete_event.ts
@@ -113,6 +113,7 @@ const createRoundFromEvents = ({
 
       const toolProgress = toolProgressions
         .filter((progressEvent) => progressEvent.tool_call_id === toolCall.tool_call_id)
+        .filter((progressEvent) => progressEvent.transient !== true)
         .map((progress) => ({
           message: progress.message,
         }));

--- a/x-pack/platform/plugins/shared/onechat/server/services/runner/utils/events.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/runner/utils/events.ts
@@ -51,11 +51,12 @@ export const createToolEventEmitter = ({
   }
 
   return {
-    reportProgress: (progressMessage) => {
+    reportProgress: (progressMessage, opts = {}) => {
       const event: InternalToolProgressEvent = {
         type: ChatEventType.toolProgress,
         data: {
           message: progressMessage,
+          transient: opts.transient,
         },
       };
       eventHandler(event);


### PR DESCRIPTION
## Summary

Similar to what we already had for transient reasoning events, this PR adds transient support for tool progression events, so that tool can emit progression which will not be persisted and only displayed as the "current" thinking event