### PR TITLE
[@kbn/observability-plugin] Split test file with duplicate `describe`…

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/storage_explorer/storage_explorer_functionality.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/storage_explorer/storage_explorer_functionality.spec.ts
@@ -13,24 +13,6 @@ const timeRange = {
   rangeTo: testData.OPBEANS_END_DATE,
 };
 
-test.describe('Storage Explorer - Viewer (No Permissions)', { tag: ['@ess', '@svlOblt'] }, () => {
-  test.beforeEach(async ({ browserAuth }) => {
-    await browserAuth.loginAsViewer();
-  });
-
-  test('displays permission denied message', async ({
-    page,
-    pageObjects: { storageExplorerPage },
-  }) => {
-    await storageExplorerPage.goto();
-    await expect(storageExplorerPage.pageTitle).toBeVisible();
-
-    await test.step('verify permission denied is shown', async () => {
-      await expect(page.getByText('You need permission')).toBeVisible();
-    });
-  });
-});
-
 test.describe('Storage Explorer - Admin User', { tag: ['@ess'] }, () => {
   test.beforeEach(async ({ browserAuth }) => {
     // Use privileged user (admin) to ensure we have all necessary permissions

--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/storage_explorer/storage_explorer_permissions.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/storage_explorer/storage_explorer_permissions.spec.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-oblt';
+import { test } from '../../fixtures';
+
+test.describe('Storage Explorer - Viewer (No Permissions)', { tag: ['@ess', '@svlOblt'] }, () => {
+  test.beforeEach(async ({ browserAuth }) => {
+    await browserAuth.loginAsViewer();
+  });
+
+  test('displays permission denied message', async ({
+    page,
+    pageObjects: { storageExplorerPage },
+  }) => {
+    await storageExplorerPage.goto();
+    await expect(storageExplorerPage.pageTitle).toBeVisible();
+
+    await test.step('verify permission denied is shown', async () => {
+      await expect(page.getByText('You need permission')).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Split `storage_explorer.spec.ts` file to 2 separate files, according to best practices.

## Problem

With the introduction of new ESLint rule that prevents the usage of > 1 describe blocks per test file, the `storage_explorer.spec.ts` file was throwing error because it was using 2 describe blocks in the same file.

## Solution

Split `storage_explorer.spec.ts` file to 2 separate files, with 1 describe block per test file.



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->