### PR TITLE
set preferCached to configs that weren't there in main

### DIFF
--- a/x-pack/solutions/observability/test/dataset_quality_api_integration/common/config.ts
+++ b/x-pack/solutions/observability/test/dataset_quality_api_integration/common/config.ts
@@ -130,7 +130,7 @@ export function createTestConfig(
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
           waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
-          preferCached: true
+          preferCached: true,
         },
       }),
       servicesRequiredForTestAnalysis: ['datasetQualityFtrConfig', 'registry'],

--- a/x-pack/solutions/observability/test/dataset_quality_api_integration/common/config.ts
+++ b/x-pack/solutions/observability/test/dataset_quality_api_integration/common/config.ts
@@ -130,6 +130,7 @@ export function createTestConfig(
           args: dockerArgs,
           waitForLogLine: 'package manifests loaded',
           waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+          preferCached: true
         },
       }),
       servicesRequiredForTestAnalysis: ['datasetQualityFtrConfig', 'registry'],

--- a/x-pack/solutions/observability/test/functional/apps/observability_logs_explorer/config.ts
+++ b/x-pack/solutions/observability/test/functional/apps/observability_logs_explorer/config.ts
@@ -66,6 +66,7 @@ export default async function createTestConfig({
         args: dockerArgs,
         waitForLogLine: 'package manifests loaded',
         waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+        preferCached: true,
       },
     }),
     services: {


### PR DESCRIPTION
## Summary
Edit on #244766 / https://github.com/elastic/kibana/pull/245211

There were a few configs that didn't exist on main where this config was introduced, so they were pulling the docker image every time, thus exhausting disk space.