### PR TITLE
[Flaky test] Fix custom threshold rule test using wrong rule name

### DIFF
--- a/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/rules_page/custom_threshold_rule/index.ts
+++ b/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/rules_page/custom_threshold_rule/index.ts
@@ -101,8 +101,10 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
         async () => await testSubjects.exists('ruleForm')
       );
 
-      // Set rule name
-      await testSubjects.setValue('ruleDetailsNameInput', CUSTOM_THRESHOLD_RULE_NAME);
+      // Set rule name (clear default value first)
+      const ruleNameInput = await testSubjects.find('ruleDetailsNameInput');
+      await ruleNameInput.clearValueWithKeyboard();
+      await ruleNameInput.type(CUSTOM_THRESHOLD_RULE_NAME);
 
       // Type the pattern to trigger "Explore matching indices" button
       await testSubjects.click('selectDataViewExpression');


### PR DESCRIPTION
It closes https://github.com/elastic/kibana/issues/244652.

### Summary

Fixes the "Custom threshold rule with ad-hoc data view" functional test which was failing because the rule was being created with a concatenated name.

### Problem

The rule type form pre-populates the name input with a default value ("Custom threshold rule"). When `testSubjects.setValue` was called, it sometimes appended the intended name instead of replacing it, resulting in:

<img width="1600" height="861" alt="ObservabilityApp Custom threshold rule with ad-hoc data view should create a cus-34f33bc48353cc4187f5949cc3d3966379d60011d6325c1a91faab151a187f48" src="https://github.com/user-attachments/assets/412bee5a-3010-4c34-a133-295d7cff84d8" />

### Solution

Clear the input field before typing the new name using `clearValueWithKeyboard()`.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->