### PR TITLE
[8.19] [ResponseOps][Connectors] Fix bug with testing MS Exchange connector  (#243763)

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/email/email_connector.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/email/email_connector.test.tsx
@@ -6,17 +6,13 @@
  */
 
 import React, { Suspense } from 'react';
-import { mountWithIntl } from '@kbn/test-jest-helpers';
-import { act, screen, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useKibana } from '@kbn/triggers-actions-ui-plugin/public';
 import EmailActionConnectorFields from './email_connector';
-import {
-  AppMockRenderer,
-  ConnectorFormTestProvider,
-  createAppMockRenderer,
-  waitForComponentToUpdate,
-} from '../lib/test_utils';
+import type { AppMockRenderer } from '../lib/test_utils';
+import { ConnectorFormTestProvider, createAppMockRenderer } from '../lib/test_utils';
+import { AdditionalEmailServices } from '../../../common';
 import { getServiceConfig } from './api';
 
 jest.mock('@kbn/triggers-actions-ui-plugin/public/common/lib/kibana');
@@ -30,12 +26,17 @@ jest.mock('./api', () => {
 
 describe('EmailActionConnectorFields', () => {
   const enabledEmailServices = ['*'];
+  let appMockRenderer: AppMockRenderer;
+
+  beforeEach(() => {
+    appMockRenderer = createAppMockRenderer();
+  });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('all connector fields are rendered', async () => {
+  it('all connector fields are rendered', async () => {
     const actionConnector = {
       secrets: {
         user: 'user',
@@ -47,11 +48,12 @@ describe('EmailActionConnectorFields', () => {
       config: {
         from: 'test@test.com',
         hasAuth: true,
+        service: 'other',
       },
       isDeprecated: false,
     };
 
-    const wrapper = mountWithIntl(
+    appMockRenderer.render(
       <ConnectorFormTestProvider connector={actionConnector}>
         <EmailActionConnectorFields
           readOnly={false}
@@ -61,20 +63,27 @@ describe('EmailActionConnectorFields', () => {
       </ConnectorFormTestProvider>
     );
 
-    await waitForComponentToUpdate();
+    const emailFromInput = await screen.findByTestId('emailFromInput');
+    expect(emailFromInput).toBeInTheDocument();
+    expect(emailFromInput).toHaveValue('test@test.com');
 
-    expect(wrapper.find('[data-test-subj="emailFromInput"]').length > 0).toBeTruthy();
-    expect(wrapper.find('[data-test-subj="emailFromInput"]').first().prop('value')).toBe(
-      'test@test.com'
-    );
-    expect(wrapper.find('[data-test-subj="emailServiceSelectInput"]').length > 0).toBeTruthy();
-    expect(wrapper.find('[data-test-subj="emailHostInput"]').length > 0).toBeTruthy();
-    expect(wrapper.find('[data-test-subj="emailPortInput"]').length > 0).toBeTruthy();
-    expect(wrapper.find('[data-test-subj="emailUserInput"]').length > 0).toBeTruthy();
-    expect(wrapper.find('[data-test-subj="emailPasswordInput"]').length > 0).toBeTruthy();
+    const emailServiceSelectInput = await screen.findByTestId('emailServiceSelectInput');
+    expect(emailServiceSelectInput).toBeInTheDocument();
+
+    const emailHostInput = await screen.findByTestId('emailHostInput');
+    expect(emailHostInput).toBeInTheDocument();
+
+    const emailPortInput = await screen.findByTestId('emailPortInput');
+    expect(emailPortInput).toBeInTheDocument();
+
+    const emailUserInput = await screen.findByTestId('emailUserInput');
+    expect(emailUserInput).toBeInTheDocument();
+
+    const emailPasswordInput = await screen.findByTestId('emailPasswordInput');
+    expect(emailPasswordInput).toBeInTheDocument();
   });
 
-  test('secret connector fields are not rendered when hasAuth false', async () => {
+  it('secret connector fields are not rendered when hasAuth false', async () => {
     const actionConnector = {
       secrets: {},
       id: 'test',
@@ -83,11 +92,12 @@ describe('EmailActionConnectorFields', () => {
       config: {
         from: 'test@test.com',
         hasAuth: false,
+        service: 'other',
       },
       isDeprecated: false,
     };
 
-    const wrapper = mountWithIntl(
+    appMockRenderer.render(
       <ConnectorFormTestProvider connector={actionConnector}>
         <EmailActionConnectorFields
           readOnly={false}
@@ -97,19 +107,21 @@ describe('EmailActionConnectorFields', () => {
       </ConnectorFormTestProvider>
     );
 
-    await waitForComponentToUpdate();
+    const emailFromInput = await screen.findByTestId('emailFromInput');
+    expect(emailFromInput).toBeInTheDocument();
+    expect(emailFromInput).toHaveValue('test@test.com');
 
-    expect(wrapper.find('[data-test-subj="emailFromInput"]').length > 0).toBeTruthy();
-    expect(wrapper.find('[data-test-subj="emailFromInput"]').first().prop('value')).toBe(
-      'test@test.com'
-    );
-    expect(wrapper.find('[data-test-subj="emailHostInput"]').length > 0).toBeTruthy();
-    expect(wrapper.find('[data-test-subj="emailPortInput"]').length > 0).toBeTruthy();
-    expect(wrapper.find('[data-test-subj="emailUserInput"]').length > 0).toBeFalsy();
-    expect(wrapper.find('[data-test-subj="emailPasswordInput"]').length > 0).toBeFalsy();
+    const emailHostInput = await screen.findByTestId('emailHostInput');
+    expect(emailHostInput).toBeInTheDocument();
+
+    const emailPortInput = await screen.findByTestId('emailPortInput');
+    expect(emailPortInput).toBeInTheDocument();
+
+    expect(screen.queryByTestId('emailUserInput')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('emailPasswordInput')).not.toBeInTheDocument();
   });
 
-  test('service field defaults to empty when not defined', async () => {
+  it('service field defaults to other when not defined', async () => {
     const actionConnector = {
       secrets: {
         user: 'user',
@@ -125,7 +137,7 @@ describe('EmailActionConnectorFields', () => {
       isDeprecated: false,
     };
 
-    const wrapper = mountWithIntl(
+    appMockRenderer.render(
       <ConnectorFormTestProvider connector={actionConnector}>
         <EmailActionConnectorFields
           readOnly={false}
@@ -135,18 +147,12 @@ describe('EmailActionConnectorFields', () => {
       </ConnectorFormTestProvider>
     );
 
-    await waitForComponentToUpdate();
-
-    expect(wrapper.find('[data-test-subj="emailFromInput"]').first().prop('value')).toBe(
-      'test@test.com'
-    );
-    expect(wrapper.find('[data-test-subj="emailServiceSelectInput"]').length > 0).toBeTruthy();
-    expect(wrapper.find('select[data-test-subj="emailServiceSelectInput"]').prop('value')).toEqual(
-      ''
-    );
+    const emailServiceSelectInput = await screen.findByTestId('emailServiceSelectInput');
+    expect(emailServiceSelectInput).toBeInTheDocument();
+    expect(emailServiceSelectInput).toHaveValue('other');
   });
 
-  test('service field are correctly selected when defined', async () => {
+  it('service field are correctly selected when defined', async () => {
     const actionConnector = {
       secrets: {
         user: 'user',
@@ -163,7 +169,7 @@ describe('EmailActionConnectorFields', () => {
       isDeprecated: false,
     };
 
-    const wrapper = mountWithIntl(
+    appMockRenderer.render(
       <ConnectorFormTestProvider connector={actionConnector}>
         <EmailActionConnectorFields
           readOnly={false}
@@ -173,15 +179,12 @@ describe('EmailActionConnectorFields', () => {
       </ConnectorFormTestProvider>
     );
 
-    await waitForComponentToUpdate();
-
-    expect(wrapper.find('[data-test-subj="emailServiceSelectInput"]').length > 0).toBeTruthy();
-    expect(wrapper.find('select[data-test-subj="emailServiceSelectInput"]').prop('value')).toEqual(
-      'gmail'
-    );
+    const emailServiceSelectInput = await screen.findByTestId('emailServiceSelectInput');
+    expect(emailServiceSelectInput).toBeInTheDocument();
+    expect(emailServiceSelectInput).toHaveValue('gmail');
   });
 
-  test('host, port and secure fields should be disabled when service field is set to well known service', async () => {
+  it('host, port and secure fields should be disabled when service field is set to well known service', async () => {
     (getServiceConfig as jest.Mock).mockResolvedValue({
       host: 'https://example.com',
       port: 80,
@@ -204,7 +207,7 @@ describe('EmailActionConnectorFields', () => {
       isDeprecated: false,
     };
 
-    const wrapper = mountWithIntl(
+    appMockRenderer.render(
       <ConnectorFormTestProvider connector={actionConnector}>
         <EmailActionConnectorFields
           readOnly={false}
@@ -214,17 +217,17 @@ describe('EmailActionConnectorFields', () => {
       </ConnectorFormTestProvider>
     );
 
-    await waitForComponentToUpdate();
+    const emailHostInput = await screen.findByTestId('emailHostInput');
+    expect(emailHostInput).toBeDisabled();
 
-    wrapper.update();
-    expect(wrapper.find('[data-test-subj="emailHostInput"]').first().prop('disabled')).toBe(true);
-    expect(wrapper.find('[data-test-subj="emailPortInput"]').first().prop('disabled')).toBe(true);
-    expect(wrapper.find('[data-test-subj="emailSecureSwitch"]').first().prop('disabled')).toBe(
-      true
-    );
+    const emailPortInput = await screen.findByTestId('emailPortInput');
+    expect(emailPortInput).toBeDisabled();
+
+    const emailSecureSwitch = await screen.findByTestId('emailSecureSwitch');
+    expect(emailSecureSwitch).toBeDisabled();
   });
 
-  test('host, port and secure fields should not be disabled when service field is set to other', async () => {
+  it('host, port and secure fields should not be disabled when service field is set to other', async () => {
     (getServiceConfig as jest.Mock).mockResolvedValue({
       host: 'https://example.com',
       port: 80,
@@ -247,7 +250,7 @@ describe('EmailActionConnectorFields', () => {
       isDeprecated: false,
     };
 
-    const wrapper = mountWithIntl(
+    appMockRenderer.render(
       <ConnectorFormTestProvider connector={actionConnector}>
         <EmailActionConnectorFields
           readOnly={false}
@@ -257,17 +260,52 @@ describe('EmailActionConnectorFields', () => {
       </ConnectorFormTestProvider>
     );
 
-    await waitForComponentToUpdate();
+    const emailHostInput = await screen.findByTestId('emailHostInput');
+    expect(emailHostInput).not.toBeDisabled();
 
-    expect(wrapper.find('[data-test-subj="emailHostInput"]').first().prop('disabled')).toBe(false);
-    expect(wrapper.find('[data-test-subj="emailPortInput"]').first().prop('disabled')).toBe(false);
-    expect(wrapper.find('[data-test-subj="emailSecureSwitch"]').first().prop('disabled')).toBe(
-      false
-    );
+    const emailPortInput = await screen.findByTestId('emailPortInput');
+    expect(emailPortInput).not.toBeDisabled();
+
+    const emailSecureSwitch = await screen.findByTestId('emailSecureSwitch');
+    expect(emailSecureSwitch).not.toBeDisabled();
   });
 
+  it.each([[null], [''], [AdditionalEmailServices.EXCHANGE]])(
+    'should not show the host, port, and secure fields when service field is %s',
+    async (service) => {
+      const actionConnector = {
+        secrets: {
+          user: 'user',
+          password: 'pass',
+        },
+        id: 'test',
+        actionTypeId: '.email',
+        name: 'email',
+        config: {
+          from: 'test@test.com',
+          hasAuth: true,
+          service,
+        },
+        isDeprecated: false,
+      };
+
+      appMockRenderer.render(
+        <ConnectorFormTestProvider connector={actionConnector}>
+          <EmailActionConnectorFields
+            readOnly={false}
+            isEdit={false}
+            registerPreSubmitValidator={() => {}}
+          />
+        </ConnectorFormTestProvider>
+      );
+
+      expect(screen.queryByTestId('emailHostInput')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('emailPortInput')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('emailSecureSwitch')).not.toBeInTheDocument();
+    }
+  );
+
   describe('Validation', () => {
-    let appMockRenderer: AppMockRenderer;
     const onSubmit = jest.fn();
     const validateEmailAddresses = jest.fn();
 
@@ -298,7 +336,7 @@ describe('EmailActionConnectorFields', () => {
         isDeprecated: false,
       };
 
-      const { getByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <ConnectorFormTestProvider
           connector={actionConnector}
           onSubmit={onSubmit}
@@ -312,11 +350,8 @@ describe('EmailActionConnectorFields', () => {
         </ConnectorFormTestProvider>
       );
 
-      await waitForComponentToUpdate();
-
-      await act(async () => {
-        await userEvent.click(getByTestId('form-test-provide-submit'));
-      });
+      const submitButton = await screen.findByTestId('form-test-provide-submit');
+      await userEvent.click(submitButton);
 
       expect(onSubmit).toBeCalledWith({
         data: {
@@ -362,7 +397,7 @@ describe('EmailActionConnectorFields', () => {
         isDeprecated: false,
       };
 
-      const { getByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <ConnectorFormTestProvider
           connector={actionConnector}
           onSubmit={onSubmit}
@@ -376,11 +411,8 @@ describe('EmailActionConnectorFields', () => {
         </ConnectorFormTestProvider>
       );
 
-      await waitForComponentToUpdate();
-
-      await act(async () => {
-        await userEvent.click(getByTestId('form-test-provide-submit'));
-      });
+      const submitButton = await screen.findByTestId('form-test-provide-submit');
+      await userEvent.click(submitButton);
 
       expect(onSubmit).toBeCalledWith({
         data: {
@@ -396,6 +428,69 @@ describe('EmailActionConnectorFields', () => {
           id: 'test',
           isDeprecated: false,
           name: 'email',
+        },
+        isValid: true,
+      });
+    });
+
+    it('submits the connector with a service correctly', async () => {
+      (getServiceConfig as jest.Mock).mockResolvedValue({
+        host: 'https://example.com',
+        port: 80,
+        secure: false,
+      });
+
+      const actionConnector = {
+        secrets: {
+          user: 'user',
+          password: 'pass',
+        },
+        id: 'test',
+        actionTypeId: '.email',
+        name: 'email',
+        config: {
+          from: 'test@test.com',
+          hasAuth: true,
+          service: 'gmail',
+        },
+        isDeprecated: false,
+      };
+
+      appMockRenderer.render(
+        <ConnectorFormTestProvider
+          connector={actionConnector}
+          onSubmit={onSubmit}
+          connectorServices={{ validateEmailAddresses, enabledEmailServices }}
+        >
+          <EmailActionConnectorFields
+            readOnly={false}
+            isEdit={false}
+            registerPreSubmitValidator={() => {}}
+          />
+        </ConnectorFormTestProvider>
+      );
+
+      const submitButton = await screen.findByTestId('form-test-provide-submit');
+      await userEvent.click(submitButton);
+
+      expect(onSubmit).toBeCalledWith({
+        data: {
+          actionTypeId: '.email',
+          config: {
+            from: 'test@test.com',
+            hasAuth: true,
+            host: 'https://example.com',
+            port: 80,
+            secure: false,
+            service: 'gmail',
+          },
+          id: 'test',
+          isDeprecated: false,
+          name: 'email',
+          secrets: {
+            user: 'user',
+            password: 'pass',
+          },
         },
         isValid: true,
       });
@@ -421,7 +516,7 @@ describe('EmailActionConnectorFields', () => {
         isDeprecated: false,
       };
 
-      const { getByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <ConnectorFormTestProvider
           connector={actionConnector}
           onSubmit={onSubmit}
@@ -435,11 +530,8 @@ describe('EmailActionConnectorFields', () => {
         </ConnectorFormTestProvider>
       );
 
-      await waitForComponentToUpdate();
-
-      await act(async () => {
-        await userEvent.click(getByTestId('form-test-provide-submit'));
-      });
+      const submitButton = await screen.findByTestId('form-test-provide-submit');
+      await userEvent.click(submitButton);
 
       expect(onSubmit).toBeCalledWith({
         data: {},
@@ -469,7 +561,7 @@ describe('EmailActionConnectorFields', () => {
         },
       };
 
-      const { getByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <ConnectorFormTestProvider
           connector={actionConnector}
           onSubmit={onSubmit}
@@ -483,57 +575,8 @@ describe('EmailActionConnectorFields', () => {
         </ConnectorFormTestProvider>
       );
 
-      await waitForComponentToUpdate();
-
-      await act(async () => {
-        await userEvent.click(getByTestId('form-test-provide-submit'));
-      });
-
-      expect(onSubmit).toBeCalledWith({
-        data: {},
-        isValid: false,
-      });
-    });
-
-    it('connector validation fails when server type is not selected', async () => {
-      const actionConnector = {
-        secrets: {
-          user: 'user',
-          password: 'password',
-        },
-        id: 'test',
-        actionTypeId: '.email',
-        isPreconfigured: false,
-        isDeprecated: false,
-        name: 'email',
-        config: {
-          from: 'test@test.com',
-          port: 2323,
-          host: 'localhost',
-          test: 'test',
-          hasAuth: true,
-        },
-      };
-
-      const { getByTestId } = appMockRenderer.render(
-        <ConnectorFormTestProvider
-          connector={actionConnector}
-          onSubmit={onSubmit}
-          connectorServices={{ validateEmailAddresses, enabledEmailServices }}
-        >
-          <EmailActionConnectorFields
-            readOnly={false}
-            isEdit={false}
-            registerPreSubmitValidator={() => {}}
-          />
-        </ConnectorFormTestProvider>
-      );
-
-      await waitForComponentToUpdate();
-
-      await act(async () => {
-        await userEvent.click(getByTestId('form-test-provide-submit'));
-      });
+      const submitButton = await screen.findByTestId('form-test-provide-submit');
+      await userEvent.click(submitButton);
 
       expect(onSubmit).toBeCalledWith({
         data: {},
@@ -560,7 +603,7 @@ describe('EmailActionConnectorFields', () => {
         },
       };
 
-      const { getByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <ConnectorFormTestProvider
           connector={actionConnector}
           onSubmit={onSubmit}
@@ -576,11 +619,8 @@ describe('EmailActionConnectorFields', () => {
         </ConnectorFormTestProvider>
       );
 
-      await waitForComponentToUpdate();
-
-      await act(async () => {
-        await userEvent.click(getByTestId('form-test-provide-submit'));
-      });
+      const submitButton = await screen.findByTestId('form-test-provide-submit');
+      await userEvent.click(submitButton);
 
       expect(onSubmit).toBeCalledWith({
         data: {},
@@ -623,11 +663,7 @@ describe('EmailActionConnectorFields', () => {
           </ConnectorFormTestProvider>
         );
 
-        await waitForComponentToUpdate();
-
-        await act(async () => {
-          await userEvent.click(getByTestId('form-test-provide-submit'));
-        });
+        await userEvent.click(getByTestId('form-test-provide-submit'));
 
         expect(onSubmit).toBeCalledWith({
           data: {},
@@ -655,7 +691,7 @@ describe('EmailActionConnectorFields', () => {
         isDeprecated: false,
       };
 
-      const { getByTestId } = appMockRenderer.render(
+      appMockRenderer.render(
         <ConnectorFormTestProvider
           connector={actionConnector}
           onSubmit={onSubmit}
@@ -669,11 +705,8 @@ describe('EmailActionConnectorFields', () => {
         </ConnectorFormTestProvider>
       );
 
-      await waitForComponentToUpdate();
-
-      await act(async () => {
-        await userEvent.click(getByTestId('form-test-provide-submit'));
-      });
+      const submitButton = await screen.findByTestId('form-test-provide-submit');
+      await userEvent.click(submitButton);
 
       expect(onSubmit).toBeCalledWith({
         data: {
@@ -747,7 +780,9 @@ describe('when not all email services are enabled', () => {
       </ConnectorFormTestProvider>
     );
 
-    const emailServiceSelect = screen.getByTestId('emailServiceSelectInput') as HTMLSelectElement;
+    const emailServiceSelect = (await screen.findByTestId(
+      'emailServiceSelectInput'
+    )) as HTMLSelectElement;
 
     const options = within(emailServiceSelect).getAllByRole('option');
     expect(options).toHaveLength(3);
@@ -788,7 +823,9 @@ describe('when not all email services are enabled', () => {
       </ConnectorFormTestProvider>
     );
 
-    const emailServiceSelect = screen.getByTestId('emailServiceSelectInput') as HTMLSelectElement;
+    const emailServiceSelect = (await screen.findByTestId(
+      'emailServiceSelectInput'
+    )) as HTMLSelectElement;
 
     const options = within(emailServiceSelect).getAllByRole('option');
     expect(options).toHaveLength(4);
@@ -796,5 +833,114 @@ describe('when not all email services are enabled', () => {
     expect(options[1].textContent).toBe('Amazon SES');
     expect(options[2].textContent).toBe('MS Exchange Server');
     expect(options[3].textContent).toBe('Other');
+  });
+
+  it('sets the service to other if the enabled services contain *', async () => {
+    const actionConnector = {
+      secrets: {
+        user: 'user',
+        password: 'pass',
+      },
+      id: 'test',
+      actionTypeId: '.email',
+      name: 'email',
+      config: {
+        from: 'test@test.com',
+        hasAuth: true,
+      },
+      isDeprecated: false,
+    };
+
+    appMockRenderer.render(
+      <ConnectorFormTestProvider
+        connector={actionConnector}
+        connectorServices={{ validateEmailAddresses, enabledEmailServices: ['google-mail', '*'] }}
+      >
+        <EmailActionConnectorFields
+          readOnly={false}
+          isEdit={false}
+          registerPreSubmitValidator={() => {}}
+        />
+      </ConnectorFormTestProvider>
+    );
+
+    const emailServiceSelectInput = await screen.findByTestId('emailServiceSelectInput');
+    expect(emailServiceSelectInput).toBeInTheDocument();
+    expect(emailServiceSelectInput).toHaveValue('other');
+  });
+
+  it('sets the service to the first available', async () => {
+    const actionConnector = {
+      secrets: {
+        user: 'user',
+        password: 'pass',
+      },
+      id: 'test',
+      actionTypeId: '.email',
+      name: 'email',
+      config: {
+        from: 'test@test.com',
+        hasAuth: true,
+      },
+      isDeprecated: false,
+    };
+
+    appMockRenderer.render(
+      <ConnectorFormTestProvider
+        connector={actionConnector}
+        connectorServices={{
+          validateEmailAddresses,
+          enabledEmailServices: ['google-mail', 'microsoft-outlook'],
+        }}
+      >
+        <EmailActionConnectorFields
+          readOnly={false}
+          isEdit={false}
+          registerPreSubmitValidator={() => {}}
+        />
+      </ConnectorFormTestProvider>
+    );
+
+    const emailServiceSelectInput = await screen.findByTestId('emailServiceSelectInput');
+    expect(emailServiceSelectInput).toBeInTheDocument();
+    expect(emailServiceSelectInput).toHaveValue('gmail');
+  });
+
+  it('does not override the service if it is defined', async () => {
+    const actionConnector = {
+      secrets: {
+        user: 'user',
+        password: 'pass',
+      },
+      id: 'test',
+      actionTypeId: '.email',
+      name: 'email',
+      config: {
+        from: 'test@test.com',
+        hasAuth: true,
+        service: 'gmail',
+      },
+      isDeprecated: false,
+    };
+
+    appMockRenderer.render(
+      <ConnectorFormTestProvider
+        connector={actionConnector}
+        connectorServices={{
+          validateEmailAddresses,
+          enabledEmailServices,
+        }}
+      >
+        <EmailActionConnectorFields
+          readOnly={false}
+          isEdit={false}
+          registerPreSubmitValidator={() => {}}
+        />
+      </ConnectorFormTestProvider>
+    );
+
+    const emailServiceSelectInput = await screen.findByTestId('emailServiceSelectInput');
+    expect(emailServiceSelectInput).toBeInTheDocument();
+    expect(emailServiceSelectInput).toHaveValue('gmail');
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/email/email_connector.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/email/email_connector.test.tsx
@@ -290,13 +290,15 @@ describe('EmailActionConnectorFields', () => {
       };
 
       appMockRenderer.render(
-        <ConnectorFormTestProvider connector={actionConnector}>
-          <EmailActionConnectorFields
-            readOnly={false}
-            isEdit={false}
-            registerPreSubmitValidator={() => {}}
-          />
-        </ConnectorFormTestProvider>
+        <Suspense fallback={null}>
+          <ConnectorFormTestProvider connector={actionConnector}>
+            <EmailActionConnectorFields
+              readOnly={false}
+              isEdit={false}
+              registerPreSubmitValidator={() => {}}
+            />
+          </ConnectorFormTestProvider>
+        </Suspense>
       );
 
       expect(screen.queryByTestId('emailHostInput')).not.toBeInTheDocument();

--- a/x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/with_email_services_enabled_kbn_config/email.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/connectors/with_email_services_enabled_kbn_config/email.ts
@@ -24,10 +24,11 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       const emailServicesOptions = await find.allByCssSelector(
         '[data-test-subj="emailServiceSelectInput"] > option'
       );
-      expect(emailServicesOptions.length).to.be(3);
-      expect(await emailServicesOptions[0].getVisibleText()).to.be(' '); // empty option
-      expect(await emailServicesOptions[1].getVisibleText()).to.be('Gmail');
-      expect(await emailServicesOptions[2].getVisibleText()).to.be('Amazon SES');
+
+      expect(emailServicesOptions.length).to.be(2);
+
+      expect(await emailServicesOptions[0].getVisibleText()).to.be('Gmail');
+      expect(await emailServicesOptions[1].getVisibleText()).to.be('Amazon SES');
     });
   });
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps][Connectors] Fix bug with testing MS Exchange connector  (#243763)](https://github.com/elastic/kibana/pull/243763)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Christos Nasikas","email":"christos.nasikas@elastic.co"},"sourceCommit":{"committedDate":"2025-11-26T09:42:14Z","message":"[ResponseOps][Connectors] Fix bug with testing MS Exchange connector  (#243763)\n\n## Summary\n\nThis PR fixes a bug where, if you open the flyout to test, it will not\nlet you because it assumes the user changed a value in the form. This\nwas happening because on first render, the `config.service` is set to\n`null` and then to the actual value. This made the host, port, and\nsecure fields render instantly, and that caused these values to change\nthe form state. This PR fixes this issue.\n\n## Testing\n- Be sure that you can create and edit an email connector with all\nservices.\n- Be sure that by going back and forth from the \"Configuration\" tab to\nthe \"Testing\" tab allows you to test the connector (assuming you did not\nchange any value)\n- Change a value in the connector. The warning banner to save your\nchanges appears.\n\nWARNING: If you have your browser's autofill turned on and it fills the\npassword fields, the form will be marked as modified by the framework.\n\nFixes: https://github.com/elastic/kibana/issues/237950\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"fa1d46e01d5ab5baaba02aa83b59ec68fbc737f1","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:version","v9.3.0","v8.19.8","v9.2.2","v9.1.8"],"title":"[ResponseOps][Connectors] Fix bug with testing MS Exchange connector ","number":243763,"url":"https://github.com/elastic/kibana/pull/243763","mergeCommit":{"message":"[ResponseOps][Connectors] Fix bug with testing MS Exchange connector  (#243763)\n\n## Summary\n\nThis PR fixes a bug where, if you open the flyout to test, it will not\nlet you because it assumes the user changed a value in the form. This\nwas happening because on first render, the `config.service` is set to\n`null` and then to the actual value. This made the host, port, and\nsecure fields render instantly, and that caused these values to change\nthe form state. This PR fixes this issue.\n\n## Testing\n- Be sure that you can create and edit an email connector with all\nservices.\n- Be sure that by going back and forth from the \"Configuration\" tab to\nthe \"Testing\" tab allows you to test the connector (assuming you did not\nchange any value)\n- Change a value in the connector. The warning banner to save your\nchanges appears.\n\nWARNING: If you have your browser's autofill turned on and it fills the\npassword fields, the form will be marked as modified by the framework.\n\nFixes: https://github.com/elastic/kibana/issues/237950\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"fa1d46e01d5ab5baaba02aa83b59ec68fbc737f1"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243763","number":243763,"mergeCommit":{"message":"[ResponseOps][Connectors] Fix bug with testing MS Exchange connector  (#243763)\n\n## Summary\n\nThis PR fixes a bug where, if you open the flyout to test, it will not\nlet you because it assumes the user changed a value in the form. This\nwas happening because on first render, the `config.service` is set to\n`null` and then to the actual value. This made the host, port, and\nsecure fields render instantly, and that caused these values to change\nthe form state. This PR fixes this issue.\n\n## Testing\n- Be sure that you can create and edit an email connector with all\nservices.\n- Be sure that by going back and forth from the \"Configuration\" tab to\nthe \"Testing\" tab allows you to test the connector (assuming you did not\nchange any value)\n- Change a value in the connector. The warning banner to save your\nchanges appears.\n\nWARNING: If you have your browser's autofill turned on and it fills the\npassword fields, the form will be marked as modified by the framework.\n\nFixes: https://github.com/elastic/kibana/issues/237950\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"fa1d46e01d5ab5baaba02aa83b59ec68fbc737f1"}},{"branch":"8.19","label":"v8.19.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/244302","number":244302,"state":"MERGED","mergeCommit":{"sha":"cf3b256cc417d9961d1b0d4897d50979d2031965","message":"[9.2] [ResponseOps][Connectors] Fix bug with testing MS Exchange connector  (#243763) (#244302)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[ResponseOps][Connectors] Fix bug with testing MS Exchange connector\n(#243763)](https://github.com/elastic/kibana/pull/243763)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Christos Nasikas <christos.nasikas@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"branch":"9.1","label":"v9.1.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/244417","number":244417,"state":"OPEN"}]}] BACKPORT-->