### PR TITLE
[Synthetics] Only update relevant monitors where maintenance windows exists

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
@@ -11,6 +11,12 @@ import type {
 } from '@kbn/core-saved-objects-api-server';
 import type { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
 import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
+import type { MaintenanceWindow } from '@kbn/maintenance-windows-plugin/server/application/types';
+import {
+  legacyMonitorAttributes,
+  syntheticsMonitorAttributes,
+  syntheticsMonitorSOTypes,
+} from '../../common/types/saved_objects';
 import { normalizeSecrets } from '../synthetics_service/utils';
 import type { PrivateLocationAttributes } from '../runtime_types/private_locations';
 import type {
@@ -18,6 +24,7 @@ import type {
   MonitorFields,
   SyntheticsMonitorWithSecretsAttributes,
 } from '../../common/runtime_types';
+import { ConfigKey } from '../../common/runtime_types';
 import { MonitorConfigRepository } from '../services/monitor_config_repository';
 import type { SyntheticsMonitorClient } from '../synthetics_service/synthetics_monitor/synthetics_monitor_client';
 import type { SyntheticsServerSetup } from '../types';
@@ -26,13 +33,106 @@ import {
   mixParamsWithGlobalParams,
 } from '../synthetics_service/formatters/public_formatters/format_configs';
 
+interface SyncConfig {
+  config: HeartbeatConfig;
+  globalParams: Record<string, string>;
+}
+
 export class DeployPrivateLocationMonitors {
   constructor(
     public serverSetup: SyntheticsServerSetup,
     public syntheticsMonitorClient: SyntheticsMonitorClient
   ) {}
 
-  async syncPackagePolicies({
+  async syncPackagePoliciesForMws({
+    allPrivateLocations,
+    encryptedSavedObjects,
+    updatedMWs,
+    missingMWIds,
+    soClient,
+    maintenanceWindows,
+  }: {
+    maintenanceWindows: MaintenanceWindow[];
+    updatedMWs?: MaintenanceWindow[];
+    missingMWIds?: string[];
+    soClient: SavedObjectsClientContract;
+    allPrivateLocations: PrivateLocationAttributes[];
+    encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
+  }) {
+    if (allPrivateLocations.length === 0) {
+      this.debugLog('No private locations found, skipping sync of private location monitors');
+      return;
+    }
+    const { syntheticsService } = this.syntheticsMonitorClient;
+
+    const encryptedClient = encryptedSavedObjects.getClient();
+
+    const paramsBySpace = await syntheticsService.getSyntheticsParams({
+      spaceId: ALL_SPACES_ID,
+    });
+
+    const updatedMwIds = updatedMWs?.map((mw) => mw.id) || [];
+
+    const allMwIdsToProcess = new Set<string>([...updatedMwIds, ...(missingMWIds || [])]);
+
+    // config can have multiple mws, so we need to track which configs have been updated to avoid duplicate processing
+    const listOfUpdatedConfigs: Array<string> = [];
+
+    return this.serverSetup.fleet.runWithCache(async () => {
+      for (const mwId of allMwIdsToProcess || []) {
+        const finder =
+          await encryptedClient.createPointInTimeFinderDecryptedAsInternalUser<SyntheticsMonitorWithSecretsAttributes>(
+            {
+              type: syntheticsMonitorSOTypes,
+              perPage: 500,
+              namespaces: ['*'],
+              // TODO: Exclude public monitors
+              filter: `${syntheticsMonitorAttributes}.${ConfigKey.MAINTENANCE_WINDOWS}: "${mwId}" or ${legacyMonitorAttributes}.${ConfigKey.MAINTENANCE_WINDOWS}: "${mwId}"`,
+            }
+          );
+
+        for await (const result of finder.find()) {
+          const monitors = result.saved_objects.filter((monitor) => {
+            // Avoid processing the same config multiple times, updating it once will update all mws on it
+            if (listOfUpdatedConfigs.includes(monitor.id)) {
+              return false;
+            }
+            listOfUpdatedConfigs.push(monitor.id);
+            return true;
+          });
+          this.debugLog(`Processing mw id: ${mwId}, monitors count: ${monitors?.length ?? 0}`);
+
+          const { configsBySpaces, monitorSpaceIds } = this.mixParamsWithMonitors(
+            monitors,
+            paramsBySpace
+          );
+
+          const mw = updatedMWs?.find((window) => window.id === mwId);
+
+          await this.deployEditMonitors({
+            allPrivateLocations,
+            configsBySpaces,
+            monitorSpaceIds,
+            paramsBySpace,
+            maintenanceWindows,
+          });
+          if (!mw) {
+            await this.removeMwsFromMonitorConfigs({
+              mwId,
+              monitors,
+              soClient,
+            });
+          }
+        }
+
+        finder.close().catch(() => {});
+
+        this.debugLog(`Syncing package policies for updated maintenance window id: ${mwId}`);
+      }
+    });
+  }
+
+  async syncAllPackagePolicies({
     allPrivateLocations,
     encryptedSavedObjects,
     soClient,
@@ -48,8 +148,6 @@ export class DeployPrivateLocationMonitors {
       return;
     }
 
-    const { privateLocationAPI } = this.syntheticsMonitorClient;
-
     const { configsBySpaces, paramsBySpace, monitorSpaceIds, maintenanceWindows } =
       await this.getAllMonitorConfigs({
         encryptedSavedObjects,
@@ -63,39 +161,61 @@ export class DeployPrivateLocationMonitors {
           ', '
         )}`
       );
-      for (const spaceId of monitorSpaceIds) {
-        const privateConfigs: Array<{
-          config: HeartbeatConfig;
-          globalParams: Record<string, string>;
-        }> = [];
-        const monitors = configsBySpaces[spaceId];
-        this.debugLog(`Processing spaceId: ${spaceId}, monitors count: ${monitors?.length ?? 0}`);
-        if (!monitors) {
-          continue;
-        }
-        for (const monitor of monitors) {
-          const { privateLocations } = this.parseLocations(monitor);
+      await this.deployEditMonitors({
+        allPrivateLocations,
+        configsBySpaces,
+        monitorSpaceIds,
+        paramsBySpace,
+        maintenanceWindows,
+      });
+      this.debugLog('Completed sync of private location monitors');
+    });
+  }
 
-          if (privateLocations.length > 0) {
-            privateConfigs.push({ config: monitor, globalParams: paramsBySpace[spaceId] });
-          }
-        }
-        if (privateConfigs.length > 0) {
-          this.debugLog(
-            `Syncing private configs for spaceId: ${spaceId}, privateConfigs count: ${privateConfigs.length}`
-          );
+  async deployEditMonitors({
+    allPrivateLocations,
+    configsBySpaces,
+    monitorSpaceIds,
+    paramsBySpace,
+    maintenanceWindows,
+  }: {
+    allPrivateLocations: PrivateLocationAttributes[];
+    configsBySpaces: Record<string, HeartbeatConfig[]>;
+    monitorSpaceIds: Set<string>;
+    paramsBySpace: Record<string, Record<string, string>>;
+    maintenanceWindows: MaintenanceWindow[];
+  }) {
+    const { privateLocationAPI } = this.syntheticsMonitorClient;
 
-          await privateLocationAPI.editMonitors(
-            privateConfigs,
-            allPrivateLocations,
-            spaceId,
-            maintenanceWindows
-          );
-        } else {
-          this.debugLog(`No privateConfigs to sync for spaceId: ${spaceId}`);
+    for (const spaceId of monitorSpaceIds) {
+      const privateConfigs: Array<SyncConfig> = [];
+      const monitors = configsBySpaces[spaceId];
+      this.debugLog(`Processing spaceId: ${spaceId}, monitors count: ${monitors?.length ?? 0}`);
+      if (!monitors) {
+        continue;
+      }
+      for (const monitor of monitors) {
+        const { privateLocations } = this.parseLocations(monitor);
+
+        if (privateLocations.length > 0) {
+          privateConfigs.push({ config: monitor, globalParams: paramsBySpace[spaceId] });
         }
       }
-    });
+      if (privateConfigs.length > 0) {
+        this.debugLog(
+          `Syncing private configs for spaceId: ${spaceId}, privateConfigs count: ${privateConfigs.length}`
+        );
+
+        await privateLocationAPI.editMonitors(
+          privateConfigs,
+          allPrivateLocations,
+          spaceId,
+          maintenanceWindows
+        );
+      } else {
+        this.debugLog(`No privateConfigs to sync for spaceId: ${spaceId}`);
+      }
+    }
   }
 
   async getAllMonitorConfigs({
@@ -181,5 +301,36 @@ export class DeployPrivateLocationMonitors {
 
   debugLog = (message: string) => {
     this.serverSetup.logger.debug(`[DeployPrivateLocationMonitors] ${message}`);
+  };
+
+  removeMwsFromMonitorConfigs = async ({
+    mwId,
+    monitors,
+    soClient,
+  }: {
+    mwId: string;
+    monitors: Array<SavedObjectsFindResult<SyntheticsMonitorWithSecretsAttributes>>;
+    soClient: SavedObjectsClientContract;
+  }) => {
+    this.debugLog(
+      `Removing maintenance window id: ${mwId} from monitors count: ${monitors?.length ?? 0}`
+    );
+    const toUpdateMonitors = monitors.map((monitor) => {
+      const existingMws = monitor.attributes[ConfigKey.MAINTENANCE_WINDOWS] || [];
+      const updatedMws = existingMws.filter((id) => id !== mwId);
+      return {
+        id: monitor.id,
+        type: monitor.type,
+        attributes: {
+          [ConfigKey.MAINTENANCE_WINDOWS]: updatedMws,
+        },
+        namespace: monitor.namespaces?.[0],
+      };
+    });
+
+    const result = await soClient.bulkUpdate(toUpdateMonitors);
+    this.debugLog(
+      `Removed maintenance window id: ${mwId} from monitors, updated monitors count: ${result.saved_objects.length}`
+    );
   };
 }

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.ts
@@ -80,7 +80,7 @@ export class SyncGlobalParamsPrivateLocationsTask {
 
         const allPrivateLocations = await getPrivateLocations(soClient, ALL_SPACES_ID);
         if (allPrivateLocations.length > 0) {
-          await this.deployPackagePolicies.syncPackagePolicies({
+          await this.deployPackagePolicies.syncAllPackagePolicies({
             allPrivateLocations,
             soClient,
             encryptedSavedObjects,

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
@@ -130,7 +130,9 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const taskInstance = getMockTaskInstance();
       jest.spyOn(task, 'hasMWsChanged').mockResolvedValue({
         hasMWsChanged: false,
-      });
+      } as any);
+      // fetchMonitorMwsIds is used in the implementation now
+      jest.spyOn(task, 'fetchMonitorMwsIds').mockResolvedValue(['mw-1']);
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
         {
           id: 'pl-1',
@@ -161,7 +163,10 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const taskInstance = getMockTaskInstance();
       jest.spyOn(task, 'hasMWsChanged').mockResolvedValue({
         hasMWsChanged: true,
-      });
+        updatedMWs: [],
+        missingMWIds: [],
+      } as any);
+      jest.spyOn(task, 'fetchMonitorMwsIds').mockResolvedValue(['mw-1']);
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
         {
           id: 'pl-1',
@@ -170,23 +175,19 @@ describe('SyncPrivateLocationMonitorsTask', () => {
           agentPolicyId: 'policy-1',
         },
       ]);
-      jest.spyOn(task.deployPackagePolicies, 'syncPackagePolicies').mockResolvedValue(undefined);
+      jest
+        .spyOn(task.deployPackagePolicies, 'syncPackagePoliciesForMws')
+        .mockResolvedValue(undefined);
 
       const result = await task.runTask({ taskInstance });
-      expect(mockLogger.debug).toHaveBeenNthCalledWith(
-        2,
-        '[PrivateLocationCleanUpTask] Starting cleanup of duplicated package policies'
-      );
 
-      expect(mockLogger.debug).toHaveBeenNthCalledWith(
-        3,
-        '[SyncPrivateLocationMonitorsTask] Syncing private location monitors because data has changed'
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Syncing private location monitors because data has changed')
       );
-      expect(mockLogger.debug).toHaveBeenNthCalledWith(
-        4,
-        '[SyncPrivateLocationMonitorsTask] Sync of private location monitors succeeded'
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Sync of private location monitors succeeded')
       );
-      expect(task.deployPackagePolicies.syncPackagePolicies).toHaveBeenCalled();
+      expect(task.deployPackagePolicies.syncPackagePoliciesForMws).toHaveBeenCalled();
       expect(result.error).toBeUndefined();
       expect(result.state).toEqual({
         disableAutoSync: false,
@@ -197,27 +198,20 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       });
     });
 
-    it('should not sync if data changed but no private locations exist', async () => {
-      const taskInstance = getMockTaskInstance();
-      jest.spyOn(task, 'hasMWsChanged').mockResolvedValue({
-        hasMWsChanged: true,
-      });
-      jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([]);
-      jest.spyOn(task.deployPackagePolicies, 'syncPackagePolicies');
-
-      await task.runTask({ taskInstance });
-
-      expect(getPrivateLocationsModule.getPrivateLocations).toHaveBeenCalled();
-      expect(task.deployPackagePolicies.syncPackagePolicies).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenLastCalledWith(
-        '[SyncPrivateLocationMonitorsTask] Sync of private location monitors succeeded'
-      );
-    });
-
     it('should handle errors during the run', async () => {
       const taskInstance = getMockTaskInstance();
       const error = new Error('Sync failed');
+      // fetchMonitorMwsIds is called before hasMWsChanged in runTask
+      jest.spyOn(task, 'fetchMonitorMwsIds').mockResolvedValue(['mw-1']);
       jest.spyOn(task, 'hasMWsChanged').mockRejectedValue(error);
+      jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
+        {
+          id: 'pl-1',
+          label: 'Private Location 1',
+          isServiceManaged: false,
+          agentPolicyId: 'policy-1',
+        },
+      ]);
 
       const result = await task.runTask({ taskInstance });
 
@@ -243,7 +237,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       };
       jest.spyOn(task, 'hasMWsChanged').mockResolvedValue({
         hasMWsChanged: false,
-      });
+      } as any);
+      jest.spyOn(task, 'fetchMonitorMwsIds').mockResolvedValue(['mw-1']);
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
         {
           id: 'pl-1',
@@ -269,6 +264,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         taskState: { lastTotalMWs: 1 } as any,
         soClient: mockSoClient as any,
         lastStartedAt: new Date().toISOString(),
+        monitorMwsIds: ['mw-1'],
       });
 
       expect(res.hasMWsChanged).toBe(true);
@@ -285,6 +281,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         taskState: taskState as any,
         soClient: mockSoClient as any,
         lastStartedAt: new Date().toISOString(),
+        monitorMwsIds: ['mw-1'],
       });
 
       expect(res.hasMWsChanged).toBe(false);
@@ -293,43 +290,62 @@ describe('SyncPrivateLocationMonitorsTask', () => {
 
   describe('hasMWsChanged', () => {
     it('returns true if updated MWs are found', async () => {
-      mockSoClient.find
-        .mockResolvedValueOnce({ total: 1 } as any) // updated
-        .mockResolvedValueOnce({ total: 5 } as any); // total
+      // mock maintenance window client to return an updated MW
+      const bulkGet = jest.fn().mockResolvedValue({
+        maintenanceWindows: [{ id: 'mw-1', updatedAt: '2024-01-02T00:00:00.000Z' }],
+      });
+      mockServerSetup.getMaintenanceWindowClientInternal = jest.fn().mockReturnValue({
+        bulkGet,
+      });
+
       const { hasMWsChanged } = await task.hasMWsChanged({
         soClient: mockSoClient as any,
-        lastStartedAt: '...',
+        lastStartedAt: '2024-01-01T00:00:00.000Z',
         taskState: {
           lastTotalMWs: 5,
         } as any,
+        monitorMwsIds: ['mw-1'],
       });
       expect(hasMWsChanged).toBe(true);
+      expect(bulkGet).toHaveBeenCalledWith({ ids: ['mw-1'] });
     });
 
-    it('returns true if total number of MWs changed', async () => {
-      mockSoClient.find
-        .mockResolvedValueOnce({ total: 0 } as any) // updated
-        .mockResolvedValueOnce({ total: 6 } as any); // total
+    it('returns true if total number of MWs changed (missing ids)', async () => {
+      // bulkGet returns no maintenance windows -> missing ids detected
+      const bulkGet = jest.fn().mockResolvedValue({
+        maintenanceWindows: [],
+      });
+      mockServerSetup.getMaintenanceWindowClientInternal = jest.fn().mockReturnValue({
+        bulkGet,
+      });
+
       const { hasMWsChanged } = await task.hasMWsChanged({
         soClient: mockSoClient as any,
         lastStartedAt: '...',
         taskState: {
           lastTotalMWs: 5,
         } as any,
+        monitorMwsIds: ['missing-mw'],
       });
       expect(hasMWsChanged).toBe(true);
     });
 
     it('returns false if no changes are detected', async () => {
-      mockSoClient.find
-        .mockResolvedValueOnce({ total: 0 } as any) // updated
-        .mockResolvedValueOnce({ total: 5 } as any); // total
+      // bulkGet returns MWs updated before lastStartedAt and all ids present
+      const bulkGet = jest.fn().mockResolvedValue({
+        maintenanceWindows: [{ id: 'mw-1', updatedAt: '2023-01-01T00:00:00.000Z' }],
+      });
+      mockServerSetup.getMaintenanceWindowClientInternal = jest.fn().mockReturnValue({
+        bulkGet,
+      });
+
       const { hasMWsChanged } = await task.hasMWsChanged({
         soClient: mockSoClient as any,
-        lastStartedAt: '...',
+        lastStartedAt: '2023-02-01T00:00:00.000Z',
         taskState: {
           lastTotalMWs: 5,
         } as any,
+        monitorMwsIds: ['mw-1'],
       });
       expect(hasMWsChanged).toBe(false);
     });
@@ -353,7 +369,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         .spyOn(task, 'parseLocations')
         .mockReturnValue({ privateLocations: ['pl-1'], publicLocations: [] } as any);
 
-      await task.deployPackagePolicies.syncPackagePolicies({
+      await task.deployPackagePolicies.syncAllPackagePolicies({
         allPrivateLocations: mockAllPrivateLocations as any,
         soClient: mockSoClient as any,
         spaceIdToSync: 'space1',
@@ -384,7 +400,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         .spyOn(task, 'parseLocations')
         .mockReturnValue({ privateLocations: [], publicLocations: [] } as any);
 
-      await task.deployPackagePolicies.syncPackagePolicies({
+      await task.deployPackagePolicies.syncAllPackagePolicies({
         allPrivateLocations: [],
         soClient: mockSoClient as any,
         encryptedSavedObjects: mockEncryptedSoClient as any,
@@ -531,6 +547,36 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         '[PrivateLocationCleanUpTask] Skipping cleanup of duplicated package policies as max retries have been reached'
       );
+    });
+  });
+
+  // Replace old monitorsHaveMaintenanceWindows tests with fetchMonitorMwsIds tests
+  describe('fetchMonitorMwsIds', () => {
+    it('returns the combined unique ids from monitor and legacy aggregations', async () => {
+      mockSoClient.find.mockResolvedValue({
+        aggregations: {
+          monitorMws: { buckets: [{ key: 'a' }, { key: 'b' }] },
+          legacyMonitorsMws: { buckets: [{ key: 'b' }, { key: 'c' }] },
+        },
+      } as any);
+
+      const res = await task.fetchMonitorMwsIds(mockSoClient as any);
+      expect(res).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+      expect(mockSoClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: expect.anything(),
+          perPage: 0,
+          namespaces: [expect.any(String)],
+          aggs: expect.any(Object),
+        })
+      );
+    });
+
+    it('returns empty array when aggregations are missing', async () => {
+      mockSoClient.find.mockResolvedValue({} as any);
+
+      const res = await task.fetchMonitorMwsIds(mockSoClient as any);
+      expect(res).toEqual([]);
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.ts
@@ -16,6 +16,12 @@ import type {
 import moment from 'moment';
 import { MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE } from '@kbn/maintenance-windows-plugin/common';
 import pRetry from 'p-retry';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import {
+  legacyMonitorAttributes,
+  syntheticsMonitorAttributes,
+  syntheticsMonitorSOTypes,
+} from '../../common/types/saved_objects';
 import { DeployPrivateLocationMonitors } from './deploy_private_location_monitors';
 import { cleanUpDuplicatedPackagePolicies } from './clean_up_duplicate_policies';
 import type { HeartbeatConfig } from '../../common/runtime_types';
@@ -29,7 +35,6 @@ const TASK_SCHEDULE = '60m';
 
 export interface SyncTaskState extends Record<string, unknown> {
   lastStartedAt: string;
-  lastTotalMWs: number;
   hasAlreadyDoneCleanup: boolean;
   maxCleanUpRetries: number;
   disableAutoSync?: boolean;
@@ -95,43 +100,78 @@ export class SyncPrivateLocationMonitorsTask {
 
     const taskState = this.getNewTaskState({ taskInstance });
 
+    const defaultState = {
+      state: taskState,
+      schedule: {
+        interval: TASK_SCHEDULE,
+      },
+    };
+
     try {
       const soClient = savedObjects.createInternalRepository([
         MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE,
       ]);
-
       const { performCleanupSync } = await this.cleanUpDuplicatedPackagePolicies(
         soClient,
         taskState
       );
 
       const allPrivateLocations = await getPrivateLocations(soClient, ALL_SPACES_ID);
-      const { hasMWsChanged } = await this.hasMWsChanged({
-        soClient,
-        taskState,
-        lastStartedAt,
-      });
+      if (allPrivateLocations.length === 0) {
+        this.debugLog(`No private locations found, skipping sync of private location monitors`);
+        return {
+          state: taskState,
+          schedule: {
+            interval: TASK_SCHEDULE,
+          },
+        };
+      }
+      if (performCleanupSync) {
+        this.debugLog(`Syncing private location monitors because cleanup performed a change`);
 
-      // Only perform syncGlobalParams if:
-      // - hasMWsChanged and disableAutoSync is false
-      // - OR performCleanupSync is true (from cleanup), regardless of disableAutoSync
+        await this.deployPackagePolicies.syncAllPackagePolicies({
+          allPrivateLocations,
+          soClient,
+          encryptedSavedObjects,
+        });
+        return defaultState;
+      }
+
+      if (taskState.disableAutoSync) {
+        this.debugLog(`Auto sync is disabled, skipping sync of private location monitors`);
+        return defaultState;
+      }
+
+      const monitorMwsIds = await this.fetchMonitorMwsIds(soClient);
+      if (monitorMwsIds.length === 0) {
+        this.debugLog(
+          `No monitors with maintenance windows found, skipping sync of private location monitors`
+        );
+        return defaultState;
+      }
+
+      const { hasMWsChanged, updatedMWs, missingMWIds, maintenanceWindows } =
+        await this.hasMWsChanged({
+          soClient,
+          taskState,
+          lastStartedAt,
+          monitorMwsIds,
+        });
+
       const dataChangeSync = hasMWsChanged && !taskState.disableAutoSync;
-      if (dataChangeSync || performCleanupSync) {
-        if (dataChangeSync) {
-          this.debugLog(`Syncing private location monitors because data has changed`);
-        } else if (performCleanupSync) {
-          this.debugLog(`Syncing private location monitors because cleanup performed a change`);
-        }
+      if (dataChangeSync) {
+        this.debugLog(`Syncing private location monitors because data has changed`);
 
-        if (allPrivateLocations.length > 0) {
-          await this.deployPackagePolicies.syncPackagePolicies({
-            allPrivateLocations,
-            soClient,
-            encryptedSavedObjects,
-          });
-        } else {
-          this.debugLog(`No private locations found, skipping sync`);
-        }
+        await this.deployPackagePolicies.syncPackagePoliciesForMws({
+          allPrivateLocations,
+          soClient,
+          encryptedSavedObjects,
+          updatedMWs,
+          missingMWIds,
+          // this is passed so we don't have to fetch them again in the method
+          maintenanceWindows,
+        });
+
         this.debugLog(`Sync of private location monitors succeeded`);
       } else {
         if (taskState.disableAutoSync) {
@@ -152,6 +192,7 @@ export class SyncPrivateLocationMonitorsTask {
         },
       };
     }
+
     return {
       state: taskState,
       schedule: {
@@ -198,45 +239,83 @@ export class SyncPrivateLocationMonitorsTask {
     return { privateLocations, publicLocations };
   }
 
+  async fetchMonitorMwsIds(soClient: SavedObjectsClientContract) {
+    const monitorsWithMws = await soClient.find<
+      unknown,
+      {
+        monitorMws: {
+          buckets: Array<{ key: string; doc_count: number }>;
+        };
+        legacyMonitorsMws: {
+          buckets: Array<{ key: string; doc_count: number }>;
+        };
+      }
+    >({
+      type: syntheticsMonitorSOTypes,
+      perPage: 0,
+      namespaces: [ALL_SPACES_ID],
+      fields: [],
+      aggs: {
+        monitorMws: {
+          terms: { field: `${syntheticsMonitorAttributes}.maintenance_windows`, size: 1000 },
+        },
+        legacyMonitorsMws: {
+          terms: { field: `${legacyMonitorAttributes}.maintenance_windows`, size: 1000 },
+        },
+      },
+    });
+    const { monitorMws, legacyMonitorsMws } = monitorsWithMws.aggregations || {};
+    const monitorMwsIds = monitorMws?.buckets.map((b) => b.key) || [];
+    const legacyMonitorMwsIds = legacyMonitorsMws?.buckets.map((b) => b.key) || [];
+
+    this.debugLog(`Fetched monitor MWs IDs: ${JSON.stringify(monitorMwsIds)}`);
+    this.debugLog(`Fetched legacy monitor MWs IDs: ${JSON.stringify(legacyMonitorMwsIds)}`);
+
+    return Array.from(new Set([...monitorMwsIds, ...legacyMonitorMwsIds]));
+  }
+
   async hasMWsChanged({
-    soClient,
     lastStartedAt,
-    taskState,
+    monitorMwsIds,
   }: {
     soClient: SavedObjectsClientContract;
     lastStartedAt: string;
     taskState: SyncTaskState;
+    monitorMwsIds: string[];
   }) {
-    const { logger } = this.serverSetup;
-    const { lastTotalMWs } = taskState;
-
-    const [editedMWs, totalMWs] = await Promise.all([
-      soClient.find({
-        type: MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE,
-        perPage: 0,
-        namespaces: [ALL_SPACES_ID],
-        filter: `${MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE}.updated_at > "${lastStartedAt}"`,
-        fields: [],
-      }),
-      soClient.find({
-        type: MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE,
-        perPage: 0,
-        namespaces: [ALL_SPACES_ID],
-        fields: [],
-      }),
-    ]);
-    logger.debug(
-      `Found ${editedMWs.total} maintenance windows updated and ${totalMWs.total} total maintenance windows`
+    const maintenanceWindowClient = this.serverSetup.getMaintenanceWindowClientInternal(
+      {} as KibanaRequest
     );
-    const updatedMWs = editedMWs.total;
-    const noOfMWs = totalMWs.total;
 
-    const hasMWsChanged = updatedMWs > 0 || noOfMWs !== lastTotalMWs;
+    if (!maintenanceWindowClient) {
+      return {
+        hasMWsChanged: false,
+        updatedMWs: [],
+        missingMWIds: [],
+        maintenanceWindows: [],
+      };
+    }
 
-    taskState.lastTotalMWs = noOfMWs;
+    const { maintenanceWindows } = await maintenanceWindowClient.bulkGet({
+      ids: monitorMwsIds,
+    });
+    // check if any of the MWs were updated since the last run
+    const updatedMWs = maintenanceWindows.filter((mw) => {
+      const updatedAt = mw.updatedAt;
+      return moment(updatedAt).isAfter(moment(lastStartedAt));
+    });
+    // check if any MWs are missing
+    const missingMWIds = monitorMwsIds.filter((mwId) => {
+      return !maintenanceWindows.find((mw) => mw.id === mwId);
+    });
+
+    this.debugLog('Missing MW IDs: ' + JSON.stringify(missingMWIds));
 
     return {
-      hasMWsChanged,
+      hasMWsChanged: updatedMWs.length > 0 || missingMWIds.length > 0,
+      updatedMWs,
+      missingMWIds,
+      maintenanceWindows,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/245866

The task will only update relevant monitors where mws exists, following queries have been updated 


Using these aggs to determine value count and short circuit the code if no value exists in the task

using this it will first fetch list of Mws Ids

```
      type: syntheticsMonitorSOTypes,
      perPage: 0,
      namespaces: [ALL_SPACES_ID],
      fields: [],
      aggs: {
        monitorMws: {
          terms: { field: `${syntheticsMonitorAttributes}.maintenance_windows`, size: 1000 },
        },
        legacyMonitorsMws: {
          terms: { field: `${legacyMonitorAttributes}.maintenance_windows`, size: 1000 },
        },
      },
```

in a following up call, it check out of these using `maintenanceWindowClient.bulkGet` which mws have been since updated or missing.

When it has list of missing and updated mws, it loops through them and fetch relevant monitors


For the updated mws , it update the monitors and for missing mws, it removed them also from monitor config.

### Testing

enable logging 

```
logging.loggers:
 - name: plugins.synthetics
   level: debug
   appenders: [console]
```

change task interval from 60m to 1m 

and add following line 
`    await taskManager.removeIfExists(PRIVATE_LOCATIONS_SYNC_TASK_ID);
`

above this line in code base

`     await taskManager.ensureScheduled({
`

define and set maintenance windows and test both use -cases

and look for following log lines

`    this.debugLog(`Found ${count} monitors with maintenance windows`);
`

<!--ONMERGE {"backportTargets":["8.19","9.2"]} ONMERGE-->