### PR TITLE
[Security Solution][Analyzer] use same dataview in analyzer preview as was selected in analyzer component

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.test.tsx
@@ -14,17 +14,16 @@ import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_f
 import { DocumentDetailsContext } from '../../shared/context';
 import { AnalyzerPreview } from './analyzer_preview';
 import { ANALYZER_PREVIEW_TEST_ID } from './test_ids';
-import { useSecurityDefaultPatterns } from '../../../../data_view_manager/hooks/use_security_default_patterns';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-
 import * as mock from '../mocks/mock_analyzer_data';
+import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 
 jest.mock('../../shared/hooks/use_alert_prevalence_from_process_tree', () => ({
   useAlertPrevalenceFromProcessTree: jest.fn(),
 }));
 const mockUseAlertPrevalenceFromProcessTree = useAlertPrevalenceFromProcessTree as jest.Mock;
 
-jest.mock('../../../../data_view_manager/hooks/use_security_default_patterns');
+jest.mock('../../../../data_view_manager/hooks/use_selected_patterns');
 jest.mock('../../../../common/hooks/use_experimental_features');
 
 const mockTreeValues = {
@@ -49,9 +48,7 @@ describe('<AnalyzerPreview />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
-    (useSecurityDefaultPatterns as jest.Mock).mockReturnValue({
-      indexPatterns: ['index'],
-    });
+    (useSelectedPatterns as jest.Mock).mockReturnValue(['index']);
   });
 
   it('shows analyzer preview correctly when documentId and index are present', () => {


### PR DESCRIPTION
## Summary

While reviewing [this PR](https://github.com/elastic/kibana/pull/245002) that is adding the functionality to persist the selected in analyzer in local storage, and while working on this [other PR](https://github.com/elastic/kibana/pull/245712) that will ensure that analyzer will not load until the data view is ready, I realize that the analyzer preview component rendered in the flyout right panel Overview tab isn't using the same data view as the analyzer component in the flyout left panel Visualize tab.

### Context

A few months ago we added the ability to select a different data view in the analyzer component that we render in the alert details flyout left panel. When we did this we never updated the analyzer preview component rendered in the alert details right panel Overview tab.
Currently - if the document does not have the expected index - we fall back to the security solution default data view.

### Changes introduced in this PR

The analyzer preview component is now using the data view selected in the analyzer component, if the document does not have the expected index. Combined with this data view being saved in local storage, this should improve performance.
By default (meaning if no data view have been selected in the analyzer component - we use the default security solution data view (same behavior as in analyzer). 

No UI changes should be visible.

## How to test the PR

As this should only happen with document that are missing the expected index, the change would only be visible for documents that don't have any value for the `kibana.alert.rule.indices` field. In those cases, the list of indices used in analyzer preview should be those from the selected data view in analyzer.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->