### PR TITLE
Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook·ts - alerting api integration security and spaces enabled - Group 2 testtest Connectors webhook action OAuth2 client credentials should refresh the token once the previous one has expired

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
@@ -2129,7 +2129,7 @@ describe('TaskManagerRunner', () => {
         expect(onTaskEvent).toHaveBeenCalledTimes(2);
       });
 
-      test('testtest emits TaskEvent when an ad-hoc task run throws an error due to timeout', async () => {
+      test('emits TaskEvent when an ad-hoc task run throws an error due to timeout', async () => {
         jest.setSystemTime(new Date(2023, 1, 1, 0, 0, 0, 0));
         const id = _.random(1, 20).toString();
         const error = new Error('Task was cancelled');

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook.ts
@@ -72,11 +72,12 @@ export default function webhookTest({ getService }: FtrProviderContext) {
       })
       .expect(200);
 
+    objectRemover.add('default', createdAction.id, 'connector', 'actions', false);
+
     return createdAction.id;
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/240923
-  describe.skip('webhook action', () => {
+  describe('webhook action', () => {
     let webhookSimulatorURL: string = '';
     let webhookServer: http.Server;
     let kibanaURL: string = '<could not determine kibana url>';
@@ -103,7 +104,9 @@ export default function webhookTest({ getService }: FtrProviderContext) {
       );
     });
 
-    afterEach(() => objectRemover.removeAll());
+    afterEach(async () => {
+      await objectRemover.removeAll();
+    });
 
     it('should return 200 when creating a webhook connector successfully with default method', async () => {
       const { body: createdAction } = await supertest
@@ -304,7 +307,6 @@ export default function webhookTest({ getService }: FtrProviderContext) {
         { method: 'post' },
         kibanaURL
       );
-      objectRemover.add('default', webhookActionId, 'connector', 'actions', false);
       const { body: result } = await supertest
         .post(`/api/actions/connector/${webhookActionId}/_execute`)
         .set('kbn-xsrf', 'test')
@@ -341,7 +343,6 @@ export default function webhookTest({ getService }: FtrProviderContext) {
         { method: 'put' },
         kibanaURL
       );
-      objectRemover.add('default', webhookActionId, 'connector', 'actions', false);
       const { body: result } = await supertest
         .post(`/api/actions/connector/${webhookActionId}/_execute`)
         .set('kbn-xsrf', 'test')
@@ -382,7 +383,6 @@ export default function webhookTest({ getService }: FtrProviderContext) {
         { method: 'get' },
         kibanaURL
       );
-      objectRemover.add('default', webhookActionId, 'connector', 'actions', false);
       const { body: result } = await supertest
         .post(`/api/actions/connector/${webhookActionId}/_execute`)
         .set('kbn-xsrf', 'test')
@@ -399,7 +399,6 @@ export default function webhookTest({ getService }: FtrProviderContext) {
         { method: 'delete' },
         kibanaURL
       );
-      objectRemover.add('default', webhookActionId, 'connector', 'actions', false);
       const { body: result } = await supertest
         .post(`/api/actions/connector/${webhookActionId}/_execute`)
         .set('kbn-xsrf', 'test')
@@ -687,9 +686,9 @@ export default function webhookTest({ getService }: FtrProviderContext) {
           })
           .expect(200);
 
-        // waits enough for the token to be expired
+        // waits enough for the token to be expired plus some buffer
         await new Promise((resolve) =>
-          setTimeout(() => resolve(true), oauth2Server.getTokenExpirationTime() * 1000)
+          setTimeout(resolve, oauth2Server.getTokenExpirationTime() * 2 * 1000)
         );
 
         // this second call should trigger a second call to the auth server because

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/index.ts
@@ -9,7 +9,7 @@ import type { FtrProviderContext } from '../../../../common/ftr_provider_context
 import { setupSpacesAndUsers, tearDown } from '../../../setup';
 
 export default function connectorsTests({ loadTestFile, getService }: FtrProviderContext) {
-  describe('testtest Connectors', () => {
+  describe('Connectors', () => {
     before(async () => {
       await setupSpacesAndUsers(getService);
     });


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/240923

## Summary

This tests that another call was made to retrieve a token after the previous one had expired. It waited the exact length of the token expiration (1 second) before calling the webhook connector again. It seems like it would occassionaly fail because a second call to retrieve a token was not made. I updated to wait a little longer (2 seconds) before trying to call the connector to ensure the expiration period had passed.

## Flaky test runner
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10061
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10063

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->