### PR TITLE
K6 example for CICD (DRAFT ONLY PLEASE IGNORE)

### DIFF
--- a/k6-performance-test.docker-compose.yml
+++ b/k6-performance-test.docker-compose.yml
@@ -1,0 +1,80 @@
+version: '3'
+services:
+
+  # This is the elasticsearch container
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.2.0
+    ports:
+      - 9200:9200
+    environment:
+      node.name: elasticsearch
+      discovery.type: 'single-node'
+      bootstrap.memory_lock: 'true'
+      xpack.security.enabled: 'true'
+      xpack.license.self_generated.type: 'trial'
+      ELASTIC_PASSWORD: 'changeme'
+      ES_JAVA_OPTS: '-Xmx2g -Xms2g'
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    post_start:
+      - command: >
+          sleep 10 &&
+          curl -v -X POST "http://localhost:9200/_security/user/kibana_system/_password" -H "Content-Type: application/json" -u elastic:changeme -d '{"password": "changeme"}'
+    healthcheck:
+      test: ["CMD-SHELL", "curl http://localhost:9200"]
+      interval: 10s
+      retries: 2
+      start_period: 20s
+      timeout: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 6Gb
+
+  # The `kibana` container runs kibana and depends on `elasticsearch`
+  kibana:
+    image: docker.elastic.co/kibana/kibana:9.2.0
+    # If we want to define some extra config it can also be done like this
+    # volumes:
+    #   - ./docker-compose.kibana.yml:/user/share/kibana/config/kibana.yml
+    environment:
+      - SERVERNAME=kibana
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - ELASTICSEARCH_USERNAME=kibana_system
+      - ELASTICSEARCH_PASSWORD=changeme
+      - SERVER_SSL_ENABLED=false
+      - XPACK_SECURITY_ENCRYPTIONKEY=xuveL6cPsCxD8aSuYt3dgTE43zrgHe8KMfcvcTFERCWUymqNCXJHFwBtUMcnmg8Cbg3c7wtW
+      - XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY=xuveL6cPsCxD8aSuYt3dgTE43zrgHe8KMfcvcTFERCWUymqNCXJHFwBtUMcnmg8Cbg3c7wtW
+      - XPACK_REPORTING_ENCRYPTIONKEY=xuveL6cPsCxD8aSuYt3dgTE43zrgHe8KMfcvcTFERCWUymqNCXJHFwBtUMcnmg8Cbg3c7wtW
+    ports:
+      - 5601:5601
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl http://localhost:5601"]
+      interval: 10s
+      retries: 2
+      start_period: 20s
+      timeout: 10s
+    # Here we define the memory/CPU limits for kibana
+    # So results are reliable across different machines
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 2Gb
+
+  # The `k6test` container runs the tests
+  k6test:
+    image: grafana/k6
+    volumes:
+      - ./k6-performance-test.script.js:/app/task/script.js
+    depends_on:
+      kibana:
+        condition: service_healthy
+    command: >
+      run /app/task/script.js

--- a/k6-performance-test.run.sh
+++ b/k6-performance-test.run.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+# This is how we run it
+docker compose -f k6-performance-test.docker-compose.yml run k6test
+
+# Or if we just want dockerised kibana on http://localhost:5601
+# docker compose -f k6-performance-test.docker-compose.yml run kibana

--- a/k6-performance-test.script.js
+++ b/k6-performance-test.script.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/* eslint-disable @kbn/imports/no_unresolvable_imports */
+/* eslint-disable @kbn/eslint/require-license-header */
+import encoding from 'k6/encoding';
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export const options = {
+  vus: 1,
+  duration: '20s',
+};
+
+const headers = {
+  Authorization: `Basic ${encoding.b64encode('elastic:changeme')}`,
+};
+
+export function setup() {
+  // Wait for 5 seconds before starting
+  sleep(5);
+}
+
+export default function () {
+  // In this K6 test, we hit the rules API endpoint repeatedly
+  http.get('http://kibana:5601/api/detection_engine/rules/_find', { headers });
+  sleep(1);
+}


### PR DESCRIPTION
# Summary

This is an example of using K6 to run performance testing against an API endpoint. 

This POC is aimed at checking if its possible to track CPU + memory consumed by various Detection Rules API endpoints inside a CI/CD runner in a predictable way.

Next steps: 

1. Expand K6 script.
2. Add logging for memory + CPU stats inside kibana during testing (either as `bash` script or`GET /kbn/api/status`) 

## How to run

```sh
./k6-performance-test.run.sh
```

<img width="800" alt="Screenshot 2025-12-04 at 13 10 36" src="https://github.com/user-attachments/assets/7f2c8efa-af1d-454e-9894-ff61e6122201" />

## Explanation

We have 3 docker containers that are dependent on each and started via `docker-compose run` command.

`k6tests` -- depends on--> `kibana` -- depends on --> `elasticsearch`

Docker compose will take care of downloading/building each container and running them in order, making sure that each is healthy before the next container is woken up.

Once elastic+kibana are up and running, the `k6tests` container will wake up and run the performance tests hitting our dockerized kibana instance.

Note that `kibana` docker container is limited in terms of RAM/CPU usage, so results can be reliably compared across different machines.

https://github.com/user-attachments/assets/1748e8e3-b153-4b92-88fa-fd6680517e76

