### PR TITLE
[Error logs] Serialize meta.error if it is an instance of Error in JSON layout

### DIFF
--- a/src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts
@@ -546,7 +546,7 @@ test('format() correctly serializes meta.error after calling meta.toJSON() if me
       logger: 'context-meta-error-with-toJSON',
     },
     message: 'message-meta-error-with-toJSON',
-    someProp: 'initialValue', // Should come from { ...record.meta }, not toJSON()
+    someProp: 'initialValue',
     error: {
       message: metaError.message,
       type: metaError.name,

--- a/src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/json_layout.test.ts
@@ -466,3 +466,95 @@ test('format() meta.toJSON() is used if present on prototype', () => {
     foo: 'bar',
   });
 });
+
+test('format() correctly serializes meta.error if it is an Error object', () => {
+  const layout = new JsonLayout();
+  const metaError = new Error('Meta error message');
+  metaError.name = 'MetaErrorType';
+  metaError.stack = 'MetaErrorStack';
+
+  expect(
+    JSON.parse(
+      layout.format({
+        level: LogLevel.Debug,
+        context: 'context-meta-error',
+        message: 'message-meta-error',
+        timestamp,
+        pid: 5355,
+        meta: {
+          server: {
+            address: 'localhost',
+          },
+          error: metaError, // This is the Error object within meta
+        },
+      })
+    )
+  ).toStrictEqual({
+    ecs: { version: expect.any(String) },
+    '@timestamp': '2012-02-01T09:30:22.011-05:00',
+    log: {
+      level: 'DEBUG',
+      logger: 'context-meta-error',
+    },
+    message: 'message-meta-error',
+    server: {
+      address: 'localhost',
+    },
+    error: {
+      message: metaError.message,
+      type: metaError.name,
+      stack_trace: metaError.stack,
+    },
+    process: {
+      pid: 5355,
+      uptime: 10,
+    },
+  });
+});
+
+test('format() correctly serializes meta.error after calling meta.toJSON() if meta.error is an Error object', () => {
+  const layout = new JsonLayout();
+  const metaError = new Error('Special meta error');
+  metaError.name = 'SpecialErrorType';
+  metaError.stack = 'SpecialErrorStack';
+
+  const customMeta = {
+    someProp: 'initialValue',
+    error: metaError,
+    toJSON() {
+      return { customData: 'toJSON-executed', someProp: this.someProp, error: this.error };
+    },
+  };
+
+  expect(
+    JSON.parse(
+      layout.format({
+        level: LogLevel.Debug,
+        context: 'context-meta-error-with-toJSON',
+        message: 'message-meta-error-with-toJSON',
+        timestamp,
+        pid: 5355,
+        meta: customMeta,
+      })
+    )
+  ).toStrictEqual({
+    ecs: { version: expect.any(String) },
+    '@timestamp': '2012-02-01T09:30:22.011-05:00',
+    customData: 'toJSON-executed',
+    log: {
+      level: 'DEBUG',
+      logger: 'context-meta-error-with-toJSON',
+    },
+    message: 'message-meta-error-with-toJSON',
+    someProp: 'initialValue', // Should come from { ...record.meta }, not toJSON()
+    error: {
+      message: metaError.message,
+      type: metaError.name,
+      stack_trace: metaError.stack,
+    },
+    process: {
+      pid: 5355,
+      uptime: 10,
+    },
+  });
+});

--- a/src/core/packages/logging/server-internal/src/layouts/json_layout.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/json_layout.ts
@@ -66,6 +66,9 @@ export class JsonLayout implements Layout {
     if (record.meta) {
       // @ts-expect-error toJSON not defined on `LogMeta`, but some structured meta can have it defined
       const serializedMeta = record.meta.toJSON ? record.meta.toJSON() : { ...record.meta };
+      if (serializedMeta.error instanceof Error) {
+        serializedMeta.error = JsonLayout.errorToSerializableObject(serializedMeta.error);
+      }
       output = merge(serializedMeta, log);
     }
 


### PR DESCRIPTION
## Summary

In this PR, we serialize meta.error to only keep the relevant attributes (message, name, stack) if it is an instance of Error.

## Release note

Fixes serialization of meta.error in JSON layouts: if the error is an Error instance, only message, name, and stack will be included — additional fields will no longer pollute the logs.


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->