### PR TITLE
[o11y agent] Add dataProviderRegistry

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_agent/server/data_registry.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent/server/data_registry.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+
+interface ObservabilityAgentDataRegistryTypes {
+  apmErrors: unknown;
+}
+
+interface ObservabilityAgentDataProviderContext {
+  request: KibanaRequest;
+}
+
+type ObservabilityAgentDataProvider<K extends keyof ObservabilityAgentDataRegistryTypes> = (
+  context: ObservabilityAgentDataProviderContext
+) => Promise<ObservabilityAgentDataRegistryTypes[K]>;
+
+export class ObservabilityAgentDataRegistry {
+  private readonly providers = new Map<
+    keyof ObservabilityAgentDataRegistryTypes,
+    ObservabilityAgentDataProvider<any>
+  >();
+
+  constructor(private readonly logger: Logger) {}
+
+  public registerDataProvider<K extends keyof ObservabilityAgentDataRegistryTypes>(
+    id: K,
+    provider: ObservabilityAgentDataProvider<K>
+  ): void {
+    if (this.providers.has(id)) {
+      this.logger.warn(`Overwriting data provider for key: ${id}`);
+    } else {
+      this.logger.debug(`Registered data provider for key: ${id}`);
+    }
+
+    this.providers.set(id, provider);
+  }
+
+  public async getData<K extends keyof ObservabilityAgentDataRegistryTypes>(
+    id: K,
+    context: ObservabilityAgentDataProviderContext
+  ): Promise<ObservabilityAgentDataRegistryTypes[K]> {
+    const provider = this.providers.get(id);
+
+    if (!provider) {
+      throw new Error(`No data provider registered for key: ${id}`);
+    }
+
+    return provider(context);
+  }
+}

--- a/x-pack/solutions/observability/plugins/observability_agent/server/data_registry.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent/server/data_registry.ts
@@ -11,12 +11,12 @@ interface ObservabilityAgentDataRegistryTypes {
   apmErrors: unknown;
 }
 
-interface ObservabilityAgentDataProviderContext {
+interface ObservabilityAgentDataProviderDependencies {
   request: KibanaRequest;
 }
 
 type ObservabilityAgentDataProvider<K extends keyof ObservabilityAgentDataRegistryTypes> = (
-  context: ObservabilityAgentDataProviderContext
+  context: ObservabilityAgentDataProviderDependencies
 ) => Promise<ObservabilityAgentDataRegistryTypes[K]>;
 
 export class ObservabilityAgentDataRegistry {
@@ -42,7 +42,7 @@ export class ObservabilityAgentDataRegistry {
 
   public async getData<K extends keyof ObservabilityAgentDataRegistryTypes>(
     id: K,
-    context: ObservabilityAgentDataProviderContext
+    context: ObservabilityAgentDataProviderDependencies
   ): Promise<ObservabilityAgentDataRegistryTypes[K]> {
     const provider = this.providers.get(id);
 

--- a/x-pack/solutions/observability/plugins/observability_agent/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent/server/plugin.ts
@@ -24,6 +24,8 @@ import type {
   ObservabilityAgentPluginStartDependencies,
 } from './types';
 
+import { ObservabilityAgentDataRegistry } from './data_registry';
+
 export class ObservabilityAgentPlugin
   implements
     Plugin<
@@ -34,9 +36,11 @@ export class ObservabilityAgentPlugin
     >
 {
   private readonly logger: Logger;
+  private readonly dataRegistry: ObservabilityAgentDataRegistry;
 
   constructor(initContext: PluginInitializerContext) {
     this.logger = initContext.logger.get();
+    this.dataRegistry = new ObservabilityAgentDataRegistry(this.logger);
   }
 
   public setup(
@@ -68,7 +72,9 @@ export class ObservabilityAgentPlugin
         this.logger.error(`Error checking whether the observability agent is enabled: ${error}`);
       });
 
-    return {};
+    return {
+      registerDataProvider: (id, provider) => this.dataRegistry.registerDataProvider(id, provider),
+    };
   }
 
   public start(

--- a/x-pack/solutions/observability/plugins/observability_agent/server/types.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent/server/types.ts
@@ -22,7 +22,12 @@ import type { SecurityPluginSetup, SecurityPluginStart } from '@kbn/security-plu
 import type { RuleRegistryPluginStartContract } from '@kbn/rule-registry-plugin/server';
 import type { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
 import type { MlPluginSetup, MlPluginStart } from '@kbn/ml-plugin/server';
-export type ObservabilityAgentPluginSetup = Record<string, never>;
+import type { ObservabilityAgentDataRegistry } from './data_registry';
+
+export interface ObservabilityAgentPluginSetup {
+  registerDataProvider: ObservabilityAgentDataRegistry['registerDataProvider'];
+}
+
 export type ObservabilityAgentPluginStart = Record<string, never>;
 
 export interface ObservabilityAgentPluginSetupDependencies {


### PR DESCRIPTION
This introduces the `ObservabilityAgentDataRegistry`, a mechanism for registering providers for Observability data. This registry makes it possible for the o11y agent to consume data from o11y solutions without depending on them.

Plugins can contribute data to the Observability Agent by registering a data provider.

### 1. Registering a data provider


Extend `ObservabilityAgentDataRegistryTypes` with the `id` and return type of the data provider:
```ts
interface ObservabilityAgentDataRegistryTypes {
  'apmServices': { count: number; status: string };
}
```

Register the data provider from the solution plugin:
```ts
observabilityAgent.registerDataProvider('apmServices', async ({ request }) => {
  const stats = await this.myService.getApmServices(request);
  
  return {
    count: stats.total,
    status: stats.health
  };
});
```

### 2. Consume the data provider

The data provider can be consumed by o11y agent:
```ts
const services = await dataRegistry.getData('apmServices', { request });
```
