### PR TITLE
[ES|QL] show a warning message when query for control has no results

### DIFF
--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/shared_form_components.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/shared_form_components.tsx
@@ -254,6 +254,8 @@ export function ControlLabel({
   label: string;
   onLabelChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) {
+  const theme = useEuiTheme();
+
   return (
     <EuiFormRow
       label={i18n.translate('esql.flyout.label.label', {
@@ -269,6 +271,9 @@ export function ControlLabel({
         </EuiText>
       }
       fullWidth
+      css={css`
+        margin-block-start: ${theme.euiTheme.size.base};
+      `}
     >
       <EuiFieldText
         placeholder={i18n.translate('esql.flyout.label.placeholder', {

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.test.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.test.tsx
@@ -361,6 +361,28 @@ describe('ValueControlForm', () => {
           expect(queryEditor.textContent).toContain('custom-logs');
         }
       });
+
+      it("should show the 'no results' callout", async () => {
+        (getESQLResults as jest.Mock).mockResolvedValueOnce({
+          response: {
+            columns: [],
+          },
+        });
+
+        const { findByTestId } = render(
+          <IntlProvider locale="en">
+            <KibanaContextProvider services={services}>
+              <ESQLControlsFlyout
+                {...defaultProps}
+                initialVariableType={ESQLVariableType.VALUES}
+                queryString="FROM foo | WHERE field.id  == 'lala' | STATS BY field.name"
+              />
+            </KibanaContextProvider>
+          </IntlProvider>
+        );
+
+        expect(await findByTestId('esqlNoValuesForControlCallout')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -24,7 +24,6 @@ import { css } from '@emotion/react';
 import type { TimeRange } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { ISearchGeneric } from '@kbn/search-types';
-import { BasicPrettyPrinter, Parser } from '@kbn/esql-ast';
 import {
   ESQLVariableType,
   EsqlControlType,
@@ -105,11 +104,8 @@ export function ValueControlForm({
       ? initialState?.esqlQuery ?? INITIAL_EMPTY_STATE_QUERY
       : ''
   );
-  const { root } = Parser.parse(valuesQuery);
-  const prettyQuery = BasicPrettyPrinter.print(root);
-  const isQueryPresent = prettyQuery.trim() !== '';
-  const [hasQueryResults, setHasQueryResults] = useState<boolean | null>(null);
 
+  const [hasQueryResults, setHasQueryResults] = useState<boolean | null>(null);
   const [esqlQueryErrors, setEsqlQueryErrors] = useState<Error[] | undefined>();
   const [queryColumns, setQueryColumns] = useState<string[]>(
     valuesRetrieval ? [valuesRetrieval] : []
@@ -303,7 +299,7 @@ export function ValueControlForm({
               defaultMessage: 'Values query',
             })}
           />
-          {isQueryPresent && hasQueryResults === false && (
+          {hasQueryResults === false && (
             <EuiFormRow
               label={i18n.translate('esql.flyout.previewValues.placeholder', {
                 defaultMessage: 'Values preview',

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -108,6 +108,7 @@ export function ValueControlForm({
   const [queryColumns, setQueryColumns] = useState<string[]>(
     valuesRetrieval ? [valuesRetrieval] : []
   );
+  const [showValuesPreview, setShowValuesPreview] = useState<boolean>(false);
   const [label, setLabel] = useState(initialState?.title ?? '');
   const [minimumWidth, setMinimumWidth] = useState(initialState?.width ?? 'medium');
   const shouldDefaultToMultiSelect = variableType === ESQLVariableType.MULTI_VALUES;
@@ -182,6 +183,7 @@ export function ValueControlForm({
           }
           const columns = results.response.columns.map((col) => col.name);
           setQueryColumns(columns);
+          setShowValuesPreview(true);
 
           if (columns.length === 1) {
             const valuesArray = results.response.values.map((value) => value[0]);
@@ -296,7 +298,7 @@ export function ValueControlForm({
               defaultMessage: 'Values query',
             })}
           />
-          {queryColumns.length === 0 && valuesQuery !== INITIAL_EMPTY_STATE_QUERY && (
+          {showValuesPreview && (
             <EuiFormRow
               label={i18n.translate('esql.flyout.previewValues.placeholder', {
                 defaultMessage: 'Values preview',
@@ -306,68 +308,61 @@ export function ValueControlForm({
                 margin-block-start: ${theme.euiTheme.size.base};
               `}
             >
-              <EuiCallOut
-                announceOnMount
-                title={i18n.translate('esql.flyout.displayNoValuesForControlCallout.title', {
-                  defaultMessage:
-                    "This query isn't returning any values. Edit it and run it again.",
-                })}
-                color="warning"
-                iconType="warning"
-                size="s"
-                data-test-subj="esqlNoValuesForControlCallout"
-              />
-            </EuiFormRow>
-          )}
-          {queryColumns.length > 0 && (
-            <EuiFormRow
-              label={i18n.translate('esql.flyout.previewValues.placeholder', {
-                defaultMessage: 'Values preview',
-              })}
-              fullWidth
-              css={css`
-                margin-block-start: ${theme.euiTheme.size.base};
-              `}
-            >
-              {queryColumns.length === 1 ? (
-                <EuiPanel
-                  paddingSize="s"
-                  color="primary"
-                  css={css`
-                    white-space: wrap;
-                    overflow-y: auto;
-                    max-height: 200px;
-                  `}
-                  data-test-subj="esqlValuesPreview"
-                >
-                  {selectedValues.map((value) => value.label).join(', ')}
-                </EuiPanel>
-              ) : (
-                <EuiCallOut
-                  announceOnMount
-                  title={i18n.translate('esql.flyout.displayMultipleColsCallout.title', {
-                    defaultMessage: 'Your query must return a single column',
-                  })}
-                  color="warning"
-                  iconType="warning"
-                  size="s"
-                  data-test-subj="esqlMoreThanOneColumnCallout"
-                >
-                  <p>
-                    <FormattedMessage
-                      id="esql.flyout.displayMultipleColsCallout.description"
-                      defaultMessage="Your query is currently returning {totalColumns} columns. Choose column {chooseColumnPopover} or use {boldText}."
-                      values={{
-                        totalColumns: queryColumns.length,
-                        boldText: <strong>STATS BY</strong>,
-                        chooseColumnPopover: (
-                          <ChooseColumnPopover columns={queryColumns} updateQuery={updateQuery} />
-                        ),
-                      }}
-                    />
-                  </p>
-                </EuiCallOut>
-              )}
+              <>
+                {queryColumns.length === 0 && (
+                  <EuiCallOut
+                    announceOnMount
+                    title={i18n.translate('esql.flyout.displayNoValuesForControlCallout.title', {
+                      defaultMessage:
+                        "This query isn't returning any values. Edit it and run it again.",
+                    })}
+                    color="warning"
+                    iconType="warning"
+                    size="s"
+                    data-test-subj="esqlNoValuesForControlCallout"
+                  />
+                )}
+                {queryColumns.length === 1 && (
+                  <EuiPanel
+                    paddingSize="s"
+                    color="primary"
+                    css={css`
+                      white-space: wrap;
+                      overflow-y: auto;
+                      max-height: 200px;
+                    `}
+                    data-test-subj="esqlValuesPreview"
+                  >
+                    {selectedValues.map((value) => value.label).join(', ')}
+                  </EuiPanel>
+                )}
+                {queryColumns.length > 1 && (
+                  <EuiCallOut
+                    announceOnMount
+                    title={i18n.translate('esql.flyout.displayMultipleColsCallout.title', {
+                      defaultMessage: 'Your query must return a single column',
+                    })}
+                    color="warning"
+                    iconType="warning"
+                    size="s"
+                    data-test-subj="esqlMoreThanOneColumnCallout"
+                  >
+                    <p>
+                      <FormattedMessage
+                        id="esql.flyout.displayMultipleColsCallout.description"
+                        defaultMessage="Your query is currently returning {totalColumns} columns. Choose column {chooseColumnPopover} or use {boldText}."
+                        values={{
+                          totalColumns: queryColumns.length,
+                          boldText: <strong>STATS BY</strong>,
+                          chooseColumnPopover: (
+                            <ChooseColumnPopover columns={queryColumns} updateQuery={updateQuery} />
+                          ),
+                        }}
+                      />
+                    </p>
+                  </EuiCallOut>
+                )}
+              </>
             </EuiFormRow>
           )}
         </>

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -303,7 +303,28 @@ export function ValueControlForm({
               defaultMessage: 'Values query',
             })}
           />
-          {isQueryPresent && hasQueryResults === false && <div>no results</div>}
+          {isQueryPresent && hasQueryResults === false && (
+            <EuiFormRow
+              label={i18n.translate('esql.flyout.previewValues.placeholder', {
+                defaultMessage: 'Values preview',
+              })}
+              fullWidth
+              css={css`
+                margin-block-start: ${theme.euiTheme.size.base};
+              `}
+            >
+              <EuiCallOut
+                announceOnMount
+                title={i18n.translate('esql.flyout.displayNoValuesForControlCallout.title', {
+                  defaultMessage: "Your query didn't return any values, change it and try again.",
+                })}
+                color="warning"
+                iconType="warning"
+                size="s"
+                data-test-subj="esqlNoValuesForControlCallout"
+              />
+            </EuiFormRow>
+          )}
           {queryColumns.length > 0 && (
             <EuiFormRow
               label={i18n.translate('esql.flyout.previewValues.placeholder', {

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -312,7 +312,7 @@ export function ValueControlForm({
               <EuiCallOut
                 announceOnMount
                 title={i18n.translate('esql.flyout.displayNoValuesForControlCallout.title', {
-                  defaultMessage: "Your query didn't return any values, change it and try again.",
+                  defaultMessage: "This query isn't returning any values. Edit it and run it again.",
                 })}
                 color="warning"
                 iconType="warning"

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -312,7 +312,8 @@ export function ValueControlForm({
               <EuiCallOut
                 announceOnMount
                 title={i18n.translate('esql.flyout.displayNoValuesForControlCallout.title', {
-                  defaultMessage: "This query isn't returning any values. Edit it and run it again.",
+                  defaultMessage:
+                    "This query isn't returning any values. Edit it and run it again.",
                 })}
                 color="warning"
                 iconType="warning"

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -104,8 +104,6 @@ export function ValueControlForm({
       ? initialState?.esqlQuery ?? INITIAL_EMPTY_STATE_QUERY
       : ''
   );
-
-  const [hasQueryResults, setHasQueryResults] = useState<boolean | null>(null);
   const [esqlQueryErrors, setEsqlQueryErrors] = useState<Error[] | undefined>();
   const [queryColumns, setQueryColumns] = useState<string[]>(
     valuesRetrieval ? [valuesRetrieval] : []
@@ -184,7 +182,6 @@ export function ValueControlForm({
           }
           const columns = results.response.columns.map((col) => col.name);
           setQueryColumns(columns);
-          setHasQueryResults(columns.length > 0);
 
           if (columns.length === 1) {
             const valuesArray = results.response.values.map((value) => value[0]);
@@ -299,7 +296,7 @@ export function ValueControlForm({
               defaultMessage: 'Values query',
             })}
           />
-          {hasQueryResults === false && (
+          {queryColumns.length === 0 && valuesQuery !== INITIAL_EMPTY_STATE_QUERY && (
             <EuiFormRow
               label={i18n.translate('esql.flyout.previewValues.placeholder', {
                 defaultMessage: 'Values preview',


### PR DESCRIPTION
## Summary

fixes https://github.com/elastic/kibana/issues/243618

On the create control flyout (e.g. from dashboards) there is no visual feedback when the query to get values for a control returns no results.

<img width="497" height="768" alt="image" src="https://github.com/user-attachments/assets/7896c46b-c976-45da-816e-86bf71939920" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





