### PR TITLE
[Synthetics] Fix SyntheticsAlertOnNoData flaky test

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/synthetics/alert_on_no_data.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/synthetics/alert_on_no_data.ts
@@ -29,8 +29,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   let adminRoleAuthc: RoleCredentials;
   const samlAuth = getService('samlAuth');
 
-  // Failing: See https://github.com/elastic/kibana/issues/240900
-  describe.skip('SyntheticsAlertOnNoData', function () {
+  describe('SyntheticsAlertOnNoData', function () {
     // Test failing on MKI and ECH
     this.tags(['skipCloud']);
 
@@ -71,6 +70,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         index: SYNTHETICS_RULE_ALERT_INDEX,
         query: { match_all: {} },
         ignore_unavailable: true,
+        conflicts: 'proceed',
       });
       await server.savedObjects.clean({ types: ['rule'] });
     });

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/synthetics/alert_on_no_data.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/synthetics/alert_on_no_data.ts
@@ -71,6 +71,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         query: { match_all: {} },
         ignore_unavailable: true,
         conflicts: 'proceed',
+        refresh: true,
       });
       await server.savedObjects.clean({ types: ['rule'] });
     });


### PR DESCRIPTION
It closes https://github.com/elastic/kibana/issues/240900.

Added conflicts: 'proceed' to the `deleteByQuery`. This tells Elasticsearch to skip documents with version conflicts and continue deleting the rest, which is appropriate for cleanup operations.