### PR TITLE
Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-presentation` files

### DIFF
--- a/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/clusters_table.tsx
+++ b/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/clusters_table.tsx
@@ -135,6 +135,9 @@ export function ClustersTable({ clusters }: Props) {
 
   return (
     <EuiBasicTable
+      tableCaption={i18n.translate('inspector.requests.clusters.table.caption', {
+        defaultMessage: 'Cluster details',
+      })}
       items={
         sortField
           ? items.sort(Comparators.property(sortField, Comparators.default(sortDirection)))

--- a/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/shards_view/shard_failure_table.tsx
+++ b/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/shards_view/shard_failure_table.tsx
@@ -102,6 +102,9 @@ export function ShardFailureTable({ failures }: Props) {
 
   return (
     <EuiBasicTable
+      tableCaption={i18n.translate('inspector.requests.clusters.shards.table.caption', {
+        defaultMessage: 'Shard failures',
+      })}
       items={failures.map((failure) => {
         return {
           rowId: getRowId(failure),

--- a/x-pack/platform/plugins/private/canvas/public/components/home/my_workpads/workpad_table.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/home/my_workpads/workpad_table.component.tsx
@@ -140,6 +140,7 @@ export const WorkpadTable = ({
       itemId="id"
       items={workpads}
       columns={columns}
+      tableCaption={strings.getTableCaption()}
       noItemsMessage={strings.getNoWorkpadsFoundMessage()}
       search={search}
       sorting={{
@@ -182,6 +183,10 @@ const strings = {
   getWorkpadSearchPlaceholder: () =>
     i18n.translate('xpack.canvas.workpadTable.searchPlaceholder', {
       defaultMessage: 'Find workpad',
+    }),
+  getTableCaption: () =>
+    i18n.translate('xpack.canvas.workpadTable.table.caption', {
+      defaultMessage: 'Canvas workpads list',
     }),
   getTableCreatedColumnTitle: () =>
     i18n.translate('xpack.canvas.workpadTable.table.createdColumnTitle', {

--- a/x-pack/platform/plugins/private/canvas/public/components/home/workpad_templates/workpad_templates.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/home/workpad_templates/workpad_templates.component.tsx
@@ -111,6 +111,7 @@ export const WorkpadTemplates = ({ templates, onCreateWorkpad }: Props) => {
       }}
       pagination={true}
       data-test-subj="canvasTemplatesTable"
+      tableCaption={strings.getTableCaption()}
     />
   );
 };
@@ -122,6 +123,10 @@ const strings = {
       values: {
         templateName,
       },
+    }),
+  getTableCaption: () =>
+    i18n.translate('xpack.canvas.workpadTemplates.table.caption', {
+      defaultMessage: 'Workpad templates',
     }),
   getTableDescriptionColumnTitle: () =>
     i18n.translate('xpack.canvas.workpadTemplates.table.descriptionColumnTitle', {

--- a/x-pack/platform/plugins/private/canvas/public/components/var_config/var_config.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/var_config/var_config.tsx
@@ -95,6 +95,10 @@ const strings = {
     i18n.translate('xpack.canvas.varConfig.titleTooltip', {
       defaultMessage: 'Add variables to store and edit common values',
     }),
+  getTableCaption: () =>
+    i18n.translate('xpack.canvas.varConfig.tableCaption', {
+      defaultMessage: 'Canvas variables list',
+    }),
 };
 
 export const VarConfig: FC<Props> = ({
@@ -219,6 +223,7 @@ export const VarConfig: FC<Props> = ({
                 pagination={false}
                 sorting={true}
                 compressed
+                tableCaption={strings.getTableCaption()}
               />
             </div>
           )}


### PR DESCRIPTION
> [!CAUTION]
> ⚠️ **Changes / translations were made by GenAI**. I’ve reviewed them carefully, but your code owners’ expert eyes will ensure they’re 100% right.

## Summary
This PR applies the auto-fix for the newly introduced `@elastic/eui/require-table-caption`.
This rule ensure `EuiInMemoryTable`, `EuiBasicTable` have a `tableCaption` prop for accessibility.

## Changes

1. 🎯 Added missing `tableCaption` attributes to elements flagged by `@elastic/eui/require-table-caption` — accessibility leveled up!  

## Related
- https://github.com/elastic/eui/pull/9168

This time, to avoid annoying approvals collection, we've broken files down by teams. Now, we are waiting a review only from your team! 


<!--ONMERGE {"backportTargets":["9.1","9.2"]} ONMERGE-->