### PR TITLE
fix workflow tags naming convention

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/components/alerts_table/common/get_columns.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alerts_table/common/get_columns.tsx
@@ -101,7 +101,7 @@ export const getColumns = (
       displayAsText: i18n.translate(
         'xpack.observability.alertsTGrid.workflowTagsColumnDescription',
         {
-          defaultMessage: 'Workflow Tags',
+          defaultMessage: 'Workflow tags',
         }
       ),
       id: ALERT_WORKFLOW_TAGS,

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/status_bar.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/status_bar.tsx
@@ -70,7 +70,7 @@ export function StatusBar({ alert, alertStatus }: StatusBarProps) {
             <EuiText size="s" color="subdued">
               <FormattedMessage
                 id="xpack.observability.pages.alertDetails.pageTitle.workflowTags"
-                defaultMessage="Workflow Tags:"
+                defaultMessage="Workflow tags:"
               />
             </EuiText>
             <TagsList tags={workflowTags} ignoreEmpty color="default" />


### PR DESCRIPTION
## Summary

Slight naming convention change to alert workflow tags

Before
<img width="445" height="154" alt="Screenshot 2025-12-04 at 11 35 44 AM" src="https://github.com/user-attachments/assets/bd3e896f-4914-47be-a92b-f5d33641d2e0" />

After
<img width="452" height="158" alt="Screenshot 2025-12-04 at 11 43 04 AM" src="https://github.com/user-attachments/assets/e9d602cc-0d62-49bf-a780-441c1456c874" />

