### PR TITLE
Update codeowners for new actionable observability team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1152,7 +1152,7 @@ x-pack/solutions/observability/plugins/apm/ftr_e2e @elastic/obs-presentation-tea
 x-pack/solutions/observability/plugins/exploratory_view @elastic/actionable-obs-team
 x-pack/solutions/observability/plugins/infra @elastic/obs-presentation-team
 x-pack/solutions/observability/plugins/metrics_data_access @elastic/obs-presentation-team
-x-pack/solutions/observability/plugins/observability @elastic/obs-ux-team
+x-pack/solutions/observability/plugins/observability @elastic/observability-ui
 x-pack/solutions/observability/plugins/observability_agent_builder @elastic/obs-ai-team
 x-pack/solutions/observability/plugins/observability_ai_assistant_app @elastic/obs-ai-team
 x-pack/solutions/observability/plugins/observability_logs_explorer @elastic/obs-exploration-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1612,40 +1612,41 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/api_integration/services/index.ts @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/api_integration/services/infra_log_views.ts @elastic/obs-presentation-team
 
-# Observability UX management team
-/src/platform/test/api_integration/apis/suggestions  @elastic/obs-ux-management-team # Assigned per https://github.com/elastic/kibana/pull/200950#discussion_r1853705079
-/x-pack/solutions/observability/test/api_integration/services/slo.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/services/slo @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/functional/apps/slo @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/observability_api_integration @elastic/obs-ux-management-team # Assigned per https://github.com/elastic/kibana/pull/182243
-/x-pack/solutions/observability/test/functional/services/observability @elastic/obs-ux-management-team
-/x-pack/platform/test/accessibility/apps/group1/uptime.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/accessibility/apps/observability.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/functional/services/slo/ @elastic/obs-ux-management-team
-/x-pack/packages/observability/alert_details @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/observability_functional @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration/apis/security/ @elastic/obs-ux-management-team
-/x-pack/solutions/observability/plugins/infra/public/alerting @elastic/obs-ux-management-team
-/x-pack/solutions/observability/plugins/infra/server/lib/alerting @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/serverless/api_integration/test_suites/es_query_rule @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/ @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/ @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/alerting_api.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/slo_api.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_monitors.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_params_api.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/ @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.synthetics.index.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/serverless/oblt.synthetics.index.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/serverless/oblt.synthetics.serverless.config.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.synthetics.index.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.synthetics.stateful.config.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/incident_management/ @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/functional/page_objects/alert_controls.ts @elastic/obs-ux-management-team
-/x-pack/platform/test/serverless/functional/page_objects/svl_custom_roles_page.ts @elastic/obs-ux-management-team
+# Actionable Observability (formerly Observability UX Management) team
+
+/src/platform/test/api_integration/apis/suggestions  @elastic/actionable-obs-team # Assigned per https://github.com/elastic/kibana/pull/200950#discussion_r1853705079
+/x-pack/solutions/observability/test/api_integration/services/slo.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/services/slo @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/functional/apps/slo @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/observability_api_integration @elastic/actionable-obs-team # Assigned per https://github.com/elastic/kibana/pull/182243
+/x-pack/solutions/observability/test/functional/services/observability @elastic/actionable-obs-team
+/x-pack/platform/test/accessibility/apps/group1/uptime.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/accessibility/apps/observability.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/functional/services/slo/ @elastic/actionable-obs-team
+/x-pack/packages/observability/alert_details @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/observability_functional @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration/apis/security/ @elastic/actionable-obs-team
+/x-pack/solutions/observability/plugins/infra/public/alerting @elastic/actionable-obs-team
+/x-pack/solutions/observability/plugins/infra/server/lib/alerting @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/serverless/api_integration/test_suites/es_query_rule @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/ @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/ @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/alerting_api.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/slo_api.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_monitors.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_params_api.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/ @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.synthetics.index.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/serverless/oblt.synthetics.index.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/serverless/oblt.synthetics.serverless.config.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.synthetics.index.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.synthetics.stateful.config.ts @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/incident_management/ @elastic/actionable-obs-team
+/x-pack/solutions/observability/test/functional/page_objects/alert_controls.ts @elastic/actionable-obs-team
+/x-pack/platform/test/serverless/functional/page_objects/svl_custom_roles_page.ts @elastic/actionable-obs-team
 
 # Elastic Stack Monitoring
 /x-pack/platform/test/monitoring_api_integration @elastic/stack-monitoring

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -417,7 +417,7 @@ src/platform/packages/shared/content-management/table_list_view_table @elastic/a
 src/platform/packages/shared/content-management/user_profiles @elastic/appex-sharedux
 src/platform/packages/shared/controls/controls-constants @elastic/kibana-presentation
 src/platform/packages/shared/controls/controls-schemas @elastic/kibana-presentation
