### PR TITLE
🌊 Streams: Fix page crash on invalid processors

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/simulation_state_machine/selectors.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/simulation_state_machine/selectors.ts
@@ -42,7 +42,10 @@ export const selectOriginalPreviewRecords = createSelector(
     }
     const filterFn = getFilterSimulationDocumentsFn(previewDocsFilter);
     // return the samples where the filterFn matches the documents at the same index
-    return samples.filter((_, index) => filterFn(documents[index]));
+    return samples.filter((_, index) => {
+      const doc = documents[index];
+      return doc ? filterFn(doc) : false;
+    });
   }
 );
 


### PR DESCRIPTION
Fixes https://github.com/elastic/observability-error-backlog/issues/304

There is a certain scenario that leads to an uncaught exception thrown as part of xstate:

* Go to processing tab
* Add a processor like grok with a valid pattern (like `%{WORD:attributes.abc}`)
* Switch the sample filter to "parsed"
* Change the pattern to something invalid (like `%{WORDDDDDDDD:attributes.abc}`)
* Page crashes

This happened because in these scenarios the simulation `documents` array is empty since the simulation can be run at all. Since we do index-based lookups between the array of samples docs and the array of "simulated" docs, this leads to an out-of-bounds index access.

This PR fixes the problem by being more robust against this problem. I think we can go even further and more clearly show what's happening, but this approach should get rid of the bug and defend against this kind of problem in general.

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->