### PR TITLE
Do not round to the nearest day when deleting

### DIFF
--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
@@ -63,7 +63,7 @@ function createRawEventLoopDelaysDailyDocs() {
     createRawObject(moment()),
     createRawObject(moment()),
     createRawObject(moment().subtract(1, 'days')),
-    createRawObject(moment().subtract(2.5, 'days')), // could be considered 4 days if we use 3 and the check is performed the following hour
+    createRawObject(moment().subtract(2, 'days')),
   ];
 
   const outdatedRawEventLoopDelaysDaily = [

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/event_loop_delays/saved_objects.test.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/event_loop_delays/saved_objects.test.ts
@@ -64,13 +64,13 @@ describe('deleteHistogramSavedObjects', () => {
       Array [
         Array [
           Object {
-            "filter": "event_loop_delays_daily.attributes.lastUpdatedAt < \\"now-3d/d\\"",
+            "filter": "event_loop_delays_daily.attributes.lastUpdatedAt < \\"now-3d\\"",
             "type": "event_loop_delays_daily",
           },
         ],
         Array [
           Object {
-            "filter": "event_loop_delays_daily.attributes.lastUpdatedAt < \\"now-20d/d\\"",
+            "filter": "event_loop_delays_daily.attributes.lastUpdatedAt < \\"now-20d\\"",
             "type": "event_loop_delays_daily",
           },
         ],

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/event_loop_delays/saved_objects.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/event_loop_delays/saved_objects.ts
@@ -52,7 +52,7 @@ export async function deleteHistogramSavedObjects(
 ) {
   const { saved_objects: savedObjects } = await internalRepository.find<EventLoopDelaysDaily>({
     type: SAVED_OBJECTS_DAILY_TYPE,
-    filter: `${SAVED_OBJECTS_DAILY_TYPE}.attributes.lastUpdatedAt < "now-${daysTimeRange}d/d"`,
+    filter: `${SAVED_OBJECTS_DAILY_TYPE}.attributes.lastUpdatedAt < "now-${daysTimeRange}d"`,
   });
 
   return await Promise.allSettled(


### PR DESCRIPTION
## Summary

Closes #231367

We were searching for documents older than 3 days, but rounding the search to the "nearest" day. This can skew our results and cause:
* A) deleting of documents that are 2-ish days old.
* B) preserving documents that are 4-ish days old.

I believe the most fair approach is to use days as in 24h periods rather than natural days.
