### PR TITLE
Move access_control to data

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/access_control_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/access_control_manager.ts
@@ -18,8 +18,8 @@ export function initializeAccessControlManager(
   savedObjectId$?: BehaviorSubject<string | undefined>
 ) {
   const accessControl$ = new BehaviorSubject<Partial<SavedObjectAccessControl>>({
-    owner: savedObjectResult?.meta?.access_control?.owner,
-    accessMode: savedObjectResult?.meta?.access_control?.access_mode,
+    owner: savedObjectResult?.data?.access_control?.owner,
+    accessMode: savedObjectResult?.data?.access_control?.access_mode,
   });
 
   async function changeAccessMode(accessMode: SavedObjectAccessControl['accessMode']) {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -73,8 +73,8 @@ export function getDashboardApi({
     isManaged,
     savedObjectId,
     accessControl: {
-      accessMode: readResult?.meta?.access_control?.access_mode,
-      owner: readResult?.meta?.access_control?.owner,
+      accessMode: readResult?.data?.access_control?.access_mode,
+      owner: readResult?.data?.access_control?.owner,
     },
     createdBy: readResult?.meta?.createdBy,
     user,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_client/dashboard_client.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_client/dashboard_client.ts
@@ -36,12 +36,6 @@ export const dashboardClient = {
     references: Reference[],
     accessMode?: SavedObjectAccessControl['accessMode']
   ) => {
-    const accessControl = accessMode
-      ? {
-          access_control: { access_mode: accessMode },
-        }
-      : undefined;
-
     return coreServices.http.post<DashboardCreateResponseBody>(`/api/dashboards/dashboard`, {
       version: DASHBOARD_API_VERSION,
       query: {
@@ -50,7 +44,7 @@ export const dashboardClient = {
       body: JSON.stringify({
         data: {
           ...dashboardState,
-          accessControl,
+          ...(accessMode && { access_control: { access_mode: accessMode } }),
           references,
         },
       }),

--- a/src/platform/plugins/shared/dashboard/public/dashboard_client/dashboard_client.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_client/dashboard_client.ts
@@ -36,6 +36,12 @@ export const dashboardClient = {
     references: Reference[],
     accessMode?: SavedObjectAccessControl['accessMode']
   ) => {
+    const accessControl = accessMode
+      ? {
+          access_control: { access_mode: accessMode },
+        }
+      : undefined;
+
     return coreServices.http.post<DashboardCreateResponseBody>(`/api/dashboards/dashboard`, {
       version: DASHBOARD_API_VERSION,
       query: {
@@ -44,13 +50,9 @@ export const dashboardClient = {
       body: JSON.stringify({
         data: {
           ...dashboardState,
+          accessControl,
           references,
         },
-        meta: accessMode
-          ? {
-              access_control: { access_mode: accessMode },
-            }
-          : undefined,
       }),
     });
   },

--- a/src/platform/plugins/shared/dashboard/public/dashboard_client/dashboard_client.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_client/dashboard_client.ts
@@ -95,6 +95,7 @@ export const dashboardClient = {
     });
   },
   update: async (id: string, dashboardState: DashboardState, references: Reference[]) => {
+    const { access_control: accessControl, ...restOfData } = dashboardState;
     const updateResponse = await coreServices.http.put<DashboardUpdateResponseBody>(
       `/api/dashboards/dashboard/${id}`,
       {
@@ -104,7 +105,7 @@ export const dashboardClient = {
         },
         body: JSON.stringify({
           data: {
-            ...dashboardState,
+            ...restOfData,
             references,
           },
         }),

--- a/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.tsx
@@ -239,8 +239,8 @@ export const useDashboardListingTable = ({
                 isGloballyAuthorized ||
                 accessControlClient.checkUserAccessControl({
                   accessControl: {
-                    owner: meta?.access_control?.owner,
-                    accessMode: meta?.access_control?.access_mode,
+                    owner: data?.access_control?.owner,
+                    accessMode: data?.access_control?.access_mode,
                   },
                   createdBy: meta.createdBy,
                   userId,
@@ -261,7 +261,7 @@ export const useDashboardListingTable = ({
                   timeRestore: Boolean(data.timeRange),
                 },
                 canManageAccessControl,
-                accessMode: meta?.access_control?.access_mode,
+                accessMode: data?.access_control?.access_mode,
               } as DashboardSavedObjectUserContent;
             }),
           };

--- a/src/platform/plugins/shared/dashboard/server/api/create/create.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/create/create.ts
@@ -21,12 +21,13 @@ export async function create(
   createBody: DashboardCreateRequestBody
 ): Promise<DashboardCreateResponseBody> {
   const { core } = await requestCtx.resolve(['core']);
+  const { access_control: accessControl, ...restOfData } = createBody.data;
 
   const {
     attributes: soAttributes,
     references: soReferences,
     error: transformInError,
-  } = transformDashboardIn(createBody.data);
+  } = transformDashboardIn(restOfData);
   if (transformInError) {
     throw Boom.badRequest(`Invalid data. ${transformInError.message}`);
   }

--- a/src/platform/plugins/shared/dashboard/server/api/create/create.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/create/create.ts
@@ -32,6 +32,8 @@ export async function create(
     throw Boom.badRequest(`Invalid data. ${transformInError.message}`);
   }
 
+  const isAccessControlEnabled = core.savedObjects.typeRegistry.isAccessControlEnabled();
+
   const savedObject = await core.savedObjects.client.create<DashboardSavedObjectAttributes>(
     DASHBOARD_SAVED_OBJECT_TYPE,
     soAttributes,
@@ -39,6 +41,10 @@ export async function create(
       references: soReferences,
       ...(createBody.id && { id: createBody.id }),
       ...(createBody.spaces && { initialNamespaces: createBody.spaces }),
+      ...(createBody.data?.access_control?.access_mode &&
+        isAccessControlEnabled && {
+          accessControl: { accessMode: createBody.data.access_control.access_mode },
+        }),
     }
   );
 

--- a/src/platform/plugins/shared/dashboard/server/api/create/create.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/create/create.ts
@@ -40,9 +40,9 @@ export async function create(
       references: soReferences,
       ...(createBody.id && { id: createBody.id }),
       ...(createBody.spaces && { initialNamespaces: createBody.spaces }),
-      ...(createBody.meta?.access_control?.access_mode &&
+      ...(createBody.data?.access_control?.access_mode &&
         isAccessControlEnabled && {
-          accessControl: { accessMode: createBody.meta.access_control.access_mode },
+          accessControl: { accessMode: createBody.data.access_control.access_mode },
         }),
     }
   );

--- a/src/platform/plugins/shared/dashboard/server/api/create/create.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/create/create.ts
@@ -31,8 +31,6 @@ export async function create(
     throw Boom.badRequest(`Invalid data. ${transformInError.message}`);
   }
 
-  const isAccessControlEnabled = core.savedObjects.typeRegistry.isAccessControlEnabled();
-
   const savedObject = await core.savedObjects.client.create<DashboardSavedObjectAttributes>(
     DASHBOARD_SAVED_OBJECT_TYPE,
     soAttributes,
@@ -40,10 +38,6 @@ export async function create(
       references: soReferences,
       ...(createBody.id && { id: createBody.id }),
       ...(createBody.spaces && { initialNamespaces: createBody.spaces }),
-      ...(createBody.data?.access_control?.access_mode &&
-        isAccessControlEnabled && {
-          accessControl: { accessMode: createBody.data.access_control.access_mode },
-        }),
     }
   );
 

--- a/src/platform/plugins/shared/dashboard/server/api/create/create.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/create/create.ts
@@ -41,9 +41,11 @@ export async function create(
       references: soReferences,
       ...(createBody.id && { id: createBody.id }),
       ...(createBody.spaces && { initialNamespaces: createBody.spaces }),
-      ...(createBody.data?.access_control?.access_mode &&
+      ...(accessControl?.access_mode &&
         isAccessControlEnabled && {
-          accessControl: { accessMode: createBody.data.access_control.access_mode },
+          accessControl: {
+            accessMode: accessControl.access_mode ?? 'default',
+          },
         }),
     }
   );

--- a/src/platform/plugins/shared/dashboard/server/api/create/schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/create/schemas.ts
@@ -9,19 +9,13 @@
 
 import { schema } from '@kbn/config-schema';
 import { getDashboardStateSchema } from '../dashboard_state_schemas';
-import {
-  accessMetaSchema,
-  baseMetaSchema,
-  createdMetaSchema,
-  updatedMetaSchema,
-} from '../meta_schemas';
+import { baseMetaSchema, createdMetaSchema, updatedMetaSchema } from '../meta_schemas';
 
 export function getCreateRequestBodySchema() {
   return schema.object({
     id: schema.maybe(schema.string()),
     data: getDashboardStateSchema(),
     spaces: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1, maxSize: 1 })),
-    meta: schema.maybe(accessMetaSchema),
   });
 }
 
@@ -29,7 +23,7 @@ export function getCreateResponseBodySchema() {
   return schema.object({
     id: schema.string(),
     data: getDashboardStateSchema(),
-    meta: schema.allOf([baseMetaSchema, createdMetaSchema, updatedMetaSchema, accessMetaSchema]),
+    meta: schema.allOf([baseMetaSchema, createdMetaSchema, updatedMetaSchema]),
     spaces: schema.maybe(schema.arrayOf(schema.string())),
   });
 }

--- a/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
@@ -176,5 +176,13 @@ export function getDashboardStateSchema() {
     timeRange: schema.maybe(timeRangeSchema),
     title: schema.string({ meta: { description: 'A human-readable title for the dashboard' } }),
     version: schema.maybe(schema.number({ meta: { deprecated: true } })),
+    access_control: schema.maybe(
+      schema.object({
+        owner: schema.maybe(schema.string()),
+        access_mode: schema.maybe(
+          schema.oneOf([schema.literal('write_restricted'), schema.literal('default')])
+        ),
+      })
+    ),
   });
 }

--- a/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
@@ -144,6 +144,15 @@ export const optionsSchema = schema.object({
   ),
 });
 
+export const accessControlSchema = schema.maybe(
+  schema.object({
+    owner: schema.maybe(schema.string()),
+    access_mode: schema.maybe(
+      schema.oneOf([schema.literal('write_restricted'), schema.literal('default')])
+    ),
+  })
+);
+
 export function getDashboardStateSchema() {
   return schema.object({
     // unsuppoted "as code" keys
@@ -176,13 +185,6 @@ export function getDashboardStateSchema() {
     timeRange: schema.maybe(timeRangeSchema),
     title: schema.string({ meta: { description: 'A human-readable title for the dashboard' } }),
     version: schema.maybe(schema.number({ meta: { deprecated: true } })),
-    access_control: schema.maybe(
-      schema.object({
-        owner: schema.maybe(schema.string()),
-        access_mode: schema.maybe(
-          schema.oneOf([schema.literal('write_restricted'), schema.literal('default')])
-        ),
-      })
-    ),
+    access_control: accessControlSchema,
   });
 }

--- a/src/platform/plugins/shared/dashboard/server/api/meta_schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/meta_schemas.ts
@@ -22,17 +22,6 @@ export const baseMetaSchema = schema.object({
   version: schema.maybe(schema.string()),
 });
 
-export const accessMetaSchema = schema.object({
-  access_control: schema.maybe(
-    schema.object({
-      owner: schema.maybe(schema.string()),
-      access_mode: schema.maybe(
-        schema.oneOf([schema.literal('write_restricted'), schema.literal('default')])
-      ),
-    })
-  ),
-});
-
 export const createdMetaSchema = schema.object({
   createdAt: schema.maybe(schema.string()),
   createdBy: schema.maybe(schema.string()),

--- a/src/platform/plugins/shared/dashboard/server/api/read/schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/read/schemas.ts
@@ -10,7 +10,6 @@
 import { schema } from '@kbn/config-schema';
 import { getDashboardStateSchema } from '../dashboard_state_schemas';
 import {
-  accessMetaSchema,
   baseMetaSchema,
   createdMetaSchema,
   resolveMetaSchema,
@@ -21,13 +20,7 @@ export function getReadResponseBodySchema() {
   return schema.object({
     id: schema.string(),
     data: getDashboardStateSchema(),
-    meta: schema.allOf([
-      baseMetaSchema,
-      createdMetaSchema,
-      updatedMetaSchema,
-      resolveMetaSchema,
-      accessMetaSchema,
-    ]),
+    meta: schema.allOf([baseMetaSchema, createdMetaSchema, updatedMetaSchema, resolveMetaSchema]),
     spaces: schema.maybe(schema.arrayOf(schema.string())),
     warnings: schema.maybe(schema.arrayOf(schema.string())),
   });

--- a/src/platform/plugins/shared/dashboard/server/api/saved_object_utils.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/saved_object_utils.ts
@@ -30,12 +30,6 @@ export function getDashboardMeta(
       createdAt: savedObject.created_at,
       createdBy: savedObject.created_by,
     }),
-    ...(savedObject.accessControl && {
-      access_control: {
-        access_mode: savedObject.accessControl.accessMode,
-        owner: savedObject.accessControl.owner,
-      },
-    }),
   };
 }
 

--- a/src/platform/plugins/shared/dashboard/server/api/saved_object_utils.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/saved_object_utils.ts
@@ -56,6 +56,12 @@ export function getDashboardCRUResponseBody(
     id: savedObject.id,
     data: {
       ...dashboardState,
+      ...(savedObject?.accessControl && {
+        access_control: {
+          access_mode: savedObject.accessControl.accessMode,
+          owner: savedObject.accessControl.owner,
+        },
+      }),
       references,
     },
     meta: getDashboardMeta(savedObject, operation),

--- a/src/platform/plugins/shared/dashboard/server/api/search/schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/search/schemas.ts
@@ -9,12 +9,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { timeRangeSchema } from '@kbn/es-query-server';
-import {
-  baseMetaSchema,
-  createdMetaSchema,
-  updatedMetaSchema,
-  accessMetaSchema,
-} from '../meta_schemas';
+import { baseMetaSchema, createdMetaSchema, updatedMetaSchema } from '../meta_schemas';
 
 export const searchRequestBodySchema = schema.object({
   page: schema.maybe(
@@ -56,8 +51,16 @@ export const searchResponseBodySchema = schema.object({
         tags: schema.maybe(schema.arrayOf(schema.string())),
         timeRange: schema.maybe(timeRangeSchema),
         title: schema.string(),
+        access_control: schema.maybe(
+          schema.object({
+            owner: schema.maybe(schema.string()),
+            access_mode: schema.maybe(
+              schema.oneOf([schema.literal('write_restricted'), schema.literal('default')])
+            ),
+          })
+        ),
       }),
-      meta: schema.allOf([baseMetaSchema, createdMetaSchema, updatedMetaSchema, accessMetaSchema]),
+      meta: schema.allOf([baseMetaSchema, createdMetaSchema, updatedMetaSchema]),
     })
   ),
   total: schema.number(),

--- a/src/platform/plugins/shared/dashboard/server/api/search/schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/search/schemas.ts
@@ -9,6 +9,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { timeRangeSchema } from '@kbn/es-query-server';
+import { accessControlSchema } from '../dashboard_state_schemas';
 import { baseMetaSchema, createdMetaSchema, updatedMetaSchema } from '../meta_schemas';
 
 export const searchRequestBodySchema = schema.object({
@@ -51,14 +52,7 @@ export const searchResponseBodySchema = schema.object({
         tags: schema.maybe(schema.arrayOf(schema.string())),
         timeRange: schema.maybe(timeRangeSchema),
         title: schema.string(),
-        access_control: schema.maybe(
-          schema.object({
-            owner: schema.maybe(schema.string()),
-            access_mode: schema.maybe(
-              schema.oneOf([schema.literal('write_restricted'), schema.literal('default')])
-            ),
-          })
-        ),
+        access_control: accessControlSchema,
       }),
       meta: schema.allOf([baseMetaSchema, createdMetaSchema, updatedMetaSchema]),
     })

--- a/src/platform/plugins/shared/dashboard/server/api/search/search.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/search/search.ts
@@ -40,10 +40,13 @@ export async function search(
 
   return {
     dashboards: soResponse.saved_objects.map((so) => {
-      const { description, tags, timeRange, title } = transformDashboardOut(
-        so.attributes,
-        so.references
-      );
+      const {
+        description,
+        tags,
+        timeRange,
+        title,
+        access_control: accessControl,
+      } = transformDashboardOut(so.attributes, so.references);
 
       return {
         id: so.id,
@@ -51,6 +54,7 @@ export async function search(
           ...(description && { description }),
           ...(tags && { tags }),
           ...(timeRange && { timeRange }),
+          ...(accessControl && { access_control: accessControl }),
           title: title ?? '',
         },
         meta: getDashboardMeta(so, 'search'),

--- a/src/platform/plugins/shared/dashboard/server/api/search/search.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/search/search.ts
@@ -51,6 +51,12 @@ export async function search(
           ...(description && { description }),
           ...(tags && { tags }),
           ...(timeRange && { timeRange }),
+          ...(so?.accessControl && {
+            access_control: {
+              owner: so.accessControl.owner,
+              access_mode: so.accessControl.accessMode,
+            },
+          }),
           title: title ?? '',
         },
         meta: getDashboardMeta(so, 'search'),

--- a/src/platform/plugins/shared/dashboard/server/api/search/search.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/search/search.ts
@@ -40,13 +40,10 @@ export async function search(
 
   return {
     dashboards: soResponse.saved_objects.map((so) => {
-      const {
-        description,
-        tags,
-        timeRange,
-        title,
-        access_control: accessControl,
-      } = transformDashboardOut(so.attributes, so.references);
+      const { description, tags, timeRange, title } = transformDashboardOut(
+        so.attributes,
+        so.references
+      );
 
       return {
         id: so.id,
@@ -54,7 +51,6 @@ export async function search(
           ...(description && { description }),
           ...(tags && { tags }),
           ...(timeRange && { timeRange }),
-          ...(accessControl && { access_control: accessControl }),
           title: title ?? '',
         },
         meta: getDashboardMeta(so, 'search'),


### PR DESCRIPTION
## Summary

This PR moves access_control to data from meta.

Closes: https://github.com/elastic/kibana/issues/244992
