### PR TITLE
🌊 Streams: Tech preview badge for pipeline suggestion and limit max steps

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/suggest_processing_pipeline_route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/suggest_processing_pipeline_route.ts
@@ -221,7 +221,7 @@ export const suggestProcessingPipelineRoute = createServerRoute({
         definition: stream,
         inferenceClient: inferenceClient.bindTo({ connectorId: params.body.connector_id }),
         parsingProcessor,
-        maxSteps: undefined,
+        maxSteps: 4, // Limit reasoning steps for latency and token cost
         signal: abortController.signal,
         documents: params.body.documents,
         esClient: scopedClusterClient.asCurrentUser,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/pipeline_suggestions/suggest_pipeline_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/pipeline_suggestions/suggest_pipeline_panel.tsx
@@ -33,7 +33,7 @@ export function SuggestPipelinePanel({ children }: React.PropsWithChildren) {
         <EuiFlexItem>
           <EuiTitle size="m">
             <h4>
-              <EuiFlexGroup alignItems="center" gutterSize="s">
+              <EuiFlexGroup alignItems="center" gutterSize="s" wrap>
                 <EuiFlexItem grow={false}>
                   {i18n.translate('xpack.streams.stepsEditor.h3.suggestAPipelineLabel', {
                     defaultMessage: 'Suggest a pipeline',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/pipeline_suggestions/suggest_pipeline_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/pipeline_suggestions/suggest_pipeline_panel.tsx
@@ -6,7 +6,15 @@
  */
 
 import React from 'react';
-import { EuiPanel, EuiTitle, EuiText, EuiFlexItem, EuiSpacer, EuiFlexGroup } from '@elastic/eui';
+import {
+  EuiPanel,
+  EuiTitle,
+  EuiText,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiFlexGroup,
+  EuiBetaBadge,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { AssetImage } from '../../../asset_image';
@@ -25,9 +33,30 @@ export function SuggestPipelinePanel({ children }: React.PropsWithChildren) {
         <EuiFlexItem>
           <EuiTitle size="m">
             <h4>
-              {i18n.translate('xpack.streams.stepsEditor.h3.suggestAPipelineLabel', {
-                defaultMessage: 'Suggest a pipeline',
-              })}
+              <EuiFlexGroup alignItems="center" gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  {i18n.translate('xpack.streams.stepsEditor.h3.suggestAPipelineLabel', {
+                    defaultMessage: 'Suggest a pipeline',
+                  })}
+                </EuiFlexItem>
+                <EuiBetaBadge
+                  label={i18n.translate(
+                    'xpack.streams.stepsEditor.pipelineSuggestion.betaBadgeLabel',
+                    {
+                      defaultMessage: 'Technical Preview',
+                    }
+                  )}
+                  tooltipContent={i18n.translate(
+                    'xpack.streams.stepsEditor.pipelineSuggestion.betaBadgeLabel.betaBadgeDescription',
+                    {
+                      defaultMessage:
+                        'This functionality is experimental and not supported. It may change or be removed at any time.',
+                    }
+                  )}
+                  alignment="middle"
+                  size="s"
+                />
+              </EuiFlexGroup>
             </h4>
           </EuiTitle>
           <EuiText size="m">


### PR DESCRIPTION
Pipeline suggestion isn't optimized yet, to manage user expectations it should be released as tech preview.

This PR adds the tech preview badge:
<img width="551" height="510" alt="Screenshot 2025-12-06 at 21 37 16" src="https://github.com/user-attachments/assets/90a28113-d704-47f7-b3de-dba07746f915" />

It also limits the maximum amount of steps to perform for reasoning