### PR TITLE
[FIPS / CI] Add skip intermediate to daily pipeline

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
@@ -25,6 +25,7 @@ spec:
       branch_configuration: main 9.1 8.19
       default_branch: main
       pipeline_file: .buildkite/pipelines/fips/fips_pipeline.sh
+      skip_intermediate_builds: false
       provider_settings:
         trigger_mode: none
       schedules:


### PR DESCRIPTION
## Summary

Since we have two builds per branch triggering at the same time, one ends up being cancelled due to `skip_intermediate_builds`

https://buildkite.com/elastic/kibana-fips


