### PR TITLE
[agent builder] conversation round telemetry

### DIFF
--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
@@ -450,6 +450,184 @@
             }
           }
         },
+        "time_to_first_token": {
+          "properties": {
+            "p50": {
+              "type": "long",
+              "_meta": {
+                "description": "50th percentile time-to-first-token in milliseconds"
+              }
+            },
+            "p75": {
+              "type": "long",
+              "_meta": {
+                "description": "75th percentile time-to-first-token in milliseconds"
+              }
+            },
+            "p90": {
+              "type": "long",
+              "_meta": {
+                "description": "90th percentile time-to-first-token in milliseconds"
+              }
+            },
+            "p95": {
+              "type": "long",
+              "_meta": {
+                "description": "95th percentile time-to-first-token in milliseconds"
+              }
+            },
+            "p99": {
+              "type": "long",
+              "_meta": {
+                "description": "99th percentile time-to-first-token in milliseconds"
+              }
+            },
+            "mean": {
+              "type": "long",
+              "_meta": {
+                "description": "Mean time-to-first-token in milliseconds"
+              }
+            },
+            "total_samples": {
+              "type": "long",
+              "_meta": {
+                "description": "Total number of TTFT samples"
+              }
+            }
+          }
+        },
+        "time_to_last_token": {
+          "properties": {
+            "p50": {
+              "type": "long",
+              "_meta": {
+                "description": "50th percentile time-to-last-token in milliseconds"
+              }
+            },
+            "p75": {
+              "type": "long",
+              "_meta": {
+                "description": "75th percentile time-to-last-token in milliseconds"
+              }
+            },
+            "p90": {
+              "type": "long",
+              "_meta": {
+                "description": "90th percentile time-to-last-token in milliseconds"
+              }
+            },
+            "p95": {
+              "type": "long",
+              "_meta": {
+                "description": "95th percentile time-to-last-token in milliseconds"
+              }
+            },
+            "p99": {
+              "type": "long",
+              "_meta": {
+                "description": "99th percentile time-to-last-token in milliseconds"
+              }
+            },
+            "mean": {
+              "type": "long",
+              "_meta": {
+                "description": "Mean time-to-last-token in milliseconds"
+              }
+            },
+            "total_samples": {
+              "type": "long",
+              "_meta": {
+                "description": "Total number of TTLT samples"
+              }
+            }
+          }
+        },
+        "latency_by_connector": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "connector_id": {
+                "type": "keyword",
+                "_meta": {
+                  "description": "Connector ID (maps to LLM provider/model)"
+                }
+              },
+              "ttft_p50": {
+                "type": "long",
+                "_meta": {
+                  "description": "50th percentile TTFT for this connector"
+                }
+              },
+              "ttft_p95": {
+                "type": "long",
+                "_meta": {
+                  "description": "95th percentile TTFT for this connector"
+                }
+              },
+              "ttlt_p50": {
+                "type": "long",
+                "_meta": {
+                  "description": "50th percentile TTLT for this connector"
+                }
+              },
+              "ttlt_p95": {
+                "type": "long",
+                "_meta": {
+                  "description": "95th percentile TTLT for this connector"
+                }
+              },
+              "sample_count": {
+                "type": "long",
+                "_meta": {
+                  "description": "Number of samples for this connector"
+                }
+              }
+            }
+          }
+        },
+        "latency_by_agent_type": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "agent_id": {
+                "type": "keyword",
+                "_meta": {
+                  "description": "Agent ID"
+                }
+              },
+              "ttft_p50": {
+                "type": "long",
+                "_meta": {
+                  "description": "50th percentile TTFT for this agent"
+                }
+              },
+              "ttft_p95": {
+                "type": "long",
+                "_meta": {
+                  "description": "95th percentile TTFT for this agent"
+                }
+              },
+              "ttlt_p50": {
+                "type": "long",
+                "_meta": {
+                  "description": "50th percentile TTLT for this agent"
+                }
+              },
+              "ttlt_p95": {
+                "type": "long",
+                "_meta": {
+                  "description": "95th percentile TTLT for this agent"
+                }
+              },
+              "sample_count": {
+                "type": "long",
+                "_meta": {
+                  "description": "Number of samples for this agent"
+                }
+              }
+            }
+          }
+        },
         "tool_calls": {
           "properties": {
             "total": {

--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
@@ -542,44 +542,44 @@
             }
           }
         },
