### PR TITLE
[CI] remove MOON_DEBUG before retrying

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -45,7 +45,6 @@ if ! (yarn kbn bootstrap "${BOOTSTRAP_PARAMS[@]}" || yarn kbn bootstrap "${BOOTS
   # So, we should just delete node_modules in between attempts
   rm -rf node_modules
 
-  export MOON_LOG=debug
   echo "--- yarn install and bootstrap, attempt 2"
   yarn kbn bootstrap --force-install || yarn kbn bootstrap
 fi


### PR DESCRIPTION
## Summary
This was a leftover from when we brought in Moon, but this is not very useful, because if bootstrap fails for some reason, a HUGE amount of logs will be thrown in and kind of hide the real error. 

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->