### PR TITLE
[Console] Implement persistent saved snippets for Dev Tools Console

### DIFF
--- a/src/platform/plugins/shared/console/README.md
+++ b/src/platform/plugins/shared/console/README.md
@@ -43,6 +43,14 @@ POST /_some_endpoint
 }
 ```
 
+### Saved Snippets (In Development)
+Console will soon support persistent saved snippets, allowing users to save, organize, and reuse frequently used Elasticsearch queries. This feature will:
+- Save queries as named snippets with descriptions and tags
+- Provide search and filtering capabilities
+- Enable sharing across Kibana spaces
+- Support import/export for backup and sharing
+- Store snippets server-side using Kibana saved objects (replacing localStorage dependency)
+
 ## Architecture
 Console uses Monaco editor that is wrapped with [`kbn-monaco`](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-monaco/index.ts), so that if needed it can easily be replaced with another editor.
 The autocomplete logic is located in [`autocomplete`](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/console/public/lib/autocomplete) folder. Autocomplete rules are computed by classes in `components` sub-folder.

--- a/src/platform/plugins/shared/console/README.md
+++ b/src/platform/plugins/shared/console/README.md
@@ -43,13 +43,39 @@ POST /_some_endpoint
 }
 ```
 
-### Saved Snippets (In Development)
-Console will soon support persistent saved snippets, allowing users to save, organize, and reuse frequently used Elasticsearch queries. This feature will:
-- Save queries as named snippets with descriptions and tags
-- Provide search and filtering capabilities
-- Enable sharing across Kibana spaces
-- Support import/export for backup and sharing
-- Store snippets server-side using Kibana saved objects (replacing localStorage dependency)
+### Saved Snippets
+Console supports saving frequently used queries as snippets for reuse. Snippets are stored server-side as saved objects, allowing them to persist across browser sessions and be shared across devices.
+
+#### Saving a Snippet
+1. Write your query in the Console editor
+2. Click "Save as snippet" in the toolbar (or use the snippets sidebar)
+3. Provide a name and optional description
+4. Click Save
+
+#### Loading a Snippet
+1. Click "Load snippet" in the toolbar to open the snippet finder
+2. Search or browse available snippets
+3. Click on a snippet to load it into the editor
+
+#### Managing Snippets
+- Access snippets via the sidebar panel (toggle with the "Snippets" button)
+- Delete unwanted snippets using the delete icon next to each snippet
+- Search by name, description, or tags using the search field
+- Import/export snippets via Saved Objects Management (`Stack Management > Saved Objects`)
+- Share snippets across Kibana spaces (when configured with `namespaceType: 'multiple-isolated'`)
+
+#### Deep Linking
+Snippets can be loaded via URL using the `loadSnippet` query parameter:
+```
+/app/dev_tools#/console?loadSnippet=<snippet-id>
+```
+
+#### Technical Details
+- Snippets are stored as saved objects of type `console-snippet`
+- Each snippet includes: title, description, query content, endpoint, method, and tags
+- Duplicate snippet titles are prevented to maintain uniqueness
+- Snippets are sorted by last update time (most recent first)
+- Pagination is implemented for large snippet collections (20 items per page)
 
 ## Architecture
 Console uses Monaco editor that is wrapped with [`kbn-monaco`](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-monaco/index.ts), so that if needed it can easily be replaced with another editor.

--- a/src/platform/plugins/shared/console/common/constants/index.ts
+++ b/src/platform/plugins/shared/console/common/constants/index.ts
@@ -19,3 +19,4 @@ export {
 } from './autocomplete_definitions';
 export { DEFAULT_INPUT_VALUE } from './editor_input';
 export { DEFAULT_LANGUAGE, AVAILABLE_LANGUAGES } from './copy_as';
+export { CONSOLE_SNIPPET_SAVED_OBJECT_TYPE } from './saved_objects';

--- a/src/platform/plugins/shared/console/common/constants/saved_objects.ts
+++ b/src/platform/plugins/shared/console/common/constants/saved_objects.ts
@@ -7,14 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { useSetInputEditor } from './use_set_input_editor';
-export { sendRequest } from './use_send_current_request';
-export { useSaveCurrentTextObject } from './use_save_current_text_object';
-export { useDataInit } from './use_data_init';
-export {
-  useSavedSnippets,
-  useSavedSnippet,
-  useSaveSnippet,
-  useUpdateSnippet,
-  useDeleteSnippet,
-} from './use_saved_snippets';
+export const CONSOLE_SNIPPET_SAVED_OBJECT_TYPE = 'console-snippet';

--- a/src/platform/plugins/shared/console/packaging/react/index.tsx
+++ b/src/platform/plugins/shared/console/packaging/react/index.tsx
@@ -45,7 +45,13 @@ import { I18nService } from '@kbn/core-i18n-browser-internal';
 import { i18n } from '@kbn/i18n';
 import { type HttpSetup } from '@kbn/core/public';
 import type { NotificationsSetup } from '@kbn/core/public';
-import { createStorage, createHistory, createSettings, setStorage } from '../../public/services';
+import {
+  createStorage,
+  createHistory,
+  createSettings,
+  setStorage,
+  createSavedSnippetsService,
+} from '../../public/services';
 import { loadActiveApi } from '../../public/lib/kb';
 
 import { createPackagingParsedRequestsProvider } from './parser';
