### PR TITLE
[8.19] [Fleet] Install global assets as part of package install (#244404)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
@@ -622,6 +622,7 @@ export interface InstallFailedAttempt {
 
 export enum INSTALL_STATES {
   CREATE_RESTART_INSTALLATION = 'create_restart_installation',
+  INSTALL_PRECHECK = 'install_precheck',
   INSTALL_KIBANA_ASSETS = 'install_kibana_assets',
   INSTALL_ILM_POLICIES = 'install_ilm_policies',
   INSTALL_ML_MODEL = 'install_ml_model',

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/install.ts
@@ -9,10 +9,7 @@ import { merge, concat, uniqBy, omit } from 'lodash';
 import Boom from '@hapi/boom';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 
-import type {
-  IndicesCreateRequest,
-  ClusterPutComponentTemplateRequest,
-} from '@elastic/elasticsearch/lib/api/types';
+import type { ClusterPutComponentTemplateRequest } from '@elastic/elasticsearch/lib/api/types';
 
 import { ElasticsearchAssetType } from '../../../../types';
 import {
@@ -502,39 +499,6 @@ export async function ensureComponentTemplate(
   }
 
   return { isCreated: !existingTemplate };
-}
-
-export async function ensureAliasHasWriteIndex(opts: {
-  esClient: ElasticsearchClient;
-  logger: Logger;
-  aliasName: string;
-  writeIndexName: string;
-  body: Omit<IndicesCreateRequest, 'index'>;
-}): Promise<void> {
-  const { esClient, logger, aliasName, writeIndexName, body } = opts;
-  const existingIndex = await retryTransientEsErrors(
-    () =>
-      esClient.indices.exists(
-        {
-          index: [aliasName],
-        },
-        {
-          ignore: [404],
-        }
-      ),
-    { logger }
-  );
-
-  if (!existingIndex) {
-    logger.info(`Creating write index [${writeIndexName}], alias [${aliasName}]`);
-
-    await retryTransientEsErrors(
-      () => esClient.indices.create({ index: writeIndexName, ...body }, { ignore: [404] }),
-      {
-        logger,
-      }
-    );
-  }
 }
 
 function countFields(fields: Fields): number {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/_state_machine_package_install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/_state_machine_package_install.ts
@@ -58,6 +58,7 @@ import {
 } from './steps';
 import type { StateMachineDefinition, StateMachineStates } from './state_machine';
 import { handleState } from './state_machine';
+import { stepInstallPrecheck } from './steps/step_install_precheck';
 
 export interface InstallContext extends StateContext<StateNames> {
   savedObjectsClient: SavedObjectsClientContract;
@@ -88,8 +89,13 @@ export interface InstallContext extends StateContext<StateNames> {
  */
 const regularStatesDefinition: StateMachineStates<StateNames> = {
   create_restart_installation: {
-    nextState: INSTALL_STATES.INSTALL_KIBANA_ASSETS,
+    nextState: INSTALL_STATES.INSTALL_PRECHECK,
     onTransition: stepCreateRestartInstallation,
+    onPostTransition: updateLatestExecutedState,
+  },
+  install_precheck: {
+    onTransition: stepInstallPrecheck,
+    nextState: INSTALL_STATES.INSTALL_KIBANA_ASSETS,
     onPostTransition: updateLatestExecutedState,
   },
   install_kibana_assets: {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_precheck.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_precheck.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ensureFleetGlobalEsAssets } from '../../../../setup/ensure_fleet_global_es_assets';
+
+import { stepInstallPrecheck } from './step_install_precheck';
+
+jest.mock('../../../..');
+jest.mock('../../../../setup/ensure_fleet_global_es_assets');
+
+describe('stepInstallPrecheck', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call ensureFleetGlobalEsAssets', async () => {
+    await stepInstallPrecheck();
+
+    expect(jest.mocked(ensureFleetGlobalEsAssets)).toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_precheck.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_install_precheck.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ensureFleetGlobalEsAssets } from '../../../../setup/ensure_fleet_global_es_assets';
+import { appContextService } from '../../../..';
+
+import { withPackageSpan } from '../../utils';
+
+export async function stepInstallPrecheck() {
+  await ensureFleetGlobalAssets();
+}
+
+async function ensureFleetGlobalAssets() {
+  await withPackageSpan('Ensure Fleet Global Assets', () =>
+    ensureFleetGlobalEsAssets(
+      {
+        logger: appContextService.getLogger(),
+        esClient: appContextService.getInternalUserESClient(),
+        soClient: appContextService.getInternalUserSOClient(),
+      },
+      {
+        reinstallPackages: false,
+      }
+    )
+  );
+}

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/ensure_fleet_global_es_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/ensure_fleet_global_es_assets.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import apm from 'elastic-apm-node';
+import pMap from 'p-map';
+
+import type { ElasticsearchClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
+
+import { ensureDefaultComponentTemplates } from '../epm/elasticsearch/template/install';
+import {
+  ensureFleetEventIngestedPipelineIsInstalled,
+  ensureFleetFinalPipelineIsInstalled,
+} from '../epm/elasticsearch/ingest_pipeline/install';
+import { getInstallations, reinstallPackageForInstallation } from '../epm/packages';
+
+import { MAX_CONCURRENT_EPM_PACKAGES_INSTALLATIONS } from '../../constants';
+
+/**
+ * Ensure ES assets shared by all Fleet index template are installed
+ */
+export async function ensureFleetGlobalEsAssets(
+  {
+    logger,
+    soClient,
+    esClient,
+  }: {
+    logger: Logger;
+    soClient: SavedObjectsClientContract;
+    esClient: ElasticsearchClient;
+  },
+  options: {
+    reinstallPackages?: boolean;
+  }
+) {
+  // Ensure Global Fleet ES assets are installed
+  logger.debug('Creating Fleet component template and ingest pipeline');
+  const globalAssetsRes = await Promise.all([
+    ensureDefaultComponentTemplates(esClient, logger), // returns an array
+    ensureFleetFinalPipelineIsInstalled(esClient, logger),
+    ensureFleetEventIngestedPipelineIsInstalled(esClient, logger),
+  ]);
+
+  if (options?.reinstallPackages) {
+    const assetResults = globalAssetsRes.flat();
+    if (assetResults.some((asset) => asset.isCreated)) {
+      // Update existing index template
+      const installedPackages = await getInstallations(soClient);
+      await pMap(
+        installedPackages.saved_objects,
+        async ({ attributes: installation }) => {
+          await reinstallPackageForInstallation({
+            soClient,
+            esClient,
+            installation,
+          }).catch((err) => {
+            apm.captureError(err);
+            logger.error(
+              `Package needs to be manually reinstalled ${installation.name} after installing Fleet global assets: ${err.message}`
+            );
+          });
+        },
+        { concurrency: MAX_CONCURRENT_EPM_PACKAGES_INSTALLATIONS }
+      );
+    }
+  }
+}

--- a/x-pack/platform/plugins/shared/fleet/server/services/setup/ensure_fleet_global_es_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/setup/ensure_fleet_global_es_assets.ts
@@ -11,13 +11,8 @@ import pMap from 'p-map';
 import type { ElasticsearchClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
 
 import { ensureDefaultComponentTemplates } from '../epm/elasticsearch/template/install';
-import {
-  ensureFleetEventIngestedPipelineIsInstalled,
-  ensureFleetFinalPipelineIsInstalled,
-} from '../epm/elasticsearch/ingest_pipeline/install';
+import { ensureFleetFinalPipelineIsInstalled } from '../epm/elasticsearch/ingest_pipeline/install';
 import { getInstallations, reinstallPackageForInstallation } from '../epm/packages';
-
-import { MAX_CONCURRENT_EPM_PACKAGES_INSTALLATIONS } from '../../constants';
 
 /**
  * Ensure ES assets shared by all Fleet index template are installed
@@ -41,7 +36,6 @@ export async function ensureFleetGlobalEsAssets(
   const globalAssetsRes = await Promise.all([
     ensureDefaultComponentTemplates(esClient, logger), // returns an array
     ensureFleetFinalPipelineIsInstalled(esClient, logger),
-    ensureFleetEventIngestedPipelineIsInstalled(esClient, logger),
   ]);
 
   if (options?.reinstallPackages) {
@@ -63,7 +57,7 @@ export async function ensureFleetGlobalEsAssets(
             );
           });
         },
-        { concurrency: MAX_CONCURRENT_EPM_PACKAGES_INSTALLATIONS }
+        { concurrency: 10 }
       );
     }
   }

--- a/x-pack/platform/test/fleet_api_integration/apis/epm/install_remove_assets.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/epm/install_remove_assets.ts
@@ -8,10 +8,15 @@
 import type { Client } from '@elastic/elasticsearch';
 import expect from '@kbn/expect';
 import { sortBy } from 'lodash';
-import { AssetReference } from '@kbn/fleet-plugin/common/types';
-import { FLEET_INSTALL_FORMAT_VERSION } from '@kbn/fleet-plugin/server/constants';
-import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import type { AssetReference } from '@kbn/fleet-plugin/common/types';
+import {
+  FLEET_GLOBALS_COMPONENT_TEMPLATE_NAME,
+  FLEET_INSTALL_FORMAT_VERSION,
+} from '@kbn/fleet-plugin/server/constants';
+import type { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+
 import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
+import { cleanFleetIndices } from '../space_awareness/helpers';
 
 function checkErrorWithResponseDataOrThrow(err: any) {
   if (!err?.response?.data) {
@@ -60,6 +65,56 @@ export default function (providerContext: FtrProviderContext) {
         pkgName,
         es,
         kibanaServer,
+      });
+    });
+
+    describe('global assets', () => {
+      before(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+
+        await cleanFleetIndices(es);
+        await fleetAndAgents.setup();
+
+        // Delete all fleet component templates and pipelines to simulate missing global assets
+        const fleetIndexTemplateNames = await es.indices
+          .getIndexTemplate({ name: '*' })
+          .then((res) =>
+            res.index_templates
+              .filter((template) => template.index_template._meta?.managed_by === 'fleet')
+              .map((template) => template.name)
+          );
+        await es.indices.deleteDataStream(
+          { name: '.logs-endpoint.*,logs-*,metrics-*' },
+          {
+            ignore: [404],
+          }
+        );
+        if (fleetIndexTemplateNames.length) {
+          await es.indices.deleteIndexTemplate({ name: fleetIndexTemplateNames.join(',') });
+        }
+        await es.cluster.deleteComponentTemplate(
+          {
+            name: FLEET_GLOBALS_COMPONENT_TEMPLATE_NAME,
+          },
+          {
+            ignore: [404],
+          }
+        );
+      });
+
+      after(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+
+        await cleanFleetIndices(es);
+      });
+
+      it('should install global assets if they are missing during package install', async () => {
+        await installPackage(pkgName, pkgVersion);
+        const template = await es.cluster.getComponentTemplate({
+          name: FLEET_GLOBALS_COMPONENT_TEMPLATE_NAME,
+        });
+
+        expect(template.component_templates.length).to.be(1);
       });
     });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Fleet] Install global assets as part of package install (#244404)](https://github.com/elastic/kibana/pull/244404)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2025-11-28T18:17:40Z","message":"[Fleet] Install global assets as part of package install (#244404)","sha":"962ab0eef0c35c2f39825b9da161f94a796a9351","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.3.0","v9.2.3","v9.1.9","v8.19.9"],"title":"[Fleet] Install global assets as part of package install","number":244404,"url":"https://github.com/elastic/kibana/pull/244404","mergeCommit":{"message":"[Fleet] Install global assets as part of package install (#244404)","sha":"962ab0eef0c35c2f39825b9da161f94a796a9351"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/244404","number":244404,"mergeCommit":{"message":"[Fleet] Install global assets as part of package install (#244404)","sha":"962ab0eef0c35c2f39825b9da161f94a796a9351"}},{"branch":"9.2","label":"v9.2.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/245682","number":245682,"state":"OPEN"},{"branch":"9.1","label":"v9.1.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->