### PR TITLE
[Security Solution] unskip ti cases Cypress tests

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/cases.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/cases.cy.ts
@@ -33,8 +33,7 @@ import { login } from '../../../tasks/login';
 
 const URL = '/app/security/threat_intelligence/indicators';
 
-// FLAKY: https://github.com/elastic/kibana/issues/244231
-describe.skip('Cases with invalid indicators', { tags: ['@ess'] }, () => {
+describe('Cases with invalid indicators', { tags: ['@ess'] }, () => {
   before(() => cy.task('esArchiverLoad', { archiveName: 'ti_indicators_data_invalid' }));
 
   after(() => cy.task('esArchiverUnload', { archiveName: 'ti_indicators_data_invalid' }));
@@ -60,8 +59,7 @@ describe.skip('Cases with invalid indicators', { tags: ['@ess'] }, () => {
   });
 });
 
-// FLAKY: https://github.com/elastic/kibana/issues/239929
-describe.skip('Cases interactions', { tags: ['@ess'] }, () => {
+describe('Cases interactions', { tags: ['@ess'] }, () => {
   before(() => cy.task('esArchiverLoad', { archiveName: 'ti_indicators_data_single' }));
 
   after(() => cy.task('esArchiverUnload', { archiveName: 'ti_indicators_data_single' }));

--- a/x-pack/solutions/security/test/security_solution_cypress/package.json
+++ b/x-pack/solutions/security/test/security_solution_cypress/package.json
@@ -8,8 +8,6 @@
     "cypress": "../../../../../node_modules/.bin/cypress",
     "junit:merge": "../../../../../node_modules/.bin/mochawesome-merge ../../../../../target/kibana-security-solution/cypress/results/mochawesome*.json > ../../../../../target/kibana-security-solution/cypress/results/output.json && ../../../../../node_modules/.bin/marge ../../../../../target/kibana-security-solution/cypress/results/output.json --reportDir ../../../../../target/kibana-security-solution/cypress/results && yarn junit:transform && mkdir -p ../../../../../target/junit && cp ../../../../../target/kibana-security-solution/cypress/results/*.xml ../../../../../target/junit/",
     "junit:transform": "node ../../plugins/security_solution/scripts/junit_transformer --pathPattern '../../../../../target/kibana-security-solution/cypress/results/*.xml' --rootDirectory ../../../../../ --reportName 'Security Solution Cypress' --writeInPlace",
-
-
     "cypress:open:ess": "TZ=UTC node ../../plugins/security_solution/scripts/start_cypress_parallel open --spec './cypress/e2e/**/*.cy.ts' --config-file ./test/security_solution_cypress/cypress/cypress.config.ts --ftr-config-file ./cli_config",
     "cypress:asset_inventory:run:ess": "yarn cypress:ess --spec '.cypress/screens/asset_inventory/**/*.cy.ts'",
     "cypress:entity_analytics:run:ess": "yarn cypress:ess --spec './cypress/e2e/entity_analytics/**/*.cy.ts'",
@@ -24,7 +22,7 @@
     "cypress:detection_engine:exceptions:run:ess": "yarn cypress:ess --spec './cypress/e2e/detection_response/detection_engine/exceptions/**/*.cy.ts'",
     "cypress:ai_assistant:run:ess": "yarn cypress:ess --spec './cypress/e2e/ai_assistant/**/*.cy.ts'",
     "cypress:run:respops:ess": "yarn cypress:ess --spec './cypress/e2e/detection_response/**/*.cy.ts'",
-    "cypress:investigations:run:ess": "yarn cypress:ess --spec './cypress/e2e/investigations/**/*.cy.ts'",
+    "cypress:investigations:run:ess": "yarn cypress:ess --spec './cypress/e2e/investigations/threat_intelligence/cases.cy.ts'",
     "cypress:explore:run:ess": "yarn cypress:ess --spec './cypress/e2e/explore/**/*.cy.ts'",
     "cypress:changed-specs-only:ess": "yarn cypress:ess --changed-specs-only --env burn=5",
     "cypress:cloud_security_posture:run:ess": "yarn cypress:ess --spec './cypress/e2e/cloud_security_posture/**/*.cy.ts'",
@@ -47,13 +45,11 @@
     "cypress:ai_assistant:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/ai_assistant/**/*.cy.ts'",
     "cypress:ai4dsoc:run:serverless": "yarn cypress:ai4dsoc:serverless --spec './cypress/e2e/ai4dsoc/**/*.cy.ts'",
     "cypress:automatic_import:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/automatic_import/**/*.cy.ts'",
-    "cypress:investigations:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/investigations/**/*.cy.ts'",
+    "cypress:investigations:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/investigations/threat_intelligence/cases.cy.ts'",
     "cypress:explore:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/explore/**/*.cy.ts'",
     "cypress:changed-specs-only:serverless": "yarn cypress:serverless --changed-specs-only --env burn=5",
     "cypress:cloud_security_posture:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/cloud_security_posture/**/*.cy.ts'",
     "cypress:burn:serverless": "yarn cypress:serverless --env burn=2",
-
-
     "cypress:qa:serverless": "TZ=UTC node ../../plugins/security_solution/scripts/start_cypress_parallel_serverless --config-file ./test/security_solution_cypress/cypress/cypress_ci_serverless_qa.config.ts",
     "cypress:open:qa:serverless": "yarn cypress:qa:serverless open",
     "cypress:run:qa:serverless:ai_assistant": "yarn cypress:qa:serverless --spec './cypress/e2e/ai_assistant/**/*.cy.ts'",

--- a/x-pack/solutions/security/test/security_solution_cypress/package.json
+++ b/x-pack/solutions/security/test/security_solution_cypress/package.json
@@ -8,6 +8,8 @@
     "cypress": "../../../../../node_modules/.bin/cypress",
     "junit:merge": "../../../../../node_modules/.bin/mochawesome-merge ../../../../../target/kibana-security-solution/cypress/results/mochawesome*.json > ../../../../../target/kibana-security-solution/cypress/results/output.json && ../../../../../node_modules/.bin/marge ../../../../../target/kibana-security-solution/cypress/results/output.json --reportDir ../../../../../target/kibana-security-solution/cypress/results && yarn junit:transform && mkdir -p ../../../../../target/junit && cp ../../../../../target/kibana-security-solution/cypress/results/*.xml ../../../../../target/junit/",
     "junit:transform": "node ../../plugins/security_solution/scripts/junit_transformer --pathPattern '../../../../../target/kibana-security-solution/cypress/results/*.xml' --rootDirectory ../../../../../ --reportName 'Security Solution Cypress' --writeInPlace",
+
+
     "cypress:open:ess": "TZ=UTC node ../../plugins/security_solution/scripts/start_cypress_parallel open --spec './cypress/e2e/**/*.cy.ts' --config-file ./test/security_solution_cypress/cypress/cypress.config.ts --ftr-config-file ./cli_config",
     "cypress:asset_inventory:run:ess": "yarn cypress:ess --spec '.cypress/screens/asset_inventory/**/*.cy.ts'",
     "cypress:entity_analytics:run:ess": "yarn cypress:ess --spec './cypress/e2e/entity_analytics/**/*.cy.ts'",
@@ -22,7 +24,7 @@
     "cypress:detection_engine:exceptions:run:ess": "yarn cypress:ess --spec './cypress/e2e/detection_response/detection_engine/exceptions/**/*.cy.ts'",
     "cypress:ai_assistant:run:ess": "yarn cypress:ess --spec './cypress/e2e/ai_assistant/**/*.cy.ts'",
     "cypress:run:respops:ess": "yarn cypress:ess --spec './cypress/e2e/detection_response/**/*.cy.ts'",
-    "cypress:investigations:run:ess": "yarn cypress:ess --spec './cypress/e2e/investigations/threat_intelligence/cases.cy.ts'",
+    "cypress:investigations:run:ess": "yarn cypress:ess --spec './cypress/e2e/investigations/**/*.cy.ts'",
     "cypress:explore:run:ess": "yarn cypress:ess --spec './cypress/e2e/explore/**/*.cy.ts'",
     "cypress:changed-specs-only:ess": "yarn cypress:ess --changed-specs-only --env burn=5",
     "cypress:cloud_security_posture:run:ess": "yarn cypress:ess --spec './cypress/e2e/cloud_security_posture/**/*.cy.ts'",
@@ -45,11 +47,13 @@
     "cypress:ai_assistant:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/ai_assistant/**/*.cy.ts'",
     "cypress:ai4dsoc:run:serverless": "yarn cypress:ai4dsoc:serverless --spec './cypress/e2e/ai4dsoc/**/*.cy.ts'",
     "cypress:automatic_import:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/automatic_import/**/*.cy.ts'",
-    "cypress:investigations:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/investigations/threat_intelligence/cases.cy.ts'",
+    "cypress:investigations:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/investigations/**/*.cy.ts'",
     "cypress:explore:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/explore/**/*.cy.ts'",
     "cypress:changed-specs-only:serverless": "yarn cypress:serverless --changed-specs-only --env burn=5",
     "cypress:cloud_security_posture:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/cloud_security_posture/**/*.cy.ts'",
     "cypress:burn:serverless": "yarn cypress:serverless --env burn=2",
+
+
     "cypress:qa:serverless": "TZ=UTC node ../../plugins/security_solution/scripts/start_cypress_parallel_serverless --config-file ./test/security_solution_cypress/cypress/cypress_ci_serverless_qa.config.ts",
     "cypress:open:qa:serverless": "yarn cypress:qa:serverless open",
     "cypress:run:qa:serverless:ai_assistant": "yarn cypress:qa:serverless --spec './cypress/e2e/ai_assistant/**/*.cy.ts'",


### PR DESCRIPTION
## Summary

This PR unskips the Threat Intelligence `cases` Cypress tests. Running the test locally and everything is working!

<img width="639" height="216" alt="Screenshot 2025-12-04 at 4 59 32 PM" src="https://github.com/user-attachments/assets/6214c138-028b-45a2-b057-c7d8740b716c" />

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10004

### Checklist

- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/244231
https://github.com/elastic/kibana/issues/239929