### PR TITLE
[8.19] Standardize how to log errors (#245030)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/async_sender.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/async_sender.ts
@@ -21,7 +21,7 @@ import { type Nullable, TelemetryChannel, TelemetryCounter } from './types';
 import * as collections from './collections_helpers';
 import { CachedSubject, retryOnError$ } from './rxjs_helpers';
 import { SenderUtils } from './sender_helpers';
-import { copyLicenseFields, newTelemetryLogger } from './helpers';
+import { copyLicenseFields, newTelemetryLogger, withErrorMessage } from './helpers';
 import { type TelemetryLogger } from './telemetry_logger';
 
 export const DEFAULT_QUEUE_CONFIG: QueueConfig = {
@@ -113,7 +113,7 @@ export class AsyncTelemetryEventsSender implements IAsyncTelemetryEventsSender {
             this.logger.warn('Failure! Unable to send events to channel', {
               events: result.events,
               channel: result.channel,
-              error: result.message,
+              error_message: result.message,
             } as LogMeta);
             this.senderUtils?.incrementCounter(
               TelemetryCounter.DOCS_LOST,
@@ -133,7 +133,7 @@ export class AsyncTelemetryEventsSender implements IAsyncTelemetryEventsSender {
           }
         },
         error: (error) => {
-          this.logger.warn('Unexpected error sending events to channel', { error });
+          this.logger.warn('Unexpected error sending events to channel', withErrorMessage(error));
         },
         complete: () => {
           this.logger.debug('Shutting down');
@@ -379,7 +379,7 @@ export class AsyncTelemetryEventsSender implements IAsyncTelemetryEventsSender {
             channel
           );
 
-          this.logger.warn('Runtime error', { error });
+          this.logger.warn('Runtime error', withErrorMessage(error));
           throw newFailure(`Error posting events: ${error}`, channel, events.length);
         });
     } catch (err: unknown) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.ts
@@ -33,7 +33,7 @@ import {
 } from './health_diagnostic_circuit_breakers.types';
 import { type HealthDiagnosticQuery, QueryType } from './health_diagnostic_service.types';
 import type { TelemetryLogger } from '../telemetry_logger';
-import { newTelemetryLogger } from '../helpers';
+import { newTelemetryLogger, withErrorMessage } from '../helpers';
 
 export class CircuitBreakingQueryExecutorImpl implements CircuitBreakingQueryExecutor {
   private readonly logger: TelemetryLogger;
@@ -160,7 +160,7 @@ export class CircuitBreakingQueryExecutorImpl implements CircuitBreakingQueryExe
 
       finalize(() => {
         this.client.closePointInTime({ id: pitId }).catch((error) => {
-          this.logger.warn('>> closePointInTime error', { error });
+          this.logger.warn('>> closePointInTime error', withErrorMessage(error));
         });
       })
     );
@@ -252,7 +252,10 @@ export class CircuitBreakingQueryExecutorImpl implements CircuitBreakingQueryExe
         return indices.filter((indexName) => indexName !== '');
       })
       .catch((error) => {
-        this.logger.info('Error while checking ILM status, assuming serverless', { error });
+        this.logger.info(
+          'Error while checking ILM status, assuming serverless',
+          withErrorMessage(error)
+        );
         return [query.index];
       });
   }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.test.ts
@@ -213,7 +213,7 @@ describe('Security Solution - Health Diagnostic Queries - HealthDiagnosticServic
 
         expect(result).toEqual([]);
         expect(mockLogger.warn).toHaveBeenCalledWith(
-          'Error getting health diagnostic queries: Artifact not found',
+          'Error getting health diagnostic queries',
           expect.any(Object)
         );
       });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.ts
@@ -41,7 +41,7 @@ import {
   TELEMETRY_HEALTH_DIAGNOSTIC_QUERY_STATS_EVENT,
 } from '../event_based/events';
 import { artifactService } from '../artifact';
-import { newTelemetryLogger } from '../helpers';
+import { newTelemetryLogger, withErrorMessage } from '../helpers';
 import { telemetryConfiguration } from '../configuration';
 import { RssGrowthCircuitBreaker } from './circuit_breakers/rss_growth_circuit_breaker';
 import { TimeoutCircuitBreaker } from './circuit_breakers/timeout_circuit_breaker';
