### PR TITLE
🌊 Streams: Show LLM errors properly

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/suggest_processing_pipeline_route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/suggest_processing_pipeline_route.ts
@@ -8,8 +8,9 @@
 import { z } from '@kbn/zod';
 import { Streams } from '@kbn/streams-schema';
 import { suggestProcessingPipeline } from '@kbn/streams-ai';
-import { from, map } from 'rxjs';
+import { from, map, catchError } from 'rxjs';
 import type { ServerSentEventBase } from '@kbn/sse-utils';
+import { createSSEInternalError } from '@kbn/sse-utils';
 import type { Observable } from 'rxjs';
 import { type FlattenRecord, flattenRecord } from '@kbn/streams-schema';
 import { type StreamlangDSL, type GrokProcessor, type DissectProcessor } from '@kbn/streamlang';
@@ -119,135 +120,139 @@ export const suggestProcessingPipelineRoute = createServerRoute({
     server,
     logger,
   }): Promise<SuggestProcessingPipelineResponse> => {
-    try {
-      logger.debug('[suggest_pipeline] Request received');
-      logger.debug(
-        `[suggest_pipeline] extracted_patterns: grok=${Boolean(
-          params.body.extracted_patterns?.grok
-        )} dissect=${Boolean(params.body.extracted_patterns?.dissect)}`
-      );
-      const isAvailableForTier = server.core.pricing.isFeatureAvailable(
-        STREAMS_TIERED_ML_FEATURE.id
-      );
-      if (!isAvailableForTier) {
-        throw new SecurityError('Cannot access API on the current pricing tier');
-      }
+    logger.debug('[suggest_pipeline] Request received');
+    logger.debug(
+      `[suggest_pipeline] extracted_patterns: grok=${Boolean(
+        params.body.extracted_patterns?.grok
+      )} dissect=${Boolean(params.body.extracted_patterns?.dissect)}`
+    );
 
-      const { inferenceClient, scopedClusterClient, streamsClient, fieldsMetadataClient } =
-        await getScopedClients({ request });
+    // Wrap entire logic in Observable so errors can be sent as SSE events
+    return from(
+      (async () => {
+        const isAvailableForTier = server.core.pricing.isFeatureAvailable(
+          STREAMS_TIERED_ML_FEATURE.id
+        );
+        if (!isAvailableForTier) {
+          throw new SecurityError('Cannot access API on the current pricing tier');
+        }
 
-      const stream = await streamsClient.getStream(params.path.name);
-      if (!Streams.ingest.all.Definition.is(stream)) {
-        throw new Error(`Stream ${stream.name} is not a valid ingest stream`);
-      }
+        const { inferenceClient, scopedClusterClient, streamsClient, fieldsMetadataClient } =
+          await getScopedClients({ request });
 
-      const abortController = new AbortController();
-      let parsingProcessor: GrokProcessor | DissectProcessor | undefined;
+        const stream = await streamsClient.getStream(params.path.name);
+        if (!Streams.ingest.all.Definition.is(stream)) {
+          throw new Error(`Stream ${stream.name} is not a valid ingest stream`);
+        }
 
-      if (params.body.extracted_patterns) {
-        const { grok, dissect } = params.body.extracted_patterns;
-        const candidatePromises: Array<
-          Promise<{
-            type: 'grok' | 'dissect';
-            processor: GrokProcessor | DissectProcessor;
-            parsedRate: number;
-          } | null>
-        > = [];
+        const abortController = new AbortController();
+        let parsingProcessor: GrokProcessor | DissectProcessor | undefined;
 
-        if (grok) {
-          logger.debug(
-            `[suggest_pipeline] (parallel) scheduling grok patternGroups=${grok.patternGroups.length} fieldName=${grok.fieldName}`
+        if (params.body.extracted_patterns) {
+          const { grok, dissect } = params.body.extracted_patterns;
+          const candidatePromises: Array<
+            Promise<{
+              type: 'grok' | 'dissect';
+              processor: GrokProcessor | DissectProcessor;
+              parsedRate: number;
+            } | null>
+          > = [];
+
+          if (grok) {
+            logger.debug(
+              `[suggest_pipeline] (parallel) scheduling grok patternGroups=${grok.patternGroups.length} fieldName=${grok.fieldName}`
+            );
+            candidatePromises.push(
+              processGrokPatterns({
+                patternGroups: grok.patternGroups,
+                fieldName: grok.fieldName,
+                streamName: stream.name,
+                connectorId: params.body.connector_id,
+                documents: params.body.documents,
+                inferenceClient,
+                scopedClusterClient,
+                streamsClient,
+                fieldsMetadataClient,
+                signal: abortController.signal,
+                logger,
+              })
+            );
+          }
+          if (dissect) {
+            logger.debug(
+              `[suggest_pipeline] (parallel) scheduling dissect messages=${dissect.messages.length} fieldName=${dissect.fieldName}`
+            );
+            candidatePromises.push(
+              processDissectPattern({
+                messages: dissect.messages,
+                fieldName: dissect.fieldName,
+                streamName: stream.name,
+                connectorId: params.body.connector_id,
+                documents: params.body.documents,
+                inferenceClient,
+                scopedClusterClient,
+                streamsClient,
+                fieldsMetadataClient,
+                signal: abortController.signal,
+                logger,
+              })
+            );
+          }
+
+          const results = await Promise.all(candidatePromises);
+          const candidates = results.filter(
+            (
+              r
+            ): r is {
+              type: 'grok' | 'dissect';
+              processor: GrokProcessor | DissectProcessor;
+              parsedRate: number;
+            } => r !== null
           );
-          candidatePromises.push(
-            processGrokPatterns({
-              patternGroups: grok.patternGroups,
-              fieldName: grok.fieldName,
-              streamName: stream.name,
-              connectorId: params.body.connector_id,
-              documents: params.body.documents,
-              inferenceClient,
+          candidates.forEach((c) =>
+            logger.debug(`[suggest_pipeline] Candidate type=${c.type} parsedRate=${c.parsedRate}`)
+          );
+          if (candidates.length > 0) {
+            candidates.sort((a, b) => b.parsedRate - a.parsedRate);
+            logger.debug(
+              `[suggest_pipeline] Selected processor type=${candidates[0].type} parsedRate=${candidates[0].parsedRate}`
+            );
+            parsingProcessor = candidates[0].processor;
+          }
+        }
+
+        return await suggestProcessingPipeline({
+          definition: stream,
+          inferenceClient: inferenceClient.bindTo({ connectorId: params.body.connector_id }),
+          parsingProcessor,
+          maxSteps: 4, // Limit reasoning steps for latency and token cost
+          signal: abortController.signal,
+          documents: params.body.documents,
+          esClient: scopedClusterClient.asCurrentUser,
+          fieldsMetadataClient,
+          simulatePipeline: (pipeline: StreamlangDSL) =>
+            simulateProcessing({
+              params: {
+                path: { name: stream.name },
+                body: { processing: pipeline, documents: params.body.documents },
+              },
               scopedClusterClient,
               streamsClient,
               fieldsMetadataClient,
-              signal: abortController.signal,
-              logger,
-            })
-          );
-        }
-        if (dissect) {
-          logger.debug(
-            `[suggest_pipeline] (parallel) scheduling dissect messages=${dissect.messages.length} fieldName=${dissect.fieldName}`
-          );
-          candidatePromises.push(
-            processDissectPattern({
-              messages: dissect.messages,
-              fieldName: dissect.fieldName,
-              streamName: stream.name,
-              connectorId: params.body.connector_id,
-              documents: params.body.documents,
-              inferenceClient,
-              scopedClusterClient,
-              streamsClient,
-              fieldsMetadataClient,
-              signal: abortController.signal,
-              logger,
-            })
-          );
-        }
-
-        const results = await Promise.all(candidatePromises);
-        const candidates = results.filter(
-          (
-            r
-          ): r is {
-            type: 'grok' | 'dissect';
-            processor: GrokProcessor | DissectProcessor;
-            parsedRate: number;
-          } => r !== null
-        );
-        candidates.forEach((c) =>
-          logger.debug(`[suggest_pipeline] Candidate type=${c.type} parsedRate=${c.parsedRate}`)
-        );
-        if (candidates.length > 0) {
-          candidates.sort((a, b) => b.parsedRate - a.parsedRate);
-          logger.debug(
-            `[suggest_pipeline] Selected processor type=${candidates[0].type} parsedRate=${candidates[0].parsedRate}`
-          );
-          parsingProcessor = candidates[0].processor;
-        }
-      }
-
-      const pipelinePromise = suggestProcessingPipeline({
-        definition: stream,
-        inferenceClient: inferenceClient.bindTo({ connectorId: params.body.connector_id }),
-        parsingProcessor,
-        maxSteps: 4, // Limit reasoning steps for latency and token cost
-        signal: abortController.signal,
-        documents: params.body.documents,
-        esClient: scopedClusterClient.asCurrentUser,
-        fieldsMetadataClient,
-        simulatePipeline: (pipeline: StreamlangDSL) =>
-          simulateProcessing({
-            params: {
-              path: { name: stream.name },
-              body: { processing: pipeline, documents: params.body.documents },
-            },
-            scopedClusterClient,
-            streamsClient,
-            fieldsMetadataClient,
-          }),
-      });
-
-      return from(pipelinePromise).pipe(
-        map((pipeline) => ({
-          type: 'suggested_processing_pipeline' as const,
-          pipeline,
-        }))
-      );
-    } catch (error) {
-      logger.error('Failed to generate pipeline suggestion:', error);
-      throw error;
-    }
+            }),
+        });
+      })()
+    ).pipe(
+      map((pipeline) => ({
+        type: 'suggested_processing_pipeline' as const,
+        pipeline,
+      })),
+      catchError((error) => {
+        logger.error('Failed to generate pipeline suggestion:', error);
+        // Convert error to SSE error event so it's sent to client with full message
+        throw createSSEInternalError(error.message || 'Failed to generate pipeline suggestion');
+      })
+    );
   },
 });
 

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/dissect_suggestions_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/dissect_suggestions_handler.ts
@@ -77,33 +77,26 @@ export const handleProcessingDissectSuggestions = async ({
   // Determine if we should use OTEL field names
   const useOtelFieldNames = await determineOtelFieldNameUsage(streamsClient, params.path.name);
 
-  try {
-    // Call LLM inference to review fields
-    const reviewResult = await callInferenceWithPrompt(
-      inferenceClient,
-      params.body.connector_id,
-      ReviewDissectFieldsPrompt,
-      params.body.sample_messages,
-      params.body.review_fields,
-      signal
-    );
+  // Call LLM inference to review fields
+  const reviewResult = await callInferenceWithPrompt(
+    inferenceClient,
+    params.body.connector_id,
+    ReviewDissectFieldsPrompt,
+    params.body.sample_messages,
+    params.body.review_fields,
+    signal
+  );
 
-    // Fetch field metadata for ECS/OTEL field name resolution
-    const fieldMetadata = await fetchFieldMetadata(
-      fieldsMetadataClient,
-      reviewResult.fields.map((field: { ecs_field: string }) => field.ecs_field)
-    );
+  // Fetch field metadata for ECS/OTEL field name resolution
+  const fieldMetadata = await fetchFieldMetadata(
+    fieldsMetadataClient,
+    reviewResult.fields.map((field: { ecs_field: string }) => field.ecs_field)
+  );
 
-    return {
-      log_source: reviewResult.log_source,
-      fields: mapFields(reviewResult.fields, fieldMetadata, useOtelFieldNames),
-    };
-  } catch (error) {
-    logger.error(error);
-    throw new Error(
-      'Failed to generate dissect suggestions due to error with the AI generation, please try again later.'
-    );
-  }
+  return {
+    log_source: reviewResult.log_source,
+    fields: mapFields(reviewResult.fields, fieldMetadata, useOtelFieldNames),
+  };
 };
 
 export function mapFields(

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/grok_suggestions_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/grok_suggestions_handler.ts
@@ -76,33 +76,26 @@ export const handleProcessingGrokSuggestions = async ({
 }: ProcessingGrokSuggestionsHandlerDeps) => {
   const stream = await streamsClient.getStream(params.path.name);
 
-  try {
-    // Call LLM inference to review fields
-    const reviewResult = await callInferenceWithPrompt(
-      inferenceClient,
-      params.body.connector_id,
-      ReviewFieldsPrompt,
-      params.body.sample_messages,
-      params.body.review_fields,
-      signal
-    );
+  // Call LLM inference to review fields
+  const reviewResult = await callInferenceWithPrompt(
+    inferenceClient,
+    params.body.connector_id,
+    ReviewFieldsPrompt,
+    params.body.sample_messages,
+    params.body.review_fields,
+    signal
+  );
 
-    // Fetch field metadata for ECS/OTEL field name resolution
-    const fieldMetadata = await fetchFieldMetadata(
-      fieldsMetadataClient,
-      reviewResult.fields.map((field: { ecs_field: string }) => field.ecs_field)
-    );
+  // Fetch field metadata for ECS/OTEL field name resolution
+  const fieldMetadata = await fetchFieldMetadata(
+    fieldsMetadataClient,
+    reviewResult.fields.map((field: { ecs_field: string }) => field.ecs_field)
+  );
 
-    return {
-      log_source: reviewResult.log_source,
-      fields: mapFields(reviewResult.fields, fieldMetadata, isOtelStream(stream)),
-    };
-  } catch (error) {
-    logger.error(error);
-    throw new Error(
-      'Failed to generate grok suggestions due to error with the AI generation, please try again later.'
-    );
-  }
+  return {
+    log_source: reviewResult.log_source,
+    fields: mapFields(reviewResult.fields, fieldMetadata, isOtelStream(stream)),
+  };
 };
 
 export function mapFields(

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/stream_enrichment_state_machine.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/stream_enrichment_state_machine.ts
@@ -34,6 +34,7 @@ import {
 import type { StreamlangWhereBlock } from '@kbn/streamlang/types/streamlang';
 import type { EnrichmentDataSource, EnrichmentUrlState } from '../../../../../../common/url_schema';
 import { getStreamTypeFromDefinition } from '../../../../../util/get_stream_type_from_definition';
+import { getFormattedError } from '../../../../../util/errors';
 import type {
   StreamEnrichmentContextType,
   StreamEnrichmentEvent,
@@ -837,12 +838,12 @@ export const createStreamEnrichmentMachineImplementations = ({
     }),
     notifySuggestionFailure: (params: { event: unknown }) => {
       const event = params.event as { error: Error };
-      core.notifications.toasts.addError(event.error, {
+      const formattedError = getFormattedError(event.error);
+      core.notifications.toasts.addError(formattedError, {
         title: i18n.translate(
           'xpack.streams.streamDetailView.managementTab.enrichment.suggestionError',
           { defaultMessage: 'Failed to generate pipeline suggestion' }
         ),
-        toastMessage: event.error.message,
       });
     },
   },


### PR DESCRIPTION
Fixes https://github.com/elastic/observability-error-backlog/issues/321
Fixes https://github.com/elastic/observability-error-backlog/issues/323
Fixes https://github.com/elastic/observability-error-backlog/issues/326
Fixes https://github.com/elastic/observability-error-backlog/issues/347
Fixes https://github.com/elastic/observability-error-backlog/issues/349
Fixes https://github.com/elastic/observability-error-backlog/issues/335


This PR makes sure upstream errors from the LLM provider are shown to the user for all AI integrations. Check diff without whitespace.

Before:
<img width="356" height="195" alt="Screenshot 2025-12-09 at 15 07 42" src="https://github.com/user-attachments/assets/18fe014c-9404-4cfc-a762-33ec3b256a6d" />

After:
<img width="366" height="355" alt="Screenshot 2025-12-09 at 15 05 39" src="https://github.com/user-attachments/assets/7a5f78c2-de22-4cd7-bdff-9bb99867087f" />
