### PR TITLE
[Security Solution] fix cell action popover closing before we can click on its content

### DIFF
--- a/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiPopover, EuiScreenReaderOnly, type EuiButtonIconProps } from '@elastic/eui';
+import { type EuiButtonIconProps, EuiPopover, EuiScreenReaderOnly } from '@elastic/eui';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
@@ -136,6 +136,7 @@ export const HoverActionsPopover: React.FC<Props> = ({
           closePopover={closePopover}
           hasArrow={false}
           isOpen={showHoverContent}
+          offset={0}
           panelPaddingSize="none"
           repositionOnScroll
           ownFocus={false}


### PR DESCRIPTION
## Summary

This PR fixes a UI issue with the `kbn-cell-actions` rendering in hover mode. A recent [EUI PR](https://github.com/elastic/kibana/pull/244032) made a change to the default `offset` value:

### Context

```
- Updated EuiPopover default prop values of hasArrow, position and offset: (https://github.com/elastic/eui/pull/9218)
  - Changed hasArrow to false
  - Changed position to downLeft
  - Changed offset to 4 when hasArrow=false
``` 

This offset change ended up making our cell actions almost unusable, as the gap that is now present between the hovered content and the content of the `EuiPopover` is not 4 pixels (instead of previously 0). This means that when leaving the hovered content and before reaching the `EuiPopover` content, the popover is actually being removed...

Before the EUI `109.2.0` commit

https://github.com/user-attachments/assets/4ff1e2ef-38cc-486e-a236-1df400b2a5d0

Right at the EUI `109.2.0` commit

https://github.com/user-attachments/assets/e4af2ca6-36fc-48e9-aee7-c8a9fc00ede3

### Solution

Add `offset={0}` to the `EuiPopover` in the `kbn-cell-actions` package. That way we do not have to change the UI and the correct behavior is restored.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
