### PR TITLE
[Agent Builder] Update attachment rendering design

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/attachment_pill.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/attachment_pill.tsx
@@ -5,7 +5,16 @@
  * 2.0.
  */
 
-import { EuiBadge } from '@elastic/eui';
+import { css } from '@emotion/css';
+import {
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiButtonIcon,
+  EuiIcon,
+  useEuiTheme,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
 import type { Attachment } from '@kbn/onechat-common/attachments';
@@ -21,39 +30,76 @@ export interface AttachmentPillProps {
 }
 
 const DEFAULT_ICON = 'document';
-const REMOVE_ICON = 'cross';
 
 export const AttachmentPill: React.FC<AttachmentPillProps> = ({
   attachment,
   onRemoveAttachment,
 }) => {
   const { attachmentsService } = useOnechatServices();
+  const { euiTheme } = useEuiTheme();
   const uiDefinition = attachmentsService.getAttachmentUiDefinition(attachment.type);
   const [isHovered, setIsHovered] = useState(false);
 
   const displayName = uiDefinition?.getLabel(attachment) ?? attachment.type;
   const canRemoveAttachment = Boolean(onRemoveAttachment);
-  const defaultIconType = uiDefinition?.getIcon?.() ?? DEFAULT_ICON;
-  const iconType = canRemoveAttachment && isHovered ? REMOVE_ICON : defaultIconType;
+  const iconType = uiDefinition?.getIcon?.() ?? DEFAULT_ICON;
+
+  const iconContainerStyles = css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: ${euiTheme.size.xl};
+    height: ${euiTheme.size.xl};
+    border-radius: ${euiTheme.border.radius.small};
+    background-color: ${euiTheme.colors.backgroundBasePrimary};
+  `;
+
+  const titleStyles = css`
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-word;
+  `;
 
   return (
-    <EuiBadge
-      onMouseEnter={() => {
-        setIsHovered(true);
-      }}
-      onMouseLeave={() => {
-        setIsHovered(false);
-      }}
-      color="default"
-      iconType={iconType}
-      iconSide="left"
-      iconOnClick={() => {
-        onRemoveAttachment?.();
-      }}
-      iconOnClickAriaLabel={canRemoveAttachment ? removeAriaLabel : undefined}
+    <EuiPanel
+      hasShadow={false}
+      hasBorder
+      color="subdued"
+      paddingSize="s"
+      css={css`
+        max-width: 200px;
+        border: ${euiTheme.border.width.thin} solid ${euiTheme.colors.darkShade};
+      `}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
       data-test-subj={`onechatAttachmentPill-${attachment.id}`}
     >
-      {displayName}
-    </EuiBadge>
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <div className={iconContainerStyles}>
+            <EuiIcon type={iconType} size="m" color="primary" />
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem style={{ minWidth: 0 }}>
+          <EuiText size="xs" className={titleStyles}>
+            <strong>{displayName}</strong>
+          </EuiText>
+        </EuiFlexItem>
+        {canRemoveAttachment && isHovered && (
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon
+              iconType="cross"
+              size="xs"
+              color="text"
+              aria-label={removeAriaLabel}
+              onClick={onRemoveAttachment}
+            />
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    </EuiPanel>
   );
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/attachment_pills_row.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/attachment_pills_row.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiBadgeGroup } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, type EuiFlexGroupProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import type { Attachment, AttachmentInput } from '@kbn/onechat-common/attachments';
@@ -15,6 +15,7 @@ import { useConversationContext } from '../../../context/conversation/conversati
 export interface AttachmentPillsRowProps {
   attachments: AttachmentInput[] | Attachment[];
   removable?: boolean;
+  justifyContent?: EuiFlexGroupProps['justifyContent'];
 }
 
 const labels = {
@@ -26,6 +27,7 @@ const labels = {
 export const AttachmentPillsRow: React.FC<AttachmentPillsRowProps> = ({
   attachments,
   removable = false,
+  justifyContent = 'flexStart',
 }) => {
   const { removeAttachment } = useConversationContext();
 
@@ -34,19 +36,23 @@ export const AttachmentPillsRow: React.FC<AttachmentPillsRowProps> = ({
   }
 
   return (
-    <EuiBadgeGroup
+    <EuiFlexGroup
       gutterSize="s"
+      wrap
+      responsive={false}
+      justifyContent={justifyContent}
       role="list"
       aria-label={labels.attachments}
       data-test-subj="onechatAttachmentPillsRow"
     >
       {attachments.map((attachment, index) => (
-        <AttachmentPill
-          key={attachment.id ?? `${attachment.type}-${index}`}
-          attachment={attachment as Attachment}
-          onRemoveAttachment={removable ? () => removeAttachment?.(index) : undefined}
-        />
+        <EuiFlexItem key={attachment.id ?? `${attachment.type}-${index}`} grow={false}>
+          <AttachmentPill
+            attachment={attachment as Attachment}
+            onRemoveAttachment={removable ? () => removeAttachment?.(index) : undefined}
+          />
+        </EuiFlexItem>
       ))}
-    </EuiBadgeGroup>
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_input/conversation_input.tsx
@@ -194,7 +194,12 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({ onSubmit }
   return (
     <InputContainer isDisabled={isInputDisabled}>
       {visibleAttachments.length > 0 && (
-        <EuiFlexItem grow={false}>
+        <EuiFlexItem
+          grow={false}
+          css={css`
+            padding-left: ${euiTheme.size.m};
+          `}
+        >
           <AttachmentPillsRow attachments={visibleAttachments} removable />
         </EuiFlexItem>
       )}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_input.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_rounds/round_input.tsx
@@ -16,7 +16,7 @@ import {
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import React, { useMemo } from 'react';
-import type { Attachment } from '@kbn/onechat-common/attachments';
+import { type Attachment } from '@kbn/onechat-common/attachments';
 import { ROUNDED_BORDER_RADIUS_LARGE } from '../conversation.styles';
 import { AttachmentPillsRow } from '../conversation_input/attachment_pills_row';
 
@@ -74,7 +74,7 @@ export const RoundInput = ({ input, attachments }: RoundInputProps) => {
       </EuiPanel>
       {visibleAttachments.length > 0 && (
         <EuiFlexItem grow={false}>
-          <AttachmentPillsRow attachments={visibleAttachments} />
+          <AttachmentPillsRow attachments={visibleAttachments} justifyContent="flexEnd" />
         </EuiFlexItem>
       )}
     </EuiFlexGroup>


### PR DESCRIPTION
## Summary

Update designs:
- attachment row wraps
- attachment label can also wraps (end we apply ellipsis if overflows)

dark:
<img width="793" height="893" alt="Screenshot 2025-12-09 at 13 11 29" src="https://github.com/user-attachments/assets/fb94603b-c219-4065-9dcb-efc5aca62538" />
light:
<img width="1014" height="932" alt="Screenshot 2025-12-09 at 13 10 20" src="https://github.com/user-attachments/assets/2598ded1-3445-489b-99d7-01a2476e9d66" />



