### PR TITLE
[CPS] remove readonly custom message and change Lens access

### DIFF
--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker.tsx
@@ -34,7 +34,6 @@ export interface ProjectPickerProps {
   onProjectRoutingChange: (projectRouting: ProjectRouting) => void;
   fetchProjects: () => Promise<ProjectsData | null>;
   isReadonly?: boolean;
-  readonlyCustomTitle?: string;
 }
 
 export const ProjectPicker = ({
@@ -42,7 +41,6 @@ export const ProjectPicker = ({
   onProjectRoutingChange,
   fetchProjects,
   isReadonly = false,
-  readonlyCustomTitle,
 }: ProjectPickerProps) => {
   const [showPopover, setShowPopover] = useState(false);
   const styles = useMemoCss(projectPickerStyles);
@@ -120,7 +118,6 @@ export const ProjectPicker = ({
           onProjectRoutingChange={onProjectRoutingChange}
           fetchProjects={fetchProjects}
           isReadonly={isReadonly}
-          readonlyCustomTitle={readonlyCustomTitle}
         />
       </EuiPopover>
     </EuiTourStep>

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_container.test.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_container.test.tsx
@@ -14,7 +14,7 @@ import { EuiThemeProvider } from '@elastic/eui';
 import { I18nProvider } from '@kbn/i18n-react';
 import { BehaviorSubject } from 'rxjs';
 import type { ProjectRouting } from '@kbn/es-query';
-import type { CPSProject, ICPSManager, ProjectPickerAccessInfo } from '../types';
+import type { CPSProject, ICPSManager } from '../types';
 import { ProjectRoutingAccess } from '../types';
 import { ProjectPickerContainer } from './project_picker_container';
 
@@ -36,7 +36,7 @@ describe('ProjectPickerContainer', () => {
   ];
 
   let mockProjectRouting$: BehaviorSubject<ProjectRouting | undefined>;
-  let mockProjectPickerAccess$: BehaviorSubject<ProjectPickerAccessInfo>;
+  let mockProjectPickerAccess$: BehaviorSubject<ProjectRoutingAccess>;
   let mockCPSManager: ICPSManager;
 
   const mockFetchProjects = jest.fn().mockResolvedValue({
@@ -66,10 +66,9 @@ describe('ProjectPickerContainer', () => {
 
     mockProjectRouting$ = new BehaviorSubject<ProjectRouting | undefined>(undefined);
     // Default to EDITABLE access (dashboards app on individual page)
-    mockProjectPickerAccess$ = new BehaviorSubject<ProjectPickerAccessInfo>({
-      access: ProjectRoutingAccess.EDITABLE,
-      readonlyMessage: undefined,
-    });
+    mockProjectPickerAccess$ = new BehaviorSubject<ProjectRoutingAccess>(
+      ProjectRoutingAccess.EDITABLE
+    );
 
     mockCPSManager = {
       fetchProjects: mockFetchProjects,
@@ -114,10 +113,7 @@ describe('ProjectPickerContainer', () => {
 
   describe('project routing access control', () => {
     it('should have EDITABLE access when on dashboard individual page', async () => {
-      mockProjectPickerAccess$.next({
-        access: ProjectRoutingAccess.EDITABLE,
-        readonlyMessage: undefined,
-      });
+      mockProjectPickerAccess$.next(ProjectRoutingAccess.EDITABLE);
 
       await renderProjectPicker();
       const button = screen.getByTestId('project-picker-button');
@@ -125,10 +121,7 @@ describe('ProjectPickerContainer', () => {
     });
 
     it('should have DISABLED access when on dashboard listing page', async () => {
-      mockProjectPickerAccess$.next({
-        access: ProjectRoutingAccess.DISABLED,
-        readonlyMessage: undefined,
-      });
+      mockProjectPickerAccess$.next(ProjectRoutingAccess.DISABLED);
 
       await renderProjectPicker();
       const button = screen.getByTestId('project-picker-button');
@@ -136,10 +129,7 @@ describe('ProjectPickerContainer', () => {
     });
 
     it('should have EDITABLE access when on dashboard create page', async () => {
-      mockProjectPickerAccess$.next({
-        access: ProjectRoutingAccess.EDITABLE,
-        readonlyMessage: undefined,
-      });
+      mockProjectPickerAccess$.next(ProjectRoutingAccess.EDITABLE);
 
       await renderProjectPicker();
       const button = screen.getByTestId('project-picker-button');
@@ -147,10 +137,7 @@ describe('ProjectPickerContainer', () => {
     });
 
     it('should have DISABLED access when on a different app', async () => {
-      mockProjectPickerAccess$.next({
-        access: ProjectRoutingAccess.DISABLED,
-        readonlyMessage: undefined,
-      });
+      mockProjectPickerAccess$.next(ProjectRoutingAccess.DISABLED);
 
       await renderProjectPicker();
       const button = screen.getByTestId('project-picker-button');
@@ -158,10 +145,7 @@ describe('ProjectPickerContainer', () => {
     });
 
     it('should default to DISABLED access when no app state is provided', async () => {
-      mockProjectPickerAccess$.next({
-        access: ProjectRoutingAccess.DISABLED,
-        readonlyMessage: undefined,
-      });
+      mockProjectPickerAccess$.next(ProjectRoutingAccess.DISABLED);
 
       await renderProjectPicker();
       const button = screen.getByTestId('project-picker-button');
@@ -169,25 +153,11 @@ describe('ProjectPickerContainer', () => {
     });
 
     it('should have READONLY access when on Lens editor page', async () => {
-      mockProjectPickerAccess$.next({
-        access: ProjectRoutingAccess.READONLY,
-        readonlyMessage: 'Please adjust project scope for each layer in the Lens editor.',
-      });
+      mockProjectPickerAccess$.next(ProjectRoutingAccess.READONLY);
 
       await renderProjectPicker();
       const button = screen.getByTestId('project-picker-button');
       // Button should not be disabled but should be in readonly mode
-      expect(button).not.toHaveAttribute('disabled');
-    });
-
-    it('should have READONLY access when on Lens listing page', async () => {
-      mockProjectPickerAccess$.next({
-        access: ProjectRoutingAccess.READONLY,
-        readonlyMessage: 'Please adjust project scope for each layer in the Lens editor.',
-      });
-
-      await renderProjectPicker();
-      const button = screen.getByTestId('project-picker-button');
       expect(button).not.toHaveAttribute('disabled');
     });
   });

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_container.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_container.tsx
@@ -25,16 +25,13 @@ interface ProjectPickerContainerProps {
  */
 export const ProjectPickerContainer: React.FC<ProjectPickerContainerProps> = ({ cpsManager }) => {
   const { projectRouting, updateProjectRouting } = useProjectRouting(cpsManager);
-  const accessInfo = useObservable(cpsManager.getProjectPickerAccess$(), {
-    access: ProjectRoutingAccess.DISABLED,
-    readonlyMessage: undefined,
-  });
+  const access = useObservable(cpsManager.getProjectPickerAccess$(), ProjectRoutingAccess.DISABLED);
 
   const fetchProjects = useCallback(() => {
     return cpsManager.fetchProjects();
   }, [cpsManager]);
 
-  if (accessInfo.access === ProjectRoutingAccess.DISABLED) {
+  if (access === ProjectRoutingAccess.DISABLED) {
     return <DisabledProjectPicker />;
   }
 
@@ -43,8 +40,7 @@ export const ProjectPickerContainer: React.FC<ProjectPickerContainerProps> = ({ 
       projectRouting={projectRouting}
       onProjectRoutingChange={updateProjectRouting}
       fetchProjects={fetchProjects}
-      isReadonly={accessInfo.access === ProjectRoutingAccess.READONLY}
-      readonlyCustomTitle={accessInfo.readonlyMessage}
+      isReadonly={access === ProjectRoutingAccess.READONLY}
     />
   );
 };

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_content.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_content.tsx
@@ -34,7 +34,6 @@ export interface ProjectPickerContentProps {
   onProjectRoutingChange: (projectRouting: ProjectRouting) => void;
   fetchProjects: () => Promise<ProjectsData | null>;
   isReadonly?: boolean;
-  readonlyCustomTitle?: string;
 }
 
 const projectPickerOptions = [
@@ -55,7 +54,6 @@ export const ProjectPickerContent = ({
   onProjectRoutingChange,
   fetchProjects,
   isReadonly = false,
-  readonlyCustomTitle,
 }: ProjectPickerContentProps) => {
   const styles = useMemoCss(projectPickerContentStyles);
   const { originProject, linkedProjects } = useFetchProjects(fetchProjects);
@@ -104,7 +102,7 @@ export const ProjectPickerContent = ({
           <EuiCallOut
             size="s"
             css={styles.callout}
-            title={readonlyCustomTitle ?? strings.getProjectPickerReadonlyCallout()}
+            title={strings.getProjectPickerReadonlyCallout()}
             iconType="info"
           />
         )}

--- a/src/platform/packages/shared/kbn-cps-utils/index.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/index.ts
@@ -9,13 +9,7 @@
 
 export type { ProjectPickerProps } from './components/project_picker';
 export type { ProjectPickerContentProps } from './components/project_picker_content';
-export type {
-  CPSProject,
-  ProjectTagsResponse,
-  ICPSManager,
-  ProjectsData,
-  ProjectPickerAccessInfo,
-} from './types';
+export type { CPSProject, ProjectTagsResponse, ICPSManager, ProjectsData } from './types';
 export type { ProjectRoutingValue } from './constants';
 export { ProjectPicker } from './components/project_picker';
 export { ProjectPickerContent } from './components/project_picker_content';

--- a/src/platform/packages/shared/kbn-cps-utils/types.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/types.ts
@@ -42,11 +42,6 @@ export interface ProjectsData {
   linkedProjects: CPSProject[];
 }
 
-export interface ProjectPickerAccessInfo {
-  access: ProjectRoutingAccess;
-  readonlyMessage?: string;
-}
-
 export interface ICPSManager {
   fetchProjects(): Promise<ProjectsData | null>;
   refresh(): Promise<ProjectsData | null>;
@@ -54,5 +49,5 @@ export interface ICPSManager {
   setProjectRouting(projectRouting: ProjectRouting | undefined): void;
   getProjectRouting(): ProjectRouting | undefined;
   getDefaultProjectRouting(): ProjectRouting;
-  getProjectPickerAccess$(): Observable<ProjectPickerAccessInfo>;
+  getProjectPickerAccess$(): Observable<ProjectRoutingAccess>;
 }

--- a/src/platform/plugins/shared/cps/moon.yml
+++ b/src/platform/plugins/shared/cps/moon.yml
@@ -24,7 +24,6 @@ dependsOn:
   - '@kbn/cps-utils'
   - '@kbn/es-query'
   - '@kbn/i18n-react'
-  - '@kbn/i18n'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/cps/public/services/access_control.test.ts
+++ b/src/platform/plugins/shared/cps/public/services/access_control.test.ts
@@ -10,7 +10,6 @@
 import { ProjectRoutingAccess } from '@kbn/cps-utils';
 import {
   getProjectRoutingAccess,
-  getReadonlyMessage,
   DEFAULT_ACCESS_CONTROL_CONFIG,
   type AccessControlConfig,
 } from './access_control';
@@ -56,22 +55,11 @@ describe('Access Control Configuration', () => {
         );
       });
 
-      it('should return READONLY for lens editor pages with hash only', () => {
-        expect(getProjectRoutingAccess('lens', '#/edit/my-lens')).toBe(
-          ProjectRoutingAccess.READONLY
-        );
-      });
-
-      it('should return READONLY for lens editor pages with full path', () => {
+      it('should return EDITABLE for lens editor pages with full path', () => {
         expect(getProjectRoutingAccess('lens', '/app/lens#/edit/my-lens')).toBe(
-          ProjectRoutingAccess.READONLY
+          ProjectRoutingAccess.EDITABLE
         );
       });
-
-      it('should return READONLY for lens listing page', () => {
-        expect(getProjectRoutingAccess('lens', '#/')).toBe(ProjectRoutingAccess.READONLY);
-      });
-
       it('should return DISABLED for unknown apps', () => {
         expect(getProjectRoutingAccess('management', '#/')).toBe(ProjectRoutingAccess.DISABLED);
       });
@@ -146,34 +134,6 @@ describe('Access Control Configuration', () => {
     });
   });
 
-  describe('getReadonlyMessage', () => {
-    it('should return custom message from default config for lens', () => {
-      expect(getReadonlyMessage('lens')).toBe(
-        'Please adjust project scope for each layer in the Lens editor.'
-      );
-    });
-
-    it('should return undefined for apps without custom message', () => {
-      expect(getReadonlyMessage('dashboards')).toBeUndefined();
-    });
-
-    it('should return custom message from custom config', () => {
-      const config: AccessControlConfig = {
-        myApp: {
-          defaultAccess: ProjectRoutingAccess.READONLY,
-          readonlyMessage: 'Custom message here',
-        },
-      };
-
-      expect(getReadonlyMessage('myApp', config)).toBe('Custom message here');
-    });
-
-    it('should return undefined for unconfigured apps', () => {
-      const config: AccessControlConfig = {};
-      expect(getReadonlyMessage('unknownApp', config)).toBeUndefined();
-    });
-  });
-
   describe('DEFAULT_ACCESS_CONTROL_CONFIG', () => {
     it('should have configuration for expected apps', () => {
       expect(DEFAULT_ACCESS_CONTROL_CONFIG).toHaveProperty('dashboards');
@@ -184,10 +144,6 @@ describe('Access Control Configuration', () => {
 
     it('should have route rules for dashboards', () => {
       expect(DEFAULT_ACCESS_CONTROL_CONFIG.dashboards.routeRules).toHaveLength(1);
-    });
-
-    it('should have readonly message for lens', () => {
-      expect(DEFAULT_ACCESS_CONTROL_CONFIG.lens.readonlyMessage).toBeDefined();
     });
   });
 });

--- a/src/platform/plugins/shared/cps/public/services/access_control.ts
+++ b/src/platform/plugins/shared/cps/public/services/access_control.ts
@@ -8,7 +8,6 @@
  */
 
 import { ProjectRoutingAccess } from '@kbn/cps-utils';
-import { i18n } from '@kbn/i18n';
 
 /**
  * Rule for determining access based on route pattern
@@ -55,8 +54,8 @@ export type AccessControlConfig = Record<string, AppAccessConfig>;
  * | discover   | all routes             | EDITABLE     | All discover pages                 |
  * | visualize  | type:vega in route     | EDITABLE     | Vega visualizations only           |
  * | visualize  | other routes           | DISABLED     | Other visualization types          |
- * | lens       | all routes             | READONLY     | All lens pages (read-only)         |
- * | maps       | all routes             | EDITABLE     | All maps pages (read-only)         |
+ * | lens       | all routes             | EDITABLE     | All lens pages       |
+ * | maps       | all routes             | EDITABLE     | All maps pages
  * | all others | all routes             | DISABLED     | Default behavior for unknown apps  |
  */
 export const DEFAULT_ACCESS_CONTROL_CONFIG: AccessControlConfig = {
@@ -82,10 +81,7 @@ export const DEFAULT_ACCESS_CONTROL_CONFIG: AccessControlConfig = {
     ],
   },
   lens: {
-    defaultAccess: ProjectRoutingAccess.READONLY,
-    readonlyMessage: i18n.translate('cps.accessControl.lensReadonlyMessage', {
-      defaultMessage: 'Please adjust project scope for each layer in the Lens editor.',
-    }),
+    defaultAccess: ProjectRoutingAccess.EDITABLE,
   },
   maps: {
     defaultAccess: ProjectRoutingAccess.EDITABLE,
@@ -113,11 +109,4 @@ export const getProjectRoutingAccess = (
     }
   }
   return appConfig.defaultAccess;
-};
-
-export const getReadonlyMessage = (
-  currentAppId?: string,
-  config: AccessControlConfig = DEFAULT_ACCESS_CONTROL_CONFIG
-): string | undefined => {
-  return currentAppId ? config[currentAppId]?.readonlyMessage : undefined;
 };

--- a/src/platform/plugins/shared/cps/public/services/async_services.ts
+++ b/src/platform/plugins/shared/cps/public/services/async_services.ts
@@ -7,5 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { getProjectRoutingAccess, getReadonlyMessage } from './access_control';
+export { getProjectRoutingAccess } from './access_control';
 export { createProjectFetcher } from './project_fetcher';

--- a/src/platform/plugins/shared/cps/tsconfig.json
+++ b/src/platform/plugins/shared/cps/tsconfig.json
@@ -15,7 +15,6 @@
     "@kbn/cps-utils",
     "@kbn/es-query",
     "@kbn/i18n-react",
-    "@kbn/i18n"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Simplifies API for CPS Project Picker, not allowing to add a readonly message, since this functionality is not needed anymore (Lens will support editable CPS picker)