### PR TITLE
[9.1] Update dependency ai to v5 (#244675)

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "pkce-challenge": "3.1.0"
   },
   "dependencies": {
+    "@ai-sdk/langchain": "^1.0.102",
     "@apidevtools/json-schema-ref-parser": "^14.1.1",
     "@appland/sql-parser": "^1.5.1",
     "@arizeai/openinference-semantic-conventions": "^1.1.0",
@@ -1152,7 +1153,7 @@
     "@xstate5/react": "npm:@xstate/react@^5.0.3",
     "@xyflow/react": "^12.9.0",
     "adm-zip": "^0.5.16",
-    "ai": "^4.3.15",
+    "ai": "^5.0.102",
     "ajv": "^8.17.1",
     "antlr4": "^4.13.1-patch-1",
     "archiver": "^7.0.1",

--- a/renovate.json
+++ b/renovate.json
@@ -2245,7 +2245,8 @@
     {
       "groupName": "search-ui ai dependency",
       "matchDepNames": [
-        "ai"
+        "ai",
+        "@ai-sdk/langchain"
       ],
       "reviewers": [
         "team:search-kibana"

--- a/src/platform/packages/shared/kbn-test/jest-preset.js
+++ b/src/platform/packages/shared/kbn-test/jest-preset.js
@@ -120,10 +120,10 @@ module.exports = {
   transformIgnorePatterns: [
     // ignore all node_modules except monaco-editor, monaco-yaml which requires babel transforms to handle dynamic import()
     // since ESM modules are not natively supported in Jest yet (https://github.com/facebook/jest/issues/4842)
-    '[/\\\\]node_modules(?![\\/\\\\](byte-size|monaco-editor|monaco-yaml|monaco-languageserver-types|monaco-marker-data-provider|monaco-worker-manager|vscode-languageserver-types|d3-interpolate|d3-color|langchain|langsmith|@cfworker|gpt-tokenizer|flat|@langchain|eventsource-parser|fast-check|@fast-check/jest|@assemblyscript|quickselect|rbush|vega-interpreter|vega-util|vega-tooltip))[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](byte-size|monaco-editor|monaco-yaml|monaco-languageserver-types|monaco-marker-data-provider|monaco-worker-manager|vscode-languageserver-types|d3-interpolate|d3-color|langchain|langsmith|@cfworker|gpt-tokenizer|flat|@langchain|eventsource-parser|fast-check|@fast-check/jest|@assemblyscript|quickselect|rbush|zod/v4|vega-interpreter|vega-util|vega-tooltip))[/\\\\].+\\.js$',
     'packages/kbn-pm/dist/index.js',
-    '[/\\\\]node_modules(?![\\/\\\\](langchain|langsmith|@langchain))/dist/[/\\\\].+\\.js$',
-    '[/\\\\]node_modules(?![\\/\\\\](langchain|langsmith|@langchain))/dist/util/[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](langchain|langsmith|@langchain|zod/v4))/dist/[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](langchain|langsmith|@langchain|zod/v4))/dist/util/[/\\\\].+\\.js$',
   ],
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files to include/exclude for code coverage

--- a/src/platform/packages/shared/kbn-test/jest_integration_node/jest-preset.js
+++ b/src/platform/packages/shared/kbn-test/jest_integration_node/jest-preset.js
@@ -23,9 +23,9 @@ module.exports = {
   // An array of regexp pattern strings that are matched against, matched files will skip transformation:
   transformIgnorePatterns: [
     // since ESM modules are not natively supported in Jest yet (https://github.com/facebook/jest/issues/4842)
-    '[/\\\\]node_modules(?![\\/\\\\](langchain|langsmith|gpt-tokenizer|flat|@langchain|eventsource-parser))[/\\\\].+\\.js$',
-    '[/\\\\]node_modules(?![\\/\\\\](langchain|langsmith|@langchain))/dist/[/\\\\].+\\.js$',
-    '[/\\\\]node_modules(?![\\/\\\\](langchain|langsmith|@langchain))/dist/util/[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](langchain|langsmith|gpt-tokenizer|flat|@langchain|eventsource-parser|zod/v4))[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](langchain|langsmith|@langchain|zod/v4))/dist/[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](langchain|langsmith|@langchain|zod/v4))/dist/util/[/\\\\].+\\.js$',
   ],
   setupFilesAfterEnv: [
     '<rootDir>/src/platform/packages/shared/kbn-test/src/jest/setup/after_env.integration.js',

--- a/x-pack/solutions/search/plugins/search_playground/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/types.ts
@@ -176,8 +176,6 @@ export interface ElasticsearchIndex {
   uuid?: Uuid;
 }
 
-export type JSONValue = null | string | number | boolean | { [x: string]: JSONValue } | JSONValue[];
-
 export interface ChatRequestOptions {
   options?: RequestOptions;
   data?: ChatRequestData;

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/api.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/api.ts
@@ -6,6 +6,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
+import type { UIMessageChunk } from 'ai';
 import { readDataStream } from './stream';
 import { Annotation, Message, MessageRole } from '../types';
 
@@ -98,40 +99,58 @@ export async function parseDataStream({
   const createdAt = getCurrentDate();
   const prefixMap: PrefixMap = {};
   let messageAnnotations: Annotation[] | undefined;
+  const streamInstanceId = generateId();
+  let messageSequence = 0;
+  const allocateResponseId = (serverAssignedId?: string) => {
+    messageSequence += 1;
+    const baseId = `${streamInstanceId}-${messageSequence}`;
+    return serverAssignedId ? `${baseId}:${serverAssignedId}` : baseId;
+  };
 
-  for await (const { type, value } of readDataStream(reader, {
+  let responseMessageId = allocateResponseId();
+
+  for await (const chunk of readDataStream(reader, {
     isAborted: () => abortControllerRef?.current === null,
   })) {
-    if (type === 'text') {
+    const { type } = chunk;
+
+    if (type === 'text-start') {
+      responseMessageId =
+        'id' in chunk && chunk.id ? allocateResponseId(chunk.id) : allocateResponseId();
+      prefixMap.text = undefined;
+      messageAnnotations = undefined;
+      continue;
+    } else if (type === 'text-delta' && 'delta' in chunk && typeof chunk.delta === 'string') {
       if (prefixMap.text) {
         prefixMap.text = {
           ...prefixMap.text,
-          content: (prefixMap.text.content || '') + value,
+          content: (prefixMap.text.content || '') + chunk.delta,
         };
       } else {
         prefixMap.text = {
-          id: generateId(),
+          id: responseMessageId,
           role: MessageRole.assistant,
-          content: value,
+          content: chunk.delta,
           createdAt,
         };
       }
-    } else if (type === 'error') {
-      handleFailure(value);
+    } else if (type === 'error' && 'errorText' in chunk) {
+      handleFailure(chunk.errorText);
       break;
-    }
-
-    let responseMessage = prefixMap.text;
-
-    if (type === 'message_annotations') {
+    } else if (type === 'data-message_annotations' && 'data' in chunk) {
+      const annotationsChunk = chunk as Extract<
+        UIMessageChunk,
+        { type: `data-${string}`; data: unknown }
+      >;
+      const annotationValues = annotationsChunk.data as Annotation[];
       if (!messageAnnotations) {
-        messageAnnotations = [...(value as unknown as Annotation[])];
+        messageAnnotations = [...annotationValues];
       } else {
-        messageAnnotations.push(...(value as unknown as Annotation[]));
+        messageAnnotations.push(...annotationValues);
       }
-
-      responseMessage = assignAnnotationsToMessage(prefixMap.text, messageAnnotations);
     }
+
+    const responseMessage = prefixMap.text;
 
     if (messageAnnotations?.length) {
       const messagePrefixKeys: Array<keyof PrefixMap> = ['text'];

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/stream.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/stream.ts
@@ -5,182 +5,79 @@
  * 2.0.
  */
 
-import { JSONValue } from '../types';
+import type { UIMessageChunk } from 'ai';
 
-export interface StreamPart<CODE extends string, NAME extends string, TYPE> {
-  code: CODE;
-  name: NAME;
-  parse: (value: JSONValue) => { type: NAME; value: TYPE };
+interface ReadDataStreamOptions {
+  isAborted?: () => boolean;
 }
 
-type StreamParts =
-  | typeof textStreamPart
-  | typeof errorStreamPart
-  | typeof messageAnnotationsStreamPart;
-/**
- * Maps the type of a stream part to its value type.
- */
-type StreamPartValueType = {
-  [P in StreamParts as P['name']]: ReturnType<P['parse']>['value'];
-};
-
-export type StreamPartType =
-  | ReturnType<typeof textStreamPart.parse>
-  | ReturnType<typeof errorStreamPart.parse>
-  | ReturnType<typeof messageAnnotationsStreamPart.parse>
-  | ReturnType<typeof bufferStreamPart.parse>;
-
-const NEWLINE = '\n'.charCodeAt(0);
-
-const concatChunks = (chunks: Uint8Array[], totalLength: number) => {
-  const concatenatedChunks = new Uint8Array(totalLength);
-
-  let offset = 0;
-  for (const chunk of chunks) {
-    concatenatedChunks.set(chunk, offset);
-    offset += chunk.length;
-  }
-  chunks.length = 0;
-
-  return concatenatedChunks;
-};
+const EVENT_SEPARATOR = '\n\n';
+const EVENT_DATA_PREFIX = 'data: ';
+const STREAM_END_PAYLOAD = '[DONE]';
 
 export async function* readDataStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
-  { isAborted }: { isAborted?: () => boolean } = {}
-): AsyncGenerator<StreamPartType> {
+  { isAborted }: ReadDataStreamOptions = {}
+): AsyncGenerator<UIMessageChunk> {
   const decoder = new TextDecoder();
-  const chunks: Uint8Array[] = [];
-  let totalLength = 0;
+  let buffer = '';
 
   while (true) {
-    const { value } = await reader.read();
+    const { done, value } = await reader.read();
 
     if (value) {
-      chunks.push(value);
-      totalLength += value.length;
-      if (value[value.length - 1] !== NEWLINE) {
-        continue;
+      buffer += decoder.decode(value, { stream: true });
+
+      let separatorIndex = buffer.indexOf(EVENT_SEPARATOR);
+      while (separatorIndex !== -1) {
+        const event = buffer.slice(0, separatorIndex);
+        buffer = buffer.slice(separatorIndex + EVENT_SEPARATOR.length);
+        separatorIndex = buffer.indexOf(EVENT_SEPARATOR);
+
+        if (!event.startsWith(EVENT_DATA_PREFIX)) {
+          continue;
+        }
+
+        const payload = event.slice(EVENT_DATA_PREFIX.length);
+
+        if (payload === STREAM_END_PAYLOAD) {
+          return;
+        }
+
+        const message = JSON.parse(payload);
+        if (isUIMessageChunk(message)) {
+          yield message;
+        } else {
+          throw new Error(`Unsupported stream event: ${payload}`);
+        }
       }
     }
 
-    if (chunks.length === 0) {
+    if (done) {
+      if (buffer.length) {
+        let payload = buffer.trim();
+        if (payload.startsWith(EVENT_DATA_PREFIX)) {
+          payload = payload.slice(EVENT_DATA_PREFIX.length).trim();
+        }
+        if (payload && payload !== STREAM_END_PAYLOAD) {
+          const message = JSON.parse(payload);
+          if (isUIMessageChunk(message)) {
+            yield message;
+          } else {
+            throw new Error(`Unsupported stream event: ${payload}`);
+          }
+        }
+      }
       break;
     }
 
-    const concatenatedChunks = concatChunks(chunks, totalLength);
-    totalLength = 0;
-
-    const streamParts = decoder
-      .decode(concatenatedChunks, { stream: true })
-      .split('\n')
-      .filter((line) => line !== '')
-      .map(parseStreamPart);
-
-    for (const streamPart of streamParts) {
-      yield streamPart;
-    }
-
     if (isAborted?.()) {
-      reader.cancel();
+      await reader.cancel();
       break;
     }
   }
 }
 
-const createStreamPart = <CODE extends string, NAME extends string, TYPE>(
-  code: CODE,
-  name: NAME,
-  parse: (value: JSONValue) => { type: NAME; value: TYPE }
-): StreamPart<CODE, NAME, TYPE> => {
-  return {
-    code,
-    name,
-    parse,
-  };
-};
-
-const textStreamPart = createStreamPart('0', 'text', (value) => {
-  if (typeof value !== 'string') {
-    throw new Error('"text" parts expect a string value.');
-  }
-  return { type: 'text', value };
-});
-
-const errorStreamPart = createStreamPart('3', 'error', (value) => {
-  if (typeof value !== 'string') {
-    throw new Error('"error" parts expect a string value.');
-  }
-  return { type: 'error', value };
-});
-
-const messageAnnotationsStreamPart = createStreamPart('8', 'message_annotations', (value) => {
-  if (!Array.isArray(value)) {
-    throw new Error('"message_annotations" parts expect an array value.');
-  }
-
-  return { type: 'message_annotations', value };
-});
-
-const bufferStreamPart = createStreamPart('10', 'buffer', (value) => {
-  if (typeof value !== 'string') {
-    throw new Error('"buffer" parts expect a string value.');
-  }
-
-  return { type: 'buffer', value };
-});
-
-const streamParts = [
-  textStreamPart,
-  errorStreamPart,
-  bufferStreamPart,
-  messageAnnotationsStreamPart,
-] as const;
-
-type StreamPartMap = {
-  [P in StreamParts as P['code']]: P;
-};
-
-const streamPartsByCode: StreamPartMap = streamParts.reduce(
-  (acc, part) => ({
-    ...acc,
-    [part.code]: part,
-  }),
-  {} as StreamPartMap
-);
-
-const validCodes = streamParts.map((part) => part.code);
-
-export const parseStreamPart = (line: string): StreamPartType => {
-  const firstSeparatorIndex = line.indexOf(':');
-
-  if (firstSeparatorIndex === -1) {
-    throw new Error('Failed to parse stream string. No separator found.');
-  }
-
-  const prefix = line.slice(0, firstSeparatorIndex) as keyof StreamPartMap;
-
-  if (!validCodes.includes(prefix)) {
-    throw new Error(`Failed to parse stream string. Invalid code ${prefix}.`);
-  }
-
-  const code = prefix as keyof StreamPartMap;
-
-  const textValue = line.slice(firstSeparatorIndex + 1);
-  const jsonValue: JSONValue = JSON.parse(textValue);
-
-  return streamPartsByCode[code].parse(jsonValue);
-};
-
-export const formatStreamPart = <T extends keyof StreamPartValueType>(
-  type: T,
-  value: StreamPartValueType[T]
-): string => {
-  const streamPart = streamParts.find((part) => part.name === type);
-
-  if (!streamPart) {
-    throw new Error(`Invalid stream part type: ${type as string}`);
-  }
-
-  return `${streamPart.code}:${JSON.stringify(value)}\n`;
-};
+function isUIMessageChunk(message: unknown): message is UIMessageChunk {
+  return Boolean(message && typeof message === 'object' && 'type' in message);
+}

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/conversational_chain.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/conversational_chain.test.ts
@@ -13,6 +13,40 @@ import { createAssist as Assist } from '../utils/assist';
 import { ConversationalChain, contextLimitCheck } from './conversational_chain';
 import { ChatMessage, MessageRole } from '../types';
 import { ContextModelLimitError } from '../../common';
+import type { UIMessageChunk } from 'ai';
+
+const readSseChunks = async (stream: ReadableStream<string>): Promise<UIMessageChunk[]> => {
+  const reader = stream.getReader();
+  const chunks: UIMessageChunk[] = [];
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (value) {
+      buffer += value;
+      let separatorIndex = buffer.indexOf('\n\n');
+      while (separatorIndex !== -1) {
+        const event = buffer.slice(0, separatorIndex);
+        buffer = buffer.slice(separatorIndex + 2);
+        separatorIndex = buffer.indexOf('\n\n');
+        if (!event.startsWith('data: ')) {
+          continue;
+        }
+        const payload = event.slice(6);
+        if (payload === '[DONE]') {
+          continue;
+        }
+        chunks.push(JSON.parse(payload));
+      }
+    }
+
+    if (done) {
+      break;
+    }
+  }
+
+  return chunks;
+};
 
 describe('conversational chain', () => {
   beforeEach(() => {
@@ -107,52 +141,33 @@ describe('conversational chain', () => {
       questionRewritePrompt: 'rewrite question {question} using {context}"',
     });
 
-    try {
-      const stream = await conversationalChain.stream(aiClient, chat);
+    const stream = await conversationalChain.stream(aiClient, chat);
+    const chunks = await readSseChunks(stream);
 
-      const streamToValue: string[] = await new Promise((resolve, reject) => {
-        const reader = stream.getReader();
-        const chunks: string[] = [];
+    const textValue =
+      chunks
+        .filter((chunk) => chunk.type === 'text-delta')
+        .map((chunk) => ('delta' in chunk ? chunk.delta : ''))
+        .join('') || '';
+    expect(textValue).toEqual(expectedFinalAnswer || '');
 
-        const read = () => {
-          reader.read().then(({ done, value }) => {
-            if (done) {
-              resolve(chunks);
-            } else {
-              chunks.push(value);
-              read();
-            }
-          }, reject);
-        };
-        read();
-      });
+    const annotations = chunks
+      .filter((chunk) => chunk.type === 'data-message_annotations')
+      .flatMap((chunk) =>
+        'data' in chunk && Array.isArray(chunk.data) ? chunk.data : []
+      ) as Array<{ type: string }>;
 
-      const textValue =
-        streamToValue
-          .filter((v) => v[0] === '0')
-          .reduce((acc, v) => acc + v.replace(/0:"(.*)"\n/, '$1'), '') || '';
-      expect(textValue).toEqual(expectedFinalAnswer || '');
-
-      const annotations = streamToValue
-        .filter((v) => v[0] === '8')
-        .map((entry) => entry.replace(/8:(.*)\n/, '$1'), '')
-        .map((entry) => JSON.parse(entry))
-        .reduce((acc, v) => acc.concat(v), []);
-
-      const error =
-        streamToValue
-          .filter((v) => v[0] === '3')
-          .reduce((acc, v) => acc + v.replace(/3:"(.*)"\n/, '$1'), '') || '';
-
-      const docValues = annotations.filter((v: { type: string }) => v.type === 'retrieved_docs');
-      const tokens = annotations.filter((v: { type: string }) => v.type.endsWith('_token_count'));
-      expect(docValues).toEqual(expectedDocs);
-      expect(tokens).toEqual(expectedTokens);
-      if (expectedErrorMessage) expect(error).toEqual(expectedErrorMessage);
-      expect(searchMock.mock.calls[0]).toEqual(expectedSearchRequest);
-    } catch (error) {
-      throw error;
+    const errorChunk = chunks.find((chunk) => chunk.type === 'error');
+    const docValues = annotations.filter((v) => v.type === 'retrieved_docs');
+    const tokens = annotations.filter((v) => v.type.endsWith('_token_count'));
+    expect(docValues).toEqual(expectedDocs);
+    expect(tokens).toEqual(expectedTokens);
+    if (expectedErrorMessage) {
+      expect(errorChunk && 'errorText' in errorChunk ? errorChunk.errorText : '').toEqual(
+        expectedErrorMessage
+      );
     }
+    expect(searchMock.mock.calls[0]).toEqual(expectedSearchRequest);
   };
 
   it('should be able to create a conversational chain', async () => {

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/conversational_chain.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/conversational_chain.ts
@@ -14,13 +14,17 @@ import {
 } from '@langchain/core/prompts';
 import { Runnable, RunnableLambda, RunnableSequence } from '@langchain/core/runnables';
 import { StringOutputParser } from '@langchain/core/output_parsers';
-import { createDataStream, LangChainAdapter } from 'ai';
-import type { DataStreamWriter } from 'ai';
-import type { DataStreamString } from '@ai-sdk/ui-utils';
-import { BaseLanguageModel } from '@langchain/core/language_models/base';
-import { BaseMessage } from '@langchain/core/messages';
+import {
+  createUIMessageStream,
+  JsonToSseTransformStream,
+  type UIMessage,
+  type UIMessageStreamWriter,
+} from 'ai';
+import { toUIMessageStream } from '@ai-sdk/langchain';
+import type { BaseLanguageModel } from '@langchain/core/language_models/base';
 import { HumanMessage, AIMessage } from '@langchain/core/messages';
-import { ChatMessage, ElasticsearchRetrieverContentField } from '../types';
+import type { BaseMessage, AIMessageChunk } from '@langchain/core/messages';
+import type { ChatMessage, ElasticsearchRetrieverContentField } from '../types';
 import { ElasticsearchRetriever } from './elasticsearch_retriever';
 import { renderTemplate } from '../utils/render_template';
 
@@ -92,6 +96,38 @@ position: ${i + 1}
   return serializedDocs.join('\n');
 };
 
+const messageContentToString = (content: BaseMessage['content']): string => {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === 'string') {
+          return part;
+        }
+        if (typeof part === 'object' && part !== null) {
+          if ('text' in part && typeof part.text === 'string') {
+            return part.text;
+          }
+        }
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n');
+  }
+  return '';
+};
+
+const isAIMessageChunk = (chunk: any): chunk is AIMessageChunk => {
+  return Boolean(
+    chunk &&
+      typeof chunk === 'object' &&
+      'constructor' in chunk &&
+      (chunk as { constructor: { name?: string } }).constructor?.name === 'AIMessageChunk'
+  );
+};
+
 export function contextLimitCheck(
   modelLimit: number | undefined,
   prompt: ChatPromptTemplate
@@ -111,9 +147,45 @@ export function contextLimitCheck(
   };
 }
 
-export function registerContextTokenCounts(data: DataStreamWriter) {
+interface RetrievedDocumentsAnnotation {
+  type: 'retrieved_docs';
+  documents: Document[];
+}
+
+interface CitationsAnnotation {
+  type: 'citations';
+  documents: Document[];
+}
+
+type PlaygroundAnnotation =
+  | RetrievedDocumentsAnnotation
+  | CitationsAnnotation
+  | { type: 'context_token_count'; count: number }
+  | { type: 'prompt_token_count'; count: number }
+  | { type: 'search_query'; question: string };
+
+interface PlaygroundDataTypes {
+  [key: string]: unknown;
+  message_annotations: PlaygroundAnnotation[];
+}
+
+type PlaygroundUIMessage = UIMessage<unknown, PlaygroundDataTypes>;
+type PlaygroundStreamWriter = UIMessageStreamWriter<PlaygroundUIMessage>;
+
+const writeAnnotations = (
+  writer: PlaygroundStreamWriter,
+  annotations: PlaygroundAnnotation | PlaygroundAnnotation[]
+) => {
+  const data = Array.isArray(annotations) ? annotations : [annotations];
+  writer.write({
+    type: 'data-message_annotations',
+    data,
+  });
+};
+
+export function registerContextTokenCounts(writer: PlaygroundStreamWriter) {
   return (input: ContextInputs) => {
-    data.writeMessageAnnotation({
+    writeAnnotations(writer, {
       type: 'context_token_count',
       count: getTokenEstimate(input.context),
     });
@@ -129,17 +201,16 @@ class ConversationalChainFn {
     this.options = options;
   }
 
-  async stream(
-    client: AssistClient,
-    msgs: ChatMessage[]
-  ): Promise<ReadableStream<DataStreamString>> {
-    return createDataStream({
-      execute: async (dataStream) => {
+  async stream(client: AssistClient, msgs: ChatMessage[]): Promise<ReadableStream<string>> {
+    const uiStream = createUIMessageStream<PlaygroundUIMessage>({
+      execute: async ({ writer }) => {
         const messages = msgs ?? [];
         const lcMessages = getMessages(messages);
         const previousMessages = lcMessages.slice(0, -1);
-        const question = lcMessages[lcMessages.length - 1]!.content;
+        const lastMessageContent = lcMessages[lcMessages.length - 1]?.content;
+        const question = messageContentToString(lastMessageContent ?? '');
         const retrievedDocs: Document[] = [];
+        let hasWrittenCitations = false;
 
         let retrievalChain: Runnable = RunnableLambda.from(() => '');
         const chatHistory = getSerialisedMessages(previousMessages);
@@ -191,14 +262,14 @@ class ConversationalChainFn {
             question: (input) => input.question,
           },
           RunnableLambda.from((inputs) => {
-            dataStream.writeMessageAnnotation({
+            writeAnnotations(writer, {
               type: 'search_query',
               question: inputs.question,
             });
             return inputs;
           }),
           RunnableLambda.from(contextLimitCheck(this.options?.rag?.inputTokensLimit, prompt)),
-          RunnableLambda.from(registerContextTokenCounts(dataStream)),
+          RunnableLambda.from(registerContextTokenCounts(writer)),
           prompt,
           this.options.model.withConfig({ metadata: { type: 'question_answer_qa' } }),
         ]);
@@ -230,20 +301,22 @@ class ConversationalChainFn {
                   metadata: Record<string, string>
                 ) {
                   if (metadata?.type === 'question_answer_qa') {
-                    dataStream.writeMessageAnnotation({
-                      type: 'prompt_token_count',
-                      count: getTokenEstimateFromMessages(msg),
-                    });
-                    dataStream.writeMessageAnnotation({
-                      type: 'search_query',
-                      question,
-                    });
+                    writeAnnotations(writer, [
+                      {
+                        type: 'prompt_token_count',
+                        count: getTokenEstimateFromMessages(msg),
+                      },
+                      {
+                        type: 'search_query',
+                        question,
+                      },
+                    ]);
                   }
                 },
                 // callback for prompt based models (Bedrock uses ActionsClientLlm)
                 handleLLMStart(llm, input, runId, parentRunId, extraParams, tags, metadata) {
                   if (metadata?.type === 'question_answer_qa') {
-                    dataStream.writeMessageAnnotation({
+                    writeAnnotations(writer, {
                       type: 'prompt_token_count',
                       count: getTokenEstimate(input[0]),
                     });
@@ -251,29 +324,27 @@ class ConversationalChainFn {
                 },
                 handleRetrieverEnd(documents) {
                   retrievedDocs.push(...documents);
-                  dataStream.writeMessageAnnotation({
+                  writeAnnotations(writer, {
                     type: 'retrieved_docs',
-                    documents: documents as any,
+                    documents,
                   });
                 },
-                handleChainEnd(outputs, runId, parentRunId) {
-                  if (outputs?.constructor?.name === 'AIMessageChunk') {
-                    dataStream.writeMessageAnnotation({
-                      type: 'citations',
-                      documents: getCitations(
-                        outputs.content as string,
-                        'inline',
-                        retrievedDocs
-                      ) as any,
-                    });
+                handleChainEnd(outputs) {
+                  if (hasWrittenCitations || !isAIMessageChunk(outputs)) {
+                    return;
                   }
+                  hasWrittenCitations = true;
+                  writeAnnotations(writer, {
+                    type: 'citations',
+                    documents: getCitations(outputs.content as string, 'inline', retrievedDocs),
+                  });
                 },
               },
             ],
           }
         );
 
-        return LangChainAdapter.mergeIntoDataStream(lcStream, { dataStream });
+        writer.merge(toUIMessageStream(lcStream));
       },
       onError: (error: unknown) => {
         if (error instanceof Error) {
@@ -282,6 +353,8 @@ class ConversationalChainFn {
         return 'An error occurred while processing the request';
       },
     });
+
+    return uiStream.pipeThrough(new JsonToSseTransformStream());
   }
 }
 

--- a/x-pack/solutions/search/plugins/search_playground/server/utils/stream_factory.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/utils/stream_factory.test.ts
@@ -25,6 +25,7 @@ describe('streamFactory', () => {
       'Cache-Control': 'no-cache',
       Connection: 'keep-alive',
       'Transfer-Encoding': 'chunked',
+      'Content-Type': 'text/event-stream; charset=utf-8',
     });
     expect(responseWithHeaders.body).toBeInstanceOf(PassThrough);
     end();

--- a/x-pack/solutions/search/plugins/search_playground/server/utils/stream_factory.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/utils/stream_factory.ts
@@ -45,9 +45,7 @@ export function streamFactory(logger: Logger, isCloud: boolean = false): StreamF
 
   const cloudProxyBufferSize = 4096;
 
-  const flushPayload = isCloud
-    ? DELIMITER + '10: "' + repeat('0', cloudProxyBufferSize * 2) + '"' + DELIMITER
-    : undefined;
+  const flushPayload = isCloud ? `: keepalive ${repeat('0', cloudProxyBufferSize)}\n\n` : undefined;
   let currentBufferSize = 0;
 
   const flushBufferIfNeeded = () => {
@@ -174,6 +172,7 @@ export function streamFactory(logger: Logger, isCloud: boolean = false): StreamF
       'Cache-Control': 'no-cache',
       Connection: 'keep-alive',
       'Transfer-Encoding': 'chunked',
+      'Content-Type': 'text/event-stream; charset=utf-8',
     },
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,36 +32,30 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.0.tgz#728c484f4e10df03d5a3acd0d8adcbbebff8ad63"
   integrity sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==
 
-"@ai-sdk/gateway@1.0.30":
-  version "1.0.30"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-1.0.30.tgz#2315a3d61c75ab192221b6ab3a5f7dbb95da8ee0"
-  integrity sha512-QdrSUryr/CLcsCISokLHOImcHj1adGXk1yy4B3qipqLhcNc33Kj/O/3crI790Qp85oDx7sc4vm7R4raf9RA/kg==
+"@ai-sdk/gateway@2.0.18":
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-2.0.18.tgz#7e81bdedddb7363af2c38d2cf7f34ac2d5e5eaa7"
+  integrity sha512-sDQcW+6ck2m0pTIHW6BPHD7S125WD3qNkx/B8sEzJp/hurocmJ5Cni0ybExg6sQMGo+fr/GWOwpHF1cmCdg5rQ==
   dependencies:
     "@ai-sdk/provider" "2.0.0"
-    "@ai-sdk/provider-utils" "3.0.10"
+    "@ai-sdk/provider-utils" "3.0.18"
+    "@vercel/oidc" "3.0.5"
 
-"@ai-sdk/provider-utils@2.2.8":
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz#ad11b92d5a1763ab34ba7b5fc42494bfe08b76d1"
-  integrity sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==
+"@ai-sdk/langchain@^1.0.102":
+  version "1.0.108"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/langchain/-/langchain-1.0.108.tgz#6eb970d7e8c1572cead93bc1eaf395420a2e92a9"
+  integrity sha512-qcUq74yvGuvbqZg93V2jVEWcgwxSspzjJD6F18CD6COlRE6vEcq+bWgaU3QAtftcDNw83whwGyEUU4TRjzW2Dw==
   dependencies:
-    ai "5.0.102"
+    ai "5.0.108"
 
-"@ai-sdk/provider-utils@3.0.10":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-3.0.10.tgz#f76010c78445bb25cfc102bcd7e162103e6e7d96"
-  integrity sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ==
+"@ai-sdk/provider-utils@3.0.18":
+  version "3.0.18"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-3.0.18.tgz#fc7757ad7eb48a48ce1976da3025f0b9215b1aff"
+  integrity sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ==
   dependencies:
     "@ai-sdk/provider" "2.0.0"
     "@standard-schema/spec" "^1.0.0"
-    eventsource-parser "^3.0.5"
-
-"@ai-sdk/provider@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-1.1.3.tgz#ebdda8077b8d2b3f290dcba32c45ad19b2704681"
-  integrity sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==
-  dependencies:
-    json-schema "^0.4.0"
+    eventsource-parser "^3.0.6"
 
 "@ai-sdk/provider@2.0.0":
   version "2.0.0"
@@ -69,33 +63,6 @@
   integrity sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==
   dependencies:
     json-schema "^0.4.0"
-
-"@ai-sdk/react@1.2.12":
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/react/-/react-1.2.12.tgz#f4250b6df566b170af98a71d5708b52108dd0ce1"
-  integrity sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==
-  dependencies:
-    "@ai-sdk/provider-utils" "2.2.8"
-    "@ai-sdk/ui-utils" "1.2.11"
-    swr "^2.2.5"
-    throttleit "2.1.0"
-
-"@ai-sdk/ui-utils@1.2.11":
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz#4f815589d08d8fef7292ade54ee5db5d09652603"
-  integrity sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==
-  dependencies:
-    "@ai-sdk/provider" "1.1.3"
-    "@ai-sdk/provider-utils" "2.2.8"
-    zod-to-json-schema "^3.24.1"
-
-"@alcalzone/ansi-tokenize@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz#9f89839561325a8e9a0c32360b8d17e48489993f"
-  integrity sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==
-  dependencies:
-    ansi-styles "^6.2.1"
-    is-fullwidth-code-point "^4.0.0"
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.0"
@@ -14845,26 +14812,14 @@ aggregate-error@^3.0.0, aggregate-error@^3.1.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ai@^4.3.15:
-  version "4.3.19"
-  resolved "https://registry.yarnpkg.com/ai/-/ai-4.3.19.tgz#e94f5b37f3885bc9c9637f892e13bddd0a1857e5"
-  integrity sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==
+ai@5.0.108, ai@^5.0.102:
+  version "5.0.108"
+  resolved "https://registry.yarnpkg.com/ai/-/ai-5.0.108.tgz#b1b6e66b705baabcf98370336b03ebaacbf1874f"
+  integrity sha512-Jex3Lb7V41NNpuqJHKgrwoU6BCLHdI1Pg4qb4GJH4jRIDRXUBySJErHjyN4oTCwbiYCeb/8II9EnqSRPq9EifA==
   dependencies:
-    "@ai-sdk/provider" "1.1.3"
-    "@ai-sdk/provider-utils" "2.2.8"
-    "@ai-sdk/react" "1.2.12"
-    "@ai-sdk/ui-utils" "1.2.11"
-    "@opentelemetry/api" "1.9.0"
-    jsondiffpatch "0.6.0"
-
-ai@^5.0.38:
-  version "5.0.56"
-  resolved "https://registry.yarnpkg.com/ai/-/ai-5.0.56.tgz#fa0691ee1170d92d541c85fc8567f3a939a2c674"
-  integrity sha512-Rl++Ogg6DxzFkVHAOJZzhqcqvqtBLGOP9mMxJOGr2EJWj5HH5zjqDcnRh6x5vBoca5kj/Gd0rvUZFMnyI+sRiw==
-  dependencies:
-    "@ai-sdk/gateway" "1.0.30"
+    "@ai-sdk/gateway" "2.0.18"
     "@ai-sdk/provider" "2.0.0"
-    "@ai-sdk/provider-utils" "3.0.10"
+    "@ai-sdk/provider-utils" "3.0.18"
     "@opentelemetry/api" "1.9.0"
 
 ajv-draft-04@^1.0.0:
@@ -16503,7 +16458,7 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2, chalk@~4.1
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.1.2, chalk@^5.3.0:
+chalk@^5.1.2:
   version "5.3.0"
   resolved "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz"
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
@@ -20017,7 +19972,7 @@ events@^3.0.0, events@^3.2.0, events@^3.3.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-eventsource-parser@^3.0.0, eventsource-parser@^3.0.5:
+eventsource-parser@^3.0.0, eventsource-parser@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.6.tgz#292e165e34cacbc936c3c92719ef326d4aeb4e90"
   integrity sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,19 +32,41 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.0.tgz#728c484f4e10df03d5a3acd0d8adcbbebff8ad63"
   integrity sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==
 
+"@ai-sdk/gateway@1.0.30":
+  version "1.0.30"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-1.0.30.tgz#2315a3d61c75ab192221b6ab3a5f7dbb95da8ee0"
+  integrity sha512-QdrSUryr/CLcsCISokLHOImcHj1adGXk1yy4B3qipqLhcNc33Kj/O/3crI790Qp85oDx7sc4vm7R4raf9RA/kg==
+  dependencies:
+    "@ai-sdk/provider" "2.0.0"
+    "@ai-sdk/provider-utils" "3.0.10"
+
 "@ai-sdk/provider-utils@2.2.8":
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz#ad11b92d5a1763ab34ba7b5fc42494bfe08b76d1"
   integrity sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==
   dependencies:
-    "@ai-sdk/provider" "1.1.3"
-    nanoid "^3.3.8"
-    secure-json-parse "^2.7.0"
+    ai "5.0.102"
+
+"@ai-sdk/provider-utils@3.0.10":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-3.0.10.tgz#f76010c78445bb25cfc102bcd7e162103e6e7d96"
+  integrity sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ==
+  dependencies:
+    "@ai-sdk/provider" "2.0.0"
+    "@standard-schema/spec" "^1.0.0"
+    eventsource-parser "^3.0.5"
 
 "@ai-sdk/provider@1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-1.1.3.tgz#ebdda8077b8d2b3f290dcba32c45ad19b2704681"
   integrity sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==
+  dependencies:
+    json-schema "^0.4.0"
+
+"@ai-sdk/provider@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-2.0.0.tgz#b853c739d523b33675bc74b6c506b2c690bc602b"
+  integrity sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==
   dependencies:
     json-schema "^0.4.0"
 
@@ -66,6 +88,14 @@
     "@ai-sdk/provider" "1.1.3"
     "@ai-sdk/provider-utils" "2.2.8"
     zod-to-json-schema "^3.24.1"
+
+"@alcalzone/ansi-tokenize@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz#9f89839561325a8e9a0c32360b8d17e48489993f"
+  integrity sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==
+  dependencies:
+    ansi-styles "^6.2.1"
+    is-fullwidth-code-point "^4.0.0"
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.0"
@@ -2487,7 +2517,7 @@
   resolved "https://registry.yarnpkg.com/@elastic/filesaver/-/filesaver-1.1.2.tgz#1998ffb3cd89c9da4ec12a7793bfcae10e30c77a"
   integrity sha512-YZbSufYFBhAj+S2cJgiKALoxIJevqXN2MSr6Yqr42rJdaPuM31cj6pUDwflkql1oDjupqD9la+MfxPFjXI1JFQ==
 
-"@elastic/kibana-d3-color@npm:@elastic/kibana-d3-color@2.0.1", "d3-color@1 - 2", "d3-color@npm:@elastic/kibana-d3-color@2.0.1":
+"@elastic/kibana-d3-color@npm:@elastic/kibana-d3-color@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@elastic/kibana-d3-color/-/kibana-d3-color-2.0.1.tgz#f83b9c2fea09273a918659de04d5e8098c82f65c"
   integrity sha512-YZ8hV2bWNyYi833Yj3UWczmTxdHzmo/Xc2IVkNXr/ZqtkrTDlTLysCyJm7SfAt9iBy6EVRGWTn8cPz8QOY6Ixw==
@@ -12954,11 +12984,6 @@
   resolved "https://registry.yarnpkg.com/@types/deep-freeze-strict/-/deep-freeze-strict-1.1.2.tgz#707d1f9721aea9251ca6188111c272c61fc5490f"
   integrity sha512-VvMETBojHvhX4f+ocYTySQlXMZfxKV3Jyb7iCWlWaC+exbedkv6Iv2bZZqI736qXjVguH6IH7bzwMBMfTT+zuQ==
 
-"@types/diff-match-patch@^1.0.36":
-  version "1.0.36"
-  resolved "https://registry.yarnpkg.com/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz#dcef10a69d357fe9d43ac4ff2eca6b85dbf466af"
-  integrity sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==
-
 "@types/doctrine@^0.0.9":
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/@types/doctrine/-/doctrine-0.0.9.tgz#d86a5f452a15e3e3113b99e39616a9baa0f9863f"
@@ -14372,6 +14397,11 @@
     "@0no-co/graphql.web" "^1.0.5"
     wonka "^6.3.2"
 
+"@vercel/oidc@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@vercel/oidc/-/oidc-3.0.5.tgz#bd8db7ee777255c686443413492db4d98ef49657"
+  integrity sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==
+
 "@vitest/expect@2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-2.0.5.tgz#f3745a6a2c18acbea4d39f5935e913f40d26fa86"
@@ -14816,9 +14846,9 @@ aggregate-error@^3.0.0, aggregate-error@^3.1.0:
     indent-string "^4.0.0"
 
 ai@^4.3.15:
-  version "4.3.15"
-  resolved "https://registry.yarnpkg.com/ai/-/ai-4.3.15.tgz#1d384d630561c7f2b4c44fb619175b21677a37a4"
-  integrity sha512-TYKRzbWg6mx/pmTadlAEIhuQtzfHUV0BbLY72+zkovXwq/9xhcH24IlQmkyBpElK6/4ArS0dHdOOtR1jOPVwtg==
+  version "4.3.19"
+  resolved "https://registry.yarnpkg.com/ai/-/ai-4.3.19.tgz#e94f5b37f3885bc9c9637f892e13bddd0a1857e5"
+  integrity sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==
   dependencies:
     "@ai-sdk/provider" "1.1.3"
     "@ai-sdk/provider-utils" "2.2.8"
@@ -14826,6 +14856,16 @@ ai@^4.3.15:
     "@ai-sdk/ui-utils" "1.2.11"
     "@opentelemetry/api" "1.9.0"
     jsondiffpatch "0.6.0"
+
+ai@^5.0.38:
+  version "5.0.56"
+  resolved "https://registry.yarnpkg.com/ai/-/ai-5.0.56.tgz#fa0691ee1170d92d541c85fc8567f3a939a2c674"
+  integrity sha512-Rl++Ogg6DxzFkVHAOJZzhqcqvqtBLGOP9mMxJOGr2EJWj5HH5zjqDcnRh6x5vBoca5kj/Gd0rvUZFMnyI+sRiw==
+  dependencies:
+    "@ai-sdk/gateway" "1.0.30"
+    "@ai-sdk/provider" "2.0.0"
+    "@ai-sdk/provider-utils" "3.0.10"
+    "@opentelemetry/api" "1.9.0"
 
 ajv-draft-04@^1.0.0:
   version "1.0.0"
@@ -17905,6 +17945,11 @@ d3-collection@^1.0.7:
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
 
+"d3-color@1 - 2", "d3-color@npm:@elastic/kibana-d3-color@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@elastic/kibana-d3-color/-/kibana-d3-color-2.0.1.tgz#f83b9c2fea09273a918659de04d5e8098c82f65c"
+  integrity sha512-YZ8hV2bWNyYi833Yj3UWczmTxdHzmo/Xc2IVkNXr/ZqtkrTDlTLysCyJm7SfAt9iBy6EVRGWTn8cPz8QOY6Ixw==
+
 "d3-color@1 - 3", d3-color@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
@@ -19972,10 +20017,10 @@ events@^3.0.0, events@^3.2.0, events@^3.3.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-eventsource-parser@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.0.tgz#9303e303ef807d279ee210a17ce80f16300d9f57"
-  integrity sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==
+eventsource-parser@^3.0.0, eventsource-parser@^3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.6.tgz#292e165e34cacbc936c3c92719ef326d4aeb4e90"
+  integrity sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==
 
 eventsource@^3.0.2:
   version "3.0.5"
@@ -23956,15 +24001,6 @@ jsonc-parser@^3.0.0:
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
 
-jsondiffpatch@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz#daa6a25bedf0830974c81545568d5f671c82551f"
-  integrity sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==
-  dependencies:
-    "@types/diff-match-patch" "^1.0.36"
-    chalk "^5.3.0"
-    diff-match-patch "^1.0.5"
-
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -25928,7 +25964,7 @@ nano-css@^5.6.2:
     stacktrace-js "^2.0.2"
     stylis "^4.3.0"
 
-nanoid@^3.3.11, nanoid@^3.3.6, nanoid@^3.3.8:
+nanoid@^3.3.11, nanoid@^3.3.6:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
@@ -29931,11 +29967,6 @@ screenfull@^5.1.0:
   resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.2.0.tgz#6533d524d30621fc1283b9692146f3f13a93d1ba"
   integrity sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==
 
-secure-json-parse@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz"
-  integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
-
 secure-json-parse@^3.0.1, secure-json-parse@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-3.0.2.tgz#255b03bb0627ba5805f64f384b0a7691d8cb021b"
@@ -31023,7 +31054,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -31040,6 +31071,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -31133,7 +31173,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -31146,6 +31186,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -31503,7 +31550,7 @@ swagger2openapi@^7.0.8:
     yaml "^1.10.0"
     yargs "^17.0.1"
 
-swr@^2.2.5, swr@^2.3.3:
+swr@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/swr/-/swr-2.3.3.tgz#9d6a703355f15f9099f45114db3ef75764444788"
   integrity sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==
@@ -31744,11 +31791,6 @@ throttle-debounce@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-3.0.1.tgz#32f94d84dfa894f786c9a1f290e7a645b6a19abb"
   integrity sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==
-
-throttleit@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-2.1.0.tgz#a7e4aa0bf4845a5bd10daa39ea0c783f631a07b4"
-  integrity sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==
 
 throttleit@^1.0.0:
   version "1.0.0"
@@ -33935,7 +33977,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -33956,6 +33998,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -34071,7 +34122,7 @@ xpath@^0.0.33:
   resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.33.tgz#5136b6094227c5df92002e7c3a13516a5074eb07"
   integrity sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==
 
-"xstate5@npm:xstate@^5.19.2", xstate@^5.19.2:
+"xstate5@npm:xstate@^5.19.2":
   version "5.19.2"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.19.2.tgz#db3f1ee614bbb6a49ad3f0c96ddbf98562d456ba"
   integrity sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==
@@ -34080,6 +34131,11 @@ xstate@^4.38.3:
   version "4.38.3"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.38.3.tgz#4e15e7ad3aa0ca1eea2010548a5379966d8f1075"
   integrity sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==
+
+xstate@^5.19.2:
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.19.2.tgz#db3f1ee614bbb6a49ad3f0c96ddbf98562d456ba"
+  integrity sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Update dependency ai to v5 (#244675)](https://github.com/elastic/kibana/pull/244675)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Samiul Monir","email":"150824886+Samiul-TheSoccerFan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-08T17:26:35Z","message":"Update dependency ai to v5 (#244675)\n\n## Summary\n\n- Update dependency ai to v5\n- Addressed the breaking changes\n\n<img width=\"2552\" height=\"1267\" alt=\"Screenshot 2025-11-28 at 2 38\n46 PM\"\nsrc=\"https://github.com/user-attachments/assets/44f9c824-79c5-4e7e-a0ad-216e79673f9e\"\n/>\n\n### Security Checklist:\n**Purpose** – `@ai-sdk/langchain` provides the official adapter that\nconverts LangChain's `Runnable.stream()` output into the AI SDK v5 `UI\nmessage stream` format. We use it in the search playground's\nconversational chain so the existing LangChain pipeline can feed the new\ncreateUIMessageStream/SSE infrastructure without rewriting the entire\nchain logic.\n\n**Justification** – AI SDK v5 moved the LangChain adapter out of the\ncore `ai` package; the only supported way to keep LangChain models\nstreaming into UI chunks is this package. Using the upstream adapter\nkeeps us aligned with Vercel's protocol changes (LC stream events, chunk\nmetadata, etc.) and avoids maintaining fragile, duplicate conversion\ncode in Kibana.\n\n**Alternatives explored** –We looked at copying the old adapter logic,\nbut the new UI chunk format (text, tools, reasoning, data events)\nchanges quickly and is easy to get wrong. Reimplementing it ourselves\nwould be brittle and hard to maintain, so we rely on the upstream\npackage instead.\n\n**Existing dependencies** – Kibana already depends on LangChain itself\nand on the base `ai` SDK, but neither now exposes a LangChain to UI\nstream bridge. `@ai-sdk/langchain` is the upstream successor to what\nused to be bundled in `ai`, so it’s effectively continuing the same\ncapability with ongoing support, making it the preferred and only viable\noption.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"81c634708ab1405b64a5ca524b0f62d84d351467","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Search","backport:all-open","ci:project-deploy-elasticsearch","v9.3.0"],"title":"Update dependency ai to v5","number":244675,"url":"https://github.com/elastic/kibana/pull/244675","mergeCommit":{"message":"Update dependency ai to v5 (#244675)\n\n## Summary\n\n- Update dependency ai to v5\n- Addressed the breaking changes\n\n<img width=\"2552\" height=\"1267\" alt=\"Screenshot 2025-11-28 at 2 38\n46 PM\"\nsrc=\"https://github.com/user-attachments/assets/44f9c824-79c5-4e7e-a0ad-216e79673f9e\"\n/>\n\n### Security Checklist:\n**Purpose** – `@ai-sdk/langchain` provides the official adapter that\nconverts LangChain's `Runnable.stream()` output into the AI SDK v5 `UI\nmessage stream` format. We use it in the search playground's\nconversational chain so the existing LangChain pipeline can feed the new\ncreateUIMessageStream/SSE infrastructure without rewriting the entire\nchain logic.\n\n**Justification** – AI SDK v5 moved the LangChain adapter out of the\ncore `ai` package; the only supported way to keep LangChain models\nstreaming into UI chunks is this package. Using the upstream adapter\nkeeps us aligned with Vercel's protocol changes (LC stream events, chunk\nmetadata, etc.) and avoids maintaining fragile, duplicate conversion\ncode in Kibana.\n\n**Alternatives explored** –We looked at copying the old adapter logic,\nbut the new UI chunk format (text, tools, reasoning, data events)\nchanges quickly and is easy to get wrong. Reimplementing it ourselves\nwould be brittle and hard to maintain, so we rely on the upstream\npackage instead.\n\n**Existing dependencies** – Kibana already depends on LangChain itself\nand on the base `ai` SDK, but neither now exposes a LangChain to UI\nstream bridge. `@ai-sdk/langchain` is the upstream successor to what\nused to be bundled in `ai`, so it’s effectively continuing the same\ncapability with ongoing support, making it the preferred and only viable\noption.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"81c634708ab1405b64a5ca524b0f62d84d351467"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/244675","number":244675,"mergeCommit":{"message":"Update dependency ai to v5 (#244675)\n\n## Summary\n\n- Update dependency ai to v5\n- Addressed the breaking changes\n\n<img width=\"2552\" height=\"1267\" alt=\"Screenshot 2025-11-28 at 2 38\n46 PM\"\nsrc=\"https://github.com/user-attachments/assets/44f9c824-79c5-4e7e-a0ad-216e79673f9e\"\n/>\n\n### Security Checklist:\n**Purpose** – `@ai-sdk/langchain` provides the official adapter that\nconverts LangChain's `Runnable.stream()` output into the AI SDK v5 `UI\nmessage stream` format. We use it in the search playground's\nconversational chain so the existing LangChain pipeline can feed the new\ncreateUIMessageStream/SSE infrastructure without rewriting the entire\nchain logic.\n\n**Justification** – AI SDK v5 moved the LangChain adapter out of the\ncore `ai` package; the only supported way to keep LangChain models\nstreaming into UI chunks is this package. Using the upstream adapter\nkeeps us aligned with Vercel's protocol changes (LC stream events, chunk\nmetadata, etc.) and avoids maintaining fragile, duplicate conversion\ncode in Kibana.\n\n**Alternatives explored** –We looked at copying the old adapter logic,\nbut the new UI chunk format (text, tools, reasoning, data events)\nchanges quickly and is easy to get wrong. Reimplementing it ourselves\nwould be brittle and hard to maintain, so we rely on the upstream\npackage instead.\n\n**Existing dependencies** – Kibana already depends on LangChain itself\nand on the base `ai` SDK, but neither now exposes a LangChain to UI\nstream bridge. `@ai-sdk/langchain` is the upstream successor to what\nused to be bundled in `ai`, so it’s effectively continuing the same\ncapability with ongoing support, making it the preferred and only viable\noption.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"81c634708ab1405b64a5ca524b0f62d84d351467"}}]}] BACKPORT-->