### PR TITLE
[ObsUX][Infra] Fix: use loading to prevent showing related dashboards when changing nodeType

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/bottom_drawer.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/bottom_drawer.tsx
@@ -36,6 +36,7 @@ interface Props {
   formatter: InfraFormatter;
   view: string;
   nodeType: InventoryItemType;
+  loading: boolean;
 }
 
 const RelatedDashboards = () => {
@@ -57,15 +58,15 @@ const RelatedDashboards = () => {
   );
 };
 
-export const BottomDrawer = ({ interval, formatter, view, nodeType }: Props) => {
+export const BottomDrawer = ({ interval, formatter, view, nodeType, loading }: Props) => {
   const { timelineOpen, changeTimelineOpen } = useWaffleOptionsContext();
   const [isOpen, setIsOpen] = useState(Boolean(timelineOpen));
 
   const { hasEcsSchema, hasSemconvSchema, hasEcsK8sIntegration, hasSemconvK8sIntegration } =
     useKubernetesDashboardPromotion(nodeType);
 
-  const showEcsK8sButton = hasEcsSchema && hasEcsK8sIntegration;
-  const showSemconvK8sButton = hasSemconvSchema && hasSemconvK8sIntegration;
+  const showEcsK8sButton = !loading && hasEcsSchema && hasEcsK8sIntegration;
+  const showSemconvK8sButton = !loading && hasSemconvSchema && hasSemconvK8sIntegration;
 
   useEffect(() => {
     if (isOpen !== timelineOpen) setIsOpen(Boolean(timelineOpen));

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/layout.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/layout.tsx
@@ -234,7 +234,13 @@ export const Layout = React.memo(({ interval, nodes, loading }: Props) => {
           </EuiFlexItem>
         </EuiFlexGroup>
       </PageContent>
-      <BottomDrawer interval={interval} formatter={formatter} view={view} nodeType={nodeType} />
+      <BottomDrawer
+        interval={interval}
+        formatter={formatter}
+        view={view}
+        nodeType={nodeType}
+        loading={loading}
+      />
     </>
   );
 });


### PR DESCRIPTION
## Summary

Fix small issue when we change `nodeType` in the Inventory UI, it may render Related dashboards when it shouldn't, this PR uses the loading state to prevent showing due to wrong conditions.

### Before

https://github.com/user-attachments/assets/565df76c-187c-4549-a49a-0ff37243f884

### After

https://github.com/user-attachments/assets/dd9770ba-49ae-4865-ac55-857155ec0bc3



<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->