### PR TITLE
[9.1] [CI / FIPS] Switch FIPS pipeline to scripts. Refactor verify step. (#243434)

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
@@ -24,18 +24,28 @@ spec:
       repository: elastic/kibana
       branch_configuration: main 8.19
       default_branch: main
-      pipeline_file: '.buildkite/pipelines/fips.yml'
+      pipeline_file: .buildkite/pipelines/fips/fips_pipeline.sh
       provider_settings:
         trigger_mode: none
       schedules:
-        Daily build (main):
-          message: Daily build
+        '140-2 Daily build (main)':
+          message: 140-2 Daily build
           branch: main
           cronline: 0 5 * * * America/New_York
-        Daily build (8.19):
-          message: Daily build
+          env:
+            KBN_FIPS_VERSION: '140-2'
+        '140-2 Daily build (9.1)':
+          message: 140-2 Daily build
+          branch: '9.1'
+          cronline: 0 5 * * * America/New_York
+          env:
+            KBN_FIPS_VERSION: '140-2'
+        '140-2 Daily build (8.19)':
+          message: 140-2 Daily build
           branch: '8.19'
           cronline: 0 5 * * * America/New_York
+          env:
+            KBN_FIPS_VERSION: '140-2'
       teams:
         kibana-operations:
           access_level: MANAGE_BUILD_AND_READ

--- a/.buildkite/pipeline-utils/buildkite/utils.ts
+++ b/.buildkite/pipeline-utils/buildkite/utils.ts
@@ -7,6 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './client';
-export * from './types';
-export * from './utils';
+import fs from 'fs';
+
+export function emitPipeline(pipelineSteps: string[]) {
+  const pipelineStr = [...new Set(pipelineSteps)].join('\n');
+  console.log(pipelineStr);
+}
+
+export const getPipeline = (filename: string, removeSteps = true) => {
+  const str = fs.readFileSync(filename).toString();
+  return removeSteps ? str.replace(/^steps:/, '') : str;
+};

--- a/.buildkite/pipelines/fips.yml
+++ b/.buildkite/pipelines/fips.yml
@@ -32,7 +32,7 @@ steps:
 
   - wait
 
-  - command: .buildkite/scripts/steps/checks/verify_fips_enabled.sh
+  - command: .buildkite/pipelines/fips/verify_fips_enabled.sh
     label: 'Verify FIPS Enabled'
     depends_on: build
     timeout_in_minutes: 10

--- a/.buildkite/pipelines/fips/fips_pipeline.sh
+++ b/.buildkite/pipelines/fips/fips_pipeline.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+ts-node .buildkite/pipelines/fips/fips_pipeline.ts

--- a/.buildkite/pipelines/fips/fips_pipeline.ts
+++ b/.buildkite/pipelines/fips/fips_pipeline.ts
@@ -7,6 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './client';
-export * from './types';
-export * from './utils';
+import { emitPipeline, getPipeline } from '#pipeline-utils';
+
+(async () => {
+  const pipeline: string[] = [];
+
+  try {
+    pipeline.push(getPipeline('.buildkite/pipelines/fips.yml', false));
+
+    emitPipeline(pipeline);
+  } catch (ex) {
+    console.error('Error while generating the pipeline steps: ' + ex.message, ex);
+    process.exit(1);
+  }
+})();

--- a/.buildkite/pipelines/fips/verify_fips_enabled.sh
+++ b/.buildkite/pipelines/fips/verify_fips_enabled.sh
@@ -3,28 +3,8 @@
 set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
-
-# shellcheck disable=SC2317
-function build_ready() {
-  build_state=$(buildkite-agent step get "state" --step "build")
-
-  if [[ "$build_state" == "finished" || "$build_state" == "ready" || "$build_state" == "ignored" ]]; then
-    echo "Build is ready, continuing..."
-  else
-    echo "Build is not ready, current state: $build_state"
-    return 1
-  fi
-}
-
-# This script is part of checks.sh in the PR pipeline but is called directly in the FIPS pipeline, so we need to bootstrap
-if [[ -z "${BASH_SOURCE[1]+x}" || "${BASH_SOURCE[1]}" != *"checks.sh"* ]]; then
-  export DISABLE_BOOTSTRAP_VALIDATION=false
-  .buildkite/scripts/bootstrap.sh
-fi
-
-# Wait 5x5 minutes for the build artifacts to be ready
-retry 5 300 build_ready
-
+export DISABLE_BOOTSTRAP_VALIDATION=false
+.buildkite/scripts/bootstrap.sh
 .buildkite/scripts/download_build_artifacts.sh
 
 echo --- Verify FIPS enabled

--- a/.buildkite/pipelines/fips/verify_fips_enabled.yml
+++ b/.buildkite/pipelines/fips/verify_fips_enabled.yml
@@ -1,0 +1,12 @@
+steps:
+  - command: .buildkite/pipelines/fips/verify_fips_enabled.sh
+    label: 'Verify FIPS Enabled'
+    depends_on: build
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+    agents:
+      machineType: n2-standard-2
+      preemptible: true

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -15,7 +15,6 @@
             }
         ] */
 
