### PR TITLE
Skip flaky APM service group count tests for cloud runs

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/service_groups/service_group_count/service_group_count.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/service_groups/service_group_count/service_group_count.spec.ts
@@ -37,7 +37,10 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     });
   };
 
-  describe('Service group counts', () => {
+  describe('Service group counts', function () {
+    // flaky when running in stateful cloud, see https://github.com/elastic/kibana/issues/244457
+    this.tags(['skipCloud']);
+
     let synthbeansServiceGroupId: string;
     let opbeansServiceGroupId: string;
     let apmSynthtraceEsClient: ApmSynthtraceEsClient;


### PR DESCRIPTION
## Summary

This PR skips the deployment agnostic APM service group count test suite for cloud runs.
Details on the failure / flakiness in #244457