### PR TITLE
[9.1] [Scout] Add support for custom roles in Scout API tests (#243187)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/common/services/custom_role.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/custom_role.ts
@@ -66,3 +66,9 @@ export const createElasticsearchCustomRole = async (
     ...role,
   });
 };
+
+export const isElasticsearchRole = (
+  role: KibanaRole | ElasticsearchRoleDescriptor
+): role is ElasticsearchRoleDescriptor => {
+  return !(role && 'kibana' in role);
+};

--- a/src/platform/packages/shared/kbn-scout/src/common/services/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/index.ts
@@ -18,5 +18,9 @@ export type { SamlSessionManager } from '@kbn/test';
 export { ScoutLogger } from './logger';
 export type { KbnClient } from '@kbn/test';
 export type { Client as EsClient } from '@elastic/elasticsearch';
-export { createCustomRole, createElasticsearchCustomRole } from './custom_role';
+export {
+  createCustomRole,
+  createElasticsearchCustomRole,
+  isElasticsearchRole,
+} from './custom_role';
 export type { ElasticsearchRoleDescriptor, KibanaRole } from './custom_role';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/api_key.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/api_key.ts
@@ -7,10 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { Client } from '@elastic/elasticsearch';
 import { coreWorkerFixtures } from './core_fixtures';
