### PR TITLE
[Synthetics] Fix SyncGlobalParamsSpaces flaky test

### DIFF
--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/services/private_location_test_service.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/services/private_location_test_service.ts
@@ -29,17 +29,13 @@ export class PrivateLocationTestService {
 
   async installSyntheticsPackage() {
     await this.supertest.post('/api/fleet/setup').set('kbn-xsrf', 'true').send().expect(200);
-    const response = await this.supertest
-      .get(`/api/fleet/epm/packages/synthetics/${INSTALLED_VERSION}`)
+    // Attempt to delete any existing package so we can install a specific version
+    await this.supertest.delete(`/api/fleet/epm/packages/synthetics`).set('kbn-xsrf', 'true');
+    await this.supertest
+      .post(`/api/fleet/epm/packages/synthetics/${INSTALLED_VERSION}`)
       .set('kbn-xsrf', 'true')
+      .send({ force: true })
       .expect(200);
-    if (response.body.item.status !== 'installed') {
-      await this.supertest
-        .post(`/api/fleet/epm/packages/synthetics/${INSTALLED_VERSION}`)
-        .set('kbn-xsrf', 'true')
-        .send({ force: true })
-        .expect(200);
-    }
   }
 
   async addFleetPolicy(name?: string) {

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_global_params_spaces.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_global_params_spaces.ts
@@ -21,8 +21,7 @@ import { comparePolicies, getTestSyntheticsPolicy } from './sample_data/test_pol
 import { omitMonitorKeys } from './add_monitor';
 
 export default function ({ getService }: FtrProviderContext) {
-  // FLAKY: https://github.com/elastic/kibana/issues/241106
-  describe.skip('SyncGlobalParamsSpaces', function () {
+  describe('SyncGlobalParamsSpaces', function () {
     this.tags('skipCloud');
     const supertestAPI = getService('supertest');
     const retry = getService('retry');


### PR DESCRIPTION
It closes https://github.com/elastic/kibana/issues/241106

Updated `installSyntheticsPackage` to match the pattern used in the deployment-agnostic version - delete any existing package (ignoring errors) and then force install.