### PR TITLE
[Discover][Header] Fix alignment of `read-only` badge and hide `context-aware` discover badge on mobile

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/ui/header/header_badge.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header_badge.tsx
@@ -52,8 +52,9 @@ export class HeaderBadge extends Component<Props, State> {
     }
 
     return (
-      <div css={({ euiTheme }) => ({ alignSelf: 'center', marginLeft: euiTheme.size.base })}>
+      <div css={({ euiTheme }) => ({ alignSelf: 'center', marginRight: euiTheme.size.s })}>
         <EuiBetaBadge
+          alignment="middle"
           data-test-subj="headerBadge"
           data-test-badge-label={this.state.badge.text}
           tabIndex={0}

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.test.ts
@@ -23,6 +23,7 @@ describe('getTopNavBadges()', function () {
   test('should not return the unsaved changes badge if no changes', () => {
     const topNavBadges = getTopNavBadges({
       hasUnsavedChanges: false,
+      isMobile: false,
       services: discoverServiceMock,
       stateContainer,
       topNavCustomization: undefined,
@@ -33,6 +34,7 @@ describe('getTopNavBadges()', function () {
   test('should return the unsaved changes badge when has changes', async () => {
     const topNavBadges = getTopNavBadges({
       hasUnsavedChanges: true,
+      isMobile: false,
       services: discoverServiceMock,
       stateContainer,
       topNavCustomization: undefined,
@@ -62,6 +64,7 @@ describe('getTopNavBadges()', function () {
     discoverServiceMockReadOnly.capabilities.discover_v2.save = false;
     const topNavBadges = getTopNavBadges({
       hasUnsavedChanges: true,
+      isMobile: false,
       services: discoverServiceMockReadOnly,
       stateContainer,
       topNavCustomization: undefined,
@@ -86,6 +89,7 @@ describe('getTopNavBadges()', function () {
     test('should return the managed badge when managed saved search', () => {
       const topNavBadges = getTopNavBadges({
         hasUnsavedChanges: false,
+        isMobile: false,
         services: discoverServiceMock,
         stateContainer: stateContainerWithManagedSavedSearch,
         topNavCustomization: undefined,
@@ -98,6 +102,7 @@ describe('getTopNavBadges()', function () {
     test('should not show save in unsaved changed badge', async () => {
       const topNavBadges = getTopNavBadges({
         hasUnsavedChanges: true,
+        isMobile: false,
         services: discoverServiceMock,
         stateContainer: stateContainerWithManagedSavedSearch,
         topNavCustomization: undefined,
@@ -116,6 +121,7 @@ describe('getTopNavBadges()', function () {
   test('should not return the unsaved changes badge when disabled in customization', () => {
     const topNavBadges = getTopNavBadges({
       hasUnsavedChanges: true,
+      isMobile: false,
       services: discoverServiceMock,
       stateContainer,
       topNavCustomization: {
@@ -138,6 +144,7 @@ describe('getTopNavBadges()', function () {
     test('should return the solutions view badge when spaces is enabled', () => {
       const topNavBadges = getTopNavBadges({
         hasUnsavedChanges: false,
+        isMobile: false,
         services: discoverServiceWithSpacesMock,
         stateContainer,
         topNavCustomization: undefined,

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
@@ -25,11 +25,13 @@ import { internalStateActions } from '../../state_management/redux';
  */
 export const getTopNavBadges = ({
   hasUnsavedChanges,
+  isMobile,
   stateContainer,
   services,
   topNavCustomization,
 }: {
   hasUnsavedChanges: boolean | undefined;
+  isMobile: boolean;
   stateContainer: DiscoverStateContainer;
   services: DiscoverServices;
   topNavCustomization: TopNavCustomization | undefined;
@@ -46,7 +48,7 @@ export const getTopNavBadges = ({
 
   const isManaged = stateContainer.savedSearchState.getState().managed;
 
-  if (services.spaces) {
+  if (services.spaces && !isMobile) {
     entries.push({
       badgeText: i18n.translate('discover.topNav.solutionViewTitle', {
         defaultMessage: 'Check out context-aware Discover',

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
@@ -9,6 +9,7 @@
 
 import { useMemo } from 'react';
 import type { DiscoverSession } from '@kbn/saved-search-plugin/common';
+import { useIsWithinBreakpoints } from '@elastic/eui';
 import { useDiscoverCustomization } from '../../../../customizations';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { useInspector } from '../../hooks/use_inspector';
@@ -34,6 +35,7 @@ export const useDiscoverTopNav = ({
   const services = useDiscoverServices();
   const topNavCustomization = useDiscoverCustomization('top_nav');
   const hasUnsavedChanges = useInternalStateSelector((state) => state.hasUnsavedChanges);
+  const isMobile = useIsWithinBreakpoints(['xs']);
 
   const topNavBadges = useMemo(
     () =>
@@ -42,8 +44,9 @@ export const useDiscoverTopNav = ({
         services,
         hasUnsavedChanges,
         topNavCustomization,
+        isMobile,
       }),
-    [stateContainer, services, hasUnsavedChanges, topNavCustomization]
+    [stateContainer, services, hasUnsavedChanges, topNavCustomization, isMobile]
   );
 
   const unsavedTabIds = useInternalStateSelector((state) => state.tabs.unsavedIds);


### PR DESCRIPTION
## Summary

This PR fixes the spacing and alignment of the `read-only` badge in the header bar. Apart from that it hides the `Check out context-aware Discover` badge on mobile, so it doesn't occupy the valuable space on this platform (now action menu and breadcrumbs can be seen without any issues). 

It closes: #234481
It closes: #245534

## Screenshots
read-only badge - before:
<img width="589" height="52" alt="Screenshot 2025-12-08 at 15 57 40" src="https://github.com/user-attachments/assets/ca60bebc-7e06-442b-83e9-071c8e73c5b3" />


read-only badge - after:
<img width="603" height="54" alt="Screenshot 2025-12-08 at 15 55 57" src="https://github.com/user-attachments/assets/489701e8-aa42-43bf-ac5f-5bb2cdb4a751" />


context-aware badge - mobile - before:
<img width="316" height="178" alt="Screenshot 2025-12-08 at 15 57 15" src="https://github.com/user-attachments/assets/067ff564-742f-425d-a9a7-1a5e862b2895" />

context-aware badge - mobile - after:
<img width="316" height="178" alt="Screenshot 2025-12-08 at 15 56 22" src="https://github.com/user-attachments/assets/b8b5537d-af95-4401-8dd3-f25e3bbd8ae1" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->