@@ -165,7 +165,7 @@ export class HealthDiagnosticServiceImpl implements HealthDiagnosticService {
                 message: error.message,
                 reason: error instanceof ValidationError ? error.result : undefined,
               };
-              this.logger.error('Error running query', { error });
+              this.logger.error('Error running query', withErrorMessage(error));
               resolve({
                 ...queryStats,
                 failure,
@@ -296,7 +296,7 @@ export class HealthDiagnosticServiceImpl implements HealthDiagnosticService {
     try {
       this.analytics.reportEvent(eventTypeOpts.eventType, eventData as object);
     } catch (error) {
-      this.logger.warn('Error sending EBT', { error });
+      this.logger.warn('Error sending EBT', withErrorMessage(error));
     }
   }
 
@@ -312,7 +312,12 @@ export class HealthDiagnosticServiceImpl implements HealthDiagnosticService {
 
         return enabled && isDueForExecution(lastExecutedAt, now, scheduleCron);
       } catch (error) {
-        this.logger.warn('Error processing health query', { error, name: query.name });
+        this.logger.warn(
+          'Error processing health query',
+          withErrorMessage(error, {
+            name: query.name,
+          } as LogMeta)
+        );
         return false;
       }
     });
@@ -323,7 +328,7 @@ export class HealthDiagnosticServiceImpl implements HealthDiagnosticService {
       const artifact = await artifactService.getArtifact(QUERY_ARTIFACT_ID);
       return parseDiagnosticQueries(artifact.data);
     } catch (error) {
-      this.logger.warn(`Error getting health diagnostic queries: ${error.message}`, { error });
+      this.logger.warn('Error getting health diagnostic queries', withErrorMessage(error));
       return [];
     }
   }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/helpers.ts
@@ -531,6 +531,14 @@ export function unflatten<T extends AnyObject = AnyObject>(object: AnyObject): T
   }, {}) as T;
 }
 
+export function withErrorMessage(error?: Error, meta?: LogMeta): LogMeta {
+  return {
+    error,
+    error_message: error?.message,
+    ...(meta ?? {}),
+  } as LogMeta;
+}
+
 function _set(object: AnyObject, key: string, value: unknown) {
   if (key.startsWith('.') || key.endsWith('.') || contiguousDotRegex.test(key)) {
     // Preserve original keys with dots used in non-path representations (e.g. '.kibana_field_name')

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/receiver.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/receiver.ts
@@ -63,6 +63,7 @@ import {
   ruleExceptionListItemToTelemetryEvent,
   setClusterInfo,
   newTelemetryLogger,
+  withErrorMessage,
 } from './helpers';
 import { Fetcher } from '../../endpoint/routes/resolver/tree/utils/fetch';
 import type { TreeOptions, TreeResponse } from '../../endpoint/routes/resolver/tree/utils/fetch';
@@ -631,8 +632,8 @@ export class TelemetryReceiver implements ITelemetryReceiver {
 
         this.logger.debug('Diagnostic alerts to return', { numOfHits } as LogMeta);
         fetchMore = numOfHits > 0 && numOfHits < telemetryConfiguration.telemetry_max_buffer_size;
-      } catch (e) {
-        this.logger.warn('Error fetching alerts', { error_message: e.message } as LogMeta);
+      } catch (error) {
+        this.logger.warn('Error fetching alerts', withErrorMessage(error));
         fetchMore = false;
       }
 
@@ -1017,10 +1018,10 @@ export class TelemetryReceiver implements ITelemetryReceiver {
 
         yield alerts;
       }
-    } catch (e) {
+    } catch (error) {
       // to keep backward compatibility with the previous implementation, silent return
       // once we start using `paginate` this error should be managed downstream
-      this.logger.warn('Error fetching alerts', { error_message: e.message } as LogMeta);
+      this.logger.warn('Error fetching alerts', withErrorMessage(error));
       return;
     } finally {
       await this.closePointInTime(pitId);
@@ -1044,10 +1045,12 @@ export class TelemetryReceiver implements ITelemetryReceiver {
     try {
       await this.esClient().closePointInTime({ id: pitId });
     } catch (error) {
-      this.logger.warn('Error trying to close point in time', {
-        pit: pitId,
-        error_message: error.message,
-      } as LogMeta);
+      this.logger.warn(
+        'Error trying to close point in time',
+        withErrorMessage(error, {
+          pit: pitId,
+        } as LogMeta)
+      );
     }
   }
 
@@ -1287,8 +1290,8 @@ export class TelemetryReceiver implements ITelemetryReceiver {
       })) as { license: ESLicense };
 
       return ret.license;
