### PR TITLE
[Agent Builder] Show round response actions on hover (copy)

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_response/round_response.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_response/round_response.tsx
@@ -6,11 +6,13 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import type { AssistantResponse, ConversationRoundStep } from '@kbn/onechat-common';
-import React from 'react';
+import React, { useState } from 'react';
 import { StreamingText } from './streaming_text';
 import { ChatMessageText } from './chat_message_text';
+import { RoundResponseActions } from './round_response_actions';
 
 export interface RoundResponseProps {
   response: AssistantResponse;
@@ -22,21 +24,35 @@ export const RoundResponse: React.FC<RoundResponseProps> = ({
   response: { message },
   steps,
   isLoading,
-}) => (
-  <EuiFlexGroup
-    direction="column"
-    gutterSize="m"
-    aria-label={i18n.translate('xpack.onechat.round.assistantResponse', {
-      defaultMessage: 'Assistant response',
-    })}
-    data-test-subj="agentBuilderRoundResponse"
-  >
-    <EuiFlexItem>
-      {isLoading ? (
-        <StreamingText content={message} steps={steps} />
-      ) : (
-        <ChatMessageText content={message} steps={steps} />
+}) => {
+  const [isHovering, setIsHovering] = useState(false);
+
+  return (
+    <EuiFlexGroup
+      direction="column"
+      gutterSize="m"
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+      aria-label={i18n.translate('xpack.onechat.round.assistantResponse', {
+        defaultMessage: 'Assistant response',
+      })}
+      data-test-subj="agentBuilderRoundResponse"
+      css={css`
+        position: relative;
+      `}
+    >
+      <EuiFlexItem>
+        {isLoading ? (
+          <StreamingText content={message} steps={steps} />
+        ) : (
+          <ChatMessageText content={message} steps={steps} />
+        )}
+      </EuiFlexItem>
+      {!isLoading && (
+        <EuiFlexItem grow={false}>
+          <RoundResponseActions content={message} isVisible={isHovering} />
+        </EuiFlexItem>
       )}
-    </EuiFlexItem>
-  </EuiFlexGroup>
-);
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_response/round_response_actions.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_response/round_response_actions.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { css } from '@emotion/react';
+import copy from 'copy-to-clipboard';
+import React, { useCallback } from 'react';
+import { i18n } from '@kbn/i18n';
+import { useToasts } from '../../../../hooks/use_toasts';
+
+const labels = {
+  copy: i18n.translate('xpack.onechat.roundResponseActions.copy', {
+    defaultMessage: 'Copy response',
+  }),
+  copySuccess: i18n.translate('xpack.onechat.roundResponseActions.copySuccess', {
+    defaultMessage: 'Response copied to clipboard',
+  }),
+};
+
+interface RoundResponseActionsProps {
+  content: string;
+  isVisible: boolean;
+}
+
+export const RoundResponseActions: React.FC<RoundResponseActionsProps> = ({
+  content,
+  isVisible,
+}) => {
+  const { addSuccessToast } = useToasts();
+
+  const handleCopy = useCallback(() => {
+    const isSuccess = copy(content);
+    if (isSuccess) {
+      addSuccessToast(labels.copySuccess);
+    }
+  }, [content, addSuccessToast]);
+
+  return (
+    <EuiFlexGroup justifyContent="flexEnd" gutterSize="xs" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon
+          iconType="copyClipboard"
+          aria-label={labels.copy}
+          onClick={handleCopy}
+          color="text"
+          css={css`
+            opacity: ${isVisible ? 1 : 0};
+            transition: opacity 0.2s ease;
+          `}
+          data-test-subj="roundResponseCopyButton"
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/search-team/issues/11948

- [x] Add round response actions on hover
- [x] For now, there is only a copy button, there will be more in the future when more backend work is done to enable them (thumbs up/down, re-generate response, etc.)

https://github.com/user-attachments/assets/1f4c6d07-74ab-44d6-82ef-349b06535adc





