### PR TITLE
Add datastream lifecycle support to indices metadata

### DIFF
--- a/x-pack/platform/plugins/private/indices_metadata/server/lib/ebt/events.ts
+++ b/x-pack/platform/plugins/private/indices_metadata/server/lib/ebt/events.ts
@@ -31,6 +31,19 @@ export const DATA_STREAM_EVENT: EventTypeOpts<DataStreams> = {
             type: 'keyword',
             _meta: { optional: true, description: 'ILM policy associated to the datastream' },
           },
+          dsl: {
+            properties: {
+              enabled: {
+                type: 'boolean',
+                _meta: { description: 'Whether the data stream is enabled' },
+              },
+              data_retention: {
+                type: 'text',
+                _meta: { optional: true, description: 'Data retention period' },
+              },
+            },
+            _meta: { optional: true, description: 'Data stream lifecycle settings' },
+          },
           template: {
             type: 'keyword',
             _meta: { optional: true, description: 'Template associated to the datastream' },

--- a/x-pack/platform/plugins/private/indices_metadata/server/lib/services/indices_metadata.ts
+++ b/x-pack/platform/plugins/private/indices_metadata/server/lib/services/indices_metadata.ts
@@ -257,6 +257,7 @@ export class IndicesMetadataService {
     this.logger.debug('Indices settings sent', { count: indicesSettings.items.length } as LogMeta);
     return indicesSettings.items.length;
   }
+
   private async publishIlmStats(indices: string[]): Promise<Set<string>> {
     const ilmNames = new Set<string>();
     const ilmsStats: IlmsStats = {

--- a/x-pack/platform/plugins/private/indices_metadata/server/lib/services/indices_metadata.types.ts
+++ b/x-pack/platform/plugins/private/indices_metadata/server/lib/services/indices_metadata.types.ts
@@ -114,9 +114,16 @@ export interface Index {
 export interface DataStreams {
   items: DataStream[];
 }
+
+export interface DataStreamLifeCycle {
+  enabled: boolean;
+  data_retention?: string;
+}
+
 export interface DataStream {
   datastream_name: string;
   ilm_policy?: string;
+  dsl?: DataStreamLifeCycle;
   template?: string;
   indices?: Index[];
 }

--- a/x-pack/platform/plugins/private/indices_metadata/server/lib/services/receiver.test.ts
+++ b/x-pack/platform/plugins/private/indices_metadata/server/lib/services/receiver.test.ts
@@ -228,6 +228,275 @@ describe('Indices Metadata - MetadataReceiver', () => {
       await expect(receiver.getDataStreams()).rejects.toThrow('Elasticsearch error');
       expect(logger.error).toHaveBeenCalledWith('Error fetching datastreams', { error });
     });
+
+    it.each([
+      { description: '7 days', retention: '7d' },
+      { description: '30 days', retention: '30d' },
+      { description: '90 days', retention: '90d' },
+      { description: '365 days', retention: '365d' },
+      { description: '1 year', retention: '1y' },
+    ])('should handle DSL enabled with retention: $description', async ({ retention }) => {
+      const mockResponse = {
+        data_streams: [
+          {
+            name: 'logs-test',
+            lifecycle: {
+              enabled: true,
+              data_retention: retention,
+            },
+            indices: [
+              {
+                index_name: '.ds-logs-test-000001',
+              },
+            ],
+          },
+        ],
+      };
+
+      (esClient.indices.getDataStream as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await receiver.getDataStreams();
+
+      expect(result).toEqual([
+        {
+          datastream_name: 'logs-test',
+          dsl: {
+            enabled: true,
+            data_retention: retention,
+          },
+          indices: [
+            {
+              index_name: '.ds-logs-test-000001',
+              ilm_policy: undefined,
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should handle DSL enabled without retention period', async () => {
+      const mockResponse = {
+        data_streams: [
+          {
+            name: 'logs-test',
+            lifecycle: {
+              enabled: true,
+            },
+            indices: [
+              {
+                index_name: '.ds-logs-test-000001',
+              },
+            ],
+          },
+        ],
+      };
+
+      (esClient.indices.getDataStream as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await receiver.getDataStreams();
+
+      expect(result).toEqual([
+        {
+          datastream_name: 'logs-test',
+          dsl: {
+            enabled: true,
+            data_retention: undefined,
+          },
+          indices: [
+            {
+              index_name: '.ds-logs-test-000001',
+              ilm_policy: undefined,
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should handle multiple datastreams with different DSL configurations', async () => {
+      const mockResponse = {
+        data_streams: [
+          {
+            name: 'logs-enabled-with-retention',
+            lifecycle: {
+              enabled: true,
+              data_retention: '30d',
+            },
+            indices: [{ index_name: '.ds-logs-1-000001' }],
+          },
+          {
+            name: 'logs-enabled-no-retention',
+            lifecycle: {
+              enabled: true,
+            },
+            indices: [{ index_name: '.ds-logs-2-000001' }],
+          },
+          {
+            name: 'logs-disabled-no-lifecycle',
+            indices: [{ index_name: '.ds-logs-3-000001' }],
+          },
+          {
+            name: 'logs-disabled-with-retention',
+            lifecycle: {
+              enabled: false,
+              data_retention: '7d',
+            },
+            indices: [{ index_name: '.ds-logs-4-000001' }],
+          },
+        ],
+      };
+
+      (esClient.indices.getDataStream as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await receiver.getDataStreams();
+
+      expect(result).toHaveLength(4);
+      expect(result).toEqual([
+        {
+          datastream_name: 'logs-enabled-with-retention',
+          dsl: { enabled: true, data_retention: '30d' },
+          indices: [{ index_name: '.ds-logs-1-000001', ilm_policy: undefined }],
+        },
+        {
+          datastream_name: 'logs-enabled-no-retention',
+          dsl: { enabled: true, data_retention: undefined },
+          indices: [{ index_name: '.ds-logs-2-000001', ilm_policy: undefined }],
+        },
+        {
+          datastream_name: 'logs-disabled-no-lifecycle',
+          dsl: { enabled: false, data_retention: undefined },
+          indices: [{ index_name: '.ds-logs-3-000001', ilm_policy: undefined }],
+        },
+        {
+          datastream_name: 'logs-disabled-with-retention',
+          dsl: { enabled: false, data_retention: '7d' },
+          indices: [{ index_name: '.ds-logs-4-000001', ilm_policy: undefined }],
+        },
+      ]);
+    });
+
+    it('should handle null lifecycle object', async () => {
+      const mockResponse = {
+        data_streams: [
+          {
+            name: 'logs-null-lifecycle',
+            lifecycle: null,
+            indices: [{ index_name: '.ds-logs-000001' }],
+          },
+        ],
+      };
+
+      (esClient.indices.getDataStream as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await receiver.getDataStreams();
+
+      expect(result).toEqual([
+        {
+          datastream_name: 'logs-null-lifecycle',
+          dsl: {
+            enabled: false,
+            data_retention: undefined,
+          },
+          indices: [{ index_name: '.ds-logs-000001', ilm_policy: undefined }],
+        },
+      ]);
+    });
+
+    it('should handle null data_retention value', async () => {
+      const mockResponse = {
+        data_streams: [
+          {
+            name: 'logs-null-retention',
+            lifecycle: {
+              enabled: true,
+              data_retention: null,
+            },
+            indices: [{ index_name: '.ds-logs-000001' }],
+          },
+        ],
+      };
+
+      (esClient.indices.getDataStream as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await receiver.getDataStreams();
+
+      expect(result).toEqual([
+        {
+          datastream_name: 'logs-null-retention',
+          dsl: {
+            enabled: true,
+            data_retention: null,
+          },
+          indices: [{ index_name: '.ds-logs-000001', ilm_policy: undefined }],
+        },
+      ]);
+    });
+
+    it.each([
+      { description: 'hours', retention: '24h' },
+      { description: 'minutes', retention: '1440m' },
+      { description: 'mixed case', retention: '30D' },
+      { description: 'with spaces', retention: '7 d' },
+      { description: 'empty string', retention: '' },
+    ])('should preserve retention format as-is: $description', async ({ retention }) => {
+      const mockResponse = {
+        data_streams: [
+          {
+            name: 'logs-format-test',
+            lifecycle: {
+              enabled: true,
+              data_retention: retention,
+            },
+            indices: [],
+          },
+        ],
+      };
+
+      (esClient.indices.getDataStream as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await receiver.getDataStreams();
+
+      expect(result[0].dsl?.data_retention).toBe(retention);
+    });
+
+    it('should handle datastreams with both DSL and ILM policy', async () => {
+      const mockResponse = {
+        data_streams: [
+          {
+            name: 'logs-both-dsl-ilm',
+            lifecycle: {
+              enabled: true,
+              data_retention: '30d',
+            },
+            indices: [
+              {
+                index_name: '.ds-logs-000001',
+                ilm_policy: 'logs-policy',
+              },
+            ],
+          },
+        ],
+      };
+
+      (esClient.indices.getDataStream as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await receiver.getDataStreams();
+
+      expect(result).toEqual([
+        {
+          datastream_name: 'logs-both-dsl-ilm',
+          dsl: {
+            enabled: true,
+            data_retention: '30d',
+          },
+          indices: [
+            {
+              index_name: '.ds-logs-000001',
+              ilm_policy: 'logs-policy',
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('getIndexTemplatesStats', () => {

--- a/x-pack/platform/plugins/private/indices_metadata/server/lib/services/receiver.test.ts
+++ b/x-pack/platform/plugins/private/indices_metadata/server/lib/services/receiver.test.ts
@@ -158,12 +158,21 @@ describe('Indices Metadata - MetadataReceiver', () => {
       expect(esClient.indices.getDataStream).toHaveBeenCalledWith({
         name: '*',
         expand_wildcards: ['open', 'hidden'],
-        filter_path: ['data_streams.name', 'data_streams.indices'],
+        filter_path: [
+          'data_streams.name',
+          'data_streams.indices',
+          'data_streams.lifecycle.enabled',
+          'data_streams.lifecycle.data_retention',
+        ],
       });
 
       expect(result).toEqual([
         {
           datastream_name: 'test-datastream',
+          dsl: {
+            enabled: false,
+            data_retention: undefined,
+          },
           indices: [
             {
               index_name: 'test-index-1',
@@ -203,6 +212,10 @@ describe('Indices Metadata - MetadataReceiver', () => {
       expect(result).toEqual([
         {
           datastream_name: 'test-datastream',
+          dsl: {
+            enabled: false,
+            data_retention: undefined,
+          },
           indices: [],
         },
       ]);

--- a/x-pack/platform/plugins/private/indices_metadata/server/lib/services/receiver.ts
+++ b/x-pack/platform/plugins/private/indices_metadata/server/lib/services/receiver.ts
@@ -89,7 +89,12 @@ export class MetadataReceiver {
     const request: IndicesGetDataStreamRequest = {
       name: '*',
       expand_wildcards: ['open', 'hidden'],
-      filter_path: ['data_streams.name', 'data_streams.indices'],
+      filter_path: [
+        'data_streams.name',
+        'data_streams.indices',
+        'data_streams.lifecycle.enabled',
+        'data_streams.lifecycle.data_retention',
+      ],
     };
 
     return this.esClient.indices
@@ -97,8 +102,13 @@ export class MetadataReceiver {
       .then((response) => {
         const streams = response.data_streams ?? [];
         return streams.map((ds) => {
+          const dsl = ds.lifecycle;
           return {
             datastream_name: ds.name,
+            dsl: {
+              enabled: dsl?.enabled ?? false,
+              data_retention: dsl?.data_retention,
+            },
             indices:
               ds.indices?.map((index) => {
                 return {


### PR DESCRIPTION
## Summary

Add [Datastream life cycle](https://www.elastic.co/docs/manage-data/lifecycle/data-stream) support to the indices metadata plugin.

For data streams using DSL, the plugin now also queries the `data_retention` and includes it in the EBT document.

Example document returned by `GET _data_stream/<ds name>/?filter_path=data_streams.name,data_streams.indices,data_streams.lifecycle.enabled,data_streams.lifecycle.data_retention`

```json
{
  "data_streams": [
    {
      "name": "dsl-test",
      "indices": [
        {
          "index_name": ".ds-dsl-test-2025.12.08-000001",
          "index_uuid": "h9nu5fEIQJ-ObVemiXTPqg",
          "managed_by": "Data stream lifecycle",
          "prefer_ilm": true,
          "index_mode": "standard"
        },
        {
          "index_name": ".ds-dsl-test-2025.12.08-000002",
          "index_uuid": "VKp5OURcTIquxTmatmNz3g",
          "managed_by": "Data stream lifecycle",
          "prefer_ilm": true,
          "index_mode": "standard"
        }
      ],
      "lifecycle": {
        "enabled": true,
        "data_retention": "1h"
      }
    }
  ]
}
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

