### PR TITLE
[DOCS][ResponseOps][Alerting][8.19]: Fixes the note about CCS priv requirements for reporting and updates Kib 8.19 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -486,7 +486,7 @@ Fields and functions variables are now described with `??` in {esql} queries. Fo
 ====
 *Details* +
 
-In 8.19.0, API keys are used for authenticating report generation requests, instead of session cookies that are based on user credentials ({kibana-pull}216558[#216558]).
+Starting in 8.19.0, report generation requests are authenticated by API keys instead of session cookies. There are several key differences between the authentication methods. API keys capture your role privileges, whereas session cookie are based on your user credentials. API keys are also longer-lived, compared to session cookies, which have a shorter lifespan ({kibana-pull}216558[#216558]).
 
 If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, in addition to the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -480,6 +480,19 @@ Before you upgrade to 8.19.0, review the breaking changes, then mitigate the imp
 Fields and functions variables are now described with `??` in {esql} queries. For value variables, you can continue to use `?` ({kibana-pull}213916[#213916]).
 ====
 
+[discrete]
+.API keys are used for authenticating report generation requests
+[%collapsible]
+====
+*Details* +
+
+In 8.19.0, API keys are used for authenticating report generation requests, instead of session cookies that are based on user credentials ({kibana-pull}216558[#216558]).
+
+If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, instead of the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
+
+====
+
+
 [float]
 [[deprecations-8.19.0]]
 === Deprecations

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -488,7 +488,7 @@ Fields and functions variables are now described with `??` in {esql} queries. Fo
 
 In 8.19.0, API keys are used for authenticating report generation requests, instead of session cookies that are based on user credentials ({kibana-pull}216558[#216558]).
 
-If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, instead of the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
+If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, in addition to the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
 
 ====
 

--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -25,7 +25,7 @@ For security, you grant users access to the {report-features} and secure the rep
 [NOTE]
 ============
 
-In 8.19.0, API keys are used to authenticate requests to generate reports. If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the leader index, instead of the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
+In 8.19.0, API keys are used to authenticate requests to generate reports. If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, instead of the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
 ============
 
 * <<grant-user-access>>

--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -25,7 +25,10 @@ For security, you grant users access to the {report-features} and secure the rep
 [NOTE]
 ============
 
-In 8.19.0, API keys are used to authenticate requests to generate reports. If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, instead of the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
+Starting in 8.19.0, report generation requests are authenticated by API keys instead of session cookies. There are several key differences between the authentication methods. API keys capture your role privileges, whereas session cookie are based on your user credentials. API keys are also longer-lived, compared to session cookies, which have a shorter lifespan.
+
+If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, in addition to the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
+
 ============
 
 * <<grant-user-access>>

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -1107,7 +1107,7 @@ logging:
 
 [discrete]
 [[breaking-216558]]
-.[Sharing & Reporting] .API keys are used for authenticating report generation requests. (8.19)
+.[Sharing & Reporting] API keys are used for authenticating report generation requests. (8.19)
 [%collapsible]
 ====
 

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -1104,6 +1104,21 @@ logging:
 
 // Sharing and reporting
 
+
+[discrete]
+[[breaking-216558]]
+.[Sharing & Reporting] .API keys are used for authenticating report generation requests. (8.19)
+[%collapsible]
+====
+
+*Details* +
+
+In 8.19.0, API keys are used for authenticating report generation requests, instead of session cookies that are based on user credentials ({kibana-pull}216558[#216558]).
+
+If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, instead of the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
+
+====
+
 [discrete]
 [[breaking-162288]]
 .[Sharing & Reporting] The Download CSV endpoint has changed. (8.10)

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -1113,9 +1113,9 @@ logging:
 
 *Details* +
 
-In 8.19.0, API keys are used for authenticating report generation requests, instead of session cookies that are based on user credentials ({kibana-pull}216558[#216558]).
+Starting in 8.19.0, report generation requests are authenticated by API keys instead of session cookies. There are several key differences between the authentication methods. API keys capture your role privileges, whereas session cookie are based on your user credentials. API keys are also longer-lived, compared to session cookies, which have a shorter lifespan ({kibana-pull}216558[#216558]).
 
-If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, instead of the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
+If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, in addition to the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
 
 ====
 

--- a/docs/user/reporting/automating-report-generation.asciidoc
+++ b/docs/user/reporting/automating-report-generation.asciidoc
@@ -4,7 +4,7 @@
 
 To automatically generate PDF and CSV reports, generate a POST URL, then submit an HTTP `POST` request using {watcher} or a script. Alternatively, use {kib} to generate reports on a recurring schedule and share them with a list of emails that you specify.
 
-NOTE: In 8.19.0, API keys are used to authenticate requests to generate reports. If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the leader index, instead of the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
+NOTE: In 8.19.0, API keys are used to authenticate requests to generate reports. If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, instead of the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
 
 [float]
 [[create-a-post-url]]

--- a/docs/user/reporting/automating-report-generation.asciidoc
+++ b/docs/user/reporting/automating-report-generation.asciidoc
@@ -4,7 +4,14 @@
 
 To automatically generate PDF and CSV reports, generate a POST URL, then submit an HTTP `POST` request using {watcher} or a script. Alternatively, use {kib} to generate reports on a recurring schedule and share them with a list of emails that you specify.
 
-NOTE: In 8.19.0, API keys are used to authenticate requests to generate reports. If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, instead of the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
+[NOTE]
+============
+
+Starting in 8.19.0, report generation requests are authenticated by API keys instead of session cookies. There are several key differences between the authentication methods. API keys capture your role privileges, whereas session cookie are based on your user credentials. API keys are also longer-lived, compared to session cookies, which have a shorter lifespan.
+
+If you have a cross-cluster search environment and want to generate reports from remote clusters, you must have the appropriate cluster and index privileges on the remote cluster and local cluster. For example, if requests are authenticated with an API key, the API key requires certain privileges on the local cluster that contains the local index, in addition to the remote. For more information and examples, refer to {ref}/remote-clusters-cert.html#remote-clusters-privileges-cert[Configure roles and users for remote clusters].
+
+============
 
 [float]
 [[create-a-post-url]]


### PR DESCRIPTION
## Summary

Contributes to http://github.com/elastic/docs-content-internal/issues/514 by updating the 8.19 reporting docs and Kibana release notes. More specifically, this PR:
- Modifies the the third sentence in note about CCS priv requirements for reporting. Replaces the term "leader" with "local".
- Adds breaking change entries to the 8.19 Kibana release notes and the Kibana upgrade notes. This should make the change more visible to users who are upgrading to 8.19. 

### Corresponding fixes
- 9.1 reporting docs: https://github.com/elastic/docs-content/pull/4211
- 9.1 Kibana release notes: https://github.com/elastic/kibana/pull/245183

## Previews

- [Automatically generate reports](https://kibana_bk_245182.docs-preview.app.elstc.co/guide/en/kibana/8.19/automating-report-generation.html) - Updated note
- [Configure reporting in Kibana | Grant users access to reporting](https://kibana_bk_245182.docs-preview.app.elstc.co/guide/en/kibana/8.19/secure-reporting.html#grant-user-access) - Updated second note in the intro section of the page
- [Upgrade notes | Breaking changes | Kibana platform](https://kibana_bk_245182.docs-preview.app.elstc.co/guide/en/kibana/8.19/breaking-changes-summary.html#_kibana_platform) - Added entry titled "[Sharing & Reporting] API keys are used for authenticating report generation requests. (8.19)"
- [Kibana 8.19.0 | Breaking changes](https://kibana_bk_245182.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.19.0.html#breaking-changes-8.19.0) - Added entry titled "API keys are used for authenticating report generation requests"
