### PR TITLE
[8.19] screenshot_creation - ownership from response-ops to cases (#244934)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2489,6 +2489,13 @@ x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/expandabl
 /x-pack/platform/plugins/shared/stack_connectors/server/connector_types/thehive @elastic/security-threat-hunting
 /x-pack/platform/plugins/shared/stack_connectors/common/thehive @elastic/security-threat-hunting
 
+/x-pack/solutions/observability/test/screenshot_creation/apps/response_ops_docs/observability_cases @elastic/kibana-cases
+/x-pack/solutions/observability/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs/cases @elastic/kibana-cases
+/x-pack/solutions/security/test/screenshot_creation/apps/response_ops_docs/security_cases @elastic/kibana-cases
+/x-pack/solutions/security/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs/cases @elastic/kibana-cases
+/x-pack/platform/test/screenshot_creation/apps/response_ops_docs/stack_cases @elastic/kibana-cases
+/x-pack/platform/test/screenshot_creation/apps/response_ops_docs/stack_connectors/cases_webhook_connector.ts @elastic/kibana-cases
+
 ## Generative AI owner connectors
 # OpenAI
 /x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai @elastic/security-generative-ai @elastic/obs-ai-assistant @elastic/appex-ai-infra


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [screenshot_creation - ownership from response-ops to cases (#244934)](https://github.com/elastic/kibana/pull/244934)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julian Gernun","email":"17549662+jcger@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-03T10:41:05Z","message":"screenshot_creation - ownership from response-ops to cases (#244934)\n\n## Summary\n\nWe noticed some leftovers that we missed while transferring ownership to\ncases","sha":"ce01b01b5d4710ae6bb5ca68dc1de52fd03bc620","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.3.0"],"title":"screenshot_creation - ownership from response-ops to cases","number":244934,"url":"https://github.com/elastic/kibana/pull/244934","mergeCommit":{"message":"screenshot_creation - ownership from response-ops to cases (#244934)\n\n## Summary\n\nWe noticed some leftovers that we missed while transferring ownership to\ncases","sha":"ce01b01b5d4710ae6bb5ca68dc1de52fd03bc620"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/244934","number":244934,"mergeCommit":{"message":"screenshot_creation - ownership from response-ops to cases (#244934)\n\n## Summary\n\nWe noticed some leftovers that we missed while transferring ownership to\ncases","sha":"ce01b01b5d4710ae6bb5ca68dc1de52fd03bc620"}}]}] BACKPORT-->