### PR TITLE
[Entity Store] Make entity creation synchronous

### DIFF
--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/transform/generate_latest_transform.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/transform/generate_latest_transform.ts
@@ -87,17 +87,7 @@ const generateTransformPutRequest = ({
       max_page_search_size: maxPageSearchSize,
     },
     pivot: {
-      group_by: {
-        ...definition.identityFields.reduce(
-          (acc, id) => ({
-            ...acc,
-            [`entity.identity.${id.field}`]: {
-              terms: { field: id.field },
-            },
-          }),
-          {}
-        ),
-      },
+      group_by: generatePivotGroup(definition.identityFields),
       aggs: {
         ...generateLatestMetricAggregations(definition),
         ...generateLatestMetadataAggregations(definition),
@@ -110,6 +100,18 @@ const generateTransformPutRequest = ({
     },
   };
 };
+
+export function generatePivotGroup(identityFields: EntityDefinition['identityFields']) {
+  return identityFields.reduce(
+    (acc, id) => ({
+      ...acc,
+      [`entity.identity.${id.field}`]: {
+        terms: { field: id.field },
+      },
+    }),
+    {}
+  );
+}
 
 function generateFilters(definition: EntityDefinition) {
   const filter = {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.test.ts
@@ -498,22 +498,22 @@ describe('EntityStoreCrudClient', () => {
             aggs: {
               count: {
                 value_count: {
-                  field: "host.name",
+                  field: 'host.name',
                 },
               },
             },
             group_by: {
-              "entity.identity.host.name": {
+              'entity.identity.host.name': {
                 terms: {
-                  field: "host.name",
+                  field: 'host.name',
                 },
               },
             },
           },
-            source: {
-              index: '.entities.v1.updates.security_host_default',
-              query: { bool: { must: { term: { 'host.name': 'host-1' } } } },
-            },
+          source: {
+            index: '.entities.v1.updates.security_host_default',
+            query: { bool: { must: { term: { 'host.name': 'host-1' } } } },
+          },
         },
         { querystring: { as_index_request: true } }
       );

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_crud_client.ts
@@ -16,6 +16,7 @@ import type {
 } from '@elastic/elasticsearch/lib/api/types';
 import { generateLatestTransformId } from '@kbn/entityManager-plugin/server/lib/entities/helpers/generate_component_id';
 import type { EntityDefinition } from '@kbn/entities-schema';
+import castArray from 'lodash/castArray';
 import type { EntityContainer } from '../../../../common/api/entity_analytics/entity_store/entities/upsert_entities_bulk.gen';
 import type { EntityType as APIEntityType } from '../../../../common/api/entity_analytics/entity_store/common.gen';
 import { EntityType } from '../../../../common/entity_analytics/types';
@@ -195,6 +196,7 @@ export class EntityStoreCrudClient {
         id: previewDoc._id,
         index: getEntitiesIndexName(type, this.namespace),
         document: buildDocumentToUpdate(type, normalizedDocToECS),
+        refresh: 'true',
       });
     }
   }
@@ -394,14 +396,7 @@ function getPreviewTransformConfigWithEntity(
       ...source,
       query: {
         bool: {
-          must: [
-            ...(Array.isArray(source.query?.bool?.must)
-              ? source.query.bool.must
-              : source.query?.bool?.must
-              ? [source.query.bool.must]
-              : []),
-            { term: { [identityField]: id } },
-          ],
+          must: [...castArray(source.query?.bool?.must ?? []), { term: { [identityField]: id } }],
           must_not: source.query?.bool?.must_not || [],
         },
       },


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/security-team/issues/14185

this PR writes to the latest entity index whenever an upsert request was made but had no existing document to update. we do this to ensure the creation is synchronous. to make sure the document we write has the same `_id` as if it was created by the actual transform, a preview transform is used with the new `as_index_request` flag and the relevant id is extracted from the returned document. 


the document generated by the CRUD client is still missing a few keys, like `entity.EngineMetadata` and some others. this will be addressed in a separate PR. the important bit is that the `_id` is the same and merging can take place.