### PR TITLE
[8.19] [ResponseOps][Alerts] Fix Security alerts table not switching view mode columns correctly (#245253)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -498,6 +498,7 @@ const DetectionEngineAlertsTableComponent: FC<Omit<DetectionEngineAlertTableProp
               sourcererScope={SourcererScopeName.detections}
             >
               <AlertsTable<SecurityAlertsTableContext>
+                key={isEventRenderedView ? 'eventRenderedView' : 'defaultView'}
                 ref={alertsTableRef}
                 // Stores separate configuration based on the view of the table
                 id={id ?? `detection-engine-alert-table-${tableType}-${tableView}`}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps][Alerts] Fix Security alerts table not switching view mode columns correctly (#245253)](https://github.com/elastic/kibana/pull/245253)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Umberto Pepato","email":"umbopepato@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-04T17:51:08Z","message":"[ResponseOps][Alerts] Fix Security alerts table not switching view mode columns correctly (#245253)\n\n## 📄 Summary\n\nForces the Security AlertsTable to rerender entirely when switching view\nmode (`Grid view/Event rendered view` dropdown in the table toolbar) to\nmake sure the columns are updated correctly.\n\n<details>\n<summary>\n\n## 🧪 Verification steps\n\n</summary>\n\n1. Create Security rules that fire alerts\n2. Navigate to Security Solution > Alerts\n3. Try switching view mode `Grid view` <> `Event rendered view` one or\nmore times, with page reloads in between too\n4. After switching mode, try adding/removing columns to the table from\nthe `Fields` toolbar menu\n5. After editing the columns, try to reset to the default ones (`Fields`\n> `Reset fields`)\n\n</details>\n\n## ⏪ Backport rationale\n\nBackporting to all branches where the issue occurs\n\n## 🔗 References\n\nFixes #245257\n\n## Release Notes\n\nFixes an issue that caused the Security alerts table to not update\ncolumns correctly when switching view mode\n\n## ☑️ Checklist\n\n- [ ] ~~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- [ ]\n~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- [ ] ~~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- [ ] ~~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3a3d46c1be1dbac5c7a647ffaabf37604fe455af","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","backport:version","v9.3.0","v9.2.3","v9.1.9","v8.19.9"],"title":"[ResponseOps][Alerts] Fix Security alerts table not switching view mode columns correctly","number":245253,"url":"https://github.com/elastic/kibana/pull/245253","mergeCommit":{"message":"[ResponseOps][Alerts] Fix Security alerts table not switching view mode columns correctly (#245253)\n\n## 📄 Summary\n\nForces the Security AlertsTable to rerender entirely when switching view\nmode (`Grid view/Event rendered view` dropdown in the table toolbar) to\nmake sure the columns are updated correctly.\n\n<details>\n<summary>\n\n## 🧪 Verification steps\n\n</summary>\n\n1. Create Security rules that fire alerts\n2. Navigate to Security Solution > Alerts\n3. Try switching view mode `Grid view` <> `Event rendered view` one or\nmore times, with page reloads in between too\n4. After switching mode, try adding/removing columns to the table from\nthe `Fields` toolbar menu\n5. After editing the columns, try to reset to the default ones (`Fields`\n> `Reset fields`)\n\n</details>\n\n## ⏪ Backport rationale\n\nBackporting to all branches where the issue occurs\n\n## 🔗 References\n\nFixes #245257\n\n## Release Notes\n\nFixes an issue that caused the Security alerts table to not update\ncolumns correctly when switching view mode\n\n## ☑️ Checklist\n\n- [ ] ~~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- [ ]\n~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- [ ] ~~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- [ ] ~~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3a3d46c1be1dbac5c7a647ffaabf37604fe455af"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245253","number":245253,"mergeCommit":{"message":"[ResponseOps][Alerts] Fix Security alerts table not switching view mode columns correctly (#245253)\n\n## 📄 Summary\n\nForces the Security AlertsTable to rerender entirely when switching view\nmode (`Grid view/Event rendered view` dropdown in the table toolbar) to\nmake sure the columns are updated correctly.\n\n<details>\n<summary>\n\n## 🧪 Verification steps\n\n</summary>\n\n1. Create Security rules that fire alerts\n2. Navigate to Security Solution > Alerts\n3. Try switching view mode `Grid view` <> `Event rendered view` one or\nmore times, with page reloads in between too\n4. After switching mode, try adding/removing columns to the table from\nthe `Fields` toolbar menu\n5. After editing the columns, try to reset to the default ones (`Fields`\n> `Reset fields`)\n\n</details>\n\n## ⏪ Backport rationale\n\nBackporting to all branches where the issue occurs\n\n## 🔗 References\n\nFixes #245257\n\n## Release Notes\n\nFixes an issue that caused the Security alerts table to not update\ncolumns correctly when switching view mode\n\n## ☑️ Checklist\n\n- [ ] ~~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- [ ]\n~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- [ ] ~~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- [ ] ~~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"3a3d46c1be1dbac5c7a647ffaabf37604fe455af"}},{"branch":"9.2","label":"v9.2.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/245295","number":245295,"state":"OPEN"},{"branch":"9.1","label":"v9.1.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->