### PR TITLE
Add server-side validation to prevent `index.refresh_interval` values…

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -38,6 +38,7 @@ export { getAdvancedParameters } from './src/helpers/get_advanced_parameters';
 export { getInheritedFieldsFromAncestors } from './src/helpers/get_inherited_fields_from_ancestors';
 export { getInheritedSettings } from './src/helpers/get_inherited_settings';
 export { buildEsqlQuery } from './src/helpers/query';
+export { parseEsTimeValueInMs, parseEsTimeValueInSeconds } from './src/helpers/duration';
 
 export * from './src/ingest_pipeline_processors';
 

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/duration.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/duration.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment';
+
+const ES_UNIT_TO_MOMENT: Record<string, moment.unitOfTime.DurationConstructor> = {
+  ms: 'milliseconds',
+  s: 'seconds',
+  m: 'minutes',
+  h: 'hours',
+  d: 'days',
+};
+
+export function parseEsTimeValueInMs(value: string): number | undefined {
+  const unit = Object.keys(ES_UNIT_TO_MOMENT).find((u) => value.endsWith(u));
+  if (!unit) {
+    return undefined;
+  }
+
+  const numericPart = value.slice(0, -unit.length);
+  const numericValue = Number(numericPart);
+
+  if (isNaN(numericValue) || numericPart.length === 0) {
+    return undefined;
+  }
+
+  const momentUnit = ES_UNIT_TO_MOMENT[unit];
+  return moment.duration(numericValue, momentUnit).asMilliseconds();
+}
+
+export function parseEsTimeValueInSeconds(value: string): number | undefined {
+  const ms = parseEsTimeValueInMs(value);
+  return ms !== undefined ? ms / 1000 : undefined;
+}


### PR DESCRIPTION
https://github.com/elastic/observability-error-backlog/issues/325

## Summary
This PR fixes an issue where setting a short `index.refresh_interval` (e.g., `1s`) in Serverless caused an "Failed to execute Elasticsearch actions" error.

## Problem
Serverless Elasticsearch enforces a minimum refresh interval of `5s` (or `-1` to disable). Kibana's Streams plugin was not validating the *value* of this setting, only ensuring the key was allowed. This caused valid-looking changes to fail asynchronously during the execution plan phase.

## Testing
- Added unit tests in `validate_stream.test.ts` covering valid (`5s`, `1m`, `-1`) and invalid (`1s`, `4s`) scenarios.