### PR TITLE
[Lens as Code] Fix lazy builder timing issues

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/lazy_builder.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lazy_builder.ts
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
+import type { Class } from 'utility-types';
+
 import type { LensConfigBuilder } from '@kbn/lens-embeddable-utils/config_builder';
 import { createGetterSetter } from '@kbn/kibana-utils-plugin/public';
 
-import { getLensFeatureFlags } from './get_feature_flags';
 import type { LensFeatureFlags } from '../common';
+import { getLensFeatureFlags } from './get_feature_flags';
 
 const [getBuilder, setBuilder] = createGetterSetter<LensConfigBuilder>('LensBuilder', false);
 
@@ -28,15 +30,27 @@ export function getLensBuilder(): LensConfigBuilder | null {
   return builder;
 }
 
+let resultPromise: Promise<{
+  LensConfigBuilder: Class<LensConfigBuilder>;
+}> | null = null;
+
 export async function setLensBuilder(
   useApiFormat: LensFeatureFlags['apiFormat']
 ): Promise<LensConfigBuilder | null> {
   if (useApiFormat) {
-    const { LensConfigBuilder } = await import('@kbn/lens-embeddable-utils');
+    resultPromise = import('@kbn/lens-embeddable-utils');
+    const { LensConfigBuilder } = await resultPromise;
     const builder = new LensConfigBuilder(undefined, useApiFormat);
     setBuilder(builder);
+    resultPromise = null;
     return builder;
   }
 
   return null;
+}
+
+export async function ensureBuilderIsInitialized(): Promise<void> {
+  if (resultPromise) {
+    await resultPromise;
+  }
 }

--- a/x-pack/platform/plugins/shared/lens/public/lazy_builder.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lazy_builder.ts
@@ -5,13 +5,11 @@
  * 2.0.
  */
 
-import type { Class } from 'utility-types';
-
 import type { LensConfigBuilder } from '@kbn/lens-embeddable-utils/config_builder';
 import { createGetterSetter } from '@kbn/kibana-utils-plugin/public';
 
-import type { LensFeatureFlags } from '../common';
 import { getLensFeatureFlags } from './get_feature_flags';
+import type { LensFeatureFlags } from '../common';
 
 const [getBuilder, setBuilder] = createGetterSetter<LensConfigBuilder>('LensBuilder', false);
 
@@ -30,27 +28,15 @@ export function getLensBuilder(): LensConfigBuilder | null {
   return builder;
 }
 
-let resultPromise: Promise<{
-  LensConfigBuilder: Class<LensConfigBuilder>;
-}> | null = null;
-
 export async function setLensBuilder(
   useApiFormat: LensFeatureFlags['apiFormat']
 ): Promise<LensConfigBuilder | null> {
   if (useApiFormat) {
-    resultPromise = import('@kbn/lens-embeddable-utils');
-    const { LensConfigBuilder } = await resultPromise;
+    const { LensConfigBuilder } = await import('@kbn/lens-embeddable-utils');
     const builder = new LensConfigBuilder(undefined, useApiFormat);
     setBuilder(builder);
-    resultPromise = null;
     return builder;
   }
 
   return null;
-}
-
-export async function ensureBuilderIsInitialized(): Promise<void> {
-  if (resultPromise) {
-    await resultPromise;
-  }
 }

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -138,7 +138,7 @@ import { setLensFeatureFlags } from './get_feature_flags';
 import type { Visualization, LensSerializedState, TypedLensByValueInput, Suggestion } from '.';
 import type { LensEmbeddableStartServices } from './react_embeddable/types';
 import type { EditorFrameServiceValue } from './editor_frame_service/editor_frame_service_context';
-import { ensureBuilderIsInitialized, setLensBuilder } from './lazy_builder';
+import { setLensBuilder } from './lazy_builder';
 
 export type { SaveProps } from './app_plugin';
 
@@ -393,7 +393,7 @@ export class LensPlugin {
         const flags = await setLensFeatureFlags(featureFlags);
 
         // This loads the builder async to allow synchronous access to builder via getLensBuilder
-        void setLensBuilder(flags.apiFormat);
+        await setLensBuilder(flags.apiFormat);
 
         embeddable.registerLegacyURLTransform(LENS_EMBEDDABLE_TYPE, async () => {
           const { getLensTransforms } = await import('./async_services');
@@ -518,8 +518,6 @@ export class LensPlugin {
         initMemoizedErrorNotification(coreStart);
 
         const frameStart = this.editorFrameService!.start(coreStart, deps);
-        // ensure builder is loaded before mounting
-        await ensureBuilderIsInitialized();
         return mountApp(core, params, {
           createEditorFrame: frameStart.createInstance,
           attributeService: getLensAttributeService(coreStart.http),

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -138,7 +138,7 @@ import { setLensFeatureFlags } from './get_feature_flags';
 import type { Visualization, LensSerializedState, TypedLensByValueInput, Suggestion } from '.';
 import type { LensEmbeddableStartServices } from './react_embeddable/types';
 import type { EditorFrameServiceValue } from './editor_frame_service/editor_frame_service_context';
-import { setLensBuilder } from './lazy_builder';
+import { ensureBuilderIsInitialized, setLensBuilder } from './lazy_builder';
 
 export type { SaveProps } from './app_plugin';
 
@@ -518,6 +518,8 @@ export class LensPlugin {
         initMemoizedErrorNotification(coreStart);
 
         const frameStart = this.editorFrameService!.start(coreStart, deps);
+        // ensure builder is loaded before mounting
+        await ensureBuilderIsInitialized();
         return mountApp(core, params, {
           createEditorFrame: frameStart.createInstance,
           attributeService: getLensAttributeService(coreStart.http),


### PR DESCRIPTION
## Summary

In some cases in the Lens app, the `LensConfigBuilder` is not loaded by the time the Lens app is mounted, causing a fatal error in the Lens app. This is a temporary fix to ensure the builder has been loaded by the time `mountApp` is called.

> ℹ️  Only an issue with feature flag enabled
> ```
> feature_flags.overrides:
>  lens.apiFormat: true
> ```

The better solution would be to restructure the `LensConfigBuilder` package to store the schemas in a separate package to avoid the need to import `joi` and load `@kbn/lens-embeddable-utils` synchronously. See #.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.