### PR TITLE
[Security Solution] fix alert flyout threat intelligence section not showing multiple values

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/threat_details_view_enrichment_accordion.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/threat_details_view_enrichment_accordion.test.tsx
@@ -8,13 +8,19 @@
 import { render } from '@testing-library/react';
 import { TestProviders } from '../../../../common/mock';
 import React from 'react';
-import { EnrichmentAccordion } from './threat_details_view_enrichment_accordion';
+import {
+  ENRICHMENT_ACCORDION_LINK_TEST_ID,
+  EnrichmentAccordion,
+  THREAT_DETAILS_ROW_FIELD_TEST_ID,
+  THREAT_DETAILS_ROW_LINK_VALUE_TEST_ID,
+  THREAT_DETAILS_ROW_STRING_VALUE_TEST_ID,
+} from './threat_details_view_enrichment_accordion';
 import { indicatorWithNestedObjects } from '../mocks/indicator_with_nested_objects';
 import type { CtiEnrichment } from '../../../../../common/search_strategy';
 
 describe('EnrichmentAccordion', () => {
-  it('should render', () => {
-    render(
+  it('should render the top level accordion', () => {
+    const { getByTestId } = render(
       <TestProviders>
         <EnrichmentAccordion
           enrichment={indicatorWithNestedObjects as unknown as CtiEnrichment}
@@ -23,6 +29,33 @@ describe('EnrichmentAccordion', () => {
       </TestProviders>
     );
 
-    expect(true).toBeTruthy();
+    expect(getByTestId(ENRICHMENT_ACCORDION_LINK_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('should render rows with EuiLink', () => {
+    const { getAllByTestId, getAllByText, getByText } = render(
+      <TestProviders>
+        <EnrichmentAccordion
+          enrichment={indicatorWithNestedObjects as unknown as CtiEnrichment}
+          index={0}
+        />
+      </TestProviders>
+    );
+
+    expect(getAllByTestId(THREAT_DETAILS_ROW_FIELD_TEST_ID).length).toBeGreaterThan(0);
+    expect(getAllByTestId(THREAT_DETAILS_ROW_STRING_VALUE_TEST_ID).length).toBeGreaterThan(0);
+    expect(getAllByTestId(THREAT_DETAILS_ROW_LINK_VALUE_TEST_ID).length).toEqual(1);
+
+    expect(getByText('@timestamp')).toBeInTheDocument();
+    expect(getAllByText('2024-02-24T17:32:37.813Z').length).toBeGreaterThan(0);
+
+    expect(getByText('agent.name')).toBeInTheDocument();
+    expect(getByText('win-10')).toBeInTheDocument();
+
+    expect(getByText('data_stream.namespace')).toBeInTheDocument();
+    expect(getByText('default')).toBeInTheDocument();
+
+    expect(getByText('indicator.reference')).toBeInTheDocument();
+    expect(getByText('indicatorReferenceValue')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/threat_details_view_enrichment_accordion.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/threat_details_view_enrichment_accordion.tsx
@@ -11,8 +11,8 @@ import {
   EuiAccordion,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiLink,
   EuiInMemoryTable,
+  EuiLink,
   EuiTitle,
   EuiToolTip,
   useEuiTheme,
@@ -24,8 +24,8 @@ import type { CtiEnrichment } from '../../../../../common/search_strategy';
 import { QUERY_ID } from '../../shared/hooks/use_investigation_enrichment';
 import { InspectButton } from '../../../../common/components/inspect';
 import {
-  getEnrichmentIdentifiers,
   buildThreatDetailsItems,
+  getEnrichmentIdentifiers,
   isInvestigationTimeEnrichment,
 } from '../../shared/utils/threat_intelligence';
 import { EnrichmentButtonContent } from './threat_details_view_enrichment_button_content';
@@ -34,6 +34,11 @@ import { REFERENCE } from '../../../../../common/cti/constants';
 const StyledH5 = styled.h5`
   line-height: 1.7rem;
 `;
+
+export const ENRICHMENT_ACCORDION_LINK_TEST_ID = 'enrichementAccordion';
+export const THREAT_DETAILS_ROW_FIELD_TEST_ID = 'threatDetailsRowField';
+export const THREAT_DETAILS_ROW_LINK_VALUE_TEST_ID = 'threatDetailsRowLinkValue';
+export const THREAT_DETAILS_ROW_STRING_VALUE_TEST_ID = 'threatDetailsRowStringValue';
 
 const INVESTIGATION_QUERY_TITLE = i18n.translate(
   'xpack.securitySolution.flyout.threatIntelligence.investigationTimeQueryTitle',
@@ -61,7 +66,7 @@ export interface ThreatDetailsRow {
     /**
      * Value of the enrichment
      */
-    value: string;
+    value: string[];
   };
 }
 
@@ -70,7 +75,7 @@ const columns: Array<EuiBasicTableColumn<ThreatDetailsRow>> = [
     field: 'title',
     truncateText: false,
     render: (title: string) => (
-      <EuiTitle size="xxxs">
+      <EuiTitle data-test-subj={THREAT_DETAILS_ROW_FIELD_TEST_ID} size="xxxs">
         <StyledH5>{title}</StyledH5>
       </EuiTitle>
     ),
@@ -82,13 +87,27 @@ const columns: Array<EuiBasicTableColumn<ThreatDetailsRow>> = [
     truncateText: false,
     render: (description: ThreatDetailsRow['description']) => {
       const { fieldName, value } = description;
-      const tooltipChild = fieldName.match(REFERENCE) ? (
-        <EuiLink href={value} target="_blank">
-          {value}
-        </EuiLink>
+
+      const renderedValue = fieldName.match(REFERENCE) ? (
+        <EuiFlexGroup direction="column" gutterSize="none">
+          {value.map((val, key) => (
+            <EuiFlexItem data-test-subj={THREAT_DETAILS_ROW_LINK_VALUE_TEST_ID} key={key}>
+              <EuiLink href={val} target="_blank">
+                {val}
+              </EuiLink>
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGroup>
       ) : (
-        <span>{value}</span>
+        <EuiFlexGroup direction="column" gutterSize="none">
+          {value.map((val, key) => (
+            <EuiFlexItem data-test-subj={THREAT_DETAILS_ROW_STRING_VALUE_TEST_ID} key={key}>
+              <span>{val}</span>
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGroup>
       );
+
       return (
         <EuiToolTip
           data-test-subj="message-tool-tip"
@@ -100,7 +119,7 @@ const columns: Array<EuiBasicTableColumn<ThreatDetailsRow>> = [
             </EuiFlexGroup>
           }
         >
-          {tooltipChild}
+          {renderedValue}
         </EuiToolTip>
       );
     },
@@ -137,6 +156,7 @@ export const EnrichmentAccordion = memo(({ enrichment, index }: EnrichmentAccord
 
   return (
     <EuiAccordion
+      data-test-subj={ENRICHMENT_ACCORDION_LINK_TEST_ID}
       id={accordionId}
       key={accordionId}
       initialIsOpen={true}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/threat_details_view_enrichment_accordion.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/threat_details_view_enrichment_accordion.tsx
@@ -176,6 +176,7 @@ export const EnrichmentAccordion = memo(({ enrichment, index }: EnrichmentAccord
           height: ${euiTheme.size.xl};
           margin-bottom: ${euiTheme.size.s};
           padding-left: ${euiTheme.size.s};
+        }
       `}
     >
       <EuiInMemoryTable

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/mocks/indicator_with_nested_objects.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/mocks/indicator_with_nested_objects.ts
@@ -143,4 +143,5 @@ export const indicatorWithNestedObjects = {
   'agent.ephemeral_id': ['0532c813-1434-4c76-800b-6abdf7eaf62c'],
   'agent.version': ['8.10.4'],
   'event.dataset': ['ti_recordedfuture.threat'],
+  'indicator.reference': ['indicatorReferenceValue'],
 } as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils/threat_intelligence.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils/threat_intelligence.test.tsx
@@ -8,11 +8,11 @@
 import { ENRICHMENT_TYPES } from '../../../../../common/cti/constants';
 import { buildEventEnrichmentMock } from '../../../../../common/search_strategy/security_solution/cti/index.mock';
 import {
+  buildThreatDetailsItems,
   filterDuplicateEnrichments,
   getEnrichmentFields,
-  parseExistingEnrichments,
   getEnrichmentIdentifiers,
-  buildThreatDetailsItems,
+  parseExistingEnrichments,
 } from './threat_intelligence';
 
 describe('parseExistingEnrichments', () => {
@@ -510,28 +510,28 @@ describe('buildThreatDetailsItems', () => {
       {
         description: {
           fieldName: 'feed.name',
-          value: 'feed name',
+          value: ['feed name'],
         },
         title: 'feed.name',
       },
       {
         description: {
           fieldName: 'matched.atomic',
-          value: 'matched atomic',
+          value: ['matched atomic'],
         },
         title: 'matched.atomic',
       },
       {
         description: {
           fieldName: 'matched.field',
-          value: 'matched field',
+          value: ['matched field'],
         },
         title: 'matched.field',
       },
       {
         description: {
           fieldName: 'matched.type',
-          value: 'matched type',
+          value: ['matched type'],
         },
         title: 'matched.type',
       },
@@ -548,7 +548,7 @@ describe('buildThreatDetailsItems', () => {
         title: 'array_values',
         description: {
           fieldName: 'array_values',
-          value: 'first value',
+          value: ['first value', 'second value'],
         },
       },
     ]);
@@ -563,7 +563,7 @@ describe('buildThreatDetailsItems', () => {
         title: 'indicator.ip',
         description: {
           fieldName: 'threat.indicator.ip',
-          value: '127.0.0.1',
+          value: ['127.0.0.1'],
         },
       },
     ]);
@@ -579,7 +579,7 @@ describe('buildThreatDetailsItems', () => {
         title: 'object_field.foo',
         description: {
           fieldName: 'object_field.foo',
-          value: 'bar',
+          value: ['bar'],
         },
       },
     ]);
@@ -597,8 +597,9 @@ describe('buildThreatDetailsItems', () => {
             title: 'flattened_object',
             description: {
               fieldName: 'flattened_object',
-              value:
+              value: [
                 'This field contains nested object values, which are not rendered here. See the full document for all fields/values',
+              ],
             },
           },
         ]);
@@ -614,8 +615,9 @@ describe('buildThreatDetailsItems', () => {
             title: 'array_field',
             description: {
               fieldName: 'array_field',
-              value:
+              value: [
                 'This field contains nested object values, which are not rendered here. See the full document for all fields/values',
+              ],
             },
           },
         ]);


### PR DESCRIPTION
## Summary

This PR makes a small code change to fix the Threat Intelligence component rendered in the alert details flyout.
Currently that component only renders the first value for each field. This PR changes that logic to render all the values instead.

| Before  | After |
| ------------- | ------------- |
| <img width="802" height="536" alt="Screenshot 2025-12-05 at 4 03 07 PM" src="https://github.com/user-attachments/assets/b2b58b05-2a45-4c09-a742-0611c3c60323" /> | <img width="803" height="590" alt="Screenshot 2025-12-05 at 4 00 05 PM" src="https://github.com/user-attachments/assets/c7330f47-45c3-4f54-b5fb-cbdc45fba062" /> |

As can be seen on the screenshots above, we're now displaying multiple values vertically. This could be further improved by showing a `Show more/Show less` button when we have to many values.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->