### PR TITLE
Fix pointer events behavior on notification indicator on SplitButton

### DIFF
--- a/src/platform/packages/private/kbn-split-button/src/split_button_with_notification.tsx
+++ b/src/platform/packages/private/kbn-split-button/src/split_button_with_notification.tsx
@@ -66,6 +66,7 @@ export const SplitButtonWithNotification = ({
             left: notificationIndicatorPosition?.left,
             bottom: notificationIndicatorPosition?.bottom,
             zIndex: 1,
+            pointerEvents: 'none',
             ...(notificationIndicatorHasStroke && {
               '& svg': {
                 stroke: 'white',
@@ -75,12 +76,14 @@ export const SplitButtonWithNotification = ({
             }),
           }}
         >
-          <EuiIconTip
-            type="dot"
-            size={notificationIndicatorSize}
-            color={notificationIndicatorColor}
-            content={notifcationIndicatorTooltipContent}
-          />
+          <span css={{ pointerEvents: 'auto' }}>
+            <EuiIconTip
+              type="dot"
+              size={notificationIndicatorSize}
+              color={notificationIndicatorColor}
+              content={notifcationIndicatorTooltipContent}
+            />
+          </span>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

This PR fixes an issue where the notification indicator wrapper would prevent the underlying button from being fully clickable. This fix still allows for tooltip to work when hovering over the dot icon.


