### PR TITLE
[Fleet] Fix bump after download source update affecting an all space policy 

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/bump_agent_policies_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/bump_agent_policies_task.ts
@@ -13,8 +13,6 @@ import type {
 import { v4 as uuidv4 } from 'uuid';
 import { uniq } from 'lodash';
 
-import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
-
 import { agentPolicyService, appContextService } from '..';
 import { runWithCache } from '../epm/packages/cache';
 import { getPackagePolicySavedObjectType } from '../package_policy';
@@ -22,6 +20,7 @@ import { mapPackagePolicySavedObjectToPackagePolicy } from '../package_policies'
 import type { PackagePolicy, PackagePolicySOAttributes } from '../../types';
 import { normalizeKuery } from '../saved_object';
 import { SO_SEARCH_LIMIT } from '../../constants';
+import { getSpaceForPackagePolicy } from '../spaces/helpers';
 
 const TASK_TYPE = 'fleet:bump_agent_policies';
 
@@ -81,7 +80,7 @@ export async function _updatePackagePoliciesThatNeedBump(
   );
 
   const packagePoliciesIndexedBySpace = packagePoliciesToBump.items.reduce((acc, policy) => {
-    const spaceId = policy.spaceIds?.[0] ?? DEFAULT_SPACE_ID;
+    const spaceId = getSpaceForPackagePolicy(policy);
     if (!acc[spaceId]) {
       acc[spaceId] = [];
     }

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -135,6 +135,7 @@ import { validatePolicyNamespaceForSpace } from './spaces/policy_namespaces';
 import { isSpaceAwarenessEnabled } from './spaces/helpers';
 import { agentlessAgentService } from './agents/agentless_agent';
 import { scheduleDeployAgentPoliciesTask } from './agent_policies/deploy_agent_policies_task';
+import { getSpaceForAgentPolicy, getSpaceForAgentPolicySO } from './spaces/helpers';
 
 function normalizeKuery(savedObjectType: string, kuery: string) {
   if (savedObjectType === LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE) {
@@ -1244,7 +1245,7 @@ class AgentPolicyService {
         agentPolicies,
         async (agentPolicy) => {
           const soClient = appContextService.getInternalUserSOClientForSpaceId(
-            agentPolicy.space_ids?.[0]
+            getSpaceForAgentPolicy(agentPolicy)
           );
           const existingAgentPolicy = await this.get(soClient, agentPolicy.id, true);
 
@@ -1267,7 +1268,7 @@ class AgentPolicyService {
         agentPolicies,
         (agentPolicy) => {
           const soClient = appContextService.getInternalUserSOClientForSpaceId(
-            agentPolicy.space_ids?.[0]
+            getSpaceForAgentPolicy(agentPolicy)
           );
           return this.update(soClient, esClient, agentPolicy.id, getAgentPolicy(agentPolicy), {
             skipValidation: true,
@@ -1308,7 +1309,9 @@ class AgentPolicyService {
         agentPolicies,
         (agentPolicy) =>
           this.update(
-            appContextService.getInternalUserSOClientForSpaceId(agentPolicy.space_ids?.[0]),
+            appContextService.getInternalUserSOClientForSpaceId(
+              getSpaceForAgentPolicy(agentPolicy)
+            ),
             esClient,
             agentPolicy.id,
             {
@@ -1342,7 +1345,7 @@ class AgentPolicyService {
             updated_by: options?.user ? options.user.username : 'system',
           },
           version: policy.version,
-          namespace: policy.namespaces?.[0],
+          namespace: getSpaceForAgentPolicySO(policy),
         };
       }
     );
@@ -1376,7 +1379,7 @@ class AgentPolicyService {
       appContextService.getTaskManagerStart()!,
       savedObjectsResults.map((policy) => ({
         id: policy.id,
-        spaceId: policy.namespaces?.[0],
+        spaceId: getSpaceForAgentPolicySO(policy),
       }))
     );
 
@@ -1937,7 +1940,9 @@ class AgentPolicyService {
         agentPolicies,
         (agentPolicy) =>
           this.update(
-            appContextService.getInternalUserSOClientForSpaceId(agentPolicy.space_ids?.[0]),
+            appContextService.getInternalUserSOClientForSpaceId(
+              getSpaceForAgentPolicy(agentPolicy)
+            ),
             esClient,
             agentPolicy.id,
             {
@@ -2110,7 +2115,7 @@ class AgentPolicyService {
       appContextService.getTaskManagerStart()!,
       updatedPoliciesSuccess.map((policy) => ({
         id: policy.id,
-        spaceId: policy.namespaces?.[0],
+        spaceId: getSpaceForAgentPolicySO(policy),
       }))
     );
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_watch.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy_watch.ts
@@ -21,6 +21,7 @@ import {
 
 import { agentPolicyService, getAgentPolicySavedObjectType } from './agent_policy';
 import { appContextService } from './app_context';
+import { getSpaceForAgentPolicy } from './spaces/helpers';
 
 export class PolicyWatcher {
   private subscription: Subscription | undefined;
@@ -93,7 +94,7 @@ export class PolicyWatcher {
                   updated_by: 'system',
                 },
                 ...(policyContent.space_ids?.length
-                  ? { namespace: policyContent.space_ids[0] }
+                  ? { namespace: getSpaceForAgentPolicy(policyContent) }
                   : {}),
               };
               return updatedPolicy;

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade_action_runner.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade_action_runner.ts
@@ -21,7 +21,7 @@ import {
 import type { Agent } from '../../types';
 
 import { HostedAgentPolicyRestrictionRelatedError, FleetError } from '../../errors';
-
+import { getValidSpaceId } from '../spaces/helpers';
 import { appContextService } from '../app_context';
 
 import { ActionRunner } from './action_runner';
@@ -76,7 +76,7 @@ export async function upgradeBatch(
   },
   spaceIds?: string[]
 ): Promise<{ actionId: string }> {
-  const soClient = appContextService.getInternalUserSOClientForSpaceId(spaceIds?.[0]);
+  const soClient = appContextService.getInternalUserSOClientForSpaceId(getValidSpaceId(spaceIds));
   const errors: Record<Agent['id'], Error> = { ...outgoingErrors };
 
   const hostedPolicies = await getHostedPolicies(soClient, givenAgents);

--- a/x-pack/platform/plugins/shared/fleet/server/services/backfill_agentless.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/backfill_agentless.ts
@@ -18,6 +18,7 @@ import { getAgentPolicySavedObjectType } from './agent_policy';
 import { appContextService } from '.';
 import { getPackagePolicySavedObjectType, packagePolicyService } from './package_policy';
 import { mapPackagePolicySavedObjectToPackagePolicy } from './package_policies';
+import { getSpaceForPackagePolicy } from './spaces/helpers';
 
 export async function backfillPackagePolicySupportsAgentless(esClient: ElasticsearchClient) {
   const apSavedObjectType = await getAgentPolicySavedObjectType();
@@ -82,7 +83,7 @@ export async function backfillPackagePolicySupportsAgentless(esClient: Elasticse
       packagePoliciesToUpdate,
       (packagePolicy: PackagePolicy) => {
         const soClient = appContextService.getInternalUserSOClientForSpaceId(
-          packagePolicy.spaceIds?.[0]
+          getSpaceForPackagePolicy(packagePolicy)
         );
         return packagePolicyService.update(
           soClient,

--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
@@ -22,6 +22,7 @@ import { packagePolicyService } from '../package_policy';
 import { agentPolicyService } from '../agent_policy';
 import { getAgentStatusForAgentPolicy } from '../agents';
 import { appContextService } from '..';
+import { getValidSpaceId } from '../spaces/helpers';
 
 /**
  * Retrieve all agent policies which has a Fleet Server package policy
@@ -37,7 +38,7 @@ export const getFleetServerPolicies = async (
   // Extract associated fleet server agent policy IDs
   const fleetServerAgentPolicyIds = fleetServerPackagePolicies.items.flatMap((p) => {
     // @ts-expect-error upgrade typescript v5.9.3
-    return p.policy_ids?.map((id) => ({ id, spaceId: p.spaceIds?.[0] ?? DEFAULT_SPACE_ID } ?? []));
+    return p.policy_ids?.map((id) => ({ id, spaceId: getValidSpaceId(p.spaceIds) } ?? []));
   });
 
   // Retrieve associated agent policies

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -196,7 +196,11 @@ import {
   validateAdditionalDatastreamsPermissionsForSpace,
   validatePolicyNamespaceForSpace,
 } from './spaces/policy_namespaces';
-import { isSpaceAwarenessEnabled, isSpaceAwarenessMigrationPending } from './spaces/helpers';
+import {
+  getSpaceForPackagePolicy,
+  isSpaceAwarenessEnabled,
+  isSpaceAwarenessMigrationPending,
+} from './spaces/helpers';
 import { updatePackagePolicySpaces } from './spaces/package_policy';
 import {
   _packagePoliciesGetUpgradeDryRunDiff,
@@ -2643,7 +2647,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
         packagePolicies,
         async (packagePolicy) => {
           const soClient = appContextService.getInternalUserSOClientForSpaceId(
-            packagePolicy.spaceIds?.[0]
+            getSpaceForPackagePolicy(packagePolicy)
           );
           const existingPackagePolicy = await this.get(soClient, packagePolicy.id);
 
@@ -2674,7 +2678,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
         packagePolicies,
         (packagePolicy) => {
           const soClient = appContextService.getInternalUserSOClientForSpaceId(
-            packagePolicy.spaceIds?.[0]
+            getSpaceForPackagePolicy(packagePolicy)
           );
           return this.update(
             soClient,

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/helpers.ts
@@ -16,7 +16,7 @@ import {
   setIsSpaceAwarenessEnabledCache,
 } from '../epm/packages/cache';
 import { getSettingsOrUndefined } from '../settings';
-import type { AgentPolicy, AgentPolicySOAttributes } from '../../types';
+import type { AgentPolicy, AgentPolicySOAttributes, PackagePolicy } from '../../types';
 
 export const PENDING_MIGRATION_TIMEOUT = 60 * 60 * 1000;
 /**
@@ -62,15 +62,21 @@ export async function isSpaceAwarenessMigrationPending(): Promise<boolean> {
 }
 
 export function getSpaceForAgentPolicy(agentPolicy: Pick<AgentPolicy, 'space_ids'>): string {
-  const space = agentPolicy.space_ids?.[0];
-
-  return space && space !== ALL_SPACES_ID ? space : DEFAULT_SPACE_ID;
+  return getValidSpaceId(agentPolicy.space_ids);
 }
 
 export function getSpaceForAgentPolicySO(
   agentPolicySO: Pick<SavedObject<AgentPolicySOAttributes>, 'namespaces'>
 ): string {
-  const space = agentPolicySO.namespaces?.[0];
+  return getValidSpaceId(agentPolicySO.namespaces);
+}
+
+export function getSpaceForPackagePolicy(packagePolicy: Pick<PackagePolicy, 'spaceIds'>): string {
+  return getValidSpaceId(packagePolicy.spaceIds);
+}
+
+export function getValidSpaceId(spacedIds?: string[]) {
+  const space = spacedIds?.[0];
 
   return space && space !== ALL_SPACES_ID ? space : DEFAULT_SPACE_ID;
 }

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/helpers.ts
@@ -5,12 +5,18 @@
  * 2.0.
  */
 
+import type { SavedObject } from '@kbn/core/server';
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
+
+import { ALL_SPACES_ID } from '../../../common/constants';
+
 import { appContextService } from '../app_context';
 import {
   getIsSpaceAwarenessEnabledCache,
   setIsSpaceAwarenessEnabledCache,
 } from '../epm/packages/cache';
 import { getSettingsOrUndefined } from '../settings';
+import type { AgentPolicy, AgentPolicySOAttributes } from '../../types';
 
 export const PENDING_MIGRATION_TIMEOUT = 60 * 60 * 1000;
 /**
@@ -53,4 +59,18 @@ export async function isSpaceAwarenessMigrationPending(): Promise<boolean> {
     return true;
   }
   return false;
+}
+
+export function getSpaceForAgentPolicy(agentPolicy: Pick<AgentPolicy, 'space_ids'>): string {
+  const space = agentPolicy.space_ids?.[0];
+
+  return space && space !== ALL_SPACES_ID ? space : DEFAULT_SPACE_ID;
+}
+
+export function getSpaceForAgentPolicySO(
+  agentPolicySO: Pick<SavedObject<AgentPolicySOAttributes>, 'namespaces'>
+): string {
+  const space = agentPolicySO.namespaces?.[0];
+
+  return space && space !== ALL_SPACES_ID ? space : DEFAULT_SPACE_ID;
 }

--- a/x-pack/platform/test/fleet_api_integration/apis/epm/rollback.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/epm/rollback.ts
@@ -10,14 +10,18 @@ import {
   PACKAGES_SAVED_OBJECT_TYPE,
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
 } from '@kbn/fleet-plugin/common/constants';
+import type { CreateAgentPolicyResponse } from '@kbn/fleet-plugin/common';
 import type { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
+import { SpaceTestApiClient } from '../space_awareness/api_helper';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const kibanaServer = getService('kibanaServer');
   const fleetAndAgents = getService('fleetAndAgents');
   const supertest = getService('supertest');
+
+  const apiClient = new SpaceTestApiClient(supertest);
 
   async function installPackage(pkgName: string, pkgVersion: string) {
     await supertest
@@ -33,12 +37,22 @@ export default function (providerContext: FtrProviderContext) {
     inputs = {}
   ) {
     for (const id of policyIds) {
+      let agentPolicy: CreateAgentPolicyResponse | undefined;
+      if (id.match(/all-spaces/)) {
+        agentPolicy = await apiClient.createAgentPolicy(undefined, {
+          name: `Agent Policy for all spaces ${id} ${Date.now()}`,
+          description: 'test ',
+          namespace: 'default',
+          space_ids: ['*'],
+        });
+      }
+
       await supertest
         .post(`/api/fleet/package_policies`)
         .set('kbn-xsrf', 'xxxx')
         .send({
           id,
-          policy_ids: [],
+          policy_ids: agentPolicy ? [agentPolicy.item.id] : [],
           package: {
             name: pkgName,
             version: pkgVersion,
@@ -136,7 +150,7 @@ export default function (providerContext: FtrProviderContext) {
     latestPkgVersion: string
   ) {
     describe(`${type} package`, () => {
-      const policyIds = [`${pkgName}-1`, `${pkgName}-2`];
+      const policyIds = [`${pkgName}-1`, `${pkgName}-2`, `${pkgName}-all-spaces-3`];
 
       beforeEach(async () => {
         await installPackage(pkgName, oldPkgVersion);
@@ -236,6 +250,8 @@ export default function (providerContext: FtrProviderContext) {
           `${pkgName}-1:prev`,
           `${pkgName}-2`,
           `${pkgName}-2:prev`,
+          `${pkgName}-all-spaces-3`,
+          `${pkgName}-all-spaces-3:prev`,
         ]);
         expect(
           packagePolicySORes.saved_objects.find((so) => so.id === `${pkgName}-1`)?.attributes
@@ -252,6 +268,14 @@ export default function (providerContext: FtrProviderContext) {
         expect(
           packagePolicySORes.saved_objects.find((so) => so.id === `${pkgName}-2:prev`)?.attributes
             .package.version
+        ).to.eql(oldPkgVersion);
+        expect(
+          packagePolicySORes.saved_objects.find((so) => so.id === `${pkgName}-all-spaces-3`)
+            ?.attributes.package.version
+        ).to.eql(newPkgVersion);
+        expect(
+          packagePolicySORes.saved_objects.find((so) => so.id === `${pkgName}-all-spaces-3:prev`)
+            ?.attributes.package.version
         ).to.eql(oldPkgVersion);
 
         await assertPackageInstallVersion(pkgName, newPkgVersion);

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/agent_policies_side_effects.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/agent_policies_side_effects.ts
@@ -100,6 +100,21 @@ export default function (providerContext: FtrProviderContext) {
           }),
         ]);
       });
+      it('should bump policies accross all spaces on update', async () => {
+        const policiesResBefore = await fetchAllPolicies();
+
+        await apiClient.putDownloadSource(
+          { name: `test update ${Date.now()}`, host: 'https://elastic.co' },
+          downloadSourceId
+        );
+
+        const policiesResAfter = await fetchAllPolicies();
+
+        for (const policyRes of policiesResBefore) {
+          const policyAfter = policiesResAfter.find((p) => p.item.id === policyRes.item.id);
+          expect(policyAfter?.item.revision).to.be.greaterThan(policyRes.item.revision);
+        }
+      });
       it('should remove download_source_id accross spaces', async () => {
         const policiesResBefore = await fetchAllPolicies();
 

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/api_helper.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/api_helper.ts
@@ -45,6 +45,7 @@ import type {
   GetSettingsResponse,
   PutSettingsRequest,
   CreateAgentlessPolicyResponse,
+  PutDownloadSourceRequest,
 } from '@kbn/fleet-plugin/common/types';
 import type {
   GetUninstallTokenResponse,
@@ -720,6 +721,15 @@ export class SpaceTestApiClient {
   ): Promise<GetOneDownloadSourceResponse> {
     const res = await this.supertest
       .post(`${this.getBaseUrl(spaceId)}/api/fleet/agent_download_sources`)
+      .set('kbn-xsrf', 'xxxx')
+      .send(data);
+    expectStatusCode200(res);
+
+    return res.body;
+  }
+  async putDownloadSource(data: PutDownloadSourceRequest['body'], id: string, spaceId?: string) {
+    const res = await this.supertest
+      .put(`${this.getBaseUrl(spaceId)}/api/fleet/agent_download_sources/${id}`)
       .set('kbn-xsrf', 'xxxx')
       .send(data);
     expectStatusCode200(res);


### PR DESCRIPTION
## Description 

Resolve #245020

There was a bug when bumping agent policies belonging to all spaces, after a download source update. that PR fix that and all other place where we bump agent policies.

## Tests

I added api integration tests.

This could be checked by:
* Creating a download source
* Creating an agent policy in all space that use that previously created download source
* Updating the download source