### PR TITLE
[Agent Builder] autoSendInitialMessage flyout api option

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input.tsx
@@ -129,7 +129,8 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({ onSubmit }
   const agentId = useAgentId();
   const conversationId = useConversationId();
   const messageEditor = useMessageEditor();
-  const { attachments } = useConversationContext();
+  const { attachments, initialMessage, autoSendInitialMessage, resetInitialMessage } =
+    useConversationContext();
 
   const validateAgentId = useValidateAgentId();
   const isAgentIdValid = validateAgentId(agentId);
@@ -151,6 +152,22 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({ onSubmit }
         id: attachment.id ?? `attachment-${idx}`,
       }));
   }, [attachments, shouldHideAttachments]);
+
+  const isNewConversation = !conversationId;
+  // Set initial message in input when {autoSendInitialMessage} is false and {initialMessage} is provided
+  useEffect(() => {
+    if (initialMessage && !autoSendInitialMessage && isNewConversation) {
+      messageEditor.setContent(initialMessage);
+      messageEditor.focus();
+      resetInitialMessage?.(); // Reset the initial message to avoid sending it again
+    }
+  }, [
+    initialMessage,
+    autoSendInitialMessage,
+    isNewConversation,
+    messageEditor,
+    resetInitialMessage,
+  ]);
 
   // Auto-focus when conversation changes
   useEffect(() => {

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/message_editor/use_message_editor.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/message_editor/use_message_editor.ts
@@ -65,6 +65,11 @@ export const useMessageEditor = (): MessageEditorInstance => {
         if (ref.current) {
           ref.current.textContent = text;
           syncIsEmpty();
+          // Set caret position at the end of the text
+          const selection = window.getSelection();
+          if (selection && ref.current.firstChild) {
+            selection.setPosition(ref.current.firstChild, text.length);
+          }
         }
       },
       clear: () => {

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/conversation_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/conversation_context.tsx
@@ -17,6 +17,7 @@ interface ConversationContextValue {
   sessionTag?: string;
   agentId?: string;
   initialMessage?: string;
+  autoSendInitialMessage?: boolean;
   resetInitialMessage?: () => void;
   attachments?: AttachmentInput[];
   resetAttachments?: () => void;

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/embeddable_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/embeddable_conversations_provider.tsx
@@ -140,13 +140,19 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
     onDeleteConversation,
   });
 
+  // Resets the {initialMessage} and {autoSendInitialMessage} flags after an initial message has been sent or set in the {ConversationInput} component
   const resetInitialMessage = useCallback(() => {
-    setCurrentProps({ ...currentProps, initialMessage: undefined });
-  }, [currentProps, setCurrentProps]);
+    setCurrentProps((prevProps) => ({
+      ...prevProps,
+      initialMessage: undefined,
+      autoSendInitialMessage: false,
+    }));
+  }, []);
 
+  // Resets the {attachments} array after attachment(s) have been sent as part of a Conversation Round.
   const resetAttachments = useCallback(() => {
-    setCurrentProps({ ...currentProps, attachments: undefined });
-  }, [currentProps]);
+    setCurrentProps((prevProps) => ({ ...prevProps, attachments: undefined }));
+  }, []);
 
   const conversationContextValue = useMemo(
     () => ({
@@ -156,6 +162,7 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
       sessionTag: currentProps.sessionTag,
       agentId: currentProps.agentId,
       initialMessage: currentProps.initialMessage,
+      autoSendInitialMessage: currentProps.autoSendInitialMessage ?? false,
       resetInitialMessage,
       browserApiTools: currentProps.browserApiTools,
       setConversationId,
@@ -168,6 +175,7 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
       currentProps.sessionTag,
       currentProps.agentId,
       currentProps.initialMessage,
+      currentProps.autoSendInitialMessage,
       currentProps.browserApiTools,
       currentProps.attachments,
       resetInitialMessage,

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/routed_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/routed_conversations_provider.tsx
@@ -116,6 +116,7 @@ export const RoutedConversationsProvider: React.FC<RoutedConversationsProviderPr
       isEmbeddedContext: false,
       conversationActions,
       initialMessage,
+      autoSendInitialMessage: true,
     }),
     [conversationId, shouldStickToBottom, conversationActions, initialMessage]
   );

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_initial_message.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/use_initial_message.ts
@@ -11,18 +11,18 @@ import { useConversationId } from '../context/conversation/use_conversation_id';
 import { useSendMessage } from '../context/send_message/send_message_context';
 
 export const useSendPredefinedInitialMessage = () => {
-  const { initialMessage, resetInitialMessage } = useConversationContext();
+  const { initialMessage, autoSendInitialMessage, resetInitialMessage } = useConversationContext();
   const conversationId = useConversationId();
   const { sendMessage } = useSendMessage();
 
   const isNewConversation = !conversationId;
 
   useEffect(() => {
-    if (initialMessage && isNewConversation) {
+    if (initialMessage && isNewConversation && autoSendInitialMessage) {
       sendMessage({ message: initialMessage });
       resetInitialMessage?.();
     }
-  }, [initialMessage, isNewConversation, sendMessage, resetInitialMessage]);
+  }, [initialMessage, autoSendInitialMessage, isNewConversation, sendMessage, resetInitialMessage]);
 
   return null;
 };

--- a/x-pack/platform/plugins/shared/onechat/public/embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/embeddable/types.ts
@@ -48,12 +48,21 @@ export interface EmbeddableConversationProps {
   agentId?: string;
 
   /**
-   * Optional initial message to automatically send when starting a new conversation.
+   * Optional initial message content to use when starting a new conversation.
    * Only applies when creating a new conversation (not when restoring existing ones).
+   * Use with `autoSendInitialMessage` to control whether this message is automatically sent.
    *
    * Example: 'Show me error logs from the last hour'
    */
   initialMessage?: string;
+  /**
+   * Whether to automatically send the initial message when starting a new conversation.
+   * Only applies when creating a new conversation (not when restoring existing ones).
+   * Requires `initialMessage` to be provided.
+   *
+   * @default false
+   */
+  autoSendInitialMessage?: boolean;
   /**
    * Optional attachments with lazy content loading.
    * Content will be fetched when starting a new conversation round.

--- a/x-pack/platform/plugins/shared/onechat/public/flyout/open_conversation_flyout.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/flyout/open_conversation_flyout.tsx
@@ -18,6 +18,8 @@ import type { EmbeddableConversationProps } from '../embeddable/types';
 
 const htmlId = htmlIdGenerator('onechat-conversation-flyout');
 
+const FLYOUT_SIZE = 600;
+
 interface OpenConversationFlyoutParams {
   coreStart: CoreStart;
   services: OnechatInternalService;
@@ -76,10 +78,11 @@ export function openConversationFlyout(
     {
       'data-test-subj': 'onechat-conversation-flyout-wrapper',
       ownFocus: false,
-      isResizable: true,
       type: 'push',
       hideCloseButton: true,
       'aria-labelledby': ariaLabelledBy,
+      isResizable: true,
+      size: FLYOUT_SIZE, // Initial size of the flyout, it remains resizable up to {maxWidth}
       maxWidth: 1200, // Maximum width for resizable flyout to prevent NaN error
       css: css`
         z-index: ${euiThemeVars.euiZFlyout + 3};


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/search-team/issues/12039 

- Adds an option: `autoSendInitialMessage` to our `openConversationFlyout` API which lets a consumer decide whether their `initialMessage` should be auto sent or not.
- Sets a default width for the flyout to 600px, as defined in our designs.

https://github.com/user-attachments/assets/3c5d188c-5177-46a2-b16b-27cd8464f1e7


