### PR TITLE
[Security Solution] Prevent global mock package installation for prebuilt rules OOM tests in 8.19

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/oom_testing/configs/ess_basic_license.config.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/oom_testing/configs/ess_basic_license.config.ts
@@ -12,9 +12,20 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     require.resolve('../../../configs/ess/rules_management.basic.config')
   );
 
+  const parentConfig = functionalConfig.getAll();
+
   const testConfig = {
-    ...functionalConfig.getAll(),
+    ...parentConfig,
     testFiles: [require.resolve('..')],
+    mochaOpts: {
+      ...parentConfig.mochaOpts,
+      // Fleet doesn't have [Spacetime][Fleet] Introduce airgapped config for bundled packages
+      // https://github.com/elastic/kibana/pull/202435 backported to 8.19. It blocks package
+      // removal when it's unable to find it in the registry.
+      //
+      // Fixing this issue by skipping global hooks installing the prebuilt rules package.
+      rootHooks: {},
+    },
     junit: {
       reportName: 'Rules Management - Prebuilt Rules OOM Testing - ESS Basic License',
     },


### PR DESCRIPTION
**Partially addresses:** https://github.com/elastic/kibana/issues/188090

## Summary

Fleet doesn't have https://github.com/elastic/kibana/pull/202435 backported to 8.19. It blocks package removal for packages installed by direct upload. With https://github.com/elastic/kibana/pull/228777 we have a We have a mock prebuilt rules package installed via upload at the global hook.

This PR fixes the issue by skipping mock prebuilt rules package installation.


