### PR TITLE
[App Menu Standardization] Allow for setting split button notification indicator size

### DIFF
--- a/src/platform/packages/private/kbn-split-button/src/split_button.stories.tsx
+++ b/src/platform/packages/private/kbn-split-button/src/split_button.stories.tsx
@@ -192,33 +192,19 @@ export const WithNotificationIndicator = {
   args: {
     showNotificationIndicator: true,
     notifcationIndicatorTooltipContent: 'You have unsaved changes',
+    notificationIndicatorColor: 'primary',
+    notificationIndicatorSize: 'l',
     size: 'm',
   },
   render: (args: {
     showNotificationIndicator: boolean;
     notifcationIndicatorTooltipContent: string;
-    size: React.ComponentProps<typeof SplitButton>['size'];
-  }) => (
-    <SplitButtonWithNotification secondaryButtonIcon={DEFAULT_SECONDARY_ICON} {...args}>
-      Save
-    </SplitButtonWithNotification>
-  ),
-};
-
-export const WithCustomColorIndicator = {
-  name: 'With custom color indicator',
-  args: {
-    showNotificationIndicator: true,
-    notificationIndicatorColor: 'success',
-    notifcationIndicatorTooltipContent: 'You have unsaved changes',
-    size: 'm',
-  },
-  render: (args: {
-    showNotificationIndicator: boolean;
     notificationIndicatorColor: React.ComponentProps<
       typeof SplitButtonWithNotification
     >['notificationIndicatorColor'];
-    notifcationIndicatorTooltipContent: string;
+    notificationIndicatorSize: React.ComponentProps<
+      typeof SplitButtonWithNotification
+    >['notificationIndicatorSize'];
     size: React.ComponentProps<typeof SplitButton>['size'];
   }) => (
     <SplitButtonWithNotification secondaryButtonIcon={DEFAULT_SECONDARY_ICON} {...args}>

--- a/src/platform/packages/private/kbn-split-button/src/split_button.stories.tsx
+++ b/src/platform/packages/private/kbn-split-button/src/split_button.stories.tsx
@@ -207,7 +207,7 @@ export const WithNotificationIndicator = {
     >['notificationIndicatorSize'];
     size: React.ComponentProps<typeof SplitButton>['size'];
   }) => (
-    <SplitButtonWithNotification secondaryButtonIcon={DEFAULT_SECONDARY_ICON} {...args}>
+    <SplitButtonWithNotification secondaryButtonIcon="arrowDown" {...args}>
       Save
     </SplitButtonWithNotification>
   ),

--- a/src/platform/packages/private/kbn-split-button/src/split_button_with_notification.tsx
+++ b/src/platform/packages/private/kbn-split-button/src/split_button_with_notification.tsx
@@ -8,19 +8,27 @@
  */
 
 import React from 'react';
-import { EuiIconTip, euiButtonSizeMap, useEuiTheme, type IconColor } from '@elastic/eui';
+import {
+  EuiIconTip,
+  euiButtonSizeMap,
+  useEuiTheme,
+  type IconColor,
+  type IconSize,
+} from '@elastic/eui';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { SplitButton, type SplitButtonProps } from './split_button';
 
 export type SplitButtonWithNotificationProps = SplitButtonProps & {
   showNotificationIndicator?: boolean;
   notificationIndicatorColor?: IconColor;
+  notificationIndicatorSize?: IconSize;
   notifcationIndicatorTooltipContent?: string;
 };
 
 export const SplitButtonWithNotification = ({
   showNotificationIndicator = false,
-  notificationIndicatorColor,
+  notificationIndicatorColor = 'primary',
+  notificationIndicatorSize = 'l',
   notifcationIndicatorTooltipContent,
   ...splitButtonProps
 }: SplitButtonWithNotificationProps) => {
@@ -34,9 +42,7 @@ export const SplitButtonWithNotification = ({
    * */
   const size = splitButtonProps?.size ?? 'm';
   const buttonSizes = euiButtonSizeMap(euiThemeContext);
-  const secondaryButtonWidth = buttonSizes[size].height;
-
-  const notificationColor = notificationIndicatorColor || euiThemeContext.euiTheme.colors.primary;
+  const secondaryButtonWidth = buttonSizes[size]?.height;
 
   return (
     <div css={styles.buttonWrapper}>
@@ -54,9 +60,9 @@ export const SplitButtonWithNotification = ({
           <EuiIconTip
             type="dot"
             iconProps={{
-              color: notificationColor,
+              color: notificationIndicatorColor,
             }}
-            size="l"
+            size={notificationIndicatorSize}
             content={notifcationIndicatorTooltipContent}
           />
         </div>

--- a/src/platform/packages/private/kbn-split-button/src/split_button_with_notification.tsx
+++ b/src/platform/packages/private/kbn-split-button/src/split_button_with_notification.tsx
@@ -59,10 +59,8 @@ export const SplitButtonWithNotification = ({
         >
           <EuiIconTip
             type="dot"
-            iconProps={{
-              color: notificationIndicatorColor,
-            }}
             size={notificationIndicatorSize}
+            color={notificationIndicatorColor}
             content={notifcationIndicatorTooltipContent}
           />
         </div>


### PR DESCRIPTION
## Summary

This PR adds the ability to change size of notification indicator for `SplitButtonWithNotification`. 
It also simplifies Storybook as the color story shouldn't really be a separate one and It also adds optional chaining to `secondaryButtonWidth` because without it, Storybook would crash when trying to change button size.

Closes: https://github.com/elastic/kibana/issues/244941



