### PR TITLE
Update empty apm agent api key wording

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_keys/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/settings/agent_keys/index.tsx
@@ -220,7 +220,7 @@ function AgentKeysContent({
           <p>
             {i18n.translate('xpack.apm.settings.agentKeys.emptyPromptBody', {
               defaultMessage:
-                'Create APM agent keys to authorize APM agent requests to the APM Server.',
+                'Create APM agent keys to authorize APM agent requests to the ingest endpoint.',
             })}
           </p>
         }


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

<img width="720" height="471" alt="image" src="https://github.com/user-attachments/assets/80994081-e651-4695-8e3a-8c94eaaf464c" />

becomes:

<img width="500" height="102" alt="image" src="https://github.com/user-attachments/assets/1080ca18-a99c-40e2-b4f2-96dbcce44413" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->