-import { ApiClientFixture } from './api_client';
-import { DefaultRolesFixture } from './default_roles';
-import { measurePerformanceAsync } from '../../../../common';
+import type { ApiClientFixture } from './api_client';
+import type { DefaultRolesFixture } from './default_roles';
+import type { ElasticsearchRoleDescriptor, KibanaRole } from '../../../../common';
+import { measurePerformanceAsync, isElasticsearchRole } from '../../../../common';
 
 export interface ApiKey {
   id: string;
@@ -30,6 +32,9 @@ export interface RoleApiCredentials {
 
 export interface RequestAuthFixture {
   getApiKey: (role: string) => Promise<RoleApiCredentials>;
+  getApiKeyForCustomRole: (
+    role: KibanaRole | ElasticsearchRoleDescriptor
+  ) => Promise<RoleApiCredentials>;
 }
 
 export const requestAuthFixture = coreWorkerFixtures.extend<
@@ -38,23 +43,68 @@ export const requestAuthFixture = coreWorkerFixtures.extend<
     requestAuth: RequestAuthFixture;
     defaultRoles: DefaultRolesFixture;
     apiClient: ApiClientFixture;
+    esClient: Client;
   }
 >({
   requestAuth: [
-    async ({ log, samlAuth, defaultRoles, apiClient }, use, workerInfo) => {
+    async ({ log, samlAuth, defaultRoles, apiClient, esClient }, use, workerInfo) => {
       const generatedApiKeys: ApiKey[] = [];
+      let isCustomRoleCreated = false;
 
       const createApiKeyPayload = (
         apiKeyName: string,
-        role: string,
+        roleName: string,
         descriptors: Record<string, any>
-      ) => ({
-        name: apiKeyName,
-        metadata: {},
-        ...(role === samlAuth.customRoleName
-          ? { kibana_role_descriptors: descriptors }
-          : { role_descriptors: descriptors }),
-      });
+      ) => {
+        const roleDescriptor = descriptors[roleName];
+
+        return {
+          name: apiKeyName,
+          metadata: {},
+          ...(isElasticsearchRole(roleDescriptor)
+            ? { role_descriptors: descriptors }
+            : { kibana_role_descriptors: descriptors }),
+        };
+      };
+
+      const createApiKeyWithAdminCredentials = async (
+        roleName: string,
+        roleDescriptors: Record<string, any>
+      ) => {
+        log.debug(
+          `Creating API key for ${roleName} with privileges: ${JSON.stringify(roleDescriptors)}`
+        );
+
+        const apiKeyName = `myTestApiKey-${generatedApiKeys.length}-${roleName}-worker-${
+          workerInfo.parallelIndex + 1
+        }`;
+
+        const adminCookieHeader = await samlAuth.session.getApiCredentialsForRole('admin');
+
+        const payload = createApiKeyPayload(apiKeyName, roleName, roleDescriptors);
+        const response = await apiClient.post('internal/security/api_key', {
+          headers: {
+            'kbn-xsrf': 'some-xsrf-token',
+            'x-elastic-internal-origin': 'kibana',
+            ...adminCookieHeader,
+          },
+          body: payload,
+          responseType: 'json',
+        });
+
+        if (response.statusCode !== 200) {
+          throw new Error(
+            `Failed to create API key for '${roleName}' role with response text: ${response.statusMessage}`
+          );
+        }
+
+        const apiKey = response.body as ApiKey;
+        const apiKeyHeader = { Authorization: `ApiKey ${apiKey.encoded}` };
+
+        log.info(`Created API key for ${roleName} role: ${apiKey.name}`);
+        generatedApiKeys.push(apiKey);
+        return { apiKey, apiKeyHeader };
+      };
 
       const invalidateApiKeys = async (apiKeys: ApiKey[]) => {
         // Get admin credentials in order to invalidate the API key
@@ -77,63 +127,54 @@ export const requestAuthFixture = coreWorkerFixtures.extend<
           if (response.statusCode !== 200) {
             log.info(`Failed to invalidate API key: ${apiKey.name}`);
           } else {
-            log.info(`Successfully invalidated API key: ${apiKey.name}`);
+            log.info(`Invalidated API key: ${apiKey.name}`);
           }
         }
       };
 
-      const getApiKey = async (role: string): Promise<RoleApiCredentials> => {
-        const apiKeyName = `myTestApiKey-${generatedApiKeys.length}-worker-${
-          workerInfo.parallelIndex + 1
-        }`;
-        const adminCookieHeader = await samlAuth.session.getApiCredentialsForRole('admin');
-
+      const getApiKey = async (predefinedRole: string): Promise<RoleApiCredentials> => {
+        // fetch role descriptors from roles.yml file
         const roleDescriptors =
-          role === 'admin'
+          predefinedRole === 'admin'
             ? {}
             : (() => {
-                const roleDescriptor = defaultRoles.get(role);
-                if (!roleDescriptor) {
-                  throw new Error(`Cannot create API key for non-existent role "${role}"`);
-                }
-                log.debug(
-                  `Creating API key for ${role} with privileges: ${JSON.stringify(roleDescriptor)}`
-                );
-                return { [role]: roleDescriptor };
+                samlAuth.session.validateRole(predefinedRole);
+                const roleDescriptor = defaultRoles.availableRoles.get(predefinedRole);
+                return { [predefinedRole]: roleDescriptor };
               })();
-
-        const payload = createApiKeyPayload(apiKeyName, role, roleDescriptors);
-        const response = await apiClient.post('internal/security/api_key', {
-          headers: {
-            'kbn-xsrf': 'some-xsrf-token',
-            'x-elastic-internal-origin': 'kibana',
-            ...adminCookieHeader,
-          },
-          body: payload,
-          responseType: 'json',
-        });
-
-        if (response.statusCode !== 200) {
-          throw new Error(
-            `Failed to create API key for '${role}' role with response text: ${response.statusMessage}`
-          );
-        }
-
-        const apiKey = response.body as ApiKey;
-        const apiKeyHeader = { Authorization: `ApiKey ${apiKey.encoded}` };
-
-        log.info(`Created API key for role: [${role}]`);
-        generatedApiKeys.push(apiKey);
-        return { apiKey, apiKeyHeader };
+        return await createApiKeyWithAdminCredentials(predefinedRole, roleDescriptors);
       };
 
-      await use({ getApiKey });
+      const getApiKeyForCustomRole = async (
+        roleDescriptor: KibanaRole | ElasticsearchRoleDescriptor
+      ): Promise<RoleApiCredentials> => {
+        isCustomRoleCreated = true;
+
+        await samlAuth.setCustomRole(roleDescriptor);
+
+        const result = await createApiKeyWithAdminCredentials(samlAuth.customRoleName, {
+          [samlAuth.customRoleName]: roleDescriptor,
+        });
+        return result;
+      };
+
+      await use({ getApiKey, getApiKeyForCustomRole });
 
       // Invalidate all API Keys after tests
       await measurePerformanceAsync(log, `Delete all API Keys`, async () => {
         log.debug(`Delete all API Keys`);
         return invalidateApiKeys(generatedApiKeys);
       });
+
+      if (isCustomRoleCreated) {
+        log.debug(`Deleting custom role with name ${samlAuth.customRoleName}`);
+        try {
+          await esClient.security.deleteRole({ name: samlAuth.customRoleName });
+          log.info(`Deleted ${samlAuth.customRoleName} custom role`);
+        } catch (error: any) {
+          log.error(`Failed to delete custom role ${samlAuth.customRoleName}: ${error.message}`);
+        }
+      }
     },
     { scope: 'worker' },
   ],

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/core_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/core_fixtures.ts
@@ -22,6 +22,7 @@ import {
   createCustomRole,
   ElasticsearchRoleDescriptor,
   KibanaRole,
+  isElasticsearchRole,
 } from '../../../../common/services';
 import type { ScoutTestOptions } from '../../../types';
 import type { ScoutTestConfig } from '.';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/core_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/core_fixtures.ts
@@ -148,10 +148,6 @@ export const coreWorkerFixtures = base.extend<{}, CoreWorkerFixtures>({
 
       const isCustomRoleSet = (roleHash: string) => roleHash === customRoleHash;
 
-      const isElasticsearchRole = (role: any): role is ElasticsearchRoleDescriptor => {
-        return 'applications' in role;
-      };
-
       const setCustomRole = async (role: KibanaRole | ElasticsearchRoleDescriptor) => {
         const newRoleHash = JSON.stringify(role);
 
@@ -172,8 +168,10 @@ export const coreWorkerFixtures = base.extend<{}, CoreWorkerFixtures>({
 
         if (isElasticsearchRole(role)) {
           await createElasticsearchCustomRole(esClient, customRoleName, role);
+          log.debug(`Created Elasticsearch custom role: ${customRoleName}`);
         } else {
           await createCustomRole(kbnClient, customRoleName, role);
+          log.debug(`Created Kibana custom role: ${customRoleName}`);
         }
 
         customRoleHash = newRoleHash;

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/default_roles.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/default_roles.ts
@@ -15,7 +15,10 @@ import {
 import { ElasticsearchRoleDescriptor } from '../../../../common';
 import { coreWorkerFixtures } from './core_fixtures';
 
-export type DefaultRolesFixture = Map<string, ElasticsearchRoleDescriptor>;
+export interface DefaultRolesFixture {
+  availableRoles: Map<string, ElasticsearchRoleDescriptor>;
+  rolesFilePath: string;
+}
 
 /**
  * Provides role descriptors for default roles.
@@ -39,7 +42,7 @@ export const defaultRolesFixture = coreWorkerFixtures.extend<
       const data = new Map<string, ElasticsearchRoleDescriptor>(Object.entries(rolesDescriptors));
 
       log.serviceLoaded('defaultRoles');
-      await use(data);
+      await use({ availableRoles: data, rolesFilePath: resourcePath });
     },
     { scope: 'worker' },
   ],

--- a/src/platform/packages/shared/kbn-test/src/auth/session_manager.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/auth/session_manager.test.ts
@@ -159,15 +159,13 @@ describe('SamlSessionManager', () => {
 
     test(`throws error when role is not in 'supportedRoles'`, async () => {
       const nonExistingRole = 'tester';
-      const expectedErrorMessage = `Role '${nonExistingRole}' not found in ${
-        supportedRoles.sourcePath
-      }. Available predefined roles: ${supportedRoles.roles.join(', ')}
-
-      Is '${nonExistingRole}' a custom test role? → Use loginWithCustomRole() to log in with custom Kibana and Elasticsearch privileges (see Scout docs to create reusable login methods)
-
-      Is '${nonExistingRole}' a predefined role? (e.g., admin, viewer, editor) → Add the role descriptor to ${
-        supportedRoles.sourcePath
-      } to enable it for testing.`;
+      const expectedErrorMessage = [
+        `Role '${nonExistingRole}' not found in ${
+          supportedRoles.sourcePath
+        }. Available predefined roles: ${supportedRoles.roles.join(', ')}.`,
+        `Is '${nonExistingRole}' a custom test role? → Use 'loginWithCustomRole()' for functional tests or 'getApiKeyForCustomRole()' for API tests to log in with custom Kibana and Elasticsearch privileges.`,
+        `Is '${nonExistingRole}' a predefined role? (e.g., admin, viewer, editor) → Add the role descriptor to ${supportedRoles.sourcePath} to enable it for testing.`,
+      ].join('\n\n');
       const samlSessionManager = new SamlSessionManager({
         ...samlSessionManagerOptions,
         supportedRoles,
@@ -375,15 +373,13 @@ describe('SamlSessionManager', () => {
 
     test(`throws error for non-existing role when 'supportedRoles' is defined`, async () => {
       const nonExistingRole = 'tester';
-      const expectedErrorMessage = `Role '${nonExistingRole}' not found in ${
-        supportedRoles.sourcePath
-      }. Available predefined roles: ${supportedRoles.roles.join(', ')}
-
-      Is '${nonExistingRole}' a custom test role? → Use loginWithCustomRole() to log in with custom Kibana and Elasticsearch privileges (see Scout docs to create reusable login methods)
-
-      Is '${nonExistingRole}' a predefined role? (e.g., admin, viewer, editor) → Add the role descriptor to ${
-        supportedRoles.sourcePath
-      } to enable it for testing.`;
+      const expectedErrorMessage = [
+        `Role '${nonExistingRole}' not found in ${
+          supportedRoles.sourcePath
+        }. Available predefined roles: ${supportedRoles.roles.join(', ')}.`,
+        `Is '${nonExistingRole}' a custom test role? → Use 'loginWithCustomRole()' for functional tests or 'getApiKeyForCustomRole()' for API tests to log in with custom Kibana and Elasticsearch privileges.`,
+        `Is '${nonExistingRole}' a predefined role? (e.g., admin, viewer, editor) → Add the role descriptor to ${supportedRoles.sourcePath} to enable it for testing.`,
+      ].join('\n\n');
       const samlSessionManager = new SamlSessionManager({
         ...samlSMOptionsWithCloudHostName,
         supportedRoles,

--- a/src/platform/packages/shared/kbn-test/src/auth/session_manager.ts
+++ b/src/platform/packages/shared/kbn-test/src/auth/session_manager.ts
@@ -191,17 +191,17 @@ Set env variable 'TEST_CLOUD=1' to run FTR against your Cloud deployment`
     return session;
   };
 
-  private validateRole = (role: string): void => {
+  validateRole = (role: string): void => {
     if (this.supportedRoles && !this.supportedRoles.roles.includes(role)) {
-      throw new Error(`Role '${role}' not found in ${
-        this.supportedRoles.sourcePath
-      }. Available predefined roles: ${this.supportedRoles.roles.join(', ')}
+      const errorMessage = [
+        `Role '${role}' not found in ${
+          this.supportedRoles.sourcePath
+        }. Available predefined roles: ${this.supportedRoles.roles.join(', ')}.`,
+        `Is '${role}' a custom test role? → Use 'loginWithCustomRole()' for functional tests or 'getApiKeyForCustomRole()' for API tests to log in with custom Kibana and Elasticsearch privileges.`,
+        `Is '${role}' a predefined role? (e.g., admin, viewer, editor) → Add the role descriptor to ${this.supportedRoles.sourcePath} to enable it for testing.`,
+      ].join('\n\n');
 
-      Is '${role}' a custom test role? → Use loginWithCustomRole() to log in with custom Kibana and Elasticsearch privileges (see Scout docs to create reusable login methods)
-
-      Is '${role}' a predefined role? (e.g., admin, viewer, editor) → Add the role descriptor to ${
-        this.supportedRoles.sourcePath
-      } to enable it for testing.`);
+      throw new Error(errorMessage);
     }
   };
 

--- a/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api.spec.ts
+++ b/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api.spec.ts
@@ -16,20 +16,24 @@ apiTest.describe(
     apiTest.beforeAll(async ({ requestAuth }) => {
       adminApiCredentials = await requestAuth.getApiKey('admin');
     });
-    apiTest('should execute a valid painless script', async ({ apiClient }) => {
-      const response = await apiClient.post('api/painless_lab/execute', {
-        headers: {
-          ...COMMON_HEADERS,
-          ...adminApiCredentials.apiKeyHeader,
-        },
-        responseType: 'json',
-        body: TEST_INPUT.script,
-      });
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toStrictEqual({
-        result: 'true',
-      });
-    });
+
+    apiTest(
+      'should execute a valid painless script using admin credentials',
+      async ({ apiClient }) => {
+        const response = await apiClient.post('api/painless_lab/execute', {
+          headers: {
+            ...COMMON_HEADERS,
+            ...adminApiCredentials.apiKeyHeader,
+          },
+          responseType: 'json',
+          body: TEST_INPUT.script,
+        });
+        expect(response.statusCode).toBe(200);
+        expect(response.body).toStrictEqual({
+          result: 'true',
+        });
+      }
+    );
 
     apiTest('should return error response for invalid painless script', async ({ apiClient }) => {
       const response = await apiClient.post('api/painless_lab/execute', {

--- a/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_custom_cluster_privileges.spec.ts
+++ b/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_custom_cluster_privileges.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest, expect, tags } from '@kbn/scout';
+import { COMMON_HEADERS, TEST_INPUT } from '../fixtures/constants';
+
+apiTest.describe(
+  'POST api/painless_lab/execute with specific cluster privileges',
+  { tag: tags.ESS_ONLY },
+  () => {
+    apiTest(
+      'should execute a valid painless script using cluster:admin/scripts/painless/execute credentials',
+      async ({ apiClient, requestAuth }) => {
+        const adminPainlessExecuteClusterPrivilegesCredentials =
+          await requestAuth.getApiKeyForCustomRole({
+            cluster: ['cluster:admin/scripts/painless/execute'],
+          });
+
+        const response = await apiClient.post('api/painless_lab/execute', {
+          headers: {
+            ...COMMON_HEADERS,
+            ...adminPainlessExecuteClusterPrivilegesCredentials.apiKeyHeader,
+          },
+          responseType: 'json',
+          body: TEST_INPUT.script,
+        });
+        expect(response.statusCode).toBe(200);
+        expect(response.body).toStrictEqual({
+          result: 'true',
+        });
+      }
+    );
+
+    apiTest(
+      'should execute a valid painless script using cluster:admin credentials',
+      async ({ apiClient, requestAuth }) => {
+        const adminClusterPrivilegesCredentials = await requestAuth.getApiKeyForCustomRole({
+          cluster: ['cluster:admin'],
+        });
+
+        const response = await apiClient.post('api/painless_lab/execute', {
+          headers: {
+            ...COMMON_HEADERS,
+            ...adminClusterPrivilegesCredentials.apiKeyHeader,
+          },
+          responseType: 'json',
+          body: TEST_INPUT.script,
+        });
+        expect(response.statusCode).toBe(200);
+        expect(response.body).toStrictEqual({
+          result: 'true',
+        });
+      }
+    );
+
+    apiTest(
+      'should return an unauthorized status code when using monitor cluster credentials',
+      async ({ apiClient, requestAuth }) => {
+        const monitorClusterPrivilegesCredentials = await requestAuth.getApiKeyForCustomRole({
+          cluster: ['monitor'],
+        });
+
+        const response = await apiClient.post('api/painless_lab/execute', {
+          headers: {
+            ...COMMON_HEADERS,
+            ...monitorClusterPrivilegesCredentials.apiKeyHeader,
+          },
+          responseType: 'json',
+          body: TEST_INPUT.script,
+        });
+        expect(response.body.status).toBe(403);
+      }
+    );
+
+    apiTest(
+      'should return an unauthorized status code when using both cluster and Kibana privileges',
+      async ({ apiClient, requestAuth }) => {
+        const monitorClusterPrivilegesCredentials = await requestAuth.getApiKeyForCustomRole({
+          elasticsearch: { cluster: ['cluster:admin/scripts/painless/execute'] },
+          kibana: [{ base: [], feature: { dev_tools: ['all'] }, spaces: ['*'] }],
+        });
+
+        const response = await apiClient.post('api/painless_lab/execute', {
+          headers: {
+            ...COMMON_HEADERS,
+            ...monitorClusterPrivilegesCredentials.apiKeyHeader,
+          },
+          responseType: 'json',
+          body: TEST_INPUT.script,
+        });
+        expect(response.statusCode).toBe(200);
+        expect(response.body).toStrictEqual({
+          result: 'true',
+        });
+      }
+    );
+  }
+);

--- a/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_custom_cluster_privileges.spec.ts
+++ b/x-pack/platform/plugins/private/painless_lab/test/scout/api/tests/execute_api_custom_cluster_privileges.spec.ts
@@ -80,7 +80,7 @@ apiTest.describe(
       'should return an unauthorized status code when using both cluster and Kibana privileges',
       async ({ apiClient, requestAuth }) => {
         const monitorClusterPrivilegesCredentials = await requestAuth.getApiKeyForCustomRole({
-          elasticsearch: { cluster: ['cluster:admin/scripts/painless/execute'] },
+          elasticsearch: { cluster: ['cluster:admin/scripts/painless/execute'], indices: [] },
           kibana: [{ base: [], feature: { dev_tools: ['all'] }, spaces: ['*'] }],
         });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Scout] Add support for custom roles in Scout API tests (#243187)](https://github.com/elastic/kibana/pull/243187)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cesare de Cal","email":"cesare.decal@elastic.co"},"sourceCommit":{"committedDate":"2025-11-26T23:41:32Z","message":"[Scout] Add support for custom roles in Scout API tests (#243187)\n\nThis PR updates the `requestAuth` fixture to expose a new\n`getApiKeyForCustomRole` method that can be used in your Scout API\ntests.\n\nThis PR also introduces a new `createApiKeyWithAdminCredentials` method\nthat both `getApiKeyForCustomRole` and `getApiKey` use as the role\ncreation logic is the same, but the source of the Kibana or\nElasticsearch role descriptors differs:\n\n* `getApiKey` fetches the role descriptors from the appropriate\nenvironment-specific `roles.yml` file\n* `getApiKeyForCustomRole` receives the role descriptor directly from\nthe function call / test itself\n\nNew tests were added to test the new method.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Brad White <Ikuni17@users.noreply.github.com>","sha":"64445f818bb4c29c3cf66069807e7a9255c6ed35","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.3.0"],"title":"[Scout] Add support for custom roles in Scout API tests","number":243187,"url":"https://github.com/elastic/kibana/pull/243187","mergeCommit":{"message":"[Scout] Add support for custom roles in Scout API tests (#243187)\n\nThis PR updates the `requestAuth` fixture to expose a new\n`getApiKeyForCustomRole` method that can be used in your Scout API\ntests.\n\nThis PR also introduces a new `createApiKeyWithAdminCredentials` method\nthat both `getApiKeyForCustomRole` and `getApiKey` use as the role\ncreation logic is the same, but the source of the Kibana or\nElasticsearch role descriptors differs:\n\n* `getApiKey` fetches the role descriptors from the appropriate\nenvironment-specific `roles.yml` file\n* `getApiKeyForCustomRole` receives the role descriptor directly from\nthe function call / test itself\n\nNew tests were added to test the new method.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Brad White <Ikuni17@users.noreply.github.com>","sha":"64445f818bb4c29c3cf66069807e7a9255c6ed35"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243187","number":243187,"mergeCommit":{"message":"[Scout] Add support for custom roles in Scout API tests (#243187)\n\nThis PR updates the `requestAuth` fixture to expose a new\n`getApiKeyForCustomRole` method that can be used in your Scout API\ntests.\n\nThis PR also introduces a new `createApiKeyWithAdminCredentials` method\nthat both `getApiKeyForCustomRole` and `getApiKey` use as the role\ncreation logic is the same, but the source of the Kibana or\nElasticsearch role descriptors differs:\n\n* `getApiKey` fetches the role descriptors from the appropriate\nenvironment-specific `roles.yml` file\n* `getApiKeyForCustomRole` receives the role descriptor directly from\nthe function call / test itself\n\nNew tests were added to test the new method.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Brad White <Ikuni17@users.noreply.github.com>","sha":"64445f818bb4c29c3cf66069807e7a9255c6ed35"}},{"url":"https://github.com/elastic/kibana/pull/244435","number":244435,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->