### PR TITLE
[9.1] [ResponseOps][Email Connector] add additional validation for the `oauthTokenUrl` config (#244267)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.test.ts
@@ -47,6 +47,19 @@ const mockedLogger: jest.Mocked<Logger> = loggerMock.create();
 let connectorType: EmailConnectorType;
 let configurationUtilities: jest.Mocked<ActionsConfigurationUtilities>;
 
+const getConfig = (overrides?: {}) => ({
+  service: 'gmail',
+  from: 'bob@example.com',
+  host: null,
+  port: null,
+  secure: false,
+  hasAuth: true,
+  tenantId: null,
+  clientId: null,
+  oauthTokenUrl: null,
+  ...overrides,
+});
+
 beforeEach(() => {
   jest.resetAllMocks();
   configurationUtilities = actionsConfigMock.create();
@@ -329,7 +342,7 @@ describe('config validation', () => {
     expect(() => {
       validateConfig(connectorType, config, { configurationUtilities: configUtilsSmtp });
     }).toThrowErrorMatchingInlineSnapshot(
-      `"error validating connector type config: [oauthTokenUrl]: host name value for 'http://auth.example.com' is not in the allowedHosts configuration"`
+      `"error validating action type config: [oauthTokenUrl]: host name value for 'http://auth.example.com' is not in the allowedHosts configuration"`
     );
   });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.test.ts
@@ -14,6 +14,8 @@ import { loggerMock } from '@kbn/logging-mocks';
 import { actionsConfigMock } from '@kbn/actions-plugin/server/actions_config.mock';
 import { actionsMock } from '@kbn/actions-plugin/server/mocks';
 import type { ActionsConfigurationUtilities } from '@kbn/actions-plugin/server/actions_config';
+import { getActionsConfigurationUtilities } from '@kbn/actions-plugin/server/actions_config';
+import { configSchema as actionsConfigSchema } from '@kbn/actions-plugin/server/config';
 import {
   validateConfig,
   validateConnector,
@@ -35,6 +37,7 @@ import type { ValidateEmailAddressesOptions } from '@kbn/actions-plugin/common';
 import { ActionExecutionSourceType } from '@kbn/actions-plugin/server/types';
 import { AdditionalEmailServices } from '../../../common';
 import { serviceParamValueToKbnSettingMap } from '../../../common/email/constants';
+import type { ActionsConfig } from '@kbn/actions-plugin/server/config';
 
 const sendEmailMock = sendEmail as jest.Mock;
 
@@ -296,6 +299,37 @@ describe('config validation', () => {
       validateConfig(connectorType, notAllowedHosts2, { configurationUtilities: configUtils });
     }).toThrowErrorMatchingInlineSnapshot(
       `"error validating action type config: [host] value 'smtp.gmail.com' is not in the allowedHosts configuration"`
+    );
+  });
+
+  test('config validation handles oauthTokenUrl in allowedHosts', () => {
+    const configUtilsAny = getActionsConfigUtils({});
+    const configUtilsSmtp = getActionsConfigUtils({
+      allowedHosts: ['smtp.example.com'],
+    });
+    const configUtilsSmtpAuth = getActionsConfigUtils({
+      allowedHosts: ['smtp.example.com', 'auth.example.com'],
+    });
+
+    const config = getConfig({
+      service: undefined,
+      host: 'smtp.example.com',
+      port: 35,
+      oauthTokenUrl: 'http://auth.example.com',
+    });
+
+    expect(
+      validateConfig(connectorType, config, { configurationUtilities: configUtilsAny })
+    ).toBeTruthy();
+
+    expect(
+      validateConfig(connectorType, config, { configurationUtilities: configUtilsSmtpAuth })
+    ).toBeTruthy();
+
+    expect(() => {
+      validateConfig(connectorType, config, { configurationUtilities: configUtilsSmtp });
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"error validating connector type config: [oauthTokenUrl]: host name value for 'http://auth.example.com' is not in the allowedHosts configuration"`
     );
   });
 
@@ -1600,4 +1634,9 @@ function validateEmailAddressesImpl(
   options?: ValidateEmailAddressesOptions
 ): string | undefined {
   return 'stub for actual message';
+}
+
+function getActionsConfigUtils(config: Partial<ActionsConfig>): ActionsConfigurationUtilities {
+  const validatedConfig = actionsConfigSchema.validate(config);
+  return getActionsConfigurationUtilities(validatedConfig);
 }

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.ts
@@ -105,6 +105,13 @@ function validateConfig(
     throw new Error(`[from]: ${invalidEmailsMessage}`);
   }
 
+  const { oauthTokenUrl } = config;
+  if (oauthTokenUrl && !configurationUtilities.isUriAllowed(oauthTokenUrl)) {
+    throw new Error(
+      `[oauthTokenUrl]: host name value for '${oauthTokenUrl}' is not in the allowedHosts configuration`
+    );
+  }
+
   // If service is set as JSON_TRANSPORT_SERVICE or EXCHANGE, host/port are ignored, when the email is sent.
   // Note, not currently making these message translated, as will be
   // emitted alongside messages from @kbn/config-schema, which does not


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ResponseOps][Email Connector] add additional validation for the `oauthTokenUrl` config (#244267)](https://github.com/elastic/kibana/pull/244267)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2025-11-26T20:06:46Z","message":"[ResponseOps][Email Connector] add additional validation for the `oauthTokenUrl` config (#244267)\n\nAdds additional validation of the email config `oauthTokenUrl`.","sha":"1223e18b94896ae7a9fcbbd046977c172f103a9a","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Actions","Team:ResponseOps","Feature:Actions/Framework","backport:all-open","v9.3.0"],"title":"[ResponseOps][Email Connector] add additional validation for  `oauthTokenUrl` config","number":244267,"url":"https://github.com/elastic/kibana/pull/244267","mergeCommit":{"message":"[ResponseOps][Email Connector] add additional validation for the `oauthTokenUrl` config (#244267)\n\nAdds additional validation of the email config `oauthTokenUrl`.","sha":"1223e18b94896ae7a9fcbbd046977c172f103a9a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/244267","number":244267,"mergeCommit":{"message":"[ResponseOps][Email Connector] add additional validation for the `oauthTokenUrl` config (#244267)\n\nAdds additional validation of the email config `oauthTokenUrl`.","sha":"1223e18b94896ae7a9fcbbd046977c172f103a9a"}}]}] BACKPORT-->