### PR TITLE
[Serverless][SecuritySolution][Endpoint] Allow access to exception list page

### DIFF
--- a/x-pack/solutions/security/packages/features/src/product_features_keys.ts
+++ b/x-pack/solutions/security/packages/features/src/product_features_keys.ts
@@ -91,6 +91,11 @@ export enum ProductFeatureSecurityKey {
   endpointAgentTamperProtection = 'endpoint_agent_tamper_protection',
 
   /**
+   * Enables access to Exceptions List page and associated views that allows management of endpoint exceptions
+   */
+  exceptionLists = 'exception_lists',
+
+  /**
    * Enables managing endpoint exceptions on rules and alerts
    */
   endpointExceptions = 'endpointExceptions',

--- a/x-pack/solutions/security/plugins/security_solution_serverless/common/pli/pli_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/common/pli/pli_config.ts
@@ -38,6 +38,7 @@ export const PLI_PRODUCT_FEATURES: PliProductFeatures = {
       ProductFeatureKey.endpointHostManagement,
       ProductFeatureKey.endpointPolicyManagement,
       ProductFeatureKey.endpointHostIsolation,
+      ProductFeatureKey.exceptionLists,
     ],
     complete: [
       ProductFeatureKey.detections,
@@ -46,6 +47,7 @@ export const PLI_PRODUCT_FEATURES: PliProductFeatures = {
       ProductFeatureKey.endpointHostManagement,
       ProductFeatureKey.endpointPolicyManagement,
       ProductFeatureKey.endpointHostIsolation,
+      ProductFeatureKey.exceptionLists,
       ProductFeatureKey.advancedInsights,
       ProductFeatureKey.assistant,
       ProductFeatureKey.attackDiscovery,

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/upselling/upsellings.tsx
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/upselling/upsellings.tsx
@@ -78,9 +78,9 @@ export const upsellingPages: UpsellingPages = [
   },
   {
     pageName: SecurityPageName.exceptions,
-    pli: ProductFeatureKey.endpointExceptions,
+    pli: ProductFeatureKey.exceptionLists,
     component: () => (
-      <EndpointExceptionsDetailsUpsellingLazy requiredPLI={ProductFeatureKey.endpointExceptions} />
+      <EndpointExceptionsDetailsUpsellingLazy requiredPLI={ProductFeatureKey.exceptionLists} />
     ),
   },
   {


### PR DESCRIPTION
## Summary

Users with only security PLI should have access to exception list page

Users wit following product line/tier should have access to contents of `app/security/exceptions` page.

With the following config in `serverless.security.dev.yml`
```
xpack.securitySolutionServerless.productTypes:
  [
    { product_line: 'security', product_tier: 'essentials' },
  ]
```
#### Before
<img width="1627" height="1360" alt="Screenshot 2025-12-03 at 11 48 21" src="https://github.com/user-attachments/assets/849f6078-2665-4056-a16c-1877e6b72d8f" />

#### After
<img width="1877" height="1529" alt="Screenshot 2025-12-03 at 11 52 26" src="https://github.com/user-attachments/assets/2b1f61c0-3f18-4899-b545-1db633632d91" />

<img width="1628" height="1366" alt="Screenshot 2025-12-03 at 11 46 06" src="https://github.com/user-attachments/assets/2eac6be7-0940-49d4-ae2e-2b4b8902c30f" />

### Testing
1. Edit the product tiers as above in `serverless.security.dev.yml`.
2. Run ES with `yarn es serverless --license trial -E xpack.security.authc.api_key.enabled=true --projectType security --kibanaUrl=http://0.0.0.0:5601 --productTier essentials`. Use `complete` for `Security Complete` tier. (This allows to test with pre-defined roles as well)
3. Run Kibana with `yarn serverless-security --no-base-path`
3. Test that you can access contents of Shared Exception list page.
<img width="1877" height="1529" alt="Screenshot 2025-12-03 at 11 52 26" src="https://github.com/user-attachments/assets/2b1f61c0-3f18-4899-b545-1db633632d91" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



