### PR TITLE
[8.19] [scout] allow global hook for single thread run + enable streams only once (#242672)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -666,6 +666,8 @@ module.exports = {
         'x-pack/platform/test/serverless/*/configs/**/*',
         'x-pack/solutions/security/test/security_solution_api_integration/*/test_suites/**/*',
         'x-pack/solutions/security/test/security_solution_api_integration/**/config*.ts',
+        '**/playwright.config.ts',
+        '**/parallel.playwright.config.ts',
       ],
       rules: {
         'import/no-default-export': 'off',

--- a/src/platform/packages/shared/kbn-scout/README.md
+++ b/src/platform/packages/shared/kbn-scout/README.md
@@ -101,6 +101,7 @@ import { createPlaywrightConfig } from '@kbn/scout';
 export default createPlaywrightConfig({
   testDir: './tests',
   workers: 2,
+  runGlobalSetup: true, // to trigger setup hook before the tests (e.g. to ingest ES data)
 });
 ```
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
@@ -45,21 +45,21 @@ export function createPlaywrightConfig(options: ScoutPlaywrightOptions): Playwri
   let scoutProjects: PlaywrightTestConfig<ScoutTestOptions>['projects'] = [];
 
   /**
-   * For parallel tests, we need to add a setup as a project dependency. While Playwright doesn't allow to read 'use'
-   * from the parent project, we have to create a setup project with the explicit 'use' object for each parent project.
+   * When runGlobalSetup is true, we add a setup project as a dependency for each project.
+   * While Playwright doesn't allow to read 'use' from the parent project, we have to create
+   * a setup project with the explicit 'use' object for each parent project.
    * This is a workaround for https://github.com/microsoft/playwright/issues/32547
    */
-  scoutProjects =
-    options.workers && options.workers > 1
-      ? scoutDefaultProjects.flatMap((project) => [
-          {
-            name: `setup-${project?.name}`,
-            use: project?.use ? { ...project.use } : {},
-            testMatch: /global.setup\.ts/,
-          },
-          { ...project, dependencies: [`setup-${project?.name}`] },
-        ])
-      : scoutDefaultProjects;
+  scoutProjects = options.runGlobalSetup
+    ? scoutDefaultProjects.flatMap((project) => [
+        {
+          name: `setup-${project?.name}`,
+          use: project?.use ? { ...project.use } : {},
+          testMatch: /global.setup\.ts/,
+        },
+        { ...project, dependencies: [`setup-${project?.name}`] },
+      ])
+    : scoutDefaultProjects;
 
   return defineConfig<ScoutTestOptions>({
     testDir: options.testDir,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/types/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/types/index.ts
@@ -26,4 +26,9 @@ export interface ScoutTestOptions extends PlaywrightTestOptions {
 export interface ScoutPlaywrightOptions extends Pick<PlaywrightTestConfig, 'testDir' | 'workers'> {
   testDir: string;
   workers?: 1 | 2 | 3; // to keep performance consistent within test suites
+  /**
+   * When true, runs global.setup.ts as a pre-step before running tests.
+   * Defaults to false.
+   */
+  runGlobalSetup?: boolean;
 }

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/playwright.config.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/playwright.config.ts
@@ -9,7 +9,6 @@
 
 import { createPlaywrightConfig } from '../../..';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './tests',
 });

--- a/src/platform/packages/shared/kbn-scout/test/scout/ui/playwright.config.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/ui/playwright.config.ts
@@ -9,7 +9,6 @@
 
 import { createPlaywrightConfig } from '../../..';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './tests',
 });

--- a/src/platform/plugins/shared/console/test/scout/api/playwright.config.ts
+++ b/src/platform/plugins/shared/console/test/scout/api/playwright.config.ts
@@ -9,7 +9,6 @@
 
 import { createPlaywrightConfig } from '@kbn/scout';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './tests',
 });

--- a/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/playwright.config.ts
+++ b/x-pack/platform/packages/private/kbn-scout-release-testing/test/scout/ui/playwright.config.ts
@@ -7,7 +7,6 @@
 
 import { createPlaywrightConfig } from '@kbn/scout';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './discovery_tests',
 });

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel.playwright.config.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel.playwright.config.ts
@@ -7,8 +7,8 @@
 
 import { createPlaywrightConfig } from '@kbn/scout';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './parallel_tests',
   workers: 2,
+  runGlobalSetup: true,
 });

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/playwright.config.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/playwright.config.ts
@@ -7,7 +7,6 @@
 
 import { createPlaywrightConfig } from '@kbn/scout';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './tests',
 });

--- a/x-pack/platform/plugins/private/painless_lab/test/scout/api/playwright.config.ts
+++ b/x-pack/platform/plugins/private/painless_lab/test/scout/api/playwright.config.ts
@@ -7,7 +7,6 @@
 
 import { createPlaywrightConfig } from '@kbn/scout';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './tests',
 });

--- a/x-pack/platform/plugins/private/painless_lab/test/scout/ui/playwright.config.ts
+++ b/x-pack/platform/plugins/private/painless_lab/test/scout/ui/playwright.config.ts
@@ -7,7 +7,6 @@
 
 import { createPlaywrightConfig } from '@kbn/scout';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './tests',
 });

--- a/x-pack/platform/plugins/shared/maps/test/scout/ui/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/maps/test/scout/ui/playwright.config.ts
@@ -7,7 +7,6 @@
 
 import { createPlaywrightConfig } from '@kbn/scout';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './tests',
 });

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts
@@ -7,7 +7,6 @@
 
 import { createPlaywrightConfig } from '@kbn/scout';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './tests',
   runGlobalSetup: true,

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/global.setup.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/global.setup.ts
@@ -5,10 +5,9 @@
  * 2.0.
  */
 
-import { createPlaywrightConfig } from '@kbn/scout';
+import { globalSetupHook } from '@kbn/scout';
 
-// eslint-disable-next-line import/no-default-export
-export default createPlaywrightConfig({
-  testDir: './tests',
-  runGlobalSetup: true,
+globalSetupHook('Setup environment for streams tests', async ({ apiServices, log }) => {
+  log.debug('[setup] Enabling streams...');
+  await apiServices.streams.enable();
 });

--- a/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel.playwright.config.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/parallel.playwright.config.ts
@@ -7,7 +7,6 @@
 
 import { createPlaywrightConfig } from '@kbn/scout-oblt';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './parallel_tests',
   workers: 2,

--- a/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/playwright.config.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/test/scout/ui/playwright.config.ts
@@ -7,7 +7,6 @@
 
 import { createPlaywrightConfig } from '@kbn/scout-oblt';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './tests',
 });

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel.playwright.config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel.playwright.config.ts
@@ -7,8 +7,8 @@
 
 import { createPlaywrightConfig } from '@kbn/scout-security';
 
-// eslint-disable-next-line import/no-default-export
 export default createPlaywrightConfig({
   testDir: './parallel_tests/',
   workers: 2,
+  runGlobalSetup: true,
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[scout] allow global hook for single thread run + enable streams only once (#242672)](https://github.com/elastic/kibana/pull/242672)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-11-26T18:20:12Z","message":"[scout] allow global hook for single thread run + enable streams only once (#242672)\n\n## Summary\n\nThe main PR purpose is to improve and speed up Stream e2e tests for\nCloud testing (ECH/MKI):\n\n1. every suite repeatedly enables/disables streams functionality via API\nsolution: add `global hook` to enable streams before the tests execution\nstart:\n\n`x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts\n(--stateful)`\nbefore: `84 passed (13.3m)`\nafter: `81 passed (9.9m)` (one test despite improved cleanup returns\ninconsistent values and fails on Cloud and I had to skip it)\n\n2. some suites have time consuming `beforeEach` hook and rather short UI\nflow\nsolution: convert UI test blocks into \"steps\" and save time on\npre-loading.\n`streams_list_view/streams_collapsible_rows.spec.ts`\nbefore: `23.8s`\nafter: `9.4s`\n\n   `data_management/streams_header.spec.ts`\n    before: `19.3s`\n    after: `15.1s`\n\n3. some suites do the cleanup in `beforeEach` hook, but missing cleanup\nin `afterAll` and affects the follow-up tests if files execution order\nis changed.\nsolution: add missing hook\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"27010a19f43ca008c8dec2daafa9d8a17c7365a0","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-infra_services","backport:version","v9.3.0","v8.19.8","v9.2.2","v9.1.8"],"title":"[scout] allow global hook for single thread run + enable streams only once","number":242672,"url":"https://github.com/elastic/kibana/pull/242672","mergeCommit":{"message":"[scout] allow global hook for single thread run + enable streams only once (#242672)\n\n## Summary\n\nThe main PR purpose is to improve and speed up Stream e2e tests for\nCloud testing (ECH/MKI):\n\n1. every suite repeatedly enables/disables streams functionality via API\nsolution: add `global hook` to enable streams before the tests execution\nstart:\n\n`x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts\n(--stateful)`\nbefore: `84 passed (13.3m)`\nafter: `81 passed (9.9m)` (one test despite improved cleanup returns\ninconsistent values and fails on Cloud and I had to skip it)\n\n2. some suites have time consuming `beforeEach` hook and rather short UI\nflow\nsolution: convert UI test blocks into \"steps\" and save time on\npre-loading.\n`streams_list_view/streams_collapsible_rows.spec.ts`\nbefore: `23.8s`\nafter: `9.4s`\n\n   `data_management/streams_header.spec.ts`\n    before: `19.3s`\n    after: `15.1s`\n\n3. some suites do the cleanup in `beforeEach` hook, but missing cleanup\nin `afterAll` and affects the follow-up tests if files execution order\nis changed.\nsolution: add missing hook\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"27010a19f43ca008c8dec2daafa9d8a17c7365a0"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/242672","number":242672,"mergeCommit":{"message":"[scout] allow global hook for single thread run + enable streams only once (#242672)\n\n## Summary\n\nThe main PR purpose is to improve and speed up Stream e2e tests for\nCloud testing (ECH/MKI):\n\n1. every suite repeatedly enables/disables streams functionality via API\nsolution: add `global hook` to enable streams before the tests execution\nstart:\n\n`x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts\n(--stateful)`\nbefore: `84 passed (13.3m)`\nafter: `81 passed (9.9m)` (one test despite improved cleanup returns\ninconsistent values and fails on Cloud and I had to skip it)\n\n2. some suites have time consuming `beforeEach` hook and rather short UI\nflow\nsolution: convert UI test blocks into \"steps\" and save time on\npre-loading.\n`streams_list_view/streams_collapsible_rows.spec.ts`\nbefore: `23.8s`\nafter: `9.4s`\n\n   `data_management/streams_header.spec.ts`\n    before: `19.3s`\n    after: `15.1s`\n\n3. some suites do the cleanup in `beforeEach` hook, but missing cleanup\nin `afterAll` and affects the follow-up tests if files execution order\nis changed.\nsolution: add missing hook\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"27010a19f43ca008c8dec2daafa9d8a17c7365a0"}},{"branch":"8.19","label":"v8.19.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/244433","number":244433,"state":"MERGED","mergeCommit":{"sha":"80f39b04bc11aa3b6ac81d0e25af046df4b5a3fe","message":"[9.2] [scout] allow global hook for single thread run + enable streams only once (#242672) (#244433)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[scout] allow global hook for single thread run + enable streams only\nonce (#242672)](https://github.com/elastic/kibana/pull/242672)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"9.1","label":"v9.1.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/244495","number":244495,"state":"MERGED","mergeCommit":{"sha":"93957d3d073d0d7af308a1d5d461a7e8572aae7b","message":"[9.1] [scout] allow global hook for single thread run + enable streams only once (#242672) (#244495)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[scout] allow global hook for single thread run + enable streams only\nonce (#242672)](https://github.com/elastic/kibana/pull/242672)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}}]}] BACKPORT-->