### PR TITLE
[SharedUX][A11y] Add missing labels to alerts and insights fields

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/email/email_params.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/email/email_params.tsx
@@ -79,6 +79,13 @@ export const EmailParamsFields = ({
   const isBCCInvalid: boolean =
     errors.bcc !== undefined && Number(errors.bcc.length) > 0 && bcc !== undefined;
 
+  const subjectLabel = i18n.translate(
+    'xpack.stackConnectors.components.email.subjectTextFieldLabel',
+    {
+      defaultMessage: 'Subject',
+    }
+  );
+
   return (
     <>
       <EuiFormRow
@@ -237,9 +244,7 @@ export const EmailParamsFields = ({
           fullWidth
           error={errors.subject as string}
           isInvalid={isSubjectInvalid}
-          label={i18n.translate('xpack.stackConnectors.components.email.subjectTextFieldLabel', {
-            defaultMessage: 'Subject',
-          })}
+          label={subjectLabel}
         >
           <TextFieldWithMessageVariables
             index={index}
@@ -248,6 +253,7 @@ export const EmailParamsFields = ({
             paramsProperty={'subject'}
             inputTargetValue={subject}
             errors={(errors.subject ?? []) as string[]}
+            aria-label={subjectLabel}
           />
         </EuiFormRow>
       )}

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/text_field_with_message_variables.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/text_field_with_message_variables.tsx
@@ -30,6 +30,7 @@ interface Props {
     label?: string;
   };
   showButtonTitle?: boolean;
+  'aria-label'?: string;
 }
 
 const Wrapper = ({
@@ -70,6 +71,7 @@ export const TextFieldWithMessageVariables: React.FunctionComponent<Props> = ({
   defaultValue,
   wrapField = false,
   showButtonTitle,
+  'aria-label': ariaLabel,
 }) => {
   const [currentTextElement, setCurrentTextElement] = useState<HTMLInputElement | null>(null);
 
@@ -107,6 +109,7 @@ export const TextFieldWithMessageVariables: React.FunctionComponent<Props> = ({
     <Wrapper wrapField={wrapField} formRowProps={formRowProps} button={VariableButton}>
       <EuiFieldText
         fullWidth
+        aria-label={ariaLabel}
         name={paramsProperty}
         id={`${paramsProperty}Id`}
         isInvalid={errors && errors.length > 0 && inputTargetValue !== undefined}

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_table.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_table.tsx
@@ -383,6 +383,13 @@ export const RulesListTable = (props: RulesListTableProps) => {
             disabled={!rule.isEditable || rule.isInternallyManaged}
             checked={isRowSelected(rule)}
             data-test-subj={`checkboxSelectRow-${rule.id}`}
+            aria-label={i18n.translate(
+              'xpack.triggersActionsUI.sections.rulesList.selectRuleCheckbox',
+              {
+                defaultMessage: 'Select rule {ruleName}',
+                values: { ruleName: rule.name },
+              }
+            )}
           />
         );
       },


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/242966
Closes https://github.com/elastic/kibana/issues/242974

## Summary

- Added `aria-label` to `subject` field in Connectors flyout (test tab) 
- Added `aria-label` to `rules` table checkbox
- axe-core scan is now healthy and screen reader announces fields with proper labels

### Testing

Connectors:

<img width="2315" height="937" alt="Screenshot 2025-12-11 at 16 03 13" src="https://github.com/user-attachments/assets/c066b01c-f995-434c-bf65-f97cfb4a67fb" />

Rules:

<img width="2296" height="943" alt="Screenshot 2025-12-11 at 16 00 18" src="https://github.com/user-attachments/assets/58eee066-0cfb-4dd9-a49f-1cb872ef9d6f" />



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->