### PR TITLE
[8.19] Renaming obs infra services to obs presentation (#244861)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1117,13 +1117,17 @@ src/platform/packages/shared/kbn-zod-helpers @elastic/security-detection-rule-ma
 # The #CC# prefix delineates Code Coverage,
 # used for the 'team' designator within Kibana Stats
 
-/x-pack/solutions/observability/test/api_integration/apis/metrics_ui @elastic/obs-ux-infra_services-team
+/x-pack/solutions/observability/test/api_integration/apis/metrics_ui @elastic/obs-presentation-team
 x-pack/platform/test/serverless/api_integration/test_suites/platform_security @elastic/kibana-security
 
 # Observability Entities Team (@elastic/obs-entities)
 /x-pack/plugins/observability_solution/entities_data_access @elastic/obs-entities
 /x-pack/platform/test/api_integration/apis/entity_manager/fixture_plugin @elastic/obs-entities
 /x-pack/platform/test/api_integration/apis/entity_manager @elastic/obs-entities
+# Metrics Experience
+/src/platform/plugins/shared/metrics_experience @elastic/obs-presentation-team
+/src/platform/test/api_integration/apis/metrics_experience @elastic/obs-presentation-team
+/src/platform/test/api_integration/fixtures/es_archiver/metrics_experience @elastic/obs-presentation-team
 
 # Data Discovery
 /x-pack/platform/test/api_integration/services/data_view_api.ts @elastic/kibana-data-discovery
@@ -1155,10 +1159,15 @@ src/platform/plugins/shared/discover/public/context_awareness/profile_providers/
 src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security @elastic/kibana-data-discovery @elastic/security-threat-hunting-investigations
 # TODO: this deprecation_logs folder should be owned by kibana management team after 9.0
 src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/deprecation_logs @elastic/kibana-data-discovery @elastic/kibana-core
-src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability @elastic/kibana-data-discovery @elastic/obs-exploration-team
-src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile @elastic/obs-ux-infra_services-team
-src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile @elastic/obs-ux-infra_services-team
-src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile @elastic/obs-exploration-team @elastic/obs-ux-infra_services-team
+/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/metrics_data_source_profile @elastic/obs-presentation-team
+/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/deprecation_logs_data_source_profile @elastic/kibana-data-discovery @elastic/kibana-core
+/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/patterns_data_source_profile @elastic/ml-ui
+/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability @elastic/kibana-data-discovery @elastic/obs-exploration-team
+/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_document_profile @elastic/obs-presentation-team
+/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile @elastic/obs-exploration-team @elastic/obs-presentation-team
+/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile @elastic/obs-presentation-team
+/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile @elastic/obs-presentation-team
+/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security @elastic/kibana-data-discovery @elastic/security-threat-hunting-investigations
 
 # Platform Docs
 /x-pack/test_serverless/functional/test_suites/security/screenshot_creation/index.ts @elastic/platform-docs
@@ -1216,7 +1225,9 @@ packages/kbn-monaco/src/esql @elastic/kibana-esql
 # ES|QL
 /src/platform/test/api_integration/apis/esql/*.ts @elastic/kibana-esql
 /src/platform/test/functional/services/esql.ts @elastic/kibana-esql
-x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions @elastic/obs-ux-infra_services-team @elastic/obs-exploration-team
+/src/platform/test/functional/page_objects/index_editor.ts @elastic/kibana-esql
+/src/platform/packages/shared/kbn-monaco/src/languages/esql @elastic/kibana-esql
+x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions @elastic/obs-presentation-team @elastic/obs-exploration-team
 
 # Global Experience
 
@@ -1304,51 +1315,53 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 ## To keep @elastic/obs-onboarding-team as codeowner of the plugin manifest without requiring a review for all the other code changes
 ## the priority on codeownership will be as follow:
 ## - infra -> both teams (automatically generated by script)
-## - infra/{common,docs,public,server}/{sub-folders}/ -> @elastic/obs-ux-infra_services-team
-## - Logs UI code exceptions -> @elastic/obs-onboarding-team
-## This should allow the infra team to work without dependencies on the @elastic/obs-onboarding-team, which will maintain ownership of the Logs UI code only.
+## - infra/{common,docs,public,server}/{sub-folders}/ -> @elastic/obs-presentation-team
+## - Logs UI code exceptions -> @elastic/obs-exploration-team
+## This should allow the infra team to work without dependencies on the @elastic/obs-exploration-team, which will maintain ownership of the Logs UI code only.
 
-## infra/{common,docs,public,server}/{sub-folders}/ -> @elastic/obs-ux-infra_services-team
+## infra/{common,docs,public,server}/{sub-folders}/ -> @elastic/obs-presentation-team
 # obs-ux-infra_services-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/ @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.index.ts @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.index.ts @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/infra/ @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.index.ts @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.serverless.config.ts @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.index.ts @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.stateful.config.ts @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/functional/page_objects/asset_details.ts @elastic/obs-ux-infra_services-team # Assigned per https://github.com/elastic/kibana/pull/200157/files/c83fae62151fe634342c498aca69b686b739fe45#r1842202022
-/x-pack/solutions/observability/test/functional/page_objects/infra_* @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/fixtures/es_archives/infra @elastic/obs-ux-infra_services-team
-/x-pack/test_serverless/**/test_suites/observability/infra/ @elastic/obs-ux-infra_services-team
-^/src/platform/test/common/plugins/otel_metrics @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/common @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/docs @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/public/alerting @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/public/apps @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/public/common @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/public/components @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/public/containers @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/public/hooks @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/public/images @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/public/lib @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/public/pages @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/public/services @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/public/test_utils @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/public/utils @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/server/lib @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/server/routes @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/server/saved_objects @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/server/services @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/server/usage @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/infra/server/utils @elastic/obs-ux-infra_services-team
-/x-pack/test_serverless/functional/test_suites/observability/infra @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/plugins/observability/public/pages/overview @elastic/obs-ux-infra_services-team # Assigned to this team since it mostly uses infra/APM components
-/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces @elastic/obs-ux-infra_services-team
-/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes @elastic/obs-ux-infra_services-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/ @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.index.ts @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.index.ts @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/infra/ @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.index.ts @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.serverless.config.ts @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.index.ts @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.stateful.config.ts @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/functional/page_objects/asset_details.ts @elastic/obs-presentation-team # Assigned per https://github.com/elastic/kibana/pull/200157/files/c83fae62151fe634342c498aca69b686b739fe45#r1842202022
+/x-pack/solutions/observability/test/functional/page_objects/infra_* @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/fixtures/es_archives/infra @elastic/obs-presentation-team
+/src/platform/test/common/plugins/otel_metrics @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/common @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/docs @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/public/alerting @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/public/apps @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/public/common @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/public/components @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/public/containers @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/public/hooks @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/public/images @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/public/lib @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/public/pages @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/public/services @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/public/test_utils @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/public/utils @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/server/lib @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/server/routes @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/server/saved_objects @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/server/services @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/server/usage @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/infra/server/utils @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/serverless/functional/test_suites/infra @elastic/obs-presentation-team
+/x-pack/solutions/observability/plugins/observability/public/pages/overview @elastic/obs-presentation-team # Assigned to this team since it mostly uses infra/APM components
+/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces @elastic/obs-presentation-team
+/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/generic @elastic/obs-presentation-team
+/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/attributes @elastic/obs-presentation-team
+/src/platform/plugins/shared/unified_doc_viewer/public/components/content_framework @elastic/obs-presentation-team
+/src/platform/packages/shared/kbn-unified-metrics-grid @elastic/obs-presentation-team
 
 
 ## Logs UI code exceptions -> @elastic/obs-onboarding-team
@@ -1374,10 +1387,10 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/infra/server/lib/log_analysis @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/routes/log_alerts @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/routes/log_analysis @elastic/obs-exploration-team
-/x-pack/solutions/observability/plugins/infra/server/services/rules @elastic/obs-ux-infra_services-team @elastic/obs-exploration-team
-/x-pack/solutions/observability/test/common/utils/synthtrace @elastic/obs-ux-infra_services-team @elastic/obs-exploration-team
-/x-pack/solutions/observability/test/common/utils/server_route_repository @elastic/obs-knowledge-team
-/src/platform/test/functional/services/synthtrace/logs_synthtrace_es_client.ts @elastic/obs-ux-infra_services-team @elastic/obs-onboarding-team @elastic/obs-exploration-team
+/x-pack/solutions/observability/plugins/infra/server/services/rules @elastic/obs-presentation-team @elastic/obs-exploration-team
+/x-pack/solutions/observability/test/common/utils/synthtrace @elastic/obs-presentation-team @elastic/obs-exploration-team
+/x-pack/platform/test/common/utils/server_route_repository @elastic/obs-knowledge-team
+/src/platform/test/functional/services/synthtrace/logs_synthtrace_es_client.ts @elastic/obs-presentation-team @elastic/obs-exploration-team
 
 ## Streams parts owned by Logs UX
 /x-pack/platform/plugins/shared/streams/server/routes/streams/processing @elastic/obs-onboarding-team
@@ -1385,11 +1398,10 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/plugins/shared/streams_app/public/components/data_management @elastic/obs-onboarding-team
 
 # Infra Monitoring tests
-/x-pack/solutions/observability/test/api_integration/apis/infra @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/functional/apps/infra @elastic/obs-ux-infra_services-team
+/x-pack/solutions/observability/test/functional/apps/infra @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/functional/apps/infra/logs @elastic/obs-exploration-team
-/x-pack/solutions/observability/test/api_integration/services/index.ts @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/api_integration/services/infra_log_views.ts @elastic/obs-ux-infra_services-team
+/x-pack/solutions/observability/test/api_integration/services/index.ts @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/api_integration/services/infra_log_views.ts @elastic/obs-presentation-team
 
 # Observability UX management team
 /src/platform/test/api_integration/apis/suggestions  @elastic/obs-ux-management-team # Assigned per https://github.com/elastic/kibana/pull/200950#discussion_r1853705079
@@ -1451,17 +1463,17 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/serverless/api_integration/services/default_fleet_setup.ts @elastic/fleet
 
 # APM
-/x-pack/platform/test/stack_functional_integration/apps/apm @elastic/obs-ux-infra_services-team @elastic/obs-onboarding-team
-/x-pack/platform/test/api_integration/services/apm_synthtrace_kibana_client.ts @elastic/obs-ux-infra_services-team @elastic/obs-onboarding-team @elastic/obs-exploration-team
-/src/platform/test/api_integration/apis/ui_metric/*.ts @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/functional/apps/apm/ @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/api_integration/apm/ @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/apm_cypress/ @elastic/obs-ux-infra_services-team
+/x-pack/platform/test/api_integration/services/apm_synthtrace_kibana_client.ts @elastic/obs-presentation-team @elastic/obs-onboarding-team @elastic/obs-exploration-team
+/x-pack/platform/test/stack_functional_integration/apps/apm @elastic/obs-presentation-team
+/src/platform/test/api_integration/apis/ui_metric/*.ts @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/functional/apps/apm/ @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/api_integration/apm/ @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/apm_cypress/ @elastic/obs-presentation-team
 /src/apm.js @elastic/kibana-core @vigneshshanmugam
 /src/platform/packages/shared/kbn-utility-types/src/dot.ts @dgieselaar
 /src/platform/packages/shared/kbn-utility-types/src/dot_test.ts @dgieselaar
-/x-pack/test_serverless/api_integration/test_suites/observability/apm_api_integration/ @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/apm_api_integration/ @elastic/obs-ux-infra_services-team
+/x-pack/solutions/observability/test/serverless/api_integration/test_suites/apm_api_integration/ @elastic/obs-presentation-team
+/x-pack/solutions/observability/test/apm_api_integration/ @elastic/obs-presentation-team
 #CC# /src/plugins/apm_oss/ @elastic/apm-ui
 #CC# /x-pack/plugins/observability_solution/observability/ @elastic/apm-ui
 
@@ -1488,11 +1500,9 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/fixtures/es_archives/observability_logs_explorer @elastic/obs-exploration-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/dataset_quality @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/functional/page_objects/dataset_quality.ts @elastic/obs-onboarding-team
-/x-pack/test_serverless/functional/test_suites/observability/index* @elastic/obs-onboarding-team
-/x-pack/test_serverless/functional/test_suites/observability/cypress @elastic/obs-onboarding-team
-/x-pack/solutions/observability/test/functional/services/infra_source_configuration_form.ts @elastic/obs-ux-infra_services-team
-/x-pack/solutions/observability/test/functional/services/logs_ui @elastic/obs-exploration-team
-/x-pack/solutions/observability/test/functional/page_objects/observability_logs_explorer.ts @elastic/obs-exploration-team
+/x-pack/solutions/observability/test/serverless/functional/configs/index* @elastic/obs-onboarding-team
+/x-pack/solutions/observability/test/serverless/functional/test_suites/cypress @elastic/obs-onboarding-team
+/x-pack/solutions/observability/test/functional/services/infra_source_configuration_form.ts @elastic/obs-presentation-team
 /src/platform/test/functional/services/selectable.ts @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/observability_onboarding_api_integration @elastic/obs-onboarding-team
 /x-pack/test_serverless/api_integration/test_suites/observability/index.feature_flags.ts @elastic/obs-onboarding-team
@@ -2759,10 +2769,10 @@ x-pack/platform/plugins/private/translations/translations
 x-pack/solutions/observability/test/profiling_cypress @elastic/obs-ux-infra_services-team
 
 # Profiling api integration testing
-x-pack/solutions/observability/test/api_integration/profiling @elastic/obs-ux-infra_services-team
+x-pack/solutions/observability/test/api_integration/profiling @elastic/obs-presentation-team
 
 # Observability shared profiling
-x-pack/solutions/observability/plugins/observability_shared/public/components/profiling @elastic/obs-ux-infra_services-team
+x-pack/solutions/observability/plugins/observability_shared/public/components/profiling @elastic/obs-presentation-team
 
 # Shared UX
 /x-pack/platform/test/serverless/api_integration/test_suites/favorites @elastic/appex-sharedux # Assigned per https://github.com/elastic/kibana/pull/200985


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Renaming obs infra services to obs presentation (#244861)](https://github.com/elastic/kibana/pull/244861)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Emma Raffenne","email":"97166868+emma-raffenne@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-02T13:27:35Z","message":"Renaming obs infra services to obs presentation (#244861)\n\nThis PR changes ownership of former Obs UX Infra and Services team to\nthe Obs Presentation team.\nTransfer of ownership to Obs Exploration will follow in a different PR\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"70e989d65e7d7d153ce7d22feb2515fe1873967d","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.3.0","Team:obs-presentation","v9.2.3"],"title":"Renaming obs infra services to obs presentation","number":244861,"url":"https://github.com/elastic/kibana/pull/244861","mergeCommit":{"message":"Renaming obs infra services to obs presentation (#244861)\n\nThis PR changes ownership of former Obs UX Infra and Services team to\nthe Obs Presentation team.\nTransfer of ownership to Obs Exploration will follow in a different PR\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"70e989d65e7d7d153ce7d22feb2515fe1873967d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/244861","number":244861,"mergeCommit":{"message":"Renaming obs infra services to obs presentation (#244861)\n\nThis PR changes ownership of former Obs UX Infra and Services team to\nthe Obs Presentation team.\nTransfer of ownership to Obs Exploration will follow in a different PR\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"70e989d65e7d7d153ce7d22feb2515fe1873967d"}},{"branch":"9.2","label":"v9.2.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/244905","number":244905,"state":"MERGED","mergeCommit":{"sha":"f225b1c86f7de63ea0eab5f5c3e3b484c175aa7b","message":"[9.2] Renaming obs infra services to obs presentation (#244861) (#244905)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [Renaming obs infra services to obs presentation\n(#244861)](https://github.com/elastic/kibana/pull/244861)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Emma Raffenne <97166868+emma-raffenne@users.noreply.github.com>"}}]}] BACKPORT-->