### PR TITLE
[Agent Builder] fix smoke tests for Gemini 2

### DIFF
--- a/x-pack/platform/test/onechat/smoke_tests/tests/converse.ts
+++ b/x-pack/platform/test/onechat/smoke_tests/tests/converse.ts
@@ -52,7 +52,7 @@ export const converseApiSuite = (
         expect(response.response.message.length).to.be.greaterThan(0);
 
         const toolCalls = response.steps.filter(isToolCallStep);
-        expect(toolCalls.length).to.eql(1);
+        expect(toolCalls.length >= 1).to.be(true);
 
         const toolCall = toolCalls[0];
         expect(toolCall.tool_id).to.eql(platformCoreTools.listIndices);


### PR DESCRIPTION
## Summary

Gemini-2 is sometimes calling multiple tools even when asked not to. Updating smoke tests to work around it


