### PR TITLE
feat(security,uiam,cps): update `@kbn/es` defaults to support CPS-enabled local projects

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/paths.ts
+++ b/src/platform/packages/shared/kbn-es/src/paths.ts
@@ -60,6 +60,8 @@ export const SERVERLESS_JWKS_PATH = resolve(__dirname, './serverless_resources/j
 
 export const SERVERLESS_IDP_METADATA_PATH = resolve(REPO_ROOT, '.es', 'idp_metadata.xml');
 
+export const SERVERLESS_OPERATOR_PATH = resolve(REPO_ROOT, '.es', 'operator');
+
 export const SERVERLESS_UIAM_ENTRYPOINT_PATH = resolve(
   __dirname,
   './serverless_resources/run_java_with_custom_ca.sh'

--- a/src/platform/packages/shared/kbn-es/src/serverless_resources/secrets.json
+++ b/src/platform/packages/shared/kbn-es/src/serverless_resources/secrets.json
@@ -5,6 +5,8 @@
   },
   "string_secrets": {
     "xpack.security.transport.ssl.keystore.secure_password": "storepass",
+    "xpack.security.remote_cluster_client.ssl.keystore.secure_password": "storepass",
+    "xpack.security.remote_cluster_server.ssl.keystore.secure_password": "storepass",
     "xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret": "my_super_secret",
     "serverless.universal_iam_service.shared_secret": "Dw7eRt5yU2iO9pL3aS4dF6gH8jK0lZ1xC2vB3nM4qW5="
   }

--- a/src/platform/packages/shared/kbn-es/src/serverless_resources/secrets_ssl.json
+++ b/src/platform/packages/shared/kbn-es/src/serverless_resources/secrets_ssl.json
@@ -6,6 +6,8 @@
   "string_secrets": {
     "xpack.security.http.ssl.keystore.secure_password": "storepass",
     "xpack.security.transport.ssl.keystore.secure_password": "storepass",
+    "xpack.security.remote_cluster_client.ssl.keystore.secure_password": "storepass",
+    "xpack.security.remote_cluster_server.ssl.keystore.secure_password": "storepass",
     "xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret": "my_super_secret",
     "serverless.universal_iam_service.shared_secret": "Dw7eRt5yU2iO9pL3aS4dF6gH8jK0lZ1xC2vB3nM4qW5="
   }

--- a/src/platform/packages/shared/kbn-es/src/utils/docker.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.test.ts
@@ -42,6 +42,7 @@ import {
   SERVERLESS_SECRETS_PATH,
   SERVERLESS_JWKS_PATH,
   SERVERLESS_IDP_METADATA_PATH,
+  SERVERLESS_OPERATOR_PATH,
 } from '../paths';
 import * as waitClusterUtil from './wait_until_cluster_ready';
 import * as waitForSecurityIndexUtil from './wait_for_security_index';
@@ -117,7 +118,7 @@ const serverlessResources = SERVERLESS_RESOURCES_PATHS.reduce<string[]>((acc, pa
 }, []);
 
 const volumeCmdTest = async (volumeCmd: string[]) => {
-  expect(volumeCmd).toHaveLength(22);
+  expect(volumeCmd).toHaveLength(24);
   expect(volumeCmd).toEqual(
     expect.arrayContaining([
       ...getESp12Volume(),
@@ -125,7 +126,8 @@ const volumeCmdTest = async (volumeCmd: string[]) => {
       `${baseEsPath}:/objectstore:z`,
       `stateless.object_store.bucket=${serverlessDir}`,
       `${SERVERLESS_SECRETS_PATH}:${SERVERLESS_CONFIG_PATH}secrets/secrets.json:z`,
-      `${SERVERLESS_JWKS_PATH}:${SERVERLESS_CONFIG_PATH}secrets/jwks.json:z`,
+      `${SERVERLESS_JWKS_PATH}:${SERVERLESS_CONFIG_PATH}jwks/jwks.json:z`,
+      `${SERVERLESS_OPERATOR_PATH}:${SERVERLESS_CONFIG_PATH}operator`,
     ])
   );
 
@@ -480,7 +482,7 @@ describe('resolveEsArgs()', () => {
         "--env",
         "xpack.security.authc.realms.saml.cloud-saml-kibana.order=0",
         "--env",
-        "xpack.security.authc.realms.saml.cloud-saml-kibana.idp.metadata.path=/usr/share/elasticsearch/config/secrets/idp_metadata.xml",
+        "xpack.security.authc.realms.saml.cloud-saml-kibana.idp.metadata.path=/usr/share/elasticsearch/config/idp_metadata.xml",
         "--env",
         "xpack.security.authc.realms.saml.cloud-saml-kibana.idp.entity_id=urn:mock-idp",
         "--env",
@@ -547,7 +549,7 @@ describe('resolveEsArgs()', () => {
         "--env",
         "xpack.security.authc.realms.saml.cloud-saml-kibana.order=0",
         "--env",
-        "xpack.security.authc.realms.saml.cloud-saml-kibana.idp.metadata.path=/usr/share/elasticsearch/config/secrets/idp_metadata.xml",
+        "xpack.security.authc.realms.saml.cloud-saml-kibana.idp.metadata.path=/usr/share/elasticsearch/config/idp_metadata.xml",
         "--env",
         "xpack.security.authc.realms.saml.cloud-saml-kibana.idp.entity_id=urn:mock-idp",
         "--env",
@@ -594,7 +596,7 @@ describe('resolveEsArgs()', () => {
         "--env",
         "xpack.security.authc.realms.saml.cloud-saml-kibana.order=0",
         "--env",
-        "xpack.security.authc.realms.saml.cloud-saml-kibana.idp.metadata.path=/usr/share/elasticsearch/config/secrets/idp_metadata.xml",
+        "xpack.security.authc.realms.saml.cloud-saml-kibana.idp.metadata.path=/usr/share/elasticsearch/config/idp_metadata.xml",
         "--env",
         "xpack.security.authc.realms.saml.cloud-saml-kibana.idp.entity_id=urn:mock-idp",
         "--env",
@@ -666,7 +668,7 @@ describe('setupServerlessVolumes()', () => {
       basePath: baseEsPath,
     });
 
-    volumeCmdTest(volumeCmd);
+    await volumeCmdTest(volumeCmd);
     await expect(Fsp.access(serverlessObjectStorePath)).resolves.not.toThrow();
   });
 
@@ -675,7 +677,7 @@ describe('setupServerlessVolumes()', () => {
 
     const volumeCmd = await setupServerlessVolumes(log, { projectType, basePath: baseEsPath });
 
-    volumeCmdTest(volumeCmd);
+    await volumeCmdTest(volumeCmd);
     await expect(
       Fsp.access(`${serverlessObjectStorePath}/cluster_state/lease`)
     ).resolves.not.toThrow();
@@ -690,7 +692,7 @@ describe('setupServerlessVolumes()', () => {
       clean: true,
     });
 
-    volumeCmdTest(volumeCmd);
+    await volumeCmdTest(volumeCmd);
     await expect(
       Fsp.access(`${serverlessObjectStorePath}/cluster_state/lease`)
     ).rejects.toThrowError();
@@ -719,7 +721,7 @@ describe('setupServerlessVolumes()', () => {
     const pathsNotIncludedInCmd = requiredPaths.filter(
       (path) => !volumeCmd.some((cmd) => cmd.includes(path))
     );
-    expect(volumeCmd).toHaveLength(24);
+    expect(volumeCmd).toHaveLength(26);
     expect(pathsNotIncludedInCmd).toEqual([]);
   });
 

--- a/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.test.ts
@@ -80,7 +80,7 @@ describe(`#runUiamContainer()`, () => {
             "curl -sk http://127.0.0.1:8080/ready | grep -q \\"\\\\\\"overall\\\\\\": true\\"",
             "--name",
             "uiam-cosmosdb",
-            "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-EN20251124",
+            "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-EN20251205",
             "--protocol",
             "https",
             "--port",
@@ -183,7 +183,7 @@ describe(`#runUiamContainer()`, () => {
             "timeout 1 bash -c \\"</dev/tcp/localhost/8080\\"",
             "--name",
             "uiam",
-            "docker.elastic.co/cloud-ci/uiam:git-fd2a53b8cf9f",
+            "docker.elastic.co/cloud-ci/uiam:git-f56eb1a3b9a8",
           ],
         ],
         Array [

--- a/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.ts
@@ -22,13 +22,13 @@ const COSMOS_DB_EMULATOR_DOCKER_REPO = `${COSMOS_DB_EMULATOR_DOCKER_REGISTRY}/co
 
 // Check new version at https://github.com/Azure/azure-cosmos-db-emulator-docker/releases. DON'T use the rolling
 // `vnext-preview` image tag.
-const COSMOS_DB_EMULATOR_DOCKER_LATEST_VERIFIED_TAG = 'vnext-EN20251124';
+const COSMOS_DB_EMULATOR_DOCKER_LATEST_VERIFIED_TAG = 'vnext-EN20251205';
 export const COSMOS_DB_EMULATOR_DEFAULT_IMAGE = `${COSMOS_DB_EMULATOR_DOCKER_REPO}:${COSMOS_DB_EMULATOR_DOCKER_LATEST_VERIFIED_TAG}`;
 
 const UIAM_DOCKER_REGISTRY = 'docker.elastic.co';
 const UIAM_DOCKER_REPO = `${UIAM_DOCKER_REGISTRY}/cloud-ci/uiam`;
 // Taken from GitOps version file for UIAM service (dev env, services/uiam/versions.yaml)
-const UIAM_DOCKER_LATEST_VERIFIED_TAG = 'git-fd2a53b8cf9f';
+const UIAM_DOCKER_LATEST_VERIFIED_TAG = 'git-f56eb1a3b9a8';
 export const UIAM_DEFAULT_IMAGE = `${UIAM_DOCKER_REPO}:${UIAM_DOCKER_LATEST_VERIFIED_TAG}`;
 
 const UIAM_COSMOS_DB_NAME = 'uiam-db';


### PR DESCRIPTION
## Summary

Update `@kbn/es` defaults to support CPS-enabled local projects.

## How to test

Run both Elasticsearch and Kibana in CPS mode:
```bash
# Run Elasticsearch Serverless
$ yarn es serverless --projectType observability --uiam \
  -E serverless.cross_project.enabled=true

# Run Kibana Serverless
$ yarn start --serverless=oblt --uiam \
  --cps.enabled=true --cps.cpsEnabled=true
```

Check local project tags with Dev Tools:
```http
GET /_project/tags
---
{
  "origin": {
    "abcde1234567890": {
      "_alias": "local_project",
      "_id": "abcde1234567890",
      "_organization": "org1234567890",
      "_type": "observability",
      "env": "local"
    }
  }
}
```

or with `cURL`:
```bash
curl -ku elastic_serverless:changeme -X GET 'https://localhost:9200/_project/tags?pretty'
---
{
  "origin" : {
    "abcde1234567890" : {
      "_alias" : "local_project",
      "_id" : "abcde1234567890",
      "_organization" : "org1234567890",
      "_type" : "observability",
      "env" : "local"
    }
  }
}
```

/cc @mbondyra 

