### PR TITLE
[CPS] Support in Lens

### DIFF
--- a/src/platform/packages/shared/kbn-lens-common/moon.yml
+++ b/src/platform/packages/shared/kbn-lens-common/moon.yml
@@ -66,6 +66,7 @@ dependsOn:
   - '@kbn/i18n'
   - '@kbn/chart-icons'
   - '@kbn/alerts-ui-shared'
+  - '@kbn/cps'
 tags:
   - shared-common
   - package

--- a/src/platform/packages/shared/kbn-lens-common/tsconfig.json
+++ b/src/platform/packages/shared/kbn-lens-common/tsconfig.json
@@ -63,6 +63,7 @@
     "@kbn/saved-objects-plugin",
     "@kbn/i18n",
     "@kbn/chart-icons",
-    "@kbn/alerts-ui-shared"
+    "@kbn/alerts-ui-shared",
+    "@kbn/cps"
   ]
 }

--- a/src/platform/packages/shared/kbn-lens-common/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/types.ts
@@ -8,7 +8,7 @@
  */
 
 import type { IconType } from '@elastic/eui/src/components/icon/icon';
-import type { Query, AggregateQuery } from '@kbn/es-query';
+import type { Query, AggregateQuery, ProjectRouting } from '@kbn/es-query';
 import { type DataView } from '@kbn/data-plugin/common';
 import type {
   DataPublicPluginStart,
@@ -77,6 +77,7 @@ import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import type { Adapters } from '@kbn/inspector-plugin/common';
 import type { InspectorOptions } from '@kbn/inspector-plugin/public';
 import type { OnSaveProps } from '@kbn/saved-objects-plugin/public';
+import type { CPSPluginStart } from '@kbn/cps/public';
 import type { NavigateToLensContext } from './convert_to_lens_types';
 import type { LensAppLocator, MainHistoryLocationState } from './locator_types';
 import type { LensSavedObjectAttributes, StructuredDatasourceStates } from './embeddable/types';
@@ -175,6 +176,7 @@ export interface LensAppServices extends StartServices {
   locator?: LensAppLocator;
   lensDocumentService: ILensDocumentService;
   serverless?: ServerlessPluginStart;
+  cps?: CPSPluginStart;
 }
 
 export type StartServices = Pick<
@@ -771,7 +773,8 @@ export interface Datasource<T = unknown, P = unknown, Q = Query | AggregateQuery
     dateRange: DateRange,
     nowInstant: Date,
     searchSessionId?: string,
-    forceDSL?: boolean
+    forceDSL?: boolean,
+    projectRouting?: ProjectRouting
   ) => ExpressionAstExpression | string | null;
 
   getDatasourceSuggestionsForField: (
@@ -1386,6 +1389,7 @@ export interface LensAppState extends EditorFrameState {
   // Dataview/Indexpattern management has moved in here from datasource
   dataViews: DataViewsState;
   annotationGroups: AnnotationGroups;
+  projectRouting?: ProjectRouting;
 
   // Whether the current visualization is managed by the system
   managed: boolean;

--- a/x-pack/platform/plugins/shared/lens/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/lens/kibana.jsonc
@@ -48,6 +48,7 @@
       "serverless",
       "licensing",
       "fieldsMetadata",
+      "cps",
     ],
     "requiredBundles": [
       "unifiedSearch",

--- a/x-pack/platform/plugins/shared/lens/moon.yml
+++ b/x-pack/platform/plugins/shared/lens/moon.yml
@@ -147,6 +147,7 @@ dependsOn:
   - '@kbn/react-kibana-context-common'
   - '@kbn/unified-tabs'
   - '@kbn/esql-composer'
+  - '@kbn/cps'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/mounter.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/mounter.tsx
@@ -97,6 +97,7 @@ export async function getLensServices(
     unifiedSearch,
     serverless,
     contentManagement,
+    cps,
   } = startDependencies;
 
   const storage = new Storage(localStorage);
@@ -133,6 +134,7 @@ export async function getLensServices(
     unifiedSearch,
     locator,
     serverless,
+    cps,
     ...coreStart,
   };
 }

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -78,6 +78,7 @@ import type { SavedObjectTaggingPluginStart } from '@kbn/saved-objects-tagging-p
 import type { ServerlessPluginStart } from '@kbn/serverless/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
+import type { CPSPluginStart } from '@kbn/cps/public';
 import type { EditorFrameService as EditorFrameServiceType } from './editor_frame_service';
 import type {
   FormBasedDatasource as FormBasedDatasourceType,
@@ -184,6 +185,7 @@ export interface LensPluginStartDependencies {
   licensing?: LicensingPluginStart;
   embeddableEnhanced?: EmbeddableEnhancedPluginStart;
   fieldsMetadata?: FieldsMetadataPublicStart;
+  cps?: CPSPluginStart;
 }
 
 export interface LensPublicSetup {

--- a/x-pack/platform/plugins/shared/lens/public/state_management/__snapshots__/load_initial.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/lens/public/state_management/__snapshots__/load_initial.test.tsx.snap
@@ -91,6 +91,7 @@ Object {
       "type": "lens",
       "visualizationType": "testVis",
     },
+    "projectRouting": undefined,
     "query": Object {
       "language": "lucene",
       "query": "",

--- a/x-pack/platform/plugins/shared/lens/public/state_management/context_middleware/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/state_management/context_middleware/index.ts
@@ -45,7 +45,7 @@ export const contextMiddleware = (storeDeps: LensStoreDeps) => (store: Middlewar
     // store stopped loading and external context is not subscribed to yet - do it now
     if (!store.getState().lens.isLoading && !unsubscribeFromExternalContext) {
       unsubscribeFromExternalContext = subscribeToExternalContext(
-        storeDeps.lensServices.data,
+        storeDeps.lensServices,
         store.getState,
         store.dispatch
       );

--- a/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
@@ -389,7 +389,6 @@ export async function loadInitial(
     lens,
     initialInput,
     isLinkedToOriginatingApp,
-    inlineEditing,
   });
 
   const loaderSharedArgs: LoaderSharedArgs = {

--- a/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
@@ -152,8 +152,6 @@ function initProjectRoutingState({
   }
 }
 
-
-
 async function loadFromLocatorState(
   store: MiddlewareAPI,
   initialState: NonNullable<LensStoreDeps['initialStateFromLocator']>,

--- a/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
@@ -8,6 +8,7 @@
 import type { MiddlewareAPI } from '@reduxjs/toolkit';
 import { i18n } from '@kbn/i18n';
 import type { History } from 'history';
+import type { ProjectRouting } from '@kbn/es-query';
 import type {
   LensStoreDeps,
   LensAppState,
@@ -114,13 +115,53 @@ type PreloadedState = Omit<
   'resolvedDateRange' | 'searchSessionId' | 'isLinkedToOriginatingApp'
 >;
 
+/**
+ * Initialize project routing in CPS Manager
+ * Determines whether to preserve or reset the project routing based on the context
+ */
+function initProjectRoutingState({
+  cps,
+  lens,
+  initialInput,
+  isLinkedToOriginatingApp = false,
+}: {
+  cps: LensAppServices['cps'];
+  lens: LensAppState;
+  initialInput?: LensSerializedState;
+  isLinkedToOriginatingApp?: boolean;
+}) {
+  if (!cps?.cpsManager) {
+    return;
+  }
+  const cpsManager = cps.cpsManager;
+
+  // Check if dataSources have been initialized already to detect save/save-as scenarios
+  const hasActiveLensSession = !Object.values(lens.datasourceStates).every(
+    (ds) => ds.state === null
+  );
+
+  // Reset when: NOT linked to originating app, NOT active session, NOT embeddable
+  const shouldReset = !isLinkedToOriginatingApp && !hasActiveLensSession && !initialInput;
+
+  if (shouldReset) {
+    const defaultRouting = cpsManager.getDefaultProjectRouting();
+    cpsManager.setProjectRouting(defaultRouting);
+    return defaultRouting;
+  } else {
+    return cpsManager.getProjectRouting();
+  }
+}
+
+
+
 async function loadFromLocatorState(
   store: MiddlewareAPI,
   initialState: NonNullable<LensStoreDeps['initialStateFromLocator']>,
   loaderSharedArgs: LoaderSharedArgs,
   { notifications, data }: LensStoreDeps['lensServices'],
   emptyState: PreloadedState,
-  autoApplyDisabled: boolean
+  autoApplyDisabled: boolean,
+  projectRouting?: ProjectRouting
 ) {
   const { lens } = store.getState();
   const locatorReferences = 'references' in initialState ? initialState.references : undefined;
@@ -169,6 +210,7 @@ async function loadFromLocatorState(
       ),
       isLoading: false,
       annotationGroups,
+      projectRouting,
     })
   );
 
@@ -183,7 +225,8 @@ async function loadFromEmptyState(
   loaderSharedArgs: LoaderSharedArgs,
   { data }: LensStoreDeps['lensServices'],
   activeDatasourceId: string | undefined,
-  autoApplyDisabled: boolean
+  autoApplyDisabled: boolean,
+  projectRouting?: ProjectRouting
 ) {
   const { lens } = store.getState();
   const { datasourceStates, indexPatterns, indexPatternRefs } = await initializeSources(
@@ -216,6 +259,7 @@ async function loadFromEmptyState(
           {}
         ),
         isLoading: false,
+        projectRouting,
       },
       initialContext: loaderSharedArgs.initialContext,
     })
@@ -232,7 +276,8 @@ async function loadFromSavedObject(
   loaderSharedArgs: LoaderSharedArgs,
   { data, chrome }: LensStoreDeps['lensServices'],
   autoApplyDisabled: boolean,
-  inlineEditing?: boolean
+  inlineEditing?: boolean,
+  projectRouting?: ProjectRouting
 ) {
   const { doc, sharingSavedObjectProps, managed } = persisted;
   if (savedObjectId) {
@@ -319,6 +364,7 @@ async function loadFromSavedObject(
       isLoading: false,
       annotationGroups,
       managed,
+      projectRouting,
     })
   );
 
@@ -337,8 +383,16 @@ export async function loadInitial(
     storeDeps;
   const { resolvedDateRange, searchSessionId, isLinkedToOriginatingApp, ...emptyState } =
     getPreloadedState(storeDeps);
-  const { notifications, data } = lensServices;
+  const { notifications, data, cps } = lensServices;
   const { lens } = store.getState();
+
+  const projectRouting = initProjectRoutingState({
+    cps,
+    lens,
+    initialInput,
+    isLinkedToOriginatingApp,
+    inlineEditing,
+  });
 
   const loaderSharedArgs: LoaderSharedArgs = {
     visualizationMap,
@@ -370,6 +424,7 @@ export async function loadInitial(
       };
       data.query.timefilter.timefilter.setTime(newTimeRange);
     }
+
     // URL Reporting is using the locator params but also passing the savedObjectId
     // so be sure to not go here as there's no full snapshot URL
     if (!initialInput) {
@@ -380,7 +435,8 @@ export async function loadInitial(
           loaderSharedArgs,
           lensServices,
           emptyState,
-          autoApplyDisabled
+          autoApplyDisabled,
+          projectRouting
         );
       } catch ({ message }) {
         notifications.toasts.addDanger({
@@ -403,6 +459,7 @@ export async function loadInitial(
     if (newFilters) {
       data.query.filterManager.setAppFilters(newFilters);
     }
+
     try {
       return loadFromEmptyState(
         store,
@@ -410,7 +467,8 @@ export async function loadInitial(
         loaderSharedArgs,
         lensServices,
         activeDatasourceId,
-        autoApplyDisabled
+        autoApplyDisabled,
+        projectRouting
       );
     } catch ({ message }) {
       notifications.toasts.addDanger({
@@ -431,7 +489,8 @@ export async function loadInitial(
           loaderSharedArgs,
           lensServices,
           autoApplyDisabled,
-          inlineEditing
+          inlineEditing,
+          projectRouting
         );
       } catch ({ message }) {
         notifications.toasts.addDanger({

--- a/x-pack/platform/plugins/shared/lens/public/state_management/lens_slice.ts
+++ b/x-pack/platform/plugins/shared/lens/public/state_management/lens_slice.ts
@@ -74,6 +74,7 @@ export const initialState: LensAppState = {
     indexPatterns: {},
   },
   annotationGroups: {},
+  projectRouting: undefined,
   managed: false,
 };
 

--- a/x-pack/platform/plugins/shared/lens/public/state_management/selectors.ts
+++ b/x-pack/platform/plugins/shared/lens/public/state_management/selectors.ts
@@ -17,6 +17,7 @@ export const selectQuery = (state: LensState) => state.lens.query;
 export const selectSearchSessionId = (state: LensState) => state.lens.searchSessionId;
 export const selectFilters = (state: LensState) => state.lens.filters;
 export const selectResolvedDateRange = (state: LensState) => state.lens.resolvedDateRange;
+export const selectProjectRouting = (state: LensState) => state.lens.projectRouting;
 export const selectAdHocDataViews = (state: LensState) =>
   Object.fromEntries(
     Object.values(state.lens.dataViews.indexPatterns)
@@ -49,12 +50,13 @@ export const selectTriggerApplyChanges = (state: LensState) => {
 
 // TODO - is there any point to keeping this around since we have selectExecutionSearchContext?
 export const selectExecutionContext = createSelector(
-  [selectQuery, selectFilters, selectResolvedDateRange],
-  (query, filters, dateRange) => ({
+  [selectQuery, selectFilters, selectResolvedDateRange, selectProjectRouting],
+  (query, filters, dateRange, projectRouting) => ({
     now: Date.now(),
     dateRange,
     query,
     filters,
+    projectRouting,
   })
 );
 
@@ -67,6 +69,7 @@ export const selectExecutionContextSearch = createSelector(selectExecutionContex
   },
   filters: res.filters,
   disableWarningToasts: true,
+  projectRouting: res.projectRouting,
 }));
 
 const selectInjectedDependencies = (_state: LensState, dependencies: unknown) => dependencies;

--- a/x-pack/platform/plugins/shared/lens/tsconfig.json
+++ b/x-pack/platform/plugins/shared/lens/tsconfig.json
@@ -134,6 +134,7 @@
     "@kbn/react-kibana-context-common",
     "@kbn/unified-tabs",
     "@kbn/esql-composer",
+    "@kbn/cps",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Adds CPS functionality to Lens, enabling to react to changes in CPS project picker. DOESN'T ALLOW TO SAVE THE SETTING.
<img width="941" height="520" alt="Screenshot 2025-12-05 at 14 24 14" src="https://github.com/user-attachments/assets/68685493-e487-40cd-8028-21fca832fab2" />

### Changes

When navigating to Lens, it either preserves or clears the project picker setting:

  - Create new Lens viz from library -> starts with default setting always
  - Direct URL to saved viz → resets to default
  - edit from dashboard → preserves
  - Edit from Discover → preserves
  - Change project in picker → visualization updates
