### PR TITLE
[Chrome Grid] Improve `EuiBottomBar` integration 

### DIFF
--- a/src/core/packages/chrome/layout/core-chrome-layout/layouts/grid/grid_global_app_style.tsx
+++ b/src/core/packages/chrome/layout/core-chrome-layout/layouts/grid/grid_global_app_style.tsx
@@ -79,13 +79,6 @@ const globalLayoutStyles = (euiTheme: UseEuiTheme['euiTheme']) => css`
     height: calc(100vh - var(--kbnHeaderBannerHeight));
     top: var(--kbnHeaderBannerHeight);
   }
-
-  // make sure fixed bottom bars are positioned relative to the application area
-  .euiBottomBar.euiBottomBar--fixed {
-    left: ${layoutVar('application.left', '0px')} !important; /* override EUI inline style */
-    right: ${layoutVar('application.right', '0px')} !important; /* override EUI inline style */
-    bottom: ${layoutVar('application.bottom', '0px')} !important; /* override EUI inline style */
-  }
 `;
 
 // temporary hacks that need to be removed after better flyout and global sidenav customization support in EUI
@@ -115,10 +108,13 @@ const globalTempHackStyles = (euiTheme: UseEuiTheme['euiTheme']) => css`
     }
   }
 
-  // push flyout should be pushing the application area, instead of body
   #${APP_MAIN_SCROLL_CONTAINER_ID} {
+    // push flyout should be pushing the application area, instead of body
     ${logicalCSS('padding-right', `var(--euiPushFlyoutOffsetInlineEnd, 0px)`)};
     ${logicalCSS('padding-left', `var(--euiPushFlyoutOffsetInlineStart, 0px)`)};
+
+    // application area should have bottom padding when bottom bar is present
+    ${logicalCSS('padding-bottom', `var(--euiBottomBarOffset, 0px)`)};
   }
   .kbnBody {
     // this is a temporary hack to override EUI's body padding with push flyout
@@ -128,6 +124,13 @@ const globalTempHackStyles = (euiTheme: UseEuiTheme['euiTheme']) => css`
     ${logicalCSS('padding-bottom', `0px !important`)};
     // just for consistency with other sides
     ${logicalCSS('padding-top', `0px !important`)};
+  }
+
+  // make sure fixed bottom bars are positioned relative to the application area
+  .euiBottomBar.euiBottomBar--fixed {
+    left: ${layoutVar('application.left', '0px')} !important; /* override EUI inline style */
+    right: ${layoutVar('application.right', '0px')} !important; /* override EUI inline style */
+    bottom: ${layoutVar('application.bottom', '0px')} !important; /* override EUI inline style */
   }
 `;
 

--- a/src/core/public/styles/_base.scss
+++ b/src/core/public/styles/_base.scss
@@ -21,8 +21,3 @@
     animation: none !important;
   }
 }
-
-// Add support for serverless navbar
-.euiBody--hasFlyout .euiBottomBar--fixed {
-  margin-left: var(--euiCollapsibleNavOffset, 0);
-}


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/242893

With the grid layout, the bottom bar could have overlapped the content area. This PR fixes it by adding padding to the content area equal to the height of the bottom bar, which pushes the content up. This is possible now due to https://github.com/elastic/eui/pull/9211

### Before: 

<img width="1509" height="261" alt="Screenshot 2025-12-02 at 10 55 53" src="https://github.com/user-attachments/assets/5edb3b98-9005-47b2-9c00-0fb9bc7fca51" />

### After:

<img width="1512" height="325" alt="Screenshot 2025-12-02 at 10 55 33" src="https://github.com/user-attachments/assets/604a69a7-fa86-4787-b87e-313eb01607f0" />






