### PR TITLE
feat(security): default API Keys view to Personal keys only

### DIFF
--- a/x-pack/platform/plugins/shared/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.tsx
@@ -53,7 +53,9 @@ const DEFAULT_TABLE_STATE = {
   },
   from: 0,
   size: 25,
-  filters: {},
+  filters: {
+    type: 'rest' as const,
+  },
 };
 
 const PLUS_SIGN_REGEX = /[+]/g;


### PR DESCRIPTION
Change the default filter state on the API Keys management page to display only Personal API keys instead of showing all types (Personal, Managed, and Cross-Cluster) by default.

Users can still toggle filters to view other key types as needed.

Closes #245255


<img width="1386" height="351" alt="Screenshot 2025-12-05 at 09 19 52" src="https://github.com/user-attachments/assets/6ba6b4f2-1b1d-42ad-a0f2-add4aa36caee" />
