### PR TITLE
[9.2] [Discover] Fix Discover tab initialization (#245752)

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/initialization_error.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/initialization_error.tsx
@@ -10,13 +10,23 @@
 import { SavedObjectNotFound } from '@kbn/kibana-utils-plugin/public';
 import useMount from 'react-use/lib/useMount';
 import { redirectWhenMissing } from '@kbn/kibana-utils-plugin/public';
-import React from 'react';
+import React, { useMemo } from 'react';
+import type { SerializedError } from '@reduxjs/toolkit';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { BrandedLoadingIndicator } from './branded_loading_indicator';
 import { useInternalStateSelector } from '../../state_management/redux';
 import { DiscoverError } from '../../../../components/common/error_alert';
 
-export const InitializationError = ({ error }: { error: Error }) => {
+export const InitializationError = ({
+  error: originalError,
+}: {
+  error: Error | SerializedError;
+}) => {
+  const error = useMemo(
+    () => (originalError instanceof Error ? originalError : new Error(originalError.message)),
+    [originalError]
+  );
+
   if (error instanceof SavedObjectNotFound) {
     return <RedirectWhenSavedObjectNotFound error={error} />;
   }

--- a/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/single_tab_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/single_tab_view.tsx
@@ -10,6 +10,7 @@
 import React, { useEffect } from 'react';
 import { type IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
+import useLatest from 'react-use/lib/useLatest';
 import { createDataViewDataSource } from '../../../../../common/data_sources';
 import type { MainHistoryLocationState } from '../../../../../common';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
@@ -24,6 +25,7 @@ import {
   useCurrentTabRuntimeState,
   useCurrentTabSelector,
   useCurrentTabAction,
+  TabInitializationStatus,
 } from '../../state_management/redux';
 import type {
   CustomizationCallback,
@@ -38,7 +40,6 @@ import { NoDataPage } from './no_data_page';
 import { DiscoverMainProvider } from '../../state_management/discover_state_provider';
 import { BrandedLoadingIndicator } from './branded_loading_indicator';
 import { DiscoverMainApp } from './main_app';
-import { useAsyncFunction } from '../../hooks/use_async_function';
 import { ScopedServicesProvider } from '../../../../components/scoped_services_provider';
 import { HideTabsBar } from '../tabs_view/hide_tabs_bar';
 import { InitializationError } from './initialization_error';
@@ -53,15 +54,6 @@ export interface SingleTabViewProps {
   searchSessionManager: DiscoverSearchSessionManager;
 }
 
-interface SessionInitializationState {
-  showNoDataPage: boolean;
-}
-
-type InitializeSingleSession = (options?: {
-  dataViewSpec?: DataViewSpec | undefined;
-  defaultUrlState?: DiscoverAppState;
-}) => Promise<SessionInitializationState>;
-
 export const SingleTabView = ({
   customizationContext,
   customizationCallbacks,
@@ -73,8 +65,9 @@ export const SingleTabView = ({
   const dispatch = useInternalStateDispatch();
   const services = useDiscoverServices();
 
-  const initializationState = useInternalStateSelector((state) => state.initializationState);
+  const appInitializationState = useInternalStateSelector((state) => state.initializationState);
   const currentTabId = useCurrentTabSelector((tab) => tab.id);
+  const currentTabInitializationState = useCurrentTabSelector((tab) => tab.initializationState);
   const currentStateContainer = useCurrentTabRuntimeState(
     runtimeStateManager,
     (tab) => tab.stateContainer$
@@ -98,8 +91,14 @@ export const SingleTabView = ({
   const adHocDataViews = useRuntimeState(runtimeStateManager.adHocDataViews$);
 
   const initializeSingleTab = useCurrentTabAction(internalStateActions.initializeSingleTab);
-  const [initializeTabState, initializeTab] = useAsyncFunction<InitializeSingleSession>(
-    async ({ dataViewSpec, defaultUrlState } = {}) => {
+  const initializeTab = useLatest(
+    async ({
+      dataViewSpec,
+      defaultUrlState,
+    }: {
+      dataViewSpec?: DataViewSpec | undefined;
+      defaultUrlState?: DiscoverAppState;
+    } = {}) => {
       const stateContainer = getDiscoverStateContainer({
         tabId: currentTabId,
         services,
@@ -114,7 +113,7 @@ export const SingleTabView = ({
         customizationCallbacks,
       });
 
-      return dispatch(
+      dispatch(
         initializeSingleTab({
           initializeSingleTabParams: {
             stateContainer,
@@ -124,38 +123,31 @@ export const SingleTabView = ({
           },
         })
       );
-    },
-    currentStateContainer && currentCustomizationService
-      ? { loading: false, value: { showNoDataPage: false } }
-      : { loading: true }
+    }
   );
 
   useEffect(() => {
-    if (!currentStateContainer && !currentCustomizationService) {
+    if (currentTabInitializationState.initializationStatus === TabInitializationStatus.NotStarted) {
       const historyLocationState = services.getScopedHistory<
         MainHistoryLocationState & { defaultState?: DiscoverAppState }
       >()?.location.state;
 
-      initializeTab({
+      initializeTab.current({
         dataViewSpec: historyLocationState?.dataViewSpec,
         defaultUrlState: historyLocationState?.defaultState,
       });
     }
-  }, [currentCustomizationService, currentStateContainer, initializeTab, services]);
+  }, [currentTabInitializationState.initializationStatus, initializeTab, services]);
 
-  if (initializeTabState.loading) {
-    return <BrandedLoadingIndicator />;
+  if (currentTabInitializationState.initializationStatus === TabInitializationStatus.Error) {
+    return <InitializationError error={currentTabInitializationState.error} />;
   }
 
-  if (initializeTabState.error) {
-    return <InitializationError error={initializeTabState.error} />;
-  }
-
-  if (initializeTabState.value.showNoDataPage) {
+  if (currentTabInitializationState.initializationStatus === TabInitializationStatus.NoData) {
     return (
       <HideTabsBar>
         <NoDataPage
-          {...initializationState}
+          {...appInitializationState}
           onDataViewCreated={async (dataViewUnknown) => {
             await dispatch(internalStateActions.loadDataViewList());
             dispatch(
@@ -165,14 +157,14 @@ export const SingleTabView = ({
               })
             );
             const dataView = dataViewUnknown as DataView;
-            initializeTab({
+            initializeTab.current({
               defaultUrlState: dataView.id
                 ? { dataSource: createDataViewDataSource({ dataViewId: dataView.id }) }
                 : undefined,
             });
           }}
           onESQLNavigationComplete={() => {
-            initializeTab();
+            initializeTab.current();
           }}
         />
       </HideTabsBar>

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/use_preview_data.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/use_preview_data.ts
@@ -34,7 +34,7 @@ export const usePreviewData = (runtimeStateManager: RuntimeStateManager) => {
           const tabId = tabState.id;
           return {
             ...acc,
-            [tabId]: getPreviewDataObservable(runtimeStateManager, tabId, tabState.initialAppState),
+            [tabId]: getPreviewDataObservable(runtimeStateManager, tabId, tabState),
           };
         }, {})
       ),
@@ -93,15 +93,15 @@ const getPreviewQuery = (query: TabPreviewData['query'] | undefined): TabPreview
 const getPreviewDataObservable = (
   runtimeStateManager: RuntimeStateManager,
   tabId: string,
-  initialAppState: TabState['initialAppState'] | undefined
+  tabState: TabState
 ) =>
   selectTabRuntimeState(runtimeStateManager, tabId).stateContainer$.pipe(
     switchMap((tabStateContainer) => {
       if (!tabStateContainer) {
         return of({
           status: TabStatus.DEFAULT,
-          query: initialAppState?.query
-            ? getPreviewQuery(initialAppState.query)
+          query: tabState.initialAppState?.query
+            ? getPreviewQuery(tabState.initialAppState.query)
             : DEFAULT_PREVIEW_QUERY,
         });
       }
@@ -115,7 +115,7 @@ const getPreviewDataObservable = (
         map(([{ fetchStatus }, { query }]) => ({ fetchStatus, query })),
         distinctUntilChanged((prev, curr) => isEqual(prev, curr)),
         map(({ fetchStatus, query }) => ({
-          status: getPreviewStatus(fetchStatus),
+          status: tabState.forceFetchOnSelect ? TabStatus.DEFAULT : getPreviewStatus(fetchStatus),
           query: getPreviewQuery(query),
         }))
       );

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/initialize_single_tab.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/initialize_single_tab.ts
@@ -11,11 +11,7 @@ import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import { cloneDeep, isEqual, isObject, pick } from 'lodash';
 import type { GlobalQueryStateFromUrl } from '@kbn/data-plugin/public';
-import {
-  internalStateSlice,
-  type TabActionPayload,
-  type InternalStateThunkActionCreator,
-} from '../internal_state';
+import { internalStateSlice, type TabActionPayload } from '../internal_state';
 import {
   getInitialState,
   type AppStateUrl,
@@ -39,6 +35,7 @@ import { selectTab } from '../selectors';
 import type { TabState, TabStateGlobalState } from '../types';
 import { GLOBAL_STATE_URL_KEY } from '../../../../../../common/constants';
 import { fromSavedObjectTabToSavedSearch } from '../tab_mapping_utils';
+import { createInternalStateAsyncThunk } from '../utils';
 
 export interface InitializeSingleTabsParams {
   stateContainer: DiscoverStateContainer;
@@ -47,24 +44,24 @@ export interface InitializeSingleTabsParams {
   defaultUrlState: DiscoverAppState | undefined;
 }
 
-export const initializeSingleTab: InternalStateThunkActionCreator<
-  [TabActionPayload<{ initializeSingleTabParams: InitializeSingleTabsParams }>],
-  Promise<{ showNoDataPage: boolean }>
-> =
-  ({
-    tabId,
-    initializeSingleTabParams: {
-      stateContainer,
-      customizationService,
-      dataViewSpec,
-      defaultUrlState,
-    },
-  }) =>
-  async (
-    dispatch,
-    getState,
-    { services, runtimeStateManager, urlStateStorage, searchSessionManager }
-  ) => {
+export const initializeSingleTab = createInternalStateAsyncThunk(
+  'internalState/initializeSingleTab',
+  async function initializeSingleTabThunkFn(
+    {
+      tabId,
+      initializeSingleTabParams: {
+        stateContainer,
+        customizationService,
+        dataViewSpec,
+        defaultUrlState,
+      },
+    }: TabActionPayload<{ initializeSingleTabParams: InitializeSingleTabsParams }>,
+    {
+      dispatch,
+      getState,
+      extra: { services, runtimeStateManager, urlStateStorage, searchSessionManager },
+    }
+  ) {
     dispatch(disconnectTab({ tabId }));
     dispatch(internalStateSlice.actions.resetOnSavedSearchChange({ tabId }));
 
@@ -93,6 +90,16 @@ export const initializeSingleTab: InternalStateThunkActionCreator<
       tabInitialInternalState = cloneDeep(tabState.initialInternalState);
     }
 
+    // Get a snapshot of the current URL state before any async work is done
+    // to avoid race conditions if the URL changes during tab initialization,
+    // e.g. if the user quickly switches tabs
+    const urlGlobalState = urlStateStorage.get<GlobalQueryStateFromUrl>(GLOBAL_STATE_URL_KEY);
+    const urlAppState = {
+      ...tabInitialAppState,
+      ...(defaultUrlState ??
+        cleanupUrlState(urlStateStorage.get<AppStateUrl>(APP_STATE_URL_KEY), services.uiSettings)),
+    };
+
     const discoverTabLoadTracker = scopedEbtManager$
       .getValue()
       .trackPerformanceEvent('discoverLoadSavedSearch');
@@ -107,12 +114,6 @@ export const initializeSingleTab: InternalStateThunkActionCreator<
             services,
           })
         : undefined;
-
-    const urlAppState = {
-      ...tabInitialAppState,
-      ...(defaultUrlState ??
-        cleanupUrlState(urlStateStorage.get<AppStateUrl>(APP_STATE_URL_KEY), services.uiSettings)),
-    };
 
     const initialQuery =
       urlAppState?.query ?? persistedTabSavedSearch?.searchSource.getField('query');
@@ -193,7 +194,6 @@ export const initializeSingleTab: InternalStateThunkActionCreator<
         : undefined),
       ...tabInitialGlobalState,
     };
-    const urlGlobalState = urlStateStorage.get<GlobalQueryStateFromUrl>(GLOBAL_STATE_URL_KEY);
 
     if (urlGlobalState?.time) {
       initialGlobalState.timeRange = urlGlobalState.time;
@@ -226,54 +226,57 @@ export const initializeSingleTab: InternalStateThunkActionCreator<
       services,
     });
 
-    // Push the tab's initial search session ID to the URL if one exists,
-    // unless it should be overridden by a search session ID already in the URL
-    if (
-      tabInitialInternalState?.searchSessionId &&
-      !searchSessionManager.hasSearchSessionIdInURL()
-    ) {
-      searchSessionManager.pushSearchSessionIdToURL(tabInitialInternalState.searchSessionId, {
-        replace: true,
-      });
-    }
-
     /**
      * Sync global services
      */
 
-    // Cleaning up the previous state
-    services.filterManager.setAppFilters([]);
-    services.data.query.queryString.clearQuery();
+    // Only update global services if this is still the current tab
+    if (getState().tabs.unsafeCurrentId === tabId) {
+      // Push the tab's initial search session ID to the URL if one exists,
+      // unless it should be overridden by a search session ID already in the URL
+      if (
+        tabInitialInternalState?.searchSessionId &&
+        !searchSessionManager.hasSearchSessionIdInURL()
+      ) {
+        searchSessionManager.pushSearchSessionIdToURL(tabInitialInternalState.searchSessionId, {
+          replace: true,
+        });
+      }
 
-    if (initialGlobalState.timeRange && isTimeRangeValid(initialGlobalState.timeRange)) {
-      services.timefilter.setTime(initialGlobalState.timeRange);
-    }
+      // Cleaning up the previous state
+      services.filterManager.setAppFilters([]);
+      services.data.query.queryString.clearQuery();
 
-    if (
-      initialGlobalState.refreshInterval &&
-      isRefreshIntervalValid(initialGlobalState.refreshInterval)
-    ) {
-      services.timefilter.setRefreshInterval(initialGlobalState.refreshInterval);
-    }
+      if (initialGlobalState.timeRange && isTimeRangeValid(initialGlobalState.timeRange)) {
+        services.timefilter.setTime(initialGlobalState.timeRange);
+      }
 
-    if (initialGlobalState.filters) {
-      services.filterManager.setGlobalFilters(cloneDeep(initialGlobalState.filters));
-    }
+      if (
+        initialGlobalState.refreshInterval &&
+        isRefreshIntervalValid(initialGlobalState.refreshInterval)
+      ) {
+        services.timefilter.setRefreshInterval(initialGlobalState.refreshInterval);
+      }
 
-    if (initialAppState.filters) {
-      services.filterManager.setAppFilters(cloneDeep(initialAppState.filters));
-    }
+      if (initialGlobalState.filters) {
+        services.filterManager.setGlobalFilters(cloneDeep(initialGlobalState.filters));
+      }
 
-    // some filters may not be valid for this context, so update
-    // the filter manager with a modified list of valid filters
-    const currentFilters = services.filterManager.getFilters();
-    const validFilters = getValidFilters(dataView, currentFilters);
-    if (!isEqual(currentFilters, validFilters)) {
-      services.filterManager.setFilters(validFilters);
-    }
+      if (initialAppState.filters) {
+        services.filterManager.setAppFilters(cloneDeep(initialAppState.filters));
+      }
 
-    if (initialAppState.query) {
-      services.data.query.queryString.setQuery(initialAppState.query);
+      // some filters may not be valid for this context, so update
+      // the filter manager with a modified list of valid filters
+      const currentFilters = services.filterManager.getFilters();
+      const validFilters = getValidFilters(dataView, currentFilters);
+      if (!isEqual(currentFilters, validFilters)) {
+        services.filterManager.setFilters(validFilters);
+      }
+
+      if (initialAppState.query) {
+        services.data.query.queryString.setQuery(initialAppState.query);
+      }
     }
 
     /**
@@ -298,9 +301,19 @@ export const initializeSingleTab: InternalStateThunkActionCreator<
     customizationService$.next(customizationService);
 
     // Begin syncing the state and trigger the initial fetch
-    stateContainer.actions.initializeAndSync();
-    stateContainer.actions.fetchData(true);
+    // if this is still the current tab, otherwise mark the
+    // tab to fetch when selected
+    if (getState().tabs.unsafeCurrentId === tabId) {
+      stateContainer.actions.initializeAndSync();
+      stateContainer.actions.fetchData(true);
+    } else {
+      dispatch(
+        internalStateSlice.actions.setForceFetchOnSelect({ tabId, forceFetchOnSelect: true })
+      );
+    }
+
     discoverTabLoadTracker.reportEvent();
 
     return { showNoDataPage: false };
-  };
+  }
+);

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -150,7 +150,7 @@ export const updateTabs: InternalStateThunkActionCreator<
           },
         },
         ...existingTab,
-        ...item,
+        ...omit(item, 'initializationState'),
       };
 
       if (!existingTab) {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
@@ -8,9 +8,10 @@
  */
 
 import type { TabItem } from '@kbn/unified-tabs';
-import { type TabState } from './types';
+import { TabInitializationStatus, type TabState } from './types';
 
 export const DEFAULT_TAB_STATE: Omit<TabState, keyof TabItem> = {
+  initializationState: { initializationStatus: TabInitializationStatus.NotStarted },
   globalState: {},
   forceFetchOnSelect: false,
   isDataViewLoading: false,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/index.ts
@@ -34,6 +34,7 @@ export {
   type TabState,
   type TabStateGlobalState,
   type InternalStateDataRequestParams,
+  TabInitializationStatus,
 } from './types';
 
 export { DEFAULT_TAB_STATE } from './constants';

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/tabs.ts
@@ -11,8 +11,7 @@ import { createSelector } from '@reduxjs/toolkit';
 import type { DiscoverInternalState } from '../types';
 import { TabsBarVisibility } from '../types';
 
-export const selectTab = (state: DiscoverInternalState, tabId: string) =>
-  state.tabs.byId[tabId] ?? state.tabs.recentlyClosedTabsById[tabId];
+export const selectTab = (state: DiscoverInternalState, tabId: string) => state.tabs.byId[tabId];
 
 export const selectAllTabs = createSelector(
   [

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/tab_mapping_utils.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/tab_mapping_utils.test.ts
@@ -108,6 +108,9 @@ describe('tab mapping utils', () => {
               "bar": "foo",
             },
           },
+          "initializationState": Object {
+            "initializationStatus": "NotStarted",
+          },
           "isDataViewLoading": false,
           "label": "Tab 2",
           "overriddenVisContextAfterInvalidation": undefined,
@@ -178,6 +181,9 @@ describe('tab mapping utils', () => {
             "visContext": Object {
               "bar": "foo",
             },
+          },
+          "initializationState": Object {
+            "initializationStatus": "NotStarted",
           },
           "isDataViewLoading": false,
           "label": "Tab 2",

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -20,6 +20,7 @@ import type { UnifiedHistogramVisContext } from '@kbn/unified-histogram';
 import type { ESQLEditorRestorableState } from '@kbn/esql-editor';
 import type { TabItem } from '@kbn/unified-tabs';
 import type { DiscoverSession } from '@kbn/saved-search-plugin/common';
+import type { SerializedError } from '@reduxjs/toolkit';
 import type { DiscoverAppState } from '../discover_app_state_container';
 import type { DiscoverLayoutRestorableState } from '../../components/layout/discover_layout_restorable_state';
 
@@ -36,7 +37,19 @@ export interface TabStateGlobalState {
   filters?: Filter[];
 }
 
+export enum TabInitializationStatus {
+  NotStarted = 'NotStarted',
+  InProgress = 'InProgress',
+  Complete = 'Complete',
+  NoData = 'NoData',
+  Error = 'Error',
+}
+
 export interface TabState extends TabItem {
+  initializationState:
+    | { initializationStatus: Exclude<TabInitializationStatus, TabInitializationStatus.Error> }
+    | { initializationStatus: TabInitializationStatus.Error; error: Error | SerializedError };
+
   // Initial state for the tab (provided before the tab is initialized).
   initialInternalState?: {
     serializedSearchSource?: SerializedSearchSourceFields;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Discover] Fix Discover tab initialization (#245752)](https://github.com/elastic/kibana/pull/245752)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2025-12-10T23:41:31Z","message":"[Discover] Fix Discover tab initialization (#245752)\n\n## Summary\n\nThis PR fixes the Discover tab initialization logic to prevent the\nfollowing:\n- State leaking between tabs when switching to another tab while the\nprevious tab is still initializing, caused by syncing tab state with\nglobal Kibana services.\n- Duplicate tab initializations when switching away from and back to a\ntab before initialization completes, caused by the initialization logic\nchecking for the existence of `DiscoverStateContainer` instead of a\ndedicated status property.\n\nThese are the main fixes:\n- Move retrieving the initial URL state to the start of tab\ninitialization before any async work in case the current tab (and URL)\nchanges while initializing.\n- Avoid the following if the current tab changes during tab\ninitialization:\n- Syncing tab state to global services, which overrides the current\ntab's state.\n- Calling `stateContainer.actions.initializeAndSync()`, which causes the\nwrong tab to be synced to the URL and global services.\n- Calling `stateContainer.actions.fetchData(true)`, which results in the\nwrong search parameters being used during data fetching.\n- Stop relying on `DiscoverStateContainer` to check if a tab is\ninitialized, and instead introduce a dedicated `TabInitializationStatus`\nto prevent duplicate initializations when switching away from and back\nto a tab during initialization.\n\nFixes #245754.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- This should probably be backported to 9.2 since it's a bad bug, but\nthere are some significant changes to the tab initialization logic. We\nshould test thoroughly for regressions before merging, and in the 9.2\nbackport.","sha":"12ae8477cbe4641c636f043fb1601539f33fac5c","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","Team:DataDiscovery","backport:version","v9.3.0","v9.2.3"],"title":"[Discover] Fix Discover tab initialization","number":245752,"url":"https://github.com/elastic/kibana/pull/245752","mergeCommit":{"message":"[Discover] Fix Discover tab initialization (#245752)\n\n## Summary\n\nThis PR fixes the Discover tab initialization logic to prevent the\nfollowing:\n- State leaking between tabs when switching to another tab while the\nprevious tab is still initializing, caused by syncing tab state with\nglobal Kibana services.\n- Duplicate tab initializations when switching away from and back to a\ntab before initialization completes, caused by the initialization logic\nchecking for the existence of `DiscoverStateContainer` instead of a\ndedicated status property.\n\nThese are the main fixes:\n- Move retrieving the initial URL state to the start of tab\ninitialization before any async work in case the current tab (and URL)\nchanges while initializing.\n- Avoid the following if the current tab changes during tab\ninitialization:\n- Syncing tab state to global services, which overrides the current\ntab's state.\n- Calling `stateContainer.actions.initializeAndSync()`, which causes the\nwrong tab to be synced to the URL and global services.\n- Calling `stateContainer.actions.fetchData(true)`, which results in the\nwrong search parameters being used during data fetching.\n- Stop relying on `DiscoverStateContainer` to check if a tab is\ninitialized, and instead introduce a dedicated `TabInitializationStatus`\nto prevent duplicate initializations when switching away from and back\nto a tab during initialization.\n\nFixes #245754.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- This should probably be backported to 9.2 since it's a bad bug, but\nthere are some significant changes to the tab initialization logic. We\nshould test thoroughly for regressions before merging, and in the 9.2\nbackport.","sha":"12ae8477cbe4641c636f043fb1601539f33fac5c"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245752","number":245752,"mergeCommit":{"message":"[Discover] Fix Discover tab initialization (#245752)\n\n## Summary\n\nThis PR fixes the Discover tab initialization logic to prevent the\nfollowing:\n- State leaking between tabs when switching to another tab while the\nprevious tab is still initializing, caused by syncing tab state with\nglobal Kibana services.\n- Duplicate tab initializations when switching away from and back to a\ntab before initialization completes, caused by the initialization logic\nchecking for the existence of `DiscoverStateContainer` instead of a\ndedicated status property.\n\nThese are the main fixes:\n- Move retrieving the initial URL state to the start of tab\ninitialization before any async work in case the current tab (and URL)\nchanges while initializing.\n- Avoid the following if the current tab changes during tab\ninitialization:\n- Syncing tab state to global services, which overrides the current\ntab's state.\n- Calling `stateContainer.actions.initializeAndSync()`, which causes the\nwrong tab to be synced to the URL and global services.\n- Calling `stateContainer.actions.fetchData(true)`, which results in the\nwrong search parameters being used during data fetching.\n- Stop relying on `DiscoverStateContainer` to check if a tab is\ninitialized, and instead introduce a dedicated `TabInitializationStatus`\nto prevent duplicate initializations when switching away from and back\nto a tab during initialization.\n\nFixes #245754.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- This should probably be backported to 9.2 since it's a bad bug, but\nthere are some significant changes to the tab initialization logic. We\nshould test thoroughly for regressions before merging, and in the 9.2\nbackport.","sha":"12ae8477cbe4641c636f043fb1601539f33fac5c"}},{"branch":"9.2","label":"v9.2.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->