### PR TITLE
[9.2] Remove expr-eval from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1257,7 +1257,6 @@
     "eventsource-parser": "^3.0.0",
     "execa": "^5.1.1",
     "exponential-backoff": "^3.1.1",
-    "expr-eval": "^2.0.2",
     "extract-zip": "^2.0.1",
     "fast-deep-equal": "^3.1.3",
     "fastest-levenshtein": "^1.0.16",


### PR DESCRIPTION
## Summary

expr-eval is not used directly, it should be removed from package.json

