### PR TITLE
[Lens] Hide clone layer button for ESQL panel

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -445,7 +445,7 @@ export function LayerPanel(props: LayerPanelProps) {
                       />
                     </EuiToolTip>
                   </EuiFlexItem>
-                  {supportsMultipleLayers ? (
+                  {supportsMultipleLayers && !isTextBasedLanguage ? (
                     <EuiFlexItem grow={false}>
                       <EuiToolTip
                         content={layerActions.cloneLayerAction.displayName}


### PR DESCRIPTION
## Summary

fix: https://github.com/elastic/kibana/issues/244522

Hide clone layer button for ESQL panel.

https://github.com/user-attachments/assets/dce73dee-52a2-4b59-9cde-c516f8e65a96


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.