### PR TITLE
[8.19] Fix "now" and mixed format date handling in share modal (#245539)

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
@@ -267,7 +267,7 @@ export function ShowShareModal({
       locator: shareService.url.locators.get(
         DASHBOARD_APP_LOCATOR
       ) as LocatorPublic<DashboardLocatorParams>,
-      params: locatorParams,
+      params: { ...locatorParams, timeRange: locatorParams.timeRange ?? undefined },
     },
   });
 }

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_share.tsx
@@ -14,6 +14,7 @@ import { AppMenuActionId, AppMenuActionType } from '@kbn/discover-utils';
 import { omit } from 'lodash';
 import { setStateToKbnUrl } from '@kbn/kibana-utils-plugin/public';
 import { i18n } from '@kbn/i18n';
+import type { TimeRange } from '@kbn/es-query';
 import type { DiscoverStateContainer } from '../../../state_management/discover_state';
 import { getSharingData, showPublicUrlSwitch } from '../../../../../utils/get_sharing_data';
 import type { DiscoverAppLocatorParams } from '../../../../../../common/app_locator';
@@ -60,14 +61,14 @@ export const getShareAppMenuItem = ({
     const filters = services.filterManager.getFilters();
 
     // Share -> Get links -> Snapshot
-    const params: DiscoverAppLocatorParams = {
+    const params: DiscoverAppLocatorParams & { timeRange: TimeRange | undefined } = {
       ...omit(appState, 'dataSource'),
       ...(savedSearch.id ? { savedSearchId: savedSearch.id } : {}),
       ...(dataView?.isPersisted()
         ? { dataViewId: dataView?.id }
         : { dataViewSpec: dataView?.toMinimalSpec() }),
       filters,
-      timeRange,
+      timeRange: timeRange ?? undefined,
       refreshInterval,
     };
     const relativeUrl = locator.getRedirectUrl(params);

--- a/src/platform/plugins/shared/share/public/components/share_context_menu.tsx
+++ b/src/platform/plugins/shared/share/public/components/share_context_menu.tsx
@@ -17,8 +17,13 @@ import type { Capabilities } from '@kbn/core/public';
 
 import type { LocatorPublic } from '../../common';
 import { UrlPanelContent } from './url_panel_content';
-import { ShareMenuItemLegacy, ShareContextMenuPanelItem, UrlParamExtension } from '../types';
-import { AnonymousAccessServiceContract } from '../../common/anonymous_access';
+import type {
+  ShareMenuItemLegacy,
+  ShareContextMenuPanelItem,
+  UrlParamExtension,
+  ShareableUrlLocatorParams,
+} from '../types';
+import type { AnonymousAccessServiceContract } from '../../common/anonymous_access';
 import type { BrowserUrlService } from '../types';
 
 export interface ShareContextMenuProps {
@@ -30,7 +35,7 @@ export interface ShareContextMenuProps {
   shareableUrlForSavedObject?: string;
   shareableUrlLocatorParams?: {
     locator: LocatorPublic<any>;
-    params: any;
+    params: ShareableUrlLocatorParams;
   };
   shareMenuItems: ShareMenuItemLegacy[];
   sharingData: any;

--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
@@ -14,7 +14,6 @@ import {
   EuiFlexItem,
   EuiForm,
   EuiSpacer,
-  EuiSwitchEvent,
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';

--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
@@ -123,20 +123,23 @@ export const LinkContent = ({
     setIsLoading(false);
   }, [snapshotUrl, delegatedShareUrlHandler, allowShortUrl, createShortUrl]);
 
-  const changeTimeType = (e: EuiSwitchEvent) => {
-    setIsAbsoluteTime(e.target.checked);
-    if (urlToCopy?.current && e.target.checked !== isAbsoluteTime) {
-      urlToCopy.current = undefined;
-    }
-  };
+  const handleTimeTypeChange = useCallback(
+    (isAbsolute: boolean) => {
+      if (urlToCopy?.current && isAbsolute !== isAbsoluteTime) {
+        urlToCopy.current = undefined;
+      }
+      setIsAbsoluteTime(isAbsolute);
+    },
+    [isAbsoluteTime]
+  );
 
   return (
     <>
       <EuiForm>
         <TimeTypeSection
           timeRange={timeRange}
-          isAbsoluteTime={isAbsoluteTime}
-          changeTimeType={changeTimeType}
+          onTimeTypeChange={handleTimeTypeChange}
+          isAbsoluteTimeByDefault={isAbsoluteTime}
         />
         {isDirty && DraftModeCallout && (
           <>

--- a/src/platform/plugins/shared/share/public/components/tabs/link/time_type_section.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/time_type_section.test.tsx
@@ -11,7 +11,6 @@ import React, { ComponentProps } from 'react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render, screen } from '@testing-library/react';
 import { TimeTypeSection } from './time_type_section';
-import * as timeUtils from '../../../lib/time_utils';
 
 const renderComponent = (props: ComponentProps<typeof TimeTypeSection>) => {
   render(
@@ -24,26 +23,14 @@ const renderComponent = (props: ComponentProps<typeof TimeTypeSection>) => {
 describe('TimeTypeSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest
-      .spyOn(timeUtils, 'convertRelativeTimeStringToAbsoluteTimeDate')
-      .mockReturnValue(new Date());
-    jest
-      .spyOn(timeUtils, 'getRelativeTimeValueAndUnitFromTimeString')
-      .mockImplementation((time) => {
-        if (time === 'now') return { value: 0, unit: 'second', roundingUnit: undefined };
-        if (time === 'now-1m') return { value: -1, unit: 'minute', roundingUnit: undefined };
-        if (time === 'now-30m') return { value: -30, unit: 'minute', roundingUnit: undefined };
-        return { value: 0, unit: 'second', roundingUnit: undefined };
-      });
-    jest.spyOn(timeUtils, 'isTimeRangeAbsoluteTime').mockReturnValue(false);
   });
 
-  it('renders null when timeRange is not provided', () => {
-    const changeTimeType = jest.fn();
+  it('should render null when timeRange is not provided', () => {
+    const onTimeTypeChange = jest.fn();
 
     renderComponent({
-      isAbsoluteTime: false,
-      changeTimeType,
+      isAbsoluteTimeByDefault: false,
+      onTimeTypeChange,
     });
 
     const timeRangeSwitch = screen.queryByRole('switch');
@@ -51,96 +38,117 @@ describe('TimeTypeSection', () => {
     expect(timeRangeSwitch).not.toBeInTheDocument();
   });
 
-  it('renders with absolute time range', () => {
+  it('should render absolute time range', () => {
     const timeRange = { from: '2022-01-01T00:00:00.000Z', to: '2022-01-02T00:00:00.000Z' };
-    const changeTimeType = jest.fn();
+    const onTimeTypeChange = jest.fn();
 
     renderComponent({
       timeRange,
-      isAbsoluteTime: true,
-      changeTimeType,
+      isAbsoluteTimeByDefault: true,
+      onTimeTypeChange,
     });
-
-    const timeRangeSwitch = screen.getByRole('switch');
-
-    expect(timeRangeSwitch).toBeChecked();
 
     const absoluteTimeInfoText = screen.getByTestId('absoluteTimeInfoText');
 
     expect(absoluteTimeInfoText).toBeInTheDocument();
+    expect(screen.getByText(/January 01, 2022/)).toBeInTheDocument();
+    expect(screen.getByText(/January 02, 2022/)).toBeInTheDocument();
   });
 
-  it('renders with relative time range (from now to specific time)', () => {
+  it('should render relative time range', () => {
     const timeRange = { from: 'now', to: 'now+15m' };
-    const changeTimeType = jest.fn();
+    const onTimeTypeChange = jest.fn();
 
     renderComponent({
       timeRange,
-      isAbsoluteTime: false,
-      changeTimeType,
+      isAbsoluteTimeByDefault: false,
+      onTimeTypeChange,
     });
 
     const timeRangeSwitch = screen.getByRole('switch');
 
     expect(timeRangeSwitch).not.toBeChecked();
 
-    const relativeTimeFromNowInfoText = screen.getByTestId('relativeTimeInfoTextFromNow');
-
-    expect(relativeTimeFromNowInfoText).toBeInTheDocument();
+    expect(screen.getByText('now')).toBeInTheDocument();
+    expect(screen.getByText('in 15 minutes')).toBeInTheDocument();
   });
 
-  it('renders with relative time range (from specific time to now)', () => {
-    const timeRange = { from: 'now-30m', to: 'now' };
-    const changeTimeType = jest.fn();
-
-    renderComponent({
-      timeRange,
-      isAbsoluteTime: false,
-      changeTimeType,
-    });
-
-    const timeRangeSwitch = screen.getByRole('switch');
-
-    expect(timeRangeSwitch).not.toBeChecked();
-
-    const relativeTimeToNowInfoText = screen.getByTestId('relativeTimeInfoTextToNow');
-
-    expect(relativeTimeToNowInfoText).toBeInTheDocument();
-  });
-
-  it('renders with relative time range (between two relative times)', () => {
-    const timeRange = { from: 'now-30m', to: 'now-1m' };
-    const changeTimeType = jest.fn();
-
-    renderComponent({
-      timeRange,
-      isAbsoluteTime: false,
-      changeTimeType,
-    });
-
-    const timeRangeSwitch = screen.getByRole('switch');
-
-    expect(timeRangeSwitch).not.toBeChecked();
-
-    const relativeTimeInfoText = screen.getByTestId('relativeTimeInfoTextDefault');
-
-    expect(relativeTimeInfoText).toBeInTheDocument();
-  });
-
-  it('disables switch when timeRange is already absolute', () => {
+  it('should hide switch when timeRange is already absolute', () => {
     const timeRange = { from: '2022-01-01T00:00:00.000Z', to: '2022-01-02T00:00:00.000Z' };
-    const changeTimeType = jest.fn();
-
-    jest.spyOn(timeUtils, 'isTimeRangeAbsoluteTime').mockReturnValue(true);
+    const onTimeTypeChange = jest.fn();
 
     renderComponent({
       timeRange,
-      isAbsoluteTime: false,
-      changeTimeType,
+      isAbsoluteTimeByDefault: true,
+      onTimeTypeChange,
     });
 
     const timeRangeSwitch = screen.queryByRole('switch');
 
     expect(timeRangeSwitch).not.toBeInTheDocument();
+  });
+
+  it('should render with mixed time range (absolute from, relative to)', () => {
+    const timeRange = { from: '2022-01-01T00:00:00.000Z', to: 'now' };
+    const onTimeTypeChange = jest.fn();
+
+    renderComponent({
+      timeRange,
+      isAbsoluteTimeByDefault: false,
+      onTimeTypeChange,
+    });
+
+    const timeRangeSwitch = screen.getByRole('switch');
+
+    expect(timeRangeSwitch).not.toBeChecked();
+
+    expect(screen.getByText(/January 01, 2022/)).toBeInTheDocument();
+    expect(screen.getByText('now')).toBeInTheDocument();
+  });
+
+  it('should render with mixed time range (relative from, absolute to)', () => {
+    const timeRange = { from: 'now-30m', to: '2022-01-01T00:00:00.000Z' };
+    const onTimeTypeChange = jest.fn();
+
+    renderComponent({
+      timeRange,
+      isAbsoluteTimeByDefault: false,
+      onTimeTypeChange,
+    });
+
+    const timeRangeSwitch = screen.getByRole('switch');
+
+    expect(timeRangeSwitch).not.toBeChecked();
+
+    expect(screen.getByText('30 minutes ago')).toBeInTheDocument();
+    expect(screen.getByText(/January 01, 2022/)).toBeInTheDocument();
+  });
+
+  it('should render "now"', () => {
+    const timeRange = { from: 'now-30m', to: 'now' };
+    const onTimeTypeChange = jest.fn();
+
+    renderComponent({
+      timeRange,
+      isAbsoluteTimeByDefault: false,
+      onTimeTypeChange,
+    });
+
+    expect(screen.getByText('30 minutes ago')).toBeInTheDocument();
+    expect(screen.getByText('now')).toBeInTheDocument();
+  });
+
+  it('should handle plain "now" value correctly in mixed ranges', () => {
+    const timeRange = { from: '2025-11-10T14:17:51.794Z', to: 'now' };
+    const onTimeTypeChange = jest.fn();
+
+    renderComponent({
+      timeRange,
+      isAbsoluteTimeByDefault: false,
+      onTimeTypeChange,
+    });
+
+    expect(screen.getByText(/November 10, 2025/)).toBeInTheDocument();
+    expect(screen.getByText('now')).toBeInTheDocument();
   });
 });

--- a/src/platform/plugins/shared/share/public/components/url_panel_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/url_panel_content.tsx
@@ -30,8 +30,8 @@ import { i18n } from '@kbn/i18n';
 import type { Capabilities } from '@kbn/core/public';
 
 import type { LocatorPublic } from '../../common';
-import { UrlParamExtension } from '../types';
-import {
+import type { ShareableUrlLocatorParams, UrlParamExtension } from '../types';
+import type {
   AnonymousAccessServiceContract,
   AnonymousAccessState,
 } from '../../common/anonymous_access';
@@ -46,7 +46,7 @@ export interface UrlPanelContentProps {
   shareableUrlForSavedObject?: string;
   shareableUrlLocatorParams?: {
     locator: LocatorPublic<any>;
-    params: any;
+    params: ShareableUrlLocatorParams;
   };
   urlParamExtensions?: UrlParamExtension[];
   anonymousAccess?: AnonymousAccessServiceContract;

--- a/src/platform/plugins/shared/share/public/index.ts
+++ b/src/platform/plugins/shared/share/public/index.ts
@@ -30,6 +30,7 @@ export type {
   ExportShareConfig,
   ExportShareDerivatives,
   RegisterShareIntegrationArgs,
+  ShareableUrlLocatorParams,
 } from './types';
 
 export type { RedirectOptions } from '../common/url_service';

--- a/src/platform/plugins/shared/share/public/lib/time_utils.tsx
+++ b/src/platform/plugins/shared/share/public/lib/time_utils.tsx
@@ -25,6 +25,15 @@ export const getRelativeTimeValueAndUnitFromTimeString = (dateString?: string) =
   const mathPart = dateString.split('/')[0]; // Ignore rounding part for matching
   const roundingPart = dateString.includes('/') ? dateString.split('/')[1] : undefined;
 
+  // Handle plain 'now' without offset
+  if (mathPart === 'now') {
+    return {
+      value: 0,
+      unit: 'second',
+      roundingUnit: undefined,
+    };
+  }
+
   const match = mathPart.match(/^now([+-]\d+)([smhdwMy])$/);
   if (!match) return;
 

--- a/src/platform/plugins/shared/share/public/types.ts
+++ b/src/platform/plugins/shared/share/public/types.ts
@@ -18,6 +18,7 @@ import {
 import { EuiContextMenuPanelItemDescriptorEntry } from '@elastic/eui/src/components/context_menu/context_menu';
 import type { ILicense } from '@kbn/licensing-plugin/public';
 import type { Capabilities } from '@kbn/core/public';
+import type { TimeRange } from '@kbn/es-query';
 import type { UrlService, LocatorPublic } from '../common/url_service';
 import type { BrowserShortUrlClientFactoryCreateParams } from './url_service/short_urls/short_url_client_factory';
 import type { BrowserShortUrlClient } from './url_service/short_urls/short_url_client';
@@ -292,6 +293,10 @@ export type BrowserUrlService = UrlService<
   BrowserShortUrlClient
 >;
 
+export type ShareableUrlLocatorParams = {
+  timeRange: TimeRange | undefined;
+} & Record<string, unknown>;
+
 /**
  * @public
  * Properties of the current object to share. Registered share
@@ -339,7 +344,7 @@ export interface ShareContext {
   shareableUrlForSavedObject?: string;
   shareableUrlLocatorParams?: {
     locator: LocatorPublic<any>;
-    params: any;
+    params: ShareableUrlLocatorParams;
   };
   sharingData: { [key: string]: unknown };
   isDirty: boolean;

--- a/src/platform/plugins/shared/share/tsconfig.json
+++ b/src/platform/plugins/shared/share/tsconfig.json
@@ -32,8 +32,8 @@
     "@kbn/std",
     "@kbn/core-logging-server-mocks",
     "@kbn/core-http-router-server-mocks",
-    "@kbn/licensing-types",
-    "@kbn/es-query"
+    "@kbn/es-query",
+    "@kbn/licensing-plugin"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/share/tsconfig.json
+++ b/src/platform/plugins/shared/share/tsconfig.json
@@ -32,7 +32,8 @@
     "@kbn/std",
     "@kbn/core-logging-server-mocks",
     "@kbn/core-http-router-server-mocks",
-    "@kbn/licensing-plugin"
+    "@kbn/licensing-types",
+    "@kbn/es-query"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix "now" and mixed format date handling in share modal (#245539)](https://github.com/elastic/kibana/pull/245539)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Krzysztof Kowalczyk","email":"krzysztof.kowalczyk@elastic.co"},"sourceCommit":{"committedDate":"2025-12-10T14:12:00Z","message":"Fix \"now\" and mixed format date handling in share modal (#245539)\n\n## Summary\n\nThis PR fixes a bug where mixed dates (e.g one absolute and one\nrelative) wouldn't work properly and \"now\" was rendering as 0 seconds in\nshare modal date switcher.\n\n<img width=\"494\" height=\"432\" alt=\"Screenshot 2025-12-09 at 13 13 05\"\nsrc=\"https://github.com/user-attachments/assets/4d5eb332-7329-40be-b725-97cf5020b73a\"\n/>\n\n\nIt also makes `ShareableUrlLocatorParams` strongly typed, requiring\n`timeRange` to be always present even if it has an undefined value, in\nresponse to a regression where dashboard time range parameter name was\nrenamed to be snake_case, which broke the functionality as\n`TimeTypeSection` would always expect `timeRange`.\n\nCloses: https://github.com/elastic/kibana/issues/241084\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bae752eb63e5e899019ab4a063a02d2f92815262","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:SharedUX","backport:all-open","papercut","v9.3.0"],"title":"Fix \"now\" and mixed format date handling in share modal","number":245539,"url":"https://github.com/elastic/kibana/pull/245539","mergeCommit":{"message":"Fix \"now\" and mixed format date handling in share modal (#245539)\n\n## Summary\n\nThis PR fixes a bug where mixed dates (e.g one absolute and one\nrelative) wouldn't work properly and \"now\" was rendering as 0 seconds in\nshare modal date switcher.\n\n<img width=\"494\" height=\"432\" alt=\"Screenshot 2025-12-09 at 13 13 05\"\nsrc=\"https://github.com/user-attachments/assets/4d5eb332-7329-40be-b725-97cf5020b73a\"\n/>\n\n\nIt also makes `ShareableUrlLocatorParams` strongly typed, requiring\n`timeRange` to be always present even if it has an undefined value, in\nresponse to a regression where dashboard time range parameter name was\nrenamed to be snake_case, which broke the functionality as\n`TimeTypeSection` would always expect `timeRange`.\n\nCloses: https://github.com/elastic/kibana/issues/241084\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bae752eb63e5e899019ab4a063a02d2f92815262"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245539","number":245539,"mergeCommit":{"message":"Fix \"now\" and mixed format date handling in share modal (#245539)\n\n## Summary\n\nThis PR fixes a bug where mixed dates (e.g one absolute and one\nrelative) wouldn't work properly and \"now\" was rendering as 0 seconds in\nshare modal date switcher.\n\n<img width=\"494\" height=\"432\" alt=\"Screenshot 2025-12-09 at 13 13 05\"\nsrc=\"https://github.com/user-attachments/assets/4d5eb332-7329-40be-b725-97cf5020b73a\"\n/>\n\n\nIt also makes `ShareableUrlLocatorParams` strongly typed, requiring\n`timeRange` to be always present even if it has an undefined value, in\nresponse to a regression where dashboard time range parameter name was\nrenamed to be snake_case, which broke the functionality as\n`TimeTypeSection` would always expect `timeRange`.\n\nCloses: https://github.com/elastic/kibana/issues/241084\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bae752eb63e5e899019ab4a063a02d2f92815262"}},{"url":"https://github.com/elastic/kibana/pull/245841","number":245841,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/245845","number":245845,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->