@@ -148,6 +154,7 @@ export const OneConsole = ({
     const objectStorageClient = localStorageObjectClient.create(storage);
     const api = createApi({ http });
     const esHostService = createEsHostService({ api });
+    const savedSnippetsService = createSavedSnippetsService(http);
 
     // Initialize autocompleteInfo like in the plugin
     const autocompleteInfo = new AutocompleteInfo();
@@ -167,6 +174,7 @@ export const OneConsole = ({
       objectStorageClient,
       esHostService,
       autocompleteInfo,
+      savedSnippetsService,
     };
   }
 
@@ -181,6 +189,7 @@ export const OneConsole = ({
     objectStorageClient,
     esHostService,
     autocompleteInfo,
+    savedSnippetsService,
   } = servicesRef.current;
 
   // Use the custom notifications provided by the consumer
@@ -246,6 +255,7 @@ export const OneConsole = ({
             data: {} as any,
             licensing: {} as any,
             application: {} as any,
+            savedSnippetsService,
           },
           config: {
             isDevMode: false,

--- a/src/platform/plugins/shared/console/public/application/containers/editor/components/context_menu/context_menu.test.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/components/context_menu/context_menu.test.tsx
@@ -58,6 +58,13 @@ const createMockContextValue = (isPackagedEnvironment?: boolean): ContextValue =
       data: {} as any,
       licensing: {} as any,
       application: {} as any,
+      savedSnippetsService: {
+        create: jest.fn(),
+        find: jest.fn(),
+        get: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      } as any,
     },
     docLinkVersion: '8.0',
     docLinks: {} as any,

--- a/src/platform/plugins/shared/console/public/application/containers/editor/editor.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/editor.tsx
@@ -41,6 +41,7 @@ import { MonacoEditor } from './monaco_editor';
 import { MonacoEditorOutput } from './monaco_editor_output';
 import { getResponseWithMostSevereStatusCode } from '../../../lib/utils';
 import { consoleEditorPanelStyles, useResizerButtonStyles } from '../styles';
+import { SaveSnippetModal, LoadSnippetFlyout } from '../snippets';
 
 const INITIAL_PANEL_SIZE = 50;
 const PANEL_MIN_SIZE = '20%';
@@ -106,6 +107,8 @@ export const Editor = memo(
     const editorDispatch = useEditorActionContext();
 
     const [fetchingAutocompleteEntities, setFetchingAutocompleteEntities] = useState(false);
+    const [showSaveModal, setShowSaveModal] = useState(false);
+    const [showLoadFlyout, setShowLoadFlyout] = useState(false);
 
     useEffect(() => {
       const debouncedSetFechingAutocompleteEntities = debounce(
@@ -219,18 +222,48 @@ export const Editor = memo(
                       color="subdued"
                       css={styles.consoleEditorPanel}
                     >
-                      <EuiButtonEmpty
-                        size="xs"
-                        color="primary"
-                        data-test-subj="clearConsoleInput"
-                        onClick={() => {
-                          setInputEditorValue('');
-                        }}
-                      >
-                        {i18n.translate('console.editor.clearConsoleInputButton', {
-                          defaultMessage: 'Clear this input',
-                        })}
-                      </EuiButtonEmpty>
+                      <EuiFlexGroup gutterSize="s" responsive={false}>
+                        <EuiFlexItem grow={false}>
+                          <EuiButtonEmpty
+                            size="xs"
+                            color="primary"
+                            iconType="save"
+                            data-test-subj="consoleSaveSnippetAction"
+                            onClick={() => setShowSaveModal(true)}
+                          >
+                            {i18n.translate('console.editor.saveSnippetButton', {
+                              defaultMessage: 'Save as snippet',
+                            })}
+                          </EuiButtonEmpty>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          <EuiButtonEmpty
+                            size="xs"
+                            color="primary"
+                            iconType="folderOpen"
+                            data-test-subj="consoleLoadSnippetAction"
+                            onClick={() => setShowLoadFlyout(true)}
+                          >
+                            {i18n.translate('console.editor.loadSnippetButton', {
+                              defaultMessage: 'Load snippet',
+                            })}
+                          </EuiButtonEmpty>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          <EuiButtonEmpty
+                            size="xs"
+                            color="primary"
+                            data-test-subj="clearConsoleInput"
+                            onClick={() => {
+                              setInputEditorValue('');
+                            }}
+                          >
+                            {i18n.translate('console.editor.clearConsoleInputButton', {
+                              defaultMessage: 'Clear this input',
+                            })}
+                          </EuiButtonEmpty>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
                     </EuiSplitPanel.Inner>
                   )}
                 </EuiSplitPanel.Outer>
@@ -311,6 +344,23 @@ export const Editor = memo(
             </>
           )}
         </EuiResizableContainer>
+
+        {showSaveModal && (
+          <SaveSnippetModal
+            currentQuery={inputEditorValue}
+            onClose={() => setShowSaveModal(false)}
+          />
+        )}
+
+        {showLoadFlyout && (
+          <LoadSnippetFlyout
+            onClose={() => setShowLoadFlyout(false)}
+            onSelect={(snippet) => {
+              setInputEditorValue(snippet.query);
+              setShowLoadFlyout(false);
+            }}
+          />
+        )}
       </>
     );
   }

--- a/src/platform/plugins/shared/console/public/application/containers/main/main.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/main/main.tsx
@@ -49,6 +49,7 @@ import { useDataInit } from '../../hooks';
 import { getTopNavConfig } from './get_top_nav';
 import { getTourSteps } from './get_tour_steps';
 import { ImportConfirmModal } from './import_confirm_modal';
+import { SnippetsSidebar, SaveSnippetModal } from '../snippets';
 import {
   SHELL_TAB_ID,
   HISTORY_TAB_ID,
@@ -124,6 +125,8 @@ export function Main({ currentTabProp, isEmbeddable = false }: MainProps) {
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isFullscreenOpen, setIsFullScreen] = useState(false);
   const [isConfirmImportOpen, setIsConfirmImportOpen] = useState<string | null>(null);
+  const [showSnippetsSidebar, setShowSnippetsSidebar] = useState(false);
+  const [showSaveSnippetModal, setShowSaveSnippetModal] = useState(false);
   const styles = useStyles(isEmbeddable);
 
   const {
@@ -311,6 +314,28 @@ export function Main({ currentTabProp, isEmbeddable = false }: MainProps) {
               </ConsoleTourStep>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
+              <EuiToolTip
+                content={i18n.translate('console.main.snippetsSidebarToggleTooltip', {
+                  defaultMessage: 'Toggle snippets sidebar',
+                })}
+              >
+                <EuiButtonEmpty
+                  iconType="save"
+                  onClick={() => setShowSnippetsSidebar(!showSnippetsSidebar)}
+                  size="xs"
+                  data-test-subj="consoleSnippetsSidebarToggle"
+                  aria-label={i18n.translate('console.main.snippetsSidebarToggleAriaLabel', {
+                    defaultMessage: 'Toggle snippets sidebar',
+                  })}
+                  color={showSnippetsSidebar ? 'primary' : 'text'}
+                >
+                  {i18n.translate('console.main.snippetsButton', {
+                    defaultMessage: 'Snippets',
+                  })}
+                </EuiButtonEmpty>
+              </EuiToolTip>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
               <ShortcutsPopover
                 button={shortcutsButton}
                 isOpen={isShortcutsOpen}
@@ -357,12 +382,28 @@ export function Main({ currentTabProp, isEmbeddable = false }: MainProps) {
           data-test-subj="consolePanel"
         >
           {currentTab === SHELL_TAB_ID && (
-            <Editor
-              loading={!done}
-              inputEditorValue={inputEditorValue}
-              setInputEditorValue={setInputEditorValue}
-              enableSuggestWidgetRepositioning={!isEmbeddable}
-            />
+            <EuiFlexGroup gutterSize="none" responsive={false} style={{ height: '100%' }}>
+              <EuiFlexItem grow={true}>
+                <Editor
+                  loading={!done}
+                  inputEditorValue={inputEditorValue}
+                  setInputEditorValue={setInputEditorValue}
+                  enableSuggestWidgetRepositioning={!isEmbeddable}
+                />
+              </EuiFlexItem>
+              {showSnippetsSidebar && (
+                <EuiFlexItem grow={false} style={{ width: 300, overflow: 'auto' }}>
+                  <SnippetsSidebar
+                    onLoadSnippet={(snippet) => {
+                      setInputEditorValue(snippet.query);
+                    }}
+                    onSaveSnippet={() => {
+                      setShowSaveSnippetModal(true);
+                    }}
+                  />
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
           )}
           {currentTab === HISTORY_TAB_ID && <History />}
           {currentTab === CONFIG_TAB_ID && <Config />}
@@ -395,6 +436,13 @@ export function Main({ currentTabProp, isEmbeddable = false }: MainProps) {
         <ImportConfirmModal
           onClose={() => setIsConfirmImportOpen(null)}
           fileContent={isConfirmImportOpen}
+        />
+      )}
+
+      {showSaveSnippetModal && (
+        <SaveSnippetModal
+          currentQuery={inputEditorValue}
+          onClose={() => setShowSaveSnippetModal(false)}
         />
       )}
     </div>

--- a/src/platform/plugins/shared/console/public/application/containers/snippets/index.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/snippets/index.ts
@@ -7,14 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { useSetInputEditor } from './use_set_input_editor';
-export { sendRequest } from './use_send_current_request';
-export { useSaveCurrentTextObject } from './use_save_current_text_object';
-export { useDataInit } from './use_data_init';
-export {
-  useSavedSnippets,
-  useSavedSnippet,
-  useSaveSnippet,
-  useUpdateSnippet,
-  useDeleteSnippet,
-} from './use_saved_snippets';
+export { SaveSnippetModal } from './save_snippet_modal';
+export { LoadSnippetFlyout } from './load_snippet_flyout';
+export { SnippetsSidebar } from './snippets_sidebar';

--- a/src/platform/plugins/shared/console/public/application/containers/snippets/load_snippet_flyout.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/snippets/load_snippet_flyout.tsx
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiFlyout,
+  EuiFlyoutHeader,
+  EuiFlyoutBody,
+  EuiTitle,
+  EuiFieldSearch,
+  EuiSpacer,
+  EuiSelectable,
+  EuiText,
+  EuiCallOut,
+  EuiLoadingSpinner,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import type { EuiSelectableOption } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useSavedSnippets } from '../../hooks/use_saved_snippets';
+import type { SavedSnippet } from '../../../services';
+
+interface Props {
+  onClose: () => void;
+  onSelect: (snippet: SavedSnippet) => void;
+}
+
+export const LoadSnippetFlyout: React.FC<Props> = ({ onClose, onSelect }) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const { data, isLoading, error } = useSavedSnippets(searchTerm);
+  const flyoutTitleId = useGeneratedHtmlId();
+
+  const options: EuiSelectableOption[] =
+    data?.snippets.map((snippet) => ({
+      key: snippet.id,
+      label: snippet.title,
+      'data-test-subj': `consoleSnippetOption-${snippet.id}`,
+      prepend: (
+        <span
+          style={{
+            fontSize: '1.2em',
+            marginRight: '8px',
+          }}
+        >
+          📄
+        </span>
+      ),
+      append: snippet.description ? (
+        <EuiText size="xs" color="subdued">
+          {snippet.description.length > 50
+            ? `${snippet.description.substring(0, 50)}...`
+            : snippet.description}
+        </EuiText>
+      ) : undefined,
+    })) || [];
+
+  const handleSelect = (newOptions: EuiSelectableOption[]) => {
+    const selected = newOptions.find((option) => option.checked === 'on');
+    if (selected && selected.key) {
+      const snippet = data?.snippets.find((s) => s.id === selected.key);
+      if (snippet) {
+        onSelect(snippet);
+      }
+    }
+  };
+
+  return (
+    <EuiFlyout
+      onClose={onClose}
+      aria-labelledby={flyoutTitleId}
+      data-test-subj="consoleLoadSnippetFlyout"
+    >
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 id={flyoutTitleId}>
+            <FormattedMessage
+              id="console.snippets.loadSnippetFlyout.title"
+              defaultMessage="Load snippet"
+            />
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+
+      <EuiFlyoutBody>
+        <EuiFieldSearch
+          placeholder={i18n.translate('console.snippets.loadSnippetFlyout.searchPlaceholder', {
+            defaultMessage: 'Search snippets',
+          })}
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          isClearable
+          fullWidth
+          data-test-subj="consoleSnippetSearchInput"
+        />
+        <EuiSpacer size="m" />
+
+        {isLoading ? (
+          <div style={{ textAlign: 'center', padding: '2rem' }}>
+            <EuiLoadingSpinner size="xl" />
+          </div>
+        ) : error ? (
+          <EuiCallOut
+            title={i18n.translate('console.snippets.loadSnippetFlyout.errorTitle', {
+              defaultMessage: 'Error loading snippets',
+            })}
+            color="danger"
+            iconType="error"
+          >
+            <p>
+              {error instanceof Error
+                ? error.message
+                : i18n.translate('console.snippets.loadSnippetFlyout.genericError', {
+                    defaultMessage: 'An unexpected error occurred',
+                  })}
+            </p>
+          </EuiCallOut>
+        ) : options.length === 0 ? (
+          <EuiCallOut
+            title={i18n.translate('console.snippets.loadSnippetFlyout.noSnippetsTitle', {
+              defaultMessage: 'No snippets found',
+            })}
+            iconType="iInCircle"
+          >
+            <p>
+              {searchTerm ? (
+                <FormattedMessage
+                  id="console.snippets.loadSnippetFlyout.noSnippetsMatchingSearch"
+                  defaultMessage="No snippets match your search. Try a different search term."
+                />
+              ) : (
+                <FormattedMessage
+                  id="console.snippets.loadSnippetFlyout.noSnippetsSaved"
+                  defaultMessage="You haven't saved any snippets yet. Save your first snippet from the editor."
+                />
+              )}
+            </p>
+          </EuiCallOut>
+        ) : (
+          <EuiSelectable
+            options={options}
+            onChange={handleSelect}
+            singleSelection="always"
+            searchable={false}
+            listProps={{
+              bordered: true,
+              rowHeight: 50,
+            }}
+          >
+            {(list) => list}
+          </EuiSelectable>
+        )}
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};

--- a/src/platform/plugins/shared/console/public/application/containers/snippets/save_snippet_modal.test.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/snippets/save_snippet_modal.test.tsx
@@ -1,0 +1,223 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import userEvent from '@testing-library/user-event';
+import type { NotificationsStart } from '@kbn/core/public';
+import { SaveSnippetModal } from './save_snippet_modal';
+import { ServicesContextProvider } from '../../contexts';
+import type { ContextValue } from '../../contexts/services_context';
+
+// Mock the React Query hook
+jest.mock('../../hooks/use_saved_snippets', () => ({
+  useSaveSnippet: () => ({
+    mutateAsync: jest.fn((snippet) => Promise.resolve({ id: 'test-id', ...snippet })),
+    isLoading: false,
+  }),
+}));
+
+const mockNotifications: Pick<NotificationsStart, 'toasts'> = {
+  toasts: {
+    addSuccess: jest.fn(),
+    addDanger: jest.fn(),
+    addWarning: jest.fn(),
+    addError: jest.fn(),
+  } as any,
+};
+
+const createMockContextValue = (): ContextValue => {
+  return {
+    services: {
+      storage: {} as any,
+      esHostService: {
+        getHost: jest.fn(() => 'http://localhost:9200'),
+        init: jest.fn(),
+      } as any,
+      history: {} as any,
+      settings: {} as any,
+      notifications: mockNotifications as any,
+      objectStorageClient: {} as any,
+      trackUiMetric: jest.fn() as any,
+      http: {} as any,
+      autocompleteInfo: {} as any,
+      data: {} as any,
+      licensing: {} as any,
+      application: {} as any,
+      savedSnippetsService: {
+        create: jest.fn(),
+        find: jest.fn(),
+        get: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      } as any,
+    },
+    docLinkVersion: '8.0',
+    docLinks: {} as any,
+    config: {
+      isDevMode: false,
+    },
+    analytics: {
+      reportEvent: jest.fn(),
+    },
+    i18n: {} as any,
+    theme: {
+      theme$: jest.fn(),
+    } as any,
+    userProfile: {} as any,
+  };
+};
+
+describe('SaveSnippetModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnSave = jest.fn();
+  const currentQuery = 'GET /_search\n{\n  "query": { "match_all": {} }\n}';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the modal with title input and description textarea', () => {
+    const contextValue = createMockContextValue();
+
+    render(
+      <I18nProvider>
+        <ServicesContextProvider value={contextValue}>
+          <SaveSnippetModal currentQuery={currentQuery} onClose={mockOnClose} onSave={mockOnSave} />
+        </ServicesContextProvider>
+      </I18nProvider>
+    );
+
+    expect(screen.getByTestId('consoleSnippetTitleInput')).toBeInTheDocument();
+    expect(screen.getByTestId('consoleSnippetDescriptionInput')).toBeInTheDocument();
+    expect(screen.getByTestId('consoleSnippetSaveButton')).toBeInTheDocument();
+    expect(screen.getByTestId('consoleSnippetCancelButton')).toBeInTheDocument();
+  });
+
+  it('should disable save button when title is empty', () => {
+    const contextValue = createMockContextValue();
+
+    render(
+      <I18nProvider>
+        <ServicesContextProvider value={contextValue}>
+          <SaveSnippetModal currentQuery={currentQuery} onClose={mockOnClose} onSave={mockOnSave} />
+        </ServicesContextProvider>
+      </I18nProvider>
+    );
+
+    const saveButton = screen.getByTestId('consoleSnippetSaveButton');
+    expect(saveButton).toBeDisabled();
+  });
+
+  it('should enable save button when title is not empty', async () => {
+    const contextValue = createMockContextValue();
+
+    render(
+      <I18nProvider>
+        <ServicesContextProvider value={contextValue}>
+          <SaveSnippetModal currentQuery={currentQuery} onClose={mockOnClose} onSave={mockOnSave} />
+        </ServicesContextProvider>
+      </I18nProvider>
+    );
+
+    const titleInput = screen.getByTestId('consoleSnippetTitleInput');
+    await userEvent.type(titleInput, 'My Test Snippet');
+
+    await waitFor(() => {
+      const saveButton = screen.getByTestId('consoleSnippetSaveButton');
+      expect(saveButton).not.toBeDisabled();
+    });
+  });
+
+  it('should disable save button when title contains only whitespace', async () => {
+    const contextValue = createMockContextValue();
+
+    render(
+      <I18nProvider>
+        <ServicesContextProvider value={contextValue}>
+          <SaveSnippetModal currentQuery={currentQuery} onClose={mockOnClose} onSave={mockOnSave} />
+        </ServicesContextProvider>
+      </I18nProvider>
+    );
+
+    const titleInput = screen.getByTestId('consoleSnippetTitleInput');
+    await userEvent.type(titleInput, '   ');
+
+    const saveButton = screen.getByTestId('consoleSnippetSaveButton');
+    expect(saveButton).toBeDisabled();
+  });
+
+  it('should call onClose when cancel button is clicked', async () => {
+    const contextValue = createMockContextValue();
+
+    render(
+      <I18nProvider>
+        <ServicesContextProvider value={contextValue}>
+          <SaveSnippetModal currentQuery={currentQuery} onClose={mockOnClose} onSave={mockOnSave} />
+        </ServicesContextProvider>
+      </I18nProvider>
+    );
+
+    const cancelButton = screen.getByTestId('consoleSnippetCancelButton');
+    await userEvent.click(cancelButton);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should accept optional description', async () => {
+    const contextValue = createMockContextValue();
+
+    render(
+      <I18nProvider>
+        <ServicesContextProvider value={contextValue}>
+          <SaveSnippetModal currentQuery={currentQuery} onClose={mockOnClose} onSave={mockOnSave} />
+        </ServicesContextProvider>
+      </I18nProvider>
+    );
+
+    const descriptionInput = screen.getByTestId('consoleSnippetDescriptionInput');
+    await userEvent.type(descriptionInput, 'This is a test description');
+
+    expect(descriptionInput).toHaveValue('This is a test description');
+  });
+
+  it('should trim title and description before saving', async () => {
+    const contextValue = createMockContextValue();
+
+    render(
+      <I18nProvider>
+        <ServicesContextProvider value={contextValue}>
+          <SaveSnippetModal currentQuery={currentQuery} onClose={mockOnClose} onSave={mockOnSave} />
+        </ServicesContextProvider>
+      </I18nProvider>
+    );
+
+    const titleInput = screen.getByTestId('consoleSnippetTitleInput');
+    const descriptionInput = screen.getByTestId('consoleSnippetDescriptionInput');
+
+    // Type values with spaces
+    await userEvent.type(titleInput, '  My Snippet  ');
+    await userEvent.type(descriptionInput, '  My Description  ');
+
+    // Save button should be enabled since title is not empty
+    const saveButton = screen.getByTestId('consoleSnippetSaveButton');
+    expect(saveButton).not.toBeDisabled();
+
+    await userEvent.click(saveButton);
+
+    // The component should call onClose after successful save
+    await waitFor(() => {
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    // The onSave callback should have been called
+    expect(mockOnSave).toHaveBeenCalled();
+  });
+});

--- a/src/platform/plugins/shared/console/public/application/containers/snippets/save_snippet_modal.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/snippets/save_snippet_modal.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiForm,
+  EuiFormRow,
+  EuiFieldText,
+  EuiTextArea,
+  EuiCallOut,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useSaveSnippet } from '../../hooks/use_saved_snippets';
+import { useServicesContext } from '../../contexts';
+import type { SavedSnippet } from '../../../services';
+
+interface Props {
+  currentQuery: string;
+  onClose: () => void;
+  onSave?: (snippet: SavedSnippet) => void;
+}
+
+export const SaveSnippetModal: React.FC<Props> = ({ currentQuery, onClose, onSave }) => {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const saveSnippet = useSaveSnippet();
+  const {
+    services: { notifications },
+  } = useServicesContext();
+
+  const modalTitleId = useGeneratedHtmlId();
+
+  const handleSave = async () => {
+    try {
+      setErrorMessage(null);
+      const snippet = await saveSnippet.mutateAsync({
+        title: title.trim(),
+        description: description.trim(),
+        query: currentQuery,
+      });
+
+      notifications.toasts.addSuccess(
+        i18n.translate('console.snippets.saveSnippetModal.successMessage', {
+          defaultMessage: 'Snippet "{title}" saved successfully',
+          values: { title: title.trim() },
+        })
+      );
+
+      if (onSave) {
+        onSave(snippet);
+      }
+      onClose();
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : i18n.translate('console.snippets.saveSnippetModal.genericError', {
+              defaultMessage: 'Failed to save snippet',
+            });
+      setErrorMessage(message);
+    }
+  };
+
+  return (
+    <EuiModal onClose={onClose} aria-labelledby={modalTitleId}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle id={modalTitleId}>
+          <FormattedMessage
+            id="console.snippets.saveSnippetModal.title"
+            defaultMessage="Save snippet"
+          />
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        <EuiForm>
+          {errorMessage && (
+            <EuiFormRow fullWidth>
+              <EuiCallOut
+                title={i18n.translate('console.snippets.saveSnippetModal.errorTitle', {
+                  defaultMessage: 'Error saving snippet',
+                })}
+                color="danger"
+                iconType="error"
+              >
+                <p>{errorMessage}</p>
+              </EuiCallOut>
+            </EuiFormRow>
+          )}
+          <EuiFormRow
+            label={i18n.translate('console.snippets.saveSnippetModal.nameLabel', {
+              defaultMessage: 'Name',
+            })}
+            fullWidth
+          >
+            <EuiFieldText
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              data-test-subj="consoleSnippetTitleInput"
+              placeholder={i18n.translate(
+                'console.snippets.saveSnippetModal.namePlaceholder',
+                {
+                  defaultMessage: 'Enter a name for this snippet',
+                }
+              )}
+              fullWidth
+            />
+          </EuiFormRow>
+          <EuiFormRow
+            label={i18n.translate('console.snippets.saveSnippetModal.descriptionLabel', {
+              defaultMessage: 'Description',
+            })}
+            fullWidth
+          >
+            <EuiTextArea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              data-test-subj="consoleSnippetDescriptionInput"
+              placeholder={i18n.translate(
+                'console.snippets.saveSnippetModal.descriptionPlaceholder',
+                {
+                  defaultMessage: 'Add an optional description',
+                }
+              )}
+              fullWidth
+              rows={3}
+            />
+          </EuiFormRow>
+        </EuiForm>
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiButtonEmpty onClick={onClose} data-test-subj="consoleSnippetCancelButton">
+          <FormattedMessage
+            id="console.snippets.saveSnippetModal.cancelButton"
+            defaultMessage="Cancel"
+          />
+        </EuiButtonEmpty>
+        <EuiButton
+          fill
+          onClick={handleSave}
+          disabled={!title.trim() || saveSnippet.isLoading}
+          isLoading={saveSnippet.isLoading}
+          data-test-subj="consoleSnippetSaveButton"
+        >
+          <FormattedMessage
+            id="console.snippets.saveSnippetModal.saveButton"
+            defaultMessage="Save"
+          />
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/src/platform/plugins/shared/console/public/application/containers/snippets/snippets_sidebar.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/snippets/snippets_sidebar.tsx
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiPanel,
+  EuiFieldSearch,
+  EuiSpacer,
+  EuiListGroup,
+  EuiListGroupItem,
+  EuiButton,
+  EuiConfirmModal,
+  EuiText,
+  EuiCallOut,
+  EuiLoadingSpinner,
+  EuiEmptyPrompt,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useSavedSnippets, useDeleteSnippet } from '../../hooks/use_saved_snippets';
+import { useServicesContext } from '../../contexts';
+import type { SavedSnippet } from '../../../services';
+
+interface Props {
+  onLoadSnippet: (snippet: SavedSnippet) => void;
+  onSaveSnippet: () => void;
+}
+
+export const SnippetsSidebar: React.FC<Props> = ({ onLoadSnippet, onSaveSnippet }) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState<SavedSnippet | null>(null);
+  const { data, isLoading, error } = useSavedSnippets(searchTerm);
+  const deleteSnippet = useDeleteSnippet();
+  const {
+    services: { notifications },
+  } = useServicesContext();
+
+  const handleDelete = async () => {
+    if (deleteTarget?.id) {
+      try {
+        await deleteSnippet.mutateAsync(deleteTarget.id);
+        notifications.toasts.addSuccess(
+          i18n.translate('console.snippets.sidebar.deleteSuccessMessage', {
+            defaultMessage: 'Snippet "{title}" deleted successfully',
+            values: { title: deleteTarget.title },
+          })
+        );
+        setDeleteTarget(null);
+      } catch (err) {
+        notifications.toasts.addDanger(
+          i18n.translate('console.snippets.sidebar.deleteErrorMessage', {
+            defaultMessage: 'Failed to delete snippet',
+          })
+        );
+      }
+    }
+  };
+
+  return (
+    <EuiPanel paddingSize="m" hasShadow={false} hasBorder>
+      <EuiText size="s">
+        <h3>
+          <FormattedMessage
+            id="console.snippets.sidebar.title"
+            defaultMessage="Saved snippets"
+          />
+        </h3>
+      </EuiText>
+      <EuiSpacer size="m" />
+
+      <EuiFieldSearch
+        placeholder={i18n.translate('console.snippets.sidebar.searchPlaceholder', {
+          defaultMessage: 'Search snippets',
+        })}
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        compressed
+        fullWidth
+        isClearable
+        data-test-subj="consoleSnippetSearch"
+      />
+      <EuiSpacer size="m" />
+
+      {isLoading ? (
+        <div style={{ textAlign: 'center', padding: '1rem' }}>
+          <EuiLoadingSpinner size="m" />
+        </div>
+      ) : error ? (
+        <EuiCallOut
+          title={i18n.translate('console.snippets.sidebar.errorTitle', {
+            defaultMessage: 'Error loading snippets',
+          })}
+          color="danger"
+          iconType="error"
+          size="s"
+        >
+          <p>
+            {error instanceof Error
+              ? error.message
+              : i18n.translate('console.snippets.sidebar.genericError', {
+                  defaultMessage: 'An unexpected error occurred',
+                })}
+          </p>
+        </EuiCallOut>
+      ) : !data?.snippets.length ? (
+        <EuiEmptyPrompt
+          iconType="documents"
+          title={
+            <h4>
+              {searchTerm ? (
+                <FormattedMessage
+                  id="console.snippets.sidebar.noResultsTitle"
+                  defaultMessage="No matching snippets"
+                />
+              ) : (
+                <FormattedMessage
+                  id="console.snippets.sidebar.emptyTitle"
+                  defaultMessage="No saved snippets"
+                />
+              )}
+            </h4>
+          }
+          body={
+            <p>
+              {searchTerm ? (
+                <FormattedMessage
+                  id="console.snippets.sidebar.noResultsBody"
+                  defaultMessage="Try a different search term"
+                />
+              ) : (
+                <FormattedMessage
+                  id="console.snippets.sidebar.emptyBody"
+                  defaultMessage="Save your first snippet using the button below"
+                />
+              )}
+            </p>
+          }
+          titleSize="xs"
+        />
+      ) : (
+        <EuiListGroup
+          flush
+          bordered
+          maxWidth={false}
+          style={{ maxHeight: '400px', overflowY: 'auto' }}
+        >
+          {data.snippets.map((snippet) => (
+            <EuiListGroupItem
+              key={snippet.id}
+              label={snippet.title}
+              onClick={() => onLoadSnippet(snippet)}
+              extraAction={{
+                iconType: 'trash',
+                'aria-label': i18n.translate('console.snippets.sidebar.deleteButtonLabel', {
+                  defaultMessage: 'Delete snippet {title}',
+                  values: { title: snippet.title },
+                }),
+                onClick: () => setDeleteTarget(snippet),
+                'data-test-subj': `consoleSnippetDelete-${snippet.id}`,
+              }}
+              data-test-subj={`consoleSnippetItem-${snippet.id}`}
+              iconType="document"
+            />
+          ))}
+        </EuiListGroup>
+      )}
+
+      <EuiSpacer size="m" />
+      <EuiButton
+        fill
+        fullWidth
+        onClick={onSaveSnippet}
+        iconType="save"
+        data-test-subj="consoleSaveSnippetButton"
+      >
+        <FormattedMessage
+          id="console.snippets.sidebar.saveButton"
+          defaultMessage="Save current query"
+        />
+      </EuiButton>
+
+      {deleteTarget && (
+        <EuiConfirmModal
+          title={i18n.translate('console.snippets.sidebar.deleteModalTitle', {
+            defaultMessage: 'Delete snippet?',
+          })}
+          onCancel={() => setDeleteTarget(null)}
+          onConfirm={handleDelete}
+          cancelButtonText={i18n.translate('console.snippets.sidebar.deleteModalCancel', {
+            defaultMessage: 'Cancel',
+          })}
+          confirmButtonText={i18n.translate('console.snippets.sidebar.deleteModalConfirm', {
+            defaultMessage: 'Delete',
+          })}
+          buttonColor="danger"
+          defaultFocusedButton="cancel"
+          data-test-subj="consoleSnippetDeleteModal"
+        >
+          <p>
+            <FormattedMessage
+              id="console.snippets.sidebar.deleteModalBody"
+              defaultMessage='Are you sure you want to delete "{title}"? This action cannot be undone.'
+              values={{ title: deleteTarget.title }}
+            />
+          </p>
+        </EuiConfirmModal>
+      )}
+    </EuiPanel>
+  );
+};

--- a/src/platform/plugins/shared/console/public/application/contexts/services_context.mock.ts
+++ b/src/platform/plugins/shared/console/public/application/contexts/services_context.mock.ts
@@ -52,6 +52,13 @@ export const serviceContextMock = {
         application: applicationServiceMock.createStartContract(),
         data: dataPluginMock.createStartContract(),
         licensing: licensingMock.createStart(),
+        savedSnippetsService: {
+          create: jest.fn(),
+          find: jest.fn(),
+          get: jest.fn(),
+          update: jest.fn(),
+          delete: jest.fn(),
+        } as any,
       },
       docLinkVersion: 'NA',
       docLinks: docLinksServiceMock.createStartContract().links,

--- a/src/platform/plugins/shared/console/public/application/contexts/services_context.tsx
+++ b/src/platform/plugins/shared/console/public/application/contexts/services_context.tsx
@@ -14,7 +14,13 @@ import type { RouteComponentProps } from 'react-router-dom';
 import type { ApplicationStart } from '@kbn/core/public';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
-import type { AutocompleteInfo, History, Settings, Storage } from '../../services';
+import type {
+  AutocompleteInfo,
+  History,
+  Settings,
+  Storage,
+  SavedSnippetsService,
+} from '../../services';
 import type { ObjectStorageClient } from '../../../common/types';
 import type { ConsoleStartServices, MetricsTracker } from '../../types';
 import type { EsHostService } from '../lib';
@@ -33,6 +39,7 @@ interface ContextServices {
   data: DataPublicPluginStart;
   licensing: LicensingPluginStart;
   application: ApplicationStart;
+  savedSnippetsService: SavedSnippetsService;
 }
 
 export interface ContextValue extends ConsoleStartServices {

--- a/src/platform/plugins/shared/console/public/application/hooks/use_saved_snippets.ts
+++ b/src/platform/plugins/shared/console/public/application/hooks/use_saved_snippets.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@kbn/react-query';
+import type { SavedSnippet } from '../../services';
+import { useServicesContext } from '../contexts';
+
+/**
+ * Hook to fetch saved snippets with optional search filtering
+ * @param searchTerm - Optional search term to filter snippets
+ * @param perPage - Number of items per page (default: 20)
+ * @param page - Page number (default: 1)
+ */
+export const useSavedSnippets = (searchTerm?: string, perPage?: number, page?: number) => {
+  const {
+    services: { savedSnippetsService },
+  } = useServicesContext();
+
+  return useQuery({
+    queryKey: ['console', 'snippets', searchTerm, perPage, page],
+    queryFn: () => savedSnippetsService.find(searchTerm, perPage, page),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+};
+
+/**
+ * Hook to fetch a single saved snippet by ID
+ * @param id - The snippet ID to fetch
+ */
+export const useSavedSnippet = (id: string) => {
+  const {
+    services: { savedSnippetsService },
+  } = useServicesContext();
+
+  return useQuery({
+    queryKey: ['console', 'snippet', id],
+    queryFn: () => savedSnippetsService.get(id),
+    enabled: !!id,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+};
+
+/**
+ * Hook to create a new saved snippet
+ */
+export const useSaveSnippet = () => {
+  const {
+    services: { savedSnippetsService },
+  } = useServicesContext();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (snippet: SavedSnippet) => savedSnippetsService.create(snippet),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['console', 'snippets'] });
+    },
+  });
+};
+
+/**
+ * Hook to update an existing saved snippet
+ */
+export const useUpdateSnippet = () => {
+  const {
+    services: { savedSnippetsService },
+  } = useServicesContext();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, snippet }: { id: string; snippet: SavedSnippet }) =>
+      savedSnippetsService.update(id, snippet),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['console', 'snippets'] });
+      queryClient.invalidateQueries({ queryKey: ['console', 'snippet', variables.id] });
+    },
+  });
+};
+
+/**
+ * Hook to delete a saved snippet
+ */
+export const useDeleteSnippet = () => {
+  const {
+    services: { savedSnippetsService },
+  } = useServicesContext();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => savedSnippetsService.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['console', 'snippets'] });
+    },
+  });
+};

