### PR TITLE
[Search] Add Cloud Connect promos for self-managed users

### DIFF
--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_callout.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_callout.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { EuiThemeProvider } from '@elastic/eui';
+
+import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
+import {
+  EIS_CALLOUT_TITLE,
+  EIS_CLOUD_CONNECT_PROMO_DESCRIPTION,
+  EIS_CLOUD_CONNECT_PROMO_TOUR_CTA,
+} from '../translations';
+import {
+  EisCloudConnectPromoCallout,
+  type EisCloudConnectPromoCalloutProps,
+} from './eis_ccm_promotional_callout';
+
+jest.mock('../hooks/use_show_eis_promotional_content');
+
+describe('EisCloudConnectPromoCallout', () => {
+  const promoId = 'testPromo';
+  const dataId = `${promoId}-cloud-connect-callout`;
+  const direction: EisCloudConnectPromoCalloutProps['direction'] = 'row';
+
+  const mockOnDismissTour = jest.fn();
+  const mockNavigateToApp = jest.fn();
+
+  const renderComponent = (props?: Partial<EisCloudConnectPromoCalloutProps>) =>
+    render(
+      <EuiThemeProvider>
+        <EisCloudConnectPromoCallout
+          promoId={promoId}
+          isSelfManaged={true}
+          navigateToApp={mockNavigateToApp}
+          direction={direction}
+          {...props}
+        />
+      </EuiThemeProvider>
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
+      isPromoVisible: true,
+      onDismissTour: mockOnDismissTour,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders callout when promo is visible and deployment is self-managed', () => {
+    renderComponent();
+
+    // Callout exists
+    const callout = screen.getByTestId(dataId);
+    expect(callout).toBeInTheDocument();
+
+    // Title, description, CTA, and image
+    expect(screen.getByText(EIS_CALLOUT_TITLE)).toBeInTheDocument();
+    expect(screen.getByText(EIS_CLOUD_CONNECT_PROMO_DESCRIPTION)).toBeInTheDocument();
+    expect(screen.getByText(EIS_CLOUD_CONNECT_PROMO_TOUR_CTA)).toBeInTheDocument();
+  });
+
+  it('calls onDismissTour when dismiss button is clicked', () => {
+    renderComponent();
+
+    const dismissButton = screen.getByTestId('euiDismissCalloutButton');
+    fireEvent.click(dismissButton);
+
+    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls navigateToApp when CTA button is clicked', () => {
+    renderComponent();
+
+    const ctaButton = screen.getByTestId('eisUpdateCalloutCtaBtn');
+    fireEvent.click(ctaButton);
+
+    expect(mockNavigateToApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render when promo is not visible', () => {
+    (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
+      isPromoVisible: false,
+      onDismissTour: mockOnDismissTour,
+    });
+
+    renderComponent();
+
+    expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();
+  });
+
+  it('does not render when deployment is not self-managed', () => {
+    renderComponent({ isSelfManaged: false });
+
+    expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();
+  });
+});

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_callout.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_callout.test.tsx
@@ -21,16 +21,39 @@ import {
   EisCloudConnectPromoCallout,
   type EisCloudConnectPromoCalloutProps,
 } from './eis_ccm_promotional_callout';
+import { useKibana } from '../hooks/use_kibana';
 
 jest.mock('../hooks/use_show_eis_promotional_content');
+jest.mock('../hooks/use_kibana');
+
+const mockUiSettingsGet = jest.fn();
+const mockNavigateToApp = jest.fn();
+const mockOnDismissTour = jest.fn();
+
+const mockUseKibana = (overrides?: Partial<any>) => {
+  (useKibana as jest.Mock).mockReturnValue({
+    services: {
+      uiSettings: {
+        get: mockUiSettingsGet,
+      },
+      application: {
+        navigateToApp: mockNavigateToApp,
+        capabilities: {
+          cloudConnect: {
+            show: true,
+            configure: true,
+          },
+        },
+      },
+      ...overrides,
+    },
+  });
+};
 
 describe('EisCloudConnectPromoCallout', () => {
   const promoId = 'testPromo';
   const dataId = `${promoId}-cloud-connect-callout`;
   const direction: EisCloudConnectPromoCalloutProps['direction'] = 'row';
-
-  const mockOnDismissTour = jest.fn();
-  const mockNavigateToApp = jest.fn();
 
   const renderComponent = (props?: Partial<EisCloudConnectPromoCalloutProps>) =>
     render(
@@ -47,6 +70,8 @@ describe('EisCloudConnectPromoCallout', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUiSettingsGet.mockReturnValue(true);
+    mockUseKibana();
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
       onDismissTour: mockOnDismissTour,

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_callout.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_callout.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiImage,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import * as i18n from '../translations';
+import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
+import searchRocketIcon from '../assets/search-rocket.svg';
+
+export interface EisCloudConnectPromoCalloutProps {
+  promoId: string;
+  isSelfManaged: boolean;
+  navigateToApp: () => void;
+  direction: 'row' | 'column';
+  addSpacer?: 'top' | 'bottom';
+}
+
+export const EisCloudConnectPromoCallout = ({
+  promoId,
+  isSelfManaged,
+  navigateToApp,
+  direction,
+  addSpacer,
+}: EisCloudConnectPromoCalloutProps) => {
+  const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
+    promoId: `${promoId}CloudConnectCallout`,
+  });
+
+  const dataId = `${promoId}-cloud-connect-callout`;
+
+  if (!isPromoVisible || !isSelfManaged) {
+    return null;
+  }
+
+  return (
+    <>
+      {addSpacer === 'top' && <EuiSpacer size="l" />}
+      <EuiCallOut
+        data-telemetry-id={dataId}
+        data-test-subj={dataId}
+        css={({ euiTheme }) => ({
+          color: euiTheme.colors.primaryText,
+          backgroundColor: `${euiTheme.colors.backgroundBaseSubdued}`,
+          border: `${euiTheme.border.thin}`,
+        })}
+        onDismiss={onDismissTour}
+      >
+        <EuiFlexGroup direction={direction} alignItems="flexStart">
+          <EuiImage src={searchRocketIcon} alt="" size="original" />
+          <div>
+            <EuiTitle>
+              <h4>{i18n.EIS_CALLOUT_TITLE}</h4>
+            </EuiTitle>
+            <EuiText color="subdued" size="s">
+              <p>{i18n.EIS_CLOUD_CONNECT_PROMO_DESCRIPTION}</p>
+            </EuiText>
+            <EuiSpacer size="m" />
+            <EuiButton
+              fullWidth={false}
+              color="text"
+              size="s"
+              onClick={navigateToApp}
+              data-test-subj="eisUpdateCalloutCtaBtn"
+              data-telemetry-id={`${dataId}-cta-btn`}
+              iconSide="right"
+              iconType="popout"
+            >
+              {i18n.EIS_CLOUD_CONNECT_PROMO_TOUR_CTA}
+            </EuiButton>
+          </div>
+        </EuiFlexGroup>
+      </EuiCallOut>
+      {addSpacer === 'bottom' && <EuiSpacer size="l" />}
+    </>
+  );
+};

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_callout.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_callout.tsx
@@ -18,6 +18,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import * as i18n from '../translations';
+import { useKibana } from '../hooks/use_kibana';
 import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
 import searchRocketIcon from '../assets/search-rocket.svg';
 
@@ -36,13 +37,20 @@ export const EisCloudConnectPromoCallout = ({
   direction,
   addSpacer,
 }: EisCloudConnectPromoCalloutProps) => {
+  const {
+    services: { application },
+  } = useKibana();
   const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
     promoId: `${promoId}CloudConnectCallout`,
   });
 
+  const hasCloudConnectPermission = Boolean(
+    application.capabilities.cloudConnect?.show || application.capabilities.cloudConnect?.configure
+  );
+
   const dataId = `${promoId}-cloud-connect-callout`;
 
-  if (!isPromoVisible || !isSelfManaged) {
+  if (!isPromoVisible || !isSelfManaged || !hasCloudConnectPermission) {
     return null;
   }
 
@@ -53,9 +61,9 @@ export const EisCloudConnectPromoCallout = ({
         data-telemetry-id={dataId}
         data-test-subj={dataId}
         css={({ euiTheme }) => ({
-          color: euiTheme.colors.primaryText,
           backgroundColor: `${euiTheme.colors.backgroundBaseSubdued}`,
           border: `${euiTheme.border.thin}`,
+          borderRadius: `${euiTheme.border.radius.medium}`,
         })}
         onDismiss={onDismissTour}
       >

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.test.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import '@testing-library/jest-dom';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
+import { fireEvent, screen } from '@testing-library/react';
+import { EisCloudConnectPromoTour } from './eis_ccm_promotional_tour';
+import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
+import * as i18n from '../translations';
+
+jest.mock('../hooks/use_show_eis_promotional_content');
+
+describe('EisCloudConnectPromoTour', () => {
+  const promoId = 'cloudConnectPromo';
+  const dataId = `${promoId}-eis-cloud-connect-promo-tour`;
+  const childTestId = 'tourChild';
+  const mockNavigateToApp = jest.fn();
+
+  const renderComponent = (
+    props: Partial<React.ComponentProps<typeof EisCloudConnectPromoTour>> = {}
+  ) =>
+    renderWithI18n(
+      <EisCloudConnectPromoTour
+        promoId={promoId}
+        isSelfManaged={true}
+        navigateToApp={mockNavigateToApp}
+        {...props}
+      >
+        <span data-test-subj={childTestId} />
+      </EisCloudConnectPromoTour>
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders children only when promo is not visible', () => {
+    (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
+      isPromoVisible: false,
+      onDismissTour: jest.fn(),
+    });
+
+    renderComponent();
+
+    expect(screen.getByTestId(childTestId)).toBeInTheDocument();
+    expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();
+  });
+
+  it('renders children and does not render the tour when isReady is false', () => {
+    (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
+      isPromoVisible: true, // would normally show the tour
+      onDismissTour: jest.fn(),
+    });
+
+    renderComponent({ isReady: false });
+
+    expect(screen.getByTestId(childTestId)).toBeInTheDocument();
+    expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();
+  });
+
+  it('renders children and does not render the tour when isSelfManaged is false', () => {
+    (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
+      isPromoVisible: true,
+      onDismissTour: jest.fn(),
+    });
+
+    renderComponent({ isSelfManaged: false });
+
+    expect(screen.getByTestId(childTestId)).toBeInTheDocument();
+    expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();
+  });
+
+  it('renders the tour when promo is visible', () => {
+    (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
+      isPromoVisible: true,
+      onDismissTour: jest.fn(),
+    });
+
+    renderComponent();
+
+    expect(screen.getByTestId(dataId)).toBeInTheDocument();
+    expect(screen.getByTestId(childTestId)).toBeInTheDocument();
+    expect(screen.getByText(i18n.EIS_CLOUD_CONNECT_PROMO_TOUR_TITLE)).toBeInTheDocument();
+  });
+
+  it('renders CTA button and calls navigateToApp when clicked', () => {
+    (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
+      isPromoVisible: true,
+      onDismissTour: jest.fn(),
+    });
+
+    renderComponent();
+
+    const ctaBtn = screen.getByTestId('eisCloudConnectPromoTourCtaBtn');
+
+    expect(ctaBtn).toBeInTheDocument();
+    expect(ctaBtn).toHaveTextContent(i18n.EIS_CLOUD_CONNECT_PROMO_TOUR_CTA);
+
+    fireEvent.click(ctaBtn);
+    expect(mockNavigateToApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the tour from DOM after clicking Dismiss, children remain', () => {
+    let visible = true;
+    const mockOnDismissTour = jest.fn(() => {
+      visible = false;
+    });
+
+    (useShowEisPromotionalContent as jest.Mock).mockImplementation(() => ({
+      get isPromoVisible() {
+        return visible;
+      },
+      onDismissTour: mockOnDismissTour,
+    }));
+
+    const { rerender } = renderComponent();
+
+    expect(screen.getByTestId(dataId)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('eisCloudConnectPromoTourCloseBtn'));
+    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <EisCloudConnectPromoTour
+        promoId={promoId}
+        isSelfManaged={true}
+        navigateToApp={mockNavigateToApp}
+      >
+        <span data-test-subj={childTestId} />
+      </EisCloudConnectPromoTour>
+    );
+
+    expect(screen.queryByTestId(dataId)).not.toBeInTheDocument();
+    expect(screen.getByTestId(childTestId)).toBeInTheDocument();
+  });
+});

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.test.tsx
@@ -12,16 +12,40 @@ import '@testing-library/jest-dom';
 import { renderWithI18n } from '@kbn/test-jest-helpers';
 import { fireEvent, screen } from '@testing-library/react';
 import { EisCloudConnectPromoTour } from './eis_ccm_promotional_tour';
