### PR TITLE
Skip serverless Observability find SLOs test suite for MKI

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/find_slo_definition.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/find_slo_definition.ts
@@ -25,6 +25,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   let adminRoleAuthc: RoleCredentials;
 
   describe('Find SLOs by outdated status and tags', function () {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/246127
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       adminRoleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('admin');
 


### PR DESCRIPTION
## Summary

This PR skips the serverless Observability find SLOs test suite for MKI runs.
Details on the flakiness/failure in #246127.