### PR TITLE
[9.2] Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-presentation` files (#245661)

### DIFF
--- a/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/clusters_table.tsx
+++ b/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/clusters_table.tsx
@@ -135,6 +135,9 @@ export function ClustersTable({ clusters }: Props) {
 
   return (
     <EuiBasicTable
+      tableCaption={i18n.translate('inspector.requests.clusters.table.caption', {
+        defaultMessage: 'Cluster details',
+      })}
       items={
         sortField
           ? items.sort(Comparators.property(sortField, Comparators.default(sortDirection)))

--- a/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/shards_view/shard_failure_table.tsx
+++ b/src/platform/plugins/shared/inspector/public/views/requests/components/details/clusters_view/clusters_table/shards_view/shard_failure_table.tsx
@@ -102,6 +102,9 @@ export function ShardFailureTable({ failures }: Props) {
 
   return (
     <EuiBasicTable
+      tableCaption={i18n.translate('inspector.requests.clusters.shards.table.caption', {
+        defaultMessage: 'Shard failures',
+      })}
       items={failures.map((failure) => {
         return {
           rowId: getRowId(failure),

--- a/x-pack/platform/plugins/private/canvas/public/components/home/my_workpads/workpad_table.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/home/my_workpads/workpad_table.component.tsx
@@ -141,6 +141,7 @@ export const WorkpadTable = ({
       items={workpads}
       columns={columns}
       message={strings.getNoWorkpadsFoundMessage()}
+      tableCaption={strings.getTableCaption()}
       search={search}
       sorting={{
         sort: {
@@ -182,6 +183,10 @@ const strings = {
   getWorkpadSearchPlaceholder: () =>
     i18n.translate('xpack.canvas.workpadTable.searchPlaceholder', {
       defaultMessage: 'Find workpad',
+    }),
+  getTableCaption: () =>
+    i18n.translate('xpack.canvas.workpadTable.table.caption', {
+      defaultMessage: 'Canvas workpads list',
     }),
   getTableCreatedColumnTitle: () =>
     i18n.translate('xpack.canvas.workpadTable.table.createdColumnTitle', {

--- a/x-pack/platform/plugins/private/canvas/public/components/home/workpad_templates/workpad_templates.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/home/workpad_templates/workpad_templates.component.tsx
@@ -111,6 +111,7 @@ export const WorkpadTemplates = ({ templates, onCreateWorkpad }: Props) => {
       }}
       pagination={true}
       data-test-subj="canvasTemplatesTable"
+      tableCaption={strings.getTableCaption()}
     />
   );
 };
@@ -122,6 +123,10 @@ const strings = {
       values: {
         templateName,
       },
+    }),
+  getTableCaption: () =>
+    i18n.translate('xpack.canvas.workpadTemplates.table.caption', {
+      defaultMessage: 'Workpad templates',
     }),
   getTableDescriptionColumnTitle: () =>
     i18n.translate('xpack.canvas.workpadTemplates.table.descriptionColumnTitle', {

--- a/x-pack/platform/plugins/private/canvas/public/components/var_config/var_config.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/var_config/var_config.tsx
@@ -95,6 +95,10 @@ const strings = {
     i18n.translate('xpack.canvas.varConfig.titleTooltip', {
       defaultMessage: 'Add variables to store and edit common values',
     }),
+  getTableCaption: () =>
+    i18n.translate('xpack.canvas.varConfig.tableCaption', {
+      defaultMessage: 'Canvas variables list',
+    }),
 };
 
 export const VarConfig: FC<Props> = ({
@@ -219,6 +223,7 @@ export const VarConfig: FC<Props> = ({
                 pagination={false}
                 sorting={true}
                 compressed
+                tableCaption={strings.getTableCaption()}
               />
             </div>
           )}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-presentation` files (#245661)](https://github.com/elastic/kibana/pull/245661)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexey Antonov","email":"alexwizp@gmail.com"},"sourceCommit":{"committedDate":"2025-12-10T13:52:49Z","message":"Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-presentation` files (#245661)\n\n> [!CAUTION]\n> ⚠️ **Changes / translations were made by GenAI**. I’ve reviewed them\ncarefully, but your code owners’ expert eyes will ensure they’re 100%\nright.\n\n## Summary\nThis PR applies the auto-fix for the newly introduced\n`@elastic/eui/require-table-caption`.\nThis rule ensure `EuiInMemoryTable`, `EuiBasicTable` have a\n`tableCaption` prop for accessibility.\n\n## Changes\n\n1. 🎯 Added missing `tableCaption` attributes to elements flagged by\n`@elastic/eui/require-table-caption` — accessibility leveled up!\n\n## Related\n- https://github.com/elastic/eui/pull/9168\n\nThis time, to avoid annoying approvals collection, we've broken files\ndown by teams. Now, we are waiting a review only from your team!","sha":"b9aa07afbd0d060c3c4dcc45d158ddb20140b857","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","backport:version","v9.3.0","v9.2.3","v9.1.9"],"title":"Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-presentation` files","number":245661,"url":"https://github.com/elastic/kibana/pull/245661","mergeCommit":{"message":"Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-presentation` files (#245661)\n\n> [!CAUTION]\n> ⚠️ **Changes / translations were made by GenAI**. I’ve reviewed them\ncarefully, but your code owners’ expert eyes will ensure they’re 100%\nright.\n\n## Summary\nThis PR applies the auto-fix for the newly introduced\n`@elastic/eui/require-table-caption`.\nThis rule ensure `EuiInMemoryTable`, `EuiBasicTable` have a\n`tableCaption` prop for accessibility.\n\n## Changes\n\n1. 🎯 Added missing `tableCaption` attributes to elements flagged by\n`@elastic/eui/require-table-caption` — accessibility leveled up!\n\n## Related\n- https://github.com/elastic/eui/pull/9168\n\nThis time, to avoid annoying approvals collection, we've broken files\ndown by teams. Now, we are waiting a review only from your team!","sha":"b9aa07afbd0d060c3c4dcc45d158ddb20140b857"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245661","number":245661,"mergeCommit":{"message":"Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-presentation` files (#245661)\n\n> [!CAUTION]\n> ⚠️ **Changes / translations were made by GenAI**. I’ve reviewed them\ncarefully, but your code owners’ expert eyes will ensure they’re 100%\nright.\n\n## Summary\nThis PR applies the auto-fix for the newly introduced\n`@elastic/eui/require-table-caption`.\nThis rule ensure `EuiInMemoryTable`, `EuiBasicTable` have a\n`tableCaption` prop for accessibility.\n\n## Changes\n\n1. 🎯 Added missing `tableCaption` attributes to elements flagged by\n`@elastic/eui/require-table-caption` — accessibility leveled up!\n\n## Related\n- https://github.com/elastic/eui/pull/9168\n\nThis time, to avoid annoying approvals collection, we've broken files\ndown by teams. Now, we are waiting a review only from your team!","sha":"b9aa07afbd0d060c3c4dcc45d158ddb20140b857"}},{"branch":"9.2","label":"v9.2.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->