### PR TITLE
[9.2] [ResponseOps][Accessibility] Buttons to the rule detail views should be links (#244108)

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_table.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_table.tsx
@@ -11,6 +11,10 @@ import { i18n } from '@kbn/i18n';
 import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
 import type { EuiTableSortingType, EuiSelectableOption } from '@elastic/eui';
 import {
+  getRuleDetailsRoute,
+  triggersActionsRoute,
+} from '@kbn/rule-data-utils/src/routes/stack_rule_paths';
+import {
   EuiBasicTable,
   EuiFlexGroup,
   EuiFlexItem,
@@ -32,6 +36,8 @@ import {
   parseDuration,
   MONITORING_HISTORY_LIMIT,
 } from '@kbn/alerting-plugin/common';
+
+import { getRouterLinkProps } from '@kbn/router-utils';
 
 import {
   SELECT_ALL_RULES,
@@ -406,13 +412,20 @@ export const RulesListTable = (props: RulesListTableProps) => {
         render: (name: string, rule: RuleTableItem) => {
           const ruleType = ruleTypesState.data.get(rule.ruleTypeId);
           const checkEnabledResult = checkRuleTypeEnabled(ruleType);
+          const pathToRuleDetails = `${triggersActionsRoute}${getRuleDetailsRoute(rule.id)}`;
+
+          const linkProps = getRouterLinkProps({
+            href: pathToRuleDetails,
+            onClick: () => onRuleClick(rule),
+          });
+
           const link = (
             <>
               <EuiFlexGroup direction="column" gutterSize="xs">
                 <EuiFlexItem grow={false}>
                   <EuiFlexGroup gutterSize="xs">
                     <EuiFlexItem grow={false}>
-                      <EuiLink title={name} onClick={() => onRuleClick(rule)}>
+                      <EuiLink title={name} {...linkProps}>
                         {name}
                       </EuiLink>
                     </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/tsconfig.json
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/tsconfig.json
@@ -91,6 +91,8 @@
     "@kbn/presentation-util",
     "@kbn/discover-utils",
     "@kbn/react-query",
+    "@kbn/router-utils",
+    "@kbn/maintenance-windows-plugin"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/tsconfig.json
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/tsconfig.json
@@ -92,7 +92,6 @@
     "@kbn/discover-utils",
     "@kbn/react-query",
     "@kbn/router-utils",
-    "@kbn/maintenance-windows-plugin"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/rule_details_page.ts
+++ b/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/rule_details_page.ts
@@ -99,7 +99,9 @@ export default ({ getService }: FtrProviderContext) => {
           'Rules table to be visible',
           async () => await testSubjects.exists('rulesList')
         );
-        await find.clickByButtonText(logThresholdRuleName);
+
+        await find.clickByLinkText(logThresholdRuleName);
+
         await retry.waitFor(
           'Rule details to be visible',
           async () => await testSubjects.exists('ruleDetails')


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[ResponseOps][Accessibility] Buttons to the rule detail views should be links (#244108)](https://github.com/elastic/kibana/pull/244108)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2025-11-27T13:26:02Z","message":"[ResponseOps][Accessibility] Buttons to the rule detail views should be links (#244108)\n\nCloses https://github.com/elastic/kibana/issues/194969\n## Summary\n\n- converted rule name cell from button to real link (anchor) by adding\nthe href\n- preserved the existing SPA navigation by keeping the onClick handler\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8a227944d3cdd746a76de24c1f0eaff44267df9e","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","ci:project-deploy-observability","backport:version","v9.3.0","v8.19.8","v9.2.2","v9.1.8"],"title":"[ResponseOps][Accessibility] Buttons to the rule detail views should be links","number":244108,"url":"https://github.com/elastic/kibana/pull/244108","mergeCommit":{"message":"[ResponseOps][Accessibility] Buttons to the rule detail views should be links (#244108)\n\nCloses https://github.com/elastic/kibana/issues/194969\n## Summary\n\n- converted rule name cell from button to real link (anchor) by adding\nthe href\n- preserved the existing SPA navigation by keeping the onClick handler\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8a227944d3cdd746a76de24c1f0eaff44267df9e"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.2","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/244108","number":244108,"mergeCommit":{"message":"[ResponseOps][Accessibility] Buttons to the rule detail views should be links (#244108)\n\nCloses https://github.com/elastic/kibana/issues/194969\n## Summary\n\n- converted rule name cell from button to real link (anchor) by adding\nthe href\n- preserved the existing SPA navigation by keeping the onClick handler\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8a227944d3cdd746a76de24c1f0eaff44267df9e"}},{"branch":"8.19","label":"v8.19.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->