### PR TITLE
[Lens] Fix dimension editor padding

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -883,25 +883,19 @@ export function LayerPanel(props: LayerPanelProps) {
               activeVisualization.DimensionEditorComponent &&
               openColumnGroup?.enableDimensionEditor && (
                 <>
-                  <div
-                    css={css`
-                      padding: ${euiTheme.size.base} 0;
-                    `}
-                  >
-                    <activeVisualization.DimensionEditorComponent
-                      {...{
-                        ...layerVisualizationConfigProps,
-                        groupId: openColumnGroup.groupId,
-                        accessor: openColumnId,
-                        datasource,
-                        setState: props.updateVisualization,
-                        addLayer: props.addLayer,
-                        removeLayer: props.onRemoveLayer,
-                        panelRef,
-                        isInlineEditing,
-                      }}
-                    />
-                  </div>
+                  <activeVisualization.DimensionEditorComponent
+                    {...{
+                      ...layerVisualizationConfigProps,
+                      groupId: openColumnGroup.groupId,
+                      accessor: openColumnId,
+                      datasource,
+                      setState: props.updateVisualization,
+                      addLayer: props.addLayer,
+                      removeLayer: props.onRemoveLayer,
+                      panelRef,
+                      isInlineEditing,
+                    }}
+                  />
                   {activeVisualization.DimensionEditorAdditionalSectionComponent && (
                     <activeVisualization.DimensionEditorAdditionalSectionComponent
                       {...{

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/xy_config_panel/annotations_config_panel/annotations_panel.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/xy_config_panel/annotations_config_panel/annotations_panel.tsx
@@ -94,22 +94,24 @@ export const AnnotationsPanel = (
   }
 
   return currentDataView ? (
-    <AnnotationEditorControls
-      annotation={currentAnnotation}
-      onAnnotationChange={(newAnnotation) => setAnnotation(newAnnotation)}
-      dataView={currentDataView}
-      getDefaultRangeEnd={(rangeStart) =>
-        getEndTimestamp(
-          props.datatableUtilities,
-          rangeStart,
-          frame,
-          localState.layers.filter(isDataLayer)
-        )
-      }
-      queryInputServices={queryInputServices}
-      calendarClassName={DONT_CLOSE_DIMENSION_CONTAINER_ON_CLICK_CLASS}
-      appName={LENS_APP_NAME}
-    />
+    <div className="lnsIndexPatternDimensionEditor--padded">
+      <AnnotationEditorControls
+        annotation={currentAnnotation}
+        onAnnotationChange={(newAnnotation) => setAnnotation(newAnnotation)}
+        dataView={currentDataView}
+        getDefaultRangeEnd={(rangeStart) =>
+          getEndTimestamp(
+            props.datatableUtilities,
+            rangeStart,
+            frame,
+            localState.layers.filter(isDataLayer)
+          )
+        }
+        queryInputServices={queryInputServices}
+        calendarClassName={DONT_CLOSE_DIMENSION_CONTAINER_ON_CLICK_CLASS}
+        appName={LENS_APP_NAME}
+      />
+    </div>
   ) : null;
 };
 

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/xy_config_panel/reference_line_config_panel/reference_line_panel.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/xy_config_panel/reference_line_config_panel/reference_line_panel.tsx
@@ -77,7 +77,7 @@ export const ReferenceLinePanel = (
   );
 
   return (
-    <>
+    <div className="lnsIndexPatternDimensionEditor--padded">
       <TextDecorationSetting
         idPrefix={idPrefix}
         setConfig={setConfig}
@@ -106,7 +106,7 @@ export const ReferenceLinePanel = (
           defaultMessage: 'Color',
         })}
       />
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary

Follow up to #235372. Fixes #243952. 

Fixes a regression where dimension editors had issues with element padding.

### Before / After

#### Data layer

<img width="45%" alt="CleanShot 2025-12-10 at 14 56 22@2x" src="https://github.com/user-attachments/assets/2d18d7b9-0c32-4372-9cce-e35748bae383" /> <img width="45%" alt="CleanShot 2025-12-10 at 14 47 53@2x" src="https://github.com/user-attachments/assets/001578d8-5200-4e9d-8e85-b13e72d94861" />

#### Annotations

<img width="45%" alt="CleanShot 2025-12-10 at 14 57 03@2x" src="https://github.com/user-attachments/assets/82b7f41e-8eb0-4c0d-857d-6175f39c950a" /> <img width="45%" alt="CleanShot 2025-12-10 at 14 47 18@2x" src="https://github.com/user-attachments/assets/689c4e07-13ce-400c-995b-33555acaa8b5" />

#### Reference line

<img width="45%"  alt="CleanShot 2025-12-10 at 14 58 41@2x" src="https://github.com/user-attachments/assets/09928852-00b2-4148-b595-b65f24c967e5" /> <img width="45%" alt="CleanShot 2025-12-10 at 14 46 01@2x" src="https://github.com/user-attachments/assets/7a7b44f2-b226-42cd-8e1a-15b6b2ba3d56" />

### Checklist

- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