-src/platform/packages/shared/dashboards/dashboards-selector @elastic/obs-ux-management-team
+src/platform/packages/shared/dashboards/dashboards-selector @elastic/actionable-obs-team
 src/platform/packages/shared/deeplinks/agent_builder @elastic/search-kibana
 src/platform/packages/shared/deeplinks/analytics @elastic/kibana-data-discovery @elastic/kibana-presentation @elastic/kibana-visualizations
 src/platform/packages/shared/deeplinks/data_connectors @elastic/search-kibana
@@ -453,7 +453,7 @@ src/platform/packages/shared/kbn-babel-register @elastic/kibana-operations
 src/platform/packages/shared/kbn-background-search @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-bench @elastic/obs-ui-devex-team
 src/platform/packages/shared/kbn-cache-cli @elastic/kibana-operations
-src/platform/packages/shared/kbn-calculate-auto @elastic/obs-ux-management-team
+src/platform/packages/shared/kbn-calculate-auto @elastic/actionable-obs-team
 src/platform/packages/shared/kbn-calculate-width-from-char-count @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-cases-components @elastic/kibana-cases
 src/platform/packages/shared/kbn-cbor @elastic/kibana-operations
@@ -573,7 +573,7 @@ src/platform/packages/shared/kbn-rison @elastic/kibana-operations
 src/platform/packages/shared/kbn-router-to-openapispec @elastic/kibana-core
 src/platform/packages/shared/kbn-router-utils @elastic/obs-exploration-team
 src/platform/packages/shared/kbn-rrule @elastic/response-ops
-src/platform/packages/shared/kbn-rule-data-utils @elastic/security-detections-response @elastic/response-ops @elastic/obs-ux-management-team
+src/platform/packages/shared/kbn-rule-data-utils @elastic/security-detections-response @elastic/response-ops @elastic/actionable-obs-team
 src/platform/packages/shared/kbn-safer-lodash-set @elastic/kibana-security
 src/platform/packages/shared/kbn-saved-search-component @elastic/obs-exploration-team
 src/platform/packages/shared/kbn-scout @elastic/appex-qa
@@ -665,7 +665,7 @@ src/platform/packages/shared/response-ops/rule_form @elastic/response-ops
 src/platform/packages/shared/response-ops/rule_params @elastic/response-ops
 src/platform/packages/shared/response-ops/rules-apis @elastic/response-ops
 src/platform/packages/shared/serverless/settings/common @elastic/appex-sharedux @elastic/kibana-management
-src/platform/packages/shared/serverless/settings/observability_project @elastic/appex-sharedux @elastic/kibana-management @elastic/obs-ux-management-team
+src/platform/packages/shared/serverless/settings/observability_project @elastic/appex-sharedux @elastic/kibana-management @elastic/obs-presentation-team
 src/platform/packages/shared/serverless/settings/search_project @elastic/search-kibana @elastic/kibana-management
 src/platform/packages/shared/serverless/settings/security_project @elastic/security-solution @elastic/kibana-management
 src/platform/packages/shared/serverless/settings/workplace_ai_project @elastic/search-kibana
@@ -870,11 +870,11 @@ x-pack/examples/third_party_vis_lens_example @elastic/kibana-visualizations
 x-pack/examples/triggers_actions_ui_example @elastic/response-ops
 x-pack/examples/ui_actions_enhanced_examples @elastic/appex-sharedux
 x-pack/packages/ai-infra/product-doc-artifact-builder @elastic/appex-ai-infra