-    } catch (err) {
-      this.logger.warn('failed retrieving license', { error_message: err.message } as LogMeta);
+    } catch (error) {
+      this.logger.warn('failed retrieving license', withErrorMessage(error));
       return undefined;
     }
   }
@@ -1378,9 +1381,9 @@ export class TelemetryReceiver implements ITelemetryReceiver {
 
         yield data;
       } while (esQuery.search_after !== undefined);
-    } catch (e) {
-      this.logger.warn('Error running paginated query', { error_message: e.message } as LogMeta);
-      throw e;
+    } catch (error) {
+      this.logger.warn('Error running paginated query', withErrorMessage(error));
+      throw error;
     } finally {
       await this.closePointInTime(pit.id);
     }
@@ -1439,7 +1442,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
         })
       )
       .catch((error) => {
-        this.logger.warn('Error fetching indices', { error_message: error } as LogMeta);
+        this.logger.warn('Error fetching indices', withErrorMessage(error));
         throw error;
       });
   }
@@ -1480,7 +1483,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
         })
       )
       .catch((error) => {
-        this.logger.warn('Error fetching datastreams', { error_message: error } as LogMeta);
+        this.logger.warn('Error fetching datastreams', withErrorMessage(error));
         throw error;
       });
   }
@@ -1545,7 +1548,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
           } as IndexStats;
         }
       } catch (error) {
-        this.logger.warn('Error fetching indices stats', { error_message: error } as LogMeta);
+        this.logger.warn('Error fetching indices stats', withErrorMessage(error));
         throw error;
       }
     }
@@ -1583,7 +1586,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
           yield entry;
         }
       } catch (error) {
-        this.logger.warn('Error fetching ilm stats', { error_message: error } as LogMeta);
+        this.logger.warn('Error fetching ilm stats', withErrorMessage(error));
         throw error;
       }
     }
@@ -1632,7 +1635,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
         })
       )
       .catch((error) => {
-        this.logger.warn('Error fetching index templates', { error_message: error } as LogMeta);
+        this.logger.warn('Error fetching index templates', withErrorMessage(error));
         throw error;
       });
   }
@@ -1688,9 +1691,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
           } as IlmPolicy;
         }
       } catch (error) {
-        this.logger.warn('Error fetching ilm policies', {
-          error_message: error.message,
-        } as LogMeta);
+        this.logger.warn('Error fetching ilm policies', withErrorMessage(error));
         throw error;
       }
     }
@@ -1761,9 +1762,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
         });
       })
       .catch((error) => {
-        this.logger.warn('Error fetching ingest pipelines stats', {
-          error_message: error,
-        } as LogMeta);
+        this.logger.warn('Error fetching ingest pipelines stats', withErrorMessage(error));
         throw error;
       });
   }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/sender.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/sender.ts
@@ -23,7 +23,12 @@ import type { ExperimentalFeatures } from '../../../common';
 import type { ITelemetryReceiver } from './receiver';
 import { copyAllowlistedFields, filterList } from './filterlists';
 import { createTelemetryTaskConfigs } from './tasks';
-import { copyLicenseFields, createUsageCounterLabel, newTelemetryLogger } from './helpers';
+import {
+  copyLicenseFields,
+  createUsageCounterLabel,
+  newTelemetryLogger,
+  withErrorMessage,
+} from './helpers';
 import { type TelemetryLogger } from './telemetry_logger';
 import type { TelemetryChannel, TelemetryEvent } from './types';
 import type { SecurityTelemetryTaskConfig } from './task';
@@ -284,7 +289,7 @@ export class TelemetryEventsSender implements ITelemetryEventsSender {
 
       return false;
     } catch (error) {
-      this.logger.warn('Error pinging telemetry services', { error });
+      this.logger.warn('Error pinging telemetry services', withErrorMessage(error));
 
       return false;
     }
@@ -347,8 +352,8 @@ export class TelemetryEventsSender implements ITelemetryEventsSender {
         licenseInfo?.uid,
         axiosInstance
       );
-    } catch (err) {
-      this.logger.warn(`Error sending telemetry events data: ${err}`);
+    } catch (error) {
+      this.logger.warn('Error sending telemetry events data', withErrorMessage(error));
       this.queue = [];
     }
     this.isSending = false;
