### PR TITLE
[9.0] [One Discover] [Logs UX] Show full title tooltips on resources badges and only truncate titles in summary column (#241557)

### DIFF
--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
@@ -161,6 +161,7 @@ export function CellActionsPopover({
 export interface FieldBadgeWithActionsProps
   extends Pick<CellActionsPopoverProps, 'onFilter' | 'property' | 'value' | 'renderValue'> {
   icon?: EuiBadgeProps['iconType'];
+  truncateTitle?: boolean;
 }
 
 interface FieldBadgeWithActionsDependencies {
@@ -177,6 +178,7 @@ export function FieldBadgeWithActions({
   property,
   renderValue,
   value,
+  truncateTitle = false,
 }: FieldBadgeWithActionsPropsAndDependencies) {
   return (
     <CellActionsPopover
@@ -186,7 +188,7 @@ export function FieldBadgeWithActions({
       renderValue={renderValue}
       renderPopoverTrigger={({ popoverTriggerProps }) => (
         <EuiBadge {...popoverTriggerProps} color="hollow" iconType={icon} iconSide="left">
-          {truncateMiddle(value)}
+          {truncateTitle ? truncateMiddle(value) : value}
         </EuiBadge>
       )}
     />

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/summary_column/resource.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/summary_column/resource.tsx
@@ -29,7 +29,14 @@ export const Resource = ({ fields, limited = false, onFilter, ...props }: Resour
   return (
     <EuiFlexGroup gutterSize="s" {...props}>
       {displayedFields.map(({ name, value, ResourceBadge, Icon }) => (
-        <ResourceBadge key={name} property={name} value={value} icon={Icon} onFilter={onFilter} />
+        <ResourceBadge
+          key={name}
+          property={name}
+          value={value}
+          icon={Icon}
+          truncateTitle={true}
+          onFilter={onFilter}
+        />
       ))}
       {extraFieldsCount > 0 && (
         <div>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[One Discover] [Logs UX] Show full title tooltips on resources badges and only truncate titles in summary column (#241557)](https://github.com/elastic/kibana/pull/241557)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Abdul Wahab Zahid","email":"awahab07@yahoo.com"},"sourceCommit":{"committedDate":"2025-11-05T09:29:30Z","message":"[One Discover] [Logs UX] Show full title tooltips on resources badges and only truncate titles in summary column (#241557)\n\n- Make the truncation configurable so that resource badges are rendered\nwithout truncation when rendered as individual columns (for Summary\ncolumn, they'll truncate).\n- Show the hover tooltip with full titles, always.\n\nBefore\n\n\nhttps://github.com/user-attachments/assets/1d296649-9967-4be8-b2e3-fcc738e46244\n\nAfter\n\n\nhttps://github.com/user-attachments/assets/ebca3b16-9cc1-4f71-b9a2-b02902fd1ac9\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4d969dfc5a7ceb3830bd02e126a27e9dfbbdb3a7","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:obs-onboarding","backport:version","v8.19.0","v9.3.0","v8.18.9","v9.0.9","v9.1.7","v9.2.1"],"title":"[One Discover] [Logs UX] Show full title tooltips on resources badges and only truncate titles in summary column","number":241557,"url":"https://github.com/elastic/kibana/pull/241557","mergeCommit":{"message":"[One Discover] [Logs UX] Show full title tooltips on resources badges and only truncate titles in summary column (#241557)\n\n- Make the truncation configurable so that resource badges are rendered\nwithout truncation when rendered as individual columns (for Summary\ncolumn, they'll truncate).\n- Show the hover tooltip with full titles, always.\n\nBefore\n\n\nhttps://github.com/user-attachments/assets/1d296649-9967-4be8-b2e3-fcc738e46244\n\nAfter\n\n\nhttps://github.com/user-attachments/assets/ebca3b16-9cc1-4f71-b9a2-b02902fd1ac9\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4d969dfc5a7ceb3830bd02e126a27e9dfbbdb3a7"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","9.0"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/243937","number":243937,"state":"OPEN"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/241557","number":241557,"mergeCommit":{"message":"[One Discover] [Logs UX] Show full title tooltips on resources badges and only truncate titles in summary column (#241557)\n\n- Make the truncation configurable so that resource badges are rendered\nwithout truncation when rendered as individual columns (for Summary\ncolumn, they'll truncate).\n- Show the hover tooltip with full titles, always.\n\nBefore\n\n\nhttps://github.com/user-attachments/assets/1d296649-9967-4be8-b2e3-fcc738e46244\n\nAfter\n\n\nhttps://github.com/user-attachments/assets/ebca3b16-9cc1-4f71-b9a2-b02902fd1ac9\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4d969dfc5a7ceb3830bd02e126a27e9dfbbdb3a7"}},{"branch":"8.18","label":"v8.18.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/241925","number":241925,"state":"MERGED","mergeCommit":{"sha":"e5083aaf1a8e16671d3fd58ed883dfaadf9aa5e0","message":"[9.1] [One Discover] [Logs UX] Show full title tooltips on resources badges and only truncate titles in summary column (#241557) (#241925)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[One Discover] [Logs UX] Show full title tooltips on resources badges\nand only truncate titles in summary column\n(#241557)](https://github.com/elastic/kibana/pull/241557)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Abdul Wahab Zahid <awahab07@yahoo.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"branch":"9.2","label":"v9.2.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/241926","number":241926,"state":"MERGED","mergeCommit":{"sha":"476596690e965d98880c7ca7d61999fe18836560","message":"[9.2] [One Discover] [Logs UX] Show full title tooltips on resources badges and only truncate titles in summary column (#241557) (#241926)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[One Discover] [Logs UX] Show full title tooltips on resources badges\nand only truncate titles in summary column\n(#241557)](https://github.com/elastic/kibana/pull/241557)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Abdul Wahab Zahid <awahab07@yahoo.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}}]}] BACKPORT-->