### PR TITLE
[ES|QL] Do not call "pre-build" script when building grammar

### DIFF
--- a/.buildkite/scripts/steps/esql_grammar_sync.sh
+++ b/.buildkite/scripts/steps/esql_grammar_sync.sh
@@ -181,9 +181,11 @@ main () {
   # Bootstrap Kibana
   .buildkite/scripts/bootstrap.sh
 
-  # Build ANTLR stuff
+  # Note: We run build commands directly instead of `yarn build:antlr4` to skip
+  # the prebuild:antlr4 hook which uses `brew` (macOS only). CI has antlr installed.
   cd ./src/platform/packages/shared/kbn-esql-ast
-  yarn build:antlr4
+  yarn build:antlr4:esql
+  yarn build:antlr4:promql
 
   # Make a commit
   BRANCH_NAME="esql_grammar_sync_$(date +%s)"


### PR DESCRIPTION
## Summary

This change should avoid calling prebuild script, which tries to install ANTLR with Brew (Mac only). Hopefully fixes: https://buildkite.com/elastic/kibana-es-ql-grammar-sync/builds/180#019ad849-f427-4b56-9468-52462c4688da

My understanding that `yarn build:antlr4` was also triggering `yarn prebuild:antlr4` automatically, but `yarn prebuild:antlr4` is meant only for local execution on Mac.

See:

> Pre and post commands with matching names will be run for those as well (e.g. premyscript, myscript, postmyscript). Scripts from dependencies can be run with npm explore <pkg> -- npm run <stage>.

- https://docs.npmjs.com/cli/v8/using-npm/scripts
