### PR TITLE
[9.2] Add fleet policy revisions cleanup task (#242612)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/routes.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/routes.ts
@@ -94,6 +94,7 @@ export const AGENT_POLICY_API_ROUTES = {
   INFO_OUTPUTS_PATTERN: `${AGENT_POLICY_API_ROOT}/{agentPolicyId}/outputs`,
   AUTO_UPGRADE_AGENTS_STATUS_PATTERN: `${AGENT_POLICY_API_ROOT}/{agentPolicyId}/auto_upgrade_agents_status`,
   CREATE_WITH_PACKAGE_POLICIES: `${INTERNAL_ROOT}/agent_and_package_policies`,
+  CLEANUP_REVISIONS_PATTERN: `${INTERNAL_ROOT}/agent_policies/_cleanup_revisions`,
 };
 
 // Cloud Connector API routes

--- a/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/experimental_features.ts
@@ -21,6 +21,7 @@ const _allowedExperimentalValues = {
   enableAgentStatusAlerting: true,
   enableAgentPrivilegeLevelChange: false,
   installIntegrationsKnowledge: false,
+  enableFleetPolicyRevisionsCleanupTask: true,
 };
 
 /**

--- a/x-pack/platform/plugins/shared/fleet/common/types/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/index.ts
@@ -111,6 +111,11 @@ export interface FleetConfigType {
   prereleaseEnabledByDefault?: boolean;
   hideDashboards?: boolean;
   installIntegrationsKnowledge?: boolean;
+  fleetPolicyRevisionsCleanup?: {
+    maxRevisions: number;
+    interval: string;
+    maxPoliciesPerRun: number;
+  };
 }
 
 // Calling Object.entries(PackagesGroupedByStatus) gave `status: string`

--- a/x-pack/platform/plugins/shared/fleet/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.test.ts
@@ -142,6 +142,18 @@ describe('Config schema', () => {
     }).not.toThrow();
   });
 
+  it('should allow to specify fleetPolicyRevisionsCleanup configuration', () => {
+    expect(() => {
+      config.schema.validate({
+        fleetPolicyRevisionsCleanup: {
+          maxRevisions: 20,
+          interval: '2h',
+          maxPoliciesPerRun: 50,
+        },
+      });
+    }).not.toThrow();
+  });
+
   describe('deprecations', () => {
     it('should add a depreciations when trying to enable a non existing experimental feature', () => {
       const res = applyConfigDeprecations({

--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -338,6 +338,13 @@ export const config: PluginConfigDescriptor = {
           taskInterval: schema.maybe(schema.string()),
         })
       ),
+      fleetPolicyRevisionsCleanup: schema.maybe(
+        schema.object({
+          maxRevisions: schema.number({ min: 1, defaultValue: 10 }),
+          interval: schema.string({ defaultValue: '1h' }),
+          maxPoliciesPerRun: schema.number({ min: 1, defaultValue: 100 }),
+        })
+      ),
       integrationsHomeOverride: schema.maybe(schema.string()),
       prereleaseEnabledByDefault: schema.boolean({ defaultValue: false }),
       hideDashboards: schema.boolean({ defaultValue: false }),

--- a/x-pack/platform/plugins/shared/fleet/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/plugin.ts
@@ -154,6 +154,7 @@ import { AutomaticAgentUpgradeTask } from './tasks/automatic_agent_upgrade_task'
 import { registerPackagesBulkOperationTask } from './tasks/packages_bulk_operations';
 import { AutoInstallContentPackagesTask } from './tasks/auto_install_content_packages_task';
 import { AgentStatusChangeTask } from './tasks/agent_status_change_task';
+import { FleetPolicyRevisionsCleanupTask } from './tasks/fleet_policy_revisions_cleanup/fleet_policy_revisions_cleanup_task';
 import { registerSetupTasks } from './tasks/setup';
 
 export interface FleetSetupDeps {
@@ -211,6 +212,7 @@ export interface FleetAppContext {
   automaticAgentUpgradeTask: AutomaticAgentUpgradeTask;
   autoInstallContentPackagesTask: AutoInstallContentPackagesTask;
   agentStatusChangeTask?: AgentStatusChangeTask;
+  fleetPolicyRevisionsCleanupTask?: FleetPolicyRevisionsCleanupTask;
   taskManagerStart?: TaskManagerStartContract;
   fetchUsage?: (abortController: AbortController) => Promise<FleetUsage | undefined>;
   syncIntegrationsTask: SyncIntegrationsTask;
@@ -325,6 +327,7 @@ export class FleetPlugin
   private automaticAgentUpgradeTask?: AutomaticAgentUpgradeTask;
   private autoInstallContentPackagesTask?: AutoInstallContentPackagesTask;
   private agentStatusChangeTask?: AgentStatusChangeTask;
+  private fleetPolicyRevisionsCleanupTask?: FleetPolicyRevisionsCleanupTask;
 
   private agentService?: AgentService;
   private packageService?: PackageService;
@@ -708,6 +711,16 @@ export class FleetPlugin
         taskInterval: config.agentStatusChange?.taskInterval,
       },
     });
+    this.fleetPolicyRevisionsCleanupTask = new FleetPolicyRevisionsCleanupTask({
+      core,
+      taskManager: deps.taskManager,
+      logFactory: this.initializerContext.logger,
+      config: {
+        maxRevisions: config.fleetPolicyRevisionsCleanup?.maxRevisions,
+        interval: config.fleetPolicyRevisionsCleanup?.interval,
+        maxPoliciesPerRun: config.fleetPolicyRevisionsCleanup?.maxPoliciesPerRun,
+      },
+    });
     this.lockManagerService = new LockManagerService(core, this.initializerContext.logger.get());
 
     // Register fields metadata extractors
@@ -766,6 +779,7 @@ export class FleetPlugin
       lockManagerService: this.lockManagerService,
       autoInstallContentPackagesTask: this.autoInstallContentPackagesTask!,
       agentStatusChangeTask: this.agentStatusChangeTask,
+      fleetPolicyRevisionsCleanupTask: this.fleetPolicyRevisionsCleanupTask,
       alertingStart: plugins.alerting,
     });
     licenseService.start(plugins.licensing.license$);
@@ -789,6 +803,9 @@ export class FleetPlugin
       ?.start({ taskManager: plugins.taskManager })
       .catch(() => {});
     this.agentStatusChangeTask?.start({ taskManager: plugins.taskManager }).catch(() => {});
+    this.fleetPolicyRevisionsCleanupTask
+      ?.start({ taskManager: plugins.taskManager })
+      .catch(() => {});
 
     const logger = appContextService.getLogger();
 

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -46,6 +46,8 @@ import type {
   GetListAgentPolicyOutputsRequestSchema,
   GetAutoUpgradeAgentsStatusRequestSchema,
   CreateAgentAndPackagePolicyRequestSchema,
+  RunAgentPolicyRevisionsCleanupTaskRequestSchema,
+  RunAgentPolicyRevisionsCleanupTaskResponseSchema,
 } from '../../types';
 
 import type {
@@ -71,6 +73,7 @@ import { updateAgentPolicySpaces } from '../../services/spaces/agent_policy';
 import { packagePolicyToSimplifiedPackagePolicy } from '../../../common/services/simplified_package_policy_helper';
 import { FLEET_API_PRIVILEGES } from '../../constants/api_privileges';
 import { getAutoUpgradeAgentsStatus } from '../../services/agents';
+import { cleanupPolicyRevisions } from '../../tasks/fleet_policy_revisions_cleanup/cleanup_policy_revisions';
 
 import { createPackagePolicyHandler } from '../package_policy/handlers';
 import { getLatestAgentAvailableDockerImageVersion } from '../../services/agents';
@@ -891,6 +894,37 @@ export const GetListAgentPolicyOutputsHandler: FleetRequestHandler<
 
   const body: GetListAgentPolicyOutputsResponse = {
     items: outputsList,
+  };
+
+  return response.ok({
+    body,
+  });
+};
+
+export const RunAgentPolicyRevisionsCleanupTaskHandler: FleetRequestHandler<
+  undefined,
+  undefined,
+  TypeOf<typeof RunAgentPolicyRevisionsCleanupTaskRequestSchema.body>
+> = async (context, request, response) => {
+  const coreContext = await context.core;
+  const esClient = coreContext.elasticsearch.client.asInternalUser;
+  const logger = appContextService.getLogger().get('httpRunAgentPolicyRevisionsCleanupTaskHandler');
+  const kbnConfig = appContextService.getConfig()?.fleetPolicyRevisionsCleanup;
+
+  const config = {
+    maxRevisions: kbnConfig?.maxRevisions,
+    maxPolicies: kbnConfig?.maxPoliciesPerRun,
+    ...request.body,
+  };
+
+  const result = await cleanupPolicyRevisions(esClient, {
+    logger,
+    config,
+  });
+
+  const body: TypeOf<typeof RunAgentPolicyRevisionsCleanupTaskResponseSchema> = {
+    success: true,
+    totalDeletedRevisions: result?.totalDeletedRevisions ?? 0,
   };
 
   return response.ok({

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/index.ts
@@ -36,6 +36,8 @@ import {
   GetAutoUpgradeAgentsStatusRequestSchema,
   GetAutoUpgradeAgentsStatusResponseSchema,
   CreateAgentAndPackagePolicyRequestSchema,
+  RunAgentPolicyRevisionsCleanupTaskRequestSchema,
+  RunAgentPolicyRevisionsCleanupTaskResponseSchema,
 } from '../../types';
 
 import { K8S_API_ROUTES } from '../../../common/constants';
@@ -60,6 +62,7 @@ import {
   GetListAgentPolicyOutputsHandler,
   getAutoUpgradeAgentsStatusHandler,
   createAgentAndPackagePoliciesHandler,
+  RunAgentPolicyRevisionsCleanupTaskHandler,
 } from './handlers';
 
 export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType) => {
@@ -633,5 +636,42 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
         },
       },
       GetAgentPolicyOutputsHandler
+    );
+  router.versioned
+    .post({
+      path: AGENT_POLICY_API_ROUTES.CLEANUP_REVISIONS_PATTERN,
+      access: 'internal',
+      enableQueryVersion: true,
+      security: {
+        authz: {
+          requiredPrivileges: [
+            FLEET_API_PRIVILEGES.AGENT_POLICIES.ALL,
+            FLEET_API_PRIVILEGES.AGENTS.READ,
+          ],
+        },
+      },
+      summary: `Run a task to cleanup excess agent policy revisions`,
+      options: {
+        tags: ['oas-tag:Elastic Agent policies'],
+      },
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.internal.v1,
+        validate: {
+          request: RunAgentPolicyRevisionsCleanupTaskRequestSchema,
+          response: {
+            200: {
+              description: 'OK: A successful request.',
+              body: () => RunAgentPolicyRevisionsCleanupTaskResponseSchema,
+            },
+            400: {
+              description: 'A bad request.',
+              body: genericErrorResponse,
+            },
+          },
+        },
+      },
+      RunAgentPolicyRevisionsCleanupTaskHandler
     );
 };

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/cleanup_policy_revisions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/cleanup_policy_revisions.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { type ElasticsearchClient } from '@kbn/core/server';
+
+import type { Context, Config } from './types';
+import { getPoliciesToClean } from './get_policies_to_clean';
+import { populateMinimumRevisionsUsedByAgents } from './populate_minimum_revisions_used_by_agents';
+import { deletePolicyRevisions } from './delete_policy_revisions';
+
+const defaultConfig = {
+  maxRevisions: 10,
+  maxPolicies: 100,
+  maxDocsToDelete: 5000,
+  timeout: '5m',
+};
+
+type ContextParam = Omit<Context, 'config'> & { config?: Partial<Config> };
+
+export const cleanupPolicyRevisions = async (
+  esClient: ElasticsearchClient,
+  context: ContextParam
+) => {
+  const { logger, abortController } = context;
+
+  const config = {
+    ...defaultConfig,
+    ...context.config,
+  };
+
+  logger.debug(
+    `[FleetPolicyRevisionsCleanupTask] Starting cleanup with max_revisions: ${config.maxRevisions}, max_policies_per_run: ${config.maxPolicies}`
+  );
+
+  const policiesToClean = await getPoliciesToClean(esClient, {
+    ...context,
+    config,
+  });
+
+  if (Object.keys(policiesToClean).length === 0) {
+    logger.info(
+      `[FleetPolicyRevisionsCleanupTask] No policies found with more than ${config.maxRevisions} revisions. Exiting cleanup task.`
+    );
+
+    return;
+  }
+
+  logger.info(
+    `[FleetPolicyRevisionsCleanupTask] Found ${
+      Object.keys(policiesToClean).length
+    } policies with more than ${config.maxRevisions} revisions.`
+  );
+
+  throwIfAborted(abortController);
+
+  const policiesRevisionSummaries = await populateMinimumRevisionsUsedByAgents(
+    esClient,
+    policiesToClean,
+    {
+      ...context,
+      config,
+    }
+  );
+
+  throwIfAborted(abortController);
+
+  const docCount = Object.values(policiesRevisionSummaries).reduce(
+    (sum, summary) => sum + (summary.count - config.maxRevisions),
+    0
+  );
+
+  logger.debug(
+    `[FleetPolicyRevisionsCleanupTask] Attempting to delete potentially ${
+      docCount >= config.maxDocsToDelete ? config.maxDocsToDelete : docCount
+    } policy revision documents.`
+  );
+
+  const result = await deletePolicyRevisions(esClient, policiesRevisionSummaries, {
+    ...context,
+    config,
+  });
+
+  if (result) {
+    logger.debug(
+      `[FleetPolicyRevisionsCleanupTask] Deleted ${result.deleted} policy revision documents.`
+    );
+  }
+  logger.debug('[FleetPolicyRevisionsCleanupTask] Cleanup completed');
+
+  return {
+    totalDeletedRevisions: result ? result.deleted : 0,
+  };
+};
+
+export const throwIfAborted = (abortController?: AbortController) => {
+  if (abortController?.signal.aborted) {
+    throw new Error('Task was aborted');
+  }
+};

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/delete_policy_revisions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/delete_policy_revisions.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { type ElasticsearchClient } from '@kbn/core/server';
+
+import { AGENT_POLICY_INDEX } from '../../../common';
+
+import type { Context, PoliciesRevisionSummaries } from './types';
+
+interface RevisionsToDeleteParams {
+  policyId: string;
+  revisionIdxCutoff: number;
+}
+
+export const deletePolicyRevisions = async (
+  esClient: ElasticsearchClient,
+  policiesRevisionSummaries: PoliciesRevisionSummaries,
+  context: Context
+) => {
+  const {
+    config: { maxRevisions },
+    logger,
+  } = context;
+
+  const policiesToDelete = Object.entries(policiesRevisionSummaries).reduce<
+    RevisionsToDeleteParams[]
+  >((acc, [policyId, summary]) => {
+    const minUsedRevisionIdxCutoff = summary.minUsedRevision
+      ? Math.max(summary.minUsedRevision - maxRevisions, 0)
+      : undefined;
+
+    // If we have a minimum used revision, but the max policy offset is less than 1, nothing to delete
+    if (minUsedRevisionIdxCutoff === 0) {
+      return acc;
+    }
+
+    // Favor a cutoff offset based on the min revision used by agents, otherwise use the max idx
+    const revisionIdxCutoff = minUsedRevisionIdxCutoff ?? summary.maxRevision - maxRevisions;
+    return [...acc, { policyId, revisionIdxCutoff, docCount: summary.count }];
+  }, []);
+
+  if (policiesToDelete.length === 0) {
+    logger.debug(
+      `[FleetPolicyRevisionsCleanupTask] No policy revisions to delete after evaluating agent usage.`
+    );
+    return;
+  }
+
+  return await queryDeletePolicyRevisions(esClient, policiesToDelete, context);
+};
+
+const queryDeletePolicyRevisions = async (
+  esClient: ElasticsearchClient,
+  policiesToDelete: Array<RevisionsToDeleteParams>,
+  context: Context
+) => {
+  if (policiesToDelete.length === 0) {
+    return;
+  }
+
+  const policyCutoffClauses = policiesToDelete.map(({ policyId, revisionIdxCutoff }) => ({
+    bool: {
+      must: [
+        { term: { policy_id: policyId } },
+        { range: { revision_idx: { lte: revisionIdxCutoff } } },
+      ],
+    },
+  }));
+
+  return await esClient.deleteByQuery(
+    {
+      index: AGENT_POLICY_INDEX,
+      max_docs: context.config.maxDocsToDelete,
+      conflicts: 'proceed',
+      scroll: context.config.timeout,
+      scroll_size: 1000,
+      wait_for_completion: true,
+      query: {
+        bool: {
+          should: policyCutoffClauses,
+        },
+      },
+    },
+    { signal: context.abortController?.signal }
+  );
+};

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/fleet_policy_revisions_cleanup_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/fleet_policy_revisions_cleanup_task.test.ts
@@ -1,0 +1,652 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { loggerMock } from '@kbn/logging-mocks';
+import { coreMock } from '@kbn/core/server/mocks';
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
+
+import { appContextService } from '../../services';
+
+import {
+  FleetPolicyRevisionsCleanupTask,
+  TYPE,
+  VERSION,
+} from './fleet_policy_revisions_cleanup_task';
+
+jest.mock('../../services');
+
+const mockAppContextService = appContextService as jest.Mocked<typeof appContextService>;
+
+const expectedDeleteByQueryConfig = {
+  conflicts: 'proceed',
+  max_docs: expect.any(Number),
+  scroll: expect.any(String),
+  scroll_size: expect.any(Number),
+  wait_for_completion: true,
+};
+
+describe('FleetPolicyRevisionsCleanupTask', () => {
+  let mockTask: FleetPolicyRevisionsCleanupTask;
+  let mockCore: ReturnType<typeof coreMock.createSetup>;
+  let mockCoreStart: ReturnType<typeof coreMock.createStart>;
+  let mockTaskManager: ReturnType<typeof taskManagerMock.createSetup>;
+  let mockTaskManagerStart: ReturnType<typeof taskManagerMock.createStart>;
+  let logFactory: ReturnType<typeof loggerMock.create>;
+  let logger: ReturnType<typeof loggerMock.create>;
+  let mockEsClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+  let abortController: AbortController;
+  let taskInstance: ConcreteTaskInstance;
+
+  const defaultConfig = {
+    maxRevisions: 10,
+    interval: '1h',
+    maxPoliciesPerRun: 100,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockCore = coreMock.createSetup();
+    mockCoreStart = coreMock.createStart();
+    mockTaskManager = taskManagerMock.createSetup();
+    mockTaskManagerStart = taskManagerMock.createStart();
+    logFactory = loggerMock.create();
+    logger = loggerMock.create();
+    mockEsClient = elasticsearchServiceMock.createElasticsearchClient();
+    abortController = new AbortController();
+
+    // Setup core services mock
+    mockCore.getStartServices.mockResolvedValue([mockCoreStart, {}, {}] as any);
+    Object.defineProperty(mockCoreStart.elasticsearch.client, 'asInternalUser', {
+      value: mockEsClient,
+      writable: true,
+    });
+
+    logFactory.get.mockReturnValue(logger);
+
+    // Setup app context service mocks
+    mockAppContextService.getExperimentalFeatures.mockReturnValue({
+      enableFleetPolicyRevisionsCleanupTask: true,
+    } as any);
+
+    taskInstance = {
+      id: `${TYPE}:${VERSION}`,
+      taskType: TYPE,
+      scheduledAt: new Date(),
+      attempts: 0,
+      status: 'idle' as any,
+      runAt: new Date(),
+      state: {},
+      params: { version: VERSION },
+      ownerId: null,
+      startedAt: null,
+      retryAt: null,
+    };
+
+    mockTask = new FleetPolicyRevisionsCleanupTask({
+      core: mockCore,
+      taskManager: mockTaskManager,
+      logFactory,
+      config: defaultConfig,
+    });
+  });
+
+  describe('constructor and setup', () => {
+    it('should register task definition with correct parameters', () => {
+      expect(mockTaskManager.registerTaskDefinitions).toHaveBeenCalledWith({
+        [TYPE]: expect.objectContaining({
+          title: 'Fleet Policy Revisions Cleanup Task',
+          timeout: '5m',
+          createTaskRunner: expect.any(Function),
+        }),
+      });
+    });
+
+    it('should use provided configuration values', () => {
+      const customConfig = {
+        maxRevisions: 20,
+        interval: '2h',
+        maxPoliciesPerRun: 50,
+      };
+
+      const task = new FleetPolicyRevisionsCleanupTask({
+        core: mockCore,
+        taskManager: mockTaskManager,
+        logFactory,
+        config: customConfig,
+      });
+
+      expect(task).toBeDefined();
+    });
+
+    it('should use default configuration values when not provided', () => {
+      const task = new FleetPolicyRevisionsCleanupTask({
+        core: mockCore,
+        taskManager: mockTaskManager,
+        logFactory,
+        config: {},
+      });
+
+      expect(task).toBeDefined();
+    });
+  });
+
+  describe('start', () => {
+    it('should successfully start and schedule task', async () => {
+      await mockTask.start({ taskManager: mockTaskManagerStart });
+
+      expect(mockTaskManagerStart.ensureScheduled).toHaveBeenCalledWith({
+        id: `${TYPE}:${VERSION}`,
+        taskType: TYPE,
+        scope: ['fleet'],
+        schedule: {
+          interval: '1h',
+        },
+        state: {},
+        params: { version: VERSION },
+      });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Started with interval of [1h], max_revisions: 10, max_policies_per_run: 100'
+        )
+      );
+    });
+
+    it('should handle scheduling errors', async () => {
+      const error = new Error('Scheduling failed');
+      mockTaskManagerStart.ensureScheduled.mockRejectedValue(error);
+
+      await mockTask.start({ taskManager: mockTaskManagerStart });
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'Error scheduling task FleetPolicyRevisionsCleanupTask, error: Scheduling failed',
+        error
+      );
+    });
+  });
+
+  describe('runTask', () => {
+    beforeEach(async () => {
+      await mockTask.start({ taskManager: mockTaskManagerStart });
+    });
+
+    it('should skip execution when feature flag is disabled', async () => {
+      mockAppContextService.getExperimentalFeatures.mockReturnValue({
+        enableFleetPolicyRevisionsCleanupTask: false,
+      } as any);
+
+      await mockTask.runTask(taskInstance, mockCore, abortController);
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        '[FleetPolicyRevisionsCleanupTask] Aborting runTask: fleet policy revision cleanup task feature is disabled'
+      );
+      expect(mockCore.getStartServices).not.toHaveBeenCalled();
+    });
+
+    it('should log errors if one is thrown', async () => {
+      const error = new Error('Test error');
+      mockEsClient.search.mockRejectedValue(error);
+
+      await mockTask.runTask(taskInstance, mockCore, abortController);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        '[FleetPolicyRevisionsCleanupTask] error: Error: Test error'
+      );
+    });
+  });
+
+  describe('cleanupPolicyRevisions', () => {
+    beforeEach(async () => {
+      await mockTask.start({ taskManager: mockTaskManagerStart });
+    });
+
+    it('should exit early when no policies need cleanup', async () => {
+      mockEsClient.search.mockResolvedValue({
+        aggregations: {
+          latest_revisions_by_policy_id: {
+            buckets: [],
+          },
+        },
+      } as any);
+
+      await mockTask.runTask(taskInstance, mockCore, abortController);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('No policies found with more than 10 revisions')
+      );
+      expect(mockEsClient.search).toHaveBeenCalledTimes(1);
+    });
+
+    it('should process policies that exceed max revisions', async () => {
+      mockEsClient.search
+        .mockResolvedValueOnce({
+          aggregations: {
+            latest_revisions_by_policy_id: {
+              buckets: [
+                {
+                  key: 'policy-1',
+                  doc_count: 15, // More than max_revisions (10)
+                  latest_revision: { value: 15 },
+                },
+                {
+                  key: 'policy-2',
+                  doc_count: 5, // Less than max_revisions, should be filtered out
+                  latest_revision: { value: 5 },
+                },
+              ],
+            },
+          },
+        } as any)
+        .mockResolvedValueOnce({
+          aggregations: {
+            min_used_revisions_by_policy_id: {
+              buckets: [
+                {
+                  key: 'policy-1',
+                  doc_count: 100,
+                  min_used_revision: { value: 15 },
+                },
+              ],
+            },
+          },
+        } as any);
+
+      mockEsClient.deleteByQuery.mockResolvedValue({
+        deleted: 5,
+      } as any);
+
+      await mockTask.runTask(taskInstance, mockCore, abortController);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[FleetPolicyRevisionsCleanupTask] Found 1 policies with more than 10 revisions.'
+      );
+      expect(mockEsClient.deleteByQuery).toHaveBeenCalledWith(
+        {
+          index: '.fleet-policies',
+          ...expectedDeleteByQueryConfig,
+          query: {
+            bool: {
+              should: [
+                {
+                  bool: {
+                    must: [
+                      { term: { policy_id: 'policy-1' } },
+                      { range: { revision_idx: { lte: 5 } } }, // 15 - 10 = 5
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+        {
+          signal: abortController.signal,
+        }
+      );
+    });
+
+    it('should favor cutting off deletions from the minimum used revision', async () => {
+      mockEsClient.search
+        .mockResolvedValueOnce({
+          aggregations: {
+            latest_revisions_by_policy_id: {
+              buckets: [
+                {
+                  key: 'policy-1',
+                  doc_count: 15, // More than max_revisions (10)
+                  latest_revision: { value: 15 },
+                },
+                {
+                  key: 'policy-2',
+                  doc_count: 5, // Less than max_revisions, should be filtered out
+                  latest_revision: { value: 5 },
+                },
+              ],
+            },
+          },
+        } as any)
+        .mockResolvedValueOnce({
+          aggregations: {
+            min_used_revisions_by_policy_id: {
+              buckets: [
+                {
+                  key: 'policy-1',
+                  doc_count: 100,
+                  min_used_revision: { value: 12 }, // Cutoff will be 2 (12 - 10 = 2)
+                },
+              ],
+            },
+          },
+        } as any);
+
+      mockEsClient.deleteByQuery.mockResolvedValue({
+        deleted: 5,
+      } as any);
+
+      await mockTask.runTask(taskInstance, mockCore, abortController);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[FleetPolicyRevisionsCleanupTask] Found 1 policies with more than 10 revisions.'
+      );
+      expect(mockEsClient.deleteByQuery).toHaveBeenCalledWith(
+        {
+          index: '.fleet-policies',
+          ...expectedDeleteByQueryConfig,
+          query: {
+            bool: {
+              should: [
+                {
+                  bool: {
+                    must: [
+                      { term: { policy_id: 'policy-1' } },
+                      { range: { revision_idx: { lte: 2 } } }, // 12 - 10 = 2
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+        {
+          signal: abortController.signal,
+        }
+      );
+    });
+
+    // Important case: We do not want deleteByQuery to be called with an empty bool.should, this can result in all revision docs being deleted
+    it('should skip deletions of a policy revision if the calculated cutoff idx from minimum used revision is equal or below 0', async () => {
+      mockEsClient.search
+        .mockResolvedValueOnce({
+          aggregations: {
+            latest_revisions_by_policy_id: {
+              buckets: [
+                {
+                  key: 'policy-1',
+                  doc_count: 15,
+                  latest_revision: { value: 15 },
+                },
+              ],
+            },
+          },
+        } as any)
+        .mockResolvedValueOnce({
+          aggregations: {
+            min_used_revisions_by_policy_id: {
+              buckets: [
+                {
+                  key: 'policy-1',
+                  doc_count: 100,
+                  min_used_revision: { value: 5 }, // Cutoff will be -5 (5 - 10 = -5)
+                },
+              ],
+            },
+          },
+        } as any);
+
+      mockEsClient.deleteByQuery.mockResolvedValue({
+        deleted: 5,
+      } as any);
+
+      await mockTask.runTask(taskInstance, mockCore, abortController);
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        '[FleetPolicyRevisionsCleanupTask] No policy revisions to delete after evaluating agent usage.'
+      );
+      expect(mockEsClient.deleteByQuery).not.toHaveBeenCalledWith();
+    });
+    it('should never run deleteByQuery if after calculating revision cutoff indexes from minimum used by agents results in no revisions to delete', async () => {
+      mockEsClient.search
+        .mockResolvedValueOnce({
+          aggregations: {
+            latest_revisions_by_policy_id: {
+              buckets: [
+                {
+                  key: 'policy-1',
+                  doc_count: 15, // More than max_revisions (10)
+                  latest_revision: { value: 15 },
+                },
+                {
+                  key: 'policy-2',
+                  doc_count: 15, // Less than max_revisions, should be filtered out
+                  latest_revision: { value: 15 },
+                },
+              ],
+            },
+          },
+        } as any)
+        .mockResolvedValueOnce({
+          aggregations: {
+            min_used_revisions_by_policy_id: {
+              buckets: [
+                {
+                  key: 'policy-1',
+                  doc_count: 100,
+                  min_used_revision: { value: 15 },
+                },
+                {
+                  key: 'policy-2',
+                  doc_count: 100,
+                  min_used_revision: { value: 5 }, // Cutoff will be -5 (5 - 10 = -5)
+                },
+              ],
+            },
+          },
+        } as any);
+
+      mockEsClient.deleteByQuery.mockResolvedValue({
+        deleted: 5,
+      } as any);
+
+      await mockTask.runTask(taskInstance, mockCore, abortController);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[FleetPolicyRevisionsCleanupTask] Found 2 policies with more than 10 revisions.'
+      );
+      expect(mockEsClient.deleteByQuery).toHaveBeenCalledWith(
+        {
+          index: '.fleet-policies',
+          ...expectedDeleteByQueryConfig,
+          query: {
+            bool: {
+              should: [
+                {
+                  bool: {
+                    must: [
+                      { term: { policy_id: 'policy-1' } },
+                      { range: { revision_idx: { lte: 5 } } }, // 15 - 10 = 5
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+        {
+          signal: abortController.signal,
+        }
+      );
+    });
+
+    it('should calculate the deletion cutoff for a policy from the latest revision if not used by agents', async () => {
+      mockEsClient.search
+        .mockResolvedValueOnce({
+          aggregations: {
+            latest_revisions_by_policy_id: {
+              buckets: [
+                {
+                  key: 'policy-1',
+                  doc_count: 20,
+                  latest_revision: { value: 20 },
+                },
+              ],
+            },
+          },
+        } as any)
+        // Mock the query for minimum revisions used by agents
+        .mockResolvedValueOnce({
+          aggregations: {
+            min_used_revisions_by_policy_id: {
+              buckets: [],
+            },
+          },
+        } as any);
+
+      mockEsClient.deleteByQuery.mockResolvedValue({
+        deleted: 5,
+      } as any);
+
+      await mockTask.runTask(taskInstance, mockCore, abortController);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[FleetPolicyRevisionsCleanupTask] Found 1 policies with more than 10 revisions.'
+      );
+      expect(mockEsClient.deleteByQuery).toHaveBeenCalledWith(
+        {
+          index: '.fleet-policies',
+          ...expectedDeleteByQueryConfig,
+          query: {
+            bool: {
+              should: [
+                {
+                  bool: {
+                    must: [
+                      { term: { policy_id: 'policy-1' } },
+                      { range: { revision_idx: { lte: 10 } } }, // 20 - 10 = 10
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+        {
+          signal: abortController.signal,
+        }
+      );
+    });
+  });
+
+  describe('query methods', () => {
+    beforeEach(async () => {
+      await mockTask.start({ taskManager: mockTaskManagerStart });
+    });
+
+    it('should query max revisions and counts correctly', async () => {
+      mockEsClient.search.mockResolvedValue({
+        aggregations: {
+          latest_revisions_by_policy_id: {
+            buckets: [],
+          },
+        },
+      } as any);
+
+      await mockTask.runTask(taskInstance, mockCore, abortController);
+
+      expect(mockEsClient.search).toHaveBeenCalledWith(
+        {
+          index: '.fleet-policies',
+          ignore_unavailable: true,
+          size: 0,
+          aggs: {
+            latest_revisions_by_policy_id: {
+              terms: {
+                field: 'policy_id',
+                order: { _count: 'desc' },
+                size: 100,
+              },
+              aggs: {
+                latest_revision: {
+                  max: {
+                    field: 'revision_idx',
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          signal: abortController.signal,
+        }
+      );
+    });
+
+    it('should query minimum revisions used by agents filtered to the policy ids with more than max revisions', async () => {
+      mockEsClient.search
+        .mockResolvedValueOnce({
+          aggregations: {
+            latest_revisions_by_policy_id: {
+              buckets: [
+                {
+                  key: 'policy-1',
+                  doc_count: 15,
+                  latest_revision: { value: 15 },
+                },
+                {
+                  key: 'policy-2',
+                  doc_count: 1,
+                  latest_revision: { value: 20 },
+                },
+                {
+                  key: 'policy-3',
+                  doc_count: 10,
+                  latest_revision: { value: 12 },
+                },
+                {
+                  key: 'policy-4',
+                  doc_count: 12,
+                  latest_revision: { value: 12 },
+                },
+              ],
+            },
+          },
+        } as any)
+        .mockResolvedValueOnce({
+          aggregations: {
+            min_used_revisions_by_policy_id: {
+              buckets: [],
+            },
+          },
+        } as any);
+
+      mockEsClient.deleteByQuery.mockResolvedValue({ deleted: 0 } as any);
+
+      await mockTask.runTask(taskInstance, mockCore, abortController);
+
+      expect(mockEsClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: '.fleet-agents',
+          query: {
+            terms: {
+              policy_id: ['policy-1', 'policy-4'],
+            },
+          },
+          aggs: {
+            min_used_revisions_by_policy_id: {
+              terms: {
+                field: 'policy_id',
+                size: 100,
+              },
+              aggs: {
+                min_used_revision: {
+                  min: {
+                    field: 'policy_revision_idx',
+                  },
+                },
+              },
+            },
+          },
+        }),
+        {
+          signal: abortController.signal,
+        }
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/fleet_policy_revisions_cleanup_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/fleet_policy_revisions_cleanup_task.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { type CoreSetup, type Logger } from '@kbn/core/server';
+import type {
+  ConcreteTaskInstance,
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import { getDeleteTaskRunResult } from '@kbn/task-manager-plugin/server/task';
+import type { LoggerFactory } from '@kbn/core/server';
+import { errors } from '@elastic/elasticsearch';
+
+import { appContextService } from '../../services';
+
+import { cleanupPolicyRevisions } from './cleanup_policy_revisions';
+
+export const TYPE = 'fleet:policy-revisions-cleanup-task';
+export const VERSION = '1.0.0';
+const TITLE = 'Fleet Policy Revisions Cleanup Task';
+const SCOPE = ['fleet'];
+const TASK_TIMEOUT = '5m';
+
+interface FleetPolicyRevisionsCleanupTaskConfig {
+  maxRevisions?: number;
+  interval?: string;
+  maxPoliciesPerRun?: number;
+}
+
+interface FleetPolicyRevisionsCleanupTaskSetupContract {
+  core: CoreSetup;
+  taskManager: TaskManagerSetupContract;
+  logFactory: LoggerFactory;
+  config: FleetPolicyRevisionsCleanupTaskConfig;
+}
+
+interface FleetPolicyRevisionsCleanupTaskStartContract {
+  taskManager: TaskManagerStartContract;
+}
+
+export class FleetPolicyRevisionsCleanupTask {
+  private logger: Logger;
+  private wasStarted: boolean = false;
+  private taskInterval: string;
+  private maxRevisions: number;
+  private maxPoliciesPerRun: number;
+
+  constructor(setupContract: FleetPolicyRevisionsCleanupTaskSetupContract) {
+    const { core, taskManager, logFactory, config } = setupContract;
+    this.logger = logFactory.get(this.taskId);
+
+    this.taskInterval = config.interval ?? '1h';
+    this.maxRevisions = config.maxRevisions ?? 10;
+    this.maxPoliciesPerRun = config.maxPoliciesPerRun ?? 100;
+
+    taskManager.registerTaskDefinitions({
+      [TYPE]: {
+        title: TITLE,
+        timeout: TASK_TIMEOUT,
+        createTaskRunner: ({
+          taskInstance,
+          abortController,
+        }: {
+          taskInstance: ConcreteTaskInstance;
+          abortController: AbortController;
+        }) => {
+          return {
+            run: async () => {
+              return this.runTask(taskInstance, core, abortController);
+            },
+            cancel: async () => {},
+          };
+        },
+      },
+    });
+  }
+
+  public start = async ({ taskManager }: FleetPolicyRevisionsCleanupTaskStartContract) => {
+    if (!taskManager) {
+      this.logger.error('[FleetPolicyRevisionsCleanupTask] Missing required service during start');
+      return;
+    }
+
+    this.wasStarted = true;
+    this.logger.info(
+      `[FleetPolicyRevisionsCleanupTask] Started with interval of [${this.taskInterval}], max_revisions: ${this.maxRevisions}, max_policies_per_run: ${this.maxPoliciesPerRun}`
+    );
+
+    try {
+      await taskManager.ensureScheduled({
+        id: this.taskId,
+        taskType: TYPE,
+        scope: SCOPE,
+        schedule: {
+          interval: this.taskInterval,
+        },
+        state: {},
+        params: { version: VERSION },
+      });
+    } catch (e) {
+      this.logger.error(
+        `Error scheduling task FleetPolicyRevisionsCleanupTask, error: ${e.message}`,
+        e
+      );
+    }
+  };
+
+  private get taskId(): string {
+    return `${TYPE}:${VERSION}`;
+  }
+
+  private endRun(msg: string = '') {
+    this.logger.debug(`[FleetPolicyRevisionsCleanupTask] runTask ended${msg ? ': ' + msg : ''}`);
+  }
+
+  public runTask = async (
+    taskInstance: ConcreteTaskInstance,
+    core: CoreSetup,
+    abortController: AbortController
+  ) => {
+    // Check if the feature flag is enabled
+    if (!appContextService.getExperimentalFeatures().enableFleetPolicyRevisionsCleanupTask) {
+      this.logger.debug(
+        '[FleetPolicyRevisionsCleanupTask] Aborting runTask: fleet policy revision cleanup task feature is disabled'
+      );
+      return;
+    }
+
+    if (!this.wasStarted) {
+      this.logger.debug('[FleetPolicyRevisionsCleanupTask] runTask Aborted. Task not started yet');
+      return;
+    }
+
+    // Check that this task is current
+    if (taskInstance.id !== this.taskId) {
+      this.logger.debug(
+        `[FleetPolicyRevisionsCleanupTask] Outdated task version: Got [${taskInstance.id}] from task instance. Current version is [${this.taskId}]`
+      );
+      return getDeleteTaskRunResult();
+    }
+
+    this.logger.debug(`[FleetPolicyRevisionsCleanupTask] runTask() started`);
+
+    const [coreStart, _startDeps] = (await core.getStartServices()) as any;
+    const esClient = coreStart.elasticsearch.client.asInternalUser;
+
+    try {
+      await cleanupPolicyRevisions(esClient, {
+        abortController,
+        logger: this.logger,
+        config: {
+          maxRevisions: this.maxRevisions,
+          maxPolicies: this.maxPoliciesPerRun,
+          timeout: TASK_TIMEOUT,
+        },
+      });
+
+      this.endRun('success');
+    } catch (err) {
+      if (err instanceof errors.RequestAbortedError) {
+        this.logger.warn(
+          `[FleetPolicyRevisionsCleanupTask] request aborted due to timeout: ${err}`
+        );
+        this.endRun();
+        return;
+      }
+      this.logger.error(`[FleetPolicyRevisionsCleanupTask] error: ${err}`);
+      this.endRun('error');
+    }
+  };
+}

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/get_policies_to_clean.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/get_policies_to_clean.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { type ElasticsearchClient } from '@kbn/core/server';
+
+import { AGENT_POLICY_INDEX } from '../../../common';
+
+import type { Context, PoliciesRevisionSummaries } from './types';
+
+export const getPoliciesToClean = async (esClient: ElasticsearchClient, context: Context) => {
+  const {
+    config: { maxRevisions },
+  } = context;
+  const results = await queryMaxRevisionsAndCounts(esClient, context);
+  return (
+    results.aggregations?.latest_revisions_by_policy_id.buckets.reduce<PoliciesRevisionSummaries>(
+      (acc, bucket) => {
+        if (bucket.doc_count > maxRevisions) {
+          acc[bucket.key] = {
+            maxRevision: bucket.latest_revision.value,
+            count: bucket.doc_count,
+          };
+        }
+        return acc;
+      },
+      {}
+    ) ?? {}
+  );
+};
+
+const queryMaxRevisionsAndCounts = async (esClient: ElasticsearchClient, context: Context) => {
+  interface Aggregations {
+    latest_revisions_by_policy_id: {
+      buckets: Array<{
+        key: string;
+        doc_count: number;
+        latest_revision: {
+          value: number;
+        };
+      }>;
+    };
+  }
+
+  return await esClient.search<{}, Aggregations>(
+    {
+      index: AGENT_POLICY_INDEX,
+      ignore_unavailable: true,
+      size: 0,
+      aggs: {
+        latest_revisions_by_policy_id: {
+          terms: {
+            field: 'policy_id',
+            order: { _count: 'desc' },
+            size: context.config.maxPolicies,
+          },
+          aggs: {
+            latest_revision: {
+              max: {
+                field: 'revision_idx',
+              },
+            },
+          },
+        },
+      },
+    },
+    { signal: context.abortController?.signal }
+  );
+};

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/populate_minimum_revisions_used_by_agents.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/populate_minimum_revisions_used_by_agents.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { type ElasticsearchClient } from '@kbn/core/server';
+
+import { AGENTS_INDEX } from '../../../common';
+
+import type { Context, PoliciesRevisionSummaries } from './types';
+
+export const populateMinimumRevisionsUsedByAgents = async (
+  esClient: ElasticsearchClient,
+  policiesRevisionSummaries: PoliciesRevisionSummaries,
+  context: Context
+) => {
+  const result = await queryMinimumRevisionsUsedByAgents(
+    esClient,
+    Object.keys(policiesRevisionSummaries),
+    context
+  );
+
+  result.aggregations?.min_used_revisions_by_policy_id.buckets.forEach((bucket) => {
+    const policySummary = policiesRevisionSummaries[bucket.key];
+    if (policySummary) {
+      policySummary.minUsedRevision = bucket.min_used_revision.value;
+    }
+  });
+
+  return policiesRevisionSummaries;
+};
+
+const queryMinimumRevisionsUsedByAgents = async (
+  esClient: ElasticsearchClient,
+  policyIds: string[],
+  context: Context
+) => {
+  interface Aggregations {
+    min_used_revisions_by_policy_id: {
+      buckets: Array<{
+        key: string;
+        doc_count: number;
+        min_used_revision: {
+          value: number;
+        };
+      }>;
+    };
+  }
+
+  return await esClient.search<{}, Aggregations>(
+    {
+      index: AGENTS_INDEX,
+      ignore_unavailable: true,
+      size: 0,
+      query: {
+        terms: {
+          policy_id: policyIds,
+        },
+      },
+      aggs: {
+        min_used_revisions_by_policy_id: {
+          terms: {
+            field: 'policy_id',
+            size: context.config.maxPolicies,
+          },
+          aggs: {
+            min_used_revision: {
+              min: {
+                field: 'policy_revision_idx',
+              },
+            },
+          },
+        },
+      },
+    },
+    { signal: context.abortController?.signal }
+  );
+};

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/types.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/fleet_policy_revisions_cleanup/types.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { type Logger } from '@kbn/core/server';
+
+export interface Config {
+  maxRevisions: number;
+  maxPolicies: number;
+  maxDocsToDelete: number;
+  timeout?: string;
+}
+
+export interface Context {
+  abortController?: AbortController;
+  logger: Logger;
+  config: Config;
+}
+
+export type PoliciesRevisionSummaries = Record<
+  string,
+  {
+    maxRevision: number;
+    minUsedRevision?: number;
+    count: number;
+  }
+>;

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agent_policy.ts
@@ -203,3 +203,27 @@ export const GetListAgentPolicyOutputsRequestSchema = {
     }),
   }),
 };
+
+export const RunAgentPolicyRevisionsCleanupTaskRequestSchema = {
+  body: schema.object({
+    maxRevisions: schema.maybe(
+      schema.number({
+        min: 1,
+        meta: { description: 'maximum revisions to keep per policy' },
+      })
+    ),
+    maxPolicies: schema.maybe(
+      schema.number({
+        min: 1,
+        meta: { description: 'maximum number of policies to process for this task' },
+      })
+    ),
+  }),
+};
+
+export const RunAgentPolicyRevisionsCleanupTaskResponseSchema = schema.object({
+  success: schema.boolean({ meta: { description: 'whether the cleanup task ran successfully' } }),
+  totalDeletedRevisions: schema.number({
+    meta: { description: 'total number of deleted policy revisions' },
+  }),
+});

--- a/x-pack/platform/plugins/shared/fleet/tsconfig.json
+++ b/x-pack/platform/plugins/shared/fleet/tsconfig.json
@@ -10,6 +10,7 @@
     "common/**/*",
     "public/**/*",
     "server/**/*",
+    "tasks/**/*",
     "server/**/*.json",
     "scripts/**/*",
     "package.json",

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/cleanup_agent_policy_revisions.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/cleanup_agent_policy_revisions.ts
@@ -1,0 +1,325 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import pRetry from 'p-retry';
+import expect from '@kbn/expect';
+import { AGENTS_INDEX, AGENT_POLICY_INDEX } from '@kbn/fleet-plugin/common';
+import type { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+
+export async function createAgentDoc(
+  providerContext: FtrProviderContext,
+  id: string,
+  policyId: string,
+  additionalData: any = {}
+) {
+  const { getService } = providerContext;
+  const es = getService('es');
+  const lastCheckin = new Date().toISOString();
+
+  await es.index({
+    index: AGENTS_INDEX,
+    id,
+    document: {
+      id,
+      type: 'PERMANENT',
+      active: true,
+      enrolled_at: new Date().toISOString(),
+      last_checkin: lastCheckin,
+      policy_id: policyId,
+      policy_revision: 1,
+      policy_revision_idx: 1,
+      agent: {
+        id,
+        version: '9.3.0',
+      },
+      local_metadata: {
+        elastic: {
+          agent: {
+            version: '9.3.0',
+            upgradeable: true,
+          },
+        },
+      },
+      ...additionalData,
+    },
+    refresh: 'wait_for',
+  });
+}
+
+export async function cleanupAgentDocs(providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+  const es = getService('es');
+
+  try {
+    await es.deleteByQuery({
+      index: AGENTS_INDEX,
+      refresh: true,
+      query: {
+        match_all: {},
+      },
+    });
+  } catch (err) {
+    // index doesn't exist
+  }
+}
+
+async function createPolicyRevision(
+  providerContext: FtrProviderContext,
+  policyId: string,
+  revisionIdx: number
+) {
+  const { getService } = providerContext;
+  const es = getService('es');
+
+  const doc = {
+    '@timestamp': new Date().toISOString(),
+    policy_id: policyId,
+    revision_idx: revisionIdx,
+    data: {
+      id: policyId,
+      name: `Test Policy ${policyId}`,
+      namespace: 'default',
+      revision: revisionIdx,
+      agent_features: [],
+      inputs: [],
+    },
+  };
+
+  await es.index({
+    index: AGENT_POLICY_INDEX,
+    id: `${policyId}:${revisionIdx}`,
+    document: doc,
+    refresh: 'wait_for',
+  });
+}
+
+export async function createPolicyRevisions(
+  providerContext: FtrProviderContext,
+  policyId: string,
+  count: number
+) {
+  const promises = [];
+  for (let i = 1; i <= count; i++) {
+    promises.push(createPolicyRevision(providerContext, policyId, 1 + i));
+  }
+  await Promise.all(promises);
+}
+
+export async function assertPolicyRevisions(
+  providerContext: FtrProviderContext,
+  policyId: string,
+  expectedCount: number,
+  expectedIndexes: number[]
+) {
+  const { getService } = providerContext;
+  const es = getService('es');
+
+  return pRetry(
+    async () => {
+      const result = await es.search({
+        index: AGENT_POLICY_INDEX,
+        query: {
+          term: {
+            policy_id: policyId,
+          },
+        },
+        sort: [{ revision_idx: { order: 'asc' } }],
+        size: 1000,
+      });
+
+      const revisions = result.hits.hits.map((hit: any) => ({
+        id: hit._id,
+        revision_idx: hit._source.revision_idx,
+      }));
+
+      if (expectedCount !== undefined) {
+        expect(revisions.length).to.eql(expectedCount);
+      }
+
+      if (expectedIndexes !== undefined) {
+        const revisionIndexes = revisions.map((r) => r.revision_idx).sort((a, b) => a - b);
+        expect(revisionIndexes).to.eql(expectedIndexes);
+      }
+    },
+    {
+      retries: 5,
+      minTimeout: 1000,
+    }
+  );
+}
+
+export async function cleanupPolicyRevisions(providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+  const es = getService('es');
+
+  await es.deleteByQuery({
+    index: AGENT_POLICY_INDEX,
+    ignore_unavailable: true,
+    refresh: true,
+    query: {
+      match_all: {},
+    },
+  });
+}
+
+const arrFromRange = (start: number, end: number) => {
+  return Array.from({ length: end - start + 1 }, (_, i) => i + start);
+};
+
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+  const supertest = getService('supertest');
+  const MAX_REVISIONS = 5;
+  let testPolicyId: string;
+
+  const runAgentPolicyRevisionsCleanup = () => {
+    return supertest
+      .post(`/internal/fleet/agent_policies/_cleanup_revisions`)
+      .set('kbn-xsrf', 'xxxx')
+      .set('elastic-api-version', '1')
+      .send({ maxRevisions: MAX_REVISIONS })
+      .expect(200);
+  };
+
+  describe('Fleet Agent Policy Revisions Cleanup', () => {
+    before(async () => {
+      await supertest.post(`/api/fleet/setup`).set('kbn-xsrf', 'xxxx').expect(200);
+    });
+
+    beforeEach(async () => {
+      const { body: agentPolicyResponse } = await supertest
+        .post('/api/fleet/agent_policies')
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: `Test policy for cleanup ${Date.now()}`,
+          namespace: 'default',
+        })
+        .expect(200);
+      testPolicyId = agentPolicyResponse.item.id;
+    });
+
+    after(async () => {
+      await supertest
+        .post('/api/fleet/agent_policies/delete')
+        .send({ agentPolicyId: testPolicyId })
+        .set('kbn-xsrf', 'xxxx')
+        .expect(200);
+    });
+
+    afterEach(async () => {
+      await cleanupAgentDocs(providerContext);
+      await cleanupPolicyRevisions(providerContext);
+    });
+
+    // With revision counts, the creation of the policy includes an implicit revision 1
+    it('should not clean up policies with revisions equal to max_revisions limit', async () => {
+      const revisionsToCreate = MAX_REVISIONS - 1;
+      await createPolicyRevisions(providerContext, testPolicyId, revisionsToCreate);
+
+      await runAgentPolicyRevisionsCleanup();
+
+      await assertPolicyRevisions(
+        providerContext,
+        testPolicyId,
+        MAX_REVISIONS,
+        arrFromRange(1, MAX_REVISIONS)
+      );
+    });
+
+    it('should clean up policies with revisions exceeding max_revisions limit', async () => {
+      const numRevisionsToAdd = MAX_REVISIONS + 3;
+      await createPolicyRevisions(providerContext, testPolicyId, numRevisionsToAdd);
+
+      await runAgentPolicyRevisionsCleanup();
+
+      await assertPolicyRevisions(providerContext, testPolicyId, MAX_REVISIONS, arrFromRange(5, 9));
+    });
+
+    it('should preserve all revisions above the minimum used revision by an agent', async () => {
+      const numRevisionsToAdd = MAX_REVISIONS + 6;
+      await createPolicyRevisions(providerContext, testPolicyId, numRevisionsToAdd);
+
+      // Create agents using older revisions that would normally be cleaned up
+      await createAgentDoc(providerContext, 'agent1', testPolicyId, {
+        policy_revision_idx: 7,
+      });
+      await createAgentDoc(providerContext, 'agent2', testPolicyId, {
+        policy_revision_idx: 6,
+      });
+
+      // Should keep all revisions from 2 and up. Min agent revision is 6, so 6 - 5 (max revisions) = 1, so keep from revision 2 and up
+      await runAgentPolicyRevisionsCleanup();
+
+      await assertPolicyRevisions(
+        providerContext,
+        testPolicyId,
+        numRevisionsToAdd,
+        arrFromRange(2, 12)
+      );
+    });
+
+    it('should not make any deletions if minimum used revision minus max_revisions has an offset at or idx 0', async () => {
+      const numRevisionsToAdd = MAX_REVISIONS + 3;
+      await createPolicyRevisions(providerContext, testPolicyId, numRevisionsToAdd);
+      // Create agents using older revisions that would normally be cleaned up
+      await createAgentDoc(providerContext, 'agent1', testPolicyId, {
+        policy_revision_idx: 2,
+      });
+
+      const expectedRevisionsCount = numRevisionsToAdd + 1;
+
+      await runAgentPolicyRevisionsCleanup();
+
+      await assertPolicyRevisions(
+        providerContext,
+        testPolicyId,
+        expectedRevisionsCount,
+        arrFromRange(1, expectedRevisionsCount)
+      );
+    });
+
+    it('should handle multiple policies in a single cleanup run', async () => {
+      // Create a second policy
+      const { body: agentPolicyResponse2 } = await supertest
+        .post('/api/fleet/agent_policies')
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: 'Test policy 2',
+          namespace: 'default',
+        })
+        .expect(200);
+      const testPolicyId2 = agentPolicyResponse2.item.id;
+
+      try {
+        const policy1RevisionsToAdd = MAX_REVISIONS + 3;
+        const policy2RevisionsToAdd = MAX_REVISIONS + 2;
+        await createPolicyRevisions(providerContext, testPolicyId, policy1RevisionsToAdd);
+        await createPolicyRevisions(providerContext, testPolicyId2, policy2RevisionsToAdd);
+
+        await runAgentPolicyRevisionsCleanup();
+
+        await assertPolicyRevisions(
+          providerContext,
+          testPolicyId,
+          MAX_REVISIONS,
+          arrFromRange(5, 9)
+        );
+        await assertPolicyRevisions(
+          providerContext,
+          testPolicyId2,
+          MAX_REVISIONS,
+          arrFromRange(4, 8)
+        );
+      } finally {
+        await supertest
+          .post('/api/fleet/agent_policies/delete')
+          .send({ agentPolicyId: testPolicyId2 })
+          .set('kbn-xsrf', 'xxxx')
+          .expect(200);
+      }
+    });
+  });
+}

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/index.js
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/index.js
@@ -14,5 +14,6 @@ export default function loadTests({ loadTestFile }) {
     loadTestFile(require.resolve('./agent_policy_root_integrations'));
     loadTestFile(require.resolve('./create_standalone_api_key'));
     loadTestFile(require.resolve('./agent_policy_outputs'));
+    loadTestFile(require.resolve('./cleanup_agent_policy_revisions'));
   });
 }

