### PR TITLE
[Lens][Lens as code] Revisit the id assignment logic for ad hoc dataViews

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -6,7 +6,6 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import { v4 as uuidv4 } from 'uuid';
 import type { SavedObjectReference } from '@kbn/core-saved-objects-common/src/server_types';
 import type {
   FormBasedLayer,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -90,6 +90,14 @@ export function isTextBasedLayer(
   return 'index' in layer && 'query' in layer;
 }
 
+function generateAdHocDataViewId(dataView: {
+  type: 'adHocDataView';
+  index: string;
+  timeFieldName: string;
+}) {
+  return `${dataView.index}-${dataView.timeFieldName ?? 'no_time_field'}`;
+}
+
 function getAdHocDataViewSpec(dataView: {
   type: 'adHocDataView';
   index: string;
@@ -97,7 +105,7 @@ function getAdHocDataViewSpec(dataView: {
 }) {
   return {
     // Improve id genertation to be more predictable and hit cache more often
-    id: `${dataView.index}-${dataView.timeFieldName ?? 'no_time_field'}`,
+    id: generateAdHocDataViewId(dataView),
     title: dataView.index,
     name: dataView.index,
     timeFieldName: dataView.timeFieldName,
@@ -130,7 +138,10 @@ export const getAdhocDataviews = (
   // dedupe and map multiple layer references to the same ad hoc dataview
   for (const [layerId, dataViewEntry] of adHocDataViewsFiltered) {
     if (!internalReferencesMap.has(dataViewEntry)) {
-      internalReferencesMap.set(dataViewEntry, { layerIds: [], id: uuidv4({}) });
+      internalReferencesMap.set(dataViewEntry, {
+        layerIds: [],
+        id: generateAdHocDataViewId(dataViewEntry),
+      });
     }
     const internalRef = internalReferencesMap.get(dataViewEntry)!;
     internalRef.layerIds.push(layerId);

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -96,7 +96,8 @@ function getAdHocDataViewSpec(dataView: {
   timeFieldName: string;
 }) {
   return {
-    id: uuidv4({}),
+    // Improve id genertation to be more predictable and hit cache more often
+    id: `${dataView.index}-${dataView.timeFieldName ?? 'no_time_field'}`,
     title: dataView.index,
     name: dataView.index,
     timeFieldName: dataView.timeFieldName,


### PR DESCRIPTION
## Summary

Make the id generated for the ad hoc dataView predictable and stable, this would have several positive side effects:
* hit the dataViews cache more often (faster dashboards)
* make the dashboard unsaved changes logic more stable


