### PR TITLE
[One Workflow][Bug] Use the workflows theme in the modal

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_manual_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_manual_form.tsx
@@ -13,6 +13,7 @@ import { CodeEditor } from '@kbn/code-editor';
 import { i18n } from '@kbn/i18n';
 import type { WorkflowInputChoiceSchema, WorkflowInputSchema, WorkflowYaml } from '@kbn/workflows';
 import { z } from '@kbn/zod';
+import { WORKFLOWS_MONACO_EDITOR_THEME } from '../../../widgets/workflow_yaml_editor/styles/use_workflows_monaco_theme';
 
 const makeWorkflowInputsValidator = (inputs: Array<z.infer<typeof WorkflowInputSchema>>) => {
   return z.object(
@@ -206,7 +207,7 @@ export const WorkflowExecuteManualForm = ({
               renderWhitespace: 'all',
               wordWrapColumn: 80,
               wrappingIndent: 'indent',
-              theme: 'vs-light',
+              theme: WORKFLOWS_MONACO_EDITOR_THEME,
               formatOnType: true,
               quickSuggestions: false,
               suggestOnTriggerCharacters: false,


### PR DESCRIPTION
## Summary

issue: https://github.com/elastic/security-team/issues/14894

Use the same theme as the rest of monaco editors in the workflows app.

Demo:

https://github.com/user-attachments/assets/ece2bb98-deff-48b0-a3b7-0deb71b8e80a

https://github.com/user-attachments/assets/1171cc28-a216-4923-a1da-cf11760ab9a1



