### PR TITLE
[Write-restricted dashboards] Add 'NEW' badge to access mode container

### DIFF
--- a/src/platform/packages/shared/content-management/access_control/access_control_public/src/components/access_mode_container.tsx
+++ b/src/platform/packages/shared/content-management/access_control/access_control_public/src/components/access_mode_container.tsx
@@ -10,6 +10,7 @@
 import React, { type ChangeEvent, useState, useEffect } from 'react';
 import {
   EuiBadge,
+  EuiBetaBadge,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIconTip,
@@ -158,14 +159,28 @@ export const AccessModeContainer = ({
   return (
     <EuiFlexGroup direction="column" gutterSize="s" data-test-subj="accessModeContainer">
       <EuiFlexItem>
-        <EuiTitle size="xs">
-          <h4>
-            <FormattedMessage
-              id="contentManagement.accessControl.accessMode.container.title"
-              defaultMessage="Permissions"
+        <EuiFlexGroup direction="row" alignItems="center" gutterSize="xs">
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="xs">
+              <h4>
+                <FormattedMessage
+                  id="contentManagement.accessControl.accessMode.container.title"
+                  defaultMessage="Permissions"
+                />
+              </h4>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiBetaBadge
+              color="accent"
+              label={i18n.translate(
+                'contentManagement.accessControl.accessMode.container.newBadgeLabel',
+                { defaultMessage: 'New' }
+              )}
+              size="s"
             />
-          </h4>
-        </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiFlexGroup direction="row" alignItems="center" gutterSize="s">


### PR DESCRIPTION
## Summary

This PR adds "new" badge to access mode container. This will later need to be removed as part of https://github.com/elastic/kibana/issues/244735

<img width="527" height="432" alt="Screenshot 2025-12-01 at 12 39 00" src="https://github.com/user-attachments/assets/ef5c036b-8a21-453d-9825-21103f3c907a" />

<img width="592" height="637" alt="Screenshot 2025-12-01 at 12 39 43" src="https://github.com/user-attachments/assets/d2a790c6-c4e4-4d76-9e88-bd635eabe786" />

Closes: https://github.com/elastic/kibana/issues/244734