### PR TITLE
[Lens] Fix ESQL dimension naming

### DIFF
--- a/src/platform/test/functional/apps/dashboard/group6/index.ts
+++ b/src/platform/test/functional/apps/dashboard/group6/index.ts
@@ -42,7 +42,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     // The dashboard_snapshot test below requires the timestamped URL which breaks the view_edit test.
     // If we don't use the timestamp in the URL, the colors in the charts will be different.
     loadTestFile(require.resolve('./dashboard_snapshots'));
-    loadTestFile(require.resolve('./dashboard_esql_chart'));
     loadTestFile(require.resolve('./dashboard_esql_no_data'));
   });
 }

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.tsx
@@ -109,14 +109,8 @@ import { LayerSettingsPanel } from './layer_settings';
 import { filterAndSortUserMessages } from '../../app_plugin/get_application_user_messages';
 import { EDITOR_INVALID_DIMENSION } from '../../user_messages_ids';
 import { getLongMessage } from '../../user_messages_utils';
+import { wrapOnDot } from '../../text_utils';
 export type { OperationType } from './operations';
-
-function wrapOnDot(str?: string) {
-  // u200B is a non-width white-space character, which allows
-  // the browser to efficiently word-wrap right after the dot
-  // without us having to draw a lot of extra DOM elements, etc
-  return str ? str.replace(/\./g, '.\u200B') : '';
-}
 
 const getSelectedFieldsFromColumns = memoizeOne(
   (columns: GenericIndexPatternColumn[]) =>

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/components/dimension_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/components/dimension_editor.tsx
@@ -16,6 +16,7 @@ import type {
   TextBasedLayer,
   DatasourceDimensionEditorProps,
   DataType,
+  TextBasedLayerColumn,
 } from '@kbn/lens-common';
 import { mergeLayer, updateColumnFormat, updateColumnLabel } from '../utils';
 import type { FormatSelectorProps } from '../../form_based/dimension_panel/format_selector';
@@ -133,12 +134,12 @@ export function TextBasedDimensionEditor(props: TextBasedDimensionEditorProps) {
           selectedField={selectedField}
           onChoose={(choice) => {
             const column = allColumns?.find((f) => f.name === choice.field);
-            const newColumn = {
+            const newColumn: TextBasedLayerColumn = {
               columnId: props.columnId,
               fieldName: choice.field,
               meta: column?.meta,
               variable: column?.variable,
-              label: choice.field,
+              customLabel: false,
             };
             return props.setState(
               !selectedField
@@ -201,8 +202,8 @@ export function TextBasedDimensionEditor(props: TextBasedDimensionEditorProps) {
           </EuiText>
 
           <NameInput
-            value={selectedField.label || ''}
-            defaultValue={''}
+            value={selectedField.customLabel ? selectedField.label ?? '' : ''}
+            defaultValue={!selectedField.customLabel ? selectedField.fieldName ?? '' : ''}
             onChange={(value) => {
               updateLayer(
                 updateColumnLabel({

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/components/dimension_trigger.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/components/dimension_trigger.tsx
@@ -8,24 +8,15 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { DimensionTrigger } from '@kbn/visualization-ui-components';
-import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
-import type { DatasourceDimensionTriggerProps, TextBasedPrivateState } from '@kbn/lens-common';
 
-export type TextBasedDimensionTrigger = DatasourceDimensionTriggerProps<TextBasedPrivateState> & {
-  columnLabelMap: Record<string, string>;
-  expressions: ExpressionsStart;
-};
-
-export function TextBasedDimensionTrigger(props: TextBasedDimensionTrigger) {
-  const customLabel: string | undefined = props.columnLabelMap[props.columnId];
-
+export function TextBasedDimensionTrigger({ id, label }: { id: string; label?: string }) {
   return (
     <DimensionTrigger
-      id={props.columnId}
-      color={customLabel ? 'primary' : 'danger'}
+      id={id}
+      color={label ? 'primary' : 'danger'}
       dataTestSubj="lns-dimensionTrigger-textBased"
       label={
-        customLabel ??
+        label ??
         i18n.translate('xpack.lens.textBasedLanguages.missingField', {
           defaultMessage: 'Missing field',
         })

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/text_based_languages.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/text_based_languages.tsx
@@ -56,6 +56,7 @@ import {
   retrieveLayerColumnsFromCache,
 } from './fieldlist_cache';
 import { TEXT_BASED_LANGUAGE_ERROR } from '../../user_messages_ids';
+import { wrapOnDot } from '../../text_utils';
 
 function getLayerReferenceName(layerId: string) {
   return `textBasedLanguages-datasource-layer-${layerId}`;
@@ -474,7 +475,7 @@ export function getTextBasedDatasource({
     },
 
     DataPanelComponent(props: DatasourceDataPanelProps<TextBasedPrivateState>) {
-      const layerFields = TextBasedDatasource?.getSelectedFields?.(props.state);
+      const layerFields = TextBasedDatasource.getSelectedFields?.(props.state);
       return (
         <TextBasedDataPanel
           data={data}
@@ -488,13 +489,10 @@ export function getTextBasedDatasource({
 
     DimensionTriggerComponent: (props: DatasourceDimensionTriggerProps<TextBasedPrivateState>) => {
       const columnLabelMap = TextBasedDatasource.uniqueLabels(props.state, props.indexPatterns);
-      return (
-        <TextBasedDimensionTrigger
-          {...props}
-          expressions={expressions}
-          columnLabelMap={columnLabelMap}
-        />
-      );
+      const uniqueLabel = columnLabelMap[props.columnId];
+      const formattedLabel = wrapOnDot(uniqueLabel);
+
+      return <TextBasedDimensionTrigger id={props.columnId} label={formattedLabel} />;
     },
 
     getRenderEventCounters(state: TextBasedPrivateState): string[] {
@@ -525,7 +523,9 @@ export function getTextBasedDatasource({
           return;
         }
         Object.values(layer.columns).forEach((column) => {
-          columnLabelMap[column.columnId] = uniqueLabelGenerator(column.fieldName);
+          columnLabelMap[column.columnId] = uniqueLabelGenerator(
+            column.customLabel && column.label ? column.label : column.fieldName
+          );
         });
       });
 
@@ -534,6 +534,7 @@ export function getTextBasedDatasource({
     getDropProps,
     onDrop,
     getPublicAPI({ state, layerId, indexPatterns }: PublicAPIProps<TextBasedPrivateState>) {
+      const columnLabelMap = TextBasedDatasource.uniqueLabels(state, indexPatterns);
       return {
         datasourceId: 'textBased',
 
@@ -548,7 +549,7 @@ export function getTextBasedDatasource({
         getOperationForColumnId: (columnId: string) => {
           const layer = state.layers[layerId];
           const column = layer?.columns?.find((c) => c.columnId === columnId);
-          const columnLabelMap = TextBasedDatasource.uniqueLabels(state, indexPatterns);
+
           let scale: OperationMetadata['scale'] = 'ordinal';
           switch (column?.meta?.type) {
             case 'date':
@@ -564,8 +565,8 @@ export function getTextBasedDatasource({
 
           if (column) {
             return {
-              dataType: column?.meta?.type as DataType,
-              label: columnLabelMap[columnId] ?? column?.fieldName,
+              dataType: column.meta?.type as DataType,
+              label: columnLabelMap[columnId] ?? column.fieldName,
               isBucketed: Boolean(isNotNumeric(column)),
               inMetricDimension: column.inMetricDimension,
               hasTimeShift: false,

--- a/x-pack/platform/plugins/shared/lens/public/text_utils.ts
+++ b/x-pack/platform/plugins/shared/lens/public/text_utils.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * u200B is a non-width white-space character, which allows the browser to efficiently
+ * word-wrap right after the dot without us having to draw a lot of extra DOM elements, etc
+ */
+export function wrapOnDot(str?: string): string {
+  return str ? str.replace(/\./g, '.\u200B') : '';
+}

--- a/x-pack/platform/test/functional/apps/lens/group7/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group7/index.ts
@@ -74,5 +74,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
 
     loadTestFile(require.resolve('./logsdb')); // 43m
     loadTestFile(require.resolve('./esql'));
+    loadTestFile(require.resolve('./dashboard_esql_chart'));
   });
 };


### PR DESCRIPTION
## Summary

This PR aligned the behaviour of the ESQL dimension naming to the one used in Form Based one.
Now also in the  ESQL editor when you change the name of a field in the Appearance panel, it will be reflected in the chart series name.


The functional test was moved under an xpack group to make use of  Lens page objects.



fix https://github.com/elastic/kibana/issues/226969

This PR replaces https://github.com/elastic/kibana/pull/227102


