### PR TITLE
[Security Assistant] Update evals config schema to include missing fields

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/scripts/genai/vault/manage_secrets.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/scripts/genai/vault/manage_secrets.ts
@@ -37,6 +37,8 @@ const SECURITY_GEN_AI_CONFIG_FILE = Path.join(
 const configSchema = schema.object({
   evaluatorConnectorId: schema.string(),
   langsmithKey: schema.string(),
+  esURL: schema.maybe(schema.string()),
+  phoenixKey: schema.maybe(schema.string()),
   connectors: schema.recordOf(
     schema.string(),
     schema.object({


### PR DESCRIPTION
## Summary

Adds support for providing `esURL` and `phoenixKey` via Security GenAI ci-secrets vault in support of running `@kbn/evals` platform evals on CI: https://github.com/elastic/kibana/pull/245064

The secrets had already been updated to include these values, which resulted in [this weekly CI failure](https://buildkite.com/elastic/kibana-ess-security-solution-gen-ai-evals/builds/35/steps/canvas), so a successful run on this PR will confirm things are 👍 


