### PR TITLE
[Infra] Fix disk max usage formula

### DIFF
--- a/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/formulas/disk.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/formulas/disk.ts
@@ -52,8 +52,7 @@ export const diskUsage: SchemaBasedFormula = {
   label: DISK_USAGE_LABEL,
   value: {
     ecs: 'max(system.filesystem.used.pct)',
-    semconv:
-      "1 - max(metrics.system.filesystem.usage, kql='state: free') / sum(metrics.system.filesystem.usage)",
+    semconv: 'max(metrics.system.filesystem.utilization)',
   },
   format: 'percent',
   decimals: 0,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/snapshot/disk_space_usage.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/snapshot/disk_space_usage.ts
@@ -12,50 +12,6 @@ export const diskSpaceUsage: SchemaBasedAggregations = {
     diskSpaceUsage: { max: { field: 'system.filesystem.used.pct' } },
   },
   semconv: {
-    disk_space_usage_free_bytes: {
-      terms: {
-        field: 'state',
-        include: ['free'],
-      },
-      aggs: {
-        max: {
-          max: {
-            field: 'system.filesystem.usage',
-          },
-        },
-      },
-    },
-    disk_usage_space_available: {
-      terms: {
-        field: 'state',
-      },
-      aggs: {
-        sum: {
-          sum: {
-            field: 'system.filesystem.usage',
-          },
-        },
-      },
-    },
-    disk_space_usage_free_bytes_total: {
-      max_bucket: {
-        buckets_path: 'disk_space_usage_free_bytes.max',
-      },
-    },
-    disk_usage_space_available_total: {
-      sum_bucket: {
-        buckets_path: 'disk_usage_space_available.sum',
-      },
-    },
-    diskSpaceUsage: {
-      bucket_script: {
-        buckets_path: {
-          diskSpaceUsageFreeBytesTotal: 'disk_space_usage_free_bytes_total',
-          diskSpaceUsageAvailableTotal: 'disk_usage_space_available_total',
-        },
-        script: '1 - params.diskSpaceUsageFreeBytesTotal / params.diskSpaceUsageAvailableTotal',
-        gap_policy: 'skip',
-      },
-    },
+    diskSpaceUsage: { max: { field: 'metrics.system.filesystem.utilization' } },
   },
 };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/243250
## Summary
Fixed disk usage max metric for OTel/semconv mode to show the maximum usage of any single partition.

#### Problem
In OTel mode, the "Disk Usage (Max)" metric was incorrectly showing incorrect percentage instead of the actual maximum usage of any individual disk partition. The formula was calculating usage across all partitions combined, rather than finding the maximum usage of a single partition.

#### Solution
Updated the disk usage max formula to use the correct OTel semantic convention field:

#### Changed:
- `diskUsage` formula (for charts/KPI): Now uses `max(metrics.system.filesystem.utilization)`
- `diskSpaceUsage` snapshot aggregation (for table): Now uses max aggregation on `metrics.system.filesystem.utilization`

#### Impact
The "Disk Usage" metric KPI now correctly displays the maximum utilization of any single disk partition/mount point
The table column "Disk Usage (max)" now shows the correct per-host maximum partition usage
Behavior now matches ECS mode where `max(system.filesystem.used.pct)` returns the highest usage across partitions

BEFORE
<img width="2932" height="1780" alt="image" src="https://github.com/user-attachments/assets/0dd35451-0803-4007-bffb-84c1728d7d7c" />
<img width="2716" height="932" alt="image" src="https://github.com/user-attachments/assets/e46a8d7f-54c8-40e0-bbad-f544fb1941e4" />
<img width="1682" height="932" alt="image" src="https://github.com/user-attachments/assets/d4e0fc57-7ea7-45b7-8512-62c488c3403f" />

AFTER

https://github.com/user-attachments/assets/87fa97cf-b4fd-4774-98a3-7301c73e2c2c

ECS comparison

https://github.com/user-attachments/assets/fe106cb5-e2dc-42f9-aafc-d5a6b0bb5534






<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->