### PR TITLE
Fix FTR failures due to incorrect data view time field

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_esql_data_view.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_esql_data_view.ts
@@ -22,10 +22,12 @@ export async function getEsqlDataView(
   services: DiscoverServices
 ) {
   const indexPatternFromQuery = getIndexPatternFromESQLQuery(query.esql);
-  const newTimeField = getTimeFieldFromESQLQuery(query.esql);
+  // Convert undefined time fields to a string since '' and undefined are equivalent here
+  const currentTimeField = currentDataView?.timeFieldName ?? '';
+  const newTimeField = getTimeFieldFromESQLQuery(query.esql) ?? '';
   const onlyTimeFieldChanged =
     indexPatternFromQuery === currentDataView?.getIndexPattern() &&
-    newTimeField !== currentDataView?.timeFieldName;
+    newTimeField !== currentTimeField;
 
   if (
     currentDataView?.isPersisted() ||

--- a/src/platform/test/functional/apps/discover/group6/_time_field_column.ts
+++ b/src/platform/test/functional/apps/discover/group6/_time_field_column.ts
@@ -39,8 +39,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     hideAnnouncements: true,
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/244544
-  describe.skip('discover time field column', function () {
+  describe('discover time field column', function () {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await esArchiver.loadIfNeeded(

--- a/src/platform/test/functional/services/data_views.ts
+++ b/src/platform/test/functional/services/data_views.ts
@@ -53,7 +53,7 @@ export class DataViewsService extends FtrService {
 
     await this.testSubjects.waitForAttributeToChange('timestampField', 'data-is-loading', '0');
 
-    if (await this.testSubjects.isEnabled('timestampField')) {
+    if (await this.testSubjects.isEnabled('timestampField > comboBoxSearchInput')) {
       if (!hasTimeField) {
         await this.comboBox.set('timestampField', "--- I don't want to use the time filter ---");
       } else if (changeTimestampField) {

--- a/src/platform/test/functional/services/data_views.ts
+++ b/src/platform/test/functional/services/data_views.ts
@@ -51,16 +51,16 @@ export class DataViewsService extends FtrService {
       return isInvalid !== 'true';
     });
 
-    if (hasTimeField) {
-      await this.retry.waitFor('timestamp field loaded', async () => {
-        const timestampField = await this.testSubjects.find('timestampField');
-        return !(await timestampField.elementHasClass('euiComboBox-isDisabled'));
-      });
+    await this.testSubjects.waitForAttributeToChange('timestampField', 'data-is-loading', '0');
 
-      if (changeTimestampField) {
-        await this.comboBox.set('timestampField', changeTimestampField);
+    if (await this.testSubjects.isEnabled('timestampField')) {
+      if (!hasTimeField) {
+        await this.comboBox.set('timestampField', "--- I don't want to use the time filter ---");
+      } else if (changeTimestampField) {
+        await this.comboBox.set('timestampField', changeTimestampField!);
       }
     }
+
     await this.testSubjects.click(adHoc ? 'exploreIndexPatternButton' : 'saveIndexPatternButton');
     await this.header.waitUntilLoadingHasFinished();
   }


### PR DESCRIPTION
## Summary

After #244028 was merged, we started seeing flakiness in some FTR tests related to an incorrect data view time field. It looks like setting the time field was always unreliable in the FTR service, but it's more apparent now that we're waiting for input validation to finish. The fix is to wait for the time field input to load and make sure the correct value is selected.

Resolves #244544.
Resolves #244565.
Resolves #244564.
Resolves #244557.
Resolves #244545.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.