### PR TITLE
[Security Solution] Disable diagnostic queries when telemetry was opted out

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/__mocks__/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/__mocks__/index.ts
@@ -9,6 +9,7 @@ import type { AnalyticsServiceStart, Logger } from '@kbn/core/server';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type { CircuitBreakingQueryExecutorImpl } from '../health_diagnostic_receiver';
 import { QueryType, Action } from '../health_diagnostic_service.types';
+import type { TelemetryConfigProvider } from '../../../../../common/telemetry_config/telemetry_config_provider';
 
 export const createMockLogger = (): jest.Mocked<Logger> =>
   ({
@@ -27,6 +28,16 @@ export const createMockTaskManager = (): jest.Mocked<TaskManagerStartContract> =
 export const createMockAnalytics = (): jest.Mocked<AnalyticsServiceStart> =>
   ({
     reportEvent: jest.fn(),
+  } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+export const createMockTelemetryConfigProvider = (
+  isOptedIn = true
+): jest.Mocked<TelemetryConfigProvider> =>
+  ({
+    getIsOptedIn: jest.fn().mockReturnValue(isOptedIn),
+    start: jest.fn(),
+    stop: jest.fn(),
+    getObservable: jest.fn(),
   } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
 export const createMockQueryExecutor = (): jest.Mocked<CircuitBreakingQueryExecutorImpl> =>

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.types.ts
@@ -11,6 +11,7 @@ import type {
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import type { CircuitBreakerResult } from './health_diagnostic_circuit_breakers.types';
+import type { TelemetryConfigProvider } from '../../../../common/telemetry_config/telemetry_config_provider';
 
 /**
  * Enum defining the types of actions that can be applied to data,
@@ -59,6 +60,7 @@ export interface HealthDiagnosticServiceStart {
   taskManager: TaskManagerStartContract;
   esClient: ElasticsearchClient;
   analytics: AnalyticsServiceStart;
+  telemetryConfigProvider: TelemetryConfigProvider;
 }
 
 export interface HealthDiagnosticService {

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -892,6 +892,7 @@ export class Plugin implements ISecuritySolutionPlugin {
         esClient: core.elasticsearch.client.asInternalUser,
         analytics: core.analytics,
         receiver: this.telemetryReceiver,
+        telemetryConfigProvider: this.telemetryConfigProvider,
       };
 
       this.healthDiagnosticService.start(serviceStart).catch((e) => {


### PR DESCRIPTION
## Summary

Even though we don't send EBT events when telemetry is opted out, this PR completely disables the diagnostic queries logic to avoid doing unnecessary work.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->