+import { useKibana } from '../hooks/use_kibana';
 import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
 import * as i18n from '../translations';
 
 jest.mock('../hooks/use_show_eis_promotional_content');
+jest.mock('../hooks/use_kibana');
+
+const mockUiSettingsGet = jest.fn();
+const mockNavigateToApp = jest.fn();
+
+const mockUseKibana = (overrides?: Partial<any>) => {
+  (useKibana as jest.Mock).mockReturnValue({
+    services: {
+      uiSettings: {
+        get: mockUiSettingsGet,
+      },
+      application: {
+        navigateToApp: mockNavigateToApp,
+        capabilities: {
+          cloudConnect: {
+            show: true,
+            configure: true,
+          },
+        },
+      },
+      ...overrides,
+    },
+  });
+};
 
 describe('EisCloudConnectPromoTour', () => {
   const promoId = 'cloudConnectPromo';
   const dataId = `${promoId}-cloud-connect-promo-tour`;
   const childTestId = 'tourChild';
-  const mockNavigateToApp = jest.fn();
 
   const renderComponent = (
     props: Partial<React.ComponentProps<typeof EisCloudConnectPromoTour>> = {}
@@ -39,6 +63,8 @@ describe('EisCloudConnectPromoTour', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUiSettingsGet.mockReturnValue(true);
+    mockUseKibana();
   });
 
   it('renders children only when promo is not visible', () => {

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.test.tsx
@@ -19,7 +19,7 @@ jest.mock('../hooks/use_show_eis_promotional_content');
 
 describe('EisCloudConnectPromoTour', () => {
   const promoId = 'cloudConnectPromo';
-  const dataId = `${promoId}-eis-cloud-connect-promo-tour`;
+  const dataId = `${promoId}-cloud-connect-promo-tour`;
   const childTestId = 'tourChild';
   const mockNavigateToApp = jest.fn();
 

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.tsx
@@ -8,25 +8,37 @@
  */
 
 import React from 'react';
-import type { EuiTourStepProps } from '@elastic/eui';
-import { EuiButton, EuiButtonEmpty, EuiText, EuiTourStep, useEuiTheme } from '@elastic/eui';
-import * as i18n from '../translations';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiText,
+  EuiTourStep,
+  useEuiTheme,
+  type EuiTourStepProps,
+} from '@elastic/eui';
+import {
+  EIS_TOUR_DISMISS,
+  EIS_CLOUD_CONNECT_PROMO_TOUR_CTA,
+  EIS_CLOUD_CONNECT_PROMO_TOUR_DESCRIPTION,
+  EIS_CLOUD_CONNECT_PROMO_TOUR_TITLE,
+} from '../translations';
 import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
 
 /**
- * Props for the EisTokenCostTour component.
+ * Props for the EisCloudConnectPromoTour component.
  *
  * @property {EuiTourStepProps['anchorPosition']} [anchorPosition='downCenter']
  *   Position of the tour step relative to its anchor element.
  *
- * @property {string} [ctaLink]
- *   Optional URL for the call-to-action button in the tour footer.
+ * @property {string} [navigateToApp]
+ *   Callback function invoked when the call-to-action button is clicked.
+ *   Navigates the user to the cloud connect management application.
  *
  * @property {string} promoId
  *   Unique identifier for this promo instance. Used for localStorage and telemetry.
  *
- * @property {boolean} isCloudEnabled
- *   Indicates that the component is running in a cloud-enabled environment.
+ * @property {boolean} isSelfManaged
+ *   Indicates that the component is running in a self-managed environment.
  *   The tour will only be shown if this is true.
  *
  * @property {boolean} [isReady=true]
@@ -37,30 +49,30 @@ import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_
  *   The anchor element for the tour step. The tour wraps this element.
  */
 
-export interface EisTokenCostTourProps {
+export interface EisCloudConnectPromoTourProps {
   anchorPosition?: EuiTourStepProps['anchorPosition'];
-  ctaLink?: string;
+  navigateToApp: () => void;
   promoId: string;
-  isCloudEnabled: boolean;
+  isSelfManaged: boolean;
   isReady?: boolean;
   children: React.ReactElement;
 }
 
-export const EisTokenCostTour = ({
+export const EisCloudConnectPromoTour = ({
   anchorPosition = 'downCenter',
-  ctaLink,
+  navigateToApp,
   promoId,
-  isCloudEnabled,
+  isSelfManaged,
   isReady = true,
   children,
-}: EisTokenCostTourProps) => {
+}: EisCloudConnectPromoTourProps) => {
   const { euiTheme } = useEuiTheme();
   const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
-    promoId: `${promoId}Tour`,
+    promoId: `${promoId}CloudConnectTour`,
   });
-  const dataId = `${promoId}-eis-costs-tour`;
+  const dataId = `${promoId}-eis-cloud-connect-promo-tour`;
 
-  if (!isPromoVisible || !isReady || !isCloudEnabled) {
+  if (!isPromoVisible || !isReady || !isSelfManaged) {
     return children;
   }
 
@@ -68,42 +80,32 @@ export const EisTokenCostTour = ({
     <EuiTourStep
       data-telemetry-id={dataId}
       data-test-subj={dataId}
-      title={i18n.EIS_COSTS_TOUR_TITLE}
+      title={EIS_CLOUD_CONNECT_PROMO_TOUR_TITLE}
       maxWidth={`${euiTheme.base * 25}px`}
       content={
         <EuiText>
-          <p>{i18n.EIS_COSTS_TOUR_DESCRIPTION}</p>
+          <p>{EIS_CLOUD_CONNECT_PROMO_TOUR_DESCRIPTION}</p>
         </EuiText>
       }
+      display="block"
       isStepOpen={isPromoVisible}
       anchorPosition={anchorPosition}
       step={1}
       stepsTotal={1}
       onFinish={onDismissTour}
       footerAction={[
-        <EuiButtonEmpty
-          data-test-subj="tokenConsumptionCostTourCloseBtn"
-          onClick={onDismissTour}
-          aria-label={i18n.EIS_COSTS_TOUR_DISMISS_ARIA}
-        >
-          {i18n.EIS_TOUR_DISMISS}
+        <EuiButtonEmpty data-test-subj="eisCloudConnectPromoTourCloseBtn" onClick={onDismissTour}>
+          {EIS_TOUR_DISMISS}
         </EuiButtonEmpty>,
-        ...(ctaLink
-          ? [
-              <EuiButton
-                fullWidth={false}
-                color="primary"
-                size="s"
-                href={ctaLink}
-                data-test-subj="eisCostsTourCtaBtn"
-                target="_blank"
-                iconSide="right"
-                iconType="popout"
-              >
-                {i18n.EIS_TOUR_CTA}
-              </EuiButton>,
-            ]
-          : []),
+        <EuiButton
+          onClick={navigateToApp}
+          data-test-subj="eisCloudConnectPromoTourCtaBtn"
+          target="_blank"
+          iconSide="right"
+          iconType="popout"
+        >
+          {EIS_CLOUD_CONNECT_PROMO_TOUR_CTA}
+        </EuiButton>,
       ]}
     >
       {children}

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.tsx
@@ -23,6 +23,8 @@ import {
   EIS_CLOUD_CONNECT_PROMO_TOUR_TITLE,
 } from '../translations';
 import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
+import { useKibana } from '../hooks/use_kibana';
+import { EIS_TOUR_ENABLED_FEATURE_FLAG_ID } from '../constants';
 
 /**
  * Props for the EisCloudConnectPromoTour component.
@@ -67,12 +69,28 @@ export const EisCloudConnectPromoTour = ({
   children,
 }: EisCloudConnectPromoTourProps) => {
   const { euiTheme } = useEuiTheme();
+  const {
+    services: { application, uiSettings },
+  } = useKibana();
+  // Setting to enable hiding the tour for FTR tests
+  const isEISTourEnabled = uiSettings?.get<boolean>(EIS_TOUR_ENABLED_FEATURE_FLAG_ID, true);
   const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
     promoId: `${promoId}CloudConnectTour`,
   });
+
   const dataId = `${promoId}-cloud-connect-promo-tour`;
 
-  if (!isPromoVisible || !isReady || !isSelfManaged) {
+  const hasCloudConnectPermission = Boolean(
+    application.capabilities.cloudConnect?.show || application.capabilities.cloudConnect?.configure
+  );
+
+  if (
+    !isPromoVisible ||
+    !isReady ||
+    !isSelfManaged ||
+    !hasCloudConnectPermission ||
+    !isEISTourEnabled
+  ) {
     return children;
   }
 

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.tsx
@@ -19,7 +19,7 @@ import {
 import {
   EIS_TOUR_DISMISS,
   EIS_CLOUD_CONNECT_PROMO_TOUR_CTA,
-  EIS_CLOUD_CONNECT_PROMO_TOUR_DESCRIPTION,
+  EIS_CLOUD_CONNECT_PROMO_DESCRIPTION,
   EIS_CLOUD_CONNECT_PROMO_TOUR_TITLE,
 } from '../translations';
 import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
@@ -70,7 +70,7 @@ export const EisCloudConnectPromoTour = ({
   const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
     promoId: `${promoId}CloudConnectTour`,
   });
-  const dataId = `${promoId}-eis-cloud-connect-promo-tour`;
+  const dataId = `${promoId}-cloud-connect-promo-tour`;
 
   if (!isPromoVisible || !isReady || !isSelfManaged) {
     return children;
@@ -84,7 +84,7 @@ export const EisCloudConnectPromoTour = ({
       maxWidth={`${euiTheme.base * 25}px`}
       content={
         <EuiText>
-          <p>{EIS_CLOUD_CONNECT_PROMO_TOUR_DESCRIPTION}</p>
+          <p>{EIS_CLOUD_CONNECT_PROMO_DESCRIPTION}</p>
         </EuiText>
       }
       display="block"
@@ -100,7 +100,6 @@ export const EisCloudConnectPromoTour = ({
         <EuiButton
           onClick={navigateToApp}
           data-test-subj="eisCloudConnectPromoTourCtaBtn"
-          target="_blank"
           iconSide="right"
           iconType="popout"
         >

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_callout.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_callout.tsx
@@ -42,12 +42,11 @@ export const EisPromotionalCallout = ({
 }: EisPromotionalCalloutProps) => {
   const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
     promoId: `${promoId}Callout`,
-    isCloudEnabled,
   });
 
   const dataId = `${promoId}-eis-promo-callout`;
 
-  if (!isPromoVisible) {
+  if (!isPromoVisible || !isCloudEnabled) {
     return null;
   }
 

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.tsx
@@ -42,11 +42,10 @@ export const EisPromotionalTour = ({
   const { euiTheme } = useEuiTheme();
   const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
     promoId: `${promoId}Tour`,
-    isCloudEnabled,
   });
   const dataId = `${promoId}-eis-promo-tour`;
 
-  if (!isPromoVisible) {
+  if (!isPromoVisible || !isCloudEnabled) {
     return children;
   }
 

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_update_callout.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_update_callout.test.tsx
@@ -102,6 +102,13 @@ describe('EisUpdateCallout', () => {
     expect(panel).not.toBeInTheDocument();
   });
 
+  it('does not render callout when user is not on cloud', () => {
+    renderEisUpdateCallout({ isCloudEnabled: false });
+
+    const panel = screen.queryByTestId(dataId);
+    expect(panel).not.toBeInTheDocument();
+  });
+
   it('does not render callout when user does not have update privileges', () => {
     renderEisUpdateCallout({ hasUpdatePrivileges: false });
 

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_update_callout.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_update_callout.tsx
@@ -41,12 +41,11 @@ export const EisUpdateCallout = ({
 }: EisUpdateCalloutProps) => {
   const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
     promoId: `${promoId}UpdateCallout`,
-    isCloudEnabled,
   });
 
   const dataId = `${promoId}-eis-update-callout`;
 
-  if (!isPromoVisible || hasUpdatePrivileges === false) {
+  if (!isPromoVisible || !isCloudEnabled || hasUpdatePrivileges === false) {
     return null;
   }
 

--- a/src/platform/packages/shared/kbn-search-api-panels/constants.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/constants.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const EIS_TOUR_ENABLED_FEATURE_FLAG_ID = 'eisPromotionalTour:enabled';

--- a/src/platform/packages/shared/kbn-search-api-panels/hooks/use_kibana.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/hooks/use_kibana.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useKibana as _useKibana } from '@kbn/kibana-react-plugin/public';
+import type { SearchApiPanelsServicesContext } from '../types';
+
+export const useKibana = () => _useKibana<SearchApiPanelsServicesContext>();

--- a/src/platform/packages/shared/kbn-search-api-panels/hooks/use_show_eis_promotional_content.test.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/hooks/use_show_eis_promotional_content.test.ts
@@ -19,36 +19,16 @@ describe('useShowEisPromotionalContent', () => {
     jest.clearAllMocks();
   });
 
-  it('should show the promo when cloud is enabled and promo is not skipped', () => {
-    const { result } = renderHook(() =>
-      useShowEisPromotionalContent({ promoId, isCloudEnabled: true })
-    );
-
-    expect(result.current.isPromoVisible).toBe(true);
-  });
-
-  it('should not show the promo when cloud is disabled (not a cloud user)', () => {
-    const { result } = renderHook(() =>
-      useShowEisPromotionalContent({ promoId, isCloudEnabled: false })
-    );
-
-    expect(result.current.isPromoVisible).toBe(false);
-  });
-
   it('should not show the promo if it was skipped previously', () => {
     localStorage.setItem(localStorageKey, 'true');
 
-    const { result } = renderHook(() =>
-      useShowEisPromotionalContent({ promoId, isCloudEnabled: true })
-    );
+    const { result } = renderHook(() => useShowEisPromotionalContent({ promoId }));
 
     expect(result.current.isPromoVisible).toBe(false);
   });
 
   it('should hide the promo and set localStorage when onDismissTour is called', () => {
-    const { result } = renderHook(() =>
-      useShowEisPromotionalContent({ promoId, isCloudEnabled: true })
-    );
+    const { result } = renderHook(() => useShowEisPromotionalContent({ promoId }));
 
     expect(result.current.isPromoVisible).toBe(true);
 
@@ -64,15 +44,15 @@ describe('useShowEisPromotionalContent', () => {
     localStorage.setItem(localStorageKey, 'true');
 
     const { result, rerender } = renderHook(
-      (props: { promoId: string; isCloudEnabled: boolean }) => useShowEisPromotionalContent(props),
+      (props: { promoId: string }) => useShowEisPromotionalContent(props),
       {
-        initialProps: { promoId, isCloudEnabled: true },
+        initialProps: { promoId },
       }
     );
 
     expect(result.current.isPromoVisible).toBe(false);
 
-    rerender({ promoId, isCloudEnabled: true });
+    rerender({ promoId });
 
     expect(result.current.isPromoVisible).toBe(false);
   });

--- a/src/platform/packages/shared/kbn-search-api-panels/hooks/use_show_eis_promotional_content.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/hooks/use_show_eis_promotional_content.ts
@@ -11,13 +11,9 @@ import { useCallback, useEffect, useState } from 'react';
 
 interface UseShowEisPromotionalContentProps {
   promoId: string;
-  isCloudEnabled: boolean;
 }
 
-export const useShowEisPromotionalContent = ({
-  promoId,
-  isCloudEnabled,
-}: UseShowEisPromotionalContentProps) => {
+export const useShowEisPromotionalContent = ({ promoId }: UseShowEisPromotionalContentProps) => {
   const localStorageKey = `${promoId}Closed`;
   const [isPromoVisible, setIsPromoVisible] = useState<boolean>(false);
   const onDismissTour = useCallback(() => {
@@ -28,10 +24,10 @@ export const useShowEisPromotionalContent = ({
   useEffect(() => {
     const isTourDismiss = localStorage.getItem(localStorageKey) === 'true';
 
-    if (!isTourDismiss && isCloudEnabled && !isPromoVisible) {
+    if (!isTourDismiss && !isPromoVisible) {
       setIsPromoVisible(true);
     }
-  }, [isCloudEnabled, isPromoVisible, localStorageKey]);
+  }, [isPromoVisible, localStorageKey]);
 
   return { isPromoVisible, onDismissTour };
 };

--- a/src/platform/packages/shared/kbn-search-api-panels/index.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/index.tsx
@@ -14,6 +14,7 @@ export * from './components/eis_promotional_callout';
 export * from './components/eis_token_cost_tour';
 export * from './components/eis_update_callout';
 export * from './components/eis_ccm_promotional_tour';
+export * from './components/eis_ccm_promotional_callout';
 
 export * from './types';
 export * from './utils';

--- a/src/platform/packages/shared/kbn-search-api-panels/index.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/index.tsx
@@ -13,6 +13,7 @@ export * from './components/eis_promotional_tour';
 export * from './components/eis_promotional_callout';
 export * from './components/eis_token_cost_tour';
 export * from './components/eis_update_callout';
+export * from './components/eis_ccm_promotional_tour';
 
 export * from './types';
 export * from './utils';

--- a/src/platform/packages/shared/kbn-search-api-panels/moon.yml
+++ b/src/platform/packages/shared/kbn-search-api-panels/moon.yml
@@ -24,6 +24,8 @@ dependsOn:
   - '@kbn/console-plugin'
   - '@kbn/try-in-console'
   - '@kbn/test-jest-helpers'
+  - '@kbn/kibana-react-plugin'
+  - '@kbn/core'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/kbn-search-api-panels/translations.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/translations.ts
@@ -19,6 +19,13 @@ export const EIS_PROMO_TOUR_TITLE = i18n.translate('searchApiPanels.eisPromotion
   defaultMessage: 'Elastic Inference Service endpoints available',
 });
 
+export const EIS_CLOUD_CONNECT_PROMO_TOUR_TITLE = i18n.translate(
+  'searchApiPanels.eisPromotion.cloudConnect.tour.title',
+  {
+    defaultMessage: 'Elastic Inference Service now available for self-managed clusters',
+  }
+);
+
 export const EIS_COSTS_TOUR_TITLE = i18n.translate('searchApiPanels.eisCosts.tour.title', {
   defaultMessage: 'Elastic Inference Service (EIS) now available',
 });
@@ -41,6 +48,14 @@ export const EIS_PROMO_TOUR_DESCRIPTION = i18n.translate(
   'searchApiPanels.eisPromotion.tour.description',
   {
     defaultMessage: 'Use GPUs for inference tasks through the Elastic Inference Service endpoints.',
+  }
+);
+
+export const EIS_CLOUD_CONNECT_PROMO_TOUR_DESCRIPTION = i18n.translate(
+  'searchApiPanels.eisPromotion.cloudConnect.tour.description',
+  {
+    defaultMessage:
+      'Connect your self-managed cluster to Elastic Cloud and use GPUs for inference tasks through the Elastic Inference Service.',
   }
 );
 
@@ -76,6 +91,12 @@ export const EIS_TOUR_CTA = i18n.translate('searchApiPanels.eis.tour.cta', {
 export const EIS_UPDATE_CALLOUT_CTA = i18n.translate('searchApiPanels.eisUpdate.callout.cta', {
   defaultMessage: 'Update to ELSER on EIS',
 });
+export const EIS_CLOUD_CONNECT_PROMO_TOUR_CTA = i18n.translate(
+  'searchApiPanels.eisPromotion.cloudConnect.tour.cta',
+  {
+    defaultMessage: 'Connect your cluster',
+  }
+);
 
 // DISMISS BUTTON
 

--- a/src/platform/packages/shared/kbn-search-api-panels/translations.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/translations.ts
@@ -51,7 +51,7 @@ export const EIS_PROMO_TOUR_DESCRIPTION = i18n.translate(
   }
 );
 
-export const EIS_CLOUD_CONNECT_PROMO_TOUR_DESCRIPTION = i18n.translate(
+export const EIS_CLOUD_CONNECT_PROMO_DESCRIPTION = i18n.translate(
   'searchApiPanels.eisPromotion.cloudConnect.tour.description',
   {
     defaultMessage:

--- a/src/platform/packages/shared/kbn-search-api-panels/tsconfig.json
+++ b/src/platform/packages/shared/kbn-search-api-panels/tsconfig.json
@@ -23,6 +23,8 @@
     "@kbn/share-plugin",
     "@kbn/console-plugin",
     "@kbn/try-in-console",
-    "@kbn/test-jest-helpers"
+    "@kbn/test-jest-helpers",
+    "@kbn/kibana-react-plugin",
+    "@kbn/core"
   ]
 }

--- a/src/platform/packages/shared/kbn-search-api-panels/types.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/types.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { ApplicationStart, IUiSettingsClient } from '@kbn/core/public';
+
 export enum Languages {
   JAVA = 'java',
   JAVASCRIPT = 'javascript',
@@ -49,4 +51,9 @@ export interface LanguageDefinition {
     label: string;
   };
   languageStyling?: string;
+}
+
+export interface SearchApiPanelsServicesContext {
+  application: ApplicationStart;
+  uiSettings: IUiSettingsClient;
 }

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/moon.yml
@@ -33,6 +33,7 @@ dependsOn:
   - '@kbn/search-api-panels'
   - '@kbn/kibana-react-plugin'
   - '@kbn/cloud-plugin'
+  - '@kbn/deeplinks-management'
 tags:
   - shared-browser
   - package

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/moon.yml
@@ -30,6 +30,9 @@ dependsOn:
   - '@kbn/spaces-plugin'
   - '@kbn/projects-solutions-groups'
   - '@kbn/react-query'
+  - '@kbn/search-api-panels'
+  - '@kbn/kibana-react-plugin'
+  - '@kbn/cloud-plugin'
 tags:
   - shared-browser
   - package

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_flyout_wrapper.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_flyout_wrapper.tsx
@@ -102,6 +102,7 @@ interface InferenceFlyoutWrapperProps {
   enforceAdaptiveAllocations?: boolean;
   onSubmitSuccess?: (inferenceId: string) => void;
   inferenceEndpoint?: InferenceEndpoint;
+  enableEisPromoTour?: boolean;
 }
 
 export const InferenceFlyoutWrapper: React.FC<InferenceFlyoutWrapperProps> = ({
@@ -112,6 +113,7 @@ export const InferenceFlyoutWrapper: React.FC<InferenceFlyoutWrapperProps> = ({
   enforceAdaptiveAllocations = false,
   onSubmitSuccess,
   inferenceEndpoint,
+  enableEisPromoTour,
 }) => {
   const inferenceCreationFlyoutId = useGeneratedHtmlId({
     prefix: 'InferenceFlyoutId',
@@ -176,6 +178,7 @@ export const InferenceFlyoutWrapper: React.FC<InferenceFlyoutWrapperProps> = ({
               enforceAdaptiveAllocations,
               isPreconfigured,
               reenterSecretsOnEdit: false,
+              enableEisPromoTour,
             }}
           />
           <EuiSpacer size="m" />

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_service_form_fields.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_service_form_fields.tsx
@@ -550,7 +550,7 @@ export const InferenceServiceFormFields: React.FC<InferenceServicesProps> = ({
           return (
             <EisCloudConnectPromoTour
               promoId="eisInferenceEndpointFlyout"
-              // TODO: Replace with cloud connect deep link once this PR is merged: https://github.com/elastic/kibana/pull/245950/
+              // TODO: Replace app string with cloud connect deep link once this PR is merged: https://github.com/elastic/kibana/pull/245950/
               navigateToApp={() => application.navigateToApp('cloud_connect')}
               isSelfManaged={!cloud?.isCloudEnabled}
               isReady={isFlyoutOpen}

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_service_form_fields.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_service_form_fields.tsx
@@ -31,6 +31,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { ConnectorFormSchema } from '@kbn/triggers-actions-ui-plugin/public';
 import type { HttpSetup, IToasts } from '@kbn/core/public';
 import { EisCloudConnectPromoTour } from '@kbn/search-api-panels';
+import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 import * as LABELS from '../translations';
 import type { Config, ConfigEntryView, InferenceProvider, Secrets } from '../types/types';
 import { FieldType, isMapWithStringValues } from '../types/types';
@@ -550,8 +551,7 @@ export const InferenceServiceFormFields: React.FC<InferenceServicesProps> = ({
           return (
             <EisCloudConnectPromoTour
               promoId="eisInferenceEndpointFlyout"
-              // TODO: Replace app string with cloud connect deep link once this PR is merged: https://github.com/elastic/kibana/pull/245950/
-              navigateToApp={() => application.navigateToApp('cloud_connect')}
+              navigateToApp={() => application.navigateToApp(CLOUD_CONNECT_NAV_ID)}
               isSelfManaged={!cloud?.isCloudEnabled}
               isReady={isFlyoutOpen}
             >

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_service_form_fields.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_service_form_fields.tsx
@@ -105,6 +105,7 @@ interface InferenceServicesProps {
     allowContextWindowLength?: boolean;
     reenterSecretsOnEdit?: boolean;
     allowTemperature?: boolean;
+    enableEisPromoTour?: boolean;
   };
   http: HttpSetup;
   toasts: IToasts;
@@ -121,6 +122,7 @@ export const InferenceServiceFormFields: React.FC<InferenceServicesProps> = ({
     isPreconfigured,
     currentSolution,
     reenterSecretsOnEdit,
+    enableEisPromoTour,
   },
 }) => {
   const {
@@ -548,47 +550,52 @@ export const InferenceServiceFormFields: React.FC<InferenceServicesProps> = ({
         {(field) => {
           const { isInvalid, errorMessage } = getFieldValidityAndErrorMessage(field);
           const selectInput = providerSuperSelect(isInvalid);
-          return (
+          const formRow = (
+            <EuiFormRow
+              id="providerSelectBox"
+              fullWidth
+              label={
+                <FormattedMessage
+                  id="xpack.inferenceEndpointUICommon.components.serviceLabel"
+                  defaultMessage="Service"
+                />
+              }
+              isInvalid={isInvalid}
+              error={errorMessage}
+            >
+              <>
+                <EuiSpacer size="s" />
+                <EuiInputPopover
+                  id={'providerInputPopoverId'}
+                  fullWidth
+                  input={selectInput}
+                  isOpen={isProviderPopoverOpen}
+                  closePopover={closeProviderPopover}
+                  className="rightArrowIcon"
+                >
+                  <SelectableProvider
+                    currentSolution={currentSolution}
+                    providers={updatedProviders ?? []}
+                    onClosePopover={closeProviderPopover}
+                    onProviderChange={onProviderChange}
+                    onSolutionFilterChange={toggleAndApplyFilter}
+                    solutionFilter={solutionFilter}
+                  />
+                </EuiInputPopover>
+              </>
+            </EuiFormRow>
+          );
+          return enableEisPromoTour ? (
             <EisCloudConnectPromoTour
               promoId="eisInferenceEndpointFlyout"
               navigateToApp={() => application.navigateToApp(CLOUD_CONNECT_NAV_ID)}
               isSelfManaged={!cloud?.isCloudEnabled}
               isReady={isFlyoutOpen}
             >
-              <EuiFormRow
-                id="providerSelectBox"
-                fullWidth
-                label={
-                  <FormattedMessage
-                    id="xpack.inferenceEndpointUICommon.components.serviceLabel"
-                    defaultMessage="Service"
-                  />
-                }
-                isInvalid={isInvalid}
-                error={errorMessage}
-              >
-                <>
-                  <EuiSpacer size="s" />
-                  <EuiInputPopover
-                    id={'providerInputPopoverId'}
-                    fullWidth
-                    input={selectInput}
-                    isOpen={isProviderPopoverOpen}
-                    closePopover={closeProviderPopover}
-                    className="rightArrowIcon"
-                  >
-                    <SelectableProvider
-                      currentSolution={currentSolution}
-                      providers={updatedProviders ?? []}
-                      onClosePopover={closeProviderPopover}
-                      onProviderChange={onProviderChange}
-                      onSolutionFilterChange={toggleAndApplyFilter}
-                      solutionFilter={solutionFilter}
-                    />
-                  </EuiInputPopover>
-                </>
-              </EuiFormRow>
+              {formRow}
             </EisCloudConnectPromoTour>
+          ) : (
+            formRow
           );
         }}
       </UseField>

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/hooks/use_kibana.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/hooks/use_kibana.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { InferenceEndpointUiCommonPluginStartDependencies } from '../types/types';
+
+const useTypedKibana = () => useKibana<InferenceEndpointUiCommonPluginStartDependencies>();
+
+export { useTypedKibana as useKibana };

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/types/types.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/types/types.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { ApplicationStart } from '@kbn/core/public';
+import type { CloudStart } from '@kbn/cloud-plugin/public';
 import type { ConfigProperties } from './dynamic_config/types';
 
 interface ConfigEntry extends ConfigProperties {
@@ -76,4 +78,9 @@ export function isMapWithStringValues(value: unknown): value is Map {
     value !== null &&
     Object.values(value).every((v) => typeof v === 'string')
   );
+}
+
+export interface InferenceEndpointUiCommonPluginStartDependencies {
+  application: ApplicationStart;
+  cloud?: CloudStart;
 }

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/tsconfig.json
@@ -31,6 +31,7 @@
     "@kbn/react-query",
     "@kbn/search-api-panels",
     "@kbn/kibana-react-plugin",
-    "@kbn/cloud-plugin"
+    "@kbn/cloud-plugin",
+    "@kbn/deeplinks-management"
   ]
 }

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/tsconfig.json
@@ -28,6 +28,9 @@
     "@kbn/core-notifications-browser-mocks",
     "@kbn/spaces-plugin",
     "@kbn/projects-solutions-groups",
-    "@kbn/react-query"
+    "@kbn/react-query",
+    "@kbn/search-api-panels",
+    "@kbn/kibana-react-plugin",
+    "@kbn/cloud-plugin"
   ]
 }

--- a/x-pack/platform/plugins/shared/index_management/moon.yml
+++ b/x-pack/platform/plugins/shared/index_management/moon.yml
@@ -73,6 +73,7 @@ dependsOn:
   - '@kbn/failure-store-modal'
   - '@kbn/react-query'
   - '@kbn/scout'
+  - '@kbn/deeplinks-management'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_empty_mappings.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_empty_mappings.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { documentationService } from '../../../../services/documentation';
 
 interface EmptyMappingsProps {
-  addFieldButton: React.ReactElement;
+  addFieldButton: React.ReactNode;
 }
 
 export const EmptyMappingsContent: React.FC<EmptyMappingsProps> = ({ addFieldButton }) => {

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content/mappings_information_panels.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content/mappings_information_panels.tsx
@@ -19,7 +19,11 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EisPromotionalCallout, EisUpdateCallout } from '@kbn/search-api-panels';
+import {
+  EisCloudConnectPromoCallout,
+  EisPromotionalCallout,
+  EisUpdateCallout,
+} from '@kbn/search-api-panels';
 
 import { documentationService } from '../../../../../services';
 import { useAppContext } from '../../../../../app_context';
@@ -43,6 +47,7 @@ export const MappingsInformationPanels = ({
 }: MappingsInformationPanelsProps) => {
   const {
     plugins: { cloud },
+    core: { application },
   } = useAppContext();
   const state = useMappingsState();
 
@@ -87,6 +92,13 @@ export const MappingsInformationPanels = ({
             )}
           </>
         )}
+        <EisCloudConnectPromoCallout
+          promoId="indexDetailsMappings"
+          isSelfManaged={!cloud?.isCloudEnabled}
+          direction="column"
+          // TODO: Replace app string with cloud connect deep link once this PR is merged: https://github.com/elastic/kibana/pull/245950/
+          navigateToApp={() => application.navigateToApp('cloud_connect')}
+        />
         <EuiPanel grow={false} paddingSize="l" hasShadow={false} hasBorder>
           <EuiFlexGroup alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content/mappings_information_panels.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content/mappings_information_panels.tsx
@@ -24,6 +24,7 @@ import {
   EisPromotionalCallout,
   EisUpdateCallout,
 } from '@kbn/search-api-panels';
+import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 
 import { documentationService } from '../../../../../services';
 import { useAppContext } from '../../../../../app_context';
@@ -96,8 +97,7 @@ export const MappingsInformationPanels = ({
           promoId="indexDetailsMappings"
           isSelfManaged={!cloud?.isCloudEnabled}
           direction="column"
-          // TODO: Replace app string with cloud connect deep link once this PR is merged: https://github.com/elastic/kibana/pull/245950/
-          navigateToApp={() => application.navigateToApp('cloud_connect')}
+          navigateToApp={() => application.navigateToApp(CLOUD_CONNECT_NAV_ID)}
         />
         <EuiPanel grow={false} paddingSize="l" hasShadow={false} hasBorder>
           <EuiFlexGroup alignItems="center" gutterSize="s">

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview.tsx
@@ -29,6 +29,7 @@ import {
   getConsoleRequest,
   EisCloudConnectPromoCallout,
 } from '@kbn/search-api-panels';
+import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 import type { Index } from '../../../../../../../common';
 import { useAppContext } from '../../../../../app_context';
 import { documentationService } from '../../../../../services';
@@ -87,8 +88,7 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
         promoId="indexDetailsOverview"
         isSelfManaged={!plugins.cloud?.isCloudEnabled}
         direction="row"
-        // TODO: Replace app string with cloud connect deep link once this PR is merged: https://github.com/elastic/kibana/pull/245950/
-        navigateToApp={() => core.application.navigateToApp('cloud_connect')}
+        navigateToApp={() => core.application.navigateToApp(CLOUD_CONNECT_NAV_ID)}
         addSpacer="bottom"
       />
       <EuiFlexGrid columns={isLarge ? 3 : 1}>

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview.tsx
@@ -27,6 +27,7 @@ import {
   CodeBox,
   getLanguageDefinitionCodeSnippet,
   getConsoleRequest,
+  EisCloudConnectPromoCallout,
 } from '@kbn/search-api-panels';
 import type { Index } from '../../../../../../../common';
 import { useAppContext } from '../../../../../app_context';
@@ -82,6 +83,14 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
 
   return (
     <>
+      <EisCloudConnectPromoCallout
+        promoId="indexDetailsOverview"
+        isSelfManaged={!plugins.cloud?.isCloudEnabled}
+        direction="row"
+        // TODO: Replace app string with cloud connect deep link once this PR is merged: https://github.com/elastic/kibana/pull/245950/
+        navigateToApp={() => core.application.navigateToApp('cloud_connect')}
+        addSpacer="bottom"
+      />
       <EuiFlexGrid columns={isLarge ? 3 : 1}>
         <StorageDetails size={size} primarySize={primarySize} primary={primary} replica={replica} />
 

--- a/x-pack/platform/plugins/shared/index_management/tsconfig.json
+++ b/x-pack/platform/plugins/shared/index_management/tsconfig.json
@@ -66,7 +66,8 @@
     "@kbn/upgrade-assistant-pkg-common",
     "@kbn/failure-store-modal",
     "@kbn/react-query",
-    "@kbn/scout"
+    "@kbn/scout",
+    "@kbn/deeplinks-management"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/solutions/search/plugins/search_indices/moon.yml
+++ b/x-pack/solutions/search/plugins/search_indices/moon.yml
@@ -55,6 +55,7 @@ dependsOn:
   - '@kbn/licensing-plugin'
   - '@kbn/react-query'
   - '@kbn/search-api-panels'
+  - '@kbn/deeplinks-management'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/search/plugins/search_indices/moon.yml
+++ b/x-pack/solutions/search/plugins/search_indices/moon.yml
@@ -54,6 +54,7 @@ dependsOn:
   - '@kbn/licensing-types'
   - '@kbn/licensing-plugin'
   - '@kbn/react-query'
+  - '@kbn/search-api-panels'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
@@ -15,8 +15,10 @@ import {
   EuiSpacer,
   EuiHorizontalRule,
 } from '@elastic/eui';
+import { EisCloudConnectPromoCallout } from '@kbn/search-api-panels';
 
 import type { UserStartPrivilegesResponse } from '../../../common';
+import { useKibana } from '../../hooks/use_kibana';
 import { useIndexMapping } from '../../hooks/api/use_index_mappings';
 import type { IndexDocuments as IndexDocumentsType } from '../../hooks/api/use_document_search';
 import { IndexDocuments } from '../index_documents/index_documents';
@@ -37,6 +39,7 @@ export const IndexDetailsData = ({
   navigateToPlayground,
   userPrivileges,
 }: IndexDetailsDataProps) => {
+  const { application, cloud } = useKibana().services;
   const { data: mappingData } = useIndexMapping(indexName);
   const documents = indexDocuments?.results?.data ?? [];
 
@@ -50,31 +53,41 @@ export const IndexDetailsData = ({
   }
 
   return (
-    <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none">
-      <EuiSpacer />
-      <EuiFlexGroup direction="column" gutterSize="s">
-        {documents.length > 0 && (
-          <>
-            <EuiFlexItem>
-              <IndexSearchExample
-                indexName={indexName}
-                documents={documents}
-                mappings={mappingData}
-                navigateToPlayground={navigateToPlayground}
-              />
-            </EuiFlexItem>
-            <EuiHorizontalRule />
-          </>
-        )}
-        <EuiFlexItem>
-          <IndexDocuments
-            indexName={indexName}
-            documents={documents}
-            mappings={mappingData}
-            userPrivileges={userPrivileges}
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiPanel>
+    <>
+      <EisCloudConnectPromoCallout
+        promoId="indexDetailsData"
+        isSelfManaged={!cloud?.isCloudEnabled}
+        direction="row"
+        // TODO: Replace app string with cloud connect deep link once this PR is merged: https://github.com/elastic/kibana/pull/245950/
+        navigateToApp={() => application.navigateToApp('cloud_connect')}
+        addSpacer="top"
+      />
+      <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none">
+        <EuiSpacer />
+        <EuiFlexGroup direction="column" gutterSize="s">
+          {documents.length > 0 && (
+            <>
+              <EuiFlexItem>
+                <IndexSearchExample
+                  indexName={indexName}
+                  documents={documents}
+                  mappings={mappingData}
+                  navigateToPlayground={navigateToPlayground}
+                />
+              </EuiFlexItem>
+              <EuiHorizontalRule />
+            </>
+          )}
+          <EuiFlexItem>
+            <IndexDocuments
+              indexName={indexName}
+              documents={documents}
+              mappings={mappingData}
+              userPrivileges={userPrivileges}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+    </>
   );
 };

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
@@ -16,6 +16,7 @@ import {
   EuiHorizontalRule,
 } from '@elastic/eui';
 import { EisCloudConnectPromoCallout } from '@kbn/search-api-panels';
+import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 
 import type { UserStartPrivilegesResponse } from '../../../common';
 import { useKibana } from '../../hooks/use_kibana';
@@ -58,8 +59,7 @@ export const IndexDetailsData = ({
         promoId="indexDetailsData"
         isSelfManaged={!cloud?.isCloudEnabled}
         direction="row"
-        // TODO: Replace app string with cloud connect deep link once this PR is merged: https://github.com/elastic/kibana/pull/245950/
-        navigateToApp={() => application.navigateToApp('cloud_connect')}
+        navigateToApp={() => application.navigateToApp(CLOUD_CONNECT_NAV_ID)}
         addSpacer="top"
       />
       <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none">

--- a/x-pack/solutions/search/plugins/search_indices/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_indices/tsconfig.json
@@ -48,6 +48,7 @@
     "@kbn/licensing-plugin",
     "@kbn/react-query",
     "@kbn/search-api-panels",
+    "@kbn/deeplinks-management",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/solutions/search/plugins/search_indices/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_indices/tsconfig.json
@@ -47,6 +47,7 @@
     "@kbn/licensing-types",
     "@kbn/licensing-plugin",
     "@kbn/react-query",
+    "@kbn/search-api-panels",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/add_inference_endpoints/add_inference_flyout_wrapper.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/add_inference_endpoints/add_inference_flyout_wrapper.tsx
@@ -38,6 +38,7 @@ export const AddInferenceFlyoutWrapper: React.FC<AddInferenceFlyoutWrapperProps>
       enforceAdaptiveAllocations={!!serverless}
       toasts={toasts}
       onSubmitSuccess={onSubmitSuccess}
+      enableEisPromoTour={true}
     />
   );
 };

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { act, screen } from '@testing-library/react';
 import { render } from '@testing-library/react';
+import { EuiThemeProvider } from '@elastic/eui';
 import { TabularPage } from './tabular_page';
 import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 
@@ -131,9 +132,43 @@ jest.mock('../../hooks/use_delete_endpoint', () => ({
   }),
 }));
 
+jest.mock('@kbn/kibana-react-plugin/public', () => {
+  const actual = jest.requireActual('@kbn/kibana-react-plugin/public');
+  return {
+    ...actual,
+    useKibana: jest.fn(() => ({
+      services: {
+        cloud: {
+          isCloudEnabled: false,
+        },
+        application: {
+          capabilities: {
+            cloudConnect: {
+              show: true,
+              configure: true,
+            },
+          },
+          navigateToApp: jest.fn(),
+        },
+        uiSettings: {
+          get: jest.fn().mockReturnValue(true),
+        },
+      },
+    })),
+  };
+});
+
+const renderTabularPageWithProviders = () => {
+  return render(
+    <EuiThemeProvider>
+      <TabularPage inferenceEndpoints={inferenceEndpoints} />
+    </EuiThemeProvider>
+  );
+};
+
 describe('When the tabular page is loaded', () => {
   it('should display all inference ids in the table', () => {
-    render(<TabularPage inferenceEndpoints={inferenceEndpoints} />);
+    renderTabularPageWithProviders();
 
     const rows = screen.getAllByRole('row');
     expect(rows[1]).toHaveTextContent('.elser-2-elastic');
@@ -151,7 +186,7 @@ describe('When the tabular page is loaded', () => {
 
   // Caveat: preconfigured endpoints display a description instead of model id
   it('should display all service and model ids or descriptions in the table', () => {
-    render(<TabularPage inferenceEndpoints={inferenceEndpoints} />);
+    renderTabularPageWithProviders();
 
     const rows = screen.getAllByRole('row');
     expect(rows[1]).toHaveTextContent('Elastic');
@@ -191,7 +226,7 @@ describe('When the tabular page is loaded', () => {
   });
 
   it('should only disable delete action for preconfigured endpoints', () => {
-    render(<TabularPage inferenceEndpoints={inferenceEndpoints} />);
+    renderTabularPageWithProviders();
 
     act(() => {
       screen.getAllByTestId('euiCollapsedItemActionsButton')[0].click();
@@ -203,7 +238,7 @@ describe('When the tabular page is loaded', () => {
   });
 
   it('should not disable delete action for other endpoints', () => {
-    render(<TabularPage inferenceEndpoints={inferenceEndpoints} />);
+    renderTabularPageWithProviders();
 
     act(() => {
       screen.getAllByTestId('euiCollapsedItemActionsButton')[6].click();
@@ -215,7 +250,7 @@ describe('When the tabular page is loaded', () => {
   });
 
   it('should show preconfigured badge only for preconfigured endpoints', () => {
-    render(<TabularPage inferenceEndpoints={inferenceEndpoints} />);
+    renderTabularPageWithProviders();
 
     const preconfigured = 'PRECONFIGURED';
 
@@ -234,7 +269,7 @@ describe('When the tabular page is loaded', () => {
   });
 
   it('should show tech preview badge only for reranker-v1 model, multilingual-embed-v1, rerank-v1, and preconfigured elser_model_2', () => {
-    render(<TabularPage inferenceEndpoints={inferenceEndpoints} />);
+    renderTabularPageWithProviders();
 
     const techPreview = 'TECH PREVIEW';
 

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
@@ -16,7 +16,7 @@ import type {
   InferenceTaskType,
 } from '@elastic/elasticsearch/lib/api/types';
 import type { ServiceProviderKeys } from '@kbn/inference-endpoint-ui-common';
-import { EisPromotionalCallout } from '@kbn/search-api-panels';
+import { EisCloudConnectPromoCallout, EisPromotionalCallout } from '@kbn/search-api-panels';
 import * as i18n from '../../../common/translations';
 
 import { useTableData } from '../../hooks/use_table_data';
@@ -41,7 +41,7 @@ interface TabularPageProps {
 
 export const TabularPage: React.FC<TabularPageProps> = ({ inferenceEndpoints }) => {
   const {
-    services: { notifications, cloud },
+    services: { notifications, cloud, application },
   } = useKibana();
   const toasts = notifications?.toasts;
   const [showDeleteAction, setShowDeleteAction] = useState(false);
@@ -232,6 +232,13 @@ export const TabularPage: React.FC<TabularPageProps> = ({ inferenceEndpoints }) 
           isCloudEnabled={cloud?.isCloudEnabled ?? false}
           ctaLink={docLinks.elasticInferenceService}
           direction="row"
+        />
+        <EisCloudConnectPromoCallout
+          promoId="inferenceEndpointManagement"
+          isSelfManaged={!cloud?.isCloudEnabled}
+          direction="row"
+          // TODO: Replace app string with cloud connect deep link once this PR is merged: https://github.com/elastic/kibana/pull/245950/
+          navigateToApp={() => application.navigateToApp('cloud_connect')}
         />
         <EuiFlexItem>
           <EuiFlexGroup gutterSize="s">

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
@@ -17,6 +17,7 @@ import type {
 } from '@elastic/elasticsearch/lib/api/types';
 import type { ServiceProviderKeys } from '@kbn/inference-endpoint-ui-common';
 import { EisCloudConnectPromoCallout, EisPromotionalCallout } from '@kbn/search-api-panels';
+import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 import * as i18n from '../../../common/translations';
 
 import { useTableData } from '../../hooks/use_table_data';
@@ -237,8 +238,7 @@ export const TabularPage: React.FC<TabularPageProps> = ({ inferenceEndpoints }) 
           promoId="inferenceEndpointManagement"
           isSelfManaged={!cloud?.isCloudEnabled}
           direction="row"
-          // TODO: Replace app string with cloud connect deep link once this PR is merged: https://github.com/elastic/kibana/pull/245950/
-          navigateToApp={() => application.navigateToApp('cloud_connect')}
+          navigateToApp={() => application.navigateToApp(CLOUD_CONNECT_NAV_ID)}
         />
         <EuiFlexItem>
           <EuiFlexGroup gutterSize="s">

--- a/x-pack/solutions/search/test/functional_search/config.ts
+++ b/x-pack/solutions/search/test/functional_search/config.ts
@@ -34,6 +34,13 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         'xpack.security.enabled=true',
       ],
     },
+    kbnTestServer: {
+      ...functionalConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...functionalConfig.get('kbnTestServer.serverArgs'),
+        `--uiSettings.overrides.eisPromotionalTour:enabled=false`,
+      ],
+    },
     testFiles: [require.resolve('.')],
     screenshots: { directory: resolve(__dirname, '../screenshots') },
     apps: {

--- a/x-pack/solutions/search/test/functional_search/config/config.basic.ts
+++ b/x-pack/solutions/search/test/functional_search/config/config.basic.ts
@@ -8,15 +8,15 @@
 import type { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
-  const searchFuncationalConfig = await readConfigFile(require.resolve('../config'));
+  const searchFunctionalConfig = await readConfigFile(require.resolve('../config'));
 
   return {
-    ...searchFuncationalConfig.getAll(),
+    ...searchFunctionalConfig.getAll(),
     junit: {
       reportName: 'Search Solution Functional Tests - Basic License',
     },
     esTestCluster: {
-      ...searchFuncationalConfig.get('esTestCluster'),
+      ...searchFunctionalConfig.get('esTestCluster'),
       license: 'basic',
       serverArgs: [
         'xpack.license.self_generated.type=basic',

--- a/x-pack/solutions/search/test/functional_search/config/config.feature_flags.ts
+++ b/x-pack/solutions/search/test/functional_search/config/config.feature_flags.ts
@@ -10,18 +10,18 @@ import type { FtrConfigProviderContext } from '@kbn/test';
 import { pageObjects } from '../page_objects';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
-  const searchFuncationalConfig = await readConfigFile(require.resolve('../config'));
+  const searchFunctionalConfig = await readConfigFile(require.resolve('../config'));
 
   return {
-    ...searchFuncationalConfig.getAll(),
+    ...searchFunctionalConfig.getAll(),
     pageObjects,
     junit: {
       reportName: 'Search Solution UI Functional Tests w/ Feature Flagged Features',
     },
     kbnTestServer: {
-      ...searchFuncationalConfig.get('kbnTestServer'),
+      ...searchFunctionalConfig.get('kbnTestServer'),
       serverArgs: [
-        ...searchFuncationalConfig.get('kbnTestServer.serverArgs'),
+        ...searchFunctionalConfig.get('kbnTestServer.serverArgs'),
         '--xpack.spaces.defaultSolution=es', // Default to Search Solution
         `--uiSettings.overrides.searchPlayground:searchModeEnabled=true`,
         `--uiSettings.overrides.agentBuilder:enabled=true`,
@@ -31,7 +31,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     // load tests in the index file
     testFiles: [require.resolve('../index.feature_flags.ts')],
     apps: {
-      ...searchFuncationalConfig.get('apps'),
+      ...searchFunctionalConfig.get('apps'),
     },
   };
 }

--- a/x-pack/solutions/search/test/functional_search/config/config.search_playground.ts
+++ b/x-pack/solutions/search/test/functional_search/config/config.search_playground.ts
@@ -8,17 +8,17 @@
 import type { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
-  const searchFuncationalConfig = await readConfigFile(require.resolve('../config'));
+  const searchFunctionalConfig = await readConfigFile(require.resolve('../config'));
 
   return {
-    ...searchFuncationalConfig.getAll(),
+    ...searchFunctionalConfig.getAll(),
     junit: {
       reportName: 'Search Solution Functional Tests - Apps - Search Playground',
     },
     kbnTestServer: {
-      ...searchFuncationalConfig.get('kbnTestServer'),
+      ...searchFunctionalConfig.get('kbnTestServer'),
       serverArgs: [
-        ...searchFuncationalConfig.get('kbnTestServer.serverArgs'),
+        ...searchFunctionalConfig.get('kbnTestServer.serverArgs'),
         '--xpack.spaces.defaultSolution=es', // Default to Search Solution
       ],
     },


### PR DESCRIPTION
## Summary

To promote Elastic Inference Service (EIS) to self-managed users, this PR adds a tour and callout encouraging the user to connect their cluster to cloud to use the service.

This PR also, removes the `isCloudEnabled` check from the `useShowEisPromotionalContent` hook and adds it directly to the tour and callouts. This is so that the tour for self-managed users can also use the hook to set local storage.

### Acceptance Criteria
For self-managed users only:
- [ ] Show a tour over the service select dropdown of the `Add inference endpoint flyout` promoting EIS, with two buttons: `Dismiss` and `Connect your cluster`
- [ ] Show a callout on the following touchpoints:
  - [ ] Inference endpoints management page
  - [ ] Index details overview/data tab
  - [ ] Index details mappings tab
- [ ] The `Connect your cluster` button navigates the Cloud Connect page
- [ ] If the `Dismiss` button is clicked, a local storage key is set to prevent it from being shown again

<img width="600" height="828" alt="Screenshot 2025-12-15 at 14 17 20" src="https://github.com/user-attachments/assets/216cd29a-59f8-48f1-a951-37d4e8a64662" />
<img width="600" height="825" alt="Screenshot 2025-12-15 at 14 15 36" src="https://github.com/user-attachments/assets/d6e9e148-de86-498b-a57d-f422e6327b16" />
<img width="600" height="824" alt="Screenshot 2025-12-15 at 14 16 18" src="https://github.com/user-attachments/assets/30adf41f-3917-4ef0-bdd5-a7f4def2aa16" />
<img width="600" height="824" alt="Screenshot 2025-12-15 at 14 16 36" src="https://github.com/user-attachments/assets/d4e932dc-6d8c-40ca-954e-31a9673f7244" />
<img width="400" height="822" alt="Screenshot 2025-12-15 at 19 47 35" src="https://github.com/user-attachments/assets/6a4f1fe2-f4fa-4462-af95-c49d917f5204" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~

