### PR TITLE
[Cases][One Attachments] Add count to attachments tab

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_attachments.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_attachments.tsx
@@ -61,7 +61,7 @@ export const CaseViewAttachments = ({
   caseData: CaseUI;
   activeTab: CASE_VIEW_PAGE_TABS;
 }>) => {
-  const caseViewTabs = useCaseAttachmentTabs({ caseData, activeTab });
+  const { tabs: caseViewTabs } = useCaseAttachmentTabs({ caseData, activeTab });
   const { navigateToCaseView } = useCaseViewNavigation();
 
   const tabAsSelectableOptions = useMemo(() => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_attachment_tabs.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_attachment_tabs.test.tsx
@@ -15,10 +15,13 @@ import { TestProviders } from '../../common/mock';
 import React from 'react';
 
 import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
+import { useGetCaseFileStats } from '../../containers/use_get_case_file_stats';
 
 const platinumLicense = licensingMock.createLicense({
   license: { type: 'platinum' },
 });
+
+jest.mock('../../containers/use_get_case_file_stats');
 
 jest.mock('./use_case_observables', () => ({
   useCaseObservables: () => ({
@@ -26,6 +29,10 @@ jest.mock('./use_case_observables', () => ({
     isLoading: false,
   }),
 }));
+
+const useGetCaseFileStatsMock = useGetCaseFileStats as jest.Mock;
+
+const fileStatsData = { total: 3 };
 
 export const caseProps: CaseViewTabsProps = {
   caseData,
@@ -43,6 +50,10 @@ export const casePropsWithEvents: CaseViewTabsProps = {
 };
 
 describe('useCaseAttachmentTabs()', () => {
+  beforeEach(() => {
+    useGetCaseFileStatsMock.mockReturnValue({ data: fileStatsData });
+  });
+
   it('returns basic case attachment tabs', async () => {
     const { result } = renderHook(
       () => {
@@ -53,12 +64,13 @@ describe('useCaseAttachmentTabs()', () => {
       }
     );
 
-    expect(result.current.map((tab) => tab.id)).toMatchInlineSnapshot(`
+    expect(result.current.tabs.map((tab) => tab.id)).toMatchInlineSnapshot(`
       Array [
         "alerts",
         "files",
       ]
     `);
+    expect(result.current.totalAttachments).toEqual(3);
   });
 
   it('returns attachment tabs based on enable features an license', async () => {
@@ -82,7 +94,7 @@ describe('useCaseAttachmentTabs()', () => {
       }
     );
 
-    expect(result.current.map((tab) => tab.id)).toMatchInlineSnapshot(`
+    expect(result.current.tabs.map((tab) => tab.id)).toMatchInlineSnapshot(`
       Array [
         "alerts",
         "events",

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_attachment_tabs.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_attachment_tabs.tsx
@@ -101,6 +101,32 @@ export const SimilarCasesBadge = ({
 
 SimilarCasesBadge.displayName = 'SimilarCasesBadge';
 
+export const AttachmentsBadge = ({
+  isActive,
+  count,
+  euiTheme,
+}: {
+  isActive: boolean;
+  count?: number;
+  euiTheme: EuiThemeComputed<{}>;
+}) => (
+  <>
+    {
+      <EuiNotificationBadge
+        css={css`
+          margin-left: ${euiTheme.size.xs};
+        `}
+        data-test-subj="case-view-attachments-badge"
+        color={isActive ? 'accent' : 'subdued'}
+      >
+        {count ?? 0}
+      </EuiNotificationBadge>
+    }
+  </>
+);
+
+AttachmentsBadge.displayName = 'AttachmentsBadge';
+
 const AlertsBadge = ({
   activeTab,
   totalAlerts,
@@ -158,13 +184,18 @@ export interface CaseViewTab {
   name: string;
 }
 
+export interface UseCaseAttachmentTabsReturnValue {
+  tabs: CaseViewTab[];
+  totalAttachments: number;
+}
+
 export const useCaseAttachmentTabs = ({
   caseData,
   activeTab,
 }: {
   caseData: CaseUI;
   activeTab: CASE_VIEW_PAGE_TABS;
-}): CaseViewTab[] => {
+}): UseCaseAttachmentTabsReturnValue => {
   const { features } = useCasesContext();
   const { euiTheme } = useEuiTheme();
   const { data: fileStatsData, isLoading: isLoadingFiles } = useGetCaseFileStats({
@@ -174,6 +205,12 @@ export const useCaseAttachmentTabs = ({
 
   const { observablesAuthorized: canShowObservableTabs, isObservablesFeatureEnabled } =
     useCasesFeatures();
+
+  const totalAttachments =
+    Number(features.alerts.enabled ? caseData.totalAlerts : 0) +
+    Number(features.events.enabled ? caseData.totalEvents : 0) +
+    Number(fileStatsData?.total) +
+    (canShowObservableTabs && isObservablesFeatureEnabled ? observables.length : 0);
 
   const tabsConfig = useMemo(
     () => [
@@ -254,5 +291,5 @@ export const useCaseAttachmentTabs = ({
     ]
   );
 
-  return tabsConfig;
+  return { tabs: tabsConfig, totalAttachments };
 };


### PR DESCRIPTION
## Summary

This PR adds count badge to attachments tab, allowing users to see if theres anything intersting inside without peeking in.

Screenshot:

<img width="744" height="518" alt="Screenshot 2025-12-02 at 14 13 31" src="https://github.com/user-attachments/assets/5b21e382-e540-4e02-85fb-f2d1e8f46d96" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



