### PR TITLE
Fix ECS-incompatible value in the logs

### DIFF
--- a/src/core/packages/elasticsearch/server-internal/src/elasticsearch_service.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/elasticsearch_service.ts
@@ -168,8 +168,11 @@ export class ElasticsearchService
         `Successfully connected to Elasticsearch after waiting for ${elasticsearchWaitTime} milliseconds`,
         {
           event: {
-            type: 'kibana_started.elasticsearch.waitTime',
+            // ECS Event reference: https://www.elastic.co/docs/reference/ecs/ecs-event
+            action: 'kibana_started.elasticsearch.waitTime',
+            category: 'database',
             duration: elasticsearchWaitTime,
+            type: 'connection',
           },
         }
       );


### PR DESCRIPTION
## Summary

According to the ECS specification, `event.type` cannot have the value `kibana_started.elasticsearch.waitTime`:

<img width="1818" height="1448" alt="image" src="https://github.com/user-attachments/assets/158f4090-9e95-422b-8fec-f764d02b50ef" />

This PR uses the correct ECS-compatible fields to report the values.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- [x] Some users might be filtering by the current field already, despite being non-ECS compliant.





<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->