### PR TITLE
[Metrics][Discover] SuggestionAPI prefer line chars for time series data POC

### DIFF
--- a/src/platform/packages/shared/kbn-lens-common/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/types.ts
@@ -1189,6 +1189,7 @@ export interface SuggestionRequest<T = unknown> {
   activeData?: Record<string, Datatable>;
   allowMixed?: boolean;
   datasourceId?: string;
+  query?: AggregateQuery;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/lens/moon.yml
+++ b/x-pack/platform/plugins/shared/lens/moon.yml
@@ -146,6 +146,7 @@ dependsOn:
   - '@kbn/lens-common-2'
   - '@kbn/react-kibana-context-common'
   - '@kbn/unified-tabs'
+  - '@kbn/esql-ast'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/suggestion_helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/suggestion_helpers.ts
@@ -25,6 +25,7 @@ import type {
   VisualizationState,
   DataViewsState,
 } from '@kbn/lens-common';
+import type { AggregateQuery } from '@kbn/es-query';
 import { showMemoizedErrorNotification } from '../../lens_ui_errors';
 import type { LensDispatch } from '../../state_management';
 import { switchVisualization, applyChanges } from '../../state_management';
@@ -50,6 +51,7 @@ export function getSuggestions({
   dataViews,
   mainPalette,
   allowMixed,
+  query,
 }: {
   datasourceMap: DatasourceMap;
   datasourceStates: DatasourceStates;
@@ -63,6 +65,7 @@ export function getSuggestions({
   dataViews: DataViewsState;
   mainPalette?: SuggestionRequest['mainPalette'];
   allowMixed?: boolean;
+  query?: AggregateQuery;
 }): Suggestion[] {
   const datasources = Object.entries(datasourceMap).filter(
     ([datasourceId]) => datasourceStates[datasourceId] && !datasourceStates[datasourceId].isLoading
@@ -169,7 +172,8 @@ export function getSuggestions({
             visualizeTriggerFieldContext && 'isVisualizeAction' in visualizeTriggerFieldContext,
             activeData,
             allowMixed,
-            datasourceId
+            datasourceId,
+            query
           );
         });
     })
@@ -240,7 +244,8 @@ function getVisualizationSuggestions(
   isFromContext?: boolean,
   activeData?: Record<string, Datatable>,
   allowMixed?: boolean,
-  datasourceId?: string
+  datasourceId?: string,
+  query?: AggregateQuery
 ) {
   try {
     return visualization
@@ -254,6 +259,7 @@ function getVisualizationSuggestions(
         activeData,
         allowMixed,
         datasourceId,
+        query,
       })
       .map(({ state, ...visualizationSuggestion }) => ({
         ...visualizationSuggestion,

--- a/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/index.ts
@@ -85,6 +85,8 @@ export const suggestionsApi = ({
 
   const initialVisualization = visualizationMap?.[Object.keys(visualizationMap)[0]] || null;
 
+  const query = context && 'query' in context ? context.query : undefined;
+
   // find the active visualizations from the context
   const suggestions = getSuggestions({
     datasourceMap,
@@ -94,6 +96,7 @@ export const suggestionsApi = ({
     visualizationState: undefined,
     visualizeTriggerFieldContext: context,
     dataViews,
+    query,
   });
   if (!suggestions.length) return [];
 
@@ -117,6 +120,7 @@ export const suggestionsApi = ({
     activeVisualization: visualizationMap[activeVisualization.visualizationId],
     visualizationState: activeVisualization.visualizationState,
     dataViews,
+    query,
   }).filter(
     (sug) =>
       // Datatables are always return as hidden suggestions

--- a/x-pack/platform/plugins/shared/lens/tsconfig.json
+++ b/x-pack/platform/plugins/shared/lens/tsconfig.json
@@ -133,6 +133,7 @@
     "@kbn/lens-common-2",
     "@kbn/react-kibana-context-common",
     "@kbn/unified-tabs",
+    "@kbn/esql-ast",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

This POC is an attempt to make the suggestion API give preference to  `line` charts when the query contains time series aggs

>[!IMPORTANT]
> I'm not sure whether it's better to change it here. An alternative could be passing the `preferredSeriesType` to the suggestion API from Discover ([here is the POC doing that](https://github.com/elastic/kibana/pull/244595)). In any case, this POC is exploring the suggestion API option. I haven't tested this thoroughly to understand the possible impacts either


**Should work**
<img width="800" height="478" alt="image" src="https://github.com/user-attachments/assets/af7be35c-ed36-45e2-b2f7-bce0ae78cc3b" />


<img width="800" height="574" alt="image" src="https://github.com/user-attachments/assets/29fea415-90ab-44db-9aa6-d30ccff31f6a" />

**Should not work**
<img width="1728" height="595" alt="image" src="https://github.com/user-attachments/assets/c199bb51-bd4c-4263-b0d0-9cc7b94cc7de" />





