### PR TITLE
[ObsUX] Rename from `@elastic/obs-ux-infra_services-team` to `@elastic/obs-presentation` pt3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1519,7 +1519,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 ## This should allow the infra team to work without dependencies on the @elastic/obs-exploration-team, which will maintain ownership of the Logs UI code only.
 
 ## infra/{common,docs,public,server}/{sub-folders}/ -> @elastic/obs-presentation-team
-# obs-ux-infra_services-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/ @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.index.ts @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts @elastic/obs-presentation-team

--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -8,7 +8,7 @@
 - 'Feature:ExpressionLanguage':
     - 'src/platform/plugins/shared/expressions/**/*.*'
     - 'src/plugins/bfetch/**/*.*'
-- 'Team:obs-ux-infra_services':
+- 'Team:obs-presentation-team':
     - 'x-pack/solutions/observability/plugins/apm/**/*.*'
     - 'x-pack/solutions/observability/test/apm_api_integration/**/*.*'
     - 'src/platform/packages/shared/kbn-synthtrace/**/*.*'

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,7 +8,7 @@ daysUntilStale: 180
 daysUntilClose: false
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
-onlyLabels: ['Team:obs-ux-infra_services']
+onlyLabels: ['Team:obs-presentation-team']
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels: ['technical debt', 'prevent stale']

--- a/renovate.json
+++ b/renovate.json
@@ -4056,7 +4056,7 @@
         "cytoscape-dagre"
       ],
       "reviewers": [
-        "team:obs-ux-infra_services-team"
+        "team:obs-presentation-team"
       ],
       "matchBaseBranches": [
         "main"
@@ -4074,7 +4074,7 @@
         "hdr-histogram-js"
       ],
       "reviewers": [
-        "team:obs-ux-infra_services-team"
+        "team:obs-presentation-team"
       ],
       "matchBaseBranches": [
         "main"

--- a/src/dev/prs/kibana_qa_pr_list.json
+++ b/src/dev/prs/kibana_qa_pr_list.json
@@ -68,7 +68,7 @@
 "Team:logs-metrics-ui",
 "Team:uptime",
 "Team:Protections Experience",
-"Team:obs-ux-infra_services",
+"Team:obs-presentation-team",
 "Team:obs-ux-management",
 "Team:Cloud Security",
 "Team:Security Generative AI",

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -58,7 +58,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/obs-docs',
     'elastic/obs-entities',
     'elastic/obs-knowledge-team',
-    'elastic/obs-ux-infra_services-team',
+    'elastic/obs-presentation-team',
     'elastic/obs-onboarding-team',
     'elastic/obs-ux-management-team',
     'elastic/observability-design',


### PR DESCRIPTION
## Summary

Follow-up from https://github.com/elastic/kibana/pull/244947

This PR replaces the leftover usages of `@elastic/obs-ux-infra_services-team` to `@elastic/obs-presentation`



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->