--- a/x-pack/platform/test/fleet_tasks/tests/index.ts
+++ b/x-pack/platform/test/fleet_tasks/tests/index.ts
@@ -8,7 +8,7 @@
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
-  describe('Fleet packages test', function () {
+  describe('Fleet tasks', function () {
     loadTestFile(require.resolve('./automatic_upgrades'));
   });
 }

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -172,6 +172,7 @@ export default function ({ getService }: FtrProviderContext) {
         'fleet:deploy_agent_policies',
         'fleet:migrate_action:retry',
         'fleet:packages-bulk-operations',
+        'fleet:policy-revisions-cleanup-task',
         'fleet:reassign_action:retry',
         'fleet:request_diagnostics:retry',
         'fleet:setup',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Add fleet policy revisions cleanup task (#242612)](https://github.com/elastic/kibana/pull/242612)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michel Losier","email":"michel.losier@elastic.co"},"sourceCommit":{"committedDate":"2025-11-24T18:53:39Z","message":"Add fleet policy revisions cleanup task (#242612)\n\nResolves: https://github.com/elastic/kibana/issues/119963\nPR to add new Kibana config to allow list:\nhttps://github.com/elastic/cloud/pull/149322\n\n* Adds the background task `FleetPolicyRevisionsCleanupTask` which\nremoves excess policy revisions from the `.fleet-policies` index\n* Enabled by default, disabled by new feature flag:\n```\n xpack.fleet.experimentalFeatures:\n  enableFleetPolicyRevisionsCleanupTask: true\n```\n* Configurable with the following:\n\n```\nxpack.fleet.fleetPolicyRevisionsCleanup:\n  interval: string // Time interval expression. Default: '1h'\n  max_revisions: number // Maximum amount of policy revisions. Default: 10.\n  max_policies_per_run: number // Maximum policies to delete revisions from per run. Default 100.\n```\n* Also adds an internal endpoint for the same operation:\n\n```\nPOST kbn:/internal/fleet/agent_policies/_cleanup_revisions?apiVersion=1\n{\n    \"maxRevisions\": number, // max revisions a policy should have\n    \"maxPolicies\": number, // max policies to process\n}\n```\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d2e01dc368b018be3f09de5eb65e2ba5e2ef95a0","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Fleet","ci:cloud-deploy","backport:version","v9.3.0","v9.2.3","v9.1.9","v8.19.9"],"title":"Add fleet policy revisions cleanup task","number":242612,"url":"https://github.com/elastic/kibana/pull/242612","mergeCommit":{"message":"Add fleet policy revisions cleanup task (#242612)\n\nResolves: https://github.com/elastic/kibana/issues/119963\nPR to add new Kibana config to allow list:\nhttps://github.com/elastic/cloud/pull/149322\n\n* Adds the background task `FleetPolicyRevisionsCleanupTask` which\nremoves excess policy revisions from the `.fleet-policies` index\n* Enabled by default, disabled by new feature flag:\n```\n xpack.fleet.experimentalFeatures:\n  enableFleetPolicyRevisionsCleanupTask: true\n```\n* Configurable with the following:\n\n```\nxpack.fleet.fleetPolicyRevisionsCleanup:\n  interval: string // Time interval expression. Default: '1h'\n  max_revisions: number // Maximum amount of policy revisions. Default: 10.\n  max_policies_per_run: number // Maximum policies to delete revisions from per run. Default 100.\n```\n* Also adds an internal endpoint for the same operation:\n\n```\nPOST kbn:/internal/fleet/agent_policies/_cleanup_revisions?apiVersion=1\n{\n    \"maxRevisions\": number, // max revisions a policy should have\n    \"maxPolicies\": number, // max policies to process\n}\n```\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d2e01dc368b018be3f09de5eb65e2ba5e2ef95a0"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/242612","number":242612,"mergeCommit":{"message":"Add fleet policy revisions cleanup task (#242612)\n\nResolves: https://github.com/elastic/kibana/issues/119963\nPR to add new Kibana config to allow list:\nhttps://github.com/elastic/cloud/pull/149322\n\n* Adds the background task `FleetPolicyRevisionsCleanupTask` which\nremoves excess policy revisions from the `.fleet-policies` index\n* Enabled by default, disabled by new feature flag:\n```\n xpack.fleet.experimentalFeatures:\n  enableFleetPolicyRevisionsCleanupTask: true\n```\n* Configurable with the following:\n\n```\nxpack.fleet.fleetPolicyRevisionsCleanup:\n  interval: string // Time interval expression. Default: '1h'\n  max_revisions: number // Maximum amount of policy revisions. Default: 10.\n  max_policies_per_run: number // Maximum policies to delete revisions from per run. Default 100.\n```\n* Also adds an internal endpoint for the same operation:\n\n```\nPOST kbn:/internal/fleet/agent_policies/_cleanup_revisions?apiVersion=1\n{\n    \"maxRevisions\": number, // max revisions a policy should have\n    \"maxPolicies\": number, // max policies to process\n}\n```\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d2e01dc368b018be3f09de5eb65e2ba5e2ef95a0"}},{"branch":"9.2","label":"v9.2.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->