### PR TITLE
[8.19] [Search] [A11y]add state changes in index details data fields  (#245658)

### DIFF
--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/result.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/result.tsx
@@ -113,6 +113,7 @@ export const Result: React.FC<ResultProps> = ({
                   tooltipRef.current?.showToolTip();
                 }}
                 aria-label={tooltipText}
+                aria-selected={isExpanded}
               />
             </EuiToolTip>
           </EuiFlexItem>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Search] [A11y]add state changes in index details data fields  (#245658)](https://github.com/elastic/kibana/pull/245658)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Saarika Bhasi","email":"55930906+saarikabhasi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-09T16:24:44Z","message":"[Search] [A11y]add state changes in index details data fields  (#245658)\n\n## Summary\n\nFix a11y issue - shows state changes for buttons \n\nCurrently, Mac VoiceOver does not show state changes for show more\nbutton in index details -> data tab. Added aria-selected attribute.\n\n### screen recording \n\n\nhttps://github.com/user-attachments/assets/2534f9ad-a6ee-45b7-a818-8284653a5bb7\n\n### Steps to reproduce\nvisit Index Management -> Indices page.\n1.Navigate to Show more fields button.\n2.Press Enter.\n3.Observe page and screen reader.\n\nUI elements + VoiceOver\nbrowser: Safari","sha":"3df99b56f63c3061642e7777513831c15c0a4634","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.3.0"],"title":"[Search] [A11y]add state changes in index details data fields ","number":245658,"url":"https://github.com/elastic/kibana/pull/245658","mergeCommit":{"message":"[Search] [A11y]add state changes in index details data fields  (#245658)\n\n## Summary\n\nFix a11y issue - shows state changes for buttons \n\nCurrently, Mac VoiceOver does not show state changes for show more\nbutton in index details -> data tab. Added aria-selected attribute.\n\n### screen recording \n\n\nhttps://github.com/user-attachments/assets/2534f9ad-a6ee-45b7-a818-8284653a5bb7\n\n### Steps to reproduce\nvisit Index Management -> Indices page.\n1.Navigate to Show more fields button.\n2.Press Enter.\n3.Observe page and screen reader.\n\nUI elements + VoiceOver\nbrowser: Safari","sha":"3df99b56f63c3061642e7777513831c15c0a4634"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245658","number":245658,"mergeCommit":{"message":"[Search] [A11y]add state changes in index details data fields  (#245658)\n\n## Summary\n\nFix a11y issue - shows state changes for buttons \n\nCurrently, Mac VoiceOver does not show state changes for show more\nbutton in index details -> data tab. Added aria-selected attribute.\n\n### screen recording \n\n\nhttps://github.com/user-attachments/assets/2534f9ad-a6ee-45b7-a818-8284653a5bb7\n\n### Steps to reproduce\nvisit Index Management -> Indices page.\n1.Navigate to Show more fields button.\n2.Press Enter.\n3.Observe page and screen reader.\n\nUI elements + VoiceOver\nbrowser: Safari","sha":"3df99b56f63c3061642e7777513831c15c0a4634"}},{"url":"https://github.com/elastic/kibana/pull/245687","number":245687,"branch":"9.1","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/245688","number":245688,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->