### PR TITLE
[Lens as code] Fix layerId mismatch for non multi-layer charts

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
@@ -165,7 +165,7 @@ describe('buildDatasourceStates', () => {
         "layers": Object {
           "textBased": Object {
             "layers": Object {
-              "metric_0": Object {
+              "layer_0": Object {
                 "columns": Array [
                   Object {
                     "columnId": "test",
@@ -182,7 +182,7 @@ describe('buildDatasourceStates', () => {
           },
         },
         "usedDataviews": Object {
-          "metric_0": Object {
+          "layer_0": Object {
             "index": "test",
             "timeFieldName": "@timestamp",
             "type": "adHocDataView",

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -364,12 +364,13 @@ export const buildDatasourceStates = (
     | { type: 'adHocDataView'; index: string; timeFieldName: string }
   > = {};
   // a few charts types support multiple layers
-  const configLayers = 'layers' in config ? config.layers : [config];
+  const hasMultipleLayers = 'layers' in config;
+  const configLayers = hasMultipleLayers ? config.layers : [config];
   // @ts-expect-error upgrade typescript v5.9.3
   for (let i = 0; i < configLayers.length; i++) {
     // @ts-expect-error upgrade typescript v5.9.3
     const layer = configLayers[i];
-    const layerId = `${layer.type ?? 'layer'}_${i}`;
+    const layerId = hasMultipleLayers && 'type' in layer ? `${layer.type}_${i}` : `layer_${i}`;
     const dataset = 'dataset' in layer ? layer.dataset : mainDataset;
 
     if (!dataset) {


### PR DESCRIPTION
## Summary

This PR fixes a regression coming from the [[Lens][Lens as code] Add XY schema and transformation logic](https://github.com/elastic/kibana/pull/243546).

In the XY implementation the `layerId` was calculated as `layerId = ${layer.type ?? 'layer'}_${i}` which applied typed layer IDs (e.g., metric_0) to all chart types that have a `type` property, not just XY charts.

This caused a `layerId` mismatch between the visualization state and datasource state for all non-XY chart types (metric, heatmap, gauge, tagcloud, etc.)

These charts expect simple numeric layer IDs (`layer_0`) but were receiving typed IDs, causing the visualizations to break.

### Screenshots
Before: 
<img width="1809" height="711" alt="Screenshot 2025-12-08 at 2 21 25 PM" src="https://github.com/user-attachments/assets/1c394606-e0b3-4968-9061-96deeaeba384" />

After: 
<img width="1807" height="737" alt="Screenshot 2025-12-08 at 2 20 27 PM" src="https://github.com/user-attachments/assets/9d24dc9e-d57c-4e34-9d02-1f27969eddd0" />

### Checklist

Check the PR satisfies following conditions. 
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.