### PR TITLE
[Docs] Removed Wiki page link and fix URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you want to use a Kibana release in production, give it a test run, or just p
 
 - Download the latest version on the [Kibana Download Page](https://www.elastic.co/downloads/kibana).
 - Learn more about Kibana's features and capabilities on the
-[Kibana Product Page](https://www.elastic.co/products/kibana).
+[Kibana Product Page](https://www.elastic.co/kibana).
 - We also offer a hosted version of Kibana on our
 [Cloud Service](https://www.elastic.co/cloud/as-a-service).
 
@@ -32,8 +32,7 @@ out an open PR:
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) will help you get Kibana up and running.
 - If you would like to contribute code, please follow our [STYLEGUIDE.mdx](STYLEGUIDE.mdx).
-- For all other questions, check out the [FAQ.md](FAQ.md) and
-[wiki](https://github.com/elastic/kibana/wiki).
+- For all other questions, check out the [FAQ.md](FAQ.md).
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

We don't have anymore a `Wiki` page here in github, so I removed the link.
I've also fixed one url to use the direct one