@@ -394,8 +399,8 @@ export class TelemetryEventsSender implements ITelemetryEventsSender {
         licenseInfo?.uid,
         axiosInstance
       );
-    } catch (err) {
-      this.logger.warn(`Error sending telemetry events data: ${err}`);
+    } catch (error) {
+      this.logger.warn('Error sending telemetry events data', withErrorMessage(error));
     }
   }
 
@@ -496,7 +501,7 @@ export class TelemetryEventsSender implements ITelemetryEventsSender {
       });
       this.logger.debug('Events sent!. Response', { status: resp.status } as LogMeta);
     } catch (error) {
-      this.logger.warn('Error sending events', { error });
+      this.logger.warn('Error sending events', withErrorMessage(error));
       const errorStatus = error?.response?.status;
       if (errorStatus !== undefined && errorStatus !== null) {
         this.telemetryUsageCounter?.incrementCounter({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/task.ts
@@ -16,7 +16,7 @@ import type { ITelemetryReceiver } from './receiver';
 import type { ITelemetryEventsSender } from './sender';
 import type { ITaskMetricsService } from './task_metrics.types';
 import { stateSchemaByVersion, emptyState, type LatestTaskStateSchema } from './task_state';
-import { newTelemetryLogger } from './helpers';
+import { newTelemetryLogger, withErrorMessage } from './helpers';
 import { type TelemetryLogger } from './telemetry_logger';
 
 export interface SecurityTelemetryTaskConfig {
@@ -136,7 +136,7 @@ export class SecurityTelemetryTask {
         params: { version: this.config.version },
       });
     } catch (error) {
-      this.logger.error('Error scheduling task', { error });
+      this.logger.error('Error scheduling task', withErrorMessage(error));
     }
   };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/configuration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/configuration.ts
@@ -13,7 +13,7 @@ import type { TaskExecutionPeriod } from '../task';
 import type { ITaskMetricsService } from '../task_metrics.types';
 import { artifactService } from '../artifact';
 import { telemetryConfiguration } from '../configuration';
-import { newTelemetryLogger } from '../helpers';
+import { newTelemetryLogger, withErrorMessage } from '../helpers';
 
 export function createTelemetryConfigurationTaskConfig() {
   const taskName = 'Security Solution Telemetry Configuration Task';
@@ -143,7 +143,7 @@ export function createTelemetryConfigurationTaskConfig() {
         log.debug('Updated TelemetryConfiguration');
         return 0;
       } catch (error) {
-        log.warn('Failed to set telemetry configuration', { error });
+        log.warn('Failed to set telemetry configuration', withErrorMessage(error));
         telemetryConfiguration.resetAllToDefault();
         await taskMetricsService.end(trace, error);
         return 0;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/custom_response_actions_rule.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/custom_response_actions_rule.ts
@@ -13,6 +13,7 @@ import {
   newTelemetryLogger,
   createUsageCounterLabel,
   safeValue,
+  withErrorMessage,
 } from '../helpers';
 import type { ITelemetryEventsSender } from '../sender';
 import type { ITelemetryReceiver } from '../receiver';
@@ -146,8 +147,9 @@ export function createTelemetryCustomResponseActionRulesTaskConfig(maxTelemetryB
         } as LogMeta);
 
         return totalCount;
-      } catch (err) {
-        await taskMetricsService.end(trace, err);
+      } catch (error) {
+        log.warn('Error running custom response actions rule task', withErrorMessage(error));
+        await taskMetricsService.end(trace, error);
         return 0;
       }
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/detection_rule.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/detection_rule.ts
@@ -14,6 +14,7 @@ import {
   newTelemetryLogger,
   createUsageCounterLabel,
   safeValue,
+  withErrorMessage,
 } from '../helpers';
 import type { ITelemetryEventsSender } from '../sender';
 import type { ITelemetryReceiver } from '../receiver';
@@ -124,8 +125,9 @@ export function createTelemetryDetectionRuleListsTaskConfig(maxTelemetryBatch: n
         log.debug('Task executed', { length: detectionRuleExceptionsJson.length } as LogMeta);
 
         return detectionRuleExceptionsJson.length;
-      } catch (err) {
-        await taskMetricsService.end(trace, err);
+      } catch (error) {
+        log.warn('Error running detection rule task', withErrorMessage(error));
+        await taskMetricsService.end(trace, error);
         return 0;
       }
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/diagnostic.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/diagnostic.ts
@@ -6,7 +6,7 @@
  */
 
 import type { LogMeta, Logger } from '@kbn/core/server';
-import { newTelemetryLogger, getPreviousDiagTaskTimestamp } from '../helpers';
+import { newTelemetryLogger, getPreviousDiagTaskTimestamp, withErrorMessage } from '../helpers';
 import type { ITelemetryEventsSender } from '../sender';
 import { TelemetryChannel, type TelemetryEvent } from '../types';
 import type { ITelemetryReceiver } from '../receiver';
@@ -69,8 +69,9 @@ export function createTelemetryDiagnosticsTaskConfig() {
 
         await taskMetricsService.end(trace);
         return alertCount;
-      } catch (err) {
-        await taskMetricsService.end(trace, err);
+      } catch (error) {
+        log.warn('Error running diagnostic task', withErrorMessage(error));
+        await taskMetricsService.end(trace, error);
         return 0;
       }
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/endpoint.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/endpoint.ts
@@ -30,6 +30,7 @@ import {
   isPackagePolicyList,
   newTelemetryLogger,
   safeValue,
+  withErrorMessage,
 } from '../helpers';
 import type { TelemetryLogger } from '../telemetry_logger';
 import type { PolicyData } from '../../../../common/endpoint/types';
@@ -98,7 +99,7 @@ export function createTelemetryEndpointTaskConfig(maxTelemetryBatch: number) {
 
         return documents.length;
       } catch (error) {
-        log.warn(`Error running endpoint alert telemetry task`, { error });
+        log.warn(`Error running endpoint alert telemetry task`, withErrorMessage(error));
         await taskMetricsService.end(trace, error);
         return 0;
       }
@@ -142,7 +143,10 @@ class EndpointMetadataProcessor {
         return policies;
       })
       .catch((error) => {
-        this.logger.warn('Error fetching fleet agents, using an empty value', { error });
+        this.logger.warn(
+          'Error fetching fleet agents, using an empty value',
+          withErrorMessage(error)
+        );
         return new Map();
       });
     const endpointPolicyById = await this.endpointPolicies(policyIdByFleetAgentId.values());
@@ -159,7 +163,10 @@ class EndpointMetadataProcessor {
         return response;
       })
       .catch((error) => {
-        this.logger.warn('Error fetching policy responses, using an empty value', { error });
+        this.logger.warn(
+          'Error fetching policy responses, using an empty value',
+          withErrorMessage(error)
+        );
         return new Map();
       });
 
