### PR TITLE
[ML] Inference/AI Connector and Inference endpoint creation providers: adds icon for Groq

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/providers/assets/images/grok.svg
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/providers/assets/images/grok.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 2000">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #f3f3ee;
+      }
+
+      .cls-2 {
+        fill: #f43e01;
+      }
+    </style>
+  </defs>
+  <rect class="cls-2" width="2009.11" height="2001.94"/>
+  <polygon class="cls-1" points="960.05 1127.97 607.8 1127.97 1185.91 404.89 1040 872.02 1392.2 872.02 814.14 1595.11 960.05 1127.97"/>
+</svg>

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/providers/render_service_provider/service_provider.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/providers/render_service_provider/service_provider.tsx
@@ -35,6 +35,7 @@ import ai21Icon from '../assets/images/ai21_labs_default.svg';
 import llamaIcon from '../assets/images/llama_stack_default.svg';
 import defaultIcon from '../assets/images/default_connector_icon.svg';
 import contextualAiIcon from '../assets/images/contextual_ai_icon.svg';
+import groqIcon from '../assets/images/grok.svg';
 
 interface ServiceProviderProps {
   providerKey: ServiceProviderKeys;
@@ -163,6 +164,11 @@ export const SERVICE_PROVIDERS: Record<ServiceProviderKeys, ServiceProviderRecor
   [ServiceProviderKeys.llama]: {
     icon: llamaIcon,
     name: 'Llama Stack',
+    solutions: ['Search'],
+  },
+  [ServiceProviderKeys.groq]: {
+    icon: groqIcon,
+    name: 'Groq',
     solutions: ['Search'],
   },
 };

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/providers/render_service_provider/service_provider.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/providers/render_service_provider/service_provider.tsx
@@ -169,7 +169,7 @@ export const SERVICE_PROVIDERS: Record<ServiceProviderKeys, ServiceProviderRecor
   [ServiceProviderKeys.groq]: {
     icon: groqIcon,
     name: 'Groq',
-    solutions: ['Search'],
+    solutions: ['Observability', 'Security', 'Search'],
   },
 };
 

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/constants.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/constants.tsx
@@ -23,6 +23,7 @@ export enum ServiceProviderKeys {
   elasticsearch = 'elasticsearch',
   googleaistudio = 'googleaistudio',
   googlevertexai = 'googlevertexai',
+  groq = 'groq',
   hugging_face = 'hugging_face',
   jinaai = 'jinaai',
   mistral = 'mistral',

--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
@@ -7026,6 +7026,12 @@
               "_meta": {
                 "description": "The number of inference connectors created using the Contextual AI provider."
               }
+            },
+            "groq": {
+              "type": "long",
+              "_meta": {
+                "description": "The number of inference connectors created using the Groq provider."
+              }
             }
           }
         }

--- a/x-pack/platform/plugins/shared/stack_connectors/server/usage/inference/inference_connectors_usage_collector.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/usage/inference/inference_connectors_usage_collector.ts
@@ -156,6 +156,12 @@ const PROVIDER_SCHEMA: Record<ServiceProviderKeys, ProviderTelemetryField> = {
       description: 'The number of inference connectors created using the Contextual AI provider.',
     },
   },
+  groq: {
+    type: 'long',
+    _meta: {
+      description: 'The number of inference connectors created using the Groq provider.',
+    },
+  },
 };
 
 export function registerInferenceConnectorsUsageCollector(


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/243696

Groq will be added to the Inference API in https://github.com/elastic/elasticsearch/pull/138251 with the service name `groq`.
This PR adds the `groq` icon to the providers list shown in the AI Connector and inference endpoint creation providers list and updates telemetry.

<img width="893" height="577" alt="image" src="https://github.com/user-attachments/assets/7e03144f-9f32-42d9-b423-7f79d48020a3" />

<img width="894" height="416" alt="image" src="https://github.com/user-attachments/assets/fc4d4ed4-8ea4-4f4b-8440-a0a7e9c1cb8b" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



