### PR TITLE
Fleet Integrations Qualitrics Give Feedback Link

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/layouts/default.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/layouts/default.tsx
@@ -5,11 +5,12 @@
  * 2.0.
  */
 import React, { memo } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiNotificationBadge } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiNotificationBadge, EuiLink, useEuiTheme } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { useLink, useStartServices } from '../../../hooks';
 import type { Section } from '../sections';
+import { INTEGRATIONS_OVERVIEW_FEEDBACK_LINK } from '../../../constants';
 
 import { WithHeaderLayout } from '.';
 
@@ -23,6 +24,9 @@ export const DefaultLayout: React.FC<Props> = memo(
   ({ section, children, notificationsBySection }) => {
     const { automaticImport } = useStartServices();
     const { getHref } = useLink();
+    const { euiTheme } = useEuiTheme();
+    // Hide feedback links in development mode
+    const isDevMode = process.env.NODE_ENV === 'development';
     const tabs = [
       {
         name: (
@@ -52,14 +56,30 @@ export const DefaultLayout: React.FC<Props> = memo(
       <WithHeaderLayout
         leftColumn={
           <EuiFlexGroup direction="column" gutterSize="none" justifyContent="center">
-            <EuiText>
-              <h1>
-                <FormattedMessage
-                  id="xpack.fleet.integrationsHeaderTitle"
-                  defaultMessage="Integrations"
-                />
-              </h1>
-            </EuiText>
+            <EuiFlexGroup gutterSize="s" alignItems="flexEnd">
+              <EuiFlexItem grow={false}>
+                <EuiText>
+                  <h1>
+                    <FormattedMessage
+                      id="xpack.fleet.integrationsHeaderTitle"
+                      defaultMessage="Integrations"
+                    />
+                  </h1>
+                </EuiText>
+              </EuiFlexItem>
+              {!isDevMode && (
+                <EuiFlexItem grow={false} style={{ paddingBottom: euiTheme.size.xs, paddingLeft: euiTheme.size.s }}>
+                  <EuiText size="s">
+                    <EuiLink href={INTEGRATIONS_OVERVIEW_FEEDBACK_LINK} external target="_blank">
+                      <FormattedMessage
+                        id="xpack.fleet.integrationsHeaderFeedbackLink"
+                        defaultMessage="Give feedback"
+                      />
+                    </EuiLink>
+                  </EuiText>
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
 
             <EuiSpacer size="s" />
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/layouts/default.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/layouts/default.tsx
@@ -5,7 +5,15 @@
  * 2.0.
  */
 import React, { memo } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiNotificationBadge, EuiLink, useEuiTheme } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiText,
+  EuiNotificationBadge,
+  EuiLink,
+  useEuiTheme,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { useLink, useStartServices } from '../../../hooks';

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/layouts/default.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/layouts/default.tsx
@@ -68,8 +68,8 @@ export const DefaultLayout: React.FC<Props> = memo(
                 </EuiText>
               </EuiFlexItem>
               {!isDevMode && (
-                <EuiFlexItem grow={false} style={{ paddingBottom: euiTheme.size.xs, paddingLeft: euiTheme.size.s }}>
-                  <EuiText size="s">
+                <EuiFlexItem grow={false} style={{ paddingBottom: euiTheme.size.xs }}>
+                  <EuiText size="s" style={{ whiteSpace: 'nowrap' }}>
                     <EuiLink href={INTEGRATIONS_OVERVIEW_FEEDBACK_LINK} external target="_blank">
                       <FormattedMessage
                         id="xpack.fleet.integrationsHeaderFeedbackLink"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -18,6 +18,7 @@ import {
   EuiDescriptionListTitle,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiSelect,
   EuiSpacer,
   EuiText,
@@ -49,7 +50,7 @@ import {
   useGetSettingsQuery,
 } from '../../../../hooks';
 import { useAgentless } from '../../../../../fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology';
-import { INTEGRATIONS_ROUTING_PATHS } from '../../../../constants';
+import { INTEGRATIONS_ROUTING_PATHS, INTEGRATIONS_DIRECTED_FEEDBACK_LINK } from '../../../../constants';
 import { useGetPackageInfoByKeyQuery, useLink, useAgentPolicyContext } from '../../../../hooks';
 import { pkgKeyFromPackageInfo } from '../../../../services';
 import type { PackageInfo } from '../../../../types';
@@ -159,6 +160,8 @@ export function Detail() {
 
   const services = useStartServices();
   const isCloud = !!services?.cloud?.cloudId;
+  // Hide feedback links in development mode
+  const isDevMode = process.env.NODE_ENV === 'development';
   const agentPolicyIdFromContext = getAgentPolicyId();
   // edit readme state
 
@@ -362,10 +365,26 @@ export function Detail() {
               {packageInfo ? (
                 <EuiFlexGroup direction="column" justifyContent="flexStart" gutterSize="xs">
                   <EuiFlexItem grow={false}>
-                    <EuiText>
-                      {/* Render space in place of package name while package info loads to prevent layout from jumping around */}
-                      <h1>{integrationInfo?.title || packageInfo?.title || '\u00A0'}</h1>
-                    </EuiText>
+                    <EuiFlexGroup gutterSize="s" alignItems="flexEnd">
+                      <EuiFlexItem grow={false}>
+                        <EuiText>
+                          {/* Render space in place of package name while package info loads to prevent layout from jumping around */}
+                          <h1>{integrationInfo?.title || packageInfo?.title || '\u00A0'}</h1>
+                        </EuiText>
+                      </EuiFlexItem>
+                      {!isDevMode && (
+                        <EuiFlexItem grow={false} style={{ paddingBottom: theme.euiTheme.size.xs, paddingLeft: theme.euiTheme.size.s }}>
+                          <EuiText size="s">
+                            <EuiLink href={INTEGRATIONS_DIRECTED_FEEDBACK_LINK} external target="_blank">
+                              <FormattedMessage
+                                id="xpack.fleet.integrationDetailsHeaderFeedbackLink"
+                                defaultMessage="Give feedback"
+                              />
+                            </EuiLink>
+                          </EuiText>
+                        </EuiFlexItem>
+                      )}
+                    </EuiFlexGroup>
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiFlexGroup gutterSize="xs">

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -50,7 +50,10 @@ import {
   useGetSettingsQuery,
 } from '../../../../hooks';
 import { useAgentless } from '../../../../../fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology';
-import { INTEGRATIONS_ROUTING_PATHS, INTEGRATIONS_DIRECTED_FEEDBACK_LINK } from '../../../../constants';
+import {
+  INTEGRATIONS_ROUTING_PATHS,
+  INTEGRATIONS_DIRECTED_FEEDBACK_LINK,
+} from '../../../../constants';
 import { useGetPackageInfoByKeyQuery, useLink, useAgentPolicyContext } from '../../../../hooks';
 import { pkgKeyFromPackageInfo } from '../../../../services';
 import type { PackageInfo } from '../../../../types';
@@ -375,7 +378,11 @@ export function Detail() {
                       {!isDevMode && (
                         <EuiFlexItem grow={false} style={{ paddingBottom: theme.euiTheme.size.xs }}>
                           <EuiText size="s" style={{ whiteSpace: 'nowrap' }}>
-                            <EuiLink href={INTEGRATIONS_DIRECTED_FEEDBACK_LINK} external target="_blank">
+                            <EuiLink
+                              href={INTEGRATIONS_DIRECTED_FEEDBACK_LINK}
+                              external
+                              target="_blank"
+                            >
                               <FormattedMessage
                                 id="xpack.fleet.integrationDetailsHeaderFeedbackLink"
                                 defaultMessage="Give feedback"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -373,8 +373,8 @@ export function Detail() {
                         </EuiText>
                       </EuiFlexItem>
                       {!isDevMode && (
-                        <EuiFlexItem grow={false} style={{ paddingBottom: theme.euiTheme.size.xs, paddingLeft: theme.euiTheme.size.s }}>
-                          <EuiText size="s">
+                        <EuiFlexItem grow={false} style={{ paddingBottom: theme.euiTheme.size.xs }}>
+                          <EuiText size="s" style={{ whiteSpace: 'nowrap' }}>
                             <EuiLink href={INTEGRATIONS_DIRECTED_FEEDBACK_LINK} external target="_blank">
                               <FormattedMessage
                                 id="xpack.fleet.integrationDetailsHeaderFeedbackLink"

--- a/x-pack/platform/plugins/shared/fleet/public/constants/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/constants/index.ts
@@ -70,3 +70,6 @@ export type TOUR_STORAGE_CONFIG = {
 };
 
 export const MAX_FLYOUT_WIDTH = 800;
+
+export const INTEGRATIONS_OVERVIEW_FEEDBACK_LINK = 'https://ela.st/integrations-overview-feedback';
+export const INTEGRATIONS_DIRECTED_FEEDBACK_LINK = 'https://ela.st/integrations-directed-feedback';


### PR DESCRIPTION
## Summary
Adds feedback links to help collect user input on the Integrations experience:
- Main overview page: Collects feedback on general integrations browsing
- Individual integration pages: Collects feedback on specific integrations

### Added Feedback Links

- Integrations Overview Page: Added a "Give feedback" link next to the "Integrations" title that points to https://ela.st/integrations-overview-feedback
- Individual Integration Detail Pages: Added a "Give feedback" link next to each integration's title that points to https://ela.st/integrations-directed-feedback

### Implementation Details

- Created two new constants in fleet/public/constants/index.ts: INTEGRATIONS_OVERVIEW_FEEDBACK_LINK, INTEGRATIONS_DIRECTED_FEEDBACK_LINK
- Links are hidden in development mode using process.env.NODE_ENV check
- Links open in a new tab with external link indicator
- Used EUI theme sizing for consistent spacing
- Links are responsive and handle text wrapping appropriately at different screen sizes

## Testing
Manually tested in browser at various screen sizes. Links only appear when running production builds.
Video Link to inspect aspect ratio resizing

https://github.com/user-attachments/assets/1681cfa6-b007-4cb8-9546-cc8e42d1a17f

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
~~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~~
~~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
~~- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
~~- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~~
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


## Identify risks
N/A

## Closes
https://github.com/elastic/kibana/issues/237854

