### PR TITLE
[ObsPresentation] Fix wrong team labels

### DIFF
--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -8,7 +8,7 @@
 - 'Feature:ExpressionLanguage':
     - 'src/platform/plugins/shared/expressions/**/*.*'
     - 'src/plugins/bfetch/**/*.*'
-- 'Team:obs-presentation-team':
+- 'Team:obs-presentation':
     - 'x-pack/solutions/observability/plugins/apm/**/*.*'
     - 'x-pack/solutions/observability/test/apm_api_integration/**/*.*'
     - 'src/platform/packages/shared/kbn-synthtrace/**/*.*'

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,7 +8,7 @@ daysUntilStale: 180
 daysUntilClose: false
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
-onlyLabels: ['Team:obs-presentation-team']
+onlyLabels: ['Team:obs-presentation']
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels: ['technical debt', 'prevent stale']

--- a/src/dev/prs/kibana_qa_pr_list.json
+++ b/src/dev/prs/kibana_qa_pr_list.json
@@ -68,7 +68,7 @@
 "Team:logs-metrics-ui",
 "Team:uptime",
 "Team:Protections Experience",
-"Team:obs-presentation-team",
+"Team:obs-presentation",
 "Team:obs-ux-management",
 "Team:Cloud Security",
 "Team:Security Generative AI",


### PR DESCRIPTION
## Summary

Follow-up of https://github.com/elastic/kibana/pull/245027

This PR fixes the wrong team name labels for certain automations


