### PR TITLE
Allow the SOR from the migrator test kit to work with 'hidden' SO types

### DIFF
--- a/src/platform/packages/private/kbn-migrator-test-kit/src/kibana_migrator_test_kit.ts
+++ b/src/platform/packages/private/kbn-migrator-test-kit/src/kibana_migrator_test_kit.ts
@@ -193,7 +193,12 @@ export const getKibanaMigratorTestKit = async ({
     typeRegistry,
     kibanaIndex,
     client,
-    loggerFactory.get('saved_objects')
+    loggerFactory.get('saved_objects'),
+    // the toolkit's SavedObjectsRepository must allow testing hidden types
+    typeRegistry
+      .getAllTypes()
+      .filter(({ hidden }) => hidden)
+      .map(({ name }) => name)
   );
 
   return {


### PR DESCRIPTION
## Summary

When SO type owners modify hidden types, the SOR used by the automated rollback CI check cannot see them, and it fails miserably with:

<img width="2280" height="644" alt="image" src="https://github.com/user-attachments/assets/cfe103d8-6103-4fa1-bb00-992fb92d6eef" />

The PR addresses this by allow-listing those hidden types, as we want the SOR to return them for testing purposes.