### PR TITLE
🌊 Streams: Fix unsaved classic stream last changed

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -587,15 +587,15 @@ export class StreamsClient {
   private getDataStreamAsIngestStream(
     dataStream: IndicesDataStream
   ): Streams.ClassicStream.Definition {
-    const now = new Date().toISOString();
+    const timestamp = new Date(0).toISOString();
 
     const definition: Streams.ClassicStream.Definition = {
       name: dataStream.name,
       description: '',
-      updated_at: now,
+      updated_at: timestamp,
       ingest: {
         lifecycle: { inherit: {} },
-        processing: { steps: [], updated_at: now },
+        processing: { steps: [], updated_at: timestamp },
         settings: {},
         classic: {},
         failure_store: { inherit: {} },

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/outdated_documents.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/outdated_documents.spec.ts
@@ -44,6 +44,17 @@ test.describe('Stream data processing - outdated documents', { tag: ['@ess', '@s
       docsPerMinute: INGESTION_RATE,
     });
 
+    // Set up basic processing to update the stream's updated_at timestamp to current time
+    await apiServices.streams.updateStreamProcessors(NEW_DOCUMENTS_STREAM, {
+      steps: [
+        {
+          action: 'set',
+          to: 'test_field',
+          value: 'test_value',
+        },
+      ],
+    });
+
     const oldDocsTime = moment().utc().subtract(1, 'day').toDate().getTime();
     oldDocumentsDateRange.from = moment(oldDocsTime)
       .utc()
@@ -58,6 +69,17 @@ test.describe('Stream data processing - outdated documents', { tag: ['@ess', '@s
       startTime: new Date(oldDocsTime - INGESTION_DURATION_MINUTES * 60 * 1000).toISOString(),
       endTime: new Date(oldDocsTime).toISOString(),
       docsPerMinute: INGESTION_RATE,
+    });
+
+    // Set up basic processing to update the stream's updated_at timestamp to current time
+    await apiServices.streams.updateStreamProcessors(OLD_DOCUMENTS_STREAM, {
+      steps: [
+        {
+          action: 'set',
+          to: 'test_field',
+          value: 'test_value',
+        },
+      ],
     });
 
     await apiServices.streams.forkStream('logs', EMPTY_STREAM, { always: {} });


### PR DESCRIPTION
Currently, a classic stream that was never saved shows up as being created right now, which triggers the "stale documents" error. This PR changes this to behave like an unmigrated existing stream.

cc @LucaWintergerst about this feature in general - we currently treat the timestamp as `event.ingested`, but this is not reliable for obvious reasons (e.g. backfills). In this case the warning can be confusing. Should we somehow make this clearer to the user or do you think it's fine?