### PR TITLE
Standardize disk sizes

### DIFF
--- a/.buildkite/pipeline-utils/agent_images.ts
+++ b/.buildkite/pipeline-utils/agent_images.ts
@@ -19,12 +19,14 @@ const DEFAULT_AGENT_IMAGE_CONFIG: BuildkiteAgentTargetingRule = {
   provider: 'gcp',
   image: 'family/kibana-ubuntu-2404',
   imageProject: ELASTIC_IMAGES_PROD_PROJECT,
+  diskSizeGb: 105,
 };
 
 const FIPS_AGENT_IMAGE_CONFIG: BuildkiteAgentTargetingRule = {
   provider: 'gcp',
   image: 'family/kibana-fips-ubuntu-2404',
   imageProject: ELASTIC_IMAGES_PROD_PROJECT,
+  diskSizeGb: 105,
 };
 
 const GITHUB_PR_LABELS = process.env.GITHUB_PR_LABELS ?? '';
@@ -61,7 +63,7 @@ function getAgentImageConfig({ returnYaml = false } = {}): string | BuildkiteAge
   return config;
 }
 
-const expandAgentQueue = (queueName: string = 'n2-4-spot') => {
+const expandAgentQueue = (queueName: string = 'n2-4-spot', diskSizeGb?: number) => {
   const [kind, cores, addition] = queueName.split('-');
   const additionalProps =
     {
@@ -72,6 +74,7 @@ const expandAgentQueue = (queueName: string = 'n2-4-spot') => {
   return {
     ...getAgentImageConfig(),
     machineType: `${kind}-standard-${cores}`,
+    ...(diskSizeGb ? { diskSizeGb } : {}),
     ...additionalProps,
   };
 };

--- a/.buildkite/pipeline-utils/buildkite/client.ts
+++ b/.buildkite/pipeline-utils/buildkite/client.ts
@@ -51,6 +51,7 @@ export interface BuildkiteAgentTargetingRule {
   machineType?: string;
   minCpuPlatform?: string;
   preemptible?: boolean;
+  diskSizeGb?: number;
 }
 
 export interface BuildkiteCommandStep {

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -340,10 +340,7 @@ export async function pickTestGroupRunOrder() {
             parallelism: unit.count,
             timeout_in_minutes: 120,
             key: 'jest',
-            agents: {
-              ...expandAgentQueue('n2-4-spot'),
-              diskSizeGb: 115,
-            },
+            agents: expandAgentQueue('n2-4-spot', 110),
             env: {
               SCOUT_TARGET_TYPE: 'local',
             },
@@ -365,7 +362,7 @@ export async function pickTestGroupRunOrder() {
             parallelism: integration.count,
             timeout_in_minutes: 120,
             key: 'jest-integration',
-            agents: expandAgentQueue('n2-4-spot'),
+            agents: expandAgentQueue('n2-4-spot', 105),
             env: {
               SCOUT_TARGET_TYPE: 'local',
             },
@@ -403,7 +400,7 @@ export async function pickTestGroupRunOrder() {
                   label: title,
                   command: getRequiredEnv('FTR_CONFIGS_SCRIPT'),
                   timeout_in_minutes: 120,
-                  agents: expandAgentQueue(queue),
+                  agents: expandAgentQueue(queue, 105),
                   env: {
                     SCOUT_TARGET_TYPE: 'local',
                     FTR_CONFIG_GROUP_KEY: key,

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -10,7 +10,6 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-      diskSizeGb: 115
     retry:
       automatic:
         - exit_status: '*'
@@ -54,7 +53,7 @@ steps:
       provider: gcp
       machineType: n2-highcpu-8
       preemptible: true
-      diskSizeGb: 115
+      diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -69,7 +68,7 @@ steps:
       provider: gcp
       machineType: n2-standard-2
       preemptible: true
-      diskSizeGb: 115
+      diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -84,7 +83,7 @@ steps:
       provider: gcp
       machineType: n2-standard-16
       preemptible: true
-      diskSizeGb: 115
+      diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -99,7 +98,7 @@ steps:
       provider: gcp
       machineType: n2-standard-32
       preemptible: true
-      diskSizeGb: 115
+      diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -116,7 +115,7 @@ steps:
       diskType: 'hyperdisk-balanced'
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c
-      diskSizeGb: 115
+      diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -148,7 +147,7 @@ steps:
       provider: gcp
       machineType: n2-highmem-4
       preemptible: true
-      diskSizeGb: 115
+      diskSizeGb: 105
     timeout_in_minutes: 80
     retry:
       automatic:
@@ -164,7 +163,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-      diskSizeGb: 115
+      diskSizeGb: 105
     timeout_in_minutes: 10
     depends_on:
       - build
@@ -181,7 +180,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
-      diskSizeGb: 115
+      diskSizeGb: 105
     timeout_in_minutes: 10
     env:
       JEST_UNIT_SCRIPT: '.buildkite/scripts/steps/test/jest.sh'
@@ -199,7 +198,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 115
+      diskSizeGb: 105
     key: build_scout_tests
     timeout_in_minutes: 15
     depends_on:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -5,7 +5,6 @@ steps:
     id: pre_build
     agents:
       machineType: n2-standard-2
-      diskSizeGb: 115
 
   - wait
 
@@ -39,7 +38,7 @@ steps:
     agents:
       machineType: n2-highcpu-8
       preemptible: true
-      diskSizeGb: 115
+      diskSizeGb: 105
     key: quick_checks
     timeout_in_minutes: 60
     retry:
@@ -53,7 +52,7 @@ steps:
     agents:
       machineType: n2-standard-2
       preemptible: true
-      diskSizeGb: 115
+      diskSizeGb: 105
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -65,7 +64,7 @@ steps:
     agents:
       machineType: n2-standard-16
       preemptible: true
-      diskSizeGb: 115
+      diskSizeGb: 105
     key: linting
     timeout_in_minutes: 60
     retry:
@@ -78,7 +77,7 @@ steps:
     agents:
       machineType: n2-standard-32
       preemptible: true
-      diskSizeGb: 115
+      diskSizeGb: 105
     key: linting_with_types
     timeout_in_minutes: 60
     retry:
@@ -105,7 +104,7 @@ steps:
       diskType: 'hyperdisk-balanced'
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c
-      diskSizeGb: 115
+      diskSizeGb: 105
     key: check_types
     timeout_in_minutes: 60
     retry:
@@ -119,7 +118,6 @@ steps:
     label: Mark CI Stats as ready
     agents:
       machineType: n2-standard-2
-      diskSizeGb: 115
     timeout_in_minutes: 10
     depends_on:
       - build
@@ -134,7 +132,7 @@ steps:
     agents:
       machineType: n2-highmem-4
       preemptible: true
-      diskSizeGb: 115
+      diskSizeGb: 105
     key: build_api_docs
     timeout_in_minutes: 90
     retry:


### PR DESCRIPTION
## Summary
Increases disk sizes across the board for FTR and Jest integration tests to 105G, reduces allocated disk space from 115->105 in several other cases. 

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->