### PR TITLE
[SharedUX][A11y] Add missing labels to watcher fields

### DIFF
--- a/x-pack/platform/plugins/private/watcher/public/application/components/form_errors.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/components/form_errors.tsx
@@ -13,6 +13,7 @@ export const ErrableFormRow = ({
   isShowingErrors,
   errors,
   children,
+  id,
   ...rest
 }: {
   errorKey: string;
@@ -20,14 +21,16 @@ export const ErrableFormRow = ({
   errors: { [key: string]: string[] };
   children: ReactElement;
   [key: string]: any;
+  id?: string;
 }) => {
   return (
     <EuiFormRow
       isInvalid={isShowingErrors && errors[errorKey].length > 0}
       error={errors[errorKey]}
+      id={id}
       {...rest}
     >
-      <Fragment>{Children.map(children, (child) => cloneElement(child))}</Fragment>
+      <Fragment>{Children.map(children, (child) => cloneElement(child, { id }))}</Fragment>
     </EuiFormRow>
   );
 };

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/json_watch_edit/json_watch_edit_form.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/json_watch_edit/json_watch_edit_form.tsx
@@ -103,7 +103,6 @@ export const JsonWatchEditForm = () => {
           })}
         >
           <EuiFieldText
-            id="watchName"
             name="name"
             value={watch.name || ''}
             data-test-subj="nameInput"
@@ -129,7 +128,6 @@ export const JsonWatchEditForm = () => {
           errors={errors}
         >
           <EuiFieldText
-            id="id"
             name="id"
             data-test-subj="idInput"
             value={watch.id || ''}

--- a/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/threshold_watch_edit.tsx
+++ b/x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/threshold_watch_edit.tsx
@@ -238,6 +238,11 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
     defaultMessage: 'AND',
   });
 
+  const watchIntervalLabel = i18n.translate(
+    'xpack.watcher.sections.watchEdit.titlePanel.watchIntervalLabel',
+    { defaultMessage: 'Run watch every' }
+  );
+
   // Users might edit the request for use outside of the Watcher app. If they do make changes to it,
   // we have no guarantee it will still be compatible with the threshold alert form, so we strip
   // the metadata to avoid potential conflicts.
@@ -404,12 +409,7 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
             <ErrableFormRow
               id="watchInterval"
               fullWidth
-              label={
-                <FormattedMessage
-                  id="xpack.watcher.sections.watchEdit.titlePanel.watchIntervalLabel"
-                  defaultMessage="Run watch every"
-                />
-              }
+              label={watchIntervalLabel}
               errorKey="triggerIntervalSize"
               isShowingErrors={hasErrors && watch.triggerIntervalSize !== undefined}
               errors={errors}
@@ -431,6 +431,7 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
                         setWatchProperty('triggerIntervalSize', '');
                       }
                     }}
+                    aria-label={watchIntervalLabel}
                   />
                 </EuiFlexItem>
                 <EuiFlexItem>

--- a/x-pack/platform/test/functional/page_objects/watcher_page.ts
+++ b/x-pack/platform/test/functional/page_objects/watcher_page.ts
@@ -25,8 +25,8 @@ export class WatcherPageObject extends FtrService {
   async createWatch(watchName: string, name: string) {
     await this.testSubjects.click('createWatchButton');
     await this.testSubjects.click('jsonWatchCreateLink');
-    await this.find.setValue('#id', watchName);
-    await this.find.setValue('#watchName', name);
+    await this.testSubjects.setValue('idInput', watchName);
+    await this.testSubjects.setValue('nameInput', name);
     await this.find.clickByCssSelector('[type="submit"]');
     await this.header.waitUntilLoadingHasFinished();
   }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/242739 
Closes https://github.com/elastic/kibana/issues/242964
Closes https://github.com/elastic/kibana/issues/242728

## Summary

- Passed down `id` to `ErrableFormRow` children so they are able to properly associate labels. 
- Removed explicit IDs from child fields since they are now automatically assigned. Updated FTRs to check already present `data-test-subj` IDs instead of those ones.
- Added explicit aria label to `EuiFieldNumber`

### Testing

Create threshold alert:

<img width="1708" height="1169" alt="Screenshot 2025-12-10 at 10 33 01" src="https://github.com/user-attachments/assets/1c5f56c7-770f-4d7e-8535-37d7ed0c9696" />


Create advanced watch:

<img width="1711" height="1116" alt="Screenshot 2025-12-10 at 10 34 57" src="https://github.com/user-attachments/assets/19ab8d54-6450-42b1-a7f2-ddf5fa08bddf" />


<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->