### PR TITLE
[MaintenanceWindows] Support namespace option in find method 

### DIFF
--- a/x-pack/platform/plugins/shared/maintenance_windows/server/application/methods/find/find_maintenance_windows.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/application/methods/find/find_maintenance_windows.ts
@@ -60,6 +60,7 @@ export async function findMaintenanceWindows(
               ...(params.page ? { page: params.page } : {}),
               ...(params.perPage ? { perPage: params.perPage } : {}),
               ...(filter ? { filter } : {}),
+              ...(params.namespaces ? { namespaces: params.namespaces } : {}),
             },
           }
         : {}),

--- a/x-pack/platform/plugins/shared/maintenance_windows/server/application/methods/find/schemas/find_maintenance_window_params_schema.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/application/methods/find/schemas/find_maintenance_window_params_schema.ts
@@ -21,4 +21,5 @@ export const findMaintenanceWindowsParamsSchema = schema.object({
   searchFields: schema.maybe(schema.arrayOf(schema.string())),
   perPage: schema.maybe(schema.number()),
   page: schema.maybe(schema.number()),
+  namespaces: schema.maybe(schema.arrayOf(schema.string())),
 });

--- a/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
@@ -69,7 +69,7 @@ export class MaintenanceWindowClientFactory {
     return this.createMaintenanceWindowClient(request, true);
   }
 
-  public create(request: KibanaRequest, excludedExtension?: string[]) {
+  public create(request: KibanaRequest, excludedExtension?:['spaces']) {
     return this.createMaintenanceWindowClient(request, false, excludedExtension);
   }
 }

--- a/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
@@ -12,6 +12,7 @@ import type {
   SecurityServiceStart,
   UiSettingsServiceStart,
 } from '@kbn/core/server';
+import { SPACES_EXTENSION_ID } from '@kbn/core/server';
 import { SECURITY_EXTENSION_ID } from '@kbn/core/server';
 import { MaintenanceWindowClient } from './client';
 import { MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE } from '../common';
