### PR TITLE
[8.19] [Discover][Header] Fix alignment of `read-only` badge and hide `context-aware` discover badge on mobile (#245536)

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/ui/header/header_badge.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header_badge.tsx
@@ -54,6 +54,7 @@ export class HeaderBadge extends Component<Props, State> {
     return (
       <div className="chrHeaderBadge__wrapper">
         <EuiBetaBadge
+          alignment="middle"
           data-test-subj="headerBadge"
           data-test-badge-label={this.state.badge.text}
           tabIndex={0}

--- a/src/core/public/styles/chrome/_index.scss
+++ b/src/core/public/styles/chrome/_index.scss
@@ -20,7 +20,7 @@
 
 .chrHeaderBadge__wrapper {
   align-self: center;
-  margin-right: $euiSize;
+  margin-right: $euiSizeS;
 }
 
 .header__toggleNavButtonSection {

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.test.ts
@@ -23,6 +23,7 @@ describe('getTopNavBadges()', function () {
   test('should not return the unsaved changes badge if no changes', () => {
     const topNavBadges = getTopNavBadges({
       hasUnsavedChanges: false,
+      isMobile: false,
       services: discoverServiceMock,
       stateContainer,
       topNavCustomization: undefined,
@@ -33,6 +34,7 @@ describe('getTopNavBadges()', function () {
   test('should return the unsaved changes badge when has changes', async () => {
     const topNavBadges = getTopNavBadges({
       hasUnsavedChanges: true,
+      isMobile: false,
       services: discoverServiceMock,
       stateContainer,
       topNavCustomization: undefined,
@@ -62,6 +64,7 @@ describe('getTopNavBadges()', function () {
     discoverServiceMockReadOnly.capabilities.discover.save = false;
     const topNavBadges = getTopNavBadges({
       hasUnsavedChanges: true,
+      isMobile: false,
       services: discoverServiceMockReadOnly,
       stateContainer,
       topNavCustomization: undefined,
@@ -86,6 +89,7 @@ describe('getTopNavBadges()', function () {
     test('should return the managed badge when managed saved search', () => {
       const topNavBadges = getTopNavBadges({
         hasUnsavedChanges: false,
+        isMobile: false,
         services: discoverServiceMock,
         stateContainer: stateContainerWithManagedSavedSearch,
         topNavCustomization: undefined,
@@ -98,6 +102,7 @@ describe('getTopNavBadges()', function () {
     test('should not show save in unsaved changed badge', async () => {
       const topNavBadges = getTopNavBadges({
         hasUnsavedChanges: true,
+        isMobile: false,
         services: discoverServiceMock,
         stateContainer: stateContainerWithManagedSavedSearch,
         topNavCustomization: undefined,
@@ -116,6 +121,7 @@ describe('getTopNavBadges()', function () {
   test('should not return the unsaved changes badge when disabled in customization', () => {
     const topNavBadges = getTopNavBadges({
       hasUnsavedChanges: true,
+      isMobile: false,
       services: discoverServiceMock,
       stateContainer,
       topNavCustomization: {
@@ -138,6 +144,7 @@ describe('getTopNavBadges()', function () {
     test('should return the solutions view badge when spaces is enabled', () => {
       const topNavBadges = getTopNavBadges({
         hasUnsavedChanges: false,
+        isMobile: false,
         services: discoverServiceWithSpacesMock,
         stateContainer,
         topNavCustomization: undefined,

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
@@ -24,11 +24,13 @@ import { SolutionsViewBadge } from './solutions_view_badge';
  */
 export const getTopNavBadges = ({
   hasUnsavedChanges,
+  isMobile,
   stateContainer,
   services,
   topNavCustomization,
 }: {
   hasUnsavedChanges: boolean | undefined;
+  isMobile: boolean;
   stateContainer: DiscoverStateContainer;
   services: DiscoverServices;
   topNavCustomization: TopNavCustomization | undefined;
@@ -46,7 +48,7 @@ export const getTopNavBadges = ({
 
   const isManaged = stateContainer.savedSearchState.getState().managed;
 
-  if (services.spaces) {
+  if (services.spaces && !isMobile) {
     entries.push({
       badgeText: i18n.translate('discover.topNav.solutionViewTitle', {
         defaultMessage: 'Check out context-aware Discover',

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
@@ -9,6 +9,7 @@
 
 import { useMemo } from 'react';
 import useObservable from 'react-use/lib/useObservable';
+import { useIsWithinBreakpoints } from '@elastic/eui';
 import { useDiscoverCustomization } from '../../../../customizations';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { useInspector } from '../../hooks/use_inspector';
@@ -34,6 +35,7 @@ export const useDiscoverTopNav = ({
   const hasUnsavedChanges = Boolean(
     hasSavedSearchChanges && stateContainer.savedSearchState.getId()
   );
+  const isMobile = useIsWithinBreakpoints(['xs']);
 
   const topNavBadges = useMemo(
     () =>
@@ -42,8 +44,9 @@ export const useDiscoverTopNav = ({
         services,
         hasUnsavedChanges,
         topNavCustomization,
+        isMobile,
       }),
-    [stateContainer, services, hasUnsavedChanges, topNavCustomization]
+    [stateContainer, services, hasUnsavedChanges, topNavCustomization, isMobile]
   );
   const savedSearchId = useSavedSearch().id;
   const savedSearchHasChanged = useSavedSearchHasChanged();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover][Header] Fix alignment of `read-only` badge and hide `context-aware` discover badge on mobile (#245536)](https://github.com/elastic/kibana/pull/245536)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miłosz Radzyński","email":"mradzynski.elastic@gmail.com"},"sourceCommit":{"committedDate":"2025-12-09T13:53:39Z","message":"[Discover][Header] Fix alignment of `read-only` badge and hide `context-aware` discover badge on mobile (#245536)\n\n## Summary\n\nThis PR fixes the spacing and alignment of the `read-only` badge in the\nheader bar. Apart from that it hides the `Check out context-aware\nDiscover` badge on mobile, so it doesn't occupy the valuable space on\nthis platform (now action menu and breadcrumbs can be seen without any\nissues).\n\nIt closes: #234481\nIt closes: #245534\n\n## Screenshots\nread-only badge - before:\n<img width=\"589\" height=\"52\" alt=\"Screenshot 2025-12-08 at 15 57 40\"\nsrc=\"https://github.com/user-attachments/assets/ca60bebc-7e06-442b-83e9-071c8e73c5b3\"\n/>\n\n\nread-only badge - after:\n<img width=\"603\" height=\"54\" alt=\"Screenshot 2025-12-08 at 15 55 57\"\nsrc=\"https://github.com/user-attachments/assets/489701e8-aa42-43bf-ac5f-5bb2cdb4a751\"\n/>\n\n\ncontext-aware badge - mobile - before:\n<img width=\"316\" height=\"178\" alt=\"Screenshot 2025-12-08 at 15 57 15\"\nsrc=\"https://github.com/user-attachments/assets/067ff564-742f-425d-a9a7-1a5e862b2895\"\n/>\n\ncontext-aware badge - mobile - after:\n<img width=\"316\" height=\"178\" alt=\"Screenshot 2025-12-08 at 15 56 22\"\nsrc=\"https://github.com/user-attachments/assets/b8b5537d-af95-4401-8dd3-f25e3bbd8ae1\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"4af804701d643040e0a7a242b46f353e555b1e94","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","backport:version","v9.3.0","v9.2.3","v9.1.9","v8.19.9"],"title":"[Discover][Header] Fix alignment of `read-only` badge and hide `context-aware` discover badge on mobile","number":245536,"url":"https://github.com/elastic/kibana/pull/245536","mergeCommit":{"message":"[Discover][Header] Fix alignment of `read-only` badge and hide `context-aware` discover badge on mobile (#245536)\n\n## Summary\n\nThis PR fixes the spacing and alignment of the `read-only` badge in the\nheader bar. Apart from that it hides the `Check out context-aware\nDiscover` badge on mobile, so it doesn't occupy the valuable space on\nthis platform (now action menu and breadcrumbs can be seen without any\nissues).\n\nIt closes: #234481\nIt closes: #245534\n\n## Screenshots\nread-only badge - before:\n<img width=\"589\" height=\"52\" alt=\"Screenshot 2025-12-08 at 15 57 40\"\nsrc=\"https://github.com/user-attachments/assets/ca60bebc-7e06-442b-83e9-071c8e73c5b3\"\n/>\n\n\nread-only badge - after:\n<img width=\"603\" height=\"54\" alt=\"Screenshot 2025-12-08 at 15 55 57\"\nsrc=\"https://github.com/user-attachments/assets/489701e8-aa42-43bf-ac5f-5bb2cdb4a751\"\n/>\n\n\ncontext-aware badge - mobile - before:\n<img width=\"316\" height=\"178\" alt=\"Screenshot 2025-12-08 at 15 57 15\"\nsrc=\"https://github.com/user-attachments/assets/067ff564-742f-425d-a9a7-1a5e862b2895\"\n/>\n\ncontext-aware badge - mobile - after:\n<img width=\"316\" height=\"178\" alt=\"Screenshot 2025-12-08 at 15 56 22\"\nsrc=\"https://github.com/user-attachments/assets/b8b5537d-af95-4401-8dd3-f25e3bbd8ae1\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"4af804701d643040e0a7a242b46f353e555b1e94"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245536","number":245536,"mergeCommit":{"message":"[Discover][Header] Fix alignment of `read-only` badge and hide `context-aware` discover badge on mobile (#245536)\n\n## Summary\n\nThis PR fixes the spacing and alignment of the `read-only` badge in the\nheader bar. Apart from that it hides the `Check out context-aware\nDiscover` badge on mobile, so it doesn't occupy the valuable space on\nthis platform (now action menu and breadcrumbs can be seen without any\nissues).\n\nIt closes: #234481\nIt closes: #245534\n\n## Screenshots\nread-only badge - before:\n<img width=\"589\" height=\"52\" alt=\"Screenshot 2025-12-08 at 15 57 40\"\nsrc=\"https://github.com/user-attachments/assets/ca60bebc-7e06-442b-83e9-071c8e73c5b3\"\n/>\n\n\nread-only badge - after:\n<img width=\"603\" height=\"54\" alt=\"Screenshot 2025-12-08 at 15 55 57\"\nsrc=\"https://github.com/user-attachments/assets/489701e8-aa42-43bf-ac5f-5bb2cdb4a751\"\n/>\n\n\ncontext-aware badge - mobile - before:\n<img width=\"316\" height=\"178\" alt=\"Screenshot 2025-12-08 at 15 57 15\"\nsrc=\"https://github.com/user-attachments/assets/067ff564-742f-425d-a9a7-1a5e862b2895\"\n/>\n\ncontext-aware badge - mobile - after:\n<img width=\"316\" height=\"178\" alt=\"Screenshot 2025-12-08 at 15 56 22\"\nsrc=\"https://github.com/user-attachments/assets/b8b5537d-af95-4401-8dd3-f25e3bbd8ae1\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"4af804701d643040e0a7a242b46f353e555b1e94"}},{"branch":"9.2","label":"v9.2.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/245654","number":245654,"state":"MERGED","mergeCommit":{"sha":"45465db09e7f32b072c4ceb871f419d26d04f8c3","message":"[9.2] [Discover][Header] Fix alignment of `read-only` badge and hide `context-aware` discover badge on mobile (#245536) (#245654)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Discover][Header] Fix alignment of `read-only` badge and hide\n`context-aware` discover badge on mobile\n(#245536)](https://github.com/elastic/kibana/pull/245536)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Miłosz Radzyński <mradzynski.elastic@gmail.com>"}},{"branch":"9.1","label":"v9.1.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->