### PR TITLE
[ES|QL ] Create Lookup Index Must Appear in the First Position

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands_registry/commands/join/autocomplete.test.ts
@@ -21,6 +21,7 @@ import {
   inOperators,
   nullCheckOperators,
 } from '../../../definitions/all_operators';
+import { SuggestionCategory } from '../../../sorting/types';
 
 type ExpectedSuggestions = string[] | { contains?: string[]; notContains?: string[] };
 
@@ -112,6 +113,7 @@ describe('JOIN Autocomplete', () => {
       );
 
       expect(createIndexCommandSuggestion).toEqual({
+        category: SuggestionCategory.CUSTOM_ACTION,
         command: {
           arguments: [{ indexName: '' }],
           id: 'esql.lookup_index.create',
@@ -183,6 +185,7 @@ describe('JOIN Autocomplete', () => {
       );
 
       expect(createIndexCommandSuggestion).toEqual({
+        category: SuggestionCategory.CUSTOM_ACTION,
         command: {
           arguments: [{ indexName: 'new_join_index' }],
           id: 'esql.lookup_index.create',

--- a/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/autocomplete/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/definitions/utils/autocomplete/helpers.ts
@@ -592,6 +592,8 @@ export function getLookupIndexCreateSuggestion(
 
     sortText: '0',
 
+    category: SuggestionCategory.CUSTOM_ACTION,
+
     command: {
       id: `esql.lookup_index.create`,
 


### PR DESCRIPTION
## Summary
the  `Create lookup Index` command now takes priority in the sorting order and appears before the indexes that are sorted alphabetically

<img width="634" height="253" alt="lookup" src="https://github.com/user-attachments/assets/c988f45c-c0d7-4778-a720-d178e4ce0202" />

