### PR TITLE
[8.19] [ObsUX] Rename from `@elastic/obs-ux-infra_services-team` to `@elastic/obs-presentation` pt3 (#245027)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1320,7 +1320,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 ## This should allow the infra team to work without dependencies on the @elastic/obs-exploration-team, which will maintain ownership of the Logs UI code only.
 
 ## infra/{common,docs,public,server}/{sub-folders}/ -> @elastic/obs-presentation-team
-# obs-ux-infra_services-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/ @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.index.ts @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts @elastic/obs-presentation-team

--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -8,7 +8,7 @@
 - 'Feature:ExpressionLanguage':
     - 'src/platform/plugins/shared/expressions/**/*.*'
     - 'src/platform/plugins/shared/bfetch/**/*.*'
-- 'Team:obs-ux-infra_services':
+- 'Team:obs-presentation':
     - 'x-pack/solutions/observability/plugins/apm/**/*.*'
     - 'x-pack/solutions/observability/test/apm_api_integration/**/*.*'
     - 'src/platform/packages/shared/kbn-apm-synthtrace/**/*.*'

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,7 +8,7 @@ daysUntilStale: 180
 daysUntilClose: false
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
-onlyLabels: ['Team:obs-ux-infra_services']
+onlyLabels: ['Team:obs-presentation']
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels: ['technical debt', 'prevent stale']

--- a/renovate.json
+++ b/renovate.json
@@ -3916,7 +3916,7 @@
         "cytoscape-dagre"
       ],
       "reviewers": [
-        "team:obs-ux-infra_services-team"
+        "team:obs-presentation-team"
       ],
       "matchBaseBranches": [
         "main"
@@ -3934,7 +3934,7 @@
         "hdr-histogram-js"
       ],
       "reviewers": [
-        "team:obs-ux-infra_services-team"
+        "team:obs-presentation-team"
       ],
       "matchBaseBranches": [
         "main"

--- a/src/dev/prs/kibana_qa_pr_list.json
+++ b/src/dev/prs/kibana_qa_pr_list.json
@@ -58,7 +58,7 @@
 "Team:logs-metrics-ui",
 "Team:uptime",
 "Team: Protections Experience",
-"Team:obs-ux-infra_services",
+"Team:obs-presentation",
 "Team:obs-ux-management",
 "Team:Cloud Security",
 "Team:obs-onboarding",

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -51,7 +51,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/obs-docs',
     'elastic/obs-entities',
     'elastic/obs-knowledge-team',
-    'elastic/obs-ux-infra_services-team',
+    'elastic/obs-presentation-team',
     'elastic/obs-onboarding-team',
     'elastic/obs-ux-management-team',
     'elastic/observability-design',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ObsUX] Rename from `@elastic/obs-ux-infra_services-team` to `@elastic/obs-presentation` pt3 (#245027)](https://github.com/elastic/kibana/pull/245027)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-12-03T10:11:39Z","message":"[ObsUX] Rename from `@elastic/obs-ux-infra_services-team` to `@elastic/obs-presentation` pt3 (#245027)","sha":"003c25dec54984f2eb183ee7cc39aa82ada1a580","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.3.0","Team:obs-presentation"],"title":"[ObsUX] Rename from `@elastic/obs-ux-infra_services-team` to `@elastic/obs-presentation` pt3","number":245027,"url":"https://github.com/elastic/kibana/pull/245027","mergeCommit":{"message":"[ObsUX] Rename from `@elastic/obs-ux-infra_services-team` to `@elastic/obs-presentation` pt3 (#245027)","sha":"003c25dec54984f2eb183ee7cc39aa82ada1a580"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245027","number":245027,"mergeCommit":{"message":"[ObsUX] Rename from `@elastic/obs-ux-infra_services-team` to `@elastic/obs-presentation` pt3 (#245027)","sha":"003c25dec54984f2eb183ee7cc39aa82ada1a580"}},{"url":"https://github.com/elastic/kibana/pull/245048","number":245048,"branch":"9.1","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/245049","number":245049,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->