-import fs from 'fs';
 import prConfigs from '../../../pull_requests.json';
 import { runPreBuild } from './pre_build';
 import {
@@ -23,6 +22,7 @@ import {
   doAnyChangesMatch,
   getAgentImageConfig,
   emitPipeline,
+  getPipeline,
 } from '#pipeline-utils';
 
 const prConfig = prConfigs.jobs.find((job) => job.pipelineSlug === 'kibana-pull-request');
@@ -36,11 +36,7 @@ if (!prConfig) {
 const GITHUB_PR_LABELS = process.env.GITHUB_PR_LABELS ?? '';
 const REQUIRED_PATHS = prConfig.always_require_ci_on_changed!.map((r) => new RegExp(r, 'i'));
 const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new RegExp(r, 'i'));
-
-const getPipeline = (filename: string, removeSteps = true) => {
-  const str = fs.readFileSync(filename).toString();
-  return removeSteps ? str.replace(/^steps:/, '') : str;
-};
+const FTR_ENABLE_FIPS_AGENT = process.env.FTR_ENABLE_FIPS_AGENT?.toLowerCase() === 'true';
 
 (async () => {
   const pipeline: string[] = [];
@@ -69,6 +65,10 @@ const getPipeline = (filename: string, removeSteps = true) => {
     } else {
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/base.yml', false));
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/pick_test_groups.yml'));
+    }
+
+    if (FTR_ENABLE_FIPS_AGENT || GITHUB_PR_LABELS.includes('ci:enable-fips-agent')) {
+      pipeline.push(getPipeline('.buildkite/pipelines/fips/verify_fips_enabled.yml'));
     }
 
     pipeline.push(getPipeline('.buildkite/pipelines/pull_request/scout_tests.yml'));

--- a/.buildkite/scripts/steps/checks.sh
+++ b/.buildkite/scripts/steps/checks.sh
@@ -6,9 +6,6 @@ export DISABLE_BOOTSTRAP_VALIDATION=false
 .buildkite/scripts/bootstrap.sh
 .buildkite/scripts/setup_es_snapshot_cache.sh
 
-if [[ "${FTR_ENABLE_FIPS_AGENT:-}" == "true" ]]; then
-  .buildkite/scripts/steps/checks/verify_fips_enabled.sh
-fi
 .buildkite/scripts/steps/checks/saved_objects_compat_changes.sh
 .buildkite/scripts/steps/checks/saved_objects_definition_change.sh
 .buildkite/scripts/steps/code_generation/elastic_assistant_codegen.sh


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[CI / FIPS] Switch FIPS pipeline to scripts. Refactor verify step. (#243434)](https://github.com/elastic/kibana/pull/243434)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-11-27T02:43:38Z","message":"[CI / FIPS] Switch FIPS pipeline to scripts. Refactor verify step. (#243434)\n\n## Summary\n\nPart 1 of #242952\n\nThis PR was part of #243112 but I want to split it so the pipeline\nresources are updated and I can test the bigger changes in the other PR\nbefore merging them. We'll need to merge this PR before the changes are\ntested in the `Daily FIPS` run afterwards and planning to monitor it.\n\n- Switch daily FIPS pipeline from `yml` to `sh`\n- This is required to dynamically switch between the two FIPS version's\nagents without duplicating all the pipelines\n- Move some pipeline utils\n- Move `Verify FIPS` out of `Checks` step for PR pipeline.\n    - Removes the need to poll for `build` step to finish\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Jon <jon@budzenski.me>","sha":"a8b419c3b324dba982b651d872f796e54c26a0dd","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","v9.3.0"],"title":"[CI / FIPS] Switch FIPS pipeline to scripts. Refactor verify step.","number":243434,"url":"https://github.com/elastic/kibana/pull/243434","mergeCommit":{"message":"[CI / FIPS] Switch FIPS pipeline to scripts. Refactor verify step. (#243434)\n\n## Summary\n\nPart 1 of #242952\n\nThis PR was part of #243112 but I want to split it so the pipeline\nresources are updated and I can test the bigger changes in the other PR\nbefore merging them. We'll need to merge this PR before the changes are\ntested in the `Daily FIPS` run afterwards and planning to monitor it.\n\n- Switch daily FIPS pipeline from `yml` to `sh`\n- This is required to dynamically switch between the two FIPS version's\nagents without duplicating all the pipelines\n- Move some pipeline utils\n- Move `Verify FIPS` out of `Checks` step for PR pipeline.\n    - Removes the need to poll for `build` step to finish\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Jon <jon@budzenski.me>","sha":"a8b419c3b324dba982b651d872f796e54c26a0dd"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243434","number":243434,"mergeCommit":{"message":"[CI / FIPS] Switch FIPS pipeline to scripts. Refactor verify step. (#243434)\n\n## Summary\n\nPart 1 of #242952\n\nThis PR was part of #243112 but I want to split it so the pipeline\nresources are updated and I can test the bigger changes in the other PR\nbefore merging them. We'll need to merge this PR before the changes are\ntested in the `Daily FIPS` run afterwards and planning to monitor it.\n\n- Switch daily FIPS pipeline from `yml` to `sh`\n- This is required to dynamically switch between the two FIPS version's\nagents without duplicating all the pipelines\n- Move some pipeline utils\n- Move `Verify FIPS` out of `Checks` step for PR pipeline.\n    - Removes the need to poll for `build` step to finish\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Jon <jon@budzenski.me>","sha":"a8b419c3b324dba982b651d872f796e54c26a0dd"}}]}] BACKPORT-->