-        "latency_by_connector": {
+        "latency_by_model": {
           "type": "array",
           "items": {
             "properties": {
-              "connector_id": {
+              "model": {
                 "type": "keyword",
                 "_meta": {
-                  "description": "Connector ID (maps to LLM provider/model)"
+                  "description": "Model identifier (e.g., gpt-4o, claude-3-sonnet)"
                 }
               },
               "ttft_p50": {
                 "type": "long",
                 "_meta": {
-                  "description": "50th percentile TTFT for this connector"
+                  "description": "50th percentile TTFT for this model"
                 }
               },
               "ttft_p95": {
                 "type": "long",
                 "_meta": {
-                  "description": "95th percentile TTFT for this connector"
+                  "description": "95th percentile TTFT for this model"
                 }
               },
               "ttlt_p50": {
                 "type": "long",
                 "_meta": {
-                  "description": "50th percentile TTLT for this connector"
+                  "description": "50th percentile TTLT for this model"
                 }
               },
               "ttlt_p95": {
                 "type": "long",
                 "_meta": {
-                  "description": "95th percentile TTLT for this connector"
+                  "description": "95th percentile TTLT for this model"
                 }
               },
               "sample_count": {
                 "type": "long",
                 "_meta": {
-                  "description": "Number of samples for this connector"
+                  "description": "Number of samples for this model"
                 }
               }
             }

--- a/x-pack/platform/plugins/shared/onechat/server/telemetry/telemetry_collector.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/telemetry/telemetry_collector.ts
@@ -14,6 +14,30 @@ import { QueryUtils } from './query_utils';
 import { ONECHAT_USAGE_DOMAIN } from './usage_counters';
 
 /**
+ * Timing percentile metrics structure
+ */
+interface TimingPercentiles {
+  p50: number;
+  p75: number;
+  p90: number;
+  p95: number;
+  p99: number;
+  mean: number;
+  total_samples: number;
+}
+
+/**
+ * Latency stats for a specific dimension (connector, agent type)
+ */
+interface LatencyStats {
+  ttft_p50: number;
+  ttft_p95: number;
+  ttlt_p50: number;
+  ttlt_p95: number;
+  sample_count: number;
+}
+
+/**
  * Telemetry payload schema for Agent Builder
  */
 export interface OnechatTelemetry {
@@ -46,6 +70,18 @@ export interface OnechatTelemetry {
     p99: number;
     mean: number;
   };
+  time_to_first_token: TimingPercentiles;
+  time_to_last_token: TimingPercentiles;
+  latency_by_connector: Array<
+    {
+      connector_id: string;
+    } & LatencyStats
+  >;
+  latency_by_agent_type: Array<
+    {
+      agent_id: string;
+    } & LatencyStats
+  >;
   tool_calls: {
     total: number;
     by_source: {
@@ -213,6 +249,176 @@ export function registerTelemetryCollector(
             },
           },
         },
+        time_to_first_token: {
+          p50: {
+            type: 'long',
+            _meta: {
+              description: '50th percentile time-to-first-token in milliseconds',
+            },
+          },
+          p75: {
+            type: 'long',
+            _meta: {
+              description: '75th percentile time-to-first-token in milliseconds',
+            },
+          },
+          p90: {
+            type: 'long',
+            _meta: {
+              description: '90th percentile time-to-first-token in milliseconds',
+            },
+          },
+          p95: {
+            type: 'long',
+            _meta: {
+              description: '95th percentile time-to-first-token in milliseconds',
+            },
+          },
+          p99: {
+            type: 'long',
+            _meta: {
+              description: '99th percentile time-to-first-token in milliseconds',
+            },
+          },
+          mean: {
+            type: 'long',
+            _meta: {
+              description: 'Mean time-to-first-token in milliseconds',
+            },
+          },
+          total_samples: {
+            type: 'long',
+            _meta: {
+              description: 'Total number of TTFT samples',
+            },
+          },
+        },
+        time_to_last_token: {
+          p50: {
+            type: 'long',
+            _meta: {
+              description: '50th percentile time-to-last-token in milliseconds',
+            },
+          },
+          p75: {
+            type: 'long',
+            _meta: {
+              description: '75th percentile time-to-last-token in milliseconds',
+            },
+          },
+          p90: {
+            type: 'long',
+            _meta: {
+              description: '90th percentile time-to-last-token in milliseconds',
+            },
+          },
+          p95: {
+            type: 'long',
+            _meta: {
+              description: '95th percentile time-to-last-token in milliseconds',
+            },
+          },
+          p99: {
+            type: 'long',
+            _meta: {
+              description: '99th percentile time-to-last-token in milliseconds',
+            },
+          },
+          mean: {
+            type: 'long',
+            _meta: {
+              description: 'Mean time-to-last-token in milliseconds',
+            },
+          },
+          total_samples: {
+            type: 'long',
+            _meta: {
+              description: 'Total number of TTLT samples',
+            },
+          },
+        },
+        latency_by_connector: {
+          type: 'array',
+          items: {
+            connector_id: {
+              type: 'keyword',
+              _meta: {
+                description: 'Connector ID (maps to LLM provider/model)',
+              },
+            },
+            ttft_p50: {
+              type: 'long',
+              _meta: {
+                description: '50th percentile TTFT for this connector',
+              },
+            },
+            ttft_p95: {
+              type: 'long',
+              _meta: {
+                description: '95th percentile TTFT for this connector',
+              },
+            },
+            ttlt_p50: {
+              type: 'long',
+              _meta: {
+                description: '50th percentile TTLT for this connector',
+              },
+            },
+            ttlt_p95: {
+              type: 'long',
+              _meta: {
+                description: '95th percentile TTLT for this connector',
+              },
+            },
+            sample_count: {
+              type: 'long',
+              _meta: {
+                description: 'Number of samples for this connector',
+              },
+            },
+          },
+        },
+        latency_by_agent_type: {
+          type: 'array',
+          items: {
+            agent_id: {
+              type: 'keyword',
+              _meta: {
+                description: 'Agent ID',
+              },
+            },
+            ttft_p50: {
+              type: 'long',
+              _meta: {
+                description: '50th percentile TTFT for this agent',
+              },
+            },
+            ttft_p95: {
+              type: 'long',
+              _meta: {
+                description: '95th percentile TTFT for this agent',
+              },
+            },
+            ttlt_p50: {
+              type: 'long',
+              _meta: {
+                description: '50th percentile TTLT for this agent',
+              },
+            },
+            ttlt_p95: {
+              type: 'long',
+              _meta: {
+                description: '95th percentile TTLT for this agent',
+              },
+            },
+            sample_count: {
+              type: 'long',
+              _meta: {
+                description: 'Number of samples for this agent',
+              },
+            },
+          },
+        },
         tool_calls: {
           total: {
             type: 'long',
@@ -344,6 +550,12 @@ export function registerTelemetryCollector(
           );
           const queryToResultTime = queryUtils.calculatePercentilesFromBuckets(queryTimeCounters);
 
+          // Fetch TTFT/TTLT metrics from conversation data
+          const timeToFirstToken = await queryUtils.getTTFTMetrics();
+          const timeToLastToken = await queryUtils.getTTLTMetrics();
+          const latencyByConnector = await queryUtils.getLatencyByConnector();
+          const latencyByAgentType = await queryUtils.getLatencyByAgentType();
+
           const toolCallCounters = await queryUtils.getCountersByPrefix(
             ONECHAT_USAGE_DOMAIN,
             'tool_call_'
@@ -414,11 +626,15 @@ export function registerTelemetryCollector(
 
           errorsByType.sort((a, b) => b.count - a.count);
 
-          const telemetry = {
+          const telemetry: OnechatTelemetry = {
             custom_tools: customTools,
             custom_agents: { total: customAgents },
             conversations,
             query_to_result_time: queryToResultTime,
+            time_to_first_token: timeToFirstToken,
+            time_to_last_token: timeToLastToken,
+            latency_by_connector: latencyByConnector,
+            latency_by_agent_type: latencyByAgentType,
             tool_calls: {
               total: totalToolCalls,
               by_source: toolCallsBySource,
@@ -458,6 +674,26 @@ export function registerTelemetryCollector(
               p99: 0,
               mean: 0,
             },
+            time_to_first_token: {
+              p50: 0,
+              p75: 0,
+              p90: 0,
+              p95: 0,
+              p99: 0,
+              mean: 0,
+              total_samples: 0,
+            },
+            time_to_last_token: {
+              p50: 0,
+              p75: 0,
+              p90: 0,
+              p95: 0,
+              p99: 0,
+              mean: 0,
+              total_samples: 0,
+            },
+            latency_by_connector: [],
+            latency_by_agent_type: [],
             tool_calls: {
               total: 0,
               by_source: {

--- a/x-pack/platform/plugins/shared/onechat/server/telemetry/telemetry_collector.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/telemetry/telemetry_collector.ts
@@ -72,9 +72,9 @@ export interface OnechatTelemetry {
   };
   time_to_first_token: TimingPercentiles;
   time_to_last_token: TimingPercentiles;
-  latency_by_connector: Array<
+  latency_by_model: Array<
     {
-      connector_id: string;
+      model: string;
     } & LatencyStats
   >;
   latency_by_agent_type: Array<
@@ -337,43 +337,43 @@ export function registerTelemetryCollector(
             },
           },
         },
-        latency_by_connector: {
+        latency_by_model: {
           type: 'array',
           items: {
-            connector_id: {
+            model: {
               type: 'keyword',
               _meta: {
-                description: 'Connector ID (maps to LLM provider/model)',
+                description: 'Model identifier (e.g., gpt-4o, claude-3-sonnet)',
               },
             },
             ttft_p50: {
               type: 'long',
               _meta: {
-                description: '50th percentile TTFT for this connector',
+                description: '50th percentile TTFT for this model',
               },
             },
             ttft_p95: {
               type: 'long',
               _meta: {
-                description: '95th percentile TTFT for this connector',
+                description: '95th percentile TTFT for this model',
               },
             },
             ttlt_p50: {
               type: 'long',
               _meta: {
-                description: '50th percentile TTLT for this connector',
+                description: '50th percentile TTLT for this model',
               },
             },
             ttlt_p95: {
               type: 'long',
               _meta: {
-                description: '95th percentile TTLT for this connector',
+                description: '95th percentile TTLT for this model',
               },
             },
             sample_count: {
               type: 'long',
               _meta: {
-                description: 'Number of samples for this connector',
+                description: 'Number of samples for this model',
               },
             },
           },
@@ -553,7 +553,7 @@ export function registerTelemetryCollector(
           // Fetch TTFT/TTLT metrics from conversation data
           const timeToFirstToken = await queryUtils.getTTFTMetrics();
           const timeToLastToken = await queryUtils.getTTLTMetrics();
-          const latencyByConnector = await queryUtils.getLatencyByConnector();
+          const latencyByModel = await queryUtils.getLatencyByModel();
           const latencyByAgentType = await queryUtils.getLatencyByAgentType();
 
           const toolCallCounters = await queryUtils.getCountersByPrefix(
@@ -633,7 +633,7 @@ export function registerTelemetryCollector(
             query_to_result_time: queryToResultTime,
             time_to_first_token: timeToFirstToken,
             time_to_last_token: timeToLastToken,
-            latency_by_connector: latencyByConnector,
+            latency_by_model: latencyByModel,
             latency_by_agent_type: latencyByAgentType,
             tool_calls: {
               total: totalToolCalls,
@@ -692,7 +692,7 @@ export function registerTelemetryCollector(
               mean: 0,
               total_samples: 0,
             },
-            latency_by_connector: [],
+            latency_by_model: [],
             latency_by_agent_type: [],
             tool_calls: {
               total: 0,


### PR DESCRIPTION
## Summary

resolves  https://github.com/elastic/search-team/issues/11979

logs:
- time_to_first_token (p50, p75, p90, p95, p99)
- time_to_last_token (p50, p75, p90, p95, p99)
- both above per each connectorid_modelid
- both above per each agent