-x-pack/packages/kbn-synthetics-private-location @elastic/obs-ux-management-team
+x-pack/packages/kbn-synthetics-private-location @elastic/actionable-obs-team
 x-pack/performance @elastic/appex-qa
 x-pack/platform/packages/private/kbn-alerting-state-types @elastic/response-ops
 x-pack/platform/packages/private/kbn-data-quality @elastic/obs-onboarding-team
-x-pack/platform/packages/private/kbn-infra-forge @elastic/obs-ux-management-team
+x-pack/platform/packages/private/kbn-infra-forge @elastic/actionable-obs-team
 x-pack/platform/packages/private/kbn-random-sampling @elastic/kibana-visualizations
 x-pack/platform/packages/private/kbn-scout-release-testing @elastic/appex-qa
 x-pack/platform/packages/private/maps/vector_tile_utils @elastic/kibana-presentation
@@ -923,7 +923,7 @@ x-pack/platform/packages/shared/ai-infra/inference-common @elastic/appex-ai-infr
 x-pack/platform/packages/shared/ai-infra/inference-langchain @elastic/appex-ai-infra
 x-pack/platform/packages/shared/ai-infra/product-doc-common @elastic/appex-ai-infra
 x-pack/platform/packages/shared/ai-insights @elastic/obs-ai-team
-x-pack/platform/packages/shared/alerting-rule-utils @elastic/obs-ux-management-team
+x-pack/platform/packages/shared/alerting-rule-utils @elastic/actionable-obs-team
 x-pack/platform/packages/shared/file-upload @elastic/ml-ui
 x-pack/platform/packages/shared/file-upload-common @elastic/ml-ui
 x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared @elastic/kibana-management
@@ -936,7 +936,7 @@ x-pack/platform/packages/shared/kbn-alerting-comparators @elastic/response-ops
 x-pack/platform/packages/shared/kbn-apm-types @elastic/obs-presentation-team
 x-pack/platform/packages/shared/kbn-classic-stream-flyout @elastic/kibana-management
 x-pack/platform/packages/shared/kbn-content-packs-schema @elastic/obs-onboarding-team
-x-pack/platform/packages/shared/kbn-data-forge @elastic/obs-ux-management-team
+x-pack/platform/packages/shared/kbn-data-forge @elastic/actionable-obs-team
 x-pack/platform/packages/shared/kbn-dissect-heuristics @elastic/obs-onboarding-team
 x-pack/platform/packages/shared/kbn-elastic-assistant @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-elastic-assistant-common @elastic/security-generative-ai
@@ -962,7 +962,7 @@ x-pack/platform/packages/shared/kbn-mcp-client @elastic/workchat-eng
 x-pack/platform/packages/shared/kbn-profiler-cli @elastic/obs-knowledge-team
 x-pack/platform/packages/shared/kbn-sample-parser @elastic/obs-onboarding-team @elastic/obs-sig-events-team
 x-pack/platform/packages/shared/kbn-search-index-documents @elastic/search-kibana
-x-pack/platform/packages/shared/kbn-slo-schema @elastic/obs-ux-management-team
+x-pack/platform/packages/shared/kbn-slo-schema @elastic/actionable-obs-team
 x-pack/platform/packages/shared/kbn-streamlang @elastic/obs-onboarding-team
 x-pack/platform/packages/shared/kbn-streamlang-tests @elastic/obs-onboarding-team
 x-pack/platform/packages/shared/kbn-streamlang-yaml-editor @elastic/obs-onboarding-team
@@ -1076,7 +1076,7 @@ x-pack/platform/plugins/shared/observability_ai_assistant @elastic/obs-ai-team
 x-pack/platform/plugins/shared/onechat @elastic/workchat-eng
 x-pack/platform/plugins/shared/osquery @elastic/security-defend-workflows
 x-pack/platform/plugins/shared/osquery/cypress @elastic/security-defend-workflows
-x-pack/platform/plugins/shared/rule_registry @elastic/response-ops @elastic/obs-ux-management-team
+x-pack/platform/plugins/shared/rule_registry @elastic/response-ops @elastic/actionable-obs-team
 x-pack/platform/plugins/shared/sample_data_ingest @elastic/search-kibana
 x-pack/platform/plugins/shared/saved_objects_tagging @elastic/appex-sharedux
 x-pack/platform/plugins/shared/screenshotting @elastic/kibana-reporting-services
