### PR TITLE
[Agent Builder] Add Intro Tour

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_actions_left.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_actions_left.tsx
@@ -18,7 +18,7 @@ export const ConversationLeftActions: React.FC<{}> = () => {
 
   return (
     <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-      <EuiTourStep {...getStepProps(TourStep.ConversationsHistory)!}>
+      <EuiTourStep {...getStepProps(TourStep.ConversationsHistory)}>
         <ConversationsHistoryButton />
       </EuiTourStep>
       {hasActiveConversation && <NewConversationButton />}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_actions_left.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_actions_left.tsx
@@ -10,7 +10,7 @@ import { EuiFlexGroup, EuiTourStep } from '@elastic/eui';
 import { ConversationsHistoryButton } from './conversations_history_button';
 import { useHasActiveConversation } from '../../../hooks/use_conversation';
 import { NewConversationButton } from './new_conversation_button';
-import { useAgentBuilderTour } from '../../../context/agent_builder_tour_context';
+import { TourStep, useAgentBuilderTour } from '../../../context/agent_builder_tour_context';
 
 export const ConversationLeftActions: React.FC<{}> = () => {
   const hasActiveConversation = useHasActiveConversation();
@@ -18,7 +18,7 @@ export const ConversationLeftActions: React.FC<{}> = () => {
 
   return (
     <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-      <EuiTourStep {...getStepProps(3)!}>
+      <EuiTourStep {...getStepProps(TourStep.ConversationsHistory)!}>
         <ConversationsHistoryButton />
       </EuiTourStep>
       {hasActiveConversation && <NewConversationButton />}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_actions_left.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_actions_left.tsx
@@ -6,17 +6,21 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup } from '@elastic/eui';
+import { EuiFlexGroup, EuiTourStep } from '@elastic/eui';
 import { ConversationsHistoryButton } from './conversations_history_button';
 import { useHasActiveConversation } from '../../../hooks/use_conversation';
 import { NewConversationButton } from './new_conversation_button';
+import { useAgentBuilderTour } from '../../../context/agent_builder_tour_context';
 
 export const ConversationLeftActions: React.FC<{}> = () => {
   const hasActiveConversation = useHasActiveConversation();
+  const { getStepProps } = useAgentBuilderTour();
 
   return (
     <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-      <ConversationsHistoryButton />
+      <EuiTourStep {...getStepProps(3)!}>
+        <ConversationsHistoryButton />
+      </EuiTourStep>
       {hasActiveConversation && <NewConversationButton />}
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_actions_right.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_actions_right.tsx
@@ -6,11 +6,18 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup } from '@elastic/eui';
+import { EuiFlexGroup, EuiTourStep } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useConversationContext } from '../../../context/conversation/conversation_context';
 import { MoreActionsButton } from './more_actions_button';
 import { CloseDockedViewButton } from './close_docked_view_button';
+import { useAgentBuilderTour } from '../../../context/agent_builder_tour_context';
+
+const labels = {
+  container: i18n.translate('xpack.onechat.conversationActions.container', {
+    defaultMessage: 'Conversation actions',
+  }),
+};
 
 export interface ConversationRightActionsProps {
   onClose?: () => void;
@@ -23,11 +30,7 @@ export const ConversationRightActions: React.FC<ConversationRightActionsProps> =
 }) => {
   const { isEmbeddedContext } = useConversationContext();
 
-  const labels = {
-    container: i18n.translate('xpack.onechat.conversationActions.container', {
-      defaultMessage: 'Conversation actions',
-    }),
-  };
+  const { getStepProps } = useAgentBuilderTour();
 
   return (
     <EuiFlexGroup
@@ -37,7 +40,9 @@ export const ConversationRightActions: React.FC<ConversationRightActionsProps> =
       aria-label={labels.container}
       responsive={false}
     >
-      <MoreActionsButton onRenameConversation={onRenameConversation} />
+      <EuiTourStep {...getStepProps(4)!}>
+        <MoreActionsButton onRenameConversation={onRenameConversation} />
+      </EuiTourStep>
       {isEmbeddedContext ? <CloseDockedViewButton onClose={onClose} /> : null}
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_actions_right.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_actions_right.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { useConversationContext } from '../../../context/conversation/conversation_context';
 import { MoreActionsButton } from './more_actions_button';
 import { CloseDockedViewButton } from './close_docked_view_button';
-import { useAgentBuilderTour } from '../../../context/agent_builder_tour_context';
+import { TourStep, useAgentBuilderTour } from '../../../context/agent_builder_tour_context';
 
 const labels = {
   container: i18n.translate('xpack.onechat.conversationActions.container', {
@@ -40,7 +40,7 @@ export const ConversationRightActions: React.FC<ConversationRightActionsProps> =
       aria-label={labels.container}
       responsive={false}
     >
-      <EuiTourStep {...getStepProps(4)!}>
+      <EuiTourStep {...getStepProps(TourStep.ConversationActions)!}>
         <MoreActionsButton onRenameConversation={onRenameConversation} />
       </EuiTourStep>
       {isEmbeddedContext ? <CloseDockedViewButton onClose={onClose} /> : null}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_actions_right.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_actions_right.tsx
@@ -40,7 +40,7 @@ export const ConversationRightActions: React.FC<ConversationRightActionsProps> =
       aria-label={labels.container}
       responsive={false}
     >
-      <EuiTourStep {...getStepProps(TourStep.ConversationActions)!}>
+      <EuiTourStep {...getStepProps(TourStep.ConversationActions)}>
         <MoreActionsButton onRenameConversation={onRenameConversation} />
       </EuiTourStep>
       {isEmbeddedContext ? <CloseDockedViewButton onClose={onClose} /> : null}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/input_actions/input_actions.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/input_actions/input_actions.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiTourStep } from '@elastic/eui';
 import React from 'react';
+import { useAgentBuilderTour } from '../../../../context/agent_builder_tour_context';
 import { AgentSelector } from './agent_selector';
 import { ConversationActionButton } from './conversation_action_button';
 import { ConnectorSelector } from './connector_selector';
@@ -24,6 +25,8 @@ export const InputActions: React.FC<InputActionsProps> = ({
   resetToPendingMessage,
   agentId,
 }) => {
+  const { getStepProps } = useAgentBuilderTour();
+
   return (
     <EuiFlexItem grow={false}>
       <EuiFlexGroup
@@ -33,12 +36,16 @@ export const InputActions: React.FC<InputActionsProps> = ({
         justifyContent="spaceBetween"
       >
         <EuiFlexItem grow={false}>
-          <ConnectorSelector />
+          <EuiTourStep {...getStepProps(2)!}>
+            <ConnectorSelector />
+          </EuiTourStep>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
             <EuiFlexItem grow={false}>
-              <AgentSelector agentId={agentId} />
+              <EuiTourStep {...getStepProps(1)!}>
+                <AgentSelector agentId={agentId} />
+              </EuiTourStep>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <ConversationActionButton

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/input_actions/input_actions.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/input_actions/input_actions.tsx
@@ -7,7 +7,7 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiTourStep } from '@elastic/eui';
 import React from 'react';
-import { useAgentBuilderTour } from '../../../../context/agent_builder_tour_context';
+import { TourStep, useAgentBuilderTour } from '../../../../context/agent_builder_tour_context';
 import { AgentSelector } from './agent_selector';
 import { ConversationActionButton } from './conversation_action_button';
 import { ConnectorSelector } from './connector_selector';
@@ -36,14 +36,14 @@ export const InputActions: React.FC<InputActionsProps> = ({
         justifyContent="spaceBetween"
       >
         <EuiFlexItem grow={false}>
-          <EuiTourStep {...getStepProps(2)!}>
+          <EuiTourStep {...getStepProps(TourStep.LlmSelector)!}>
             <ConnectorSelector />
           </EuiTourStep>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
             <EuiFlexItem grow={false}>
-              <EuiTourStep {...getStepProps(1)!}>
+              <EuiTourStep {...getStepProps(TourStep.AgentSelector)!}>
                 <AgentSelector agentId={agentId} />
               </EuiTourStep>
             </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/input_actions/input_actions.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/input_actions/input_actions.tsx
@@ -36,14 +36,14 @@ export const InputActions: React.FC<InputActionsProps> = ({
         justifyContent="spaceBetween"
       >
         <EuiFlexItem grow={false}>
-          <EuiTourStep {...getStepProps(TourStep.LlmSelector)!}>
+          <EuiTourStep {...getStepProps(TourStep.LlmSelector)}>
             <ConnectorSelector />
           </EuiTourStep>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
             <EuiFlexItem grow={false}>
-              <EuiTourStep {...getStepProps(TourStep.AgentSelector)!}>
+              <EuiTourStep {...getStepProps(TourStep.AgentSelector)}>
                 <AgentSelector agentId={agentId} />
               </EuiTourStep>
             </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversations_view.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversations_view.tsx
@@ -12,6 +12,7 @@ import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import React from 'react';
 import { Conversation } from './conversation';
 import { ConversationHeader } from './conversation_header/conversation_header';
+import { AgentBuilderTourProvider } from '../../context/agent_builder_tour_context';
 import { RoutedConversationsProvider } from '../../context/conversation/routed_conversations_provider';
 import { SendMessageProvider } from '../../context/send_message/send_message_context';
 import { conversationBackgroundStyles } from './conversation.styles';
@@ -50,37 +51,39 @@ export const OnechatConversationsView: React.FC<{}> = () => {
   return (
     <RoutedConversationsProvider>
       <SendMessageProvider>
-        <KibanaPageTemplate
-          offset={0}
-          restrictWidth={false}
-          data-test-subj="onechatPageConversations"
-          grow={false}
-          panelled={false}
-          mainProps={{
-            css: mainStyles,
-          }}
-          responsive={[]}
-        >
-          <KibanaPageTemplate.Header
-            css={headerStyles}
-            bottomBorder={false}
-            aria-label={labels.header}
-            paddingSize="m"
-            responsive={false}
-          >
-            <ConversationHeader />
-          </KibanaPageTemplate.Header>
-          <KibanaPageTemplate.Section
-            paddingSize="none"
-            grow
-            contentProps={{
-              css: contentStyles,
+        <AgentBuilderTourProvider>
+          <KibanaPageTemplate
+            offset={0}
+            restrictWidth={false}
+            data-test-subj="onechatPageConversations"
+            grow={false}
+            panelled={false}
+            mainProps={{
+              css: mainStyles,
             }}
-            aria-label={labels.content}
+            responsive={[]}
           >
-            <Conversation />
-          </KibanaPageTemplate.Section>
-        </KibanaPageTemplate>
+            <KibanaPageTemplate.Header
+              css={headerStyles}
+              bottomBorder={false}
+              aria-label={labels.header}
+              paddingSize="m"
+              responsive={false}
+            >
+              <ConversationHeader />
+            </KibanaPageTemplate.Header>
+            <KibanaPageTemplate.Section
+              paddingSize="none"
+              grow
+              contentProps={{
+                css: contentStyles,
+              }}
+              aria-label={labels.content}
+            >
+              <Conversation />
+            </KibanaPageTemplate.Section>
+          </KibanaPageTemplate>
+        </AgentBuilderTourProvider>
       </SendMessageProvider>
     </RoutedConversationsProvider>
   );

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/agent_builder_tour_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/agent_builder_tour_context.tsx
@@ -1,0 +1,222 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  type PropsWithChildren,
+  useEffect,
+} from 'react';
+
+import { EuiButton, EuiButtonEmpty, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { storageKeys } from '../storage_keys';
+import { useConversationContext } from './conversation/conversation_context';
+
+interface AgentBuilderTourContextValue {
+  isTourActive: boolean;
+  setIsTourActive: React.Dispatch<React.SetStateAction<boolean>>;
+  currentStep: number;
+  getStepProps: (step: number) => TourStep | undefined;
+  tourConfig: {
+    tourPopoverWidth: number;
+  };
+}
+
+const AgentBuilderTourContext = createContext<AgentBuilderTourContextValue | undefined>(undefined);
+
+const DEFAULT_STEP = 1;
+
+const tourConfig = {
+  tourPopoverWidth: 370,
+};
+
+const labels = {
+  step1: {
+    title: i18n.translate('xpack.onechat.agentBuilderTour.step1', {
+      defaultMessage: 'Meet your active agent 🕵️‍♂️',
+    }),
+    content: i18n.translate('xpack.onechat.agentBuilderTour.step1Content', {
+      defaultMessage:
+        'I’m here to help with your questions. Pick a different agent or customize a new one anytime.',
+    }),
+  },
+  step2: {
+    title: i18n.translate('xpack.onechat.agentBuilderTour.step2', {
+      defaultMessage: 'You’re using this model 🧠',
+    }),
+    content: i18n.translate('xpack.onechat.agentBuilderTour.step2Content', {
+      defaultMessage: 'I’ll answer using this LLM. Switch to another model you have setup.',
+    }),
+  },
+  step3: {
+    title: i18n.translate('xpack.onechat.agentBuilderTour.step3', {
+      defaultMessage: 'Reuse your prompts ✍️',
+    }),
+    content: i18n.translate('xpack.onechat.agentBuilderTour.step3Content', {
+      defaultMessage: 'Store your favorite queries here. Pick one to drop it into the chat.',
+    }),
+  },
+  step4: {
+    title: i18n.translate('xpack.onechat.agentBuilderTour.step4', {
+      defaultMessage: 'Your conversations 💬',
+    }),
+    content: i18n.translate('xpack.onechat.agentBuilderTour.step4Content', {
+      defaultMessage: 'Come back to earlier chats or jump between them from here.',
+    }),
+  },
+  step5: {
+    title: i18n.translate('xpack.onechat.agentBuilderTour.step5', {
+      defaultMessage: 'Additional actions ⚙️',
+    }),
+    content: i18n.translate('xpack.onechat.agentBuilderTour.step5Content', {
+      defaultMessage:
+        'Access conversation actions, agent controls, and management settings from here.',
+    }),
+  },
+  closeTour: i18n.translate('xpack.onechat.agentBuilderTour.closeTour', {
+    defaultMessage: 'Close tour',
+  }),
+  next: i18n.translate('xpack.onechat.agentBuilderTour.next', {
+    defaultMessage: 'Next',
+  }),
+  finishTour: i18n.translate('xpack.onechat.agentBuilderTour.finishTour', {
+    defaultMessage: 'Finish tour',
+  }),
+};
+
+interface TourStep {
+  step: number;
+  title: string;
+  content: React.ReactNode;
+  anchorRef: string;
+  footerActions: React.ReactNode[];
+}
+
+export const AgentBuilderTourProvider: React.FC<PropsWithChildren<{}>> = ({ children }) => {
+  const { isEmbeddedContext } = useConversationContext();
+
+  const [currentStep, setCurrentStep] = useState(DEFAULT_STEP);
+
+  const [isTourActive, setIsTourActive] = useState(false);
+
+  useEffect(() => {
+    const hasSeenTour = localStorage.getItem(storageKeys.hasSeenAgentBuilderTour);
+    if (!isEmbeddedContext && !hasSeenTour) {
+      setIsTourActive(true);
+    }
+  }, [isEmbeddedContext]);
+
+  const handleMoveToNextStep = () => {
+    setCurrentStep((prev) => prev + 1);
+  };
+
+  const handleFinishTour = () => {
+    setIsTourActive(false);
+    localStorage.setItem(storageKeys.hasSeenAgentBuilderTour, 'true');
+  };
+
+  const footerActions = [
+    <EuiButtonEmpty size="s" color="text" onClick={handleFinishTour}>
+      {labels.closeTour}
+    </EuiButtonEmpty>,
+    <EuiButton color="success" size="s" onClick={handleMoveToNextStep}>
+      {labels.next}
+    </EuiButton>,
+  ];
+
+  const footerActionsFinish = [
+    <EuiButton color="success" size="s" onClick={handleFinishTour}>
+      {labels.finishTour}
+    </EuiButton>,
+  ];
+
+  const tourSteps: TourStep[] = [
+    {
+      step: 1,
+      title: labels.step1.title,
+      content: (
+        <EuiText size="s">
+          <p>{labels.step1.content}</p>
+        </EuiText>
+      ),
+      anchorRef: 'step1Anchor',
+      footerActions,
+    },
+    {
+      step: 2,
+      title: labels.step2.title,
+      content: (
+        <EuiText size="s">
+          <p>{labels.step2.content}</p>
+        </EuiText>
+      ),
+      anchorRef: 'step2Anchor',
+      footerActions,
+    },
+    {
+      step: 3,
+      title: labels.step3.title,
+      content: (
+        <EuiText size="s">
+          <p>{labels.step3.content}</p>
+        </EuiText>
+      ),
+      anchorRef: 'step3Anchor',
+      footerActions,
+    },
+    {
+      step: 4,
+      title: labels.step4.title,
+      content: (
+        <EuiText size="s">
+          <p>{labels.step4.content}</p>
+        </EuiText>
+      ),
+      anchorRef: 'step4Anchor',
+      footerActions,
+    },
+    {
+      step: 5,
+      title: labels.step5.title,
+      content: (
+        <EuiText size="s">
+          <p>{labels.step5.content}</p>
+        </EuiText>
+      ),
+      anchorRef: 'step5Anchor',
+      footerActions: footerActionsFinish,
+    },
+  ];
+
+  const getStepProps = (step: number) => {
+    return tourSteps.find((s) => s.step === step);
+  };
+
+  const contextValue = {
+    isTourActive,
+    setIsTourActive,
+    currentStep,
+    getStepProps,
+    tourConfig,
+  };
+
+  return (
+    <AgentBuilderTourContext.Provider value={contextValue}>
+      {children}
+    </AgentBuilderTourContext.Provider>
+  );
+};
+
+export const useAgentBuilderTour = (): AgentBuilderTourContextValue => {
+  const context = useContext(AgentBuilderTourContext);
+  if (!context) {
+    throw new Error('useAgentBuilderTour must be used within an AgentBuilderTourProvider');
+  }
+  return context;
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/agent_builder_tour_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/agent_builder_tour_context.tsx
@@ -57,44 +57,44 @@ const tourConfig = {
 
 const labels = {
   agentSelector: {
-    title: i18n.translate('xpack.onechat.agentBuilderTour.step1', {
+    title: i18n.translate('xpack.onechat.agentBuilderTour.agentSelector.title', {
       defaultMessage: 'Meet your active agent 🕵️‍♂️',
     }),
-    content: i18n.translate('xpack.onechat.agentBuilderTour.step1Content', {
+    content: i18n.translate('xpack.onechat.agentBuilderTour.agentSelector.content', {
       defaultMessage:
         'I’m here to help with your questions. Pick a different agent or customize a new one anytime.',
     }),
   },
   llmSelector: {
-    title: i18n.translate('xpack.onechat.agentBuilderTour.step2', {
+    title: i18n.translate('xpack.onechat.agentBuilderTour.llmSelector.title', {
       defaultMessage: 'You’re using this model 🧠',
     }),
-    content: i18n.translate('xpack.onechat.agentBuilderTour.step2Content', {
+    content: i18n.translate('xpack.onechat.agentBuilderTour.llmSelector.content', {
       defaultMessage: 'I’ll answer using this LLM. Switch to another model you have setup.',
     }),
   },
   // TODO: Add prompts step once we have prompts.
   // prompts: {
-  //   title: i18n.translate('xpack.onechat.agentBuilderTour.step3', {
+  //   title: i18n.translate('xpack.onechat.agentBuilderTour.prompts.title', {
   //     defaultMessage: 'Reuse your prompts ✍️',
   //   }),
-  //   content: i18n.translate('xpack.onechat.agentBuilderTour.step3Content', {
+  //   content: i18n.translate('xpack.onechat.agentBuilderTour.prompts.content', {
   //     defaultMessage: 'Store your favorite queries here. Pick one to drop it into the chat.',
   //   }),
   // },
   conversationsHistory: {
-    title: i18n.translate('xpack.onechat.agentBuilderTour.step3', {
+    title: i18n.translate('xpack.onechat.agentBuilderTour.conversationsHistory.title', {
       defaultMessage: 'Your conversations 💬',
     }),
-    content: i18n.translate('xpack.onechat.agentBuilderTour.step3Content', {
+    content: i18n.translate('xpack.onechat.agentBuilderTour.conversationsHistory.content', {
       defaultMessage: 'Come back to earlier chats or jump between them from here.',
     }),
   },
   conversationActions: {
-    title: i18n.translate('xpack.onechat.agentBuilderTour.step4', {
+    title: i18n.translate('xpack.onechat.agentBuilderTour.conversationActions.title', {
       defaultMessage: 'Additional actions ⚙️',
     }),
-    content: i18n.translate('xpack.onechat.agentBuilderTour.step4Content', {
+    content: i18n.translate('xpack.onechat.agentBuilderTour.conversationActions.content', {
       defaultMessage:
         'Access conversation actions, agent controls, and management settings from here.',
     }),

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/agent_builder_tour_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/agent_builder_tour_context.tsx
@@ -19,6 +19,13 @@ import type { PopoverAnchorPosition } from '@elastic/eui/src/components/popover/
 import { storageKeys } from '../storage_keys';
 import { useConversationContext } from './conversation/conversation_context';
 
+export enum TourStep {
+  AgentSelector = 'agent-selector',
+  LlmSelector = 'llm-selector',
+  ConversationsHistory = 'conversations-history',
+  ConversationActions = 'conversation-actions',
+}
+
 export type TourStepProps = Pick<
   EuiTourStepProps,
   | 'maxWidth'
@@ -34,7 +41,7 @@ export type TourStepProps = Pick<
 
 interface AgentBuilderTourContextValue {
   isTourActive: boolean;
-  getStepProps: (step: number) => TourStepProps | undefined;
+  getStepProps: (step: TourStep) => TourStepProps | undefined;
 }
 
 const AgentBuilderTourContext = createContext<AgentBuilderTourContextValue | undefined>(undefined);
@@ -49,7 +56,7 @@ const tourConfig = {
 };
 
 const labels = {
-  step1: {
+  agentSelector: {
     title: i18n.translate('xpack.onechat.agentBuilderTour.step1', {
       defaultMessage: 'Meet your active agent 🕵️‍♂️',
     }),
@@ -58,7 +65,7 @@ const labels = {
         'I’m here to help with your questions. Pick a different agent or customize a new one anytime.',
     }),
   },
-  step2: {
+  llmSelector: {
     title: i18n.translate('xpack.onechat.agentBuilderTour.step2', {
       defaultMessage: 'You’re using this model 🧠',
     }),
@@ -66,8 +73,8 @@ const labels = {
       defaultMessage: 'I’ll answer using this LLM. Switch to another model you have setup.',
     }),
   },
-  // TODO: Add step 3 once we have prompts.
-  // step3: {
+  // TODO: Add prompts step once we have prompts.
+  // prompts: {
   //   title: i18n.translate('xpack.onechat.agentBuilderTour.step3', {
   //     defaultMessage: 'Reuse your prompts ✍️',
   //   }),
@@ -75,7 +82,7 @@ const labels = {
   //     defaultMessage: 'Store your favorite queries here. Pick one to drop it into the chat.',
   //   }),
   // },
-  step3: {
+  conversationsHistory: {
     title: i18n.translate('xpack.onechat.agentBuilderTour.step3', {
       defaultMessage: 'Your conversations 💬',
     }),
@@ -83,7 +90,7 @@ const labels = {
       defaultMessage: 'Come back to earlier chats or jump between them from here.',
     }),
   },
-  step4: {
+  conversationActions: {
     title: i18n.translate('xpack.onechat.agentBuilderTour.step4', {
       defaultMessage: 'Additional actions ⚙️',
     }),
@@ -104,6 +111,7 @@ const labels = {
 };
 
 interface TourStepConfig {
+  step: number;
   title: string;
   content: React.ReactNode;
   footerActions: React.ReactNode[];
@@ -158,56 +166,60 @@ export const AgentBuilderTourProvider: React.FC<PropsWithChildren<{}>> = ({ chil
     </EuiButton>,
   ];
 
-  const tourSteps: Record<number, TourStepConfig> = {
-    1: {
-      title: labels.step1.title,
+  const tourSteps: Record<TourStep, TourStepConfig> = {
+    [TourStep.AgentSelector]: {
+      title: labels.agentSelector.title,
       content: (
         <EuiText size="s">
-          <p>{labels.step1.content}</p>
+          <p>{labels.agentSelector.content}</p>
         </EuiText>
       ),
       footerActions,
+      step: 1,
     },
-    2: {
-      title: labels.step2.title,
+    [TourStep.LlmSelector]: {
+      title: labels.llmSelector.title,
       content: (
         <EuiText size="s">
-          <p>{labels.step2.content}</p>
+          <p>{labels.llmSelector.content}</p>
         </EuiText>
       ),
       footerActions,
+      step: 2,
     },
-    3: {
-      title: labels.step3.title,
+    [TourStep.ConversationsHistory]: {
+      title: labels.conversationsHistory.title,
       content: (
         <EuiText size="s">
-          <p>{labels.step3.content}</p>
+          <p>{labels.conversationsHistory.content}</p>
         </EuiText>
       ),
       footerActions,
+      step: 3,
     },
-    4: {
-      title: labels.step4.title,
+    [TourStep.ConversationActions]: {
+      title: labels.conversationActions.title,
       content: (
         <EuiText size="s">
-          <p>{labels.step4.content}</p>
+          <p>{labels.conversationActions.content}</p>
         </EuiText>
       ),
       footerActions: footerActionsFinish,
+      step: 4,
     },
   };
 
-  const getStepProps = (step: number): TourStepProps | undefined => {
+  const getStepProps = (step: TourStep): TourStepProps | undefined => {
     const stepConfig = tourSteps[step];
     if (!stepConfig) return undefined;
 
     return {
       maxWidth: tourConfig.tourPopoverWidth,
-      isStepOpen: currentStep === step && isTourActive,
+      isStepOpen: currentStep === stepConfig.step && isTourActive,
       title: stepConfig.title,
       content: stepConfig.content,
       onFinish: handleFinishTour,
-      step,
+      step: stepConfig.step,
       stepsTotal: tourConfig.maxSteps,
       anchorPosition: tourConfig.anchorPosition,
       footerAction: stepConfig.footerActions,

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/agent_builder_tour_context.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/agent_builder_tour_context.tsx
@@ -41,7 +41,7 @@ export type TourStepProps = Pick<
 
 interface AgentBuilderTourContextValue {
   isTourActive: boolean;
-  getStepProps: (step: TourStep) => TourStepProps | undefined;
+  getStepProps: (step: TourStep) => TourStepProps;
 }
 
 const AgentBuilderTourContext = createContext<AgentBuilderTourContextValue | undefined>(undefined);
@@ -209,9 +209,8 @@ export const AgentBuilderTourProvider: React.FC<PropsWithChildren<{}>> = ({ chil
     },
   };
 
-  const getStepProps = (step: TourStep): TourStepProps | undefined => {
+  const getStepProps = (step: TourStep): TourStepProps => {
     const stepConfig = tourSteps[step];
-    if (!stepConfig) return undefined;
 
     return {
       maxWidth: tourConfig.tourPopoverWidth,

--- a/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/embeddable_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/context/conversation/embeddable_conversations_provider.tsx
@@ -19,6 +19,7 @@ import { SendMessageProvider } from '../send_message/send_message_context';
 import { useConversationActions } from './use_conversation_actions';
 import { usePersistedConversationId } from '../../hooks/use_persisted_conversation_id';
 import { AppLeaveContext } from '../app_leave_context';
+import { AgentBuilderTourProvider } from '../agent_builder_tour_context';
 
 const noopOnAppLeave = () => {};
 interface EmbeddableConversationsProviderProps extends EmbeddableConversationInternalProps {
@@ -201,7 +202,9 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
           <OnechatServicesContext.Provider value={services}>
             <AppLeaveContext.Provider value={noopOnAppLeave}>
               <ConversationContext.Provider value={conversationContextValue}>
-                <SendMessageProvider>{children}</SendMessageProvider>
+                <AgentBuilderTourProvider>
+                  <SendMessageProvider>{children}</SendMessageProvider>
+                </AgentBuilderTourProvider>
               </ConversationContext.Provider>
             </AppLeaveContext.Provider>
           </OnechatServicesContext.Provider>

--- a/x-pack/platform/plugins/shared/onechat/public/application/storage_keys.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/storage_keys.ts
@@ -9,6 +9,7 @@ export const storageKeys = {
   agentId: 'agentBuilder.agentId',
   lastUsedConnector: 'agentBuilder.lastUsedConnector',
   welcomeMessageDismissed: 'agentBuilder.welcomeMessageDismissed',
+  hasSeenAgentBuilderTour: 'agentBuilder.hasSeenTour',
 
   getLastConversationKey: (sessionTag?: string, agentId?: string): string => {
     const tag = sessionTag || 'default';


### PR DESCRIPTION
On the first time a user goes to the full screen agent builder experience, we should trigger a "tour" of the space to situate them. This is one time (first time) only and once dismissed doesn't need to be triggerable again unless we find people are looking for it (doubtful).

- Tour launches on first visit of full page agent builder page.
- Tour can be dismissed and then not return on subsequent visit.
- Tour should launch after loading animation (glowing border around chat input)

**Not included:**
- EuiTourStep for Prompts - we do not have Prompts yet.

closes https://github.com/elastic/search-team/issues/12088

https://github.com/user-attachments/assets/0b54ff71-4691-4c8c-adda-ed22c3f3e036
