### PR TITLE
Improve error suppression for background telemetry job

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/server/services/data_telemetry/helpers.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/services/data_telemetry/helpers.ts
@@ -673,14 +673,16 @@ async function safeEsCall<T>(fn: () => Promise<T>): Promise<T> {
   } catch (error) {
     // Handle transient errors during telemetry collection:
     // - 404: index/resource not found
-    // - Custom ES errors: deleted or unavailable resources
+    // - Custom ES errors: deleted, unavailable, or unknown resources
     // - Cluster state errors: master not discovered, cluster blocks
     const is404 = error.meta?.statusCode === 404 || error.meta?.body?.status === 404;
     const isCustomError = error.meta?.body?.ok === false;
     const errorMessage = error.meta?.body?.message?.toLowerCase() || '';
     const errorType = error.meta?.body?.error?.type || '';
     const isTransientResourceError =
-      errorMessage.includes('deleted') || errorMessage.includes('unavailable');
+      errorMessage.includes('deleted') ||
+      errorMessage.includes('unavailable') ||
+      errorMessage.includes('unknown');
     const isClusterStateError =
       errorType === 'master_not_discovered_exception' ||
       errorType === 'cluster_block_exception' ||


### PR DESCRIPTION
Fixes https://github.com/elastic/observability-error-backlog/issues/48

Resources can be deleted, unavailable, but also "unknown" - the telemetry job should be robust against this and don't throw.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->