### PR TITLE
[Search] Small tweaks to the EIS promos

### DIFF
--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_callout.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_callout.test.tsx
@@ -25,7 +25,7 @@ describe('EisPromotionalCallout', () => {
   const dataId = `${promoId}-eis-promo-callout`;
   const ctaLink = 'https://example.com';
   const direction: EisPromotionalCalloutProps['direction'] = 'row';
-  const mockOnSkipTour = jest.fn();
+  const mockOnDismissTour = jest.fn();
 
   const renderEisPromotionalCallout = (props?: Partial<EisPromotionalCalloutProps>) => {
     return render(
@@ -45,7 +45,7 @@ describe('EisPromotionalCallout', () => {
     jest.clearAllMocks();
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onSkipTour: mockOnSkipTour,
+      onDismissTour: mockOnDismissTour,
     });
   });
 
@@ -67,19 +67,19 @@ describe('EisPromotionalCallout', () => {
     expect(screen.getByAltText(EIS_PROMO_CALLOUT_ICON_ALT)).toBeInTheDocument();
   });
 
-  it('calls onSkipTour when dismiss button is clicked', () => {
+  it('calls onDismissTour when dismiss button is clicked', () => {
     renderEisPromotionalCallout();
 
-    const dismissButton = screen.getByLabelText('Dismiss');
+    const dismissButton = screen.getByTestId('eisPromoCalloutDismissBtn');
     fireEvent.click(dismissButton);
 
-    expect(mockOnSkipTour).toHaveBeenCalledTimes(1);
+    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
   });
 
   it('does not render callout when promo is not visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: false,
-      onSkipTour: mockOnSkipTour,
+      onDismissTour: mockOnDismissTour,
     });
 
     renderEisPromotionalCallout();

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_callout.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_callout.tsx
@@ -22,6 +22,7 @@ import searchRocketIcon from '../assets/search-rocket.svg';
 import {
   EIS_PROMO_CALLOUT_CTA,
   EIS_PROMO_CALLOUT_DESCRIPTION,
+  EIS_PROMO_CALLOUT_DISMISS_ARIA,
   EIS_PROMO_CALLOUT_ICON_ALT,
   EIS_PROMO_CALLOUT_TITLE,
 } from '../translations';
@@ -40,7 +41,7 @@ export const EisPromotionalCallout = ({
   isCloudEnabled,
   direction,
 }: EisPromotionalCalloutProps) => {
-  const { isPromoVisible, onSkipTour } = useShowEisPromotionalContent({
+  const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
     promoId: `${promoId}Callout`,
     isCloudEnabled,
   });
@@ -65,7 +66,13 @@ export const EisPromotionalCallout = ({
       color="subdued"
     >
       <div style={{ position: 'absolute', top: 8, right: 8 }}>
-        <EuiButtonIcon iconType="cross" aria-label="Dismiss" onClick={onSkipTour} size="s" />
+        <EuiButtonIcon
+          data-test-subj="eisPromoCalloutDismissBtn"
+          iconType="cross"
+          aria-label={EIS_PROMO_CALLOUT_DISMISS_ARIA}
+          onClick={onDismissTour}
+          size="s"
+        />
       </div>
       <EuiFlexGroup direction={direction} alignItems="flexStart">
         <EuiImage src={searchRocketIcon} alt={EIS_PROMO_CALLOUT_ICON_ALT} size="original" />

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.test.tsx
@@ -38,7 +38,7 @@ describe('EisPromotionalTour', () => {
   it('renders children only when promo is not visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: false,
-      onSkipTour: jest.fn(),
+      onDismissTour: jest.fn(),
     });
 
     renderEisPromotionalTour();
@@ -53,7 +53,7 @@ describe('EisPromotionalTour', () => {
   it('renders the tour when promo is visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onSkipTour: jest.fn(),
+      onDismissTour: jest.fn(),
     });
 
     renderEisPromotionalTour();
@@ -68,11 +68,11 @@ describe('EisPromotionalTour', () => {
     expect(screen.getByText(EIS_PROMO_TOUR_TITLE)).toBeInTheDocument();
   });
 
-  it('calls onSkipTour when clicking the close button', () => {
-    const mockOnSkip = jest.fn();
+  it('calls onDismissTour when clicking the close button', () => {
+    const mockOnDismissTour = jest.fn();
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onSkipTour: mockOnSkip,
+      onDismissTour: mockOnDismissTour,
     });
 
     renderEisPromotionalTour();
@@ -80,14 +80,14 @@ describe('EisPromotionalTour', () => {
     const closeBtn = screen.getByTestId('eisPromoTourCloseBtn');
     fireEvent.click(closeBtn);
 
-    expect(mockOnSkip).toHaveBeenCalledTimes(1);
+    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
   });
 
   it('renders CTA button only when ctaLink is provided', () => {
     const ctaLink = 'https://example.com';
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onSkipTour: jest.fn(),
+      onDismissTour: jest.fn(),
     });
 
     renderEisPromotionalTour({ ctaLink });
@@ -101,7 +101,7 @@ describe('EisPromotionalTour', () => {
   it('does not render CTA button when ctaLink is undefined', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onSkipTour: jest.fn(),
+      onDismissTour: jest.fn(),
     });
 
     renderEisPromotionalTour({ ctaLink: undefined });
@@ -115,7 +115,7 @@ describe('EisPromotionalTour', () => {
   it('removes the tour from the DOM when close button is clicked, child remains', () => {
     // Use a variable to simulate state
     let isVisible = true;
-    const mockOnSkip = jest.fn(() => {
+    const mockOnDismissTour = jest.fn(() => {
       isVisible = false;
     });
 
@@ -123,7 +123,7 @@ describe('EisPromotionalTour', () => {
       get isPromoVisible() {
         return isVisible;
       },
-      onSkipTour: mockOnSkip,
+      onDismissTour: mockOnDismissTour,
     }));
 
     const { rerender } = renderEisPromotionalTour();
@@ -134,7 +134,7 @@ describe('EisPromotionalTour', () => {
 
     // Click the close button
     fireEvent.click(screen.getByTestId('eisPromoTourCloseBtn'));
-    expect(mockOnSkip).toHaveBeenCalledTimes(1);
+    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
 
     // Re-render component to simulate state update
     rerender(

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.tsx
@@ -13,6 +13,7 @@ import {
   EuiButtonEmpty,
   EuiText,
   EuiTourStep,
+  useEuiTheme,
   type EuiTourStepProps,
 } from '@elastic/eui';
 import {
@@ -38,7 +39,8 @@ export const EisPromotionalTour = ({
   isCloudEnabled,
   children,
 }: EisPromotionalTourProps) => {
-  const { isPromoVisible, onSkipTour } = useShowEisPromotionalContent({
+  const { euiTheme } = useEuiTheme();
+  const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
     promoId: `${promoId}Tour`,
     isCloudEnabled,
   });
@@ -53,7 +55,7 @@ export const EisPromotionalTour = ({
       data-telemetry-id={dataId}
       data-test-subj={dataId}
       title={EIS_PROMO_TOUR_TITLE}
-      maxWidth="400px"
+      maxWidth={`${euiTheme.base * 25}px`}
       content={
         <EuiText>
           <p>{EIS_PROMO_TOUR_DESCRIPTION}</p>
@@ -63,9 +65,9 @@ export const EisPromotionalTour = ({
       anchorPosition={anchorPosition}
       step={1}
       stepsTotal={1}
-      onFinish={onSkipTour}
+      onFinish={onDismissTour}
       footerAction={[
-        <EuiButtonEmpty data-test-subj="eisPromoTourCloseBtn" onClick={onSkipTour}>
+        <EuiButtonEmpty data-test-subj="eisPromoTourCloseBtn" onClick={onDismissTour}>
           {EIS_TOUR_DISMISS}
         </EuiButtonEmpty>,
         ...(ctaLink

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_token_cost_tour.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_token_cost_tour.test.tsx
@@ -36,7 +36,7 @@ describe('EisTokenCostTour', () => {
   it('renders children only when promo is not visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: false,
-      onSkipTour: jest.fn(),
+      onDismissTour: jest.fn(),
     });
 
     renderComponent();
@@ -51,7 +51,7 @@ describe('EisTokenCostTour', () => {
   it('renders children and does not render the tour when isReady is false', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true, // would normally show the tour
-      onSkipTour: jest.fn(),
+      onDismissTour: jest.fn(),
     });
 
     renderComponent({ isReady: false });
@@ -66,7 +66,7 @@ describe('EisTokenCostTour', () => {
   it('renders the tour when promo is visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onSkipTour: jest.fn(),
+      onDismissTour: jest.fn(),
     });
 
     renderComponent();
@@ -83,7 +83,7 @@ describe('EisTokenCostTour', () => {
 
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onSkipTour: jest.fn(),
+      onDismissTour: jest.fn(),
     });
 
     renderComponent({ ctaLink });
@@ -98,7 +98,7 @@ describe('EisTokenCostTour', () => {
   it('does not render CTA button when ctaLink is undefined', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onSkipTour: jest.fn(),
+      onDismissTour: jest.fn(),
     });
 
     renderComponent({ ctaLink: undefined });
@@ -109,7 +109,7 @@ describe('EisTokenCostTour', () => {
 
   it('removes the tour from DOM after clicking close, children remain', () => {
     let visible = true;
-    const mockOnSkip = jest.fn(() => {
+    const mockOnDismissTour = jest.fn(() => {
       visible = false;
     });
 
@@ -117,7 +117,7 @@ describe('EisTokenCostTour', () => {
       get isPromoVisible() {
         return visible;
       },
-      onSkipTour: mockOnSkip,
+      onDismissTour: mockOnDismissTour,
     }));
 
     const { rerender } = renderComponent();
@@ -125,7 +125,7 @@ describe('EisTokenCostTour', () => {
     expect(screen.getByTestId(dataId)).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('tokenConsumptionCostTourCloseBtn'));
-    expect(mockOnSkip).toHaveBeenCalledTimes(1);
+    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
 
     rerender(
       <EisTokenCostTour promoId={promoId} isCloudEnabled={true}>

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_token_cost_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_token_cost_tour.tsx
@@ -55,7 +55,7 @@ export const EisTokenCostTour = ({
   children,
 }: EisTokenCostTourProps) => {
   const { euiTheme } = useEuiTheme();
-  const { isPromoVisible, onSkipTour } = useShowEisPromotionalContent({
+  const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
     promoId: `${promoId}Tour`,
     isCloudEnabled,
   });
@@ -80,11 +80,11 @@ export const EisTokenCostTour = ({
       anchorPosition={anchorPosition}
       step={1}
       stepsTotal={1}
-      onFinish={onSkipTour}
+      onFinish={onDismissTour}
       footerAction={[
         <EuiButtonEmpty
           data-test-subj="tokenConsumptionCostTourCloseBtn"
-          onClick={onSkipTour}
+          onClick={onDismissTour}
           aria-label={i18n.EIS_COSTS_TOUR_DISMISS_ARIA}
         >
           {i18n.EIS_TOUR_DISMISS}

--- a/src/platform/packages/shared/kbn-search-api-panels/hooks/use_show_eis_promotional_content.test.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/hooks/use_show_eis_promotional_content.test.ts
@@ -45,7 +45,7 @@ describe('useShowEisPromotionalContent', () => {
     expect(result.current.isPromoVisible).toBe(false);
   });
 
-  it('should hide the promo and set localStorage when onSkipTour is called', () => {
+  it('should hide the promo and set localStorage when onDismissTour is called', () => {
     const { result } = renderHook(() =>
       useShowEisPromotionalContent({ promoId, isCloudEnabled: true })
     );
@@ -53,7 +53,7 @@ describe('useShowEisPromotionalContent', () => {
     expect(result.current.isPromoVisible).toBe(true);
 
     act(() => {
-      result.current.onSkipTour();
+      result.current.onDismissTour();
     });
 
     expect(localStorage.getItem(localStorageKey)).toBe('true');

--- a/src/platform/packages/shared/kbn-search-api-panels/hooks/use_show_eis_promotional_content.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/hooks/use_show_eis_promotional_content.ts
@@ -20,18 +20,18 @@ export const useShowEisPromotionalContent = ({
 }: UseShowEisPromotionalContentProps) => {
   const localStorageKey = `${promoId}Closed`;
   const [isPromoVisible, setIsPromoVisible] = useState<boolean>(false);
-  const onSkipTour = useCallback(() => {
+  const onDismissTour = useCallback(() => {
     localStorage.setItem(localStorageKey, 'true');
     setIsPromoVisible(false);
   }, [localStorageKey]);
 
   useEffect(() => {
-    const isTourSkipped = localStorage.getItem(localStorageKey) === 'true';
+    const isTourDismiss = localStorage.getItem(localStorageKey) === 'true';
 
-    if (!isTourSkipped && isCloudEnabled && !isPromoVisible) {
+    if (!isTourDismiss && isCloudEnabled && !isPromoVisible) {
       setIsPromoVisible(true);
     }
   }, [isCloudEnabled, isPromoVisible, localStorageKey]);
 
-  return { isPromoVisible, onSkipTour };
+  return { isPromoVisible, onDismissTour };
 };

--- a/src/platform/packages/shared/kbn-search-api-panels/translations.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/translations.ts
@@ -70,7 +70,14 @@ export const EIS_TOUR_DISMISS = i18n.translate('searchApiPanels.eis.tour.dismiss
 export const EIS_COSTS_TOUR_DISMISS_ARIA = i18n.translate(
   'searchApiPanels.eisCosts.tour.dismiss.aria',
   {
-    defaultMessage: 'Close the cost tour',
+    defaultMessage: 'Close the Elastic Inference Service cost tour',
+  }
+);
+
+export const EIS_PROMO_CALLOUT_DISMISS_ARIA = i18n.translate(
+  'searchApiPanels.eisPromotion.callout.dismiss.aria',
+  {
+    defaultMessage: 'Dismiss the Elastic Inference Service callout',
   }
 );
 

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/cloud_serverless_promo/cloud_serverless_promo.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/cloud_serverless_promo/cloud_serverless_promo.tsx
@@ -68,8 +68,8 @@ export const PromoItem = ({ promoItem }: { promoItem: 'serverless' | 'hosted' })
   const assetBasePath = useAssetBasePath();
   const { euiTheme } = useEuiTheme();
   const logoStyle = css({
-    'min-width': euiTheme.size.xxxxl,
-    'min-height': euiTheme.size.xxxxl,
+    minWidth: euiTheme.size.xxxxl,
+    minHeight: euiTheme.size.xxxxl,
     width: euiTheme.size.xxxxl,
     height: euiTheme.size.xxxxl,
   });

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_endpoint/endpoint_info.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_endpoint/endpoint_info.tsx
@@ -8,19 +8,15 @@
 import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import React from 'react';
 import type { InferenceInferenceEndpointInfo } from '@elastic/elasticsearch/lib/api/types';
-import { EisPromotionalTour } from '@kbn/search-api-panels';
 import { isEndpointPreconfigured } from '../../../../utils/preconfigured_endpoint_helper';
 import * as i18n from './translations';
 import { isProviderTechPreview } from '../../../../utils/reranker_helper';
-import { docLinks } from '../../../../../common/doc_links';
 
 export interface EndpointInfoProps {
   inferenceId: string;
   endpointInfo: InferenceInferenceEndpointInfo;
   isCloudEnabled?: boolean;
 }
-
-const EIS_TOUR_ENDPOINT = '.elser-2-elastic';
 
 export const EndpointInfo: React.FC<EndpointInfoProps> = ({
   inferenceId,
@@ -31,22 +27,9 @@ export const EndpointInfo: React.FC<EndpointInfoProps> = ({
     <EuiFlexItem grow={false}>
       <EuiFlexGroup gutterSize="s" alignItems="center" wrap>
         <EuiFlexItem grow={false}>
-          {inferenceId === EIS_TOUR_ENDPOINT ? (
-            <EisPromotionalTour
-              promoId="eisInferenceEndpoint"
-              ctaLink={docLinks.elasticInferenceService}
-              isCloudEnabled={isCloudEnabled ?? false}
-              anchorPosition="rightCenter"
-            >
-              <span>
-                <strong>{inferenceId}</strong>
-              </span>
-            </EisPromotionalTour>
-          ) : (
-            <span>
-              <strong>{inferenceId}</strong>
-            </span>
-          )}
+          <span>
+            <strong>{inferenceId}</strong>
+          </span>
         </EuiFlexItem>
         {isProviderTechPreview(endpointInfo) ? (
           <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary

This PR mainly makes some small tweaks around the EIS promo related components. These tweaks are based on suggestions from Copilot and peer reviews. The following changes were made:

- The callback function in `useShowEisPromotionalContent` has been renamed `onDismissTour` to better reflect the context of its usage
- The width of the tours is now being calculated through EUI variables: `maxWidth={${euiTheme.base * 25}px}`
- An aria label was added to the `EisPromotionalCallout` callout dismiss button
- The tour over the `.elser-2-elastic` inference endpoint has been removed as it's no longer needed. However, he component hasn't been removed because we will possibly be using it for something else. It will be removed if the decision is made not to have any promo tours.
- The kebab case CSS styles were removed from `cloud_serverless_promo.tsx` as they were causing a console error 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~


