### PR TITLE
[9.2] [scout] allow global hook for single thread run + enable streams only once (#242672)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -794,6 +794,7 @@ module.exports = {
         'x-pack/solutions/security/test/security_solution_api_integration/*/test_suites/**/*',
         'x-pack/solutions/security/test/security_solution_api_integration/**/config*.ts',
         '**/playwright.config.ts',
+        '**/parallel.playwright.config.ts',
       ],
       rules: {
         'import/no-default-export': 'off',

--- a/src/platform/packages/shared/kbn-scout/README.md
+++ b/src/platform/packages/shared/kbn-scout/README.md
@@ -101,6 +101,7 @@ import { createPlaywrightConfig } from '@kbn/scout';
 export default createPlaywrightConfig({
   testDir: './tests',
   workers: 2,
+  runGlobalSetup: true, // to trigger setup hook before the tests (e.g. to ingest ES data)
 });
 ```
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
@@ -47,21 +47,21 @@ export function createPlaywrightConfig(options: ScoutPlaywrightOptions): Playwri
   let scoutProjects: PlaywrightTestConfig<ScoutTestOptions>['projects'] = [];
 
   /**
-   * For parallel tests, we need to add a setup as a project dependency. While Playwright doesn't allow to read 'use'
-   * from the parent project, we have to create a setup project with the explicit 'use' object for each parent project.
+   * When runGlobalSetup is true, we add a setup project as a dependency for each project.
+   * While Playwright doesn't allow to read 'use' from the parent project, we have to create
+   * a setup project with the explicit 'use' object for each parent project.
    * This is a workaround for https://github.com/microsoft/playwright/issues/32547
    */
-  scoutProjects =
-    options.workers && options.workers > 1
-      ? scoutDefaultProjects.flatMap((project) => [
-          {
-            name: `setup-${project?.name}`,
-            use: project?.use ? { ...project.use } : {},
-            testMatch: /global.setup\.ts/,
-          },
-          { ...project, dependencies: [`setup-${project?.name}`] },
-        ])
-      : scoutDefaultProjects;
+  scoutProjects = options.runGlobalSetup
+    ? scoutDefaultProjects.flatMap((project) => [
+        {
+          name: `setup-${project?.name}`,
+          use: project?.use ? { ...project.use } : {},
+          testMatch: /global.setup\.ts/,
+        },
+        { ...project, dependencies: [`setup-${project?.name}`] },
+      ])
+    : scoutDefaultProjects;
 
   return defineConfig<ScoutTestOptions>({
     testDir: options.testDir,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/types/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/types/index.ts
@@ -26,4 +26,9 @@ export interface ScoutTestOptions extends PlaywrightTestOptions {
 export interface ScoutPlaywrightOptions extends Pick<PlaywrightTestConfig, 'testDir' | 'workers'> {
   testDir: string;
   workers?: 1 | 2 | 3; // to keep performance consistent within test suites
+  /**
+   * When true, runs global.setup.ts as a pre-step before running tests.
+   * Defaults to false.
+   */
+  runGlobalSetup?: boolean;
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/idle_routing_stream_entry.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/idle_routing_stream_entry.tsx
@@ -178,6 +178,7 @@ export function IdleRoutingStreamEntry({
         </EuiFlexGroup>
         <EuiFlexItem
           grow={false}
+          data-test-subj={`streamDetailRoutingItem-${routingRule.destination}`}
           className={css`
             overflow: hidden;
             padding: ${euiTheme.size.xs} 0px;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/stream_name_form_row.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/stream_name_form_row.tsx
@@ -101,7 +101,7 @@ export function StreamNameFormRow({
                 })}
               </span>
             </EuiScreenReaderOnly>