@@ -45,7 +46,7 @@ export class MaintenanceWindowClientFactory {
     const { securityService } = this;
     const savedObjectsClient = this.savedObjectsService.getScopedClient(request, {
       includedHiddenTypes: [MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE],
-      ...(withAuth ? {} : { excludedExtensions: [SECURITY_EXTENSION_ID] }),
+      ...(withAuth ? {} : { excludedExtensions: [SECURITY_EXTENSION_ID, SPACES_EXTENSION_ID] }),
     });
 
     const uiSettingClient = this.uiSettings.asScopedToClient(savedObjectsClient);

--- a/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
@@ -12,7 +12,6 @@ import type {
   SecurityServiceStart,
   UiSettingsServiceStart,
 } from '@kbn/core/server';
-import { SPACES_EXTENSION_ID } from '@kbn/core/server';
 import { SECURITY_EXTENSION_ID } from '@kbn/core/server';
 import { MaintenanceWindowClient } from './client';
 import { MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE } from '../common';
@@ -42,11 +41,15 @@ export class MaintenanceWindowClientFactory {
     this.uiSettings = options.uiSettings;
   }
 
-  private createMaintenanceWindowClient(request: KibanaRequest, withAuth: boolean) {
+  private createMaintenanceWindowClient(
+    request: KibanaRequest,
+    withAuth: boolean,
+    excludedExtensions: string[] = [SECURITY_EXTENSION_ID]
+  ) {
     const { securityService } = this;
     const savedObjectsClient = this.savedObjectsService.getScopedClient(request, {
       includedHiddenTypes: [MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE],
-      ...(withAuth ? {} : { excludedExtensions: [SECURITY_EXTENSION_ID, SPACES_EXTENSION_ID] }),
+      ...(withAuth ? {} : { excludedExtensions }),
     });
 
     const uiSettingClient = this.uiSettings.asScopedToClient(savedObjectsClient);
@@ -66,7 +69,7 @@ export class MaintenanceWindowClientFactory {
     return this.createMaintenanceWindowClient(request, true);
   }
 
-  public create(request: KibanaRequest) {
-    return this.createMaintenanceWindowClient(request, false);
+  public create(request: KibanaRequest, excludedExtension?: string[]) {
+    return this.createMaintenanceWindowClient(request, false, excludedExtension);
   }
 }

--- a/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
@@ -44,12 +44,14 @@ export class MaintenanceWindowClientFactory {
   private createMaintenanceWindowClient(
     request: KibanaRequest,
     withAuth: boolean,
-    excludedExtensions?:['spaces']
+    excludedExtensions?: ['spaces']
   ) {
     const { securityService } = this;
     const savedObjectsClient = this.savedObjectsService.getScopedClient(request, {
       includedHiddenTypes: [MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE],
-      ...(withAuth ? {} : { excludedExtensions: [....excludedExtensions, SECURITY_EXTENSION_ID] }),
+      ...(withAuth
+        ? {}
+        : { excludedExtensions: [...(excludedExtensions ?? []), SECURITY_EXTENSION_ID] }),
     });
 
     const uiSettingClient = this.uiSettings.asScopedToClient(savedObjectsClient);
@@ -69,7 +71,7 @@ export class MaintenanceWindowClientFactory {
     return this.createMaintenanceWindowClient(request, true);
   }
 
-  public create(request: KibanaRequest, excludedExtension?:['spaces']) {
+  public create(request: KibanaRequest, excludedExtension?: ['spaces']) {
     return this.createMaintenanceWindowClient(request, false, excludedExtension);
   }
 }

--- a/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
@@ -49,7 +49,7 @@ export class MaintenanceWindowClientFactory {
     const { securityService } = this;
     const savedObjectsClient = this.savedObjectsService.getScopedClient(request, {
       includedHiddenTypes: [MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE],
-      ...(withAuth ? {} : { excludedExtensions }),
+      ...(withAuth ? {} : { excludedExtensions: [....excludedExtensions, SECURITY_EXTENSION_ID] }),
     });
 
     const uiSettingClient = this.uiSettings.asScopedToClient(savedObjectsClient);

--- a/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
@@ -44,7 +44,7 @@ export class MaintenanceWindowClientFactory {
   private createMaintenanceWindowClient(
     request: KibanaRequest,
     withAuth: boolean,
-    excludedExtensions: string[] = [SECURITY_EXTENSION_ID]
+    excludedExtensions?:['spaces']
   ) {
     const { securityService } = this;
     const savedObjectsClient = this.savedObjectsService.getScopedClient(request, {

--- a/x-pack/platform/plugins/shared/maintenance_windows/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/plugin.ts
@@ -112,9 +112,10 @@ export class MaintenanceWindowsPlugin
     };
 
     const getMaintenanceWindowClientInternal = (
-      request: KibanaRequest
+      request: KibanaRequest,
+      excludedExtension?: string[]
     ): MaintenanceWindowClientApi => {
-      return maintenanceWindowClientFactory.create(request);
+      return maintenanceWindowClientFactory.create(request, excludedExtension);
     };
 
     scheduleMaintenanceWindowEventsGenerator(this.logger, plugins.taskManager).catch(() => {});

--- a/x-pack/platform/plugins/shared/maintenance_windows/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/plugin.ts
@@ -113,7 +113,7 @@ export class MaintenanceWindowsPlugin
 
     const getMaintenanceWindowClientInternal = (
       request: KibanaRequest,
-      excludedExtension?: string[]
+      excludedExtension?: ['spaces']
     ): MaintenanceWindowClientApi => {
       return maintenanceWindowClientFactory.create(request, excludedExtension);
     };

--- a/x-pack/platform/plugins/shared/maintenance_windows/server/types.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/types.ts
@@ -38,6 +38,9 @@ export interface MaintenanceWindowsServerStartDependencies {
 }
 
 export interface MaintenanceWindowsServerStart {
-  getMaintenanceWindowClientInternal(request: KibanaRequest): MaintenanceWindowClientApi;
+  getMaintenanceWindowClientInternal(
+    request: KibanaRequest,
+    excludedExtension?: string[]
+  ): MaintenanceWindowClientApi;
   getMaintenanceWindowClientWithAuth(request: KibanaRequest): MaintenanceWindowClientApi;
 }

--- a/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
@@ -13,7 +13,7 @@ import type {
   SavedObjectsClientContract,
   KibanaRequest,
 } from '@kbn/core/server';
-import { SECURITY_EXTENSION_ID, SPACES_EXTENSION_ID } from '@kbn/core/server';
+import { SPACES_EXTENSION_ID } from '@kbn/core/server';
 import { SavedObjectsClient } from '@kbn/core/server';
 import { mappingFromFieldMap } from '@kbn/alerting-plugin/common';
 import { Dataset } from '@kbn/rule-registry-plugin/server';
@@ -131,7 +131,6 @@ export class Plugin implements PluginType {
       }
 
       return pluginsStart.maintenanceWindows?.getMaintenanceWindowClientInternal(request, [
-        SECURITY_EXTENSION_ID,
         SPACES_EXTENSION_ID,
       ]);
     };

--- a/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
@@ -13,6 +13,7 @@ import type {
   SavedObjectsClientContract,
   KibanaRequest,
 } from '@kbn/core/server';
+import { SECURITY_EXTENSION_ID, SPACES_EXTENSION_ID } from '@kbn/core/server';
 import { SavedObjectsClient } from '@kbn/core/server';
 import { mappingFromFieldMap } from '@kbn/alerting-plugin/common';
 import { Dataset } from '@kbn/rule-registry-plugin/server';
@@ -129,7 +130,10 @@ export class Plugin implements PluginType {
         return;
       }
 
-      return pluginsStart.maintenanceWindows?.getMaintenanceWindowClientInternal(request);
+      return pluginsStart.maintenanceWindows?.getMaintenanceWindowClientInternal(request, [
+        SECURITY_EXTENSION_ID,
+        SPACES_EXTENSION_ID,
+      ]);
     };
 
     if (this.server) {

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.ts
@@ -53,7 +53,7 @@ export class SyntheticsMonitorClient {
     const publicConfigs: ConfigData[] = [];
 
     const paramsBySpace = await this.syntheticsService.getSyntheticsParams({ spaceId });
-    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows([spaceId]);
+    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows(spaceId);
 
     for (const monitorObj of monitors) {
       const { formattedConfig, params, config } = await this.formatConfigWithParams(
@@ -100,7 +100,7 @@ export class SyntheticsMonitorClient {
     const deletedPublicConfigs: ConfigData[] = [];
 
     const paramsBySpace = await this.syntheticsService.getSyntheticsParams({ spaceId });
-    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows([spaceId]);
+    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows(spaceId);
 
     for (const editedMonitor of monitors) {
       const { str: paramsString, params } = mixParamsWithGlobalParams(
@@ -307,7 +307,7 @@ export class SyntheticsMonitorClient {
       canSave,
       hideParams,
     });
-    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows([spaceId]);
+    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows(spaceId);
 
     const { formattedConfig, params, config } = await this.formatConfigWithParams(
       monitorObj,

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.ts
@@ -53,7 +53,7 @@ export class SyntheticsMonitorClient {
     const publicConfigs: ConfigData[] = [];
 
     const paramsBySpace = await this.syntheticsService.getSyntheticsParams({ spaceId });
-    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows();
+    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows([spaceId]);
 
     for (const monitorObj of monitors) {
       const { formattedConfig, params, config } = await this.formatConfigWithParams(
@@ -100,7 +100,7 @@ export class SyntheticsMonitorClient {
     const deletedPublicConfigs: ConfigData[] = [];
 
     const paramsBySpace = await this.syntheticsService.getSyntheticsParams({ spaceId });
-    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows();
+    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows([spaceId]);
 
     for (const editedMonitor of monitors) {
       const { str: paramsString, params } = mixParamsWithGlobalParams(
@@ -307,7 +307,7 @@ export class SyntheticsMonitorClient {
       canSave,
       hideParams,
     });
-    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows();
+    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows([spaceId]);
 
     const { formattedConfig, params, config } = await this.formatConfigWithParams(
       monitorObj,

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.test.ts
@@ -18,6 +18,7 @@ import { LocationStatus } from '../../common/runtime_types';
 import { mockEncryptedSO } from './utils/mocks';
 import * as apiKeys from './get_api_key';
 import type { SyntheticsServerSetup } from '../types';
+import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
 
 jest.mock('axios', () => jest.fn());
 
@@ -254,7 +255,7 @@ describe('SyntheticsService', () => {
 
       (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
 
-      await service.pushAllConfigs();
+      await service.pushConfigs(ALL_SPACES_ID);
 
       expect(axios).not.toHaveBeenCalled();
 
@@ -277,7 +278,7 @@ describe('SyntheticsService', () => {
 
       (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
 
-      await service.pushAllConfigs();
+      await service.pushConfigs(ALL_SPACES_ID);
 
       expect(serverMock.logger.debug).toBeCalledWith(
         'API key is not valid. Cannot push monitor configuration to synthetics public testing locations'
@@ -350,7 +351,7 @@ describe('SyntheticsService', () => {
 
       (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
 
-      await service.pushAllConfigs();
+      await service.pushConfigs(ALL_SPACES_ID);
 
       expect(axios).toHaveBeenCalledTimes(1);
       expect(axios).toHaveBeenCalledWith(
@@ -400,7 +401,7 @@ describe('SyntheticsService', () => {
 
         (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
 
-        await expect(service.pushAllConfigs()).rejects.toThrow(errorMessage);
+        await expect(service.pushConfigs(ALL_SPACES_ID)).rejects.toThrow(errorMessage);
       }
     );
   });
@@ -566,7 +567,7 @@ describe('SyntheticsService', () => {
 
       (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
 
-      await service.pushAllConfigs();
+      await service.pushConfigs(ALL_SPACES_ID);
 
       expect(syncSpy).toHaveBeenCalledTimes(72);
       expect(axios).toHaveBeenCalledTimes(72);

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.test.ts
@@ -254,7 +254,7 @@ describe('SyntheticsService', () => {
 
       (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
 
-      await service.pushConfigs();
+      await service.pushAllConfigs();
 
       expect(axios).not.toHaveBeenCalled();
 
@@ -277,7 +277,7 @@ describe('SyntheticsService', () => {
 
       (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
 
-      await service.pushConfigs();
+      await service.pushAllConfigs();
 
       expect(serverMock.logger.debug).toBeCalledWith(
         'API key is not valid. Cannot push monitor configuration to synthetics public testing locations'
@@ -350,7 +350,7 @@ describe('SyntheticsService', () => {
 
       (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
 
-      await service.pushConfigs();
+      await service.pushAllConfigs();
 
       expect(axios).toHaveBeenCalledTimes(1);
       expect(axios).toHaveBeenCalledWith(
@@ -400,7 +400,7 @@ describe('SyntheticsService', () => {
 
         (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
 
-        await expect(service.pushConfigs()).rejects.toThrow(errorMessage);
+        await expect(service.pushAllConfigs()).rejects.toThrow(errorMessage);
       }
     );
   });
@@ -566,7 +566,7 @@ describe('SyntheticsService', () => {
 
       (axios as jest.MockedFunction<typeof axios>).mockResolvedValue({} as AxiosResponse);
 
-      await service.pushConfigs();
+      await service.pushAllConfigs();
 
       expect(syncSpy).toHaveBeenCalledTimes(72);
       expect(axios).toHaveBeenCalledTimes(72);

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -681,6 +681,7 @@ export class SyntheticsService {
     const mws = await maintenanceWindowClient.find({
       page: 0,
       perPage: 1000,
+      namespaces: [ALL_SPACES_ID],
     });
     return mws.data;
   }

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -217,7 +217,7 @@ export class SyntheticsService {
 
                 if (service.isAllowed && service.config.manifestUrl) {
                   void service.setupIndexTemplates();
-                  await service.pushConfigs();
+                  await service.pushAllConfigs();
                 } else {
                   if (!service.isAllowed) {
                     service.logger.debug('User is not allowed to access Synthetics service.');
@@ -430,7 +430,7 @@ export class SyntheticsService {
     }
   }
 
-  async pushConfigs() {
+  private async pushAllConfigs() {
     const license = await this.getLicense();
     const service = this;
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -440,7 +440,7 @@ export class SyntheticsService {
     let output: ServiceData['output'] | null = null;
 
     const paramsBySpace = await this.getSyntheticsParams();
-    const maintenanceWindows = await this.getMaintenanceWindows();
+    const maintenanceWindows = await this.getMaintenanceWindows([ALL_SPACES_ID]);
     const finder = await this.getSOClientFinder({ pageSize: PER_PAGE });
 
     const bucketsByLocation: Record<string, MonitorFields[]> = {};
@@ -669,7 +669,7 @@ export class SyntheticsService {
     return paramsBySpace;
   }
 
-  async getMaintenanceWindows() {
+  async getMaintenanceWindows(spaceIds: string[]) {
     const maintenanceWindowClient = this.server.getMaintenanceWindowClientInternal(
       {} as KibanaRequest
     );
@@ -681,7 +681,7 @@ export class SyntheticsService {
     const mws = await maintenanceWindowClient.find({
       page: 0,
       perPage: 1000,
-      namespaces: [ALL_SPACES_ID],
+      namespaces: spaceIds,
     });
     return mws.data;
   }

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -430,7 +430,7 @@ export class SyntheticsService {
     }
   }
 
-  private async pushAllConfigs() {
+  async pushAllConfigs() {
     const license = await this.getLicense();
     const service = this;
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -440,7 +440,7 @@ export class SyntheticsService {
     let output: ServiceData['output'] | null = null;
 
     const paramsBySpace = await this.getSyntheticsParams();
-    const maintenanceWindows = await this.getMaintenanceWindows([ALL_SPACES_ID]);
+    const maintenanceWindows = await this.getMaintenanceWindows(ALL_SPACES_ID);
     const finder = await this.getSOClientFinder({ pageSize: PER_PAGE });
 
     const bucketsByLocation: Record<string, MonitorFields[]> = {};
@@ -669,7 +669,7 @@ export class SyntheticsService {
     return paramsBySpace;
   }
 
-  async getMaintenanceWindows(spaceIds: string[]) {
+  async getMaintenanceWindows(spaceId: string) {
     const maintenanceWindowClient = this.server.getMaintenanceWindowClientInternal(
       {} as KibanaRequest
     );
@@ -681,7 +681,7 @@ export class SyntheticsService {
     const mws = await maintenanceWindowClient.find({
       page: 0,
       perPage: 1000,
-      namespaces: spaceIds,
+      namespaces: [spaceId],
     });
     return mws.data;
   }

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -217,7 +217,7 @@ export class SyntheticsService {
 
                 if (service.isAllowed && service.config.manifestUrl) {
                   void service.setupIndexTemplates();
-                  await service.pushAllConfigs();
+                  await service.pushConfigs(ALL_SPACES_ID);
                 } else {
                   if (!service.isAllowed) {
                     service.logger.debug('User is not allowed to access Synthetics service.');
@@ -430,7 +430,7 @@ export class SyntheticsService {
     }
   }
 
-  async pushAllConfigs() {
+  async pushConfigs(spaceId: string) {
     const license = await this.getLicense();
     const service = this;
 
@@ -440,7 +440,7 @@ export class SyntheticsService {
     let output: ServiceData['output'] | null = null;
 
     const paramsBySpace = await this.getSyntheticsParams();
-    const maintenanceWindows = await this.getMaintenanceWindows(ALL_SPACES_ID);
+    const maintenanceWindows = await this.getMaintenanceWindows(spaceId);
     const finder = await this.getSOClientFinder({ pageSize: PER_PAGE });
 
     const bucketsByLocation: Record<string, MonitorFields[]> = {};

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
@@ -109,7 +109,7 @@ export class DeployPrivateLocationMonitors {
   }) {
     const { syntheticsService } = this.syntheticsMonitorClient;
     const paramsBySpacePromise = syntheticsService.getSyntheticsParams({ spaceId });
-    const maintenanceWindowsPromise = syntheticsService.getMaintenanceWindows();
+    const maintenanceWindowsPromise = syntheticsService.getMaintenanceWindows([spaceId]);
     const monitorConfigRepository = new MonitorConfigRepository(
       soClient,
       encryptedSavedObjects.getClient()

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
@@ -109,7 +109,7 @@ export class DeployPrivateLocationMonitors {
   }) {
     const { syntheticsService } = this.syntheticsMonitorClient;
     const paramsBySpacePromise = syntheticsService.getSyntheticsParams({ spaceId });
-    const maintenanceWindowsPromise = syntheticsService.getMaintenanceWindows([spaceId]);
+    const maintenanceWindowsPromise = syntheticsService.getMaintenanceWindows(spaceId);
     const monitorConfigRepository = new MonitorConfigRepository(
       soClient,
       encryptedSavedObjects.getClient()


### PR DESCRIPTION
## Summary

Support namespace option in maintenance windows client find method, this is required for synthetics to perform sync using internal client internal when sync task is working across monitors from multiple spaces.

This is blocking the PR we have in progress https://github.com/elastic/kibana/pull/246088



<!--ONMERGE {"backportTargets":["8.18","9.2"]} ONMERGE-->