### PR TITLE
UI fixes to current search home page

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/observability.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/observability.tsx
@@ -37,10 +37,6 @@ export const Observability: React.FC = () => {
     return http.basePath.prepend('/app/management/kibana/spaces/create');
   }, [http]);
 
-  // const analyzeLogsIntegration = useMemo(() => {
-  //   return http.basePath.prepend('/app/integrations/browse/observability');
-  // }, [http]);
-
   return (
     <EuiFlexGroup justifyContent="flexStart" gutterSize="l" data-test-subj="observabilitySection">
       <EuiFlexItem grow={false}>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/observability.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/observability.tsx
@@ -6,7 +6,6 @@
  */
 
 import {
-  EuiAvatar,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLink,
@@ -14,17 +13,13 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
-  useEuiTheme,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { css } from '@emotion/react';
 
 import React, { useMemo } from 'react';
 import { useKibana } from '../../hooks/use_kibana';
-import { docLinks } from '../../../common/doc_links';
 
 export const Observability: React.FC = () => {
-  const { euiTheme } = useEuiTheme();
   const { http, cloud } = useKibana().services;
 
   const isServerless: boolean = cloud?.isServerlessEnabled ?? false;
@@ -41,11 +36,11 @@ export const Observability: React.FC = () => {
     return http.basePath.prepend('/app/management/kibana/spaces/create');
   }, [http]);
 
-  const analyzeLogsIntegration = useMemo(() => {
-    return http.basePath.prepend('/app/integrations/browse/observability');
-  }, [http]);
+  // const analyzeLogsIntegration = useMemo(() => {
+  //   return http.basePath.prepend('/app/integrations/browse/observability');
+  // }, [http]);
 
-  const logoContainerStyle = css({
+  const LogoContainerStyle = ({ euiTheme }: UseEuiTheme) => ({
     borderRadius: euiTheme.border.radius.medium,
     padding: euiTheme.size.base,
     backgroundColor: euiTheme.colors.backgroundBaseSubdued,
@@ -59,7 +54,7 @@ export const Observability: React.FC = () => {
     <EuiFlexGroup justifyContent="flexStart" gutterSize="l" data-test-subj="observabilitySection">
       <EuiFlexItem grow={false}>
         <EuiFlexGroup justifyContent="center" alignItems="flexStart">
-          <EuiFlexItem css={logoContainerStyle} grow={false}>
+          <EuiFlexItem css={LogoContainerStyle} grow={false}>
             <EuiIcon size="xxl" type="logoObservability" name="Observability" />
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/observability.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/observability.tsx
@@ -10,12 +10,15 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiLink,
+  EuiIcon,
   EuiSpacer,
   EuiText,
   EuiTitle,
   useEuiTheme,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
+
 import React, { useMemo } from 'react';
 import { useKibana } from '../../hooks/use_kibana';
 import { docLinks } from '../../../common/doc_links';
@@ -42,118 +45,60 @@ export const Observability: React.FC = () => {
     return http.basePath.prepend('/app/integrations/browse/observability');
   }, [http]);
 
+  const logoContainerStyle = css({
+    borderRadius: euiTheme.border.radius.medium,
+    padding: euiTheme.size.base,
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    width: `${euiTheme.base * 6}px`,
+    height: `${euiTheme.base * 6}px`,
+    justifyContent: 'center',
+    alignItems: 'center',
+  });
+
   return (
-    <EuiFlexGroup gutterSize="m" data-test-subj="observabilitySection">
+    <EuiFlexGroup justifyContent="flexStart" gutterSize="l" data-test-subj="observabilitySection">
       <EuiFlexItem grow={false}>
-        <EuiAvatar
-          size="xl"
-          color="plain"
-          name="Observability"
-          iconType="logoObservability"
-          style={{ border: euiTheme.border.thin }}
-        />
+        <EuiFlexGroup justifyContent="center" alignItems="flexStart">
+          <EuiFlexItem css={logoContainerStyle} grow={false}>
+            <EuiIcon size="xxl" type="logoObservability" name="Observability" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiFlexGroup direction="column" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiTitle size="s">
-              <h4>
+            <EuiTitle size="xs">
+              <h3>
                 {i18n.translate('xpack.searchHomepage.observability.title', {
                   defaultMessage: 'Observability',
                 })}
-              </h4>
+              </h3>
             </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText size="s" color="subdued">
-              <span>
+            <EuiText size="relative" color="subdued">
+              <p>
                 {i18n.translate('xpack.searchHomepage.observability.description', {
                   defaultMessage:
                     'Consolidate your logs, metrics, application traces, and system availability with purpose-built UIs.',
                 })}
-              </span>
+              </p>
             </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiSpacer size="s" />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-              <EuiFlexItem grow={false}>
-                <EuiFlexGroup gutterSize="s" direction="column">
-                  <EuiFlexItem grow={false}>
-                    <EuiTitle size="xxs">
-                      <span>
-                        {i18n.translate('xpack.searchHomepage.observability.logsTitle', {
-                          defaultMessage: 'Collect and analyze logs',
-                        })}
-                      </span>
-                    </EuiTitle>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    {isServerless ? (
-                      <EuiLink
-                        href={docLinks.analyzeLogs}
-                        data-test-subj="exploreLogstashAndBeatsLink"
-                      >
-                        {i18n.translate('xpack.searchHomepage.observability.exploreLogstashBeats', {
-                          defaultMessage: 'Explore Logstash and Beats',
-                        })}
-                      </EuiLink>
-                    ) : (
-                      <EuiLink
-                        href={analyzeLogsIntegration}
-                        data-test-subj="analyzeLogsBrowseIntegrations"
-                      >
-                        {i18n.translate('xpack.searchHomepage.observability.exploreLogstashBeats', {
-                          defaultMessage: 'Explore Logstash and Beats',
-                        })}
-                      </EuiLink>
-                    )}
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiFlexGroup gutterSize="s" direction="column">
-                  <EuiFlexItem grow={false}>
-                    <EuiTitle size="xxs">
-                      <span>
-                        {i18n.translate(
-                          'xpack.searchHomepage.observability.performanceMonitoringTitle',
-                          {
-                            defaultMessage: 'Powerful performance monitoring',
-                          }
-                        )}
-                      </span>
-                    </EuiTitle>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    {isServerless ? (
-                      <EuiLink href={o11yTrialLink} data-test-subj="createObservabilityProjectLink">
-                        {i18n.translate(
-                          'xpack.searchHomepage.observability.createObservabilityProjectLink',
-                          {
-                            defaultMessage: 'Create an Observability project',
-                          }
-                        )}
-                      </EuiLink>
-                    ) : (
-                      <EuiLink
-                        href={o11yCreateSpaceLink}
-                        data-test-subj="createObservabilitySpaceLink"
-                      >
-                        {i18n.translate(
-                          'xpack.searchHomepage.observability.createObservabilitySpaceLink',
-                          {
-                            defaultMessage: 'Create an Observability space',
-                          }
-                        )}
-                      </EuiLink>
-                    )}
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-            </EuiFlexGroup>
+            <EuiSpacer size="m" />
+            {isServerless ? (
+              <EuiLink href={o11yTrialLink} data-test-subj="createObservabilityProjectLink">
+                {i18n.translate(
+                  'xpack.searchHomepage.observability.createObservabilityProjectLink',
+                  {
+                    defaultMessage: 'Create an Observability project',
+                  }
+                )}
+              </EuiLink>
+            ) : (
+              <EuiLink href={o11yCreateSpaceLink} data-test-subj="createObservabilitySpaceLink">
+                {i18n.translate('xpack.searchHomepage.observability.createObservabilitySpaceLink', {
+                  defaultMessage: 'Create an Observability space',
+                })}
+              </EuiLink>
+            )}
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/observability.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/observability.tsx
@@ -18,6 +18,7 @@ import { i18n } from '@kbn/i18n';
 
 import React, { useMemo } from 'react';
 import { useKibana } from '../../hooks/use_kibana';
+import { LogoContainerStyle } from './styles';
 
 export const Observability: React.FC = () => {
   const { http, cloud } = useKibana().services;
@@ -39,16 +40,6 @@ export const Observability: React.FC = () => {
   // const analyzeLogsIntegration = useMemo(() => {
   //   return http.basePath.prepend('/app/integrations/browse/observability');
   // }, [http]);
-
-  const LogoContainerStyle = ({ euiTheme }: UseEuiTheme) => ({
-    borderRadius: euiTheme.border.radius.medium,
-    padding: euiTheme.size.base,
-    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
-    width: `${euiTheme.base * 6}px`,
-    height: `${euiTheme.base * 6}px`,
-    justifyContent: 'center',
-    alignItems: 'center',
-  });
 
   return (
     <EuiFlexGroup justifyContent="flexStart" gutterSize="l" data-test-subj="observabilitySection">

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/security.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/security.tsx
@@ -17,18 +17,9 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { docLinks } from '../../../common/doc_links';
+import { LogoContainerStyle } from './styles';
 
 export const Security: React.FC = () => {
-  const LogoContainerStyle = ({ euiTheme }: UseEuiTheme) => ({
-    borderRadius: euiTheme.border.radius.medium,
-    padding: euiTheme.size.base,
-    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
-    width: `${euiTheme.base * 6}px`,
-    height: `${euiTheme.base * 6}px`,
-    justifyContent: 'center',
-    alignItems: 'center',
-  });
-
   return (
     <EuiFlexGroup justifyContent="flexStart" gutterSize="l" data-test-subj="securitySection">
       <EuiFlexItem grow={false}>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/security.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/security.tsx
@@ -13,18 +13,13 @@ import {
   EuiText,
   EuiSpacer,
   EuiLink,
-  EuiAvatar,
-  useEuiTheme,
   EuiIcon,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { css } from '@emotion/react';
 import { docLinks } from '../../../common/doc_links';
 
 export const Security: React.FC = () => {
-  const { euiTheme } = useEuiTheme();
-
-  const logoContainerStyle = css({
+  const LogoContainerStyle = ({ euiTheme }: UseEuiTheme) => ({
     borderRadius: euiTheme.border.radius.medium,
     padding: euiTheme.size.base,
     backgroundColor: euiTheme.colors.backgroundBaseSubdued,
@@ -35,10 +30,10 @@ export const Security: React.FC = () => {
   });
 
   return (
-    <EuiFlexGroup justifyContent="flexStart" gutterSize="l" data-test-subj="securitySection" >
+    <EuiFlexGroup justifyContent="flexStart" gutterSize="l" data-test-subj="securitySection">
       <EuiFlexItem grow={false}>
         <EuiFlexGroup justifyContent="center" alignItems="flexStart">
-          <EuiFlexItem css={logoContainerStyle} grow={false}>
+          <EuiFlexItem css={LogoContainerStyle} grow={false}>
             <EuiIcon size="xxl" type="logoSecurity" name="Security" />
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/security.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/security.tsx
@@ -15,120 +15,58 @@ import {
   EuiLink,
   EuiAvatar,
   useEuiTheme,
+  EuiIcon,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
 import { docLinks } from '../../../common/doc_links';
 
 export const Security: React.FC = () => {
   const { euiTheme } = useEuiTheme();
 
+  const logoContainerStyle = css({
+    borderRadius: euiTheme.border.radius.medium,
+    padding: euiTheme.size.base,
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    width: `${euiTheme.base * 6}px`,
+    height: `${euiTheme.base * 6}px`,
+    justifyContent: 'center',
+    alignItems: 'center',
+  });
+
   return (
-    <EuiFlexGroup gutterSize="m">
+    <EuiFlexGroup justifyContent="flexStart" gutterSize="l" data-test-subj="securitySection" >
       <EuiFlexItem grow={false}>
-        <EuiAvatar
-          size="xl"
-          color="plain"
-          name="Security"
-          iconType="logoSecurity"
-          style={{ border: euiTheme.border.thin }}
-        />
+        <EuiFlexGroup justifyContent="center" alignItems="flexStart">
+          <EuiFlexItem css={logoContainerStyle} grow={false}>
+            <EuiIcon size="xxl" type="logoSecurity" name="Security" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiFlexGroup direction="column" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiTitle size="s">
-              <span>
+            <EuiTitle size="xs">
+              <h3>
                 {i18n.translate('xpack.searchHomepage.security.title', {
                   defaultMessage: 'Security',
                 })}
-              </span>
+              </h3>
             </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText size="s" color="subdued">
-              <span>
+            <EuiText size="relative" color="subdued">
+              <p>
                 {i18n.translate('xpack.searchHomepage.security.description', {
                   defaultMessage:
                     'Prevent, collect, detect, and respond to threats for unified protection across your infrastructure.',
                 })}
-              </span>
+              </p>
             </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiSpacer size="s" />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-              <EuiFlexItem grow={false}>
-                <EuiFlexGroup gutterSize="s" direction="column">
-                  <EuiFlexItem grow={false}>
-                    <EuiTitle size="xxs">
-                      <span>
-                        {i18n.translate('xpack.searchHomepage.security.detectThreatsTitle', {
-                          defaultMessage: 'Detect threats in your data',
-                        })}
-                      </span>
-                    </EuiTitle>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiLink data-test-subj="setupSiemLink" href={docLinks.ingestDataToSecurity}>
-                      {i18n.translate('xpack.searchHomepage.security.setupSiem', {
-                        defaultMessage: 'Set up your SIEM',
-                      })}
-                    </EuiLink>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiFlexGroup gutterSize="s" direction="column">
-                  <EuiFlexItem grow={false}>
-                    <EuiTitle size="xxs">
-                      <span>
-                        {i18n.translate('xpack.searchHomepage.security.secureEndpointTitle', {
-                          defaultMessage: 'Secure your endpoints',
-                        })}
-                      </span>
-                    </EuiTitle>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiLink
-                      data-test-subj="setupElasticDefendLink"
-                      href={docLinks.installElasticDefend}
-                    >
-                      {i18n.translate('xpack.searchHomepage.security.setupElasticDefend', {
-                        defaultMessage: 'Set up Elastic Defend',
-                      })}
-                    </EuiLink>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiFlexGroup gutterSize="s" direction="column">
-                  <EuiFlexItem grow={false}>
-                    <EuiTitle size="xxs">
-                      <span>
-                        {i18n.translate('xpack.searchHomepage.security.secureCloudAssetsTitle', {
-                          defaultMessage: 'Secure your cloud assets',
-                        })}
-                      </span>
-                    </EuiTitle>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiLink
-                      data-test-subj="cloudSecurityPostureManagementLink"
-                      href={docLinks.cloudSecurityPosture}
-                    >
-                      {i18n.translate(
-                        'xpack.searchHomepage.security.cloudSecurityPostureManagementLink',
-                        {
-                          defaultMessage: 'Cloud Security Posture Management',
-                        }
-                      )}
-                    </EuiLink>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-            </EuiFlexGroup>
+            <EuiSpacer size="m" />
+            <EuiLink data-test-subj="setupElasticDefendLink" href={docLinks.installElasticDefend}>
+              {i18n.translate('xpack.searchHomepage.security.setupElasticDefend', {
+                defaultMessage: 'Set up Elastic Defend',
+              })}
+            </EuiLink>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/styles.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/styles.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import type { UseEuiTheme } from "@elastic/eui";
+import type { UseEuiTheme } from '@elastic/eui';
 
 export const LogoContainerStyle = ({ euiTheme }: UseEuiTheme) => ({
-    borderRadius: euiTheme.border.radius.medium,
-    padding: euiTheme.size.base,
-    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
-    width: `${euiTheme.base * 6}px`,
-    height: `${euiTheme.base * 6}px`,
-    justifyContent: 'center',
-    alignItems: 'center',
-  });
+  borderRadius: euiTheme.border.radius.medium,
+  padding: euiTheme.size.base,
+  backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+  width: `${euiTheme.base * 6}px`,
+  height: `${euiTheme.base * 6}px`,
+  justifyContent: 'center',
+  alignItems: 'center',
+});

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/styles.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/alternate_solutions/styles.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseEuiTheme } from "@elastic/eui";
+
+export const LogoContainerStyle = ({ euiTheme }: UseEuiTheme) => ({
+    borderRadius: euiTheme.border.radius.medium,
+    padding: euiTheme.size.base,
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    width: `${euiTheme.base * 6}px`,
+    height: `${euiTheme.base * 6}px`,
+    justifyContent: 'center',
+    alignItems: 'center',
+  });

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/cloud_serverless_promo/cloud_serverless_promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/cloud_serverless_promo/cloud_serverless_promo.tsx
@@ -15,14 +15,17 @@ import {
   EuiText,
   EuiTitle,
   useEuiTheme,
+  useCurrentEuiBreakpoint
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 
 export const CloudServerlessPromo = () => {
+    const currentBreakpoint = useCurrentEuiBreakpoint();
+  
   return (
-    <EuiFlexGroup>
+    <EuiFlexGroup gutterSize='xl' direction={currentBreakpoint === 'xl' ? 'row' : 'column'}>
       <EuiFlexItem>
         <PromoItem promoItem="hosted" />
       </EuiFlexItem>
@@ -83,9 +86,10 @@ export const PromoItem = ({ promoItem }: { promoItem: 'serverless' | 'hosted' })
     alignItems: 'center',
   });
   const { logoPath, logoAltText, promoTitle, description, externalLink } = PROMO_ITEMS[promoItem];
+  
 
   return (
-    <EuiFlexGroup justifyContent="flexStart" gutterSize="l">
+    <EuiFlexGroup justifyContent="flexStart" gutterSize="l" >
       <EuiFlexItem grow={false}>
         <EuiFlexGroup justifyContent="center" alignItems="flexStart">
           <EuiFlexItem css={logoContainerStyle} grow={false}>
@@ -96,7 +100,7 @@ export const PromoItem = ({ promoItem }: { promoItem: 'serverless' | 'hosted' })
       <EuiFlexItem grow={false}>
         <EuiFlexGroup direction="column" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiTitle size="s">
+            <EuiTitle size="xs">
               <h3>{promoTitle}</h3>
             </EuiTitle>
           </EuiFlexItem>
@@ -104,7 +108,7 @@ export const PromoItem = ({ promoItem }: { promoItem: 'serverless' | 'hosted' })
             <EuiText size="s" color="subdued" grow={false}>
               {description}
             </EuiText>
-            <EuiSpacer size="s" />
+            <EuiSpacer size="m" />
             <EuiLink
               data-test-subj={`searchHomepagePromoItemExternalLink-${promoItem}`}
               external

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/cloud_serverless_promo/cloud_serverless_promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/cloud_serverless_promo/cloud_serverless_promo.tsx
@@ -15,17 +15,17 @@ import {
   EuiText,
   EuiTitle,
   useEuiTheme,
-  useCurrentEuiBreakpoint
+  useCurrentEuiBreakpoint,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 
 export const CloudServerlessPromo = () => {
-    const currentBreakpoint = useCurrentEuiBreakpoint();
-  
+  const currentBreakpoint = useCurrentEuiBreakpoint();
+
   return (
-    <EuiFlexGroup gutterSize='xl' direction={currentBreakpoint === 'xl' ? 'row' : 'column'}>
+    <EuiFlexGroup gutterSize="xl" direction={currentBreakpoint === 'xl' ? 'row' : 'column'}>
       <EuiFlexItem>
         <PromoItem promoItem="hosted" />
       </EuiFlexItem>
@@ -86,10 +86,9 @@ export const PromoItem = ({ promoItem }: { promoItem: 'serverless' | 'hosted' })
     alignItems: 'center',
   });
   const { logoPath, logoAltText, promoTitle, description, externalLink } = PROMO_ITEMS[promoItem];
-  
 
   return (
-    <EuiFlexGroup justifyContent="flexStart" gutterSize="l" >
+    <EuiFlexGroup justifyContent="flexStart" gutterSize="l">
       <EuiFlexItem grow={false}>
         <EuiFlexGroup justifyContent="center" alignItems="flexStart">
           <EuiFlexItem css={logoContainerStyle} grow={false}>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/dive_deeper/dive_deeper_with_elasticsearch.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/dive_deeper/dive_deeper_with_elasticsearch.tsx
@@ -14,7 +14,7 @@ import { DocCallouts } from './doc_callouts';
 export const DiveDeeperWithElasticsearch: React.FC = () => {
   const currentBreakpoint = useCurrentEuiBreakpoint();
   return (
-    <EuiFlexGroup direction={currentBreakpoint === 'xl' ? 'row' : 'column'}>
+    <EuiFlexGroup direction={currentBreakpoint === 'xl' ? 'row' : 'column'} gutterSize='xl'>
       <EuiFlexItem data-test-subj="searchLabsSection">
         <DocCallouts
           title={i18n.translate('xpack.searchHomepage.searchLabs.title', {

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/dive_deeper/dive_deeper_with_elasticsearch.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/dive_deeper/dive_deeper_with_elasticsearch.tsx
@@ -14,7 +14,7 @@ import { DocCallouts } from './doc_callouts';
 export const DiveDeeperWithElasticsearch: React.FC = () => {
   const currentBreakpoint = useCurrentEuiBreakpoint();
   return (
-    <EuiFlexGroup direction={currentBreakpoint === 'xl' ? 'row' : 'column'} gutterSize='xl'>
+    <EuiFlexGroup direction={currentBreakpoint === 'xl' ? 'row' : 'column'} gutterSize="xl">
       <EuiFlexItem data-test-subj="searchLabsSection">
         <DocCallouts
           title={i18n.translate('xpack.searchHomepage.searchLabs.title', {

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/dive_deeper/doc_callouts.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/dive_deeper/doc_callouts.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButton, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { EuiButton, EuiLink, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 import React from 'react';
 
 export interface DocCalloutsProps {
@@ -25,8 +25,8 @@ export const DocCallouts: React.FC<DocCalloutsProps> = ({
 }) => {
   return (
     <>
-      <EuiTitle size="s">
-        <h4>{title}</h4>
+      <EuiTitle size="xs">
+        <h3>{title}</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
 
@@ -35,15 +35,13 @@ export const DocCallouts: React.FC<DocCalloutsProps> = ({
       </EuiText>
       <EuiSpacer size="m" />
       <span>
-        <EuiButton
-          iconType="popout"
+        <EuiLink
+          external
           href={buttonHref}
-          iconSide="right"
           data-test-subj={dataTestSubj}
-          color="text"
         >
           {buttonLabel}
-        </EuiButton>
+        </EuiLink>
       </span>
     </>
   );

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/dive_deeper/doc_callouts.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/dive_deeper/doc_callouts.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButton, EuiLink, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { EuiLink, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 import React from 'react';
 
 export interface DocCalloutsProps {
@@ -35,11 +35,7 @@ export const DocCallouts: React.FC<DocCalloutsProps> = ({
       </EuiText>
       <EuiSpacer size="m" />
       <span>
-        <EuiLink
-          external
-          href={buttonHref}
-          data-test-subj={dataTestSubj}
-        >
+        <EuiLink external href={buttonHref} data-test-subj={dataTestSubj}>
           {buttonLabel}
         </EuiLink>
       </span>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/get_started_with_elasticsearch.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/get_started_with_elasticsearch.tsx
@@ -87,8 +87,9 @@ const GettingStartedCards: React.FC<GettingStartedCardsProps> = ({
           alignItems="flexStart"
         >
           <EuiFlexItem grow={false}>
-            <EuiText size="relative">{card.description}</EuiText>
+            <EuiText size="relative" color='subdued'>{card.description}</EuiText>
           </EuiFlexItem>
+          <EuiSpacer size='s' />
           <EuiFlexItem>{card.buttonComponent}</EuiFlexItem>
         </EuiFlexGroup>
       </EuiCard>
@@ -330,6 +331,7 @@ export const GetStartedWithElasticsearch = () => {
             })}
           </p>
         </EuiText>
+        <EuiSpacer size="m" />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiFlexGrid columns={isSmallScreen ? 2 : 4} gutterSize="l" responsive={false}>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/get_started_with_elasticsearch.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/get_started_with_elasticsearch.tsx
@@ -87,9 +87,11 @@ const GettingStartedCards: React.FC<GettingStartedCardsProps> = ({
           alignItems="flexStart"
         >
           <EuiFlexItem grow={false}>
-            <EuiText size="relative" color='subdued'>{card.description}</EuiText>
+            <EuiText size="relative" color="subdued">
+              {card.description}
+            </EuiText>
           </EuiFlexItem>
-          <EuiSpacer size='s' />
+          <EuiSpacer size="s" />
           <EuiFlexItem>{card.buttonComponent}</EuiFlexItem>
         </EuiFlexGroup>
       </EuiCard>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/index.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiPageTemplate, EuiFlexGroup, EuiFlexItem, useEuiTheme, EuiImage } from '@elastic/eui';
+import { EuiPageTemplate, EuiFlexGroup, EuiFlexItem, useEuiTheme, useCurrentEuiBreakpoint, EuiImage } from '@elastic/eui';
 
 import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 import { useKibana } from '../../hooks/use_kibana';
@@ -16,6 +16,7 @@ export const SearchHomepageHeader: React.FC = () => {
   const { euiTheme, colorMode } = useEuiTheme();
   const assetBasePath = useAssetBasePath();
   const { cloud } = useKibana().services;
+  const currentBreakpoint = useCurrentEuiBreakpoint();
 
   return (
     <EuiPageTemplate.Section
@@ -29,9 +30,16 @@ export const SearchHomepageHeader: React.FC = () => {
         style={{
           paddingLeft: euiTheme.size.xxl,
           paddingRight: euiTheme.size.xxl,
+          flexFlow: currentBreakpoint === 'xs' ? 'column-reverse' : 'initial', 
         }}
       >
-        <EuiFlexItem style={{ alignSelf: 'center' }}>
+        <EuiFlexItem
+          style={{
+            alignSelf: 'center',
+            paddingTop: euiTheme.size.xxl,
+            paddingBottom: euiTheme.size.xxl,
+          }}
+        >
           {cloud?.isServerlessEnabled ? <StatelessHeaderPromo /> : <StatefulHeaderPromo />}
         </EuiFlexItem>
 

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/index.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/index.tsx
@@ -5,7 +5,14 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiPageTemplate, EuiFlexGroup, EuiFlexItem, useEuiTheme, useCurrentEuiBreakpoint, EuiImage } from '@elastic/eui';
+import {
+  EuiPageTemplate,
+  EuiFlexGroup,
+  EuiFlexItem,
+  useEuiTheme,
+  useCurrentEuiBreakpoint,
+  EuiImage,
+} from '@elastic/eui';
 
 import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 import { useKibana } from '../../hooks/use_kibana';
@@ -30,7 +37,7 @@ export const SearchHomepageHeader: React.FC = () => {
         style={{
           paddingLeft: euiTheme.size.xxl,
           paddingRight: euiTheme.size.xxl,
-          flexFlow: currentBreakpoint === 'xs' ? 'column-reverse' : 'initial', 
+          flexFlow: currentBreakpoint === 'xs' ? 'column-reverse' : 'initial',
         }}
       >
         <EuiFlexItem

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/header/promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/header/promo.tsx
@@ -17,7 +17,7 @@ export interface HeaderPromoProps {
 
 export const HeaderPromo = ({ title, description, updates, actions }: HeaderPromoProps) => {
   return (
-    <EuiPanel color="transparent" paddingSize="xl">
+    <EuiPanel color="transparent" paddingSize="none">
       <EuiTitle size="l">
         <h1>{title}</h1>
       </EuiTitle>
@@ -25,7 +25,7 @@ export const HeaderPromo = ({ title, description, updates, actions }: HeaderProm
       <EuiText grow={false}>
         <p>{description}</p>
       </EuiText>
-      <EuiSpacer size="xl" />
+      <EuiSpacer size="m" />
       {updates && updates.length > 0 ? <FeatureUpdateGroup updates={updates} /> : null}
       <EuiFlexGroup alignItems="center" gutterSize="m">
         {actions}

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_body.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_body.tsx
@@ -7,7 +7,14 @@
 
 import React, { useEffect } from 'react';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
-import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, useEuiTheme } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  useEuiTheme,
+  EuiTitle,
+  EuiSpacer,
+} from '@elastic/eui';
 
 import { css } from '@emotion/react';
 import { ConnectToElasticsearch } from './connect_to_elasticsearch';
@@ -19,6 +26,7 @@ import { AnalyticsEvents } from '../analytics/constants';
 import { GetStartedWithElasticsearch } from './get_started_with_elasticsearch';
 import { CloudServerlessPromo } from './cloud_serverless_promo/cloud_serverless_promo';
 import { useKibana } from '../hooks/use_kibana';
+import { i18n } from '@kbn/i18n';
 
 export const SearchHomepageBody = () => {
   const usageTracker = useUsageTracker();
@@ -47,34 +55,34 @@ export const SearchHomepageBody = () => {
         <EuiFlexItem css={itemPadding}>
           <GetStartedWithElasticsearch />
         </EuiFlexItem>
-        {!isCloudEnabled && (
-          <>
-            <EuiFlexItem>
-              <EuiHorizontalRule />
-            </EuiFlexItem>
-            <EuiFlexItem css={itemPadding}>
-              <CloudServerlessPromo />
-            </EuiFlexItem>
-          </>
-        )}
         <EuiFlexItem>
           <EuiHorizontalRule />
         </EuiFlexItem>
         <EuiFlexItem css={itemPadding}>
-          <DiveDeeperWithElasticsearch />
+          <EuiTitle size="s">
+            <h3>
+              {i18n.translate('xpack.searchHomepage.getStarted.title', {
+                defaultMessage: 'Explore additional solutions',
+              })}
+            </h3>
+          </EuiTitle>
+          <EuiSpacer size="xl" />
+
+          <EuiFlexItem>
+            {!isCloudEnabled && (
+              <>
+                <CloudServerlessPromo />
+                <EuiSpacer size="xl" />
+                <EuiSpacer size="xl" />
+              </>
+            )}
+            <AlternateSolutions />
+            <EuiSpacer size="xl" />
+            <EuiHorizontalRule margin="xxl" />
+            <DiveDeeperWithElasticsearch />
+          </EuiFlexItem>
         </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiHorizontalRule />
-        </EuiFlexItem>
-        <EuiFlexItem css={itemPadding}>
-          <AlternateSolutions />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiHorizontalRule />
-        </EuiFlexItem>
-        <EuiFlexItem css={itemPadding}>
-          <Footer />
-        </EuiFlexItem>
+
       </EuiFlexGroup>
     </KibanaPageTemplate.Section>
   );

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_body.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_body.tsx
@@ -17,16 +17,15 @@ import {
 } from '@elastic/eui';
 
 import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
 import { ConnectToElasticsearch } from './connect_to_elasticsearch';
 import { AlternateSolutions } from './alternate_solutions/alternate_solutions';
 import { DiveDeeperWithElasticsearch } from './dive_deeper/dive_deeper_with_elasticsearch';
-import { Footer } from './footer/footer';
 import { useUsageTracker } from '../contexts/usage_tracker_context';
 import { AnalyticsEvents } from '../analytics/constants';
 import { GetStartedWithElasticsearch } from './get_started_with_elasticsearch';
 import { CloudServerlessPromo } from './cloud_serverless_promo/cloud_serverless_promo';
 import { useKibana } from '../hooks/use_kibana';
-import { i18n } from '@kbn/i18n';
 
 export const SearchHomepageBody = () => {
   const usageTracker = useUsageTracker();
@@ -82,7 +81,6 @@ export const SearchHomepageBody = () => {
             <DiveDeeperWithElasticsearch />
           </EuiFlexItem>
         </EuiFlexItem>
-
       </EuiFlexGroup>
     </KibanaPageTemplate.Section>
   );

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_body.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_body.tsx
@@ -67,19 +67,17 @@ export const SearchHomepageBody = () => {
           </EuiTitle>
           <EuiSpacer size="xl" />
 
-          <EuiFlexItem>
-            {!isCloudEnabled && (
-              <>
-                <CloudServerlessPromo />
-                <EuiSpacer size="xl" />
-                <EuiSpacer size="xl" />
-              </>
-            )}
-            <AlternateSolutions />
-            <EuiSpacer size="xl" />
-            <EuiHorizontalRule margin="xxl" />
-            <DiveDeeperWithElasticsearch />
-          </EuiFlexItem>
+          {!isCloudEnabled && (
+            <>
+              <CloudServerlessPromo />
+              <EuiSpacer size="xl" />
+              <EuiSpacer size="xl" />
+            </>
+          )}
+          <AlternateSolutions />
+          <EuiSpacer size="xl" />
+          <EuiHorizontalRule margin="xxl" />
+          <DiveDeeperWithElasticsearch />
         </EuiFlexItem>
       </EuiFlexGroup>
     </KibanaPageTemplate.Section>

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_body.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_body.tsx
@@ -60,7 +60,7 @@ export const SearchHomepageBody = () => {
         <EuiFlexItem css={itemPadding}>
           <EuiTitle size="s">
             <h3>
-              {i18n.translate('xpack.searchHomepage.getStarted.title', {
+              {i18n.translate('xpack.searchHomepage.additionalSolutions.title', {
                 defaultMessage: 'Explore additional solutions',
               })}
             </h3>

--- a/x-pack/solutions/search/plugins/search_homepage/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_homepage/tsconfig.json
@@ -8,6 +8,7 @@
     "common/**/*",
     "public/**/*",
     "server/**/*",
+    "../../../../../typings/emotion.d.ts"
   ],
   "kbn_references": [
     "@kbn/core",


### PR DESCRIPTION
## Summary

Fixes some UI papercuts on the current home page:
Closes https://github.com/elastic/search-team/issues/11831
Closes https://github.com/elastic/search-team/issues/11835
Closes https://github.com/elastic/search-team/issues/11836

- Fixes small typography discrepancies across page

**Before**
<img width="4316" height="2760" alt="CleanShot 2025-12-04 at 16 32 00@2x" src="https://github.com/user-attachments/assets/1b83bd3a-0ed1-4370-a1b7-f8d6aac4fea5" />
<img width="4316" height="2766" alt="CleanShot 2025-12-04 at 16 33 56@2x" src="https://github.com/user-attachments/assets/3ec2583d-202d-4388-a6f5-bdbe91fcc41e" />


**After**
<img width="4316" height="2762" alt="CleanShot 2025-12-04 at 16 25 55@2x" src="https://github.com/user-attachments/assets/b7d079bd-ee4c-4c39-8a73-7a57bfea561d" />
<img width="4312" height="2680" alt="CleanShot 2025-12-04 at 16 34 26@2x" src="https://github.com/user-attachments/assets/47ef0c5a-8f62-47a3-8f2a-c866a1ed5af9" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)





<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->