@@ -1131,28 +1131,28 @@ x-pack/platform/test/task_manager_claimer_update_by_query/plugins/sample_task_pl
 x-pack/platform/test/ui_capabilities/common/plugins/foo_plugin @elastic/kibana-security
 x-pack/platform/test/usage_collection/plugins/application_usage_test @elastic/kibana-core
 x-pack/platform/test/usage_collection/plugins/stack_management_usage_test @elastic/kibana-management
-x-pack/solutions/observability/packages/alert-details @elastic/obs-ux-management-team
-x-pack/solutions/observability/packages/alerting-test-data @elastic/obs-ux-management-team
-x-pack/solutions/observability/packages/get-padded-alert-time-range-util @elastic/obs-ux-management-team
+x-pack/solutions/observability/packages/alert-details @elastic/actionable-obs-team
+x-pack/solutions/observability/packages/alerting-test-data @elastic/actionable-obs-team
+x-pack/solutions/observability/packages/get-padded-alert-time-range-util @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/kbn-alerts-grouping @elastic/response-ops
 x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant @elastic/obs-ai-team
 x-pack/solutions/observability/packages/kbn-genai-cli @elastic/obs-knowledge-team
-x-pack/solutions/observability/packages/kbn-observability-schema @elastic/obs-ux-management-team
+x-pack/solutions/observability/packages/kbn-observability-schema @elastic/obs-presentation-team
 x-pack/solutions/observability/packages/kbn-scout-oblt @elastic/appex-qa
-x-pack/solutions/observability/packages/nav-icons @elastic/obs-ux-management-team
+x-pack/solutions/observability/packages/nav-icons @elastic/obs-presentation-team
 x-pack/solutions/observability/packages/observability-ai/observability-ai-common @elastic/obs-ai-team
 x-pack/solutions/observability/packages/observability-ai/observability-ai-server @elastic/obs-ai-team
-x-pack/solutions/observability/packages/synthetics-test-data @elastic/obs-ux-management-team
+x-pack/solutions/observability/packages/synthetics-test-data @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/utils-browser @elastic/observability-ui
 x-pack/solutions/observability/packages/utils-common @elastic/observability-ui
 x-pack/solutions/observability/packages/utils-server @elastic/observability-ui
 x-pack/solutions/observability/plugins/apm @elastic/obs-presentation-team
 x-pack/solutions/observability/plugins/apm_data_access @elastic/obs-presentation-team
 x-pack/solutions/observability/plugins/apm/ftr_e2e @elastic/obs-presentation-team
-x-pack/solutions/observability/plugins/exploratory_view @elastic/obs-ux-management-team
+x-pack/solutions/observability/plugins/exploratory_view @elastic/actionable-obs-team
 x-pack/solutions/observability/plugins/infra @elastic/obs-presentation-team
 x-pack/solutions/observability/plugins/metrics_data_access @elastic/obs-presentation-team
-x-pack/solutions/observability/plugins/observability @elastic/obs-ux-management-team
+x-pack/solutions/observability/plugins/observability @elastic/obs-ux-team
 x-pack/solutions/observability/plugins/observability_agent_builder @elastic/obs-ai-team
 x-pack/solutions/observability/plugins/observability_ai_assistant_app @elastic/obs-ai-team
 x-pack/solutions/observability/plugins/observability_logs_explorer @elastic/obs-exploration-team
@@ -1160,12 +1160,12 @@ x-pack/solutions/observability/plugins/observability_onboarding @elastic/obs-onb
 x-pack/solutions/observability/plugins/observability_shared @elastic/observability-ui
 x-pack/solutions/observability/plugins/profiling @elastic/obs-presentation-team
 x-pack/solutions/observability/plugins/profiling_data_access @elastic/obs-presentation-team