-            <EuiTextTruncate text={prefix} truncation="start" />
+            <EuiTextTruncate text={prefix} truncation="start" data-test-subj={`streamNamePrefix`} />
           </EuiFormLabel>,
         ]}
       />

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -208,15 +208,15 @@ export class StreamsApp {
   }
 
   async saveRoutingRule() {
-    await this.page.getByRole('button', { name: 'Save' }).click();
+    await this.page.testSubj.locator('streamsAppStreamDetailRoutingSaveButton').click();
   }
 
   async updateRoutingRule() {
-    await this.page.getByRole('button', { name: 'Change routing' }).click();
+    await this.page.testSubj.locator('streamsAppStreamDetailRoutingUpdateButton').click();
   }
 
   async cancelRoutingRule() {
-    await this.page.getByRole('button', { name: 'Cancel' }).click();
+    await this.page.testSubj.locator('streamsAppRoutingStreamEntryCancelButton').click();
   }
 
   async removeRoutingRule() {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts
@@ -9,4 +9,5 @@ import { createPlaywrightConfig } from '@kbn/scout';
 
 export default createPlaywrightConfig({
   testDir: './tests',
+  runGlobalSetup: true,
 });

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_mapping.spec.ts
@@ -13,7 +13,6 @@ import { generateLogsData } from '../../fixtures/generators';
 
 test.describe('Stream data mapping - schema editor', { tag: ['@ess', '@svlOblt'] }, () => {
   test.beforeAll(async ({ apiServices, logsSynthtraceEsClient }) => {
-    await apiServices.streams.enable();
     // Clear existing rules
     await apiServices.streams.clearStreamChildren('logs');
     // Create a test stream with routing rules first
@@ -34,8 +33,8 @@ test.describe('Stream data mapping - schema editor', { tag: ['@ess', '@svlOblt']
   });
 
   test.afterAll(async ({ apiServices, logsSynthtraceEsClient }) => {
+    await apiServices.streams.clearStreamChildren('logs');
     await logsSynthtraceEsClient.clean();
-    await apiServices.streams.disable();
   });
 
   test('should display a list of stream mappings', async ({ page, pageObjects }) => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts
@@ -10,8 +10,7 @@ import { test } from '../../../fixtures';
 import { generateLogsData } from '../../../fixtures/generators';
 
 test.describe('Stream data processing - creating steps', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeAll(async ({ apiServices, logsSynthtraceEsClient }) => {
-    await apiServices.streams.enable();
+  test.beforeAll(async ({ logsSynthtraceEsClient }) => {
     await generateLogsData(logsSynthtraceEsClient)({ index: 'logs-generic-default' });
   });
 
@@ -24,8 +23,8 @@ test.describe('Stream data processing - creating steps', { tag: ['@ess', '@svlOb
   });
 
   test.afterAll(async ({ apiServices, logsSynthtraceEsClient }) => {
+    await apiServices.streams.clearStreamProcessors('logs-generic-default');
     await logsSynthtraceEsClient.clean();
-    await apiServices.streams.disable();
   });
 
   test('should create a new processor successfully', async ({ pageObjects }) => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/data_sources_management.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/data_sources_management.spec.ts
@@ -17,8 +17,7 @@ test.describe(
   'Stream data processing - data sources management',
   { tag: ['@ess', '@svlOblt'] },
   () => {
-    test.beforeAll(async ({ apiServices, logsSynthtraceEsClient }) => {
-      await apiServices.streams.enable();
+    test.beforeAll(async ({ logsSynthtraceEsClient }) => {
       await generateLogsData(logsSynthtraceEsClient)({ index: 'logs-generic-default' });
     });
 
@@ -31,8 +30,8 @@ test.describe(
     });
 
     test.afterAll(async ({ apiServices, logsSynthtraceEsClient }) => {
+      await apiServices.streams.clearStreamProcessors('logs-generic-default');
       await logsSynthtraceEsClient.clean();
-      await apiServices.streams.disable();
     });
 
     test('should load by default a random samples data source', async ({ pageObjects }) => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/edit_steps.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/edit_steps.spec.ts
@@ -10,8 +10,7 @@ import { test } from '../../../fixtures';
 import { generateLogsData } from '../../../fixtures/generators';
 
 test.describe('Stream data processing - editing steps', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeAll(async ({ apiServices, logsSynthtraceEsClient }) => {
-    await apiServices.streams.enable();
+  test.beforeAll(async ({ logsSynthtraceEsClient }) => {
     await generateLogsData(logsSynthtraceEsClient)({ index: 'logs-generic-default' });
   });
 
@@ -33,9 +32,8 @@ test.describe('Stream data processing - editing steps', { tag: ['@ess', '@svlObl
     await pageObjects.streams.gotoProcessingTab('logs-generic-default');
   });
 
-  test.afterAll(async ({ apiServices, logsSynthtraceEsClient }) => {
+  test.afterAll(async ({ logsSynthtraceEsClient }) => {
     await logsSynthtraceEsClient.clean();
-    await apiServices.streams.disable();
   });
 
   test('should edit an existing processor', async ({ page, pageObjects }) => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/error_handling.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/error_handling.spec.ts
@@ -13,8 +13,7 @@ test.describe(
   'Stream data processing - error handling and recovery',
   { tag: ['@ess', '@svlOblt'] },
   () => {
-    test.beforeAll(async ({ apiServices, logsSynthtraceEsClient }) => {
-      await apiServices.streams.enable();
+    test.beforeAll(async ({ logsSynthtraceEsClient }) => {
       await generateLogsData(logsSynthtraceEsClient)({ index: 'logs-generic-default' });
     });
 
@@ -27,8 +26,8 @@ test.describe(
     });
 
     test.afterAll(async ({ apiServices, logsSynthtraceEsClient }) => {
+      await apiServices.streams.clearStreamProcessors('logs-generic-default');
       await logsSynthtraceEsClient.clean();
-      await apiServices.streams.disable();
     });
 
     test('should handle network failures during a processor creation', async ({

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/processing_simulation_preview.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/processing_simulation_preview.spec.ts
@@ -16,8 +16,7 @@ import { test } from '../../../fixtures';
 import { generateLogsData } from '../../../fixtures/generators';
 
 test.describe('Stream data processing - simulation preview', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeAll(async ({ apiServices, logsSynthtraceEsClient }) => {
-    await apiServices.streams.enable();
+  test.beforeAll(async ({ logsSynthtraceEsClient }) => {
     await generateLogsData(logsSynthtraceEsClient)({ index: 'logs-generic-default' });
   });
 
@@ -30,8 +29,8 @@ test.describe('Stream data processing - simulation preview', { tag: ['@ess', '@s
   });
 
   test.afterAll(async ({ apiServices, logsSynthtraceEsClient }) => {
+    await apiServices.streams.clearStreamProcessors('logs-generic-default');
     await logsSynthtraceEsClient.clean();
-    await apiServices.streams.disable();
   });
 
   test('should display default samples when no processors are configured', async ({

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_quality.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_quality.spec.ts
@@ -9,14 +9,8 @@ import { expect } from '@kbn/scout';
 import { test } from '../../fixtures';
 
 test.describe('Stream data quality', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeAll(async ({ apiServices }) => {
-    await apiServices.streams.enable();
-  });
-
   test.beforeEach(async ({ apiServices, browserAuth, pageObjects }) => {
     await browserAuth.loginAsAdmin();
-    // Clear existing rules
-    await apiServices.streams.clearStreamChildren('logs');
     // Create a test stream with routing rules first
     await apiServices.streams.forkStream('logs', 'logs.nginx', {
       field: 'service.name',
@@ -26,8 +20,9 @@ test.describe('Stream data quality', { tag: ['@ess', '@svlOblt'] }, () => {
     await pageObjects.streams.gotoDataQualityTab('logs.nginx');
   });
 
-  test.afterAll(async ({ apiServices }) => {
-    await apiServices.streams.disable();
+  test.afterEach(async ({ apiServices }) => {
+    // Clear existing rules
+    await apiServices.streams.clearStreamChildren('logs');
   });
 
   test('should show data quality metrics', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/data_retention.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/data_retention.spec.ts
@@ -12,10 +12,6 @@ test.describe(
   'Stream data retention - updating data retention',
   { tag: ['@ess', '@svlOblt'] },
   () => {
-    test.beforeAll(async ({ apiServices }) => {
-      await apiServices.streams.enable();
-    });
-
     test.beforeEach(async ({ apiServices, browserAuth, pageObjects }) => {
       await browserAuth.loginAsAdmin();
       // Clear existing rules
@@ -30,7 +26,8 @@ test.describe(
     });
 
     test.afterAll(async ({ apiServices }) => {
-      await apiServices.streams.disable();
+      // Clear existing rules
+      await apiServices.streams.clearStreamChildren('logs');
     });
 
     test('should update a stream data retention policy successfully', async ({ page }) => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/failure_store.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/failure_store.spec.ts
@@ -14,7 +14,6 @@ test.describe(
   { tag: ['@ess', '@svlOblt'] },
   () => {
     test.beforeAll(async ({ apiServices, logsSynthtraceEsClient, esClient }) => {
-      await apiServices.streams.enable();
       await generateLogsData(logsSynthtraceEsClient)({ index: 'logs-generic-default' });
       await esClient.indices.putDataStreamOptions(
         {
@@ -40,9 +39,9 @@ test.describe(
       });
     });
 
-    test.afterAll(async ({ apiServices, logsSynthtraceEsClient }) => {
+    test.afterAll(async ({ logsSynthtraceEsClient, apiServices }) => {
+      await apiServices.streams.clearStreamChildren('logs');
       await logsSynthtraceEsClient.clean();
-      await apiServices.streams.disable();
     });
 
     test('should edit failure store successfully for classic streams', async ({

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/failure_store.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/failure_store.spec.ts
@@ -13,7 +13,7 @@ test.describe(
   'Stream data retention - updating failure store',
   { tag: ['@ess', '@svlOblt'] },
   () => {
-    test.beforeAll(async ({ apiServices, logsSynthtraceEsClient, esClient }) => {
+    test.beforeAll(async ({ logsSynthtraceEsClient, esClient }) => {
       await generateLogsData(logsSynthtraceEsClient)({ index: 'logs-generic-default' });
       await esClient.indices.putDataStreamOptions(
         {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/edit_routing_rules.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/edit_routing_rules.spec.ts
@@ -12,10 +12,6 @@ import { expect } from '@kbn/scout';
 import { test } from '../../../fixtures';
 
 test.describe('Stream data routing - editing routing rules', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeAll(async ({ apiServices }) => {
-    await apiServices.streams.enable();
-  });
-
   test.beforeEach(async ({ apiServices, browserAuth, pageObjects }) => {
     await browserAuth.loginAsAdmin();
     // Clear existing rules
@@ -32,33 +28,38 @@ test.describe('Stream data routing - editing routing rules', { tag: ['@ess', '@s
   test.afterAll(async ({ apiServices }) => {
     // Clear existing rules
     await apiServices.streams.clearStreamChildren('logs');
-    await apiServices.streams.disable();
   });
 
   test('should edit an existing routing rule', async ({ page, pageObjects }) => {
-    await pageObjects.streams.clickEditRoutingRule('logs.edit-test');
+    const rountingRuleName = 'logs.edit-test';
+    await pageObjects.streams.clickEditRoutingRule(rountingRuleName);
 
     // Update condition
     await pageObjects.streams.fillConditionEditor({ value: 'updated-service' });
     await pageObjects.streams.updateRoutingRule();
 
     // Verify success
-    await expect(page.getByText('service.name')).toBeVisible();
-    await expect(page.getByText('equals')).toBeVisible();
-    await expect(page.getByText('updated-service')).toBeVisible();
+    const routingRuleLocator = page.testSubj.locator(`streamDetailRoutingItem-${rountingRuleName}`);
+    await expect(routingRuleLocator).toBeVisible();
+    await expect(routingRuleLocator.locator('[title="service.name"]')).toBeVisible();
+    await expect(routingRuleLocator.locator('text=equals')).toBeVisible();
+    await expect(routingRuleLocator.locator('[title="updated-service"]')).toBeVisible();
   });
 
   test('should cancel editing routing rule', async ({ page, pageObjects }) => {
-    await pageObjects.streams.clickEditRoutingRule('logs.edit-test');
+    const rountingRuleName = 'logs.edit-test';
+    await pageObjects.streams.clickEditRoutingRule(rountingRuleName);
 
     // Update and cancel changes
     await pageObjects.streams.fillConditionEditor({ value: 'updated-service' });
     await pageObjects.streams.cancelRoutingRule();
 
     // Verify success
-    await expect(page.getByText('service.name')).toBeVisible();
-    await expect(page.getByText('equals')).toBeVisible();
-    await expect(page.getByText('test-service')).toBeVisible();
+    const routingRuleLocator = page.testSubj.locator(`streamDetailRoutingItem-${rountingRuleName}`);
+    await expect(routingRuleLocator).toBeVisible();
+    await expect(routingRuleLocator.locator('[title="service.name"]')).toBeVisible();
+    await expect(routingRuleLocator.locator('text=equals')).toBeVisible();
+    await expect(routingRuleLocator.locator('[title="test-service"]')).toBeVisible();
   });
 
   test('should switch between editing different rules', async ({ pageObjects, page }) => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/error_handling.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/error_handling.spec.ts
@@ -12,10 +12,6 @@ test.describe(
   'Stream data routing - error handling and recovery',
   { tag: ['@ess', '@svlOblt'] },
   () => {
-    test.beforeAll(async ({ apiServices }) => {
-      await apiServices.streams.enable();
-    });
-
     test.beforeEach(async ({ browserAuth, pageObjects }) => {
       await browserAuth.loginAsAdmin();
       await pageObjects.streams.gotoPartitioningTab('logs');
@@ -24,7 +20,6 @@ test.describe(
     test.afterAll(async ({ apiServices }) => {
       // Clear existing rules
       await apiServices.streams.clearStreamChildren('logs');
-      await apiServices.streams.disable();
     });
 
     test('should handle network failures during rule creation', async ({

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/reorder_routing_rules.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/reorder_routing_rules.spec.ts
@@ -14,10 +14,6 @@ test.describe(
   'Stream data routing - reordering routing rules',
   { tag: ['@ess', '@svlOblt'] },
   () => {
-    test.beforeAll(async ({ apiServices }) => {
-      await apiServices.streams.enable();
-    });
-
     test.beforeEach(async ({ apiServices, browserAuth, pageObjects }) => {
       await browserAuth.loginAsAdmin();
       // Clear existing rules
@@ -37,7 +33,6 @@ test.describe(
     test.afterAll(async ({ apiServices }) => {
       // Clear existing rules
       await apiServices.streams.clearStreamChildren('logs');
-      await apiServices.streams.disable();
     });
 
     test('should reorder routing rules via drag and drop', async ({ pageObjects }) => {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/routing_data_preview.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/routing_data_preview.spec.ts
@@ -13,8 +13,7 @@ import { test } from '../../../fixtures';
 import { DATE_RANGE, generateLogsData } from '../../../fixtures/generators';
 
 test.describe('Stream data routing - previewing data', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeAll(async ({ apiServices, logsSynthtraceEsClient }) => {
-    await apiServices.streams.enable();
+  test.beforeAll(async ({ logsSynthtraceEsClient }) => {
     // Generate logs data only
     await logsSynthtraceEsClient.clean();
     await generateLogsData(logsSynthtraceEsClient)({ index: 'logs' });
@@ -26,10 +25,9 @@ test.describe('Stream data routing - previewing data', { tag: ['@ess', '@svlOblt
     await pageObjects.datePicker.setAbsoluteRange(DATE_RANGE);
   });
 
-  test.afterAll(async ({ apiServices, logsSynthtraceEsClient }) => {
+  test.afterAll(async ({ logsSynthtraceEsClient }) => {
     // Clear synthtrace data
     await logsSynthtraceEsClient.clean();
-    await apiServices.streams.disable();
   });
 
   test('should show preview during rule creation', async ({ pageObjects }) => {
@@ -213,7 +211,12 @@ test.describe('Stream data routing - previewing data', { tag: ['@ess', '@svlOblt
     await expect(page.getByTestId('routingPreviewUnmatchedFilterButton')).toContainText('%');
   });
 
-  test('should switch between matched and unmatched documents', async ({ page, pageObjects }) => {
+  // This test is failing in Cloud run even with improved cleanup b/w test spec files
+  // See https://github.com/elastic/kibana/issues/242931
+  test.skip('should switch between matched and unmatched documents', async ({
+    page,
+    pageObjects,
+  }) => {
     await pageObjects.streams.clickCreateRoutingRule();
     await pageObjects.streams.fillRoutingRuleName('filter-switch-test');
 

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/streams_header.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/streams_header.spec.ts
@@ -12,9 +12,8 @@ const INGESTION_DURATION_MINUTES = 5;
 const TEST_STREAM_NAME = 'logs-test-stream';
 
 test.describe('Stream detail header', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeAll(async ({ apiServices, logsSynthtraceEsClient }) => {
+  test.beforeAll(async ({ logsSynthtraceEsClient }) => {
     const currentTime = Date.now();
-    await apiServices.streams.enable();
     // Generate 50 logs over the last 5 minutes
     await generateLogsData(logsSynthtraceEsClient)({
       index: TEST_STREAM_NAME,
@@ -31,23 +30,31 @@ test.describe('Stream detail header', { tag: ['@ess', '@svlOblt'] }, () => {
 
   test.afterAll(async ({ apiServices }) => {
     await apiServices.streams.deleteStream(TEST_STREAM_NAME);
-    await apiServices.streams.disable();
   });
 
-  test('shows correct Discover badge', async ({ pageObjects }) => {
+  test('shows correct badges', async ({ pageObjects, config }) => {
     await pageObjects.streams.gotoDataRetentionTab(TEST_STREAM_NAME);
-    await pageObjects.streams.verifyDiscoverButtonLink(TEST_STREAM_NAME);
+    await test.step('verify Discover badge link', async () => {
+      await pageObjects.streams.verifyDiscoverButtonLink(TEST_STREAM_NAME);
+    });
+
+    await test.step('verify Lifecycle badge link', async () => {
+      const isServerless = config.serverless ?? false;
+
+      await pageObjects.streams.verifyLifecycleBadge(
+        TEST_STREAM_NAME,
+        isServerless ? 'Indefinite' : 'ILM Policy: logs'
+      );
+    });
+
+    await test.step('verify Classic badge on classic stream', async () => {
+      await pageObjects.streams.verifyClassicBadge();
+    });
   });
 
-  test('shows correct Lifecycle badge', async ({ pageObjects, config }) => {
-    await pageObjects.streams.gotoDataRetentionTab(TEST_STREAM_NAME);
-
-    const isServerless = config.serverless ?? false;
-
-    await pageObjects.streams.verifyLifecycleBadge(
-      TEST_STREAM_NAME,
-      isServerless ? 'Indefinite' : 'ILM Policy: logs'
-    );
+  test('shows Wired badge on wired stream', async ({ pageObjects }) => {
+    await pageObjects.streams.gotoDataRetentionTab('logs');
+    await pageObjects.streams.verifyWiredBadge();
   });
 
   test('transitions data quality from Good -> Degraded -> Poor for stream', async ({
@@ -88,15 +95,5 @@ test.describe('Stream detail header', { tag: ['@ess', '@svlOblt'] }, () => {
 
     // We should have 55 documents in total now, 5 degraded -> ~9.09% degraded docs -> > 3% so Poor quality
     await pageObjects.streams.verifyDataQuality(TEST_STREAM_NAME, 'Poor');
-  });
-
-  test('shows Classic badge on classic stream', async ({ pageObjects }) => {
-    await pageObjects.streams.gotoDataRetentionTab(TEST_STREAM_NAME);
-    await pageObjects.streams.verifyClassicBadge();
-  });
-
-  test('shows Wired badge on wired stream', async ({ pageObjects }) => {
-    await pageObjects.streams.gotoDataRetentionTab('logs');
-    await pageObjects.streams.verifyWiredBadge();
   });
 });

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/global.setup.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/global.setup.ts
@@ -5,10 +5,9 @@
  * 2.0.
  */
 
-import { createPlaywrightConfig } from '@kbn/scout';
+import { globalSetupHook } from '@kbn/scout';
 
-export default createPlaywrightConfig({
-  testDir: './parallel_tests',
-  workers: 2,
-  runGlobalSetup: true,
+globalSetupHook('Setup environment for streams tests', async ({ apiServices, log }) => {
+  log.debug('[setup] Enabling streams...');
+  await apiServices.streams.enable();
 });

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/streams_collapsible_rows.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/streams_collapsible_rows.spec.ts
@@ -11,10 +11,6 @@ test.describe(
   'Stream list view - expand and collapse streams in the table',
   { tag: ['@ess', '@svlOblt'] },
   () => {
-    test.beforeAll(async ({ apiServices }) => {
-      await apiServices.streams.enable();
-    });
-
     test.beforeEach(async ({ apiServices, browserAuth, pageObjects }) => {
       await browserAuth.loginAsAdmin();
       // Clear existing rules
@@ -46,84 +42,82 @@ test.describe(
       await pageObjects.streams.gotoStreamMainPage();
     });
 
-    test.afterAll(async ({ apiServices }) => {
-      await apiServices.streams.disable();
-    });
+    test('should expand and collapse', async ({ pageObjects }) => {
+      await test.step('a stream node in the table', async () => {
+        // Wait for the streams table to load
+        await pageObjects.streams.expectStreamsTableVisible();
 
-    test('should expand and collapse a stream node in the table', async ({ pageObjects }) => {
-      // Wait for the streams table to load
-      await pageObjects.streams.expectStreamsTableVisible();
+        // Verify that all child streams are initially expanded and visible
+        await pageObjects.streams.verifyStreamsAreInTable([
+          'logs.child1',
+          'logs.child1.child1',
+          'logs.child1.child2',
+          'logs.child2',
+          'logs.child3',
+        ]);
 
-      // Verify that all child streams are initially expanded and visible
-      await pageObjects.streams.verifyStreamsAreInTable([
-        'logs.child1',
-        'logs.child1.child1',
-        'logs.child1.child2',
-        'logs.child2',
-        'logs.child3',
-      ]);
+        // Collapse the 'logs.child1' stream node
+        await pageObjects.streams.collapseExpandStream('logs.child1', true);
 
-      // Collapse the 'logs.child1' stream node
-      await pageObjects.streams.collapseExpandStream('logs.child1', true);
+        // Verify that the child streams are no longer visible
+        await pageObjects.streams.verifyStreamsAreNotInTable([
+          'logs.child1.child1',
+          'logs.child1.child2',
+        ]);
 
-      // Verify that the child streams are no longer visible
-      await pageObjects.streams.verifyStreamsAreNotInTable([
-        'logs.child1.child1',
-        'logs.child1.child2',
-      ]);
+        // Expand the 'logs.child1' stream node
+        await pageObjects.streams.collapseExpandStream('logs.child1', false);
 
-      // Expand the 'logs.child1' stream node
-      await pageObjects.streams.collapseExpandStream('logs.child1', false);
+        // Verify that the child streams are visible again
+        await pageObjects.streams.verifyStreamsAreInTable([
+          'logs.child1',
+          'logs.child1.child1',
+          'logs.child1.child2',
+        ]);
+      });
 
-      // Verify that the child streams are visible again
-      await pageObjects.streams.verifyStreamsAreInTable([
-        'logs.child1',
-        'logs.child1.child1',
-        'logs.child1.child2',
-      ]);
-    });
+      await test.step('all stream nodes in the table', async () => {
+        // Wait for the streams table to load
+        await pageObjects.streams.expectStreamsTableVisible();
 
-    test('should expand and collapse all stream nodes in the table', async ({ pageObjects }) => {
-      // Wait for the streams table to load
-      await pageObjects.streams.expectStreamsTableVisible();
+        // Collapse all stream nodes
+        await pageObjects.streams.collapseAllStreams();
 
-      // Collapse all stream nodes
-      await pageObjects.streams.collapseAllStreams();
+        // Verify that all child streams are no longer visible
+        await pageObjects.streams.verifyStreamsAreNotInTable([
+          'logs.child1',
+          'logs.child2',
+          'logs.child3',
+        ]);
 
-      // Verify that all child streams are no longer visible
-      await pageObjects.streams.verifyStreamsAreNotInTable([
-        'logs.child1',
-        'logs.child2',
-        'logs.child3',
-      ]);
+        // Expand all stream nodes
+        await pageObjects.streams.expandAllStreams();
 
-      // Expand all stream nodes
-      await pageObjects.streams.expandAllStreams();
+        // Verify that all child streams are visible
+        await pageObjects.streams.verifyStreamsAreInTable([
+          'logs.child1.child1',
+          'logs.child1.child2',
+          'logs.child2',
+          'logs.child3',
+        ]);
 
-      // Verify that all child streams are visible
-      await pageObjects.streams.verifyStreamsAreInTable([
-        'logs.child1.child1',
-        'logs.child1.child2',
-        'logs.child2',
-        'logs.child3',
-      ]);
+        // Collapse a single stream node to verify individual expand/collapse still works
+        await pageObjects.streams.collapseExpandStream('logs.child1', true);
+        await pageObjects.streams.verifyStreamsAreNotInTable([
+          'logs.child1.child1',
+          'logs.child1.child2',
+        ]);
 
-      // Collapse a single stream node to verify individual expand/collapse still works
-      await pageObjects.streams.collapseExpandStream('logs.child1', true);
-      await pageObjects.streams.verifyStreamsAreNotInTable([
-        'logs.child1.child1',
-        'logs.child1.child2',
-      ]);
-
-      // Expand all again to verify all nodes expand
-      await pageObjects.streams.expandAllStreams();
-      // Verify that all child streams are visible
-      await pageObjects.streams.verifyStreamsAreInTable([
-        'logs.child1.child1',
-        'logs.child1.child2',
-        'logs.child2',
-        'logs.child3',
-      ]);
+        // Expand all again to verify all nodes expand
+        await pageObjects.streams.expandAllStreams();
+        // Verify that all child streams are visible
+        await pageObjects.streams.verifyStreamsAreInTable([
+          'logs.child1.child1',
+          'logs.child1.child2',
+          'logs.child2',
+          'logs.child3',
+        ]);
+      });
     });
   }
 );

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/streams_table_values.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/streams_table_values.spec.ts
@@ -16,7 +16,6 @@ const POOR_QUALITY_STREAM = 'logs-poor-quality';
 
 test.describe('Stream list view - table values', { tag: ['@ess', '@svlOblt'] }, () => {
   test.beforeAll(async ({ apiServices, logsSynthtraceEsClient }) => {
-    await apiServices.streams.enable();
     const currentTime = Date.now();
     // Stream 1: Good quality stream - no failed or degraded docs, 50 docs total
     await generateLogsData(logsSynthtraceEsClient)({
@@ -108,7 +107,6 @@ test.describe('Stream list view - table values', { tag: ['@ess', '@svlOblt'] }, 
     await apiServices.streams.deleteStream(GOOD_QUALITY_STREAM);
     await apiServices.streams.deleteStream(DEGRADED_QUALITY_STREAM);
     await apiServices.streams.deleteStream(POOR_QUALITY_STREAM);
-    await apiServices.streams.disable();
   });
 
   test('should display correct doc count in the table', async ({ pageObjects, page }) => {

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel.playwright.config.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel.playwright.config.ts
@@ -7,8 +7,8 @@
 
 import { createPlaywrightConfig } from '@kbn/scout-oblt';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './parallel_tests',
   workers: 2,
+  runGlobalSetup: true,
 });

--- a/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel.playwright.config.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel.playwright.config.ts
@@ -7,7 +7,6 @@
 
 import { createPlaywrightConfig } from '@kbn/scout-oblt';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './parallel_tests',
   workers: 2,

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel.playwright.config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel.playwright.config.ts
@@ -7,8 +7,8 @@
 
 import { createPlaywrightConfig } from '@kbn/scout-security';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './parallel_tests/',
   workers: 2,
+  runGlobalSetup: true,
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[scout] allow global hook for single thread run + enable streams only once (#242672)](https://github.com/elastic/kibana/pull/242672)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-11-26T18:20:12Z","message":"[scout] allow global hook for single thread run + enable streams only once (#242672)\n\n## Summary\n\nThe main PR purpose is to improve and speed up Stream e2e tests for\nCloud testing (ECH/MKI):\n\n1. every suite repeatedly enables/disables streams functionality via API\nsolution: add `global hook` to enable streams before the tests execution\nstart:\n\n`x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts\n(--stateful)`\nbefore: `84 passed (13.3m)`\nafter: `81 passed (9.9m)` (one test despite improved cleanup returns\ninconsistent values and fails on Cloud and I had to skip it)\n\n2. some suites have time consuming `beforeEach` hook and rather short UI\nflow\nsolution: convert UI test blocks into \"steps\" and save time on\npre-loading.\n`streams_list_view/streams_collapsible_rows.spec.ts`\nbefore: `23.8s`\nafter: `9.4s`\n\n   `data_management/streams_header.spec.ts`\n    before: `19.3s`\n    after: `15.1s`\n\n3. some suites do the cleanup in `beforeEach` hook, but missing cleanup\nin `afterAll` and affects the follow-up tests if files execution order\nis changed.\nsolution: add missing hook\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"27010a19f43ca008c8dec2daafa9d8a17c7365a0","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.3.0","v9.2.2","v9.1.8"],"title":"[scout] allow global hook for single thread run + enable streams only once","number":242672,"url":"https://github.com/elastic/kibana/pull/242672","mergeCommit":{"message":"[scout] allow global hook for single thread run + enable streams only once (#242672)\n\n## Summary\n\nThe main PR purpose is to improve and speed up Stream e2e tests for\nCloud testing (ECH/MKI):\n\n1. every suite repeatedly enables/disables streams functionality via API\nsolution: add `global hook` to enable streams before the tests execution\nstart:\n\n`x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts\n(--stateful)`\nbefore: `84 passed (13.3m)`\nafter: `81 passed (9.9m)` (one test despite improved cleanup returns\ninconsistent values and fails on Cloud and I had to skip it)\n\n2. some suites have time consuming `beforeEach` hook and rather short UI\nflow\nsolution: convert UI test blocks into \"steps\" and save time on\npre-loading.\n`streams_list_view/streams_collapsible_rows.spec.ts`\nbefore: `23.8s`\nafter: `9.4s`\n\n   `data_management/streams_header.spec.ts`\n    before: `19.3s`\n    after: `15.1s`\n\n3. some suites do the cleanup in `beforeEach` hook, but missing cleanup\nin `afterAll` and affects the follow-up tests if files execution order\nis changed.\nsolution: add missing hook\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"27010a19f43ca008c8dec2daafa9d8a17c7365a0"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/242672","number":242672,"mergeCommit":{"message":"[scout] allow global hook for single thread run + enable streams only once (#242672)\n\n## Summary\n\nThe main PR purpose is to improve and speed up Stream e2e tests for\nCloud testing (ECH/MKI):\n\n1. every suite repeatedly enables/disables streams functionality via API\nsolution: add `global hook` to enable streams before the tests execution\nstart:\n\n`x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts\n(--stateful)`\nbefore: `84 passed (13.3m)`\nafter: `81 passed (9.9m)` (one test despite improved cleanup returns\ninconsistent values and fails on Cloud and I had to skip it)\n\n2. some suites have time consuming `beforeEach` hook and rather short UI\nflow\nsolution: convert UI test blocks into \"steps\" and save time on\npre-loading.\n`streams_list_view/streams_collapsible_rows.spec.ts`\nbefore: `23.8s`\nafter: `9.4s`\n\n   `data_management/streams_header.spec.ts`\n    before: `19.3s`\n    after: `15.1s`\n\n3. some suites do the cleanup in `beforeEach` hook, but missing cleanup\nin `afterAll` and affects the follow-up tests if files execution order\nis changed.\nsolution: add missing hook\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"27010a19f43ca008c8dec2daafa9d8a17c7365a0"}},{"branch":"9.2","label":"v9.2.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->