### PR TITLE
[Metrics][Discover] use lastReloadRequestTime from fetchParam

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/moon.yml
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/moon.yml
@@ -44,6 +44,7 @@ dependsOn:
   - '@kbn/field-utils'
   - '@kbn/react-query'
   - '@kbn/restorable-state'
+  - '@kbn/esql-types'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/hooks/use_lens_props.ts
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { EmbeddableComponentProps } from '@kbn/lens-plugin/public';
 import useLatest from 'react-use/lib/useLatest';
 import { useStableCallback } from '@kbn/unified-histogram';
+import type { ESQLControlVariable } from '@kbn/esql-types';
 import {
   filter,
   Observable,
@@ -38,6 +39,7 @@ export type LensProps = Pick<
   | 'viewMode'
   | 'timeRange'
   | 'attributes'
+  | 'esqlVariables'
   | 'noPadding'
   | 'searchSessionId'
   | 'executionContext'
@@ -87,11 +89,17 @@ export const useLensProps = ({
       return getLensProps({
         searchSessionId: fetchParams.searchSessionId,
         timeRange: fetchParams.relativeTimeRange, // same as in the time picker
+        esqlVariables: fetchParams.esqlVariables,
         attributes,
-        lastReloadRequestTime: Date.now(),
+        lastReloadRequestTime: fetchParams.lastReloadRequestTime,
       });
     },
-    [fetchParams.searchSessionId, fetchParams.relativeTimeRange]
+    [
+      fetchParams.searchSessionId,
+      fetchParams.relativeTimeRange,
+      fetchParams.lastReloadRequestTime,
+      fetchParams.esqlVariables,
+    ]
   );
 
   const [lensPropsContext, setLensPropsContext] = useState<ReturnType<typeof buildLensProps>>();
@@ -186,9 +194,11 @@ const getLensProps = ({
   timeRange,
   attributes,
   lastReloadRequestTime,
+  esqlVariables,
 }: {
   searchSessionId?: string;
   attributes: LensAttributes;
+  esqlVariables: ESQLControlVariable[] | undefined;
   timeRange: TimeRange;
   lastReloadRequestTime?: number;
 }): LensProps => ({
@@ -197,6 +207,7 @@ const getLensProps = ({
   timeRange,
   attributes,
   noPadding: true,
+  esqlVariables,
   searchSessionId,
   executionContext: {
     description: 'metrics experience chart data',

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/tsconfig.json
@@ -31,6 +31,7 @@
     "@kbn/esql-utils",
     "@kbn/field-utils",
     "@kbn/react-query",
-    "@kbn/restorable-state"
+    "@kbn/restorable-state",
+    "@kbn/esql-types"
   ]
 }


### PR DESCRIPTION
part of [239158](https://github.com/elastic/kibana/issues/239158)
## Summary

This PR is a follow-up from the changes made for [239158](https://github.com/elastic/kibana/issues/239158). `lastReloadRequestTime` was receiving `Date.now()` and this was causing the chart to reload whenever it returned to the viewport. `fetchParams` provides a `lastReloadRequestTime` attribute, which is safer to use

### How to test
- Start a local Kibana instance and point it to an oblt cluster 
```yml
feature_flags.overrides:
  metricsExperienceEnabled: true
 ```
- Navigate to Discover and Switch to ESQL mode
- After the grid loads, scroll up or down. The charts should not try to load data.


