### PR TITLE
[One Workflow] Add spec connectors schemas 

### DIFF
--- a/src/platform/plugins/shared/workflows_management/common/connector_action_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/connector_action_schema.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { connectorsSpecs } from '@kbn/connector-specs';
 import { i18n } from '@kbn/i18n';
 import type { BaseConnectorContract } from '@kbn/workflows';
 import { z } from '@kbn/zod/v4';
@@ -114,21 +115,17 @@ import {
 /**
  * Connector input schemas
  */
-
-// TODO: When migration to Zod V4 is complete:
-// import connectorsSpecs from "kbn-connector-specs" and use the following code instead of the empty map below
-export const ConnectorSpecsInputSchemas = new Map<string, Record<string, z.ZodSchema>>();
-// export const ConnectorSpecsInputSchemas = new Map<string, Record<string, z.ZodSchema>>(
-//   Object.values(connectorsSpecs).map((connectorSpec) => [
-//     connectorSpec.metadata.id,
-//     Object.fromEntries(
-//       Object.entries(connectorSpec.actions).map(([actionName, action]) => [
-//         actionName,
-//         action.input,
-//       ])
-//     ),
-//   ])
-// );
+export const ConnectorSpecsInputSchemas = new Map<string, Record<string, z.ZodSchema>>(
+  Object.values(connectorsSpecs).map((connectorSpec) => [
+    connectorSpec.metadata.id,
+    Object.fromEntries(
+      Object.entries(connectorSpec.actions).map(([actionName, action]) => [
+        actionName,
+        action.input,
+      ])
+    ),
+  ])
+);
 
 export const ConnectorInputSchemas = new Map<string, z.ZodSchema>([
   ['.slack', SlackParamsSchema],


### PR DESCRIPTION
## Summary

was dependent on zodV4 migration implemented in:
- https://github.com/elastic/kibana/pull/243542

### Changes

Adds support for completion and validation to (single-file) connector schemas in workflows:

### Demo

given `virustotal` action:

https://github.com/elastic/kibana/blob/b0b74a61d1fa15f6ac14bc523f8d8e4278827e0f/src/platform/packages/shared/kbn-connector-specs/src/specs/virustotal.ts#L116-L120

https://github.com/user-attachments/assets/35760fb0-8b7f-4731-ad4c-a7afe3796c9a

