### PR TITLE
[Actionable Obs] - Update alert table muting icon to rely on the alert doc

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerts-table/components/mute_alert_action.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/components/mute_alert_action.tsx
@@ -7,7 +7,6 @@
 
 import { EuiContextMenuItem } from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
-import { i18n } from '@kbn/i18n';
 import { ALERT_STATUS, ALERT_STATUS_ACTIVE } from '@kbn/rule-data-utils';
 import { useMuteAlertInstance } from '@kbn/response-ops-alerts-apis/hooks/use_mute_alert_instance';
 import { useUnmuteAlertInstance } from '@kbn/response-ops-alerts-apis/hooks/use_unmute_alert_instance';
@@ -29,7 +28,7 @@ export const MuteAlertAction = typedMemo(
     const {
       services: { http, notifications },
     } = useAlertsTableContext();
-    const { isMuted, ruleId, rule, alertInstanceId } = useAlertMutedState(alert);
+    const { isMuted, ruleId, alertInstanceId } = useAlertMutedState(alert);
     const { mutateAsync: muteAlert } = useMuteAlertInstance({ http, notifications });
     const { mutateAsync: unmuteAlert } = useUnmuteAlertInstance({ http, notifications });
     const isAlertActive = useMemo(() => alert[ALERT_STATUS]?.[0] === ALERT_STATUS_ACTIVE, [alert]);
@@ -52,19 +51,8 @@ export const MuteAlertAction = typedMemo(
     }
 
     return (
-      <EuiContextMenuItem
-        data-test-subj="toggle-alert"
-        onClick={toggleAlert}
-        size="s"
-        disabled={!rule}
-      >
-        {!rule
-          ? i18n.translate('xpack.triggersActionsUI.alertsTable.loadingMutedState', {
-              defaultMessage: 'Loading muted state',
-            })
-          : isMuted
-          ? UNMUTE
-          : MUTE}
+      <EuiContextMenuItem data-test-subj="toggle-alert" onClick={toggleAlert} size="s">
+        {isMuted ? UNMUTE : MUTE}
       </EuiContextMenuItem>
     );
   }

--- a/x-pack/platform/packages/shared/response-ops/alerts-table/hooks/use_alert_muted_state.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerts-table/hooks/use_alert_muted_state.ts
@@ -6,21 +6,19 @@
  */
 
 import { useMemo } from 'react';
-import { ALERT_INSTANCE_ID, ALERT_RULE_UUID } from '@kbn/rule-data-utils';
+import { ALERT_INSTANCE_ID, ALERT_RULE_UUID, ALERT_MUTED } from '@kbn/rule-data-utils';
 import type { Alert } from '@kbn/alerting-types';
-import { useAlertsTableContext } from '../contexts/alerts_table_context';
 
 export const useAlertMutedState = (alert?: Alert) => {
-  const { mutedAlerts } = useAlertsTableContext();
   const alertInstanceId = alert && (alert[ALERT_INSTANCE_ID]?.[0] as string);
   const ruleId = alert && (alert[ALERT_RULE_UUID]?.[0] as string);
+  const alertMutedValue = alert?.[ALERT_MUTED];
+  const isMuted = Array.isArray(alertMutedValue) && alertMutedValue[0] === true;
   return useMemo(() => {
-    const rule = ruleId ? mutedAlerts?.[ruleId] ?? [] : [];
     return {
-      isMuted: alertInstanceId ? rule?.includes(alertInstanceId) : null,
+      isMuted,
       ruleId,
-      rule,
       alertInstanceId,
     };
-  }, [alertInstanceId, mutedAlerts, ruleId]);
+  }, [alertInstanceId, isMuted, ruleId]);
 };


### PR DESCRIPTION
## Summary

After merging [Store Alert Muted Status Directly in Alert Documents](https://github.com/elastic/kibana/pull/240996)
We need the alert table to use the new field instead of the rule SO, especially when the KQL filter is used to have a consistent user experience  
Also, this PR adds mute and unmute functional tests.

## How to test 🧪
- Create a rule that fires alerts
- Mute alert(s)
- Apply `kibana.alert.muted: true` in the KQL filter 
- You should ONLY see the muted alerts

(redo the same thing with unmute)