### PR TITLE
[Fields Metadata] Prioritize OTel over ECS for prefixed fields

### DIFF
--- a/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/fields_metadata_client.test.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/fields_metadata_client.test.ts
@@ -27,6 +27,17 @@ const ecsFields = {
     short: 'Date/time when the event originated.',
     type: 'date',
   },
+  'user.name': {
+    dashed_name: 'user-name',
+    description: 'Short name or login of the user.',
+    example: 'a.einstein',
+    flat_name: 'user.name',
+    level: 'core',
+    name: 'name',
+    normalize: [],
+    short: 'Short name or login of the user.',
+    type: 'keyword',
+  },
 } as TEcsFields;
 
 const metadataFields = {
@@ -107,6 +118,13 @@ const otelFields = {
     name: 'severity_text',
     description: 'The severity text (also known as log level).',
     type: 'keyword',
+  },
+  // Add a native OTel field with the 'attributes.' prefix to test priority
+  'attributes.custom.otel.field': {
+    name: 'attributes.custom.otel.field',
+    description: 'A native OTel field with attributes prefix.',
+    type: 'keyword',
+    example: 'otel-value',
   },
 } as Partial<TOtelFields>;
 
@@ -397,6 +415,40 @@ describe('FieldsMetadataClient class', () => {
       expect(fields['@timestamp'].source).toBe('ecs'); // Second priority
       expect(fields['service.name'].source).toBe('otel'); // Lowest priority (fallback)
       expect(fields['http.request.method'].source).toBe('otel'); // Lowest priority (fallback)
+    });
+
+    it('should prioritize OTel over ECS for prefixed fields (attributes.* and resource.attributes.*)', async () => {
+      // Test that native OTel prefixed fields take priority over ECS proxy-generated prefixed fields
+      const nativeOtelField = await fieldsMetadataClient.getByName('attributes.custom.otel.field');
+
+      expectToBeDefined(nativeOtelField);
+      expect(nativeOtelField.source).toBe('otel');
+      expect(nativeOtelField.description).toBe('A native OTel field with attributes prefix.');
+      expect(nativeOtelField.example).toBe('otel-value');
+    });
+
+    it('should return ECS proxy-generated prefixed field when OTel does not have that base field', async () => {
+      // When requesting a prefixed field where OTel doesn't have the base field,
+      // it should fall back to the ECS proxy-generated field
+      // Use a field that exists in ECS but not in OTel
+      const ecsProxyField = await fieldsMetadataClient.getByName('attributes.user.name');
+
+      expectToBeDefined(ecsProxyField);
+      // Since 'user.name' doesn't exist in our mock OTel fields, it falls back to ECS
+      expect(ecsProxyField.source).toBe('ecs');
+      expect(ecsProxyField.name).toBe('attributes.user.name');
+      expect(ecsProxyField.flat_name).toBe('attributes.user.name');
+    });
+
+    it('should prioritize OTel for prefixed fields when OTel has the base field', async () => {
+      // When requesting a prefixed field where OTel DOES have the base field,
+      // OTel should be prioritized over ECS
+      const otelField = await fieldsMetadataClient.getByName('attributes.@timestamp');
+
+      expectToBeDefined(otelField);
+      // OTel has '@timestamp', so even with 'attributes.' prefix, OTel takes priority
+      expect(otelField.source).toBe('otel');
+      expect(otelField.description).toContain('Time when the event occurred');
     });
   });
 

