### PR TITLE
[Streams] Make attachments setting visible in advanced settings

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/feature_flags.ts
+++ b/x-pack/platform/plugins/shared/streams/server/feature_flags.ts
@@ -122,8 +122,6 @@ export function registerFeatureFlags(
       requiresPageReload: true,
       solutionViews: ['classic', 'oblt'],
       technicalPreview: true,
-      readonly: true,
-      readonlyMode: 'ui',
     },
   });
 }


### PR DESCRIPTION
### Summary

Exposes the "Streams attachments" advanced setting in the UI, allowing users to enable the attachments tab on streams.

### Changes

- Removed `readonly` and `readonlyMode` properties from the attachments UI setting registration
- Setting remains disabled by default and marked as technical preview


https://github.com/user-attachments/assets/64175bf5-024d-4292-9765-30e4598982d3

