### PR TITLE
[9.2] [Unified Data Table] Split test into 3 smaller tests (#245045)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -1371,40 +1371,56 @@ describe('UnifiedDataTable', () => {
       EXTENDED_JEST_TIMEOUT
     );
 
-    it(
-      'should show the reset width button only for absolute width columns, and allow resetting to default width',
-      async () => {
-        await renderDataTable({
-          columns: ['message', 'extension'],
-          settings: {
-            columns: {
-              '@timestamp': { width: 50 },
-              extension: { width: 50 },
+    describe('given a column with absolute width', () => {
+      describe('when it is the time column', () => {
+        it('should use default time column width when resetting', async () => {
+          await renderDataTable({
+            columns: [],
+            settings: {
+              columns: {
+                '@timestamp': { width: 50 },
+              },
             },
-          },
-        });
-        expect(getColumnHeader('@timestamp')).toHaveStyle({ width: '50px' });
-        await openColumnActions('@timestamp');
-        await clickColumnAction('Reset width');
-        await waitFor(() => {
+          });
+
+          expect(getColumnHeader('@timestamp')).toHaveStyle({ width: '50px' });
+          await openColumnActions('@timestamp');
+          await userEvent.click(screen.getByTestId('unifiedDataTableResetColumnWidth'));
           expect(getColumnHeader('@timestamp')).toHaveStyle({
             width: `${defaultTimeColumnWidth}px`,
           });
         });
+      });
+
+      describe('when it is not the time column', () => {
+        it('should use EUI default column width when resetting', async () => {
+          await renderDataTable({
+            columns: ['extension'],
+            settings: {
+              columns: {
+                extension: { width: 50 },
+              },
+            },
+          });
+
+          expect(getColumnHeader('extension')).toHaveStyle({ width: '50px' });
+          await openColumnActions('extension');
+          await userEvent.click(screen.getByTestId('unifiedDataTableResetColumnWidth'));
+          expect(getColumnHeader('extension')).toHaveStyle({
+            width: EUI_DEFAULT_COLUMN_WIDTH,
+          });
+        });
+      });
+    });
+
+    describe('given a column without absolute width', () => {
+      it('should not show the reset width button', async () => {
+        await renderDataTable({ columns: ['message'] });
         expect(getColumnHeader('message')).toHaveStyle({ width: EUI_DEFAULT_COLUMN_WIDTH });
         await openColumnActions('message');
-        expect(queryButton('Reset width')).not.toBeInTheDocument();
-        await waitFor(() => {
-          expect(getColumnHeader('extension')).toHaveStyle({ width: '50px' });
-        });
-        await openColumnActions('extension');
-        await clickColumnAction('Reset width');
-        await waitFor(() => {
-          expect(getColumnHeader('extension')).toHaveStyle({ width: EUI_DEFAULT_COLUMN_WIDTH });
-        });
-      },
-      EXTENDED_JEST_TIMEOUT
-    );
+        expect(screen.queryByTestId('unifiedDataTableResetColumnWidth')).not.toBeInTheDocument();
+      });
+    });
 
     it(
       'should have columnVisibility configuration',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Unified Data Table] Split test into 3 smaller tests (#245045)](https://github.com/elastic/kibana/pull/245045)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alejandro García Parrondo","email":"31973472+AlexGPlay@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-03T15:25:03Z","message":"[Unified Data Table] Split test into 3 smaller tests (#245045)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/234829\n\nRight now we have the `should show the reset width button only for\nabsolute width columns, and allow resetting to default width` test that\nis asserting 3 different things:\n- When resetting the width of the time column from absolute it goes back\nto the default\n- When resetting the width of a column that isn't the time column from\nabsolute it goes back to the default\n- A column without absolute width can't be reset\n\nThis means that we can split the test into 3 smaller and more focused\ntests for each of those scenarios. This should help with the timeout as\nwe are no longer waiting for a big one.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f7266e765f0eafdb5548fd1e2ac845b8dd5658fa","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","backport:version","v9.2.0","v9.3.0"],"title":"[Unified Data Table] Split test into 3 smaller tests","number":245045,"url":"https://github.com/elastic/kibana/pull/245045","mergeCommit":{"message":"[Unified Data Table] Split test into 3 smaller tests (#245045)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/234829\n\nRight now we have the `should show the reset width button only for\nabsolute width columns, and allow resetting to default width` test that\nis asserting 3 different things:\n- When resetting the width of the time column from absolute it goes back\nto the default\n- When resetting the width of a column that isn't the time column from\nabsolute it goes back to the default\n- A column without absolute width can't be reset\n\nThis means that we can split the test into 3 smaller and more focused\ntests for each of those scenarios. This should help with the timeout as\nwe are no longer waiting for a big one.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f7266e765f0eafdb5548fd1e2ac845b8dd5658fa"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245045","number":245045,"mergeCommit":{"message":"[Unified Data Table] Split test into 3 smaller tests (#245045)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/234829\n\nRight now we have the `should show the reset width button only for\nabsolute width columns, and allow resetting to default width` test that\nis asserting 3 different things:\n- When resetting the width of the time column from absolute it goes back\nto the default\n- When resetting the width of a column that isn't the time column from\nabsolute it goes back to the default\n- A column without absolute width can't be reset\n\nThis means that we can split the test into 3 smaller and more focused\ntests for each of those scenarios. This should help with the timeout as\nwe are no longer waiting for a big one.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"f7266e765f0eafdb5548fd1e2ac845b8dd5658fa"}}]}] BACKPORT-->