### PR TITLE
refactor(api keys): Display personal API keys as default view

### DIFF
--- a/x-pack/platform/plugins/shared/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.tsx
@@ -53,7 +53,9 @@ const DEFAULT_TABLE_STATE = {
   },
   from: 0,
   size: 25,
-  filters: {},
+  filters: {
+    type: 'rest' as const,
+  },
 };
 
 const PLUS_SIGN_REGEX = /[+]/g;

--- a/x-pack/platform/test/functional/apps/api_keys/home_page.ts
+++ b/x-pack/platform/test/functional/apps/api_keys/home_page.ts
@@ -506,6 +506,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
 
       it('active/expired filter buttons work as expected', async () => {
+        await pageObjects.apiKeys.clickTypeFilters('personal');
         await pageObjects.apiKeys.clickExpiryFilters('active');
         await ensureApiKeysExist(['my api key', 'Alerting: Managed', 'test_cross_cluster']);
         await ensureApiKeyDoesNotExist('test_api_key');
@@ -536,6 +537,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
 
       it('username filter buttons work as expected', async () => {
+        await pageObjects.apiKeys.clickTypeFilters('personal');
         await pageObjects.apiKeys.clickUserNameDropdown();
         expect(
           await testSubjects.exists('userProfileSelectableOption-system_indices_superuser')
@@ -553,6 +555,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
 
       it('search bar works as expected', async () => {
+        await pageObjects.apiKeys.clickTypeFilters('personal');
         await pageObjects.apiKeys.setSearchBarValue('test_user_api_key');
 
         await ensureApiKeysExist(['test_user_api_key']);
@@ -562,6 +565,11 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
         await pageObjects.apiKeys.setSearchBarValue('"api"');
         await ensureApiKeysExist(['my api key']);
+      });
+
+      it('loads default view', async () => {
+        // Default view should be personal API keys
+        await ensureApiKeysExist(['test_user_api_key', 'test_api_key']);
       });
     });
   });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/245255

## Summary

Changes the default display view of the API Keys page to show Personal keys only. 

### Release note
API Keys management page now defaults to showing personal API Keys only


### How to test
- Start ES and Kibana
- Navigate to Stack Management -> API Keys
- Create a few different types of Keys: Personal, Cross Cluster 
- Create a Managed key by setting the metadata to 
```
{
    "managed": true
}
```
- Now when reloading the page, the default view should only show the Personal keys and the Personal filter tab should be selected. 


### Screenshots

- On Main
<img width="1716" height="1284" alt="Screenshot 2025-12-04 at 15 49 35" src="https://github.com/user-attachments/assets/c693eab0-3e5a-4292-9895-9cb86b008dda" />

- On this PR
<img width="1718" height="1287" alt="Screenshot 2025-12-04 at 15 50 06" src="https://github.com/user-attachments/assets/e0606424-fda8-42e4-b735-6fb7cfa5be8e" />


If no personal keys are present, but managed/cross cluster are then the view defaults to showing no keys and the filter still enabled

<img width="1471" height="584" alt="image" src="https://github.com/user-attachments/assets/cdcdba01-0ebe-4309-bb78-b001a6c72b3f" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->