### PR TITLE
fix(security,uiam): bump UIAM containers health check timeouts and populate UIAM shared secret for Elasticsearch

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/serverless_resources/secrets.json
+++ b/src/platform/packages/shared/kbn-es/src/serverless_resources/secrets.json
@@ -5,6 +5,7 @@
   },
   "string_secrets": {
     "xpack.security.transport.ssl.keystore.secure_password": "storepass",
-    "xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret": "my_super_secret"
+    "xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret": "my_super_secret",
+    "serverless.universal_iam_service.shared_secret": "Dw7eRt5yU2iO9pL3aS4dF6gH8jK0lZ1xC2vB3nM4qW5="
   }
 }

--- a/src/platform/packages/shared/kbn-es/src/serverless_resources/secrets_ssl.json
+++ b/src/platform/packages/shared/kbn-es/src/serverless_resources/secrets_ssl.json
@@ -6,6 +6,7 @@
   "string_secrets": {
     "xpack.security.http.ssl.keystore.secure_password": "storepass",
     "xpack.security.transport.ssl.keystore.secure_password": "storepass",
-    "xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret": "my_super_secret"
+    "xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret": "my_super_secret",
+    "serverless.universal_iam_service.shared_secret": "Dw7eRt5yU2iO9pL3aS4dF6gH8jK0lZ1xC2vB3nM4qW5="
   }
 }

--- a/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.test.ts
@@ -55,7 +55,7 @@ describe(`#runUiamContainer()`, () => {
             "--health-timeout",
             "2s",
             "--health-retries",
-            "15",
+            "30",
             "--health-start-period",
             "3s",
             "--net",
@@ -80,7 +80,7 @@ describe(`#runUiamContainer()`, () => {
             "curl -sk http://127.0.0.1:8080/ready | grep -q \\"\\\\\\"overall\\\\\\": true\\"",
             "--name",
             "uiam-cosmosdb",
-            "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator@sha256:2062ea5f8dc4416381014dae9bb66059ac2ac29912f2ca6f47bd1b4f360d7445",
+            "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-EN20251124",
             "--protocol",
             "https",
             "--port",
@@ -124,7 +124,7 @@ describe(`#runUiamContainer()`, () => {
             "--health-timeout",
             "2s",
             "--health-retries",
-            "15",
+            "30",
             "--health-start-period",
             "3s",
             "--net",
@@ -308,7 +308,7 @@ describe(`#runUiamContainer()`, () => {
     );
 
     // Skip the first call to `docker run` as we checked it in the previous test.
-    expect(execa.mock.calls.slice(1)).toHaveLength(15);
+    expect(execa.mock.calls.slice(1)).toHaveLength(30);
 
     execa.mockClear();
 
@@ -322,7 +322,7 @@ describe(`#runUiamContainer()`, () => {
     );
 
     // Skip the first call to `docker run` as we checked it in the previous test.
-    expect(execa.mock.calls.slice(1)).toHaveLength(15);
+    expect(execa.mock.calls.slice(1)).toHaveLength(30);
   });
 });
 

--- a/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.ts
@@ -20,16 +20,10 @@ import { SERVERLESS_UIAM_ENTRYPOINT_PATH, SERVERLESS_UIAM_CERTIFICATE_BUNDLE_PAT
 const COSMOS_DB_EMULATOR_DOCKER_REGISTRY = 'mcr.microsoft.com';
 const COSMOS_DB_EMULATOR_DOCKER_REPO = `${COSMOS_DB_EMULATOR_DOCKER_REGISTRY}/cosmosdb/linux/azure-cosmos-emulator`;
 
-// We're pinning to a specific SHA256 tag to avoid unexpected breakages from image updates.
-// This tag has been verified to work with UIAM as of 2025-11-25.
-// To update this tag, please do the following:
-// 1. Pull the latest version of the tag
-//   $ docker pull mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
-// 2. Get the digest
-//   $ docker inspect --format='{{index .RepoDigests 0}}' mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
-const COSMOS_DB_EMULATOR_DOCKER_LATEST_VERIFIED_TAG =
-  '2062ea5f8dc4416381014dae9bb66059ac2ac29912f2ca6f47bd1b4f360d7445';
-export const COSMOS_DB_EMULATOR_DEFAULT_IMAGE = `${COSMOS_DB_EMULATOR_DOCKER_REPO}@sha256:${COSMOS_DB_EMULATOR_DOCKER_LATEST_VERIFIED_TAG}`;
+// Check new version at https://github.com/Azure/azure-cosmos-db-emulator-docker/releases. DON'T use the rolling
+// `vnext-preview` image tag.
+const COSMOS_DB_EMULATOR_DOCKER_LATEST_VERIFIED_TAG = 'vnext-EN20251124';
+export const COSMOS_DB_EMULATOR_DEFAULT_IMAGE = `${COSMOS_DB_EMULATOR_DOCKER_REPO}:${COSMOS_DB_EMULATOR_DOCKER_LATEST_VERIFIED_TAG}`;
 
 const UIAM_DOCKER_REGISTRY = 'docker.elastic.co';
 const UIAM_DOCKER_REPO = `${UIAM_DOCKER_REGISTRY}/cloud-ci/uiam`;
@@ -45,7 +39,7 @@ const UIAM_COSMOS_DB_COLLECTION_API_KEYS = 'api-keys';
 const UIAM_COSMOS_DB_COLLECTION_USERS = 'users';
 const UIAM_COSMOS_DB_COLLECTION_TOKEN_INVALIDATION = 'token-invalidation';
 
-const MAX_HEALTHCHECK_RETRIES = 15;
+const MAX_HEALTHCHECK_RETRIES = 30;
 
 const ENV_DEFAULTS = {
   UIAM_API_PORT: '8080',
@@ -214,7 +208,7 @@ export async function runUiamContainer(
     }
 
     log.info(chalk.bold(`Waiting for "${container.name}" container (${currentStatus})…`));
-    await setTimeoutAsync(1000);
+    await setTimeoutAsync(2000);
 
     healthcheckRetries++;
     if (healthcheckRetries >= MAX_HEALTHCHECK_RETRIES) {


### PR DESCRIPTION
## Summary

It turned out that starting UIAM containers on CI takes 20-25 seconds, which is more than we initially anticipated. Therefore, I'm bumping health check timeouts (plus some buffer) to be on the safe side.

In this PR, I'm also handling the breaking change in the most recent Elasticsearch Serverless that now makes `serverless.universal_iam_service.shared_secret` required if UIAM is enabled.

Additionally, I'm switching from a SHA256-based Docker image tag to a proper named one.