### PR TITLE
[Security Solution][Alert details] show session view in full height

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
@@ -40,6 +40,13 @@ export const SESSION_VIEWER_BANNER = {
   textColor: 'warning',
 };
 
+const EUI_HEADER_HEIGHT = 96;
+const EXPANDABLE_FLYOUT_LEFT_SECTION_HEADER_HEIGHT = 72;
+const VISUALIZE_WRAPPER_PADDING = 16;
+const VISUALIZE_BUTTON_GROUP_HEIGHT = 32;
+const EUI_SPACER_HEIGHT = 16;
+const SESSION_VIEW_SEARCH_BAR_HEIGHT = 64;
+
 /**
  * Session view displayed in the document details expandable flyout left section under the Visualize tab
  */
@@ -146,10 +153,20 @@ export const SessionView: FC = memo(() => {
 
   const closeDetailsInPreview = useCallback(() => closePreviewPanel(), [closePreviewPanel]);
 
+  const height =
+    window.innerHeight -
+    EUI_HEADER_HEIGHT -
+    EXPANDABLE_FLYOUT_LEFT_SECTION_HEADER_HEIGHT -
+    2 * VISUALIZE_WRAPPER_PADDING -
+    VISUALIZE_BUTTON_GROUP_HEIGHT -
+    EUI_SPACER_HEIGHT -
+    SESSION_VIEW_SEARCH_BAR_HEIGHT;
+
   return isEnabled ? (
     <div data-test-subj={SESSION_VIEW_TEST_ID}>
       {sessionView.getSessionView({
         ...sessionViewConfig,
+        height,
         isFullScreen: true,
         loadAlertDetails: openAlertDetailsPreview,
         openDetails: (selectedProcess: Process | null) => openDetailsInPreview(selectedProcess),


### PR DESCRIPTION
## Summary

This PR makes a super small change to the way we render the Analyzer graph within the expandable flyout.

### Context

Session View - prior to be rendered in the expandable flyout (see [this PR](https://github.com/elastic/kibana/pull/192531) and [that one](https://github.com/elastic/kibana/pull/200270) that did the migration) - was rendered in place of the alerts table directly on the alerts page, and also in Timeline.

Since Kibana `8.16`, Session View was moved to the expandable flyout, which is renderer full height. The default height value for Session View is `500px` and we've never customized this.

### Changes

The PR makes a very small change to leverage that full height. While the code might not be the cleanest of best approach, the goal was to get something quick and safe. As the flyout is undergoing a pretty involve change to move to the new EUI flyout system, things are going to change drastically over the next few months, so the idea was to not spend too much time on this right now, but provide a very nice UI improvement to all our users!

| Before  | After |
| ------------- | ------------- |
| <img width="1252" height="1300" alt="Screenshot 2025-12-10 at 11 20 25 AM" src="https://github.com/user-attachments/assets/8f6e7608-7ebf-4457-88ba-cc6051af8aeb" /> | <img width="1252" height="1300" alt="Screenshot 2025-12-10 at 11 19 13 AM" src="https://github.com/user-attachments/assets/c8202a1e-6ee8-4513-a817-93708c902919" /> |

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->