### PR TITLE
[9.2] [SideNav][A11y] Add screen reader announcements to side nav (#243062)

### DIFF
--- a/src/core/packages/chrome/navigation/src/__tests__/__snapshots__/both_modes.test.tsx.snap
+++ b/src/core/packages/chrome/navigation/src/__tests__/__snapshots__/both_modes.test.tsx.snap
@@ -39,6 +39,12 @@ exports[`Both modes should render the side navigation 1`] = `
           </div>
         </a>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="main-navigation-instructions_generated-id"
+      >
+        You are in the main navigation primary menu. Use Up and Down arrow keys to navigate the menu.
+      </p>
       <nav
         aria-label="Main"
         class="css-9lp0kg-styles"
@@ -51,7 +57,10 @@ exports[`Both modes should render the side navigation 1`] = `
             class="euiPopover emotion-euiPopover-block"
           >
             <a
+              aria-describedby="main-navigation-instructions_generated-id"
               aria-haspopup="false"
+              aria-posinset="1"
+              aria-setsize="3"
               class="css-1p9ljkz-buttonStyles"
               data-highlighted="false"
               data-menu-item="true"
@@ -86,6 +95,8 @@ exports[`Both modes should render the side navigation 1`] = `
           >
             <a
               aria-haspopup="false"
+              aria-posinset="2"
+              aria-setsize="3"
               class="css-1p9ljkz-buttonStyles"
               data-highlighted="false"
               data-menu-item="true"
@@ -115,12 +126,21 @@ exports[`Both modes should render the side navigation 1`] = `
         <div
           class="css-1y7bpvk-wrapperStyles"
         >
+          <p
+            class="emotion-euiScreenReaderOnly"
+            id="popover-enter-exit-instructions_generated-id"
+          >
+            Press Enter to go to the submenu.
+          </p>
           <div
             class="euiPopover emotion-euiPopover-block"
           >
             <a
+              aria-describedby="popover-enter-exit-instructions_generated-id"
               aria-expanded="false"
               aria-haspopup="true"
+              aria-posinset="3"
+              aria-setsize="3"
               class="css-1p9ljkz-buttonStyles"
               data-highlighted="false"
               data-menu-item="true"
@@ -148,6 +168,12 @@ exports[`Both modes should render the side navigation 1`] = `
           </div>
         </div>
       </nav>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="footer-navigation-instructions_generated-id"
+      >
+        You are in the main navigation footer menu. Use Up and Down arrow keys to navigate the menu.
+      </p>
       <footer
         aria-label="Side navigation"
         class="css-4kpxr2-SideNavFooter"
@@ -162,6 +188,7 @@ exports[`Both modes should render the side navigation 1`] = `
               class="euiToolTipAnchor  emotion-euiToolTipAnchor-inlineBlock-wrapperStyles"
             >
               <a
+                aria-describedby="footer-navigation-instructions_generated-id"
                 aria-haspopup="false"
                 aria-label="Getting started"
                 class="euiButtonIcon emotion-euiButtonIcon-s-empty-text-buttonStyles"
@@ -215,6 +242,12 @@ exports[`Both modes should render the side navigation 1`] = `
         <div
           class="css-1y7bpvk-wrapperStyles"
         >
+          <p
+            class="emotion-euiScreenReaderOnly"
+            id="popover-enter-exit-instructions_generated-id"
+          >
+            Press Enter to go to the submenu.
+          </p>
           <div
             class="euiPopover emotion-euiPopover-block"
           >
@@ -222,6 +255,7 @@ exports[`Both modes should render the side navigation 1`] = `
               class="css-1g7fa48-wrapperStyles"
             >
               <a
+                aria-describedby="popover-enter-exit-instructions_generated-id"
                 aria-expanded="false"
                 aria-haspopup="true"
                 aria-label="Settings"

--- a/src/core/packages/chrome/navigation/src/__tests__/__snapshots__/collapsed_mode.test.tsx.snap
+++ b/src/core/packages/chrome/navigation/src/__tests__/__snapshots__/collapsed_mode.test.tsx.snap
@@ -43,6 +43,12 @@ exports[`Collapsed mode should render the side navigation 1`] = `
           </a>
         </div>
       </span>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="main-navigation-instructions_generated-id"
+      >
+        You are in the main navigation primary menu. Use Up and Down arrow keys to navigate the menu.
+      </p>
       <nav
         aria-label="Main"
         class="css-1v1tn-styles"
@@ -58,7 +64,10 @@ exports[`Collapsed mode should render the side navigation 1`] = `
               class="euiToolTipAnchor  emotion-euiToolTipAnchor-inlineBlock-wrapperStyles"
             >
               <a
+                aria-describedby="main-navigation-instructions_generated-id"
                 aria-haspopup="false"
+                aria-posinset="1"
+                aria-setsize="3"
                 class="css-1p9ljkz-buttonStyles"
                 data-highlighted="false"
                 data-menu-item="true"
@@ -97,6 +106,8 @@ exports[`Collapsed mode should render the side navigation 1`] = `
             >
               <a
                 aria-haspopup="false"
+                aria-posinset="2"
+                aria-setsize="3"
                 class="css-1p9ljkz-buttonStyles"
                 data-highlighted="false"
                 data-menu-item="true"
@@ -127,12 +138,21 @@ exports[`Collapsed mode should render the side navigation 1`] = `
         <div
           class="css-1y7bpvk-wrapperStyles"
         >
+          <p
+            class="emotion-euiScreenReaderOnly"
+            id="popover-enter-exit-instructions_generated-id"
+          >
+            Press Enter to go to the submenu.
+          </p>
           <div
             class="euiPopover emotion-euiPopover-block"
           >
             <a
+              aria-describedby="popover-enter-exit-instructions_generated-id"
               aria-expanded="false"
               aria-haspopup="true"
+              aria-posinset="3"
+              aria-setsize="3"
               class="css-1p9ljkz-buttonStyles"
               data-highlighted="false"
               data-menu-item="true"
@@ -160,6 +180,12 @@ exports[`Collapsed mode should render the side navigation 1`] = `
           </div>
         </div>
       </nav>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="footer-navigation-instructions_generated-id"
+      >
+        You are in the main navigation footer menu. Use Up and Down arrow keys to navigate the menu.
+      </p>
       <footer
         aria-label="Side navigation"
         class="css-5bzxab-SideNavFooter"
@@ -174,6 +200,7 @@ exports[`Collapsed mode should render the side navigation 1`] = `
               class="euiToolTipAnchor  emotion-euiToolTipAnchor-inlineBlock-wrapperStyles"
             >
               <a
+                aria-describedby="footer-navigation-instructions_generated-id"
                 aria-haspopup="false"
                 aria-label="Getting started"
                 class="euiButtonIcon emotion-euiButtonIcon-s-empty-text-buttonStyles"
@@ -227,6 +254,12 @@ exports[`Collapsed mode should render the side navigation 1`] = `
         <div
           class="css-1y7bpvk-wrapperStyles"
         >
+          <p
+            class="emotion-euiScreenReaderOnly"
+            id="popover-enter-exit-instructions_generated-id"
+          >
+            Press Enter to go to the submenu.
+          </p>
           <div
             class="euiPopover emotion-euiPopover-block"
           >
@@ -234,6 +267,7 @@ exports[`Collapsed mode should render the side navigation 1`] = `
               class="css-1g7fa48-wrapperStyles"
             >
               <a
+                aria-describedby="popover-enter-exit-instructions_generated-id"
                 aria-expanded="false"
                 aria-haspopup="true"
                 aria-label="Settings"

--- a/src/core/packages/chrome/navigation/src/__tests__/__snapshots__/expanded_mode.test.tsx.snap
+++ b/src/core/packages/chrome/navigation/src/__tests__/__snapshots__/expanded_mode.test.tsx.snap
@@ -39,6 +39,12 @@ exports[`Expanded mode should render the side navigation 1`] = `
           </div>
         </a>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="main-navigation-instructions_generated-id"
+      >
+        You are in the main navigation primary menu. Use Up and Down arrow keys to navigate the menu.
+      </p>
       <nav
         aria-label="Main"
         class="css-9lp0kg-styles"
@@ -51,7 +57,10 @@ exports[`Expanded mode should render the side navigation 1`] = `
             class="euiPopover emotion-euiPopover-block"
           >
             <a
+              aria-describedby="main-navigation-instructions_generated-id"
               aria-haspopup="false"
+              aria-posinset="1"
+              aria-setsize="3"
               class="css-1p9ljkz-buttonStyles"
               data-highlighted="false"
               data-menu-item="true"
@@ -86,6 +95,8 @@ exports[`Expanded mode should render the side navigation 1`] = `
           >
             <a
               aria-haspopup="false"
+              aria-posinset="2"
+              aria-setsize="3"
               class="css-1p9ljkz-buttonStyles"
               data-highlighted="false"
               data-menu-item="true"
@@ -115,12 +126,21 @@ exports[`Expanded mode should render the side navigation 1`] = `
         <div
           class="css-1y7bpvk-wrapperStyles"
         >
+          <p
+            class="emotion-euiScreenReaderOnly"
+            id="popover-enter-exit-instructions_generated-id"
+          >
+            Press Enter to go to the submenu.
+          </p>
           <div
             class="euiPopover emotion-euiPopover-block"
           >
             <a
+              aria-describedby="popover-enter-exit-instructions_generated-id"
               aria-expanded="false"
               aria-haspopup="true"
+              aria-posinset="3"
+              aria-setsize="3"
               class="css-1p9ljkz-buttonStyles"
               data-highlighted="false"
               data-menu-item="true"
@@ -148,6 +168,12 @@ exports[`Expanded mode should render the side navigation 1`] = `
           </div>
         </div>
       </nav>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="footer-navigation-instructions_generated-id"
+      >
+        You are in the main navigation footer menu. Use Up and Down arrow keys to navigate the menu.
+      </p>
       <footer
         aria-label="Side navigation"
         class="css-4kpxr2-SideNavFooter"
@@ -162,6 +188,7 @@ exports[`Expanded mode should render the side navigation 1`] = `
               class="euiToolTipAnchor  emotion-euiToolTipAnchor-inlineBlock-wrapperStyles"
             >
               <a
+                aria-describedby="footer-navigation-instructions_generated-id"
                 aria-haspopup="false"
                 aria-label="Getting started"
                 class="euiButtonIcon emotion-euiButtonIcon-s-empty-text-buttonStyles"
@@ -215,6 +242,12 @@ exports[`Expanded mode should render the side navigation 1`] = `
         <div
           class="css-1y7bpvk-wrapperStyles"
         >
+          <p
+            class="emotion-euiScreenReaderOnly"
+            id="popover-enter-exit-instructions_generated-id"
+          >
+            Press Enter to go to the submenu.
+          </p>
           <div
             class="euiPopover emotion-euiPopover-block"
           >
@@ -222,6 +255,7 @@ exports[`Expanded mode should render the side navigation 1`] = `
               class="css-1g7fa48-wrapperStyles"
             >
               <a
+                aria-describedby="popover-enter-exit-instructions_generated-id"
                 aria-expanded="false"
                 aria-haspopup="true"
                 aria-label="Settings"

--- a/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/header.tsx
+++ b/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/header.tsx
@@ -18,9 +18,10 @@ import { useMenuHeaderStyle } from '../../hooks/use_menu_header_style';
 
 export interface HeaderProps {
   title?: string;
+  'aria-describedby'?: string;
 }
 
-export const Header: FC<HeaderProps> = ({ title }) => {
+export const Header: FC<HeaderProps> = ({ title, 'aria-describedby': ariaDescribedBy }) => {
   const { goBack } = useNestedMenu();
   const { euiTheme } = useEuiTheme();
   const headerStyle = useMenuHeaderStyle();
@@ -37,6 +38,7 @@ export const Header: FC<HeaderProps> = ({ title }) => {
   return (
     <div css={titleStyle}>
       <EuiButtonIcon
+        aria-describedby={ariaDescribedBy}
         aria-label={i18n.translate('core.ui.chrome.sideNavigation.goBackButtonIconAriaLabel', {
           defaultMessage: 'Go back',
         })}

--- a/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/menu_panel.tsx
+++ b/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/menu_panel.tsx
@@ -10,18 +10,51 @@
 import type { FC, ReactNode } from 'react';
 import React, { useCallback } from 'react';
 
+import { i18n } from '@kbn/i18n';
+import { EuiScreenReaderOnly, useGeneratedHtmlId } from '@elastic/eui';
 import { SecondaryMenu } from '../secondary_menu';
 import { useNestedMenu } from './use_nested_menu';
 import { getFocusableElements } from '../../utils/get_focusable_elements';
 
+export interface PanelIds {
+  panelNavigationInstructionsId: string;
+  panelEnterSubmenuInstructionsId: string;
+}
+
+export type PanelChildren = ReactNode | ((ids: PanelIds) => ReactNode);
 export interface PanelProps {
-  children: ReactNode;
+  children: PanelChildren;
   id: string;
   title?: string;
 }
 
 export const Panel: FC<PanelProps> = ({ children, id, title }) => {
   const { currentPanel, panelStackDepth, returnFocusId } = useNestedMenu();
+
+  const panelNavigationInstructionsId = useGeneratedHtmlId({
+    prefix: `panel-navigation-instructions-${id}`,
+  });
+  const panelEnterSubmenuInstructionsId = useGeneratedHtmlId({
+    prefix: `panel-enter-submenu-instructions-${id}`,
+  });
+  const isRootPanel = panelStackDepth === 0;
+
+  const navigationInstructions = isRootPanel
+    ? i18n.translate('core.ui.chrome.sideNavigation.morePanelInstructions', {
+        defaultMessage:
+          'You are in the More primary menu dialog. Use Up and Down arrow keys to navigate. Press Escape to exit to the menu trigger.',
+      })
+    : i18n.translate('core.ui.chrome.sideNavigation.nestedPanelInstructions', {
+        defaultMessage:
+          'You are in a submenu. Use Up and Down arrow keys to navigate. Press Go back or Escape to exit to the parent menu.',
+      });
+
+  const enterSubmenuInstructions = i18n.translate(
+    'core.ui.chrome.sideNavigation.panelEnterSubmenuInstruction',
+    {
+      defaultMessage: 'Press Enter to go to the submenu.',
+    }
+  );
 
   const panelRef = useCallback(
     (node: HTMLDivElement | null) => {
@@ -34,7 +67,7 @@ export const Panel: FC<PanelProps> = ({ children, id, title }) => {
       }
 
       // If we are at the root panel, we don't need to focus anything
-      if (panelStackDepth === 0) return;
+      if (isRootPanel) return;
 
       // Otherwise, we focus the first focusable element in the panel
       if (node) {
@@ -42,8 +75,18 @@ export const Panel: FC<PanelProps> = ({ children, id, title }) => {
         elements[0]?.focus();
       }
     },
-    [currentPanel, id, panelStackDepth, returnFocusId]
+    [currentPanel, id, isRootPanel, returnFocusId]
   );
+
+  const renderChildren = () => {
+    if (typeof children === 'function') {
+      return children({
+        panelNavigationInstructionsId,
+        panelEnterSubmenuInstructionsId,
+      });
+    }
+    return children;
+  };
 
   if (currentPanel !== id) return null;
 
@@ -55,14 +98,23 @@ export const Panel: FC<PanelProps> = ({ children, id, title }) => {
         title={title}
         isPanel={false}
       >
-        {children}
+        <EuiScreenReaderOnly>
+          <p id={panelNavigationInstructionsId}>{navigationInstructions}</p>
+        </EuiScreenReaderOnly>
+        <EuiScreenReaderOnly>
+          <p id={panelEnterSubmenuInstructionsId}>{enterSubmenuInstructions}</p>
+        </EuiScreenReaderOnly>
+        {renderChildren()}
       </SecondaryMenu>
     );
   }
 
   return (
     <div data-test-subj={`nestedSecondaryMenuPanel-${id}`} ref={panelRef}>
-      {children}
+      <EuiScreenReaderOnly>
+        <p id={panelNavigationInstructionsId}>{navigationInstructions}</p>
+      </EuiScreenReaderOnly>
+      {renderChildren()}
     </div>
   );
 };

--- a/src/core/packages/chrome/navigation/src/components/secondary_menu/item.tsx
+++ b/src/core/packages/chrome/navigation/src/components/secondary_menu/item.tsx
@@ -92,7 +92,7 @@ export const SecondaryMenuItemComponent = ({
   );
 
   return (
-    <li ref={activeItemRef}>
+    <li ref={activeItemRef} role="none">
       {isHighlighted ? (
         <EuiButton
           aria-current={isCurrent ? 'page' : undefined}

--- a/src/core/packages/chrome/navigation/src/components/secondary_menu/section.tsx
+++ b/src/core/packages/chrome/navigation/src/components/secondary_menu/section.tsx
@@ -37,7 +37,7 @@ export const SecondaryMenuSectionComponent = ({
   const sectionId = label ? label.replace(/\s+/g, '-').toLowerCase() : undefined;
 
   return (
-    <nav
+    <div
       css={css`
         padding: ${euiTheme.size.m};
 
@@ -45,6 +45,7 @@ export const SecondaryMenuSectionComponent = ({
           border-bottom: 1px ${euiTheme.colors.borderBaseSubdued} solid;
         }
       `}
+      role="group"
       aria-labelledby={sectionId || undefined}
     >
       {label && (
@@ -68,9 +69,10 @@ export const SecondaryMenuSectionComponent = ({
           width: 100%;
           gap: ${euiTheme.size.xxs};
         `}
+        role="none"
       >
         {children}
       </ul>
-    </nav>
+    </div>
   );
 };

--- a/src/core/packages/chrome/navigation/src/components/side_nav/footer.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/footer.tsx
@@ -10,46 +10,71 @@
 import type { ReactNode } from 'react';
 import React from 'react';
 import { css } from '@emotion/react';
-import { useEuiTheme } from '@elastic/eui';
+import { EuiScreenReaderOnly, useEuiTheme, useGeneratedHtmlId } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { getFocusableElements } from '../../utils/get_focusable_elements';
 import { updateTabIndices } from '../../utils/update_tab_indices';
 import { handleRovingIndex } from '../../utils/handle_roving_index';
 
+export interface FooterIds {
+  footerNavigationInstructionsId: string;
+}
+
+export type FooterChildren = ReactNode | ((ids: FooterIds) => ReactNode);
 export interface SideNavFooterProps {
-  children: ReactNode;
+  children: FooterChildren;
   isCollapsed: boolean;
 }
 
 export const SideNavFooter = ({ children, isCollapsed }: SideNavFooterProps): JSX.Element => {
   const { euiTheme } = useEuiTheme();
+  const footerNavigationInstructionsId = useGeneratedHtmlId({
+    prefix: 'footer-navigation-instructions',
+  });
+
+  const renderChildren = () => {
+    if (typeof children === 'function') {
+      return children({ footerNavigationInstructionsId });
+    }
+    return children;
+  };
 
   return (
-    // The footer itself is not interactive but the children are
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-    <footer
-      aria-label={i18n.translate('core.ui.chrome.sideNavigation.footerAriaLabel', {
-        defaultMessage: 'Side navigation',
-      })}
-      css={css`
-        align-items: center;
-        border-top: 1px solid ${euiTheme.colors.borderBaseSubdued};
-        display: flex;
-        flex-direction: column;
-        gap: ${euiTheme.size.xs};
-        justify-content: center;
-        padding-top: ${isCollapsed ? euiTheme.size.s : euiTheme.size.m};
-      `}
-      onKeyDown={handleRovingIndex}
-      ref={(ref) => {
-        if (ref) {
-          const elements = getFocusableElements(ref);
-          updateTabIndices(elements);
-        }
-      }}
-    >
-      {children}
-    </footer>
+    <>
+      <EuiScreenReaderOnly>
+        <p id={footerNavigationInstructionsId}>
+          {i18n.translate('core.ui.chrome.sideNavigation.footerInstructions', {
+            defaultMessage:
+              'You are in the main navigation footer menu. Use Up and Down arrow keys to navigate the menu.',
+          })}
+        </p>
+      </EuiScreenReaderOnly>
+      {/* The footer itself is not interactive but the children are */}
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+      <footer
+        aria-label={i18n.translate('core.ui.chrome.sideNavigation.footerAriaLabel', {
+          defaultMessage: 'Side navigation',
+        })}
+        css={css`
+          align-items: center;
+          border-top: 1px solid ${euiTheme.colors.borderBaseSubdued};
+          display: flex;
+          flex-direction: column;
+          gap: ${euiTheme.size.xs};
+          justify-content: center;
+          padding-top: ${isCollapsed ? euiTheme.size.s : euiTheme.size.m};
+        `}
+        onKeyDown={handleRovingIndex}
+        ref={(ref) => {
+          if (ref) {
+            const elements = getFocusableElements(ref);
+            updateTabIndices(elements);
+          }
+        }}
+      >
+        {renderChildren()}
+      </footer>
+    </>
   );
 };

--- a/src/core/packages/chrome/navigation/src/components/side_nav/primary_menu.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/primary_menu.tsx
@@ -11,21 +11,29 @@ import React, { forwardRef } from 'react';
 import type { ForwardedRef, ReactNode } from 'react';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import { useEuiTheme } from '@elastic/eui';
+import { EuiScreenReaderOnly, useEuiTheme, useGeneratedHtmlId } from '@elastic/eui';
 
 import { PRIMARY_NAVIGATION_ID } from '../../constants';
 import { handleRovingIndex } from '../../utils/handle_roving_index';
 import { getFocusableElements } from '../../utils/get_focusable_elements';
 import { updateTabIndices } from '../../utils/update_tab_indices';
 
+export interface PrimaryMenuIds {
+  mainNavigationInstructionsId: string;
+}
+
+export type PrimaryMenuChildren = ReactNode | ((ids: PrimaryMenuIds) => ReactNode);
 export interface SideNavPrimaryMenuProps {
-  children: ReactNode;
+  children: PrimaryMenuChildren;
   isCollapsed: boolean;
 }
 
 export const SideNavPrimaryMenu = forwardRef<HTMLElement, SideNavPrimaryMenuProps>(
   ({ children, isCollapsed }, ref: ForwardedRef<HTMLElement>): JSX.Element => {
     const { euiTheme } = useEuiTheme();
+    const mainNavigationInstructionsId = useGeneratedHtmlId({
+      prefix: 'main-navigation-instructions',
+    });
 
     const styles = css`
       align-items: center;
@@ -36,28 +44,45 @@ export const SideNavPrimaryMenu = forwardRef<HTMLElement, SideNavPrimaryMenuProp
       min-height: 0;
     `;
 
-    return (
-      // The nav itself is not interactive but the children are
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-      <nav
-        aria-label={i18n.translate('core.ui.chrome.sideNavigation.primaryMenuAriaLabel', {
-          defaultMessage: 'Main',
-        })}
-        css={styles}
-        id={PRIMARY_NAVIGATION_ID}
-        onKeyDown={handleRovingIndex}
-        ref={(node) => {
-          if (node) {
-            const elements = getFocusableElements(node);
-            updateTabIndices(elements);
-          }
+    const renderChildren = () => {
+      if (typeof children === 'function') {
+        return children({ mainNavigationInstructionsId });
+      }
+      return children;
+    };
 
-          if (typeof ref === 'function') ref(node);
-          else if (ref && 'current' in ref) ref.current = node;
-        }}
-      >
-        {children}
-      </nav>
+    return (
+      <>
+        <EuiScreenReaderOnly>
+          <p id={mainNavigationInstructionsId}>
+            {i18n.translate('core.ui.chrome.sideNavigation.primaryMenuInstructions', {
+              defaultMessage:
+                'You are in the main navigation primary menu. Use Up and Down arrow keys to navigate the menu.',
+            })}
+          </p>
+        </EuiScreenReaderOnly>
+        {/* The nav itself is not interactive but the children are */}
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+        <nav
+          aria-label={i18n.translate('core.ui.chrome.sideNavigation.primaryMenuAriaLabel', {
+            defaultMessage: 'Main',
+          })}
+          css={styles}
+          id={PRIMARY_NAVIGATION_ID}
+          onKeyDown={handleRovingIndex}
+          ref={(node) => {
+            if (node) {
+              const elements = getFocusableElements(node);
+              updateTabIndices(elements);
+            }
+
+            if (typeof ref === 'function') ref(node);
+            else if (ref && 'current' in ref) ref.current = node;
+          }}
+        >
+          {renderChildren()}
+        </nav>
+      </>
     );
   }
 );

--- a/src/core/packages/chrome/navigation/src/components/side_nav/primary_menu_item.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/primary_menu_item.tsx
@@ -30,6 +30,8 @@ export interface SideNavPrimaryMenuItemProps extends MenuItem {
   isCollapsed: boolean;
   isHorizontal?: boolean;
   onClick?: () => void;
+  'aria-posinset'?: number;
+  'aria-setsize'?: number;
 }
 
 export const SideNavPrimaryMenuItem = forwardRef<HTMLAnchorElement, SideNavPrimaryMenuItemProps>(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[SideNav][A11y] Add screen reader announcements to side nav (#243062)](https://github.com/elastic/kibana/pull/243062)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ángeles Martínez Barrio","email":"angeles.martinezbarrio@elastic.co"},"sourceCommit":{"committedDate":"2025-11-27T16:12:00Z","message":"[SideNav][A11y] Add screen reader announcements to side nav (#243062)\n\nCloses https://github.com/elastic/kibana-team/issues/2193\n\n## Summary\n\n- This PR adds Screen Reader announcements on arrow navigation for the\nprimary menu, the footer menu, the side panel and the popover.\n- It also adds announcements on how to enter and exit the popover menus.\n- Since the whole `nav` is not focusable, the approach taken was to\nannounce the navigation instructions when focusing on the first element\nof each navigation.\n\n### Testing\n\nTested in Safari + VO and VMWareFusion + Edge + NVDA:\n\n| Safari | Edge |\n|----------|----------|\n| Primary menu 1st Element |\n| <img width=\"1275\" height=\"842\" alt=\"primary_first_Screenshot\n2025-11-17 at 11 43 50\"\nsrc=\"https://github.com/user-attachments/assets/6e9b1f8b-d24b-417f-a615-480333409fc9\"\n/> | <img width=\"1356\" height=\"757\" alt=\"Screenshot 2025-11-17 at 12 21\n43\"\nsrc=\"https://github.com/user-attachments/assets/50899e23-3a1d-4db5-a3a6-e71937a37f28\"\n/> |\n| Primary menu item with popover menu - How to enter/exit |\n| <img width=\"1279\" height=\"849\" alt=\"primary_with_popover_Screenshot\n2025-11-17 at 11 44 09\"\nsrc=\"https://github.com/user-attachments/assets/75e669bc-f868-4a25-9f26-68fce5dd9678\"\n/> | <img width=\"1358\" height=\"762\" alt=\"Screenshot 2025-11-17 at 12 22\n09\"\nsrc=\"https://github.com/user-attachments/assets/a1016ee3-4feb-430b-bf5c-208960c050c0\"\n/> |\n| Primary menu item with popover - Side panel already open  |\n| <img width=\"1266\" height=\"816\" alt=\"Screenshot 2025-11-17 at 12 51 40\"\nsrc=\"https://github.com/user-attachments/assets/6ed5a872-ee8c-48b9-bd0b-78e608db2842\"\n/> | <img width=\"1361\" height=\"761\" alt=\"Screenshot 2025-11-17 at 12 24\n51\"\nsrc=\"https://github.com/user-attachments/assets/6225630b-d50a-4aad-bd19-acb90e139055\"\n/> |\n| Inside popover navigation instructions |\n| <img width=\"1252\" height=\"775\" alt=\"Screenshot 2025-11-17 at 12 54 50\"\nsrc=\"https://github.com/user-attachments/assets/904a01ea-80c7-48de-81c4-3633fa2eb168\"\n/> | <img width=\"1354\" height=\"762\" alt=\"Screenshot 2025-11-17 at 12 22\n51\"\nsrc=\"https://github.com/user-attachments/assets/cd20475d-3793-43c6-b5ab-50c0c9576120\"\n/> |\n| Side panel navigation instructions |\n| <img width=\"1277\" height=\"842\" alt=\"side_Screenshot 2025-11-17 at 11\n46 24\"\nsrc=\"https://github.com/user-attachments/assets/82a82e25-0d03-40bd-8885-dbf121997387\"\n/> | <img width=\"1351\" height=\"760\" alt=\"Screenshot 2025-11-17 at 12 23\n47\"\nsrc=\"https://github.com/user-attachments/assets/fcfbb8b6-b68e-41da-bd3f-2c8d6d4b26d9\"\n/> |\n| Footer menu 1st Element |\n| <img width=\"1268\" height=\"843\" alt=\"footer_Screenshot 2025-11-17 at 11\n48 01\"\nsrc=\"https://github.com/user-attachments/assets/834af3ef-17ae-4c5e-9962-1ff8cc729d36\"\n/> | <img width=\"1361\" height=\"760\" alt=\"Screenshot 2025-11-17 at 12 24\n17\"\nsrc=\"https://github.com/user-attachments/assets/81225a4e-8a05-4b51-b356-067e962a2e0a\"\n/> |\n\n---------\n\nCo-authored-by: Weronika Olejniczak <weronika.olejniczak@elastic.co>","sha":"1be6312474ccf91f3c210ad01afcaa392b3e3c00","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:SharedUX","backport:version","a11y","v9.3.0","v9.2.1"],"title":"[SideNav][A11y] Add screen reader announcements to side nav","number":243062,"url":"https://github.com/elastic/kibana/pull/243062","mergeCommit":{"message":"[SideNav][A11y] Add screen reader announcements to side nav (#243062)\n\nCloses https://github.com/elastic/kibana-team/issues/2193\n\n## Summary\n\n- This PR adds Screen Reader announcements on arrow navigation for the\nprimary menu, the footer menu, the side panel and the popover.\n- It also adds announcements on how to enter and exit the popover menus.\n- Since the whole `nav` is not focusable, the approach taken was to\nannounce the navigation instructions when focusing on the first element\nof each navigation.\n\n### Testing\n\nTested in Safari + VO and VMWareFusion + Edge + NVDA:\n\n| Safari | Edge |\n|----------|----------|\n| Primary menu 1st Element |\n| <img width=\"1275\" height=\"842\" alt=\"primary_first_Screenshot\n2025-11-17 at 11 43 50\"\nsrc=\"https://github.com/user-attachments/assets/6e9b1f8b-d24b-417f-a615-480333409fc9\"\n/> | <img width=\"1356\" height=\"757\" alt=\"Screenshot 2025-11-17 at 12 21\n43\"\nsrc=\"https://github.com/user-attachments/assets/50899e23-3a1d-4db5-a3a6-e71937a37f28\"\n/> |\n| Primary menu item with popover menu - How to enter/exit |\n| <img width=\"1279\" height=\"849\" alt=\"primary_with_popover_Screenshot\n2025-11-17 at 11 44 09\"\nsrc=\"https://github.com/user-attachments/assets/75e669bc-f868-4a25-9f26-68fce5dd9678\"\n/> | <img width=\"1358\" height=\"762\" alt=\"Screenshot 2025-11-17 at 12 22\n09\"\nsrc=\"https://github.com/user-attachments/assets/a1016ee3-4feb-430b-bf5c-208960c050c0\"\n/> |\n| Primary menu item with popover - Side panel already open  |\n| <img width=\"1266\" height=\"816\" alt=\"Screenshot 2025-11-17 at 12 51 40\"\nsrc=\"https://github.com/user-attachments/assets/6ed5a872-ee8c-48b9-bd0b-78e608db2842\"\n/> | <img width=\"1361\" height=\"761\" alt=\"Screenshot 2025-11-17 at 12 24\n51\"\nsrc=\"https://github.com/user-attachments/assets/6225630b-d50a-4aad-bd19-acb90e139055\"\n/> |\n| Inside popover navigation instructions |\n| <img width=\"1252\" height=\"775\" alt=\"Screenshot 2025-11-17 at 12 54 50\"\nsrc=\"https://github.com/user-attachments/assets/904a01ea-80c7-48de-81c4-3633fa2eb168\"\n/> | <img width=\"1354\" height=\"762\" alt=\"Screenshot 2025-11-17 at 12 22\n51\"\nsrc=\"https://github.com/user-attachments/assets/cd20475d-3793-43c6-b5ab-50c0c9576120\"\n/> |\n| Side panel navigation instructions |\n| <img width=\"1277\" height=\"842\" alt=\"side_Screenshot 2025-11-17 at 11\n46 24\"\nsrc=\"https://github.com/user-attachments/assets/82a82e25-0d03-40bd-8885-dbf121997387\"\n/> | <img width=\"1351\" height=\"760\" alt=\"Screenshot 2025-11-17 at 12 23\n47\"\nsrc=\"https://github.com/user-attachments/assets/fcfbb8b6-b68e-41da-bd3f-2c8d6d4b26d9\"\n/> |\n| Footer menu 1st Element |\n| <img width=\"1268\" height=\"843\" alt=\"footer_Screenshot 2025-11-17 at 11\n48 01\"\nsrc=\"https://github.com/user-attachments/assets/834af3ef-17ae-4c5e-9962-1ff8cc729d36\"\n/> | <img width=\"1361\" height=\"760\" alt=\"Screenshot 2025-11-17 at 12 24\n17\"\nsrc=\"https://github.com/user-attachments/assets/81225a4e-8a05-4b51-b356-067e962a2e0a\"\n/> |\n\n---------\n\nCo-authored-by: Weronika Olejniczak <weronika.olejniczak@elastic.co>","sha":"1be6312474ccf91f3c210ad01afcaa392b3e3c00"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243062","number":243062,"mergeCommit":{"message":"[SideNav][A11y] Add screen reader announcements to side nav (#243062)\n\nCloses https://github.com/elastic/kibana-team/issues/2193\n\n## Summary\n\n- This PR adds Screen Reader announcements on arrow navigation for the\nprimary menu, the footer menu, the side panel and the popover.\n- It also adds announcements on how to enter and exit the popover menus.\n- Since the whole `nav` is not focusable, the approach taken was to\nannounce the navigation instructions when focusing on the first element\nof each navigation.\n\n### Testing\n\nTested in Safari + VO and VMWareFusion + Edge + NVDA:\n\n| Safari | Edge |\n|----------|----------|\n| Primary menu 1st Element |\n| <img width=\"1275\" height=\"842\" alt=\"primary_first_Screenshot\n2025-11-17 at 11 43 50\"\nsrc=\"https://github.com/user-attachments/assets/6e9b1f8b-d24b-417f-a615-480333409fc9\"\n/> | <img width=\"1356\" height=\"757\" alt=\"Screenshot 2025-11-17 at 12 21\n43\"\nsrc=\"https://github.com/user-attachments/assets/50899e23-3a1d-4db5-a3a6-e71937a37f28\"\n/> |\n| Primary menu item with popover menu - How to enter/exit |\n| <img width=\"1279\" height=\"849\" alt=\"primary_with_popover_Screenshot\n2025-11-17 at 11 44 09\"\nsrc=\"https://github.com/user-attachments/assets/75e669bc-f868-4a25-9f26-68fce5dd9678\"\n/> | <img width=\"1358\" height=\"762\" alt=\"Screenshot 2025-11-17 at 12 22\n09\"\nsrc=\"https://github.com/user-attachments/assets/a1016ee3-4feb-430b-bf5c-208960c050c0\"\n/> |\n| Primary menu item with popover - Side panel already open  |\n| <img width=\"1266\" height=\"816\" alt=\"Screenshot 2025-11-17 at 12 51 40\"\nsrc=\"https://github.com/user-attachments/assets/6ed5a872-ee8c-48b9-bd0b-78e608db2842\"\n/> | <img width=\"1361\" height=\"761\" alt=\"Screenshot 2025-11-17 at 12 24\n51\"\nsrc=\"https://github.com/user-attachments/assets/6225630b-d50a-4aad-bd19-acb90e139055\"\n/> |\n| Inside popover navigation instructions |\n| <img width=\"1252\" height=\"775\" alt=\"Screenshot 2025-11-17 at 12 54 50\"\nsrc=\"https://github.com/user-attachments/assets/904a01ea-80c7-48de-81c4-3633fa2eb168\"\n/> | <img width=\"1354\" height=\"762\" alt=\"Screenshot 2025-11-17 at 12 22\n51\"\nsrc=\"https://github.com/user-attachments/assets/cd20475d-3793-43c6-b5ab-50c0c9576120\"\n/> |\n| Side panel navigation instructions |\n| <img width=\"1277\" height=\"842\" alt=\"side_Screenshot 2025-11-17 at 11\n46 24\"\nsrc=\"https://github.com/user-attachments/assets/82a82e25-0d03-40bd-8885-dbf121997387\"\n/> | <img width=\"1351\" height=\"760\" alt=\"Screenshot 2025-11-17 at 12 23\n47\"\nsrc=\"https://github.com/user-attachments/assets/fcfbb8b6-b68e-41da-bd3f-2c8d6d4b26d9\"\n/> |\n| Footer menu 1st Element |\n| <img width=\"1268\" height=\"843\" alt=\"footer_Screenshot 2025-11-17 at 11\n48 01\"\nsrc=\"https://github.com/user-attachments/assets/834af3ef-17ae-4c5e-9962-1ff8cc729d36\"\n/> | <img width=\"1361\" height=\"760\" alt=\"Screenshot 2025-11-17 at 12 24\n17\"\nsrc=\"https://github.com/user-attachments/assets/81225a4e-8a05-4b51-b356-067e962a2e0a\"\n/> |\n\n---------\n\nCo-authored-by: Weronika Olejniczak <weronika.olejniczak@elastic.co>","sha":"1be6312474ccf91f3c210ad01afcaa392b3e3c00"}},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->