### PR TITLE
[Agent builder] `includeKibanaIndices` when index pattern is not wildcard

### DIFF
--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/index_explorer.test.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/index_explorer.test.ts
@@ -7,7 +7,14 @@
 
 import { EsResourceType } from '@kbn/onechat-common';
 import type { ResourceDescriptor } from './index_explorer';
-import { createIndexSelectorPrompt, formatResource } from './index_explorer';
+import { createIndexSelectorPrompt, formatResource, indexExplorer } from './index_explorer';
+import { listSearchSources } from './steps/list_search_sources';
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import type { ScopedModel } from '@kbn/onechat-server';
+
+jest.mock('./steps/list_search_sources');
+
+const listSearchSourcesMock = listSearchSources as jest.Mock;
 
 describe('createIndexSelectorPrompt', () => {
   const nlQuery = 'some NL query';
@@ -39,5 +46,64 @@ describe('createIndexSelectorPrompt', () => {
     const userPrompt = (messages[1] as string[])[1];
 
     expect(userPrompt).toContain(formatResource(indexDescriptor));
+  });
+});
+
+describe('indexExplorer', () => {
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+  let model: ScopedModel;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    esClient = elasticsearchServiceMock.createElasticsearchClient();
+    model = {
+      chatModel: {
+        withStructuredOutput: jest.fn().mockReturnValue({
+          invoke: jest.fn().mockResolvedValue({
+            targets: [],
+          }),
+        }),
+      },
+    } as unknown as ScopedModel;
+
+    listSearchSourcesMock.mockResolvedValue({
+      indices: [],
+      aliases: [],
+      data_streams: [],
+    });
+  });
+
+  it('passes includeKibanaIndices as false when indexPattern is "*"', async () => {
+    await indexExplorer({
+      nlQuery: 'test query',
+      indexPattern: '*',
+      esClient,
+      model,
+    });
+
+    expect(listSearchSourcesMock).toHaveBeenCalledWith({
+      pattern: '*',
+      excludeIndicesRepresentedAsDatastream: true,
+      excludeIndicesRepresentedAsAlias: false,
+      esClient,
+      includeKibanaIndices: false,
+    });
+  });
+
+  it('passes includeKibanaIndices as true when indexPattern is not "*"', async () => {
+    await indexExplorer({
+      nlQuery: 'test query',
+      indexPattern: 'logs-*',
+      esClient,
+      model,
+    });
+
+    expect(listSearchSourcesMock).toHaveBeenCalledWith({
+      pattern: 'logs-*',
+      excludeIndicesRepresentedAsDatastream: true,
+      excludeIndicesRepresentedAsAlias: false,
+      esClient,
+      includeKibanaIndices: true,
+    });
   });
 });

--- a/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/index_explorer.ts
+++ b/x-pack/platform/packages/shared/onechat/onechat-genai-utils/tools/index_explorer.ts
@@ -128,6 +128,7 @@ export const indexExplorer = async ({
     excludeIndicesRepresentedAsDatastream: true,
     excludeIndicesRepresentedAsAlias: false,
     esClient,
+    includeKibanaIndices: indexPattern !== '*',
   });
 
   const indexCount = sources.indices.length;


### PR DESCRIPTION
## Summary

I ran into an issue with the `runSearchTool` with our alerts tool and security labs tool because both use a Kibana index alias (`.alerts-security.alerts-default`). We need `includeKibanaIndices` to be true when calling `listSearchSources` in order for the Kibana indices to be properly returned. @pgayvallet recommended this condition `includeKibanaIndices: indexPattern !== '*'` when calling `listSearchSources` from `indexExplorer`

