### PR TITLE
[`on-merge-unsupported` pipeline] Use new Actionable Obs Slack team handle on Synthetics tests failure

### DIFF
--- a/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
+++ b/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
@@ -38,7 +38,7 @@ steps:
       preemptible: true
     depends_on: build
     env:
-      PING_SLACK_TEAM: "@obs-ux-management-team"
+      PING_SLACK_TEAM: '@actionable-obs-team'
     timeout_in_minutes: 120
     artifact_paths:
       - 'x-pack/solutions/observability/plugins/synthetics/e2e/.journeys/**/*'


### PR DESCRIPTION
We noticed Synthetics tests failures in the `kibana-unsupported-ftrs-alerts` pipeline weren't pinging the new Actionable Obs Slack team handle (`@actionable-obs-team`). The old Slack handle was used, `@obs-ux-management-team`, which no longer notified the team. This PR fixes it.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->