### PR TITLE
[ES|QL] Fixes the hover in the editor copy and paste problem

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -1086,15 +1086,7 @@ const ESQLEditorInternal = function ESQLEditor({
                     // Add Tab keybinding rules for inline suggestions
                     addTabKeybindingRules();
 
-                    // this is fixing a bug between the EUIPopover and the monaco editor
-                    // when the user clicks the editor, we force it to focus and the onDidFocusEditorText
-                    // to fire, the timeout is needed because otherwise it refocuses on the popover icon
-                    // and the user needs to click again the editor.
-                    // IMPORTANT: The popover needs to be wrapped with the EuiOutsideClickDetector component.
                     editor.onMouseDown(() => {
-                      setTimeout(() => {
-                        editor.focus();
-                      }, 100);
                       if (datePickerOpenStatusRef.current) {
                         setPopoverPosition({});
                       }


### PR DESCRIPTION
## Summary

We had added this patch to fix a bug but this bug doesn't exist anymore and the documentation is not a popover anymore but a flyout. 

This patch is creating problems when you hover over the query and you want to copy paste part of the message. After removing this unnecessary patch, the users are able to select

<img width="1543" height="379" alt="image" src="https://github.com/user-attachments/assets/faf53702-6e22-4538-a305-921155304084" />