-x-pack/solutions/observability/plugins/serverless_observability @elastic/obs-ux-management-team
-x-pack/solutions/observability/plugins/slo @elastic/obs-ux-management-team
-x-pack/solutions/observability/plugins/synthetics @elastic/obs-ux-management-team
-x-pack/solutions/observability/plugins/synthetics/e2e @elastic/obs-ux-management-team
-x-pack/solutions/observability/plugins/uptime @elastic/obs-ux-management-team
-x-pack/solutions/observability/plugins/ux @elastic/obs-ux-management-team
+x-pack/solutions/observability/plugins/serverless_observability @elastic/obs-presentation-team
+x-pack/solutions/observability/plugins/slo @elastic/actionable-obs-team
+x-pack/solutions/observability/plugins/synthetics @elastic/actionable-obs-team
+x-pack/solutions/observability/plugins/synthetics/e2e @elastic/actionable-obs-team
+x-pack/solutions/observability/plugins/uptime @elastic/actionable-obs-team
+x-pack/solutions/observability/plugins/ux @elastic/actionable-obs-team
 x-pack/solutions/observability/test
 x-pack/solutions/search/packages/kbn-ipynb @elastic/search-kibana
 x-pack/solutions/search/packages/kbn-search-api-keys-components @elastic/search-kibana

--- a/src/platform/packages/shared/dashboards/dashboards-selector/kibana.jsonc
+++ b/src/platform/packages/shared/dashboards/dashboards-selector/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-browser",
   "id": "@kbn/dashboards-selector",
-  "owner": "@elastic/obs-ux-management-team",
+  "owner": "@elastic/actionable-obs-team",
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/dashboards/dashboards-selector/moon.yml
+++ b/src/platform/packages/shared/dashboards/dashboards-selector/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/dashboards-selector'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/dashboards-selector'
   description: Moon project for @kbn/dashboards-selector
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: src/platform/packages/shared/dashboards/dashboards-selector
 dependsOn:

--- a/src/platform/packages/shared/kbn-calculate-auto/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-calculate-auto/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/calculate-auto",
-  "owner": "@elastic/obs-ux-management-team",
+  "owner": "@elastic/actionable-obs-team",
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-calculate-auto/moon.yml
+++ b/src/platform/packages/shared/kbn-calculate-auto/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/calculate-auto'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/calculate-auto'
   description: Moon project for @kbn/calculate-auto
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-calculate-auto
 dependsOn: []

