### PR TITLE
[ci/build] Increase serverless build timeout

### DIFF
--- a/.buildkite/pipelines/artifacts_container_image.yml
+++ b/.buildkite/pipelines/artifacts_container_image.yml
@@ -7,4 +7,4 @@ steps:
       provider: gcp
       machineType: n2-standard-16
       diskSizeGb: 150
-    timeout_in_minutes: 60
+    timeout_in_minutes: 90


### PR DESCRIPTION
This pipeline has been hovering around the timeout length and occasionally surpassing it recently.  

Solution specific images are the primary reason for the longer build time.