### PR TITLE
[Console] Fix left border of selection box overlapping with folding arrow

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/styles.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/styles.ts
@@ -42,7 +42,7 @@ export const useHighlightedLinesClassName = () => {
       position: absolute;
       top: 0;
       bottom: calc(-${euiTheme.size.base} * 0.1);
-      left: calc(-${euiTheme.size.base} * 0.5);
+      left: calc(-${euiTheme.size.base} * 0.35);
       right: 0;
       background: ${transparentize(euiTheme.colors.primary, 0.05)};
       border: ${euiTheme.border.thin};


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/225681

## Summary
Left border of selection box was overlapping with folding arrow. I just slightly decrease the left position of the highlighting.

### Before
<img width="839" height="233" alt="Screenshot 2025-12-01 at 11 20 36" src="https://github.com/user-attachments/assets/0f46b74a-d27d-4014-a1df-b5ab98660846" />

### After
<img width="829" height="218" alt="Screenshot 2025-12-01 at 11 20 17" src="https://github.com/user-attachments/assets/06edf3ef-d2ae-4d77-8c31-ee8d0211765a" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->