### PR TITLE
[moon] Fix single `moon.yml` regeneration

### DIFF
--- a/packages/kbn-moon/src/cli/regenerate_moon_projects.ts
+++ b/packages/kbn-moon/src/cli/regenerate_moon_projects.ts
@@ -76,10 +76,9 @@ export function regenerateMoonProjects() {
       skip: [],
     };
 
-    const packages: Package[] = filter?.length
-      ? filterPackages(getPackages(REPO_ROOT), filter)
-      : getPackages(REPO_ROOT);
-    const packageIds = packages.map((pkg) => pkg.name);
+    const allPackages = getPackages(REPO_ROOT);
+    const packages: Package[] = filter?.length ? filterPackages(allPackages, filter) : allPackages;
+    const allPackageIds = allPackages.map((pkg) => pkg.name);
 
     for (const pkg of packages) {
       log.verbose(`Generating project configuration for ${pkg.name}`);
@@ -90,7 +89,7 @@ export function regenerateMoonProjects() {
 
       applyTsConfigSettings(projectConfig, {
         tsConfigPath: pathInPackage('tsconfig.json'),
-        allPackageIds: packageIds,
+        allPackageIds,
         includeDependencies,
       });
 


### PR DESCRIPTION
## Summary
Fixes `moon` regeneration for single project dependencies. 

There was a small bug when a single project was regenerated and dependencies would be also filtered to the filtered package set.