### PR TITLE
[8.19] Fix IDP Initiated Authentication for Multiple OIDC Providers (#243869)

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -293,6 +293,7 @@ enabled:
   - x-pack/platform/test/security_api_integration/oidc_implicit_flow.config.ts
   - x-pack/platform/test/security_api_integration/oidc.config.ts
   - x-pack/platform/test/security_api_integration/oidc.http2.config.ts
+  - x-pack/platform/test/security_api_integration/oidc_multiple_realms.config.ts
   - x-pack/platform/test/security_api_integration/pki.config.ts
   - x-pack/platform/test/security_api_integration/saml.config.ts
   - x-pack/platform/test/security_api_integration/saml.http2.config.ts

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/oidc.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/oidc.test.ts
@@ -65,6 +65,7 @@ describe('OIDCAuthenticationProvider', () => {
       mockOptions.client.asInternalUser.transport.request.mockResolvedValue({
         state: 'statevalue',
         nonce: 'noncevalue',
+        realm: 'oidc1',
         redirect:
           'https://op-host/path/login?response_type=code' +
           '&scope=openid%20profile%20email' +
@@ -113,6 +114,7 @@ describe('OIDCAuthenticationProvider', () => {
       mockOptions.client.asInternalUser.transport.request.mockResolvedValue({
         state: 'statevalue',
         nonce: 'noncevalue',
+        realm: 'oidc1',
         redirect:
           'https://op-host/path/login?response_type=code' +
           '&scope=openid%20profile%20email' +
@@ -151,6 +153,70 @@ describe('OIDCAuthenticationProvider', () => {
         method: 'POST',
         path: '/_security/oidc/prepare',
         body: { realm: 'oidc1' },
+      });
+    });
+
+    describe('returns "NotHandled" result if ES realm does not match provider', () => {
+      it('when initiated by the User', async () => {
+        const request = httpServerMock.createKibanaRequest();
+
+        mockOptions.client.asInternalUser.transport.request.mockResolvedValue({
+          state: 'statevalue',
+          nonce: 'noncevalue',
+          realm: 'other-realm',
+          redirect:
+            'https://op-host/path/login?response_type=code' +
+            '&scope=openid%20profile%20email' +
+            '&client_id=s6BhdRkqt3' +
+            '&state=statevalue' +
+            '&redirect_uri=https%3A%2F%2Ftest-hostname:1234%2Ftest-base-path%2Fapi%2Fsecurity%2Fv1%2F/oidc' +
+            '&login_hint=loginhint',
+        });
+
+        await expect(
+          provider.login(request, {
+            type: OIDCLogin.LoginInitiatedByUser,
+            redirectURL: '/mock-server-basepath/app/super-kibana#some-hash',
+          })
+        ).resolves.toEqual(AuthenticationResult.notHandled());
+
+        expect(mockOptions.client.asInternalUser.transport.request).toHaveBeenCalledTimes(1);
+        expect(mockOptions.client.asInternalUser.transport.request).toHaveBeenCalledWith({
+          method: 'POST',
+          path: '/_security/oidc/prepare',
+          body: { realm: 'oidc1' },
+        });
+      });
+
+      it('when initiated by 3rd party', async () => {
+        const request = httpServerMock.createKibanaRequest();
+
+        mockOptions.client.asInternalUser.transport.request.mockResolvedValue({
+          state: 'statevalue',
+          nonce: 'noncevalue',
+          realm: 'other-realm',
+          redirect:
+            'https://op-host/path/login?response_type=code' +
+            '&scope=openid%20profile%20email' +
+            '&client_id=s6BhdRkqt3' +
+            '&state=statevalue' +
+            '&redirect_uri=https%3A%2F%2Ftest-hostname:1234%2Ftest-base-path%2Fapi%2Fsecurity%2Fv1%2F/oidc' +
+            '&login_hint=loginhint',
+        });
+
+        await expect(
+          provider.login(request, {
+            type: OIDCLogin.LoginInitiatedBy3rdParty,
+            iss: 'some-issuer',
+          })
+        ).resolves.toEqual(AuthenticationResult.notHandled());
+
+        expect(mockOptions.client.asInternalUser.transport.request).toHaveBeenCalledTimes(1);
+        expect(mockOptions.client.asInternalUser.transport.request).toHaveBeenCalledWith({
+          method: 'POST',
+          path: '/_security/oidc/prepare',
+          body: { iss: 'some-issuer' },
+        });
       });
     });
 
@@ -392,6 +458,7 @@ describe('OIDCAuthenticationProvider', () => {
       mockOptions.client.asInternalUser.transport.request.mockResolvedValue({
         state: 'statevalue',
         nonce: 'noncevalue',
+        realm: 'oidc1',
         redirect:
           'https://op-host/path/login?response_type=code' +
           '&scope=openid%20profile%20email' +

--- a/x-pack/platform/test/security_api_integration/oidc_multiple_realms.config.ts
+++ b/x-pack/platform/test/security_api_integration/oidc_multiple_realms.config.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const xPackAPITestsConfig = await readConfigFile(require.resolve('../api_integration/config.ts'));
+  const kibanaPort = xPackAPITestsConfig.get('servers.kibana.port');
+  const jwksPath = require.resolve('@kbn/security-api-integration-helpers/oidc/jwks.json');
+  const oidcAPITestsConfig = await readConfigFile(require.resolve('./oidc.config.ts'));
+
+  return {
+    ...oidcAPITestsConfig.getAll(),
+    testFiles: [require.resolve('./tests/oidc/multiple_realms')],
+
+    junit: {
+      reportName: 'X-Pack Security API Integration Tests (OIDC - Multiple OIDC Realms)',
+    },
+
+    esTestCluster: {
+      ...oidcAPITestsConfig.get('esTestCluster'),
+      serverArgs: [
+        ...oidcAPITestsConfig.get('esTestCluster.serverArgs'),
+        'xpack.security.authc.realms.oidc.oidc2.order=1',
+        `xpack.security.authc.realms.oidc.oidc2.rp.client_id=0oa8sqpov3TxMWJOt356`,
+        `xpack.security.authc.realms.oidc.oidc2.rp.client_secret=0oa8sqpov3TxMWJOt356`,
+        `xpack.security.authc.realms.oidc.oidc2.rp.response_type=code`,
+        `xpack.security.authc.realms.oidc.oidc2.rp.redirect_uri=http://localhost:${kibanaPort}/api/security/oidc/callback`,
+        `xpack.security.authc.realms.oidc.oidc2.op.authorization_endpoint=https://test-op-2.elastic.co/oauth2/v1/authorize`,
+        `xpack.security.authc.realms.oidc.oidc2.op.endsession_endpoint=https://test-op-2.elastic.co/oauth2/v1/endsession`,
+        `xpack.security.authc.realms.oidc.oidc2.op.token_endpoint=http://localhost:${kibanaPort}/api/oidc_provider/token_endpoint/${encodeURIComponent(
+          'https://test-op-2.elastic.co'
+        )}`,
+        `xpack.security.authc.realms.oidc.oidc2.op.userinfo_endpoint=http://localhost:${kibanaPort}/api/oidc_provider/userinfo_endpoint`,
+        `xpack.security.authc.realms.oidc.oidc2.op.issuer=https://test-op-2.elastic.co`,
+        `xpack.security.authc.realms.oidc.oidc2.op.jwkset_path=${jwksPath}`,
+        `xpack.security.authc.realms.oidc.oidc2.claims.principal=sub`,
+      ],
+    },
+
+    kbnTestServer: {
+      ...oidcAPITestsConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...oidcAPITestsConfig
+          .get('kbnTestServer.serverArgs')
+          .filter(
+            (arg: string) =>
+              !arg.includes('xpack.security.authProviders') &&
+              !arg.includes('xpack.security.authc.oidc.realm')
+          ),
+        '--xpack.security.authc.providers.oidc.oidc1.order=0',
+        '--xpack.security.authc.providers.oidc.oidc1.realm="oidc1"',
+        '--xpack.security.authc.providers.oidc.oidc2.order=1',
+        '--xpack.security.authc.providers.oidc.oidc2.realm="oidc2"',
+      ],
+    },
+  };
+}

--- a/x-pack/platform/test/security_api_integration/packages/helpers/oidc/oidc_tools.ts
+++ b/x-pack/platform/test/security_api_integration/packages/helpers/oidc/oidc_tools.ts
@@ -18,7 +18,7 @@ function fromBase64(base64: string) {
   return base64.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
 }
 
-export function createTokens(userId: string, nonce: string) {
+export function createTokens(userId: string, nonce: string, issuer: string) {
   const idTokenHeader = fromBase64(
     Buffer.from(JSON.stringify({ alg: 'RS256' })).toString('base64')
   );
@@ -29,7 +29,7 @@ export function createTokens(userId: string, nonce: string) {
   const idTokenBody = fromBase64(
     Buffer.from(
       JSON.stringify({
-        iss: 'https://test-op.elastic.co',
+        iss: issuer,
         sub: `user${userId}`,
         aud: '0oa8sqpov3TxMWJOt356',
         nonce,

--- a/x-pack/platform/test/security_api_integration/plugins/oidc_provider/server/init_routes.ts
+++ b/x-pack/platform/test/security_api_integration/plugins/oidc_provider/server/init_routes.ts
@@ -62,15 +62,22 @@ export function initRoutes(router: IRouter) {
 
   router.post(
     {
-      path: '/api/oidc_provider/token_endpoint',
-      validate: { body: (value) => ({ value }) },
+      path: '/api/oidc_provider/token_endpoint/{issuer?}',
+      security: { authc: { enabled: false, reason: '' }, authz: { enabled: false, reason: '' } },
+      validate: {
+        body: (value) => ({ value }),
+        params: schema.object({
+          issuer: schema.string({ defaultValue: 'https://test-op.elastic.co' }),
+        }),
+      },
       // Token endpoint needs authentication (with the client credentials) but we don't attempt to
       // validate this OIDC behavior here
-      options: { authRequired: false, xsrfRequired: false },
+      options: { xsrfRequired: false },
     },
     (context, request, response) => {
       const userId = request.body.code.substring(4);
-      const { accessToken, idToken } = createTokens(userId, nonce);
+
+      const { accessToken, idToken } = createTokens(userId, nonce, request.params.issuer);
       return response.ok({
         body: {
           access_token: accessToken,

--- a/x-pack/platform/test/security_api_integration/tests/oidc/implicit_flow/oidc_auth.ts
+++ b/x-pack/platform/test/security_api_integration/tests/oidc/implicit_flow/oidc_auth.ts
@@ -83,7 +83,11 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       it('should fail if OpenID Connect response is not complemented with handshake cookie', async () => {
-        const { idToken, accessToken } = createTokens('1', stateAndNonce.nonce);
+        const { idToken, accessToken } = createTokens(
+          '1',
+          stateAndNonce.nonce,
+          'https://test-op.elastic.co'
+        );
         const authenticationResponse = `https://kibana.com/api/security/oidc/implicit#id_token=${idToken}&state=${stateAndNonce.state}&token_type=bearer&access_token=${accessToken}`;
 
         const unauthenticatedResponse = await supertest
@@ -99,7 +103,11 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       it('should fail if state is not matching', async () => {
-        const { idToken, accessToken } = createTokens('1', stateAndNonce.nonce);
+        const { idToken, accessToken } = createTokens(
+          '1',
+          stateAndNonce.nonce,
+          'https://test-op.elastic.co'
+        );
         const authenticationResponse = `https://kibana.com/api/security/oidc/implicit#id_token=${idToken}&state=$someothervalue&token_type=bearer&access_token=${accessToken}`;
 
         const unauthenticatedResponse = await supertest
@@ -116,7 +124,11 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       it('should succeed if both the OpenID Connect response and the cookie are provided', async () => {
-        const { idToken, accessToken } = createTokens('1', stateAndNonce.nonce);
+        const { idToken, accessToken } = createTokens(
+          '1',
+          stateAndNonce.nonce,
+          'https://test-op.elastic.co'
+        );
         const authenticationResponse = `https://kibana.com/api/security/oidc/implicit#id_token=${idToken}&state=${stateAndNonce.state}&token_type=bearer&access_token=${accessToken}`;
 
         const oidcAuthenticationResponse = await supertest

--- a/x-pack/platform/test/security_api_integration/tests/oidc/multiple_realms/index.ts
+++ b/x-pack/platform/test/security_api_integration/tests/oidc/multiple_realms/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('security APIs - OIDC (Multiple OIDC Realms)', function () {
+    loadTestFile(require.resolve('./oidc_auth'));
+  });
+}

--- a/x-pack/platform/test/security_api_integration/tests/oidc/multiple_realms/oidc_auth.ts
+++ b/x-pack/platform/test/security_api_integration/tests/oidc/multiple_realms/oidc_auth.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { parse as parseCookie } from 'tough-cookie';
+import url from 'url';
+
+import expect from '@kbn/expect';
+import { getStateAndNonce } from '@kbn/security-api-integration-helpers/oidc/oidc_tools';
+
+import type { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const supertest = getService('supertestWithoutAuth');
+
+  describe('OpenID Connect authentication', () => {
+    describe('With multiple OIDC realms configured', () => {
+      it('should successfully authenticate to the first realm', async () => {
+        const handshakeResponse = await supertest
+          .post('/api/security/oidc/initiate_login')
+          .send({ iss: 'https://test-op.elastic.co' })
+          .expect(302);
+
+        const handshakeCookies = handshakeResponse.headers['set-cookie'];
+        expect(handshakeCookies).to.have.length(1);
+
+        const handshakeCookie = parseCookie(handshakeCookies[0])!;
+        expect(handshakeCookie.key).to.be('sid');
+        expect(handshakeCookie.value).to.not.be.empty();
+        expect(handshakeCookie.path).to.be('/');
+        expect(handshakeCookie.httpOnly).to.be(true);
+
+        const redirectURL = url.parse(
+          handshakeResponse.headers.location,
+          true /* parseQueryString */
+        );
+        expect(
+          redirectURL.href!.startsWith(`https://test-op.elastic.co/oauth2/v1/authorize`)
+        ).to.be(true);
+        expect(redirectURL.query.scope).to.not.be.empty();
+        expect(redirectURL.query.response_type).to.not.be.empty();
+        expect(redirectURL.query.client_id).to.not.be.empty();
+        expect(redirectURL.query.redirect_uri).to.not.be.empty();
+        expect(redirectURL.query.state).to.not.be.empty();
+        expect(redirectURL.query.nonce).to.not.be.empty();
+
+        const stateAndNonce = getStateAndNonce(handshakeResponse.headers.location);
+
+        await supertest
+          .post('/api/oidc_provider/setup')
+          .set('kbn-xsrf', 'xxx')
+          .send({ nonce: stateAndNonce.nonce })
+          .expect(200);
+
+        const oidcAuthenticationResponse = await supertest
+          .get(`/api/security/oidc/callback?code=code2&state=${stateAndNonce.state}`)
+          .set('Cookie', handshakeCookie.cookieString())
+          .expect(302);
+        const authenticationResponseCookies = oidcAuthenticationResponse.headers['set-cookie'];
+        expect(authenticationResponseCookies).to.have.length(1);
+
+        const sessionCookie = parseCookie(authenticationResponseCookies[0])!;
+        expect(sessionCookie.key).to.be('sid');
+        expect(sessionCookie.value).to.not.be.empty();
+        expect(sessionCookie.path).to.be('/');
+        expect(sessionCookie.httpOnly).to.be(true);
+
+        const apiResponse = await supertest
+          .get('/internal/security/me')
+          .set('kbn-xsrf', 'xxx')
+          .set('Cookie', sessionCookie.cookieString())
+          .expect(200);
+        expect(apiResponse.body).to.have.keys([
+          'username',
+          'full_name',
+          'email',
+          'roles',
+          'metadata',
+          'enabled',
+          'authentication_realm',
+          'lookup_realm',
+          'authentication_provider',
+          'authentication_type',
+          'elastic_cloud_user',
+        ]);
+
+        expect(apiResponse.body.username).to.be('user2');
+        expect(apiResponse.body.authentication_realm).to.eql({ name: 'oidc1', type: 'oidc' });
+        expect(apiResponse.body.authentication_provider).to.eql({ type: 'oidc', name: 'oidc1' });
+        expect(apiResponse.body.authentication_type).to.be('token');
+      });
+
+      it('should successfully authenticate to the second realm', async () => {
+        const handshakeResponse = await supertest
+          .post('/api/security/oidc/initiate_login')
+          .send({ iss: 'https://test-op-2.elastic.co' })
+          .expect(302);
+
+        const handshakeCookies = handshakeResponse.headers['set-cookie'];
+        expect(handshakeCookies).to.have.length(1);
+
+        const handshakeCookie = parseCookie(handshakeCookies[0])!;
+        expect(handshakeCookie.key).to.be('sid');
+        expect(handshakeCookie.value).to.not.be.empty();
+        expect(handshakeCookie.path).to.be('/');
+        expect(handshakeCookie.httpOnly).to.be(true);
+
+        const redirectURL = url.parse(
+          handshakeResponse.headers.location,
+          true /* parseQueryString */
+        );
+        expect(
+          redirectURL.href!.startsWith(`https://test-op-2.elastic.co/oauth2/v1/authorize`)
+        ).to.be(true);
+        expect(redirectURL.query.scope).to.not.be.empty();
+        expect(redirectURL.query.response_type).to.not.be.empty();
+        expect(redirectURL.query.client_id).to.not.be.empty();
+        expect(redirectURL.query.redirect_uri).to.not.be.empty();
+        expect(redirectURL.query.state).to.not.be.empty();
+        expect(redirectURL.query.nonce).to.not.be.empty();
+
+        const stateAndNonce = getStateAndNonce(handshakeResponse.headers.location);
+
+        await supertest
+          .post('/api/oidc_provider/setup')
+          .set('kbn-xsrf', 'xxx')
+          .send({ nonce: stateAndNonce.nonce })
+          .expect(200);
+
+        const oidcAuthenticationResponse = await supertest
+          .get(`/api/security/oidc/callback?code=code2&state=${stateAndNonce.state}`)
+          .set('Cookie', handshakeCookie.cookieString())
+          .expect(302);
+        const authenticationResponseCookies = oidcAuthenticationResponse.headers['set-cookie'];
+        expect(authenticationResponseCookies).to.have.length(1);
+
+        const sessionCookie = parseCookie(authenticationResponseCookies[0])!;
+        expect(sessionCookie.key).to.be('sid');
+        expect(sessionCookie.value).to.not.be.empty();
+        expect(sessionCookie.path).to.be('/');
+        expect(sessionCookie.httpOnly).to.be(true);
+
+        const apiResponse = await supertest
+          .get('/internal/security/me')
+          .set('kbn-xsrf', 'xxx')
+          .set('Cookie', sessionCookie.cookieString())
+          .expect(200);
+        expect(apiResponse.body).to.have.keys([
+          'username',
+          'full_name',
+          'email',
+          'roles',
+          'metadata',
+          'enabled',
+          'authentication_realm',
+          'lookup_realm',
+          'authentication_provider',
+          'authentication_type',
+          'elastic_cloud_user',
+        ]);
+
+        expect(apiResponse.body.username).to.be('user2');
+        expect(apiResponse.body.authentication_realm).to.eql({ name: 'oidc2', type: 'oidc' });
+        expect(apiResponse.body.authentication_provider).to.eql({ type: 'oidc', name: 'oidc2' });
+        expect(apiResponse.body.authentication_type).to.be('token');
+      });
+    });
+  });
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix IDP Initiated Authentication for Multiple OIDC Providers (#243869)](https://github.com/elastic/kibana/pull/243869)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ryan","email":"ryan.godfrey@elastic.co"},"sourceCommit":{"committedDate":"2025-12-03T19:16:44Z","message":"Fix IDP Initiated Authentication for Multiple OIDC Providers (#243869)\n\nCloses https://github.com/elastic/kibana/issues/190177\n\n## Summary\n\nFixes a bug where Authentication does not work when there are multiple\nOIDC providers configured.\n\nWhen OIDC authentication is initiated using the `iss`, ES sends back the\nredirect URL and realm configured for that OIDC provider. If the realm\nfrom ES does not match the configured realm in Kibana then the OIDC\nprovider will now return not handled instead of redirecting the user to\nthe OIDC redirect URL. This allows the authentication chain to move onto\nthe second OIDC provider instead of being rejected by the first provider\nafter being redirected.\n\n## Release Notes\n\nFixes a bug preventing IDP initiated login with multiple OIDC providers\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7ae2c48d479143f73c93ab7cca9ae20257fc8edd","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Security","Feature:Security/Authentication","backport:all-open","v9.3.0"],"title":"Fix IDP Initiated Authentication for Multiple OIDC Providers","number":243869,"url":"https://github.com/elastic/kibana/pull/243869","mergeCommit":{"message":"Fix IDP Initiated Authentication for Multiple OIDC Providers (#243869)\n\nCloses https://github.com/elastic/kibana/issues/190177\n\n## Summary\n\nFixes a bug where Authentication does not work when there are multiple\nOIDC providers configured.\n\nWhen OIDC authentication is initiated using the `iss`, ES sends back the\nredirect URL and realm configured for that OIDC provider. If the realm\nfrom ES does not match the configured realm in Kibana then the OIDC\nprovider will now return not handled instead of redirecting the user to\nthe OIDC redirect URL. This allows the authentication chain to move onto\nthe second OIDC provider instead of being rejected by the first provider\nafter being redirected.\n\n## Release Notes\n\nFixes a bug preventing IDP initiated login with multiple OIDC providers\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7ae2c48d479143f73c93ab7cca9ae20257fc8edd"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243869","number":243869,"mergeCommit":{"message":"Fix IDP Initiated Authentication for Multiple OIDC Providers (#243869)\n\nCloses https://github.com/elastic/kibana/issues/190177\n\n## Summary\n\nFixes a bug where Authentication does not work when there are multiple\nOIDC providers configured.\n\nWhen OIDC authentication is initiated using the `iss`, ES sends back the\nredirect URL and realm configured for that OIDC provider. If the realm\nfrom ES does not match the configured realm in Kibana then the OIDC\nprovider will now return not handled instead of redirecting the user to\nthe OIDC redirect URL. This allows the authentication chain to move onto\nthe second OIDC provider instead of being rejected by the first provider\nafter being redirected.\n\n## Release Notes\n\nFixes a bug preventing IDP initiated login with multiple OIDC providers\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7ae2c48d479143f73c93ab7cca9ae20257fc8edd"}},{"url":"https://github.com/elastic/kibana/pull/245148","number":245148,"branch":"9.1","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/245149","number":245149,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->