@@ -175,7 +182,10 @@ class EndpointMetadataProcessor {
         return response;
       })
       .catch((error) => {
-        this.logger.warn('Error fetching endpoint metadata, using an empty value', { error });
+        this.logger.warn(
+          'Error fetching endpoint metadata, using an empty value',
+          withErrorMessage(error)
+        );
         return new Map();
       });
 
@@ -208,9 +218,7 @@ class EndpointMetadataProcessor {
       // something happened in the middle of the pagination, log the error
       // and return what we collect so far instead of aborting the
       // whole execution
-      this.logger.warn('Error fetching endpoint metrics by id', {
-        error,
-      });
+      this.logger.warn('Error fetching endpoint metrics by id', withErrorMessage(error));
     }
 
     return telemetryPayloads;
@@ -235,8 +243,8 @@ class EndpointMetadataProcessor {
     const endpointPolicyCache = new Map<string, PolicyData>();
     for (const policyId of policies) {
       if (!endpointPolicyCache.has(policyId)) {
-        const agentPolicy = await this.receiver.fetchPolicyConfigs(policyId).catch((e) => {
-          this.logger.warn(`error fetching policy config due to ${e?.message}`);
+        const agentPolicy = await this.receiver.fetchPolicyConfigs(policyId).catch((error) => {
+          this.logger.warn('error fetching policy config', withErrorMessage(error));
           return null;
         });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/filterlists.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/filterlists.ts
@@ -13,7 +13,7 @@ import type { ITaskMetricsService } from '../task_metrics.types';
 import type { TaskExecutionPeriod } from '../task';
 import { artifactService } from '../artifact';
 import { filterList } from '../filterlists';
-import { newTelemetryLogger } from '../helpers';
+import { newTelemetryLogger, withErrorMessage } from '../helpers';
 
 export function createTelemetryFilterListArtifactTaskConfig() {
   const taskName = 'Security Solution Telemetry Filter List Artifact Task';
@@ -55,7 +55,7 @@ export function createTelemetryFilterListArtifactTaskConfig() {
         await taskMetricsService.end(trace);
         return 0;
       } catch (error) {
-        log.warn('Failed to set telemetry filterlist artifact', { error });
+        log.warn('Failed to set telemetry filterlist artifact', withErrorMessage(error));
         filterList.resetAllToDefault();
         await taskMetricsService.end(trace, error);
         return 0;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/indices.metadata.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/indices.metadata.ts
@@ -14,6 +14,7 @@ import {
   createUsageCounterLabel,
   getPreviousDailyTaskTimestamp,
   newTelemetryLogger,
+  withErrorMessage,
 } from '../helpers';
 import {
   TELEMETRY_DATA_STREAM_EVENT,
@@ -182,7 +183,7 @@ export function createTelemetryIndicesMetadataTaskConfig() {
             return count;
           })
           .catch((error) => {
-            log.warn(`Error getting indices stats`, { error });
+            log.warn(`Error getting indices stats`, withErrorMessage(error));
             incrementCounter(TelemetryCounter.RUNTIME_ERROR, 'indices-stats', 1);
             return 0;
           });
@@ -194,7 +195,7 @@ export function createTelemetryIndicesMetadataTaskConfig() {
             return names;
           })
           .catch((error) => {
-            log.warn(`Error getting ILM stats`, { error });
+            log.warn(`Error getting ILM stats`, withErrorMessage(error));
             incrementCounter(TelemetryCounter.RUNTIME_ERROR, 'ilm-stats', 1);
             return new Set<string>();
           });
@@ -206,7 +207,7 @@ export function createTelemetryIndicesMetadataTaskConfig() {
             return count;
           })
           .catch((error) => {
-            log.warn(`Error getting ILM policies`, { error });
+            log.warn(`Error getting ILM policies`, withErrorMessage(error));
             incrementCounter(TelemetryCounter.RUNTIME_ERROR, 'ilm-policies', 1);
             return 0;
           });
@@ -220,7 +221,7 @@ export function createTelemetryIndicesMetadataTaskConfig() {
             return count;
           })
           .catch((error) => {
-            log.warn(`Error getting index templates`, { error });
+            log.warn(`Error getting index templates`, withErrorMessage(error));
             incrementCounter(TelemetryCounter.RUNTIME_ERROR, 'index-templates', 1);
             return 0;
           });
@@ -238,7 +239,7 @@ export function createTelemetryIndicesMetadataTaskConfig() {
 
         return indicesCount;
       } catch (error) {
-        log.warn(`Error running indices metadata task`, { error });
+        log.warn(`Error running indices metadata task`, withErrorMessage(error));
         await taskMetricsService.end(trace, error);
         return 0;
       }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/ingest_pipelines_stats.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/ingest_pipelines_stats.ts
@@ -15,6 +15,7 @@ import {
   createUsageCounterLabel,
   getPreviousDailyTaskTimestamp,
   newTelemetryLogger,
+  withErrorMessage,
 } from '../helpers';
 import { TELEMETRY_NODE_INGEST_PIPELINES_STATS_EVENT } from '../event_based/events';
 import { telemetryConfiguration } from '../configuration';
@@ -82,10 +83,12 @@ export function createIngestStatsTaskConfig() {
 
         return ingestStats.length;
       } catch (error) {
-        log.warn(`Error running ingest stats task`, {
-          error,
-          elapsed: performance.now() - start,
-        });
+        log.warn(
+          `Error running ingest stats task`,
+          withErrorMessage(error, {
+            elapsed: performance.now() - start,
+          } as LogMeta)
+        );
         await taskMetricsService.end(trace, error);
         return 0;
       }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/prebuilt_rule_alerts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/prebuilt_rule_alerts.ts
@@ -19,6 +19,7 @@ import {
   getPreviousDailyTaskTimestamp,
   safeValue,
   unflatten,
+  withErrorMessage,
 } from '../helpers';
 import { copyAllowlistedFields, filterList } from '../filterlists';
 import type { AllowlistFields } from '../filterlists/types';
@@ -116,7 +117,7 @@ export function createTelemetryPrebuiltRuleAlertsTaskConfig(maxTelemetryBatch: n
         await taskMetricsService.end(trace);
         return 0;
       } catch (error) {
-        logger.error('could not complete task', { error });
+        log.error('could not complete task', withErrorMessage(error));
         await taskMetricsService.end(trace, error);
         return 0;
       }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/security_lists.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/security_lists.ts
@@ -20,6 +20,7 @@ import {
   formatValueListMetaData,
   createUsageCounterLabel,
   newTelemetryLogger,
+  withErrorMessage,
 } from '../helpers';
 import type { ITelemetryEventsSender } from '../sender';
 import type { ITelemetryReceiver } from '../receiver';
@@ -159,8 +160,9 @@ export function createTelemetrySecurityListTaskConfig(maxTelemetryBatch: number)
         }
         await taskMetricsService.end(trace);
         return trustedApplicationsCount + endpointExceptionsCount + endpointEventFiltersCount;
-      } catch (err) {
-        await taskMetricsService.end(trace, err);
+      } catch (error) {
+        log.warn('Error running security lists task', withErrorMessage(error));
+        await taskMetricsService.end(trace, error);
         return 0;
       }
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/timelines.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/timelines.ts
@@ -16,6 +16,7 @@ import {
   TelemetryTimelineFetcher,
   newTelemetryLogger,
   getPreviousDailyTaskTimestamp,
+  withErrorMessage,
 } from '../helpers';
 import { telemetryConfiguration } from '../configuration';
 
@@ -93,7 +94,7 @@ export function createTelemetryTimelineTaskConfig() {
 
         return counter;
       } catch (error) {
-        logger.error('could not complete task', { error });
+        logger.error('could not complete task', withErrorMessage(error));
         await taskMetricsService.end(trace, error);
         return 0;
       }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/timelines_diagnostic.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/tasks/timelines_diagnostic.ts
@@ -11,7 +11,7 @@ import type { ITelemetryReceiver } from '../receiver';
 import type { TaskExecutionPeriod } from '../task';
 import type { ITaskMetricsService } from '../task_metrics.types';
 import { DEFAULT_DIAGNOSTIC_INDEX, TELEMETRY_CHANNEL_TIMELINE } from '../constants';
-import { ranges, TelemetryTimelineFetcher, newTelemetryLogger } from '../helpers';
+import { ranges, TelemetryTimelineFetcher, newTelemetryLogger, withErrorMessage } from '../helpers';
 import { telemetryConfiguration } from '../configuration';
 
 export function createTelemetryDiagnosticTimelineTaskConfig() {
@@ -83,7 +83,7 @@ export function createTelemetryDiagnosticTimelineTaskConfig() {
 
         return counter;
       } catch (error) {
-        logger.error('could not complete task', { error });
+        log.error('could not complete task', withErrorMessage(error));
         await taskMetricsService.end(trace, error);
         return 0;
       }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Standardize how to log errors (#245030)](https://github.com/elastic/kibana/pull/245030)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sebastián Zaffarano","email":"sebastian.zaffarano@elastic.co"},"sourceCommit":{"committedDate":"2025-12-05T15:03:38Z","message":"Standardize how to log errors (#245030)\n\n## Summary\n\nUpdates how we log within the security solution telemetry code. It's\nmainly to use the same object types in the `LogMeta`.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"cab156c3ba4e4a42fcaff4faf8be563ae1d94235","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:Logging","Team: SecuritySolution","backport:all-open","ci:build-cloud-image","ci:build-serverless-image","v9.3.0"],"title":"Standardize how to log errors","number":245030,"url":"https://github.com/elastic/kibana/pull/245030","mergeCommit":{"message":"Standardize how to log errors (#245030)\n\n## Summary\n\nUpdates how we log within the security solution telemetry code. It's\nmainly to use the same object types in the `LogMeta`.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"cab156c3ba4e4a42fcaff4faf8be563ae1d94235"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245030","number":245030,"mergeCommit":{"message":"Standardize how to log errors (#245030)\n\n## Summary\n\nUpdates how we log within the security solution telemetry code. It's\nmainly to use the same object types in the `LogMeta`.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"cab156c3ba4e4a42fcaff4faf8be563ae1d94235"}},{"url":"https://github.com/elastic/kibana/pull/245403","number":245403,"branch":"9.1","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/245404","number":245404,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->