### PR TITLE
[APM] Update traces experience callout visibility logic to work for Serverless

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/traces_in_discover_callout/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/traces_in_discover_callout/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useMemo } from 'react';
+import useObservable from 'react-use/lib/useObservable';
 import { i18n } from '@kbn/i18n';
 import { EuiButton, EuiCallOut, EuiSpacer, EuiText } from '@elastic/eui';
 import { DISCOVER_APP_LOCATOR } from '@kbn/deeplinks-analytics';
@@ -13,7 +14,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { from, where } from '@kbn/esql-composer';
 import { SERVICE_ENVIRONMENT } from '@kbn/apm-types';
 import type { SolutionId } from '@kbn/core-chrome-browser/src/project_navigation';
-import { useFetcher, useKibanaSpace } from '@kbn/observability-shared-plugin/public';
+import { useFetcher } from '@kbn/observability-shared-plugin/public';
 import type { ApmSourceAccessPluginStart } from '@kbn/apm-sources-access-plugin/public';
 import {
   ENVIRONMENT_ALL_VALUE,
@@ -66,8 +67,7 @@ function getEsqlQuery(environment: string, tracesIndex: string): string {
 }
 
 export function TracesInDiscoverCallout() {
-  const { share } = useApmPluginContext();
-  const { space } = useKibanaSpace();
+  const { share, core } = useApmPluginContext();
   const {
     services: { apmSourcesAccess },
   } = useKibana<ApmPluginStartDeps>();
@@ -80,6 +80,8 @@ export function TracesInDiscoverCallout() {
     tracesInDiscoverCalloutStorageKey,
     false
   );
+
+  const currentSolutionNavId = useObservable(core.chrome.getActiveSolutionNavId$());
   const obltSolutionId: SolutionId = 'oblt';
 
   const discoverHref = useMemo(() => {
@@ -95,7 +97,7 @@ export function TracesInDiscoverCallout() {
     });
   }, [share.url.locators, tracesIndex, environment, rangeFrom, rangeTo]);
 
-  if (dismissedCallout || !discoverHref || space?.solution !== obltSolutionId) {
+  if (dismissedCallout || !discoverHref || currentSolutionNavId !== obltSolutionId) {
     return null;
   }
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/traces_in_discover_callout/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/traces_in_discover_callout/index.tsx
@@ -13,7 +13,6 @@ import { DISCOVER_APP_LOCATOR } from '@kbn/deeplinks-analytics';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { from, where } from '@kbn/esql-composer';
 import { SERVICE_ENVIRONMENT } from '@kbn/apm-types';
-import type { SolutionId } from '@kbn/core-chrome-browser/src/project_navigation';
 import { useFetcher } from '@kbn/observability-shared-plugin/public';
 import type { ApmSourceAccessPluginStart } from '@kbn/apm-sources-access-plugin/public';
 import {
@@ -82,7 +81,6 @@ export function TracesInDiscoverCallout() {
   );
 
   const currentSolutionNavId = useObservable(core.chrome.getActiveSolutionNavId$());
-  const obltSolutionId: SolutionId = 'oblt';
 
   const discoverHref = useMemo(() => {
     if (!tracesIndex) return undefined;
@@ -97,7 +95,7 @@ export function TracesInDiscoverCallout() {
     });
   }, [share.url.locators, tracesIndex, environment, rangeFrom, rangeTo]);
 
-  if (dismissedCallout || !discoverHref || currentSolutionNavId !== obltSolutionId) {
+  if (dismissedCallout || !discoverHref || currentSolutionNavId !== 'oblt') {
     return null;
   }
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/traces_in_discover_callout/traces_in_discover_callout.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/traces_in_discover_callout/traces_in_discover_callout.test.tsx
@@ -6,7 +6,10 @@
  */
 
 import React from 'react';
+import { type Observable, of } from 'rxjs';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import type { SolutionId } from '@kbn/core-chrome-browser/src/project_navigation';
+
 import {
   ENVIRONMENT_ALL_VALUE,
   ENVIRONMENT_NOT_DEFINED_VALUE,
@@ -16,7 +19,9 @@ import { TracesInDiscoverCallout } from '.';
 const mockGetRedirectUrl = jest.fn(() => 'mock-discover-url');
 const mockTraceIndex = 'apm-span, apm-transaction';
 
-let mockGetActiveSpace = {
+let mockGetActiveSolutionNavId: Observable<SolutionId | null> = of('oblt');
+
+const mockGetActiveSpace = {
   solution: 'oblt',
 };
 let mockQuery = {
@@ -26,6 +31,11 @@ let mockQuery = {
 };
 jest.mock('../../../../context/apm_plugin/use_apm_plugin_context', () => ({
   useApmPluginContext: () => ({
+    core: {
+      chrome: {
+        getActiveSolutionNavId$: jest.fn(() => mockGetActiveSolutionNavId),
+      },
+    },
     share: {
       url: {
         locators: {
@@ -66,111 +76,130 @@ describe('TracesInDiscoverCallout', () => {
     mockDismissedCallout = false; // reset default
   });
 
-  it('renders the callout with title, content and button', async () => {
-    await act(async () => {
-      render(<TracesInDiscoverCallout />);
-    });
+  describe('Rendering', () => {
+    it('renders the callout with title, content and button', async () => {
+      await act(async () => {
+        render(<TracesInDiscoverCallout />);
+      });
 
-    expect(
-      await screen.findByText('Try the new traces experience in Discover')
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(
-        'Now you can view and analyse the full-screen waterfall and explore your trace data in context.'
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('apmServiceInventoryTracesInDiscoverCalloutButton')
-    ).toBeInTheDocument();
-  });
-
-  it('dismisses the callout when clicking close', async () => {
-    await act(async () => {
-      render(<TracesInDiscoverCallout />);
-    });
-    const closeButton = await screen.findByTestId('euiDismissCalloutButton');
-    fireEvent.click(closeButton);
-
-    expect(mockSetDismissedCallout).toHaveBeenCalledWith(true);
-  });
-
-  it('does not render if dismissed', async () => {
-    mockDismissedCallout = true;
-    await act(async () => {
-      render(<TracesInDiscoverCallout />);
-    });
-
-    expect(
-      screen.queryByTestId('apmServiceInventoryTracesInDiscoverCallout')
-    ).not.toBeInTheDocument();
-  });
-
-  it('does not render if solutionId is not oblt', async () => {
-    mockGetActiveSpace = { solution: 'other' };
-    render(<TracesInDiscoverCallout />);
-
-    await waitFor(() => {
       expect(
-        screen.queryByTestId('apmServiceInventoryTracesInDiscoverCalloutButton')
+        await screen.findByText('Try the new traces experience in Discover')
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText(
+          'Now you can view and analyse the full-screen waterfall and explore your trace data in context.'
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('apmServiceInventoryTracesInDiscoverCalloutButton')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Dismissal Behavior', () => {
+    it('dismisses the callout when clicking close', async () => {
+      await act(async () => {
+        render(<TracesInDiscoverCallout />);
+      });
+      const closeButton = await screen.findByTestId('euiDismissCalloutButton');
+      fireEvent.click(closeButton);
+
+      expect(mockSetDismissedCallout).toHaveBeenCalledWith(true);
+    });
+
+    it('does not render if dismissed', async () => {
+      mockDismissedCallout = true;
+      await act(async () => {
+        render(<TracesInDiscoverCallout />);
+      });
+
+      expect(
+        screen.queryByTestId('apmServiceInventoryTracesInDiscoverCallout')
       ).not.toBeInTheDocument();
     });
   });
 
-  it('calls getRedirectUrl with correct ES|QL for defined environment', async () => {
-    await act(async () => {
+  describe('Visibility Logic', () => {
+    it('does not render if currentSolutionNavId is not oblt', async () => {
+      mockGetActiveSolutionNavId = of('security');
       render(<TracesInDiscoverCallout />);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('apmServiceInventoryTracesInDiscoverCalloutButton')
+        ).not.toBeInTheDocument();
+      });
     });
 
-    expect(mockGetRedirectUrl).toHaveBeenCalledWith({
-      query: {
-        esql: `FROM ${mockTraceIndex}\n  | WHERE service.environment == "${mockQuery.environment}"`,
-      },
-      timeRange: {
-        from: mockQuery.rangeFrom,
-        to: mockQuery.rangeTo,
-      },
+    it('does not render if currentSolutionNavId is null', async () => {
+      mockGetActiveSolutionNavId = of(null);
+      render(<TracesInDiscoverCallout />);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('apmServiceInventoryTracesInDiscoverCalloutButton')
+        ).not.toBeInTheDocument();
+      });
     });
   });
 
-  it('calls getRedirectUrl with correct ES|QL for ENVIRONMENT_ALL_VALUE', async () => {
-    mockQuery = {
-      ...mockQuery,
-      environment: ENVIRONMENT_ALL_VALUE,
-    };
+  describe('ES|QL Query Generation', () => {
+    it('calls getRedirectUrl with correct ES|QL for defined environment', async () => {
+      await act(async () => {
+        render(<TracesInDiscoverCallout />);
+      });
 
-    await act(async () => {
-      render(<TracesInDiscoverCallout />);
+      expect(mockGetRedirectUrl).toHaveBeenCalledWith({
+        query: {
+          esql: `FROM ${mockTraceIndex}\n  | WHERE service.environment == "${mockQuery.environment}"`,
+        },
+        timeRange: {
+          from: mockQuery.rangeFrom,
+          to: mockQuery.rangeTo,
+        },
+      });
     });
 
-    expect(mockGetRedirectUrl).toHaveBeenCalledWith({
-      query: {
-        esql: `FROM ${mockTraceIndex}`,
-      },
-      timeRange: {
-        from: mockQuery.rangeFrom,
-        to: mockQuery.rangeTo,
-      },
+    it('calls getRedirectUrl with correct ES|QL for ENVIRONMENT_ALL_VALUE', async () => {
+      mockQuery = {
+        ...mockQuery,
+        environment: ENVIRONMENT_ALL_VALUE,
+      };
+
+      await act(async () => {
+        render(<TracesInDiscoverCallout />);
+      });
+
+      expect(mockGetRedirectUrl).toHaveBeenCalledWith({
+        query: {
+          esql: `FROM ${mockTraceIndex}`,
+        },
+        timeRange: {
+          from: mockQuery.rangeFrom,
+          to: mockQuery.rangeTo,
+        },
+      });
     });
-  });
 
-  it('calls getRedirectUrl with correct ES|QL for ENVIRONMENT_NOT_DEFINED_VALUE', async () => {
-    mockQuery = {
-      ...mockQuery,
-      environment: ENVIRONMENT_NOT_DEFINED_VALUE,
-    };
+    it('calls getRedirectUrl with correct ES|QL for ENVIRONMENT_NOT_DEFINED_VALUE', async () => {
+      mockQuery = {
+        ...mockQuery,
+        environment: ENVIRONMENT_NOT_DEFINED_VALUE,
+      };
 
-    await act(async () => {
-      render(<TracesInDiscoverCallout />);
-    });
+      await act(async () => {
+        render(<TracesInDiscoverCallout />);
+      });
 
-    expect(mockGetRedirectUrl).toHaveBeenCalledWith({
-      query: {
-        esql: `FROM ${mockTraceIndex}\n  | WHERE service.environment IS NULL`,
-      },
-      timeRange: {
-        from: mockQuery.rangeFrom,
-        to: mockQuery.rangeTo,
-      },
+      expect(mockGetRedirectUrl).toHaveBeenCalledWith({
+        query: {
+          esql: `FROM ${mockTraceIndex}\n  | WHERE service.environment IS NULL`,
+        },
+        timeRange: {
+          from: mockQuery.rangeFrom,
+          to: mockQuery.rangeTo,
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/245207

Recently we noticed that, for serverless oblt projects, the “Try the new traces experience in Discover” callout shown in the APM services inventory wasn’t visible. This happened because we were relying on `space.solution`, which is empty for serverless projects.

<img width="1285" height="960" alt="Screenshot 2025-12-10 at 15 34 15" src="https://github.com/user-attachments/assets/ecff96dc-b466-4de8-a24c-2c5a0a48cf3c" />


To make sure we display the callout in the same situations where the traces Discover experience is enabled, we checked the logic used in the profiles resolver and it relies on the `rootProfile`, which comes from the "active solution nav" concept. 

https://github.com/elastic/kibana/blob/d0b93c955c75b989f55635b9c6563940d745ce00/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_root_profile.tsx#L38-L61

Using the same source of truth felt like the most consistent approach, so this PR updates the callout to follow that logic.






<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->