### PR TITLE
[Unified Data Table] Split test into 3 smaller tests

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -1366,37 +1366,56 @@ describe('UnifiedDataTable', () => {
       EXTENDED_JEST_TIMEOUT
     );
 
-    it(
-      'should show the reset width button only for absolute width columns, and allow resetting to default width',
-      async () => {
-        await renderDataTable({
-          columns: ['message', 'extension'],
-          settings: {
-            columns: {
-              '@timestamp': { width: 50 },
-              extension: { width: 50 },
+    describe('given a column with absolute width', () => {
+      describe('when it is the time column', () => {
+        it('should use default time column width when resetting', async () => {
+          await renderDataTable({
+            columns: [],
+            settings: {
+              columns: {
+                '@timestamp': { width: 50 },
+              },
             },
-          },
-        });
-        expect(getColumnHeader('@timestamp')).toHaveStyle({ width: '50px' });
+          });
 
-        await openColumnActions('@timestamp');
-        await userEvent.click(screen.getByTestId('unifiedDataTableResetColumnWidth'));
-        expect(getColumnHeader('@timestamp')).toHaveStyle({
-          width: `${defaultTimeColumnWidth}px`,
+          expect(getColumnHeader('@timestamp')).toHaveStyle({ width: '50px' });
+          await openColumnActions('@timestamp');
+          await userEvent.click(screen.getByTestId('unifiedDataTableResetColumnWidth'));
+          expect(getColumnHeader('@timestamp')).toHaveStyle({
+            width: `${defaultTimeColumnWidth}px`,
+          });
         });
+      });
 
+      describe('when it is not the time column', () => {
+        it('should use EUI default column width when resetting', async () => {
+          await renderDataTable({
+            columns: ['extension'],
+            settings: {
+              columns: {
+                extension: { width: 50 },
+              },
+            },
+          });
+
+          expect(getColumnHeader('extension')).toHaveStyle({ width: '50px' });
+          await openColumnActions('extension');
+          await userEvent.click(screen.getByTestId('unifiedDataTableResetColumnWidth'));
+          expect(getColumnHeader('extension')).toHaveStyle({
+            width: EUI_DEFAULT_COLUMN_WIDTH,
+          });
+        });
+      });
+    });
+
+    describe('given a column without absolute width', () => {
+      it('should not show the reset width button', async () => {
+        await renderDataTable({ columns: ['message'] });
         expect(getColumnHeader('message')).toHaveStyle({ width: EUI_DEFAULT_COLUMN_WIDTH });
         await openColumnActions('message');
         expect(screen.queryByTestId('unifiedDataTableResetColumnWidth')).not.toBeInTheDocument();
-
-        expect(getColumnHeader('extension')).toHaveStyle({ width: '50px' });
-        await openColumnActions('extension');
-        await userEvent.click(screen.getByTestId('unifiedDataTableResetColumnWidth'));
-        expect(getColumnHeader('extension')).toHaveStyle({ width: EUI_DEFAULT_COLUMN_WIDTH });
-      },
-      EXTENDED_JEST_TIMEOUT
-    );
+      });
+    });
 
     it(
       'should have columnVisibility configuration',


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/234829

Right now we have the `should show the reset width button only for absolute width columns, and allow resetting to default width` test that is asserting 3 different things:
- When resetting the width of the time column from absolute it goes back to the default
- When resetting the width of a column that isn't the time column from absolute it goes back to the default
- A column without absolute width can't be reset

This means that we can split the test into 3 smaller and more focused tests for each of those scenarios. This should help with the timeout as we are no longer waiting for a big one.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->