### PR TITLE
Disable geopoint mapping in the processing preview

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/field_actions.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/field_actions.tsx
@@ -31,7 +31,14 @@ export const FieldActionsCell = ({ field }: { field: SchemaField }) => {
   const [popoverIsOpen, { off: closePopover, toggle }] = useBoolean(false);
 
   const panels = useMemo(() => {
-    const { onFieldUpdate, onAddField, stream, withFieldSimulation, fields } = schemaEditorContext;
+    const {
+      onFieldUpdate,
+      onAddField,
+      stream,
+      withFieldSimulation,
+      fields,
+      enableGeoPointSuggestions,
+    } = schemaEditorContext;
 
     let actions = [];
 
@@ -57,6 +64,7 @@ export const FieldActionsCell = ({ field }: { field: SchemaField }) => {
               stream={stream}
               withFieldSimulation={withFieldSimulation}
               fields={fields}
+              enableGeoPointSuggestions={enableGeoPointSuggestions}
               {...props}
             />
           </StreamsAppContextProvider>,
@@ -108,19 +116,22 @@ export const FieldActionsCell = ({ field }: { field: SchemaField }) => {
           },
         ];
 
-        const geoSuggestion = getGeoPointSuggestion({
-          fieldName: field.name,
-          fields,
-          streamType: Streams.WiredStream.Definition.is(stream) ? 'wired' : 'classic',
-        });
-
-        if (geoSuggestion) {
-          actions.push({
-            name: i18n.translate('xpack.streams.actions.mapAsGeoFieldLabel', {
-              defaultMessage: 'Map as geo field',
-            }),
-            onClick: () => openFlyout({ isEditingByDefault: true, applyGeoPointSuggestion: true }),
+        if (enableGeoPointSuggestions !== false) {
+          const geoSuggestion = getGeoPointSuggestion({
+            fieldName: field.name,
+            fields,
+            streamType: Streams.WiredStream.Definition.is(stream) ? 'wired' : 'classic',
           });
+
+          if (geoSuggestion) {
+            actions.push({
+              name: i18n.translate('xpack.streams.actions.mapAsGeoFieldLabel', {
+                defaultMessage: 'Map as geo field',
+              }),
+              onClick: () =>
+                openFlyout({ isEditingByDefault: true, applyGeoPointSuggestion: true }),
+            });
+          }
         }
         break;
       case 'inherited':

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/field_summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/field_summary.tsx
@@ -212,8 +212,8 @@ export const FieldSummary = (props: FieldSummaryProps) => {
         <EuiHorizontalRule margin="xs" />
       </EuiFlexGroup>
       {isEditing &&
-        Streams.WiredStream.Definition.is(stream) &&
-        stream.ingest.wired.routing.length > 0 ? (
+      Streams.WiredStream.Definition.is(stream) &&
+      stream.ingest.wired.routing.length > 0 ? (
         <EuiFlexItem grow={false}>
           <ChildrenAffectedCallout childStreams={stream.ingest.wired.routing} />
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/field_summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/field_summary.tsx
@@ -59,10 +59,11 @@ interface FieldSummaryProps {
   toggleEditMode: () => void;
   stream: Streams.ingest.all.Definition;
   onChange: (field: Partial<SchemaField>) => void;
+  enableGeoPointSuggestions?: boolean;
 }
 
 export const FieldSummary = (props: FieldSummaryProps) => {
-  const { field, isEditing, toggleEditMode, onChange, stream } = props;
+  const { field, isEditing, toggleEditMode, onChange, stream, enableGeoPointSuggestions } = props;
 
   const router = useStreamsAppRouter();
 
@@ -163,6 +164,7 @@ export const FieldSummary = (props: FieldSummaryProps) => {
               isEditing={isEditing}
               onTypeChange={(type) => onChange({ type })}
               streamType={streamType}
+              enableGeoPointSuggestions={enableGeoPointSuggestions}
             />
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -210,8 +212,8 @@ export const FieldSummary = (props: FieldSummaryProps) => {
         <EuiHorizontalRule margin="xs" />
       </EuiFlexGroup>
       {isEditing &&
-      Streams.WiredStream.Definition.is(stream) &&
-      stream.ingest.wired.routing.length > 0 ? (
+        Streams.WiredStream.Definition.is(stream) &&
+        stream.ingest.wired.routing.length > 0 ? (
         <EuiFlexItem grow={false}>
           <ChildrenAffectedCallout childStreams={stream.ingest.wired.routing} />
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/index.tsx
@@ -38,6 +38,7 @@ export interface SchemaEditorFlyoutProps {
   stream: Streams.ingest.all.Definition;
   withFieldSimulation?: boolean;
   fields?: SchemaField[];
+  enableGeoPointSuggestions?: boolean;
 }
 
 export const SchemaEditorFlyout = ({
@@ -49,6 +50,7 @@ export const SchemaEditorFlyout = ({
   applyGeoPointSuggestion: applyGeoPointSuggestionProp = false,
   withFieldSimulation = false,
   fields,
+  enableGeoPointSuggestions = true,
 }: SchemaEditorFlyoutProps) => {
   const [isEditing, toggleEditMode] = useToggle(isEditingByDefault);
   const [isValidAdvancedFieldMappings, setValidAdvancedFieldMappings] = useState(true);
@@ -62,12 +64,15 @@ export const SchemaEditorFlyout = ({
   const flyoutId = useGeneratedHtmlId({ prefix: 'streams-edit-field' });
 
   const geoPointSuggestion = useMemo(() => {
+    if (!enableGeoPointSuggestions) {
+      return null;
+    }
     return getGeoPointSuggestion({
       fieldName: field.name,
       fields,
       streamType: Streams.WiredStream.Definition.is(stream) ? 'wired' : 'classic',
     });
-  }, [field.name, fields, stream]);
+  }, [enableGeoPointSuggestions, field.name, fields, stream]);
 
   const initialField = useMemo(() => {
     if (applyGeoPointSuggestionProp && geoPointSuggestion) {
@@ -83,10 +88,10 @@ export const SchemaEditorFlyout = ({
 
   const [nextField, setNextField] = useReducer(
     (prev: SchemaField, updated: Partial<SchemaField>) =>
-      ({
-        ...prev,
-        ...updated,
-      } as SchemaField),
+    ({
+      ...prev,
+      ...updated,
+    } as SchemaField),
     initialField
   );
 
@@ -177,6 +182,7 @@ export const SchemaEditorFlyout = ({
             toggleEditMode={toggleEditMode}
             onChange={setNextField}
             stream={stream}
+            enableGeoPointSuggestions={enableGeoPointSuggestions}
           />
           <AdvancedFieldMappingOptions
             value={nextField.additionalParameters}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/flyout/index.tsx
@@ -88,10 +88,10 @@ export const SchemaEditorFlyout = ({
 
   const [nextField, setNextField] = useReducer(
     (prev: SchemaField, updated: Partial<SchemaField>) =>
-    ({
-      ...prev,
-      ...updated,
-    } as SchemaField),
+      ({
+        ...prev,
+        ...updated,
+      } as SchemaField),
     initialField
   );
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/index.tsx
@@ -40,6 +40,7 @@ export function SchemaEditor({
   withFieldSimulation = false,
   withTableActions = false,
   withToolbar = true,
+  enableGeoPointSuggestions = true,
 }: SchemaEditorProps) {
   const [controls, updateControls] = useControls();
   const [isLoadingRecommendations, setIsLoadingRecommendations] = React.useState(false);
@@ -197,6 +198,7 @@ export function SchemaEditor({
       withControls={withControls}
       withFieldSimulation={withFieldSimulation}
       withTableActions={withTableActions}
+      enableGeoPointSuggestions={enableGeoPointSuggestions}
     >
       <EuiFlexGroup
         direction="column"

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/schema_editor/types.ts
@@ -66,6 +66,7 @@ export interface SchemaEditorProps {
   withFieldSimulation?: boolean;
   withTableActions?: boolean;
   withToolbar?: boolean;
+  enableGeoPointSuggestions?: boolean;
 }
 
 export const isSchemaFieldTyped = (field: SchemaField): field is MappedSchemaField => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/detected_fields_editor.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/detected_fields_editor.tsx
@@ -81,6 +81,9 @@ export const DetectedFieldsEditor = ({ schemaEditorFields }: DetectedFieldsEdito
         defaultColumns={['name', 'type', 'format', 'status', 'result']}
         fields={schemaEditorFields}
         stream={definition.stream}
+        // Geo-point helpers are disabled in the Processing tab for now
+        // We will enable it once we add geo_point support for wired.
+        enableGeoPointSuggestions={false}
         onFieldUpdate={(field) => {
           if (field.status === 'mapped') {
             mapField(field);


### PR DESCRIPTION
## Summary

Related to : https://elastic.slack.com/archives/C07B24L5NNM/p1765054476410809

This PR disables `all geo_point`  mapping suggestions and options  in the Processing tab, keeping them available only in the Schema tab. 