### PR TITLE
Update documentation instructions to take into account new documentation framework

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/README.md
+++ b/x-pack/platform/plugins/shared/stack_connectors/README.md
@@ -408,9 +408,9 @@ Connectors that take URLs or hostnames should check that those values are allowe
 
 ## Documentation
 
-You should create asciidoc for the new connector type. Add an entry to the connector type index - [`docs/user/alerting/action-types.asciidoc`](../../../../../docs/user/alerting/action-types.asciidoc), which points to a new document for the connector type that should be in the directory [`docs/user/alerting/action-types`](../../../docs/user/alerting/action-types).
+You should create markdown docs for the new connector type. Add an entry to appropriate location in the table of content - [`docs/reference/toc.yml`](../../../../../docs/reference/toc.yml), which points to a new document for the connector type that should be in the [`docs/reference/connectors-kibana`](../../../../../docs/reference/connectors-kibana) directory.
 
-We suggest following the template provided in `docs/action-type-template.asciidoc`. The [Email action type](https://www.elastic.co/guide/en/kibana/master/email-action-type.html) is an example of documentation created following the template.
+We suggest following the template provided in `docs/action-type-template.md`. The [Email action type](https://www.elastic.co/docs/reference/kibana/connectors-kibana/email-action-type) is an example of documentation created following the template.
 
 ## Tests
 


### PR DESCRIPTION
Updated documentation instructions for new connector types to reflect the use of markdown instead of asciidoc and revised the related file paths.

