### PR TITLE
[Controls Anywhere] Fix test for ES|QL control chaining

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.test.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.test.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { EsqlControlType, ESQLVariableType, type ESQLControlState } from '@kbn/esql-types';
-import { getMockedControlGroupApi, getMockedFinalizeApi } from '../mocks/control_mocks';
+import { getMockedFinalizeApi } from '../mocks/control_mocks';
 import { getESQLControlFactory } from './get_esql_control_factory';
 import { BehaviorSubject } from 'rxjs';
 
@@ -128,22 +128,18 @@ describe('ESQLControlApi', () => {
         esqlQuery: 'FROM foo | WHERE column1 == ?variable1 | STATS BY column2',
         controlType: EsqlControlType.VALUES_FROM_QUERY,
       } as ESQLControlState;
-      await factory.buildControl({
-        initialState,
+      await factory.buildEmbeddable({
+        initialState: { rawState: initialState },
         finalizeApi,
         uuid,
-        controlGroupApi,
+        parentApi: dashboardApi,
       });
       await waitFor(() => {
         expect(mockGetESQLSingleColumnValues).toHaveBeenCalledTimes(1);
         expect(mockIsSuccess).toHaveBeenCalledTimes(1);
       });
-      const controlFetch$ = controlGroupApi.controlFetch$(
-        uuid
-      ) as BehaviorSubject<ControlFetchContext>;
-
       // Variable change
-      controlFetch$.next({
+      mockFetch$.next({
         esqlVariables: [
           {
             key: 'variable1',

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
@@ -8,13 +8,12 @@
  */
 
 import React from 'react';
-import { BehaviorSubject, merge } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 import { ESQL_CONTROL } from '@kbn/controls-constants';
 import type { EmbeddableFactory } from '@kbn/embeddable-plugin/public';
 import type { ESQLControlState } from '@kbn/esql-types';
 import { apiPublishesESQLVariables } from '@kbn/esql-types';
-import { i18n } from '@kbn/i18n';
 import { initializeUnsavedChanges } from '@kbn/presentation-containers';
 import {
   type PublishingSubject,


### PR DESCRIPTION
## Summary

Closes #245565 

After resolving merge conflicts with `main`, ES|QL control chaining worked as expected on the Controls Anywhere feature branch. This PR simply updates the test to reflect new API methods.


