### PR TITLE
[8.19] chore(deps): bump `js-yaml` from `3.14.1` to `3.14.2` and `4.1.0` to `4.1.1` (#244157)

### DIFF
--- a/.buildkite/package-lock.json
+++ b/.buildkite/package-lock.json
@@ -11,7 +11,7 @@
         "@octokit/rest": "^22.0.0",
         "axios": "^1.8.3",
         "globby": "^11.1.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "minimatch": "^5.0.1",
         "minimist": "^1.2.8",
         "p-limit": "^3.1.0",
@@ -766,9 +766,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3945,9 +3945,10 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5753,9 +5754,9 @@
           }
         },
         "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "version": "3.14.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+          "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -7995,9 +7996,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "requires": {
         "argparse": "^2.0.1"
       }

--- a/.buildkite/package.json
+++ b/.buildkite/package.json
@@ -11,7 +11,7 @@
     "@octokit/rest": "^22.0.0",
     "axios": "^1.8.3",
     "globby": "^11.1.0",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.1.1",
     "minimatch": "^5.0.1",
     "minimist": "^1.2.8",
     "p-limit": "^3.1.0",

--- a/.buildkite/scripts/steps/openapi_publishing/package-lock.json
+++ b/.buildkite/scripts/steps/openapi_publishing/package-lock.json
@@ -231,9 +231,10 @@
       }
     },
     "node_modules/@oclif/core/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -427,9 +428,10 @@
       }
     },
     "node_modules/@oclif/plugin-help/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1232,9 +1234,10 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/oas_docs/package-lock.json
+++ b/oas_docs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@redocly/cli": "^2.11.0",
+        "@redocly/cli": "^2.11.1",
         "bump-cli": "^2.8.4"
       }
     },

--- a/oas_docs/package.json
+++ b/oas_docs/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "bump-cli": "^2.8.4",
-    "@redocly/cli": "^2.11.0"
+    "@redocly/cli": "^2.11.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23341,9 +23341,9 @@ js-tiktoken@^1.0.12:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
-  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
+  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(deps): bump `js-yaml` from `3.14.1` to `3.14.2` and `4.1.0` to `4.1.1` (#244157)](https://github.com/elastic/kibana/pull/244157)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2025-11-26T10:13:29Z","message":"chore(deps): bump `js-yaml` from `3.14.1` to `3.14.2` and `4.1.0` to `4.1.1` (#244157)\n\n## Summary\n\nBump `js-yaml` from `3.14.1` to `3.14.2`.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3215b0dfd2778bb8bad0dd26f90eb715b0e46492","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","release_note:skip","dependencies","backport:all-open","v9.3.0","v9.1.8"],"title":"chore(deps): bump `js-yaml` from `3.14.1` to `3.14.2` and `4.1.0` to `4.1.1`","number":244157,"url":"https://github.com/elastic/kibana/pull/244157","mergeCommit":{"message":"chore(deps): bump `js-yaml` from `3.14.1` to `3.14.2` and `4.1.0` to `4.1.1` (#244157)\n\n## Summary\n\nBump `js-yaml` from `3.14.1` to `3.14.2`.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3215b0dfd2778bb8bad0dd26f90eb715b0e46492"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/244157","number":244157,"mergeCommit":{"message":"chore(deps): bump `js-yaml` from `3.14.1` to `3.14.2` and `4.1.0` to `4.1.1` (#244157)\n\n## Summary\n\nBump `js-yaml` from `3.14.1` to `3.14.2`.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3215b0dfd2778bb8bad0dd26f90eb715b0e46492"}},{"branch":"9.1","label":"v9.1.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/244319","number":244319,"state":"MERGED","mergeCommit":{"sha":"9c7235788a7a51cc8381ed936f97b613d59bc0c3","message":"[9.1] chore(deps): bump `js-yaml` from `3.14.1` to `3.14.2` and `4.1.0` to `4.1.1` (#244157) (#244319)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [chore(deps): bump `js-yaml` from `3.14.1` to `3.14.2` and `4.1.0` to\n`4.1.1` (#244157)](https://github.com/elastic/kibana/pull/244157)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Aleh Zasypkin <aleh.zasypkin@elastic.co>"}}]}] BACKPORT-->