--- a/src/platform/packages/shared/kbn-rule-data-utils/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-rule-data-utils/kibana.jsonc
@@ -4,7 +4,7 @@
   "owner": [
     "@elastic/security-detections-response",
     "@elastic/response-ops",
-    "@elastic/obs-ux-management-team"
+    "@elastic/actionable-obs-team"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/serverless/settings/observability_project/kibana.jsonc
+++ b/src/platform/packages/shared/serverless/settings/observability_project/kibana.jsonc
@@ -4,7 +4,7 @@
   "owner": [
     "@elastic/appex-sharedux",
     "@elastic/kibana-management",
-    "@elastic/obs-ux-management-team"
+    "@elastic/obs-presentation-team"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/x-pack/packages/kbn-synthetics-private-location/kibana.jsonc
+++ b/x-pack/packages/kbn-synthetics-private-location/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/synthetics-private-location",
-  "owner": "@elastic/obs-ux-management-team",
+  "owner": "@elastic/actionable-obs-team",
   "group": "platform",
   "visibility": "private",
   "devOnly": true

--- a/x-pack/packages/kbn-synthetics-private-location/moon.yml
+++ b/x-pack/packages/kbn-synthetics-private-location/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/synthetics-private-location'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/synthetics-private-location'
   description: Moon project for @kbn/synthetics-private-location
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/packages/kbn-synthetics-private-location
 dependsOn:

--- a/x-pack/platform/packages/private/kbn-infra-forge/kibana.jsonc
+++ b/x-pack/platform/packages/private/kbn-infra-forge/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/infra-forge",
   "owner": [
-    "@elastic/obs-ux-management-team",
+    "@elastic/actionable-obs-team",
   ],
   "group": "platform",
   "visibility": "private"

--- a/x-pack/platform/packages/private/kbn-infra-forge/moon.yml
+++ b/x-pack/platform/packages/private/kbn-infra-forge/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/infra-forge'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/infra-forge'
   description: Moon project for @kbn/infra-forge
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/platform/packages/private/kbn-infra-forge
 dependsOn:

--- a/x-pack/platform/packages/shared/alerting-rule-utils/kibana.jsonc
+++ b/x-pack/platform/packages/shared/alerting-rule-utils/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/alerting-rule-utils",
-  "owner": "@elastic/obs-ux-management-team",
+  "owner": "@elastic/actionable-obs-team",
   // TODO refactor and transfer owner / contents to response-ops / alerting
   "group": "platform",
   "visibility": "shared"

--- a/x-pack/platform/packages/shared/alerting-rule-utils/moon.yml
+++ b/x-pack/platform/packages/shared/alerting-rule-utils/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/alerting-rule-utils'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/alerting-rule-utils'
   description: Moon project for @kbn/alerting-rule-utils
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/platform/packages/shared/alerting-rule-utils
 dependsOn:

--- a/x-pack/platform/packages/shared/kbn-data-forge/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-data-forge/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/data-forge",
   "owner": [
-    "@elastic/obs-ux-management-team"
+    "@elastic/actionable-obs-team"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/x-pack/platform/packages/shared/kbn-data-forge/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-data-forge/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/data-forge'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/data-forge'
   description: Moon project for @kbn/data-forge
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/platform/packages/shared/kbn-data-forge
 dependsOn:

--- a/x-pack/platform/packages/shared/kbn-slo-schema/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/slo-schema",
   "owner": [
-    "@elastic/obs-ux-management-team"
+    "@elastic/actionable-obs-team"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/x-pack/platform/packages/shared/kbn-slo-schema/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/slo-schema'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/slo-schema'
   description: Moon project for @kbn/slo-schema
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/platform/packages/shared/kbn-slo-schema
 dependsOn:

--- a/x-pack/platform/plugins/shared/rule_registry/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/rule_registry/kibana.jsonc
@@ -3,7 +3,7 @@
   "id": "@kbn/rule-registry-plugin",
   "owner": [
     "@elastic/response-ops",
-    "@elastic/obs-ux-management-team"
+    "@elastic/actionable-obs-team"
   ],
   "group": "platform",
   "visibility": "shared",

--- a/x-pack/solutions/observability/packages/alert-details/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/alert-details/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/observability-alert-details",
   "owner": [
-    "@elastic/obs-ux-management-team"
+    "@elastic/actionable-obs-team"
   ],
   "group": "observability",
   "visibility": "private"

--- a/x-pack/solutions/observability/packages/alert-details/moon.yml
+++ b/x-pack/solutions/observability/packages/alert-details/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-alert-details'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/observability-alert-details'
   description: Moon project for @kbn/observability-alert-details
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/packages/alert-details
 dependsOn:

--- a/x-pack/solutions/observability/packages/alerting-test-data/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/alerting-test-data/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/observability-alerting-test-data",
-  "owner": "@elastic/obs-ux-management-team",
+  "owner": "@elastic/actionable-obs-team",
   "group": "observability",
   "visibility": "private"
 }

--- a/x-pack/solutions/observability/packages/alerting-test-data/moon.yml
+++ b/x-pack/solutions/observability/packages/alerting-test-data/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-alerting-test-data'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/observability-alerting-test-data'
   description: Moon project for @kbn/observability-alerting-test-data
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/packages/alerting-test-data
 dependsOn:

--- a/x-pack/solutions/observability/packages/get-padded-alert-time-range-util/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/get-padded-alert-time-range-util/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/observability-get-padded-alert-time-range-util",
   "owner": [
-    "@elastic/obs-ux-management-team"
+    "@elastic/actionable-obs-team"
   ],
   "group": "observability",
   "visibility": "private"

--- a/x-pack/solutions/observability/packages/get-padded-alert-time-range-util/moon.yml
+++ b/x-pack/solutions/observability/packages/get-padded-alert-time-range-util/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-get-padded-alert-time-range-util'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/observability-get-padded-alert-time-range-util'
   description: Moon project for @kbn/observability-get-padded-alert-time-range-util
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/packages/get-padded-alert-time-range-util
 dependsOn: []

--- a/x-pack/solutions/observability/packages/kbn-observability-schema/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/kbn-observability-schema/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/observability-schema",
-  "owner": "@elastic/obs-ux-management-team",
+  "owner": "@elastic/obs-presentation-team",
   "group": "observability",
   "visibility": "private",
 }

--- a/x-pack/solutions/observability/packages/kbn-observability-schema/moon.yml
+++ b/x-pack/solutions/observability/packages/kbn-observability-schema/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-schema'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/obs-presentation-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/observability-schema'
   description: Moon project for @kbn/observability-schema
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/obs-presentation-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/packages/kbn-observability-schema
 dependsOn:

--- a/x-pack/solutions/observability/packages/nav-icons/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/nav-icons/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-browser",
   "id": "@kbn/observability-nav-icons",
   "owner": [
-    "@elastic/obs-ux-management-team"
+    "@elastic/obs-presentation-team"
   ],
   "group": "observability",
   "visibility": "private"

--- a/x-pack/solutions/observability/packages/nav-icons/moon.yml
+++ b/x-pack/solutions/observability/packages/nav-icons/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-nav-icons'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/obs-presentation-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/observability-nav-icons'
   description: Moon project for @kbn/observability-nav-icons
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/obs-presentation-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/packages/nav-icons
 tags:

--- a/x-pack/solutions/observability/packages/synthetics-test-data/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/synthetics-test-data/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/observability-synthetics-test-data",
-  "owner": "@elastic/obs-ux-management-team",
+  "owner": "@elastic/actionable-obs-team",
   "group": "observability",
   "visibility": "private",
   "devOnly": true

--- a/x-pack/solutions/observability/packages/synthetics-test-data/moon.yml
+++ b/x-pack/solutions/observability/packages/synthetics-test-data/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-synthetics-test-data'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/observability-synthetics-test-data'
   description: Moon project for @kbn/observability-synthetics-test-data
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/packages/synthetics-test-data
 dependsOn:

--- a/x-pack/solutions/observability/plugins/exploratory_view/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/exploratory_view/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "plugin",
   "id": "@kbn/exploratory-view-plugin",
   "owner": [
-    "@elastic/obs-ux-management-team"
+    "@elastic/actionable-obs-team"
   ],
   "group": "observability",
   "visibility": "private",

--- a/x-pack/solutions/observability/plugins/exploratory_view/moon.yml
+++ b/x-pack/solutions/observability/plugins/exploratory_view/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/exploratory-view-plugin'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/exploratory-view-plugin'
   description: Moon project for @kbn/exploratory-view-plugin
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/plugins/exploratory_view
 dependsOn:

--- a/x-pack/solutions/observability/plugins/observability/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "plugin",
   "id": "@kbn/observability-plugin",
   "owner": [
-    "@elastic/obs-ux-management-team"
+    "@elastic/obs-ux-team"
   ],
   "group": "observability",
   "visibility": "private",

--- a/x-pack/solutions/observability/plugins/observability/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "plugin",
   "id": "@kbn/observability-plugin",
   "owner": [
-    "@elastic/obs-ux-team"
+    "@elastic/observability-ui"
   ],
   "group": "observability",
   "visibility": "private",

--- a/x-pack/solutions/observability/plugins/observability/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-plugin'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/obs-ux-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/observability-plugin'
   description: Moon project for @kbn/observability-plugin
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/obs-ux-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/plugins/observability
 dependsOn:

--- a/x-pack/solutions/observability/plugins/observability/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/observability-plugin'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-team'
+  defaultOwner: '@elastic/observability-ui'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/observability-plugin'
   description: Moon project for @kbn/observability-plugin
   channel: ''
-  owner: '@elastic/obs-ux-team'
+  owner: '@elastic/observability-ui'
   metadata:
     sourceRoot: x-pack/solutions/observability/plugins/observability
 dependsOn:

--- a/x-pack/solutions/observability/plugins/serverless_observability/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/serverless_observability/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/serverless-observability",
-  "owner": ["@elastic/obs-ux-management-team"],
+  "owner": ["@elastic/obs-presentation-team"],
   "group": "observability",
   "visibility": "private",
   "description": "Serverless customizations for observability.",

--- a/x-pack/solutions/observability/plugins/serverless_observability/moon.yml
+++ b/x-pack/solutions/observability/plugins/serverless_observability/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/serverless-observability'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/obs-presentation-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/serverless-observability'
   description: Moon project for @kbn/serverless-observability
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/obs-presentation-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/plugins/serverless_observability
 dependsOn:

--- a/x-pack/solutions/observability/plugins/slo/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/slo/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/slo-plugin",
-  "owner": ["@elastic/obs-ux-management-team"],
+  "owner": ["@elastic/actionable-obs-team"],
   "group": "observability",
   "visibility": "private",
   "plugin": {

--- a/x-pack/solutions/observability/plugins/slo/moon.yml
+++ b/x-pack/solutions/observability/plugins/slo/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/slo-plugin'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/slo-plugin'
   description: Moon project for @kbn/slo-plugin
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/plugins/slo
 dependsOn:

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "test-helper",
   "id": "@kbn/synthetics-e2e",
-  "owner": "@elastic/obs-ux-management-team",
+  "owner": "@elastic/actionable-obs-team",
   "group": "observability",
   "visibility": "private",
   "devOnly": true

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/moon.yml
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/synthetics-e2e'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/synthetics-e2e'
   description: Moon project for @kbn/synthetics-e2e
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/plugins/synthetics/e2e
 dependsOn:

--- a/x-pack/solutions/observability/plugins/synthetics/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/synthetics/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/synthetics-plugin",
-  "owner": ["@elastic/obs-ux-management-team"],
+  "owner": ["@elastic/actionable-obs-team"],
   "group": "observability",
   "visibility": "private",
   "description": "This plugin visualizes data from Synthetics and Heartbeat, and integrates with other Observability solutions.",

--- a/x-pack/solutions/observability/plugins/synthetics/moon.yml
+++ b/x-pack/solutions/observability/plugins/synthetics/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/synthetics-plugin'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/synthetics-plugin'
   description: Moon project for @kbn/synthetics-plugin
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/plugins/synthetics
 dependsOn:

--- a/x-pack/solutions/observability/plugins/uptime/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/uptime/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "plugin",
   "id": "@kbn/uptime-plugin",
   "owner": [
-    "@elastic/obs-ux-management-team"
+    "@elastic/actionable-obs-team"
   ],
   "group": "observability",
   "visibility": "private",

--- a/x-pack/solutions/observability/plugins/uptime/moon.yml
+++ b/x-pack/solutions/observability/plugins/uptime/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/uptime-plugin'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/uptime-plugin'
   description: Moon project for @kbn/uptime-plugin
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/plugins/uptime
 dependsOn:

--- a/x-pack/solutions/observability/plugins/ux/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/ux/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "plugin",
   "id": "@kbn/ux-plugin",
   "owner": [
-    "@elastic/obs-ux-management-team"
+    "@elastic/actionable-obs-team"
   ],
   "group": "observability",
   "visibility": "private",

--- a/x-pack/solutions/observability/plugins/ux/moon.yml
+++ b/x-pack/solutions/observability/plugins/ux/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/ux-plugin'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ux-management-team'
+  defaultOwner: '@elastic/actionable-obs-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/ux-plugin'
   description: Moon project for @kbn/ux-plugin
   channel: ''
-  owner: '@elastic/obs-ux-management-team'
+  owner: '@elastic/actionable-obs-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/plugins/ux
 dependsOn:


### PR DESCRIPTION
## Summary

This PR updates the CODEOWNERS values for all of the @elastic/actionable-obs-team (changing over from previous name @elastic/obs-ux-management-team). This includes all of the plugin and package kibana.jsonc files as well as the CODEOWNER overrides at the bottom of that file directly.

There are a few exceptions to the direct find-and-replace. Observability overview and the observability navigation have both been transferred to @elastic/obs-presentation-team recently. Along with those, the following have been transferred to them as well in this PR:

* src/platform/packages/shared/serverless/settings/observability_project/kibana.jsonc
* x-pack/solutions/observability/packages/kbn-observability-schema/kibana.jsonc
* x-pack/solutions/observability/packages/nav-icons/kibana.jsonc
* x-pack/solutions/observability/plugins/serverless_observability/kibana.jsonc

In addition, it seemed odd to have our team as the sole top-level owners of x-pack/solutions/observability/plugins/observability/kibana.jsonc -- I think we should add all of our teams, or possibly the obs-ux-team, for this root ownership (more specific ownership gets overrides directly in CODEOWNERS within this directory). In the PR currently I've applied @elastic/obs-ux-team for this purpose.

