### PR TITLE
[Search] [A11y]add state changes in index details data fields 

### DIFF
--- a/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result.tsx
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result.tsx
@@ -119,6 +119,7 @@ export const Result: React.FC<ResultProps> = ({
                     tooltipRef.current?.showToolTip();
                   }}
                   aria-label={tooltipText}
+                  aria-selected={isExpanded}
                 />
               </EuiToolTip>
             </EuiFlexItem>


### PR DESCRIPTION
## Summary

Fix a11y issue - shows state changes for buttons 

Currently, Mac VoiceOver does not show state changes for show more button in index details -> data tab. Added aria-selected attribute. 

### screen recording 

https://github.com/user-attachments/assets/2534f9ad-a6ee-45b7-a818-8284653a5bb7

### Steps to reproduce
visit Index Management -> Indices page.
1.Navigate to Show more fields button.
2.Press Enter.
3.Observe page and screen reader.

UI elements + VoiceOver
browser: Safari 


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->