### PR TITLE
[Agent Builder] Constrain width of thinking panel codeblock styles

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/codeblock.styles.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/codeblock.styles.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { css } from '@emotion/react';
+
+export const codeblockStyles = css`
+  overflow-x: auto;
+  word-break: break-word;
+`;

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/codeblock.styles.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/codeblock.styles.ts
@@ -8,6 +8,5 @@
 import { css } from '@emotion/react';
 
 export const codeblockStyles = css`
-  overflow-x: auto;
   word-break: break-word;
 `;

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/error_result_step.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/error_result_step.tsx
@@ -10,6 +10,7 @@ import type { ErrorResult } from '@kbn/onechat-common/tools/tool_result';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
+import { codeblockStyles } from './codeblock.styles';
 
 const labels = {
   title: i18n.translate('xpack.onechat.round.thinking.steps.errorResultStep.title', {
@@ -35,7 +36,7 @@ export const ErrorResultStep: React.FC<ErrorResultStepProps> = ({ result: { data
           </EuiText>
         </EuiSplitPanel.Inner>
         <EuiSplitPanel.Inner paddingSize="none">
-          <EuiCodeBlock isCopyable paddingSize="m" lineNumbers>
+          <EuiCodeBlock isCopyable paddingSize="m" lineNumbers css={codeblockStyles}>
             {data.message}
           </EuiCodeBlock>
         </EuiSplitPanel.Inner>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/other_result_step.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/other_result_step.tsx
@@ -9,6 +9,7 @@ import { EuiCodeBlock, useEuiTheme } from '@elastic/eui';
 import type { ToolResult } from '@kbn/onechat-common/tools/tool_result';
 import React from 'react';
 import { css } from '@emotion/react';
+import { codeblockStyles } from './codeblock.styles';
 
 interface OtherResultStepProps {
   result: ToolResult;
@@ -21,7 +22,14 @@ export const OtherResultStep: React.FC<OtherResultStepProps> = ({ result }) => {
   `;
   return (
     <div css={paddingLeftStyles}>
-      <EuiCodeBlock language="json" fontSize="s" paddingSize="s" isCopyable={false} color="subdued">
+      <EuiCodeBlock
+        language="json"
+        fontSize="s"
+        paddingSize="s"
+        isCopyable={false}
+        color="subdued"
+        css={codeblockStyles}
+      >
         {JSON.stringify(result.data, null, 2)}
       </EuiCodeBlock>
     </div>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/query_result_step.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/query_result_step.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import type { QueryResult } from '@kbn/onechat-common/tools/tool_result';
 import { css } from '@emotion/react';
+import { codeblockStyles } from './codeblock.styles';
 
 const labels = {
   title: i18n.translate('xpack.onechat.round.thinking.steps.queryResultStep.title', {
@@ -34,7 +35,13 @@ export const QueryResultStep: React.FC<QueryResultStepProps> = ({ result: { data
           </EuiText>
         </EuiSplitPanel.Inner>
         <EuiSplitPanel.Inner paddingSize="none">
-          <EuiCodeBlock language="esql" isCopyable paddingSize="m" lineNumbers>
+          <EuiCodeBlock
+            language="esql"
+            isCopyable
+            paddingSize="m"
+            lineNumbers
+            css={codeblockStyles}
+          >
             {data.esql}
           </EuiCodeBlock>
         </EuiSplitPanel.Inner>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/thinking_item_layout.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_thinking/steps/thinking_item_layout.tsx
@@ -22,6 +22,7 @@ import {
 import type { ToolCallStep } from '@kbn/onechat-common';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
+import { codeblockStyles } from './codeblock.styles';
 
 const labels = {
   parameters: i18n.translate('xpack.onechat.round.thinking.steps.thinkingItemLayout.parameters', {
@@ -70,7 +71,7 @@ const Accordion = ({ children, accordionContent }: AccordionProps) => {
             </EuiText>
           </EuiSplitPanel.Inner>
           <EuiSplitPanel.Inner paddingSize="none">
-            <EuiCodeBlock isCopyable paddingSize="m" lineNumbers>
+            <EuiCodeBlock isCopyable paddingSize="m" lineNumbers css={codeblockStyles}>
               {JSON.stringify(accordionContent, null, 2)}
             </EuiCodeBlock>
           </EuiSplitPanel.Inner>


### PR DESCRIPTION
## Summary

Before
<img width="950" height="467" alt="image" src="https://github.com/user-attachments/assets/1e18b9cf-2957-4f04-a382-36226ae3aa53" />
<img width="1728" height="1042" alt="image" src="https://github.com/user-attachments/assets/ca4961e4-be09-4811-84eb-03b088f4f1ac" />

After
<img width="1728" height="1043" alt="image" src="https://github.com/user-attachments/assets/b44f28b3-31b9-4646-beb8-2dcd7b27b2ae" />
<img width="1728" height="1041" alt="image" src="https://github.com/user-attachments/assets/9344e7ab-64c3-4f8e-9747-c3049502166a" />

- [x] Constrains the width of the code block styles, which stops the thinking panel from expanding when large queries are present



