### PR TITLE
[8.19] [Synthetics] Add global params sync internal API !! (#239284)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
@@ -24,6 +24,8 @@ export enum SYNTHETICS_API_URLS {
   SYNTHETICS_PROJECT_APIKEY = '/internal/synthetics/service/api_key',
   SYNTHETICS_HAS_INTEGRATION_MONITORS = '/internal/synthetics/fleet/has_integration_monitors',
   PRIVATE_LOCATIONS_CLEANUP = `/internal/synthetics/private_locations/_cleanup`,
+  SYNC_GLOBAL_PARAMS = `/internal/synthetics/sync_global_params`,
+  SYNC_GLOBAL_PARAMS_SETTINGS = `/internal/synthetics/sync_global_params/_settings`,
 
   PINGS = '/internal/synthetics/pings',
   MONITOR_STATUS_HEATMAP = '/internal/synthetics/ping_heatmap',

--- a/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
@@ -93,9 +93,9 @@ export class Plugin implements PluginType {
 
     this.syncPrivateLocationMonitorsTask = new SyncPrivateLocationMonitorsTask(
       this.server,
-      plugins.taskManager,
       this.syntheticsMonitorClient
     );
+    this.syncPrivateLocationMonitorsTask.registerTaskDefinition(plugins.taskManager);
 
     return {};
   }

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { syncParamsSettingsParamsRoute } from './settings/params/sync_global_params_settings';
+import { syncParamsSyntheticsParamsRoute } from './settings/params/sync_global_params';
 import { cleanupPrivateLocationRoute } from './settings/private_locations/cleanup_private_locations';
 import { getSyntheticsTriggerTaskRun } from './tasks/trigger_task_run';
 import { syntheticsInspectStatusRuleRoute } from './rules/inspect_status_rule';
@@ -108,6 +110,8 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   syntheticsInspectTLSRuleRoute,
   getSyntheticsTriggerTaskRun,
   cleanupPrivateLocationRoute,
+  syncParamsSyntheticsParamsRoute,
+  syncParamsSettingsParamsRoute,
 ];
 
 export const syntheticsAppPublicRestApiRoutes: SyntheticsRestApiRouteFactory[] = [

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/sync_global_params.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/sync_global_params.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SyncPrivateLocationMonitorsTask } from '../../../tasks/sync_private_locations_monitors_task';
+import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { getPrivateLocations } from '../../../synthetics_service/get_private_locations';
+import type { SyntheticsRestApiRouteFactory } from '../../types';
+
+export const syncParamsSyntheticsParamsRoute: SyntheticsRestApiRouteFactory = () => ({
+  method: 'PUT',
+  path: SYNTHETICS_API_URLS.SYNC_GLOBAL_PARAMS,
+  validate: {},
+  options: {
+    // 5 minutes
+    timeout: {
+      payload: 1000 * 60 * 5,
+    },
+  },
+  writeAccess: true,
+  handler: async ({ syntheticsMonitorClient, server }): Promise<any> => {
+    const soClient = server.coreStart.savedObjects.createInternalRepository();
+
+    const allPrivateLocations = await getPrivateLocations(soClient);
+
+    const syncTask = new SyncPrivateLocationMonitorsTask(server, syntheticsMonitorClient);
+    if (allPrivateLocations.length > 0) {
+      await syncTask.syncGlobalParams({
+        allPrivateLocations,
+        soClient,
+      });
+    }
+
+    return { success: true };
+  },
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/sync_global_params_settings.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/sync_global_params_settings.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { disableSyncPrivateLocationTask } from '../../../tasks/sync_private_locations_monitors_task';
+import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import type { SyntheticsRestApiRouteFactory } from '../../types';
+
+export const syncParamsSettingsParamsRoute: SyntheticsRestApiRouteFactory = () => ({
+  method: 'PUT',
+  path: SYNTHETICS_API_URLS.SYNC_GLOBAL_PARAMS_SETTINGS,
+  validate: {
+    body: schema.object({
+      enable: schema.boolean(),
+    }),
+  },
+  writeAccess: true,
+  handler: async ({ server, request }): Promise<any> => {
+    const { enable } = request.body as { enable: boolean };
+    await disableSyncPrivateLocationTask({ server, disableAutoSync: !enable });
+    return { success: true };
+  },
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { TaskManagerSetupContract } from '@kbn/task-manager-plugin/server/plugin';
 import {
   SyncPrivateLocationMonitorsTask,
   runSynPrivateLocationMonitorsTaskSoon,

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
@@ -84,7 +84,6 @@ describe('SyncPrivateLocationMonitorsTask', () => {
     jest.clearAllMocks();
     task = new SyncPrivateLocationMonitorsTask(
       mockServerSetup as any,
-      mockTaskManager as unknown as TaskManagerSetupContract,
       mockSyntheticsMonitorClient as unknown as SyntheticsMonitorClient
     );
     mockSoClient.createInternalRepository.mockReturnValue(mockSoClient as any);
@@ -92,12 +91,13 @@ describe('SyncPrivateLocationMonitorsTask', () => {
 
   describe('constructor', () => {
     it('should register task definitions correctly', () => {
+      task.registerTaskDefinition(mockTaskManager as any);
       expect(mockTaskManager.registerTaskDefinitions).toHaveBeenCalledWith({
         'Synthetics:Sync-Private-Location-Monitors': expect.objectContaining({
           title: 'Synthetics Sync Global Params Task',
           description:
             'This task is executed so that we can sync private location monitors for example when global params are updated',
-          timeout: '5m',
+          timeout: '10m',
           maxAttempts: 1,
           createTaskRunner: expect.any(Function),
         }),
@@ -150,6 +150,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(mockSyntheticsMonitorClient.privateLocationAPI.editMonitors).not.toHaveBeenCalled();
       expect(result.error).toBeUndefined();
       expect(result.state).toEqual({
+        disableAutoSync: false,
         hasAlreadyDoneCleanup: false,
         lastStartedAt: expect.anything(),
         lastTotalParams: 1,
@@ -190,6 +191,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(task.syncGlobalParams).toHaveBeenCalled();
       expect(result.error).toBeUndefined();
       expect(result.state).toEqual({
+        disableAutoSync: false,
         lastTotalParams: 1,
         lastTotalMWs: 1,
         maxCleanUpRetries: 2,
@@ -227,6 +229,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       );
       expect(result.error).toBe(error);
       expect(result.state).toEqual({
+        disableAutoSync: false,
         lastStartedAt: expect.anything(),
         lastTotalParams: 1,
         lastTotalMWs: 1,
@@ -414,7 +417,6 @@ describe('SyncPrivateLocationMonitorsTask', () => {
 
       await task.syncGlobalParams({
         allPrivateLocations: mockAllPrivateLocations as any,
-        encryptedSavedObjects: mockEncryptedSoClient as any,
         soClient: mockSoClient as any,
       });
 
@@ -445,7 +447,6 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       await task.syncGlobalParams({
         allPrivateLocations: [],
         soClient: mockSoClient as any,
-        encryptedSavedObjects: mockEncryptedSoClient as any,
       });
 
       expect(mockSyntheticsMonitorClient.privateLocationAPI.editMonitors).not.toHaveBeenCalled();
@@ -506,7 +507,6 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       mockSoClient.createPointInTimeFinder = jest.fn().mockReturnValue(mockFinder);
       task = new SyncPrivateLocationMonitorsTask(
         mockServerSetup as any,
-        mockTaskManager as unknown as TaskManagerSetupContract,
         mockSyntheticsMonitorClient as unknown as SyntheticsMonitorClient
       );
     });
@@ -519,10 +519,10 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       );
       const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, {} as any);
       expect(mockFleet.packagePolicyService.delete).not.toHaveBeenCalled();
-      expect(result.performSync).toBe(false);
+      expect(result.performCleanupSync).toBe(false);
     });
 
-    it('should delete unexpected policies and set performSync true', async () => {
+    it('should delete unexpected policies and set performCleanupSync true', async () => {
       mockFleet.packagePolicyService.fetchAllItemIds.mockResolvedValue(
         (async function* () {
           yield ['monitor1-loc1-space1', 'unexpected-policy'];
@@ -535,30 +535,30 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         ['unexpected-policy'],
         { force: true }
       );
-      expect(result.performSync).toBe(true);
+      expect(result.performCleanupSync).toBe(true);
     });
 
-    it('should set performSync true if expected policies are missing', async () => {
+    it('should set performCleanupSync true if expected policies are missing', async () => {
       mockFleet.packagePolicyService.fetchAllItemIds.mockResolvedValue(
         (async function* () {
           yield [];
         })()
       );
       const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, {} as any);
-      expect(result.performSync).toBe(true);
+      expect(result.performCleanupSync).toBe(true);
     });
 
-    it('should handle errors gracefully and return performSync', async () => {
+    it('should handle errors gracefully and return performCleanupSync', async () => {
       mockFleet.packagePolicyService.fetchAllItemIds.mockRejectedValue(new Error('fail'));
       const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, {} as any);
       expect(mockLogger.error).toHaveBeenCalled();
-      expect(result).toHaveProperty('performSync');
+      expect(result).toHaveProperty('performCleanupSync');
     });
 
     it('should skip cleanup if hasAlreadyDoneCleanup is true', async () => {
       const state = { hasAlreadyDoneCleanup: true, maxCleanUpRetries: 3 };
       const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, state as any);
-      expect(result.performSync).toBe(false);
+      expect(result.performCleanupSync).toBe(false);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         '[SyncPrivateLocationMonitorsTask] Skipping cleanup of duplicated package policies as it has already been done once'
       );
@@ -567,7 +567,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
     it('should skip cleanup if maxCleanUpRetries is 0 or less', async () => {
       const state = { hasAlreadyDoneCleanup: false, maxCleanUpRetries: 0 };
       const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, state as any);
-      expect(result.performSync).toBe(false);
+      expect(result.performCleanupSync).toBe(false);
       expect(state.hasAlreadyDoneCleanup).toBe(true);
       expect(state.maxCleanUpRetries).toBe(3);
       expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -581,7 +581,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const state = { hasAlreadyDoneCleanup: false, maxCleanUpRetries: 2 };
       const result = await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, state as any);
       expect(state.maxCleanUpRetries).toBe(1);
-      expect(result).toHaveProperty('performSync');
+      expect(result).toHaveProperty('performCleanupSync');
       // Call again to reach 0
       await task.cleanUpDuplicatedPackagePolicies(mockSoClient as any, state as any);
       expect(state.hasAlreadyDoneCleanup).toBe(true);

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
@@ -50,6 +50,7 @@ interface TaskState extends Record<string, unknown> {
   lastTotalMWs: number;
   hasAlreadyDoneCleanup: boolean;
   maxCleanUpRetries: number;
+  disableAutoSync?: boolean;
 }
 
 export type CustomTaskInstance = Omit<ConcreteTaskInstance, 'state'> & {
@@ -59,15 +60,16 @@ export type CustomTaskInstance = Omit<ConcreteTaskInstance, 'state'> & {
 export class SyncPrivateLocationMonitorsTask {
   constructor(
     public serverSetup: SyntheticsServerSetup,
-    public taskManager: TaskManagerSetupContract,
     public syntheticsMonitorClient: SyntheticsMonitorClient
-  ) {
+  ) {}
+
+  registerTaskDefinition(taskManager: TaskManagerSetupContract) {
     taskManager.registerTaskDefinitions({
       [TASK_TYPE]: {
         title: 'Synthetics Sync Global Params Task',
         description:
           'This task is executed so that we can sync private location monitors for example when global params are updated',
-        timeout: '5m',
+        timeout: '10m',
         maxAttempts: 1,
         createTaskRunner: ({ taskInstance }) => {
           return {
@@ -93,27 +95,26 @@ export class SyncPrivateLocationMonitorsTask {
 
     const {
       coreStart: { savedObjects },
-      encryptedSavedObjects,
       logger,
     } = this.serverSetup;
-    const lastStartedAt =
-      taskInstance.state.lastStartedAt || moment().subtract(10, 'minute').toISOString();
-    const startedAt = taskInstance.startedAt || new Date();
 
-    const taskState = {
-      lastStartedAt: startedAt.toISOString(),
-      lastTotalParams: taskInstance.state.lastTotalParams || 0,
-      lastTotalMWs: taskInstance.state.lastTotalMWs || 0,
-      hasAlreadyDoneCleanup: taskInstance.state.hasAlreadyDoneCleanup || false,
-      maxCleanUpRetries: taskInstance.state.maxCleanUpRetries || 3,
-    };
+    let lastStartedAt = taskInstance.state.lastStartedAt;
+    // if it's too old, set it to 10 minutes ago to avoid syncing everything the first time
+    if (!lastStartedAt || moment(lastStartedAt).isBefore(moment().subtract(6, 'hour'))) {
+      lastStartedAt = moment().subtract(10, 'minute').toISOString();
+    }
+
+    const taskState = this.getNewTaskState({ taskInstance });
 
     try {
       const soClient = savedObjects.createInternalRepository([
         MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE,
       ]);
 
-      const { performSync } = await this.cleanUpDuplicatedPackagePolicies(soClient, taskState);
+      const { performCleanupSync } = await this.cleanUpDuplicatedPackagePolicies(
+        soClient,
+        taskState
+      );
 
       const allPrivateLocations = await getPrivateLocations(soClient, ALL_SPACES_ID);
       const { hasDataChanged } = await this.hasAnyDataChanged({
@@ -122,10 +123,14 @@ export class SyncPrivateLocationMonitorsTask {
         lastStartedAt,
       });
 
-      if (hasDataChanged || performSync) {
-        if (hasDataChanged) {
+      // Only perform syncGlobalParams if:
+      // - hasDataChanged and disableAutoSync is false
+      // - OR performCleanupSync is true (from cleanup), regardless of disableAutoSync
+      const dataChangeSync = hasDataChanged && !taskState.disableAutoSync;
+      if (dataChangeSync || performCleanupSync) {
+        if (dataChangeSync) {
           this.debugLog(`Syncing private location monitors because data has changed`);
-        } else {
+        } else if (performCleanupSync) {
           this.debugLog(`Syncing private location monitors because cleanup performed a change`);
         }
 
@@ -133,16 +138,19 @@ export class SyncPrivateLocationMonitorsTask {
           await this.syncGlobalParams({
             allPrivateLocations,
             soClient,
-            encryptedSavedObjects,
           });
         } else {
           this.debugLog(`No private locations found, skipping sync`);
         }
         this.debugLog(`Sync of private location monitors succeeded`);
       } else {
-        this.debugLog(
-          `No data has changed since last run ${lastStartedAt}, skipping sync of private location monitors`
-        );
+        if (taskState.disableAutoSync) {
+          this.debugLog(`Auto sync is disabled, skipping sync of private location monitors`);
+        } else {
+          this.debugLog(
+            `No data has changed since last run ${lastStartedAt}, skipping sync of private location monitors`
+          );
+        }
       }
     } catch (error) {
       logger.error(`Sync of private location monitors failed: ${error.message}`);
@@ -159,6 +167,19 @@ export class SyncPrivateLocationMonitorsTask {
       schedule: {
         interval: TASK_SCHEDULE,
       },
+    };
+  }
+
+  getNewTaskState({ taskInstance }: { taskInstance: CustomTaskInstance }): TaskState {
+    const startedAt = taskInstance.startedAt || new Date();
+
+    return {
+      lastStartedAt: startedAt.toISOString(),
+      lastTotalParams: taskInstance.state.lastTotalParams || 0,
+      lastTotalMWs: taskInstance.state.lastTotalMWs || 0,
+      hasAlreadyDoneCleanup: taskInstance.state.hasAlreadyDoneCleanup || false,
+      maxCleanUpRetries: taskInstance.state.maxCleanUpRetries || 3,
+      disableAutoSync: taskInstance.state.disableAutoSync ?? false,
     };
   }
 
@@ -209,18 +230,16 @@ export class SyncPrivateLocationMonitorsTask {
 
   async syncGlobalParams({
     allPrivateLocations,
-    encryptedSavedObjects,
     soClient,
   }: {
     soClient: SavedObjectsClientContract;
     allPrivateLocations: PrivateLocationAttributes[];
-    encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
   }) {
     const { privateLocationAPI } = this.syntheticsMonitorClient;
 
     const { configsBySpaces, paramsBySpace, spaceIds, maintenanceWindows } =
       await this.getAllMonitorConfigs({
-        encryptedSavedObjects,
+        encryptedSavedObjects: this.serverSetup.encryptedSavedObjects,
         soClient,
       });
 
@@ -428,20 +447,20 @@ export class SyncPrivateLocationMonitorsTask {
     soClient: SavedObjectsClientContract,
     taskState: TaskState
   ) {
-    let performSync = false;
+    let performCleanupSync = false;
 
     if (taskState.hasAlreadyDoneCleanup) {
       this.debugLog(
         'Skipping cleanup of duplicated package policies as it has already been done once'
       );
-      return { performSync };
+      return { performCleanupSync };
     } else if (taskState.maxCleanUpRetries <= 0) {
       this.debugLog(
         'Skipping cleanup of duplicated package policies as max retries have been reached'
       );
       taskState.hasAlreadyDoneCleanup = true;
       taskState.maxCleanUpRetries = 3;
-      return { performSync };
+      return { performCleanupSync };
     }
     this.debugLog('Starting cleanup of duplicated package policies');
     const { fleet } = this.serverSetup.pluginsStart;
@@ -499,7 +518,7 @@ export class SyncPrivateLocationMonitorsTask {
       }
 
       // if we have any to delete or any expected that were not found we need to perform a sync
-      performSync = packagePoliciesToDelete.length > 0 || expectedPackagePolicies.size > 0;
+      performCleanupSync = packagePoliciesToDelete.length > 0 || expectedPackagePolicies.size > 0;
 
       if (packagePoliciesToDelete.length > 0) {
         logger.info(
@@ -513,7 +532,7 @@ export class SyncPrivateLocationMonitorsTask {
       }
       taskState.hasAlreadyDoneCleanup = true;
       taskState.maxCleanUpRetries = 3;
-      return { performSync };
+      return { performCleanupSync };
     } catch (e) {
       taskState.maxCleanUpRetries -= 1;
       if (taskState.maxCleanUpRetries <= 0) {
@@ -527,7 +546,7 @@ export class SyncPrivateLocationMonitorsTask {
         '[SyncPrivateLocationMonitorsTask] Error cleaning up duplicated package policies',
         { error: e }
       );
-      return { performSync };
+      return { performCleanupSync };
     }
   }
 }
@@ -578,4 +597,25 @@ export const resetSyncPrivateCleanUpState = async ({
   }));
   await runSynPrivateLocationMonitorsTaskSoon({ server });
   logger.debug(`Synthetics sync private location monitors cleanup state reset successfully`);
+};
+
+export const disableSyncPrivateLocationTask = async ({
+  server,
+  disableAutoSync,
+}: {
+  server: SyntheticsServerSetup;
+  disableAutoSync: boolean;
+}) => {
+  const {
+    logger,
+    pluginsStart: { taskManager },
+  } = server;
+  logger.debug(
+    `Setting Synthetics sync private location monitors disableAutoSync to ${disableAutoSync}`
+  );
+  await taskManager.bulkUpdateState([PRIVATE_LOCATIONS_SYNC_TASK_ID], (state) => ({
+    ...state,
+    disableAutoSync,
+  }));
+  logger.debug(`Synthetics sync private location monitors disableAutoSync set successfully`);
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Add global params sync internal API !! (#239284)](https://github.com/elastic/kibana/pull/239284)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2025-12-09T08:45:43Z","message":"[Synthetics] Add global params sync internal API !! (#239284)\n\n## Summary\n\nThese two endpoints are added to provide bit more control around the\nsync task functionality, they are currently not being used in UI.\n\nFollowing two endpoints have been added to be used internally !!\n\n`/internal/synthetics/sync_global_params`\n\nThis will trigger syncing of global params to private locations. \n\n\n```\n`PUT /internal/synthetics/sync_global_params/_settings`\n{\n\tenable: false\n}\n```\n\nThis can be used to disable/enable the task which performs auto syncing\nof global params to private locations.\n\n---------\n\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>\nCo-authored-by: Justin Kambic <jk@elastic.co>","sha":"d40cdc43feac6995a0036c0b80d59584fea874be","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:feature","Team:actionable-obs","backport:version","author:obs-ux-management","v8.19.6","Team:obs-ux-management","v9.2.3","v8.19.9"],"title":"[Synthetics] Add global params sync internal API !!","number":239284,"url":"https://github.com/elastic/kibana/pull/239284","mergeCommit":{"message":"[Synthetics] Add global params sync internal API !! (#239284)\n\n## Summary\n\nThese two endpoints are added to provide bit more control around the\nsync task functionality, they are currently not being used in UI.\n\nFollowing two endpoints have been added to be used internally !!\n\n`/internal/synthetics/sync_global_params`\n\nThis will trigger syncing of global params to private locations. \n\n\n```\n`PUT /internal/synthetics/sync_global_params/_settings`\n{\n\tenable: false\n}\n```\n\nThis can be used to disable/enable the task which performs auto syncing\nof global params to private locations.\n\n---------\n\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>\nCo-authored-by: Justin Kambic <jk@elastic.co>","sha":"d40cdc43feac6995a0036c0b80d59584fea874be"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/245599","number":245599,"state":"OPEN"}]}] BACKPORT-->