### PR TITLE
[ResponseOps][ConnectorsV2] Include additional headers in `actionsClient.getAxiosInstance`

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_axios_instance/get_axios_instance.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_axios_instance/get_axios_instance.test.ts
@@ -124,6 +124,7 @@ describe('getAxiosInstance()', () => {
         id: defaultConnectorTypeId,
         isSystemActionType: true,
         supportedFeatureIds: ['workflows'],
+        globalAuthHeaders: { foo: 'bar' },
         validate: {
           config: { schema: z.object({}) },
           secrets: { schema: z.object({ foobar: z.boolean() }) },
@@ -156,13 +157,14 @@ describe('getAxiosInstance()', () => {
     getEventLogClient.mockResolvedValue(eventLogClient);
   });
 
-  it('calls the getAxiosInstanceWithAuth with the connector secrets', async () => {
+  it('calls getAxiosInstanceWithAuth with the correct params', async () => {
     unsecuredSavedObjectsClient.get.mockResolvedValueOnce(actionTypeIdFromSavedObjectMock());
     await actionsClient.getAxiosInstance(defaultConnectorId);
     expect(getAxiosInstanceWithAuth).toHaveBeenCalledWith({
       connectorId: defaultConnectorId,
       connectorTokenClient,
       secrets: { foobar: true },
+      additionalHeaders: { foo: 'bar' },
     });
   });
 

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_axios_instance/get_axios_instance.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_axios_instance/get_axios_instance.ts
@@ -111,6 +111,7 @@ export async function getAxiosInstance(
   return await getAxiosInstanceWithAuth({
     connectorId,
     connectorTokenClient,
+    additionalHeaders: actionType.globalAuthHeaders,
     secrets: validatedSecrets,
   });
 }


### PR DESCRIPTION
## Summary

Updates #244619 with the changes in #245132 .