--- a/src/platform/plugins/shared/console/public/plugin.ts
+++ b/src/platform/plugins/shared/console/public/plugin.ts
@@ -29,6 +29,7 @@ import {
   createStorage,
   setStorage,
   httpService,
+  createSavedSnippetsService,
 } from './services';
 
 export class ConsoleUIPlugin
@@ -150,6 +151,11 @@ export class ConsoleUIPlugin
       isEmbeddedConsoleEnabled &&
       core.application.capabilities?.dev_tools?.show === true &&
       embeddedConsoleUiSetting;
+
+    // Initialize saved snippets service
+    if (isConsoleUiEnabled) {
+      consoleStart.savedSnippetsService = createSavedSnippetsService(core.http);
+    }
 
     if (embeddedConsoleAvailable) {
       consoleStart.EmbeddableConsole = (_props: {}) => {

--- a/src/platform/plugins/shared/console/public/services/index.ts
+++ b/src/platform/plugins/shared/console/public/services/index.ts
@@ -19,5 +19,11 @@ export {
 } from './autocomplete';
 export { EmbeddableConsoleInfo } from './embeddable_console';
 export { httpService } from './http';
+export {
+  createSavedSnippetsService,
+  type SavedSnippetsService,
+  type SavedSnippet,
+  type FindSavedSnippetsResponse,
+} from './saved_snippets_service';
 
 export { convertRequestToLanguage } from './api';

--- a/src/platform/plugins/shared/console/public/services/saved_snippets_service.ts
+++ b/src/platform/plugins/shared/console/public/services/saved_snippets_service.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { HttpStart } from '@kbn/core/public';
+
+export interface SavedSnippet {
+  id?: string;
+  title: string;
+  description?: string;
+  query: string;
+  endpoint?: string;
+  method?: string;
+  tags?: string[];
+  createdBy?: string;
+  updatedBy?: string;
+}
+
+export interface FindSavedSnippetsResponse {
+  total: number;
+  snippets: SavedSnippet[];
+}
+
+export const createSavedSnippetsService = (http: HttpStart) => {
+  const version = '2023-10-31';
+  const basePath = '/internal/console/saved_snippets';
+
+  return {
+    async create(snippet: SavedSnippet): Promise<SavedSnippet> {
+      return http.post<SavedSnippet>(basePath, {
+        body: JSON.stringify(snippet),
+        version,
+      });
+    },
+
+    async find(
+      search?: string,
+      perPage: number = 20,
+      page: number = 1
+    ): Promise<FindSavedSnippetsResponse> {
+      return http.post<FindSavedSnippetsResponse>(`${basePath}/_find`, {
+        body: JSON.stringify({ search, perPage, page }),
+        version,
+      });
+    },
+
+    async get(id: string): Promise<SavedSnippet> {
+      return http.get<SavedSnippet>(`${basePath}/${id}`, { version });
+    },
+
+    async update(id: string, snippet: SavedSnippet): Promise<SavedSnippet> {
+      return http.put<SavedSnippet>(`${basePath}/${id}`, {
+        body: JSON.stringify(snippet),
+        version,
+      });
+    },
+
+    async delete(id: string): Promise<void> {
+      await http.delete(`${basePath}/${id}`, { version });
+    },
+  };
+};
+
+export type SavedSnippetsService = ReturnType<typeof createSavedSnippetsService>;

--- a/src/platform/plugins/shared/console/public/types/plugin_dependencies.ts
+++ b/src/platform/plugins/shared/console/public/types/plugin_dependencies.ts
@@ -94,4 +94,8 @@ export interface ConsolePluginStart {
    * When registering an alternate view ensure that the content component you register is lazy loaded.
    */
   registerEmbeddedConsoleAlternateView?: (view: EmbeddedConsoleView | null) => void;
+  /**
+   * Service for managing saved Console snippets
+   */
+  savedSnippetsService?: import('../services').SavedSnippetsService;
 }

--- a/src/platform/plugins/shared/console/server/plugin.ts
+++ b/src/platform/plugins/shared/console/server/plugin.ts
@@ -19,6 +19,7 @@ import { registerRoutes } from './routes';
 
 import type { ESConfigForProxy, ConsoleSetup, ConsoleStart } from './types';
 import { handleEsError } from './shared_imports';
+import { consoleSnippetSavedObjectType } from './saved_objects/console_snippet';
 
 interface PluginsSetup {
   cloud?: CloudSetup;
@@ -34,7 +35,7 @@ export class ConsoleServerPlugin implements Plugin<ConsoleSetup, ConsoleStart> {
     this.log = this.ctx.logger.get();
   }
 
-  setup({ http, capabilities, elasticsearch }: CoreSetup, { cloud }: PluginsSetup) {
+  setup({ http, capabilities, elasticsearch, savedObjects }: CoreSetup, { cloud }: PluginsSetup) {
     capabilities.registerProvider(() => ({
       dev_tools: {
         show: true,
@@ -52,6 +53,9 @@ export class ConsoleServerPlugin implements Plugin<ConsoleSetup, ConsoleStart> {
       pathFilters = (config as ConsoleConfig7x).proxyFilter.map((str: string) => new RegExp(str));
       proxyConfigCollection = new ProxyConfigCollection((config as ConsoleConfig7x).proxyConfig);
     }
+
+    // Register saved object type for console snippets
+    savedObjects.registerType(consoleSnippetSavedObjectType);
 
     this.esLegacyConfigService.setup(elasticsearch.legacy.config$, cloud);
 

--- a/src/platform/plugins/shared/console/server/routes/api/console/saved_snippets/index.ts
+++ b/src/platform/plugins/shared/console/server/routes/api/console/saved_snippets/index.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { IRouter } from '@kbn/core/server';
+import {
+  createSavedSnippet,
+  updateSavedSnippet,
+  deleteSavedSnippet,
+  getSavedSnippet,
+  findSavedSnippets,
+} from './route_handlers';
+
+const version = '2023-10-31';
+const basePath = '/internal/console/saved_snippets';
+
+const snippetAttributesSchema = schema.object({
+  title: schema.string(),
+  description: schema.maybe(schema.string()),
+  query: schema.string(),
+  endpoint: schema.maybe(schema.string()),
+  method: schema.maybe(schema.string()),
+  tags: schema.maybe(schema.arrayOf(schema.string())),
+  createdBy: schema.maybe(schema.string()),
+  updatedBy: schema.maybe(schema.string()),
+});
+
+export const registerSavedSnippetRoutes = (router: IRouter) => {
+  // Create snippet
+  router.versioned
+    .post({
+      path: basePath,
+      access: 'public',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+    })
+    .addVersion(
+      {
+        version,
+        validate: {
+          request: {
+            body: snippetAttributesSchema,
+          },
+        },
+      },
+      async (context, request, response) => {
+        try {
+          const result = await createSavedSnippet(context, request.body);
+          return response.ok({ body: result });
+        } catch (error) {
+          if (error.isBoom && error.output.statusCode === 409) {
+            return response.conflict({ body: { message: error.message } });
+          }
+          return response.badRequest({ body: error });
+        }
+      }
+    );
+
+  // Find snippets
+  router.versioned
+    .post({
+      path: `${basePath}/_find`,
+      access: 'public',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+    })
+    .addVersion(
+      {
+        version,
+        validate: {
+          request: {
+            body: schema.object({
+              search: schema.maybe(schema.string()),
+              perPage: schema.maybe(schema.number()),
+              page: schema.maybe(schema.number()),
+            }),
+          },
+        },
+      },
+      async (context, request, response) => {
+        try {
+          const { search, perPage, page } = request.body;
+          const result = await findSavedSnippets(context, search, perPage, page);
+          return response.ok({ body: result });
+        } catch (error) {
+          return response.badRequest({ body: error });
+        }
+      }
+    );
+
+  // Get snippet by ID
+  router.versioned
+    .get({
+      path: `${basePath}/{id}`,
+      access: 'public',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+    })
+    .addVersion(
+      {
+        version,
+        validate: {
+          request: {
+            params: schema.object({
+              id: schema.string(),
+            }),
+          },
+        },
+      },
+      async (context, request, response) => {
+        try {
+          const result = await getSavedSnippet(context, request.params.id);
+          return response.ok({ body: result });
+        } catch (error) {
+          if (error.isBoom && error.output.statusCode === 404) {
+            return response.notFound({ body: { message: error.message } });
+          }
+          return response.badRequest({ body: error });
+        }
+      }
+    );
+
+  // Update snippet
+  router.versioned
+    .put({
+      path: `${basePath}/{id}`,
+      access: 'public',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+    })
+    .addVersion(
+      {
+        version,
+        validate: {
+          request: {
+            params: schema.object({
+              id: schema.string(),
+            }),
+            body: snippetAttributesSchema,
+          },
+        },
+      },
+      async (context, request, response) => {
+        try {
+          const result = await updateSavedSnippet(context, request.params.id, request.body);
+          return response.ok({ body: result });
+        } catch (error) {
+          if (error.isBoom && error.output.statusCode === 409) {
+            return response.conflict({ body: { message: error.message } });
+          }
+          if (error.isBoom && error.output.statusCode === 404) {
+            return response.notFound({ body: { message: error.message } });
+          }
+          return response.badRequest({ body: error });
+        }
+      }
+    );
+
+  // Delete snippet
+  router.versioned
+    .delete({
+      path: `${basePath}/{id}`,
+      access: 'public',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+    })
+    .addVersion(
+      {
+        version,
+        validate: {
+          request: {
+            params: schema.object({
+              id: schema.string(),
+            }),
+          },
+        },
+      },
+      async (context, request, response) => {
+        try {
+          await deleteSavedSnippet(context, request.params.id);
+          return response.ok({ body: { success: true } });
+        } catch (error) {
+          if (error.isBoom && error.output.statusCode === 404) {
+            return response.notFound({ body: { message: error.message } });
+          }
+          return response.badRequest({ body: error });
+        }
+      }
+    );
+};

--- a/src/platform/plugins/shared/console/server/routes/api/console/saved_snippets/route_handlers.test.ts
+++ b/src/platform/plugins/shared/console/server/routes/api/console/saved_snippets/route_handlers.test.ts
@@ -1,0 +1,465 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { RequestHandlerContext, SavedObjectsClientContract } from '@kbn/core/server';
+import Boom from '@hapi/boom';
+import {
+  createSavedSnippet,
+  updateSavedSnippet,
+  deleteSavedSnippet,
+  getSavedSnippet,
+  findSavedSnippets,
+} from './route_handlers';
+import { CONSOLE_SNIPPET_SAVED_OBJECT_TYPE } from '../../../../../common/constants';
+
+describe('Route Handlers', () => {
+  let mockSavedObjectsClient: jest.Mocked<SavedObjectsClientContract>;
+  let mockContext: RequestHandlerContext;
+
+  beforeEach(() => {
+    mockSavedObjectsClient = {
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      get: jest.fn(),
+      find: jest.fn(),
+    } as any;
+
+    mockContext = {
+      core: Promise.resolve({
+        savedObjects: {
+          client: mockSavedObjectsClient,
+        },
+      }),
+    } as any;
+  });
+
+  describe('createSavedSnippet', () => {
+    it('should create a snippet with titleKeyword', async () => {
+      const attributes = {
+        title: 'Test Snippet',
+        description: 'Test description',
+        query: 'GET /_search',
+      };
+
+      mockSavedObjectsClient.find.mockResolvedValue({
+        total: 0,
+        saved_objects: [],
+        per_page: 20,
+        page: 1,
+      });
+
+      mockSavedObjectsClient.create.mockResolvedValue({
+        id: 'test-id',
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        attributes: {
+          ...attributes,
+          titleKeyword: 'Test Snippet',
+        },
+        references: [],
+        updated_at: '2024-01-01T00:00:00.000Z',
+        created_at: '2024-01-01T00:00:00.000Z',
+      } as any);
+
+      const result = await createSavedSnippet(mockContext, attributes);
+
+      expect(mockSavedObjectsClient.create).toHaveBeenCalledWith(
+        CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        expect.objectContaining({
+          title: 'Test Snippet',
+          titleKeyword: 'Test Snippet',
+          description: 'Test description',
+          query: 'GET /_search',
+        })
+      );
+
+      expect(result).toEqual({
+        id: 'test-id',
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        attributes: expect.objectContaining({
+          title: 'Test Snippet',
+        }),
+        updated_at: '2024-01-01T00:00:00.000Z',
+        created_at: '2024-01-01T00:00:00.000Z',
+      });
+    });
+
+    it('should trim title when creating titleKeyword', async () => {
+      const attributes = {
+        title: '  Test Snippet  ',
+        description: 'Test description',
+        query: 'GET /_search',
+      };
+
+      mockSavedObjectsClient.find.mockResolvedValue({
+        total: 0,
+        saved_objects: [],
+        per_page: 20,
+        page: 1,
+      });
+
+      mockSavedObjectsClient.create.mockResolvedValue({
+        id: 'test-id',
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        attributes: {
+          ...attributes,
+          titleKeyword: 'Test Snippet',
+        },
+        references: [],
+      } as any);
+
+      await createSavedSnippet(mockContext, attributes);
+
+      expect(mockSavedObjectsClient.create).toHaveBeenCalledWith(
+        CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        expect.objectContaining({
+          titleKeyword: 'Test Snippet',
+        })
+      );
+    });
+
+    it('should throw conflict error if snippet with same title already exists', async () => {
+      const attributes = {
+        title: 'Existing Snippet',
+        description: 'Test description',
+        query: 'GET /_search',
+      };
+
+      mockSavedObjectsClient.find.mockResolvedValue({
+        total: 1,
+        saved_objects: [
+          {
+            id: 'existing-id',
+            type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+            attributes,
+            references: [],
+            score: 1,
+          },
+        ],
+        per_page: 20,
+        page: 1,
+      });
+
+      await expect(createSavedSnippet(mockContext, attributes)).rejects.toThrow(
+        Boom.conflict('A snippet with this title already exists')
+      );
+
+      expect(mockSavedObjectsClient.create).not.toHaveBeenCalled();
+    });
+
+    it('should search for duplicates using titleKeyword field', async () => {
+      const attributes = {
+        title: 'Test Snippet',
+        description: 'Test description',
+        query: 'GET /_search',
+      };
+
+      mockSavedObjectsClient.find.mockResolvedValue({
+        total: 0,
+        saved_objects: [],
+        per_page: 20,
+        page: 1,
+      });
+
+      mockSavedObjectsClient.create.mockResolvedValue({
+        id: 'test-id',
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        attributes,
+        references: [],
+      } as any);
+
+      await createSavedSnippet(mockContext, attributes);
+
+      expect(mockSavedObjectsClient.find).toHaveBeenCalledWith({
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        searchFields: ['titleKeyword'],
+        search: '"Test Snippet"',
+      });
+    });
+  });
+
+  describe('updateSavedSnippet', () => {
+    it('should update a snippet with new attributes', async () => {
+      const id = 'test-id';
+      const attributes = {
+        title: 'Updated Snippet',
+        description: 'Updated description',
+        query: 'GET /_search',
+      };
+
+      mockSavedObjectsClient.find.mockResolvedValue({
+        total: 0,
+        saved_objects: [],
+        per_page: 20,
+        page: 1,
+      });
+
+      mockSavedObjectsClient.update.mockResolvedValue({
+        id,
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        attributes: {
+          ...attributes,
+          titleKeyword: 'Updated Snippet',
+        },
+        references: [],
+        updated_at: '2024-01-01T00:00:00.000Z',
+      } as any);
+
+      const result = await updateSavedSnippet(mockContext, id, attributes);
+
+      expect(mockSavedObjectsClient.update).toHaveBeenCalledWith(
+        CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        id,
+        expect.objectContaining({
+          title: 'Updated Snippet',
+          titleKeyword: 'Updated Snippet',
+        })
+      );
+
+      expect(result).toEqual({
+        id,
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        attributes,
+        updated_at: '2024-01-01T00:00:00.000Z',
+      });
+    });
+
+    it('should allow update if duplicate title belongs to the same snippet', async () => {
+      const id = 'test-id';
+      const attributes = {
+        title: 'Test Snippet',
+        description: 'Test description',
+        query: 'GET /_search',
+      };
+
+      mockSavedObjectsClient.find.mockResolvedValue({
+        total: 1,
+        saved_objects: [
+          {
+            id, // Same ID as the one being updated
+            type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+            attributes,
+            references: [],
+            score: 1,
+          },
+        ],
+        per_page: 20,
+        page: 1,
+      });
+
+      mockSavedObjectsClient.update.mockResolvedValue({
+        id,
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        attributes,
+        references: [],
+      } as any);
+
+      await expect(updateSavedSnippet(mockContext, id, attributes)).resolves.not.toThrow();
+    });
+
+    it('should throw conflict error if another snippet has the same title', async () => {
+      const id = 'test-id';
+      const attributes = {
+        title: 'Existing Snippet',
+        description: 'Test description',
+        query: 'GET /_search',
+      };
+
+      mockSavedObjectsClient.find.mockResolvedValue({
+        total: 1,
+        saved_objects: [
+          {
+            id: 'different-id', // Different ID
+            type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+            attributes,
+            references: [],
+            score: 1,
+          },
+        ],
+        per_page: 20,
+        page: 1,
+      });
+
+      await expect(updateSavedSnippet(mockContext, id, attributes)).rejects.toThrow(
+        Boom.conflict('A snippet with this title already exists')
+      );
+
+      expect(mockSavedObjectsClient.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteSavedSnippet', () => {
+    it('should delete a snippet by id', async () => {
+      const id = 'test-id';
+
+      mockSavedObjectsClient.delete.mockResolvedValue({});
+
+      await deleteSavedSnippet(mockContext, id);
+
+      expect(mockSavedObjectsClient.delete).toHaveBeenCalledWith(
+        CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        id
+      );
+    });
+  });
+
+  describe('getSavedSnippet', () => {
+    it('should get a snippet by id', async () => {
+      const id = 'test-id';
+      const attributes = {
+        title: 'Test Snippet',
+        description: 'Test description',
+        query: 'GET /_search',
+      };
+
+      mockSavedObjectsClient.get.mockResolvedValue({
+        id,
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        attributes,
+        references: [],
+        updated_at: '2024-01-01T00:00:00.000Z',
+        created_at: '2024-01-01T00:00:00.000Z',
+      } as any);
+
+      const result = await getSavedSnippet(mockContext, id);
+
+      expect(mockSavedObjectsClient.get).toHaveBeenCalledWith(
+        CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        id
+      );
+
+      expect(result).toEqual({
+        id,
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        attributes,
+        updated_at: '2024-01-01T00:00:00.000Z',
+        created_at: '2024-01-01T00:00:00.000Z',
+      });
+    });
+  });
+
+  describe('findSavedSnippets', () => {
+    it('should find snippets with default pagination', async () => {
+      const snippets = [
+        {
+          id: 'snippet-1',
+          type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+          attributes: {
+            title: 'Snippet 1',
+            query: 'GET /_search',
+          },
+          references: [],
+          score: 1,
+        },
+        {
+          id: 'snippet-2',
+          type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+          attributes: {
+            title: 'Snippet 2',
+            query: 'GET /_cat/indices',
+          },
+          references: [],
+          score: 1,
+        },
+      ];
+
+      mockSavedObjectsClient.find.mockResolvedValue({
+        total: 2,
+        saved_objects: snippets,
+        per_page: 20,
+        page: 1,
+      });
+
+      const result = await findSavedSnippets(mockContext);
+
+      expect(mockSavedObjectsClient.find).toHaveBeenCalledWith({
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        search: undefined,
+        searchFields: ['title', 'description', 'tags'],
+        perPage: 20,
+        page: 1,
+        sortField: 'updated_at',
+        sortOrder: 'desc',
+      });
+
+      expect(result).toEqual({
+        total: 2,
+        snippets: expect.arrayContaining([
+          expect.objectContaining({ id: 'snippet-1' }),
+          expect.objectContaining({ id: 'snippet-2' }),
+        ]),
+      });
+    });
+
+    it('should find snippets with search term', async () => {
+      mockSavedObjectsClient.find.mockResolvedValue({
+        total: 1,
+        saved_objects: [
+          {
+            id: 'snippet-1',
+            type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+            attributes: {
+              title: 'Search Snippet',
+              query: 'GET /_search',
+            },
+            references: [],
+            score: 1,
+          },
+        ],
+        per_page: 20,
+        page: 1,
+      });
+
+      await findSavedSnippets(mockContext, 'search');
+
+      expect(mockSavedObjectsClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          search: 'search',
+          searchFields: ['title', 'description', 'tags'],
+        })
+      );
+    });
+
+    it('should support custom pagination', async () => {
+      mockSavedObjectsClient.find.mockResolvedValue({
+        total: 100,
+        saved_objects: [],
+        per_page: 50,
+        page: 2,
+      });
+
+      await findSavedSnippets(mockContext, undefined, 50, 2);
+
+      expect(mockSavedObjectsClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          perPage: 50,
+          page: 2,
+        })
+      );
+    });
+
+    it('should sort by updated_at descending', async () => {
+      mockSavedObjectsClient.find.mockResolvedValue({
+        total: 0,
+        saved_objects: [],
+        per_page: 20,
+        page: 1,
+      });
+
+      await findSavedSnippets(mockContext);
+
+      expect(mockSavedObjectsClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sortField: 'updated_at',
+          sortOrder: 'desc',
+        })
+      );
+    });
+  });
+});

--- a/src/platform/plugins/shared/console/server/routes/api/console/saved_snippets/route_handlers.ts
+++ b/src/platform/plugins/shared/console/server/routes/api/console/saved_snippets/route_handlers.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { RequestHandlerContext, SavedObject, SavedObjectsFindResponse } from '@kbn/core/server';
+import Boom from '@hapi/boom';
+import { CONSOLE_SNIPPET_SAVED_OBJECT_TYPE } from '../../../../../common/constants';
+
+export interface ConsoleSnippetAttributes {
+  title: string;
+  description?: string;
+  query: string;
+  endpoint?: string;
+  method?: string;
+  tags?: string[];
+  createdBy?: string;
+  updatedBy?: string;
+}
+
+export interface SavedSnippet {
+  id: string;
+  type: string;
+  attributes: ConsoleSnippetAttributes;
+  updated_at?: string;
+  created_at?: string;
+}
+
+function transformToSavedSnippet(savedObject: SavedObject<ConsoleSnippetAttributes>): SavedSnippet {
+  return {
+    id: savedObject.id,
+    type: savedObject.type,
+    attributes: savedObject.attributes,
+    updated_at: savedObject.updated_at,
+    created_at: savedObject.created_at,
+  };
+}
+
+export async function createSavedSnippet(
+  context: RequestHandlerContext,
+  attributes: ConsoleSnippetAttributes
+): Promise<SavedSnippet> {
+  const { savedObjects } = await context.core;
+  const soClient = savedObjects.client;
+
+  // Check for duplicate titles
+  const duplicates = await soClient.find<ConsoleSnippetAttributes>({
+    type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+    searchFields: ['titleKeyword'],
+    search: `"${attributes.title.trim()}"`,
+  });
+
+  if (duplicates.total > 0) {
+    throw Boom.conflict('A snippet with this title already exists');
+  }
+
+  // Add titleKeyword for exact matching
+  const internalAttributes = {
+    ...attributes,
+    titleKeyword: attributes.title.trim(),
+  };
+
+  const savedObject = await soClient.create<ConsoleSnippetAttributes>(
+    CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+    internalAttributes
+  );
+
+  return transformToSavedSnippet(savedObject);
+}
+
+export async function updateSavedSnippet(
+  context: RequestHandlerContext,
+  id: string,
+  attributes: ConsoleSnippetAttributes
+): Promise<SavedSnippet> {
+  const { savedObjects } = await context.core;
+  const soClient = savedObjects.client;
+
+  // Check for duplicate titles (excluding current snippet)
+  const duplicates = await soClient.find<ConsoleSnippetAttributes>({
+    type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+    searchFields: ['titleKeyword'],
+    search: `"${attributes.title.trim()}"`,
+  });
+
+  if (duplicates.total > 0 && duplicates.saved_objects.some((obj) => obj.id !== id)) {
+    throw Boom.conflict('A snippet with this title already exists');
+  }
+
+  // Add titleKeyword for exact matching
+  const internalAttributes = {
+    ...attributes,
+    titleKeyword: attributes.title.trim(),
+  };
+
+  const savedObject = await soClient.update<ConsoleSnippetAttributes>(
+    CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+    id,
+    internalAttributes
+  );
+
+  return {
+    id: savedObject.id,
+    type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+    attributes,
+    updated_at: savedObject.updated_at,
+  };
+}
+
+export async function deleteSavedSnippet(
+  context: RequestHandlerContext,
+  id: string
+): Promise<void> {
+  const { savedObjects } = await context.core;
+  const soClient = savedObjects.client;
+
+  await soClient.delete(CONSOLE_SNIPPET_SAVED_OBJECT_TYPE, id);
+}
+
+export async function getSavedSnippet(
+  context: RequestHandlerContext,
+  id: string
+): Promise<SavedSnippet> {
+  const { savedObjects } = await context.core;
+  const soClient = savedObjects.client;
+
+  const savedObject = await soClient.get<ConsoleSnippetAttributes>(
+    CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+    id
+  );
+
+  return transformToSavedSnippet(savedObject);
+}
+
+export async function findSavedSnippets(
+  context: RequestHandlerContext,
+  search?: string,
+  perPage: number = 20,
+  page: number = 1
+): Promise<{ total: number; snippets: SavedSnippet[] }> {
+  const { savedObjects } = await context.core;
+  const soClient = savedObjects.client;
+
+  const result: SavedObjectsFindResponse<ConsoleSnippetAttributes> = await soClient.find({
+    type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+    search,
+    searchFields: ['title', 'description', 'tags'],
+    perPage,
+    page,
+    sortField: 'updated_at',
+    sortOrder: 'desc',
+  });
+
+  return {
+    total: result.total,
+    snippets: result.saved_objects.map(transformToSavedSnippet),
+  };
+}

--- a/src/platform/plugins/shared/console/server/routes/index.ts
+++ b/src/platform/plugins/shared/console/server/routes/index.ts
@@ -20,6 +20,7 @@ import { registerProxyRoute } from './api/console/proxy';
 import { registerSpecDefinitionsRoute } from './api/console/spec_definitions';
 import { registerAutocompleteEntitiesRoute } from './api/console/autocomplete_entities';
 import { registerConvertRequestRoute } from './api/console/convert_request_to_language';
+import { registerSavedSnippetRoutes } from './api/console/saved_snippets';
 
 export interface ProxyDependencies {
   readLegacyESConfig: () => Promise<ESConfigForProxy>;
@@ -47,4 +48,5 @@ export const registerRoutes = (dependencies: RouteDependencies) => {
   registerSpecDefinitionsRoute(dependencies);
   registerAutocompleteEntitiesRoute(dependencies);
   registerConvertRequestRoute(dependencies);
+  registerSavedSnippetRoutes(dependencies.router);
 };

--- a/src/platform/plugins/shared/console/server/saved_objects/console_snippet.test.ts
+++ b/src/platform/plugins/shared/console/server/saved_objects/console_snippet.test.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ANALYTICS_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import { CONSOLE_SNIPPET_SAVED_OBJECT_TYPE } from '../../common/constants';
+import { consoleSnippetSavedObjectType } from './console_snippet';
+
+describe('Console Snippet Saved Object Type', () => {
+  it('should have correct type name', () => {
+    expect(consoleSnippetSavedObjectType.name).toBe(CONSOLE_SNIPPET_SAVED_OBJECT_TYPE);
+  });
+
+  it('should use analytics index pattern', () => {
+    expect(consoleSnippetSavedObjectType.indexPattern).toBe(ANALYTICS_SAVED_OBJECT_INDEX);
+  });
+
+  it('should not be hidden', () => {
+    expect(consoleSnippetSavedObjectType.hidden).toBe(false);
+  });
+
+  it('should be isolated by namespace', () => {
+    expect(consoleSnippetSavedObjectType.namespaceType).toBe('multiple-isolated');
+  });
+
+  it('should have convertToMultiNamespaceTypeVersion set', () => {
+    expect(consoleSnippetSavedObjectType.convertToMultiNamespaceTypeVersion).toBe('8.0.0');
+  });
+
+  describe('management configuration', () => {
+    it('should have console icon', () => {
+      expect(consoleSnippetSavedObjectType.management?.icon).toBe('console');
+    });
+
+    it('should use title as default search field', () => {
+      expect(consoleSnippetSavedObjectType.management?.defaultSearchField).toBe('title');
+    });
+
+    it('should be importable and exportable', () => {
+      expect(consoleSnippetSavedObjectType.management?.importableAndExportable).toBe(true);
+    });
+
+    it('should extract title from attributes', () => {
+      const obj = {
+        id: 'test-id',
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        attributes: { title: 'Test Snippet' },
+        references: [],
+      };
+      expect(consoleSnippetSavedObjectType.management?.getTitle?.(obj)).toBe('Test Snippet');
+    });
+
+    it('should generate correct in-app URL', () => {
+      const obj = {
+        id: 'test-id-123',
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        attributes: { title: 'Test Snippet' },
+        references: [],
+      };
+      const inAppUrl = consoleSnippetSavedObjectType.management?.getInAppUrl?.(obj);
+      expect(inAppUrl?.path).toBe('/app/dev_tools#/console?loadSnippet=test-id-123');
+      expect(inAppUrl?.uiCapabilitiesPath).toBe('dev_tools.show');
+    });
+
+    it('should properly encode snippet ID in URL', () => {
+      const obj = {
+        id: 'test id with spaces',
+        type: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+        attributes: { title: 'Test Snippet' },
+        references: [],
+      };
+      const inAppUrl = consoleSnippetSavedObjectType.management?.getInAppUrl?.(obj);
+      expect(inAppUrl?.path).toContain(encodeURIComponent('test id with spaces'));
+    });
+  });
+
+  describe('mappings', () => {
+    it('should have dynamic mapping disabled', () => {
+      expect(consoleSnippetSavedObjectType.mappings.dynamic).toBe(false);
+    });
+
+    it('should have all required field mappings', () => {
+      const properties = consoleSnippetSavedObjectType.mappings.properties;
+      expect(properties).toHaveProperty('title');
+      expect(properties).toHaveProperty('titleKeyword');
+      expect(properties).toHaveProperty('description');
+      expect(properties).toHaveProperty('query');
+      expect(properties).toHaveProperty('endpoint');
+      expect(properties).toHaveProperty('method');
+      expect(properties).toHaveProperty('tags');
+      expect(properties).toHaveProperty('createdBy');
+      expect(properties).toHaveProperty('updatedBy');
+    });
+
+    it('should have correct field types', () => {
+      const properties = consoleSnippetSavedObjectType.mappings.properties;
+      expect(properties.title).toEqual({ type: 'text' });
+      expect(properties.titleKeyword).toEqual({ type: 'keyword' });
+      expect(properties.description).toEqual({ type: 'text' });
+      expect(properties.query).toEqual({ type: 'text' });
+      expect(properties.endpoint).toEqual({ type: 'keyword' });
+      expect(properties.method).toEqual({ type: 'keyword' });
+      expect(properties.tags).toEqual({ type: 'keyword' });
+      expect(properties.createdBy).toEqual({ type: 'keyword' });
+      expect(properties.updatedBy).toEqual({ type: 'keyword' });
+    });
+  });
+
+  describe('model versions', () => {
+    it('should have version 1 defined', () => {
+      expect(consoleSnippetSavedObjectType.modelVersions).toHaveProperty('1');
+    });
+
+    it('should have schemas for version 1', () => {
+      const modelVersions = consoleSnippetSavedObjectType.modelVersions;
+      if (typeof modelVersions === 'function') {
+        // Skip if it's a provider function
+        return;
+      }
+      const version1 = modelVersions?.[1];
+      expect(version1?.schemas).toHaveProperty('forwardCompatibility');
+      expect(version1?.schemas).toHaveProperty('create');
+    });
+
+    it('should have no changes for version 1', () => {
+      const modelVersions = consoleSnippetSavedObjectType.modelVersions;
+      if (typeof modelVersions === 'function') {
+        // Skip if it's a provider function
+        return;
+      }
+      const version1 = modelVersions?.[1];
+      expect(version1?.changes).toEqual([]);
+    });
+  });
+});

--- a/src/platform/plugins/shared/console/server/saved_objects/console_snippet.ts
+++ b/src/platform/plugins/shared/console/server/saved_objects/console_snippet.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { SavedObjectsType } from '@kbn/core/server';
+import { ANALYTICS_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import { consoleSnippetSchemaV1 } from '../schemas/console_snippet';
+import { CONSOLE_SNIPPET_SAVED_OBJECT_TYPE } from '../../common/constants';
+
+export const consoleSnippetSavedObjectType: SavedObjectsType = {
+  name: CONSOLE_SNIPPET_SAVED_OBJECT_TYPE,
+  indexPattern: ANALYTICS_SAVED_OBJECT_INDEX,
+  hidden: false,
+  namespaceType: 'multiple-isolated',
+  convertToMultiNamespaceTypeVersion: '8.0.0',
+  management: {
+    icon: 'console',
+    defaultSearchField: 'title',
+    importableAndExportable: true,
+    getTitle: (obj) => obj.attributes.title,
+    getInAppUrl: (obj) => ({
+      path: `/app/dev_tools#/console?loadSnippet=${encodeURIComponent(obj.id)}`,
+      uiCapabilitiesPath: 'dev_tools.show',
+    }),
+  },
+  mappings: {
+    dynamic: false,
+    properties: {
+      title: { type: 'text' },
+      titleKeyword: { type: 'keyword' },
+      description: { type: 'text' },
+      query: { type: 'text' },
+      endpoint: { type: 'keyword' },
+      method: { type: 'keyword' },
+      tags: { type: 'keyword' },
+      createdBy: { type: 'keyword' },
+      updatedBy: { type: 'keyword' },
+    },
+  },
+  modelVersions: {
+    1: {
+      changes: [],
+      schemas: {
+        forwardCompatibility: consoleSnippetSchemaV1.extends({}, { unknowns: 'ignore' }),
+        create: consoleSnippetSchemaV1,
+      },
+    },
+  },
+};

--- a/src/platform/plugins/shared/console/server/schemas/console_snippet.ts
+++ b/src/platform/plugins/shared/console/server/schemas/console_snippet.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { schema } from '@kbn/config-schema';
+
+export const consoleSnippetSchemaV1 = schema.object({
+  title: schema.string(),
+  titleKeyword: schema.string(),
+  description: schema.string({ defaultValue: '' }),
+  query: schema.string(),
+  endpoint: schema.string({ defaultValue: '' }),
+  method: schema.string({ defaultValue: 'GET' }),
+  tags: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  createdBy: schema.string({ defaultValue: '' }),
+  updatedBy: schema.string({ defaultValue: '' }),
+});


### PR DESCRIPTION
## Summary

This PR implements persistent saved snippets for Dev Tools Console, allowing users to save, organize, and reuse frequently used Elasticsearch queries. Snippets are stored server-side as Kibana saved objects, enabling persistence across browser sessions and sharing across devices.

### Features

- **Save snippets**: Save current Console queries with name, description, and tags
- **Load snippets**: Browse and load saved snippets into the Console editor
- **Search & filter**: Find snippets by name, description, or tags
- **Space sharing**: Share snippets across Kibana spaces (configurable)
- **Import/export**: Backup and share snippets via Saved Objects Management
- **Deep linking**: Load specific snippets via URL parameter (`?loadSnippet=<id>`)

## Implementation

This implementation follows established Kibana patterns for saved objects:

### Backend
- New saved object type: `console-snippet`
- Versioned REST API endpoints for CRUD operations
- Schema validation with duplicate title prevention
- Comprehensive test coverage for route handlers

### Frontend
- Client-side service integrated into Console plugin contract
- React hooks using React Query for data management
- UI components: save modal, load flyout, snippets sidebar
- Full integration with Console editor and toolbar
- URL-based deep linking support

### Saved Object Configuration
- **Type**: `console-snippet`
- **Namespace**: `multiple-isolated` (shareable across spaces)
- **Management**: Importable/exportable with direct Console links
- **Mappings**: Optimized for search by title, tags, and content

## Test Plan

### Manual Testing
- [ ] Save a snippet from Console editor
- [ ] Load a snippet and execute it successfully
- [ ] Verify snippets persist across browser sessions
- [ ] Search snippets by title, description, and tags
- [ ] Delete snippets with confirmation dialog
- [ ] Import/export via Saved Objects Management
- [ ] Deep linking: `/app/dev_tools#/console?loadSnippet=<id>`
- [ ] Cross-space snippet sharing (when applicable)
- [ ] No regressions in existing Console functionality

### Automated Testing
- Unit tests for saved object configuration
- Integration tests for API route handlers
- Component tests for UI elements
- All existing Console tests pass

## Screenshots

_To be added_

## Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section
- [ ] This renders correctly on smaller devices (or does not apply)