### PR TITLE
Update `offset` of EuiPopover usages with hover behavior

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/components/get_comments/content_reference/components/popover_reference.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/components/get_comments/content_reference/components/popover_reference.tsx
@@ -47,6 +47,7 @@ export const PopoverReference: React.FC<React.PropsWithChildren<Props>> = ({
       className={css`
         vertical-align: baseline;
       `}
+      offset={0}
       {...rest}
     >
       {children}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/hover_popover/hover_popover.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/hover_popover/hover_popover.tsx
@@ -109,6 +109,7 @@ export const HoverPopover = React.memo<PropsWithChildren<HoverPopoverProps>>(
           panelStyle={{ minInlineSize: 'fit-content' }}
           panelClassName="HoverPopover__popover"
           repositionOnScroll={true}
+          offset={0}
         >
           {isOpen ? <div onKeyDown={onKeyDown}>{hoverContent}</div> : null}
         </EuiPopover>


### PR DESCRIPTION
## Summary

This PR is a follow-up to changes added in https://github.com/elastic/kibana/pull/244032

EUI updated the default `offset` value for `EuiPopover` to `4` when `hasArrow=false` (set as default).
This results in the popover closing unexpectedly when the popover has custom closing behavior on `onMouseLeave` due to the `4px` gap between the trigger and the panel elements.

>[!NOTE]
`EuiPopover` currently does not support open/close behavior on mouseenter/mouseleave due to general accessibility concerns ([docs](https://eui.elastic.co/v109.1.0/docs/components/containers/popover/)).
The implementations use custom functionality which is not considered by the default `offset` value.

### Changes

- updates `offset` to `0` for `EuiPopover` usages that apply custom open/close behavior on mouseenter/mouseleave

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



