### PR TITLE
Revert "[Response Ops][Reporting] Classifying CSV timeouts with row count warnings as user error (#241349)

### DIFF
--- a/src/platform/packages/private/kbn-generate-csv/src/generate_csv.test.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/generate_csv.test.ts
@@ -494,7 +494,6 @@ describe('CsvGenerator', () => {
               "rows": 0,
             },
           },
-          "user_error": undefined,
           "warnings": Array [
             "Unable to close the Point-In-Time used for search. Check the Kibana server logs.",
           ],
@@ -1452,84 +1451,6 @@ describe('CsvGenerator', () => {
     );
   });
 
-  it('will return warning and user_error if search results does not match expected total', async () => {
-    const mockJobUsingPitPaging = createMockJob({
-      columns: ['date', 'ip', 'message'],
-      pagingStrategy: 'pit',
-    });
-    mockDataClient.search = jest
-      .fn()
-      .mockImplementationOnce(() =>
-        Rx.of({
-          rawResponse: getMockRawResponse(
-            range(0, (HITS_TOTAL - 20) / 10).map(
-              () =>
-                ({
-                  fields: {
-                    date: ['2020-12-31T00:14:28.000Z'],
-                    ip: ['110.135.176.89'],
-                    message: ['hit from the initial search'],
-                  },
-                } as unknown as estypes.SearchHit)
-            ),
-            HITS_TOTAL
-          ),
-        })
-      )
-      .mockImplementation(() =>
-        Rx.of({
-          rawResponse: getMockRawResponse(
-            range(0, HITS_TOTAL / 10).map(
-              () =>
-                ({
-                  fields: {
-                    date: ['2020-12-31T00:14:28.000Z'],
-                    ip: ['110.135.176.89'],
-                    message: ['hit from a subsequent scroll'],
-                  },
-                } as unknown as estypes.SearchHit)
-            )
-          ),
-        })
-      );
-
-    const generateCsv = new CsvGenerator(
-      mockJobUsingPitPaging,
-      mockConfig,
-      mockTaskInstanceFields,
-      {
-        es: mockEsClient,
-        data: mockDataClient,
-        uiSettings: uiSettingsClient,
-      },
-      {
-        searchSourceStart: mockSearchSourceService,
-        fieldFormatsRegistry: mockFieldFormatsRegistry,
-      },
-      new CancellationToken(),
-      mockLogger,
-      stream
-    );
-    const csvResult = await generateCsv.generateData();
-    expect(csvResult).toMatchInlineSnapshot(`
-      Object {
-        "content_type": "text/csv",
-        "csv_contains_formulas": false,
-        "error_code": undefined,
-        "max_size_reached": false,
-        "metrics": Object {
-          "csv": Object {
-            "rows": 108,
-          },
-        },
-        "user_error": true,
-        "warnings": Array [
-          "Encountered an error with the number of CSV rows generated from the search: expected 100, received 108.",
-        ],
-      }
-    `);
-  });
-
   it('will return partial data if the scroll or search fails', async () => {
     mockDataClient.search = jest.fn().mockImplementation(() => {
       throw new esErrors.ResponseError({
@@ -1567,7 +1488,6 @@ describe('CsvGenerator', () => {
             "rows": 0,
           },
         },
-        "user_error": undefined,
         "warnings": Array [
           "Received a 500 response from Elasticsearch: my error",
           "Encountered an error with the number of CSV rows generated from the search: expected rows were indeterminable, received 0.",
@@ -1620,7 +1540,6 @@ describe('CsvGenerator', () => {
             "rows": 0,
           },
         },
-        "user_error": undefined,
         "warnings": Array [
           "Encountered an unknown error: An unknown error",
           "Encountered an error with the number of CSV rows generated from the search: expected rows were indeterminable, received 0.",

--- a/src/platform/packages/private/kbn-generate-csv/src/generate_csv.ts
+++ b/src/platform/packages/private/kbn-generate-csv/src/generate_csv.ts
@@ -300,7 +300,6 @@ export class CsvGenerator {
     const indexPatternTitle = index.getIndexPattern();
     const builder = new MaxSizeStringBuilder(this.stream, byteSizeValueToNumber(maxSizeBytes), bom);
     const warnings: string[] = [];
-    let userError: boolean | undefined;
     let first = true;
     let currentRecord = -1;
     let totalRecords: number | undefined;
@@ -466,7 +465,6 @@ export class CsvGenerator {
         warnings.push(
           i18nTexts.csvRowCountError({ expected: totalRecords, received: this.csvRowCount })
         );
-        userError = true;
       } else {
         warnings.push(i18nTexts.csvRowCountIndeterminable({ received: this.csvRowCount }));
       }
@@ -498,7 +496,6 @@ export class CsvGenerator {
         csv: { rows: this.csvRowCount },
       },
       warnings,
-      user_error: userError,
       error_code: reportingError?.code,
     };
   }

--- a/src/platform/packages/private/kbn-reporting/common/types.ts
+++ b/src/platform/packages/private/kbn-reporting/common/types.ts
@@ -33,7 +33,6 @@ export interface TaskRunResult {
   max_size_reached?: boolean;
   warnings?: string[];
   metrics?: TaskRunMetrics;
-  user_error?: boolean;
   /**
    * When running a report task we may finish with warnings that were triggered
    * by an error. We can pass the error code via the task run result to the

--- a/x-pack/platform/plugins/private/reporting/server/lib/tasks/run_report.ts
+++ b/x-pack/platform/plugins/private/reporting/server/lib/tasks/run_report.ts
@@ -7,6 +7,7 @@
 
 import moment from 'moment';
 import * as Rx from 'rxjs';
+import { timeout } from 'rxjs';
 import type { Writable } from 'stream';
 import type { FakeRawRequest, Headers } from '@kbn/core-http-server';
 import type { UpdateResponse } from '@elastic/elasticsearch/lib/api/types';
@@ -16,7 +17,6 @@ import {
   CancellationToken,
   KibanaShuttingDownError,
   MissingAuthenticationError,
-  QueueTimeoutError,
   numberToDuration,
 } from '@kbn/reporting-common';
 import type {
@@ -28,8 +28,6 @@ import type {
 } from '@kbn/reporting-common/types';
 import { ScheduleType, decryptJobHeaders, type ReportingConfigType } from '@kbn/reporting-server';
 import {
-  TaskErrorSource,
-  createTaskRunError,
   throwRetryableError,
   type ConcreteTaskInstance,
   type RunContext,
@@ -99,11 +97,6 @@ export interface PrepareJobResults {
   report?: SavedReport;
   task?: ReportTaskParams;
   scheduledReport?: SavedObject<ScheduledReportType>;
-}
-
-interface PerformJobResults {
-  result: TaskRunResult;
-  timedOut: boolean;
 }
 
 type ReportTaskParamsType = Record<string, any>;
@@ -387,7 +380,7 @@ export abstract class RunReportTask<TaskParams extends ReportTaskParamsType>
     taskInstanceFields,
     cancellationToken,
     stream,
-  }: PerformJobOpts): Promise<PerformJobResults> {
+  }: PerformJobOpts): Promise<TaskRunResult> {
     const exportType = this.exportTypesRegistry.getByJobType(task.jobtype);
     if (!exportType) {
       throw new Error(`No export type from ${task.jobtype} found to execute report`);
@@ -403,30 +396,18 @@ export abstract class RunReportTask<TaskParams extends ReportTaskParamsType>
       encryptedHeaders: task.payload.headers,
     });
 
-    // We use this internal timeout mechanism (vs relying solely on the task manager cancel function)
-    // to handle scheduled exports that have been configured to retry multiple times within a single task run
-    // because task manager does not retry recurring tasks.
-    let jobTimedOut: boolean = false;
-    const timerId = setTimeout(() => {
-      cancellationToken.cancel();
-      jobTimedOut = true;
-    }, this.queueTimeout);
-
-    const runTaskPromise = exportType.runTask({
-      jobId: task.id,
-      payload: task.payload,
-      request,
-      taskInstanceFields,
-      cancellationToken,
-      stream,
-    });
-
-    try {
-      const result = await runTaskPromise;
-      return { result, timedOut: jobTimedOut };
-    } finally {
-      clearTimeout(timerId);
-    }
+    return Rx.lastValueFrom(
+      Rx.from(
+        exportType.runTask({
+          jobId: task.id,
+          payload: task.payload,
+          request,
+          taskInstanceFields,
+          cancellationToken,
+          stream,
+        })
+      ).pipe(timeout(this.queueTimeout)) // throw an error if a value is not emitted before timeout
+    );
   }
 
   protected async completeJob(
@@ -500,8 +481,7 @@ export abstract class RunReportTask<TaskParams extends ReportTaskParamsType>
     // Keep a separate local stack for each task run
     return ({ taskInstance, fakeRequest }: RunContext) => {
       let jobId: string;
-      let output: PerformJobResults;
-      let cancellationToken: CancellationToken | undefined;
+      const cancellationToken = new CancellationToken();
       const { retryAt: taskRetryAt, startedAt: taskStartedAt } = taskInstance;
 
       return {
@@ -567,7 +547,6 @@ export abstract class RunReportTask<TaskParams extends ReportTaskParamsType>
               retries,
               report,
               operation: async (rep: SavedReport) => {
-                cancellationToken = new CancellationToken();
                 // keep track of the number of times we try within the task
                 atmpts = isNumber(atmpts) ? atmpts + 1 : undefined;
                 const jobContentEncoding = this.getJobContentEncoding(jobType);
@@ -585,20 +564,16 @@ export abstract class RunReportTask<TaskParams extends ReportTaskParamsType>
                 );
                 eventLog.logExecutionStart();
 
-                output = await Promise.race<PerformJobResults>([
+                const output = await Promise.race<TaskRunResult>([
                   this.performJob({
                     task,
                     fakeRequest,
                     taskInstanceFields: { retryAt: taskRetryAt, startedAt: taskStartedAt },
-                    cancellationToken: cancellationToken!,
+                    cancellationToken,
                     stream,
                   }),
                   this.throwIfKibanaShutsDown(),
                 ]);
-
-                if (output.timedOut) {
-                  throw new QueueTimeoutError();
-                }
 
                 stream.end();
 
@@ -610,26 +585,27 @@ export abstract class RunReportTask<TaskParams extends ReportTaskParamsType>
                 rep._primary_term = stream.getPrimaryTerm()!;
 
                 const byteSize = stream.bytesWritten;
-                eventLog.logExecutionComplete({ ...(output.result.metrics ?? {}), byteSize });
+                eventLog.logExecutionComplete({ ...(output.metrics ?? {}), byteSize });
 
-                if (output.result) {
+                if (output) {
                   logger.debug(`Job output size: ${byteSize} bytes.`);
                   // Update the job status to "completed"
                   report = await this.completeJob(rep, isNumber(atmpts) ? atmpts : rep.attempts, {
-                    ...output.result,
+                    ...output,
                     size: byteSize,
                   });
 
                   await this.notify(
                     report,
                     taskInstance,
-                    output.result,
+                    output,
                     byteSize,
                     scheduledReport,
                     task.payload.spaceId
                   );
                 }
 
+                // untrack the report for concurrency awareness
                 logger.debug(`Stopping ${jobId}.`);
               },
             });
@@ -643,9 +619,7 @@ export abstract class RunReportTask<TaskParams extends ReportTaskParamsType>
               }
             );
 
-            if (cancellationToken) {
-              cancellationToken.cancel();
-            }
+            cancellationToken.cancel();
 
             if (isLastAttempt) {
               this.logger.info(
@@ -657,17 +631,8 @@ export abstract class RunReportTask<TaskParams extends ReportTaskParamsType>
               );
             }
 
-            let error = failedToExecuteErr;
-            if (
-              failedToExecuteErr instanceof QueueTimeoutError &&
-              output?.result.user_error === true
-            ) {
-              error = createTaskRunError(failedToExecuteErr, TaskErrorSource.USER);
-            }
-
-            throwRetryableError(error, new Date(Date.now() + TIME_BETWEEN_ATTEMPTS));
+            throwRetryableError(failedToExecuteErr, new Date(Date.now() + TIME_BETWEEN_ATTEMPTS));
           } finally {
-            // untrack the report for concurrency awareness
             this.opts.reporting.untrackReport(jobId);
             logger.debug(`Reports running: ${this.opts.reporting.countConcurrentReports()}.`);
           }
@@ -681,9 +646,7 @@ export abstract class RunReportTask<TaskParams extends ReportTaskParamsType>
           if (jobId) {
             this.logger.get(jobId).warn(`Cancelling job ${jobId}...`);
           }
-          if (cancellationToken) {
-            cancellationToken.cancel();
-          }
+          cancellationToken.cancel();
         },
       };
     };


### PR DESCRIPTION
This reverts commit 4f021d74c9a08a728f84b4202f23528ffc1fe235.

## Summary

We are seeing instances of `uncaughtException` in serverless after this was deployed that may be related to error handling when a report is cancelled. Since this PR was a nice to have for classifying user errors, seems like we can revert first and investigate after.