### PR TITLE
[DE] skipping flakey ML cypress test in MKI

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/machine_learning_rule.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/alert_suppression/machine_learning_rule.cy.ts
@@ -42,7 +42,7 @@ import { CREATE_RULE_URL } from '../../../../urls/navigation';
 describe(
   'Machine Learning Detection Rules - Alert suppression',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
   },
   () => {
     let mlRule: ReturnType<typeof getMachineLearningRule>;


### PR DESCRIPTION
## Summary

ML cypress suite is flakey in MKI. Skipping in MKI for now.


