### PR TITLE
[Security Solution][Alert details] show analyzer in full height

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useContext, useCallback } from 'react';
+import React, { useCallback, useContext } from 'react';
 import { useSelector } from 'react-redux';
 import { EuiLoadingSpinner } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -17,7 +17,7 @@ import { ProcessEventDot } from './process_event_dot';
 import { useCamera } from './use_camera';
 import { SymbolDefinitions } from './symbol_definitions';
 import { useStateSyncingActions } from './use_state_syncing_actions';
-import { StyledMapContainer, GraphContainer, StyledPanel } from './styles';
+import { GraphContainer, StyledMapContainer, StyledPanel } from './styles';
 import * as nodeModel from '../../../common/endpoint/models/node';
 import { SideEffectContext } from './side_effect_context';
 import type { ResolverProps } from '../types';
@@ -27,6 +27,7 @@ import { useSyncSelectedNode } from './use_sync_selected_node';
 import { ResolverNoProcessEvents } from './resolver_no_process_events';
 import { useAutotuneTimerange } from './use_autotune_timerange';
 import type { State } from '../../common/store/types';
+
 /**
  * The highest level connected Resolver component. Needs a `Provider` in its ancestry to work.
  */
@@ -109,7 +110,11 @@ export const ResolverWithoutProviders = React.memo(
     const colorMap = useColors();
 
     return (
-      <StyledMapContainer className={className} backgroundColor={colorMap.resolverBackground}>
+      <StyledMapContainer
+        className={className}
+        backgroundColor={colorMap.resolverBackground}
+        windowHeight={window.innerHeight}
+      >
         {isLoading ? (
           <div data-test-subj="resolver:graph:loading" className="loading-container">
             <EuiLoadingSpinner size="xl" />

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/styles.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/styles.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiPanel, EuiCallOut } from '@elastic/eui';
+import { EuiCallOut, EuiPanel } from '@elastic/eui';
 import styled from 'styled-components';
 import { NodeSubMenuComponents } from './submenu';
 
@@ -76,11 +76,17 @@ export const NodeSubMenu = styled(NodeSubMenuComponents)`
   }
 `;
 
+const EUI_HEADER_HEIGHT = '96px';
+const EXPANDABLE_FLYOUT_LEFT_SECTION_HEADER_HEIGHT = '72px';
+const VISUALIZE_WRAPPER_PADDING = '16px';
+const VISUALIZE_BUTTON_GROUP_HEIGHT = '32px';
+const EUI_SPACER_HEIGHT = '16px';
+
 /**
  * The top level DOM element for Resolver
  * NB: `styled-components` may be used to wrap this.
  */
-export const StyledMapContainer = styled.div<{ backgroundColor: string }>`
+export const StyledMapContainer = styled.div<{ backgroundColor: string; windowHeight: number }>`
   /**
    * Take up all availble space
    */
@@ -99,7 +105,11 @@ export const StyledMapContainer = styled.div<{ backgroundColor: string }>`
   * Set to force base-height necessary for resolver to show up in timeline.
   * Was previously set in events_viewer.tsx, but more appropriate here
    */
-  min-height: 652px;
+  min-height: calc(
+    ${(props) => props.windowHeight}px - ${EUI_HEADER_HEIGHT} -
+      ${EXPANDABLE_FLYOUT_LEFT_SECTION_HEADER_HEIGHT} - 2 * ${VISUALIZE_WRAPPER_PADDING} -
+      ${VISUALIZE_BUTTON_GROUP_HEIGHT} - ${EUI_SPACER_HEIGHT}
+  );
   /**
    * The placeholder components use absolute positioning.
    */


### PR DESCRIPTION
## Summary

This PR makes a super small change to the way we render the Analyzer graph within the expandable flyout.

### Context

Analyzer - prior to be rendered in the expandable flyout (see [this PR](https://github.com/elastic/kibana/pull/192531) and [that one](https://github.com/elastic/kibana/pull/192643) that did the migration) - was rendered in place of the alerts table directly on the alerts page, and also in Timeline. Because of this, we had hardcoded some `min-height` value to a seemingly random `652px` (not sure why?).

Since Kibana `8.16`, Analyzer was moved to the expandable flyout, which is renderer full height, but we never went ahead and updated the part of the code to make Analyzer leverage that full height.

### Changes

The PR makes a very small change to leverage that full height. While the code might not be the cleanest of best approach, the goal was to get something quick and safe. As the flyout is undergoing a pretty involve change to move to the new EUI flyout system, things are going to change drastically over the next few months, so the idea was to not spend too much time on this right now, but provide a very nice UI improvement to all our users!

| Before  | After |
| ------------- | ------------- |
| <img width="1370" height="1207" alt="Screenshot 2025-12-10 at 9 06 16 AM" src="https://github.com/user-attachments/assets/f2d7c45a-1d35-46fa-8e8f-c6eb7c7f2da3" /> | <img width="1366" height="1207" alt="Screenshot 2025-12-10 at 9 30 13 AM" src="https://github.com/user-attachments/assets/a9f8c3d8-34d2-4656-96ec-18617de39024" /> |

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->