### PR TITLE
apply padding when code editor in fullscreen with no line numbers

### DIFF
--- a/src/platform/packages/shared/shared-ux/code_editor/impl/mods/hooks/use_fullscreen.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/mods/hooks/use_fullscreen.tsx
@@ -30,6 +30,14 @@ const getFullscreenStyles = (euiTheme: UseEuiTheme['euiTheme']) => {
       left: 0;
       top: 0;
       background: ${euiTheme.colors.body};
+
+      &
+        .monaco-editor
+        .margin:not(:has(.line-numbers))
+        + .monaco-scrollable-element
+        .monaco-mouse-cursor-text {
+        padding: 0 ${euiTheme.size.base};
+      }
     `,
   };
 };


### PR DESCRIPTION
## Summary

Closes #219275

Applies padding when code editor is in fullscreen mode with no line numbers being displayed.

### Before
<img width="1890" height="415" alt="519711318-171c648a-963a-46bd-b0da-e479f10991c9" src="https://github.com/user-attachments/assets/d2ca04f3-6711-47b6-8c43-15d9ba69ea53" />

### After
<img width="2560" height="1265" alt="Screenshot 2025-12-09 at 11 52 31" src="https://github.com/user-attachments/assets/ff73a206-a55d-442b-bab4-1c40bb650aff" />


<!--

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


-->


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->