### PR TITLE
[Fleet] Set keep_monitoring_alive:true for agentless policies

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.test.ts
@@ -236,6 +236,7 @@ describe('createAgentPolicyWithPackages', () => {
         namespace: 'default',
         supports_agentless: true,
         monitoring_enabled: [],
+        keep_monitoring_alive: true,
       },
       expect.objectContaining({ skipDeploy: true })
     );

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_create.ts
@@ -171,6 +171,10 @@ export async function createAgentPolicyWithPackages({
   if (monitoringEnabledParams?.length && !monitoringEnabled?.length) {
     logger.info(`Disabling monitoring for agentless policy [${newPolicy.name}]`);
   }
+  if (newPolicy.supports_agentless) {
+    newPolicy.keep_monitoring_alive = true;
+    logger.info(`Enabling keep monitoring alive for agentless policy [${newPolicy.name}]`);
+  }
 
   if (withSysMonitoring) {
     packagesToInstall.push(FLEET_SYSTEM_PACKAGE);

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.ts
@@ -107,6 +107,7 @@ export async function syncAgentlessDeployments(
               )} Updating agentless policy monitoring settings ${agentPolicy.id}`
             );
             await agentPolicyService.update(spacedScoppedSoClient, esClient, agentPolicy.id, {
+              // Ensure agentless policies keep monitoring alive so http monitoring server continue to work even without monitoring enabled
               keep_monitoring_alive: true,
               monitoring_enabled: [],
             });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/deployment_sync.ts
@@ -94,6 +94,23 @@ export async function syncAgentlessDeployments(
                 });
             }
           } else if (
+            !agentPolicy.keep_monitoring_alive ||
+            (agentPolicy.monitoring_enabled?.length ?? 0) > 0
+          ) {
+            const esClient = appContextService.getInternalUserESClient();
+            const spacedScoppedSoClient = appContextService.getInternalUserSOClientForSpaceId(
+              agentPolicy.namespace || undefined
+            );
+            logger.info(
+              `[Agentless Deployment Sync]${dryRunTag(
+                opts?.dryRun
+              )} Updating agentless policy monitoring settings ${agentPolicy.id}`
+            );
+            await agentPolicyService.update(spacedScoppedSoClient, esClient, agentPolicy.id, {
+              keep_monitoring_alive: true,
+              monitoring_enabled: [],
+            });
+          } else if (
             deployment.revision_idx === undefined ||
             deployment.revision_idx < agentPolicy.revision
           ) {


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/ingest-dev/issues/6409

Set `keep_monitoring_alive:true` for agentless policies, as I had to backfill existing policies, I use the opportunity to also address https://github.com/elastic/ingest-dev/issues/6409 to set `monitoring_enabled:[]` for all agentless policies.

`keep_monitoring_alive:true` allow the http monitoring server to continue to work even if monitoring is not enabled for the policy, this is needed for the agentless liveness probe to work correctly 