--- a/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/fields_metadata_client.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/fields_metadata_client.ts
@@ -104,7 +104,7 @@ export class FieldsMetadataClient implements IFieldsMetadataClient {
        * followed by the ECS fields repository for base fields,
        * followed by the OpenTel fields repository for base fields.
        *
-       * Note: For prefixed fields (attributes.* and resource.attributes.*), 
+       * Note: For prefixed fields (attributes.* and resource.attributes.*),
        * OpenTelemetry takes priority over ECS when using getByName() to avoid
        * conflicts with namespaced ECS fields. However, when returning all fields,
        * we merge in this order to ensure ECS base fields are preferred, and the

--- a/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/fields_metadata_client.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/fields_metadata_client.ts
@@ -10,6 +10,7 @@ import { isEmpty } from 'lodash';
 import type { FieldMetadata } from '../../../common/fields_metadata/models/field_metadata';
 import { FieldsMetadataDictionary } from '../../../common/fields_metadata/models/fields_metadata_dictionary';
 import type { FieldName, FieldSource } from '../../../common';
+import { extractPrefixParts } from '../../../common/fields_metadata/utils/create_proxied_fields_map';
 
 import type { EcsFieldsRepository } from './repositories/ecs_fields_repository';
 import type { IntegrationFieldsRepository } from './repositories/integration_fields_repository';
@@ -52,6 +53,7 @@ export class FieldsMetadataClient implements IFieldsMetadataClient {
     this.logger.debug(`Retrieving field metadata for: ${fieldName}`);
 
     const isSourceAllowed = this.makeSourceValidator(source);
+    const { prefix } = extractPrefixParts(fieldName);
 
     let field: FieldMetadata | undefined;
 
@@ -60,17 +62,23 @@ export class FieldsMetadataClient implements IFieldsMetadataClient {
       field = this.metadataFieldsRepository.getByName(fieldName);
     }
 
-    // 2. Try resolving from ECS static metadata (authoritative schema)
+    // 2. For prefixed fields (attributes.* or resource.attributes.*),
+    //    prioritize OpenTelemetry over ECS to avoid conflicts with namespaced ECS fields
+    if (!field && prefix && isSourceAllowed('otel')) {
+      field = this.otelFieldsRepository.getByName(fieldName);
+    }
+
+    // 3. Try resolving from ECS static metadata (authoritative schema for non-prefixed fields)
     if (!field && isSourceAllowed('ecs')) {
       field = this.ecsFieldsRepository.getByName(fieldName);
     }
 
-    // 3. Try resolving from OpenTelemetry semantic conventions (fallback)
-    if (!field && isSourceAllowed('otel')) {
+    // 4. For non-prefixed fields, try OpenTelemetry as fallback
+    if (!field && !prefix && isSourceAllowed('otel')) {
       field = this.otelFieldsRepository.getByName(fieldName);
     }
 
-    // 4. Try searching for the field in the Elastic Package Registry (integration-specific)
+    // 5. Try searching for the field in the Elastic Package Registry (integration-specific)
     if (!field && isSourceAllowed('integration') && this.hasFleetPermissions(this.capabilities)) {
       field = await this.integrationFieldsRepository.getByName(fieldName, {
         integration,
@@ -93,10 +101,14 @@ export class FieldsMetadataClient implements IFieldsMetadataClient {
       /**
        * The merge order is important here.
        * The metadata fields repository has the highest priority,
-       * followed by the ECS fields repository,
-       * followed by the OpenTel fields repository.
+       * followed by the ECS fields repository for base fields,
+       * followed by the OpenTel fields repository for base fields.
        *
-       * This is because we want the ECS fields repository to be more authoritative than the OpenTel fields repository.
+       * Note: For prefixed fields (attributes.* and resource.attributes.*), 
+       * OpenTelemetry takes priority over ECS when using getByName() to avoid
+       * conflicts with namespaced ECS fields. However, when returning all fields,
+       * we merge in this order to ensure ECS base fields are preferred, and the
+       * proxy will generate prefixed variants as needed.
        */
       return FieldsMetadataDictionary.create({
         ...(isSourceAllowed('otel') && this.otelFieldsRepository.find().getFields()),

--- a/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/repositories/otel_fields_repository.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/repositories/otel_fields_repository.ts
@@ -80,7 +80,13 @@ export class OtelFieldsRepository {
   }
 
   getByName(fieldName: OtelFieldName | AnyFieldName): FieldMetadata | undefined {
-    // Strip OTel prefixes before looking up the field
+    // First, try to find the field directly (handles native prefixed fields)
+    const directMatch = this.otelFields[fieldName as OtelFieldName];
+    if (directMatch) {
+      return directMatch;
+    }
+
+    // If not found, strip OTel prefixes and try again (handles base fields with prefix lookups)
     const strippedFieldName = stripOtelPrefixes(fieldName as string);
     return this.otelFields[strippedFieldName as OtelFieldName];
   }


### PR DESCRIPTION
Fix overlap issue where ECS proxy-generated prefixed fields were taking priority over native OpenTelemetry fields.

When requesting prefixed fields (attributes.* or resource.attributes.*), OpenTelemetry semantic conventions should take priority over ECS to ensure the correct field metadata is returned for OTel-native fields.

Changes:
- Update FieldsMetadataClient to check OTel before ECS for prefixed fields
- Update OtelFieldsRepository to support native prefixed fields via direct lookup before stripping prefixes
- Add test coverage for prefixed field priority resolution


`attributes.http.response.status_code` is both an otel and a namespaced ECS field - now it auto-maps as otel field instead of trying to be a namespaced ECS field.

<img width="835" height="352" alt="Screenshot 2025-12-09 at 16 38 42" src="https://github.com/user-attachments/assets/cd6b4ea5-9184-41b0-90cf-4ca2486d2ca7" />
