### PR TITLE
add trusted ancestor advanced options

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -2697,7 +2697,8 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     documentation: i18n.translate(
       'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.trusted_ancestors',
       {
-        defaultMessage: 'Enable support for trusted ancestors, allowing children of trusted processes to become trusted by default',
+        defaultMessage:
+          'Enable support for trusted ancestors, allowing children of trusted processes to become trusted by default',
       }
     ),
   },
@@ -2707,7 +2708,8 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     documentation: i18n.translate(
       'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.trusted_ancestors',
       {
-        defaultMessage: 'Enable support for trusted ancestors, allowing children of trusted processes to become trusted by default',
+        defaultMessage:
+          'Enable support for trusted ancestors, allowing children of trusted processes to become trusted by default',
       }
     ),
   },
@@ -2717,7 +2719,8 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     documentation: i18n.translate(
       'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.trusted_ancestors',
       {
-        defaultMessage: 'Enable support for trusted ancestors, allowing children of trusted processes to become trusted by default',
+        defaultMessage:
+          'Enable support for trusted ancestors, allowing children of trusted processes to become trusted by default',
       }
     ),
   },

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -2691,4 +2691,34 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       }
     ),
   },
+  {
+    key: 'mac.advanced.trusted_ancestors',
+    first_supported_version: '9.3',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.trusted_ancestors',
+      {
+        defaultMessage: 'Enable support for trusted ancestors, allowing children of trusted processes to become trusted by default',
+      }
+    ),
+  },
+  {
+    key: 'linux.advanced.trusted_ancestors',
+    first_supported_version: '9.3',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.trusted_ancestors',
+      {
+        defaultMessage: 'Enable support for trusted ancestors, allowing children of trusted processes to become trusted by default',
+      }
+    ),
+  },
+  {
+    key: 'windows.advanced.trusted_ancestors',
+    first_supported_version: '9.3',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.trusted_ancestors',
+      {
+        defaultMessage: 'Enable support for trusted ancestors, allowing children of trusted processes to become trusted by default',
+      }
+    ),
+  },
 ];


### PR DESCRIPTION
## Summary

This PR adds support for the coming trusted ancestors feature, which is gated by a global `PLATFORM.advanced.trusted_ancestors` flag. 

I've never tinkered with the policy config in Kibana before, so if this is totally wrong....just tell me.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



