### PR TITLE
🌊 Fix validation for partially invalid streamlang steps

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/shared/flatten_steps.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/shared/flatten_steps.test.ts
@@ -66,4 +66,55 @@ describe('flattenSteps', () => {
     const steps = [{ action: 'set', to: 'foo', value: 'bar' }] as StreamlangStep[];
     expect(flattenSteps(steps)).toEqual([{ action: 'set', to: 'foo', value: 'bar' }]);
   });
+
+  it('should handle where blocks with customIdentifier and nested where conditions', () => {
+    const steps = [
+      {
+        action: 'grok',
+        from: 'message',
+        patterns: ['%{WORD:abc}'],
+        customIdentifier: 'i31b51cb0-d1c9-11f0-a523-ed186b43cf76',
+      },
+      {
+        where: {
+          field: 'sdfds',
+          eq: 'dsfsdf',
+          steps: [
+            {
+              action: 'grok',
+              from: '',
+              patterns: [''],
+              ignore_failure: true,
+              ignore_missing: true,
+              where: {
+                always: {},
+              },
+              customIdentifier: 'i3b6100d0-d1c9-11f0-a523-ed186b43cf76',
+            },
+          ],
+        },
+        customIdentifier: 'i342ea830-d1c9-11f0-a523-ed186b43cf76',
+      },
+    ] as StreamlangStep[];
+
+    expect(flattenSteps(steps)).toEqual([
+      {
+        action: 'grok',
+        from: 'message',
+        patterns: ['%{WORD:abc}'],
+        customIdentifier: 'i31b51cb0-d1c9-11f0-a523-ed186b43cf76',
+      },
+      {
+        action: 'grok',
+        from: '',
+        patterns: [''],
+        ignore_failure: true,
+        ignore_missing: true,
+        where: {
+          and: [{ field: 'sdfds', eq: 'dsfsdf' }, { always: {} }],
+        },
+        customIdentifier: 'i3b6100d0-d1c9-11f0-a523-ed186b43cf76',
+      },
+    ]);
+  });
 });

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/shared/flatten_steps.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/shared/flatten_steps.ts
@@ -8,7 +8,7 @@
 import type { StreamlangProcessorDefinition } from '../../../types/processors';
 import type { Condition } from '../../../types/conditions';
 import type { StreamlangStep } from '../../../types/streamlang';
-import { isWhereBlockSchema } from '../../../types/streamlang';
+import { isWhereBlock } from '../../../types/streamlang';
 
 /**
  * Helper to combine two conditions as an "and" logical condition.
@@ -30,7 +30,7 @@ export function flattenSteps(
 ): StreamlangProcessorDefinition[] {
   return steps.flatMap((step) => {
     // Handle where blocks (conditional execution)
-    if (isWhereBlockSchema(step)) {
+    if (isWhereBlock(step)) {
       const conditionWithSteps = step.where;
       // Strip steps for the resursive call, everything left is the condition.
       const { steps: nestedSteps, ...rest } = conditionWithSteps;
@@ -50,7 +50,7 @@ export function flattenSteps(
         {
           ...rest,
           where: combinedCondition,
-        } as StreamlangProcessorDefinition,
+        },
       ];
     }
 
@@ -58,8 +58,8 @@ export function flattenSteps(
     const processorCopy = { ...processor };
     if ('where' in processorCopy) delete processorCopy.where;
     if (parentCondition) {
-      return [{ ...processorCopy, where: parentCondition } as StreamlangProcessorDefinition];
+      return [{ ...processorCopy, where: parentCondition }];
     }
-    return [processorCopy as StreamlangProcessorDefinition];
+    return [processorCopy];
   });
 }


### PR DESCRIPTION
This PR fixes the problem that after adding a condition, it's not possible to add more processors anymore.

This happened because `isWhereBlockSchema` would return false for a well-formed where-block if it contains an invalid processor, which is the case when adding a new processor (because the default grok state has an empty field name, which is not valid as per the schema). This broke the validation logic.

By using `isWhereBlock` it makes the check cheaper and also doesn't fail on invalid children. Also added a test for this.