### PR TITLE
[Cases] Add search in attachment tab

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_page.tsx
@@ -6,7 +6,7 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { CASE_VIEW_PAGE_TABS } from '../../../common/types';
 import { useUrlParams } from '../../common/navigation';
 import { useCasesContext } from '../cases_context/use_cases_context';
@@ -25,6 +25,7 @@ import { useOnUpdateField } from './use_on_update_field';
 import { CaseViewSimilarCases } from './components/case_view_similar_cases';
 import { CaseViewEvents } from './components/case_view_events';
 import { CaseViewAttachments } from './components/case_view_attachments';
+import { filterCaseAttachmentsBySearchTerm } from './components/helpers';
 
 const getActiveTabId = (tabId?: string) => {
   if (tabId && Object.values(CASE_VIEW_PAGE_TABS).includes(tabId as CASE_VIEW_PAGE_TABS)) {
@@ -56,6 +57,20 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
     const { features } = useCasesContext();
     const { urlParams } = useUrlParams();
     const refreshCaseViewPage = useRefreshCaseViewPage();
+
+    const [searchTerm, setSearchTerm] = useState<string>('');
+    const onSearch = useCallback(
+      (newSearch: string) => {
+        const trimSearch = newSearch.trim();
+        setSearchTerm(trimSearch);
+      },
+      [setSearchTerm]
+    );
+
+    const caseWithFilteredAttachments = useMemo(
+      () => filterCaseAttachmentsBySearchTerm(caseData, searchTerm),
+      [caseData, searchTerm]
+    );
 
     useCasesTitleBreadcrumbs(caseData.title);
 
@@ -126,30 +141,42 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
           {activeTabId === CASE_VIEW_PAGE_TABS.ACTIVITY && (
             <CaseViewActivity
               ruleDetailsNavigation={ruleDetailsNavigation}
-              caseData={caseData}
+              caseData={caseWithFilteredAttachments}
+              searchTerm={searchTerm}
               actionsNavigation={actionsNavigation}
               showAlertDetails={showAlertDetails}
               useFetchAlertData={useFetchAlertData}
             />
           )}
           {ATTACHMENT_TABS.includes(activeTabId as CASE_VIEW_PAGE_TABS) && (
-            <CaseViewAttachments activeTab={activeTabId as CASE_VIEW_PAGE_TABS} caseData={caseData}>
+            <CaseViewAttachments
+              onSearch={onSearch}
+              searchTerm={searchTerm}
+              activeTab={activeTabId as CASE_VIEW_PAGE_TABS}
+              caseData={caseWithFilteredAttachments}
+            >
               <>
                 {activeTabId === CASE_VIEW_PAGE_TABS.ALERTS && features.alerts.enabled && (
                   <CaseViewAlerts
-                    caseData={caseData}
+                    caseData={caseWithFilteredAttachments}
                     renderAlertsTable={renderAlertsTable}
                     onAlertsTableLoaded={onAlertsTableLoaded}
                   />
                 )}
                 {activeTabId === CASE_VIEW_PAGE_TABS.EVENTS && features.events.enabled && (
-                  <CaseViewEvents caseData={caseData} renderEventsTable={renderEventsTable} />
+                  <CaseViewEvents
+                    caseData={caseWithFilteredAttachments}
+                    renderEventsTable={renderEventsTable}
+                  />
                 )}
-                {activeTabId === CASE_VIEW_PAGE_TABS.FILES && <CaseViewFiles caseData={caseData} />}
+                {activeTabId === CASE_VIEW_PAGE_TABS.FILES && (
+                  <CaseViewFiles caseData={caseWithFilteredAttachments} searchTerm={searchTerm} />
+                )}
                 {activeTabId === CASE_VIEW_PAGE_TABS.OBSERVABLES && (
                   <CaseViewObservables
                     isLoading={false}
-                    caseData={caseData}
+                    caseData={caseWithFilteredAttachments}
+                    searchTerm={searchTerm}
                     onUpdateField={onUpdateField}
                   />
                 )}
@@ -157,7 +184,7 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
             </CaseViewAttachments>
           )}
           {activeTabId === CASE_VIEW_PAGE_TABS.SIMILAR_CASES && (
-            <CaseViewSimilarCases caseData={caseData} />
+            <CaseViewSimilarCases caseData={caseWithFilteredAttachments} searchTerm={searchTerm} />
           )}
         </EuiFlexGroup>
       </>

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_tabs.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_tabs.tsx
@@ -28,11 +28,16 @@ import {
 export interface CaseViewTabsProps {
   caseData: CaseUI;
   activeTab: CASE_VIEW_PAGE_TABS;
+  searchTerm?: string;
 }
 
-export const CaseViewTabs = React.memo<CaseViewTabsProps>(({ caseData, activeTab }) => {
+export const CaseViewTabs = React.memo<CaseViewTabsProps>(({ caseData, activeTab, searchTerm }) => {
   const { navigateToCaseView } = useCaseViewNavigation();
-  const { tabs: attachmentTabs, totalAttachments } = useCaseAttachmentTabs({ caseData, activeTab });
+  const { tabs: attachmentTabs, totalAttachments } = useCaseAttachmentTabs({
+    caseData,
+    activeTab,
+    searchTerm,
+  });
 
   const { euiTheme } = useEuiTheme();
 

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_activity.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_activity.tsx
@@ -59,6 +59,7 @@ const LOCALSTORAGE_SORT_ORDER_KEY = 'cases.userActivity.sortOrder';
 export const CaseViewActivity = ({
   ruleDetailsNavigation,
   caseData,
+  searchTerm,
   actionsNavigation,
   showAlertDetails,
   useFetchAlertData,
@@ -68,6 +69,7 @@ export const CaseViewActivity = ({
   actionsNavigation?: CasesNavigation<string, 'configurable'>;
   showAlertDetails?: (alertId: string, index: string) => void;
   useFetchAlertData: UseFetchAlertData;
+  searchTerm?: string;
 }) => {
   const [sortOrder, setSortOrder] = useCasesLocalStorage<UserActivitySortOrder>(
     LOCALSTORAGE_SORT_ORDER_KEY,
@@ -211,7 +213,11 @@ export const CaseViewActivity = ({
           max-width: 75%;
         `}
       >
-        <CaseViewTabs caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.ACTIVITY} />
+        <CaseViewTabs
+          caseData={caseData}
+          activeTab={CASE_VIEW_PAGE_TABS.ACTIVITY}
+          searchTerm={searchTerm}
+        />
         <EuiSpacer size="l" />
         <Description
           isLoadingDescription={isLoadingDescription}

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_attachments.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_attachments.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { alertCommentWithIndices, basicCase } from '../../../containers/mock';
+import { alertCommentWithIndices, eventComment, basicCase } from '../../../containers/mock';
 import type { CaseUI } from '../../../../common';
 import { renderWithTestingProviders } from '../../../common/mock';
 import { CaseViewAttachments } from './case_view_attachments';
@@ -43,6 +43,7 @@ const platinumLicense = licensingMock.createLicense({
 });
 
 const fileStatsData = { total: 3 };
+const onSearchMock = jest.fn();
 
 describe('Case View Attachments tab', () => {
   beforeEach(() => {
@@ -55,15 +56,40 @@ describe('Case View Attachments tab', () => {
 
   it('should render the case view attachments tab', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />
     );
 
     expect(screen.getByTestId('case-view-tabs')).toBeInTheDocument();
+    expect(screen.getByTestId('cases-files-search')).toBeInTheDocument();
+  });
+
+  it('should call the onSearch callback when the search field is changed', async () => {
+    renderWithTestingProviders(
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />
+    );
+
+    await userEvent.type(screen.getByTestId('cases-files-search'), 'search{Enter}');
+
+    await waitFor(() => {
+      expect(onSearchMock).toHaveBeenCalledWith('search');
+    });
   });
 
   it('shows the files tab as active', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.FILES} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.FILES}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense },
       }
@@ -77,7 +103,11 @@ describe('Case View Attachments tab', () => {
 
   it('shows the events tab as active', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.EVENTS} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.EVENTS}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense, features: { events: { enabled: true } } },
       }
@@ -91,7 +121,11 @@ describe('Case View Attachments tab', () => {
 
   it('shows the files tab with the correct count', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.FILES} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.FILES}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense },
       }
@@ -106,7 +140,11 @@ describe('Case View Attachments tab', () => {
     useGetCaseFileStatsMock.mockReturnValue({ isLoading: true, data: fileStatsData });
 
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.FILES} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.FILES}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense },
       }
@@ -116,10 +154,15 @@ describe('Case View Attachments tab', () => {
   });
 
   it('shows the alerts tab with the correct count', async () => {
+    const alerts = Array.from({ length: 3 }, (_, i) => ({
+      ...alertCommentWithIndices,
+      id: `alert-${i}`,
+    }));
     renderWithTestingProviders(
       <CaseViewAttachments
-        caseData={{ ...caseData, totalAlerts: 3 }}
+        caseData={{ ...caseData, comments: alerts }}
         activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
       />,
       {
         wrapperProps: { license: basicLicense },
@@ -136,6 +179,7 @@ describe('Case View Attachments tab', () => {
       <CaseViewAttachments
         caseData={{ ...caseData, totalAlerts: 3 }}
         activeTab={CASE_VIEW_PAGE_TABS.FILES}
+        onSearch={onSearchMock}
       />,
       {
         wrapperProps: { license: basicLicense },
@@ -150,7 +194,11 @@ describe('Case View Attachments tab', () => {
   it('navigates to the alerts tab when the alerts tab is clicked', async () => {
     const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense },
       }
@@ -169,7 +217,11 @@ describe('Case View Attachments tab', () => {
   it('navigates to the files tab when the files tab is clicked', async () => {
     const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense },
       }
@@ -188,7 +240,11 @@ describe('Case View Attachments tab', () => {
   it('navigates to the events tab when the events tab is clicked', async () => {
     const navigateToCaseViewMock = useCaseViewNavigationMock().navigateToCaseView;
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense, features: { events: { enabled: true } } },
       }
@@ -206,7 +262,11 @@ describe('Case View Attachments tab', () => {
 
   it('should display the alerts tab when the feature is enabled', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense, features: { alerts: { enabled: true } } },
       }
@@ -217,7 +277,11 @@ describe('Case View Attachments tab', () => {
 
   it('should not display the alerts tab when the feature is disabled', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense, features: { alerts: { enabled: false } } },
       }
@@ -229,7 +293,11 @@ describe('Case View Attachments tab', () => {
 
   it('should not show the experimental badge on the alerts table', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense, features: { alerts: { isExperimental: false } } },
       }
@@ -243,7 +311,11 @@ describe('Case View Attachments tab', () => {
 
   it('should show the experimental badge on the alerts table', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense, features: { alerts: { isExperimental: true } } },
       }
@@ -255,10 +327,15 @@ describe('Case View Attachments tab', () => {
   });
 
   it('should display the events tab with correct count when the feature is enabled', async () => {
+    const events = Array.from({ length: 4 }, (_, i) => ({
+      ...eventComment,
+      id: `event-${i}`,
+    }));
     renderWithTestingProviders(
       <CaseViewAttachments
-        caseData={{ ...caseData, totalEvents: 4 }}
+        caseData={{ ...caseData, comments: events }}
         activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
       />,
       {
         wrapperProps: { license: basicLicense, features: { events: { enabled: true } } },
@@ -273,7 +350,11 @@ describe('Case View Attachments tab', () => {
 
   it('should not display the events tab when the feature is disabled', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense, features: { events: { enabled: false } } },
       }
@@ -285,7 +366,11 @@ describe('Case View Attachments tab', () => {
 
   it('should not show observable tabs in non-platinum tiers', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: basicLicense },
       }
@@ -296,7 +381,11 @@ describe('Case View Attachments tab', () => {
 
   it('should not show observable tabs if the observables feature is not enabled', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.ALERTS} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: {
           license: basicLicense,
@@ -312,7 +401,11 @@ describe('Case View Attachments tab', () => {
     const spyOnUseGetSimilarCases = jest.spyOn(similarCasesHook, 'useGetSimilarCases');
 
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.OBSERVABLES} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.OBSERVABLES}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: platinumLicense },
       }
@@ -326,7 +419,11 @@ describe('Case View Attachments tab', () => {
 
   it('should show the observables tab', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.OBSERVABLES} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.OBSERVABLES}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: platinumLicense },
       }
@@ -336,7 +433,11 @@ describe('Case View Attachments tab', () => {
   });
   it('shows the observables tab with the correct count', async () => {
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.OBSERVABLES} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.OBSERVABLES}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: platinumLicense },
       }
@@ -351,7 +452,11 @@ describe('Case View Attachments tab', () => {
     useGetCaseObservablesMock.mockReturnValue({ isLoading: true, observables: [] });
 
     renderWithTestingProviders(
-      <CaseViewAttachments caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.OBSERVABLES} />,
+      <CaseViewAttachments
+        caseData={caseData}
+        activeTab={CASE_VIEW_PAGE_TABS.OBSERVABLES}
+        onSearch={onSearchMock}
+      />,
       {
         wrapperProps: { license: platinumLicense },
       }

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_attachments.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_attachments.test.tsx
@@ -153,16 +153,34 @@ describe('Case View Attachments tab', () => {
     expect(screen.queryByTestId('case-view-files-stats-badge')).not.toBeInTheDocument();
   });
 
-  it('shows the alerts tab with the correct count', async () => {
+  it('shows the alerts tab based on totalAlerts when search is not applied', async () => {
+    renderWithTestingProviders(
+      <CaseViewAttachments
+        caseData={{ ...caseData, totalAlerts: 3 }}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+      />,
+      {
+        wrapperProps: { license: basicLicense },
+      }
+    );
+
+    const badge = await screen.findByTestId('case-view-alerts-stats-badge');
+
+    expect(badge).toHaveTextContent('3');
+  });
+
+  it('shows the alerts tab based on alert comment count when search is applied', async () => {
     const alerts = Array.from({ length: 3 }, (_, i) => ({
       ...alertCommentWithIndices,
       id: `alert-${i}`,
     }));
     renderWithTestingProviders(
       <CaseViewAttachments
-        caseData={{ ...caseData, comments: alerts }}
+        caseData={{ ...caseData, totalAlerts: 5, comments: alerts }}
         activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
         onSearch={onSearchMock}
+        searchTerm="search"
       />,
       {
         wrapperProps: { license: basicLicense },
@@ -326,14 +344,10 @@ describe('Case View Attachments tab', () => {
     ).toBeInTheDocument();
   });
 
-  it('should display the events tab with correct count when the feature is enabled', async () => {
-    const events = Array.from({ length: 4 }, (_, i) => ({
-      ...eventComment,
-      id: `event-${i}`,
-    }));
+  it('should display the events tab based on totalEvents when the feature is enabled and search is not applied', async () => {
     renderWithTestingProviders(
       <CaseViewAttachments
-        caseData={{ ...caseData, comments: events }}
+        caseData={{ ...caseData, totalEvents: 4 }}
         activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
         onSearch={onSearchMock}
       />,
@@ -346,6 +360,29 @@ describe('Case View Attachments tab', () => {
 
     const badge = await screen.findByTestId('case-view-events-stats-badge');
     expect(badge).toHaveTextContent('4');
+  });
+
+  it('should display the events tab with correct count when the feature is enabled', async () => {
+    const events = Array.from({ length: 2 }, (_, i) => ({
+      ...eventComment,
+      id: `event-${i}`,
+    }));
+    renderWithTestingProviders(
+      <CaseViewAttachments
+        caseData={{ ...caseData, totalEvents: 4, comments: events }}
+        activeTab={CASE_VIEW_PAGE_TABS.ALERTS}
+        onSearch={onSearchMock}
+        searchTerm="search"
+      />,
+      {
+        wrapperProps: { license: basicLicense, features: { events: { enabled: true } } },
+      }
+    );
+
+    expect(await screen.findByTestId('case-view-tab-title-events')).toBeInTheDocument();
+
+    const badge = await screen.findByTestId('case-view-events-stats-badge');
+    expect(badge).toHaveTextContent('2');
   });
 
   it('should not display the events tab when the feature is disabled', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_attachments.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_attachments.tsx
@@ -13,6 +13,7 @@ import {
   EuiSelectable,
   EuiSpacer,
   EuiTitle,
+  EuiFieldSearch,
 } from '@elastic/eui';
 import type { PropsWithChildren } from 'react';
 import React, { useMemo } from 'react';
@@ -29,6 +30,7 @@ import {
   FILES_TAB,
   OBSERVABLES_TAB,
 } from '../translations';
+import { SEARCH_PLACEHOLDER } from '../../actions/translations';
 
 const translateTitle = (activeTab: CASE_VIEW_PAGE_TABS) => {
   switch (activeTab) {
@@ -57,12 +59,16 @@ const translateTitle = (activeTab: CASE_VIEW_PAGE_TABS) => {
 export const CaseViewAttachments = ({
   caseData,
   activeTab,
+  onSearch,
+  searchTerm,
   children,
 }: PropsWithChildren<{
   caseData: CaseUI;
   activeTab: CASE_VIEW_PAGE_TABS;
+  onSearch: (searchTerm: string) => void;
+  searchTerm?: string;
 }>) => {
-  const { tabs: caseViewTabs } = useCaseAttachmentTabs({ caseData, activeTab });
+  const { tabs: caseViewTabs } = useCaseAttachmentTabs({ caseData, activeTab, searchTerm });
   const { navigateToCaseView } = useCaseViewNavigation();
   const trackSubTabClick = useAttachmentsSubTabClickedEBT();
 
@@ -87,7 +93,14 @@ export const CaseViewAttachments = ({
   return (
     <>
       <EuiFlexItem grow={6}>
-        <CaseViewTabs caseData={caseData} activeTab={activeTab} />
+        <CaseViewTabs caseData={caseData} activeTab={activeTab} searchTerm={searchTerm} />
+        <EuiSpacer size="s" />
+        <EuiFieldSearch
+          placeholder={SEARCH_PLACEHOLDER}
+          onSearch={onSearch}
+          data-test-subj="cases-files-search"
+          fullWidth
+        />
         <EuiSpacer size="m" />
         <EuiFlexGroup direction="row" responsive={false} data-test-subj="case-view-attachments">
           <EuiFlexItem grow={1} css={{ minWidth: '18rem', maxWidth: '18rem' }}>

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_files.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_files.test.tsx
@@ -39,7 +39,6 @@ describe('Case View Page files tab', () => {
     renderWithTestingProviders(<CaseViewFiles caseData={caseData} />);
 
     expect((await screen.findAllByTestId('cases-files-add')).length).toBe(2);
-    expect(await screen.findByTestId('cases-files-search')).toBeInTheDocument();
   });
 
   it('should render the files table', async () => {
@@ -89,18 +88,15 @@ describe('Case View Page files tab', () => {
   });
 
   it('search by word triggers calls to useGetCaseFiles', async () => {
-    renderWithTestingProviders(<CaseViewFiles caseData={caseData} />);
+    renderWithTestingProviders(<CaseViewFiles caseData={caseData} searchTerm="search" />);
 
     expect(await screen.findByTestId('cases-files-table')).toBeInTheDocument();
-
-    await userEvent.type(screen.getByTestId('cases-files-search'), 'Foobar{enter}');
-
     await waitFor(() =>
       expect(useGetCaseFilesMock).toHaveBeenCalledWith({
         caseId: basicCase.id,
         page: DEFAULT_CASE_FILES_FILTERING_OPTIONS.page,
         perPage: DEFAULT_CASE_FILES_FILTERING_OPTIONS.perPage,
-        searchTerm: 'Foobar',
+        searchTerm: 'search',
       })
     );
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_files.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_files.tsx
@@ -4,8 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { isEqual } from 'lodash/fp';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { Criteria } from '@elastic/eui';
 import type { FileJSON } from '@kbn/shared-ux-file-types';
@@ -21,6 +20,7 @@ import { FilesUtilityBar } from '../../files/files_utility_bar';
 
 interface CaseViewFilesProps {
   caseData: CaseUI;
+  searchTerm?: string;
 }
 
 export const DEFAULT_CASE_FILES_FILTERING_OPTIONS = {
@@ -28,10 +28,25 @@ export const DEFAULT_CASE_FILES_FILTERING_OPTIONS = {
   perPage: 10,
 };
 
-export const CaseViewFiles = ({ caseData }: CaseViewFilesProps) => {
-  const [filteringOptions, setFilteringOptions] = useState<CaseFilesFilteringOptions>(
-    DEFAULT_CASE_FILES_FILTERING_OPTIONS
-  );
+export const CaseViewFiles = ({ caseData, searchTerm }: CaseViewFilesProps) => {
+  const searchTermRef = useRef<string | undefined>(searchTerm);
+  const [filteringOptions, setFilteringOptions] = useState<CaseFilesFilteringOptions>({
+    ...DEFAULT_CASE_FILES_FILTERING_OPTIONS,
+    ...(searchTerm && { searchTerm }),
+  });
+
+  useEffect(() => {
+    if (searchTermRef.current !== searchTerm) {
+      searchTermRef.current = searchTerm;
+      setFilteringOptions((prev) => ({
+        // reset pagination when search term changes
+        page: 0,
+        perPage: prev.perPage,
+        ...(searchTerm && { searchTerm }),
+      }));
+    }
+  }, [searchTerm, setFilteringOptions]);
+
   const {
     data: caseFiles,
     isLoading,
@@ -54,19 +69,6 @@ export const CaseViewFiles = ({ caseData }: CaseViewFilesProps) => {
     [filteringOptions, isPreviousData]
   );
 
-  const onSearchChange = useCallback(
-    (newSearch: string) => {
-      const trimSearch = newSearch.trim();
-      if (!isEqual(trimSearch, filteringOptions.searchTerm)) {
-        setFilteringOptions({
-          ...filteringOptions,
-          searchTerm: trimSearch,
-        });
-      }
-    },
-    [filteringOptions]
-  );
-
   const pagination = useMemo(
     () => ({
       pageIndex: filteringOptions.page,
@@ -79,20 +81,16 @@ export const CaseViewFiles = ({ caseData }: CaseViewFilesProps) => {
   );
 
   return (
-    <EuiFlexGroup>
+    <EuiFlexGroup gutterSize="none">
       <EuiFlexItem>
-        <EuiFlexGroup>
-          <EuiFlexItem>
-            <FilesUtilityBar caseId={caseData.id} onSearch={onSearchChange} />
-            <FilesTable
-              caseId={caseData.id}
-              isLoading={isLoading}
-              items={caseFiles?.files ?? []}
-              onChange={onTableChange}
-              pagination={pagination}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <FilesUtilityBar caseId={caseData.id} />
+        <FilesTable
+          caseId={caseData.id}
+          isLoading={isLoading}
+          items={caseFiles?.files ?? []}
+          onChange={onTableChange}
+          pagination={pagination}
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_observables.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_observables.tsx
@@ -16,16 +16,18 @@ import type { OnUpdateFields } from '../types';
 
 interface CaseViewObservablesProps {
   caseData: CaseUI;
+  searchTerm?: string;
   isLoading: boolean;
   onUpdateField: (args: OnUpdateFields) => void;
 }
 
 export const CaseViewObservables = ({
   caseData,
+  searchTerm,
   isLoading,
   onUpdateField,
 }: CaseViewObservablesProps) => {
-  const { observables, isLoading: isLoadingObservables } = useCaseObservables(caseData);
+  const { observables, isLoading: isLoadingObservables } = useCaseObservables(caseData, searchTerm);
 
   const caseDataWithFilteredObservables: CaseUI = useMemo(() => {
     return {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_similar_cases.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_similar_cases.tsx
@@ -18,9 +18,10 @@ import { SimilarCasesTable } from '../../similar_cases/table';
 
 interface CaseViewSimilarCasesProps {
   caseData: CaseUI;
+  searchTerm?: string;
 }
 
-export const CaseViewSimilarCases = ({ caseData }: CaseViewSimilarCasesProps) => {
+export const CaseViewSimilarCases = ({ caseData, searchTerm }: CaseViewSimilarCasesProps) => {
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(CASES_TABLE_PER_PAGE_VALUES[0]);
 
@@ -49,7 +50,11 @@ export const CaseViewSimilarCases = ({ caseData }: CaseViewSimilarCasesProps) =>
   return (
     <EuiFlexGroup>
       <EuiFlexItem>
-        <CaseViewTabs caseData={caseData} activeTab={CASE_VIEW_PAGE_TABS.SIMILAR_CASES} />
+        <CaseViewTabs
+          caseData={caseData}
+          activeTab={CASE_VIEW_PAGE_TABS.SIMILAR_CASES}
+          searchTerm={searchTerm}
+        />
         <EuiFlexGroup>
           <EuiFlexItem>
             <SimilarCasesTable

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
@@ -141,6 +141,56 @@ describe('Case view helpers', () => {
           [fieldName]: [`${type}-123`, `${type}-123-abc`],
         });
       });
+
+      it(`filters out ${type} comments with empty string ${fieldName}`, () => {
+        const caseData = {
+          ...basicCase,
+          comments: [
+            { ...commentTemplate, [fieldName]: '' },
+            { ...commentTemplate, [fieldName]: `${type}-123` },
+          ],
+        };
+        const result = filterCaseAttachmentsBySearchTerm(caseData, '123');
+        expect(result.comments).toHaveLength(1);
+        expect(result.comments[0]).toEqual({
+          ...commentTemplate,
+          [fieldName]: [`${type}-123`],
+        });
+      });
+
+      it(`filters out ${type} comments with empty array ${fieldName}`, () => {
+        const caseData = {
+          ...basicCase,
+          comments: [
+            { ...commentTemplate, [fieldName]: [] },
+            { ...commentTemplate, [fieldName]: `${type}-123` },
+          ],
+        };
+        const result = filterCaseAttachmentsBySearchTerm(caseData, '123');
+        expect(result.comments).toHaveLength(1);
+        expect(result.comments[0]).toEqual({
+          ...commentTemplate,
+          [fieldName]: [`${type}-123`],
+        });
+      });
+
+      it(`filters out empty strings from array ${fieldName} while keeping valid IDs`, () => {
+        const caseData = {
+          ...basicCase,
+          comments: [
+            {
+              ...commentTemplate,
+              [fieldName]: ['', `${type}-123`, '', `${type}-456`],
+            },
+          ],
+        };
+        const result = filterCaseAttachmentsBySearchTerm(caseData, '123');
+        expect(result.comments).toHaveLength(1);
+        expect(result.comments[0]).toEqual({
+          ...commentTemplate,
+          [fieldName]: [`${type}-123`],
+        });
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.test.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { alertComment } from '../../../containers/mock';
-import { getManualAlertIds } from './helpers';
+import { alertComment, eventComment, basicCase, basicComment } from '../../../containers/mock';
+import { getManualAlertIds, filterCaseAttachmentsBySearchTerm } from './helpers';
 
 const comment = {
   ...alertComment,
@@ -34,6 +34,113 @@ describe('Case view helpers', () => {
     it('returns the alerts id from multiple alerts in a comment', () => {
       const result = getManualAlertIds([comment, comment2, comment3]);
       expect(result).toEqual(['alert-id-1', 'alert-id-2', 'nested1', 'nested2', 'nested3']);
+    });
+  });
+
+  describe('filterCaseAttachmentsBySearchTerm', () => {
+    it('returns the case data unchanged when search term is empty', () => {
+      const caseData = {
+        ...basicCase,
+        comments: [alertComment, eventComment, basicComment],
+      };
+      const result = filterCaseAttachmentsBySearchTerm(caseData, '');
+      expect(result).toBe(caseData);
+      expect(result).toEqual(caseData);
+    });
+
+    it('filters out comments when no IDs match the search term', () => {
+      const caseData = {
+        ...basicCase,
+        comments: [
+          { ...alertComment, alertId: 'alert-123' },
+          { ...eventComment, eventId: 'event-123' },
+        ],
+      };
+      const result = filterCaseAttachmentsBySearchTerm(caseData, 'xyz');
+      expect(result.comments).toHaveLength(0);
+    });
+
+    it('preserves non-alert and non-event comments', () => {
+      const caseData = {
+        ...basicCase,
+        comments: [alertComment, eventComment, basicComment],
+      };
+      const result = filterCaseAttachmentsBySearchTerm(caseData, 'xyz');
+      expect(result.comments).toHaveLength(1);
+      expect(result.comments[0]).toEqual(basicComment);
+    });
+
+    it('filters mixed comment types correctly', () => {
+      const caseData = {
+        ...basicCase,
+        comments: [
+          { ...alertComment, alertId: 'alert-123' },
+          { ...alertComment, alertId: 'alert-456' },
+          { ...eventComment, eventId: 'event-123' },
+          { ...eventComment, eventId: 'event-789' },
+        ],
+      };
+      const result = filterCaseAttachmentsBySearchTerm(caseData, '123');
+      expect(result.comments).toHaveLength(2);
+      expect(result.comments[0]).toEqual({ ...alertComment, alertId: ['alert-123'] });
+      expect(result.comments[1]).toEqual({ ...eventComment, eventId: ['event-123'] });
+    });
+
+    const testCases = [
+      ['alert', 'alertId', alertComment] as const,
+      ['event', 'eventId', eventComment] as const,
+    ];
+
+    testCases.forEach(([type, fieldName, commentTemplate]) => {
+      it(`filters ${type} comments with single ${fieldName} that matches search term`, () => {
+        const caseData = {
+          ...basicCase,
+          comments: [
+            { ...commentTemplate, [fieldName]: `${type}-123` },
+            { ...commentTemplate, [fieldName]: `${type}-456` },
+          ],
+        };
+        const result = filterCaseAttachmentsBySearchTerm(caseData, '123');
+        expect(result.comments).toHaveLength(1);
+        expect(result.comments[0]).toEqual({
+          ...commentTemplate,
+          [fieldName]: [`${type}-123`],
+        });
+      });
+
+      it(`filters ${type} comments with array ${fieldName} that matches search term`, () => {
+        const caseData = {
+          ...basicCase,
+          comments: [
+            { ...commentTemplate, [fieldName]: [`${type}-123`, `${type}-456`, `${type}-789`] },
+            { ...commentTemplate, [fieldName]: [`${type}-abc`, `${type}-def`] },
+          ],
+        };
+        const result = filterCaseAttachmentsBySearchTerm(caseData, '123');
+        expect(result.comments).toHaveLength(1);
+        expect(result.comments[0]).toEqual({
+          ...commentTemplate,
+          [fieldName]: [`${type}-123`],
+        });
+      });
+
+      it(`filters multiple matching IDs in array ${fieldName}`, () => {
+        const caseData = {
+          ...basicCase,
+          comments: [
+            {
+              ...commentTemplate,
+              [fieldName]: [`${type}-123`, `${type}-123-abc`, `${type}-456`],
+            },
+          ],
+        };
+        const result = filterCaseAttachmentsBySearchTerm(caseData, '123');
+        expect(result.comments).toHaveLength(1);
+        expect(result.comments[0]).toEqual({
+          ...commentTemplate,
+          [fieldName]: [`${type}-123`, `${type}-123-abc`],
+        });
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
@@ -7,6 +7,7 @@
 
 import { AttachmentType } from '../../../../common/types/domain';
 import type { AttachmentUI } from '../../../containers/types';
+import type { CaseUI, AlertAttachmentUI, EventAttachmentUI } from '../../../../common/ui/types';
 
 export const getManualAlertIds = (comments: AttachmentUI[]): string[] => {
   const dedupeAlerts = comments.reduce((alertIds, comment: AttachmentUI) => {
@@ -18,4 +19,63 @@ export const getManualAlertIds = (comments: AttachmentUI[]): string[] => {
     return alertIds;
   }, new Set<string>());
   return Array.from(dedupeAlerts);
+};
+
+const isAlertAttachment = (comment: AttachmentUI): comment is AlertAttachmentUI => {
+  return comment.type === AttachmentType.alert;
+};
+
+const filterAlertCommentByIds = (
+  comment: AlertAttachmentUI,
+  searchTerm: string
+): AlertAttachmentUI | null => {
+  const ids = Array.isArray(comment.alertId) ? comment.alertId : [comment.alertId];
+  const filteredIds = ids.filter((id: string) => id.includes(searchTerm));
+  if (filteredIds.length === 0) {
+    return null;
+  }
+  return {
+    ...comment,
+    alertId: filteredIds,
+  };
+};
+
+const isEventAttachment = (comment: AttachmentUI): comment is EventAttachmentUI => {
+  return comment.type === AttachmentType.event;
+};
+
+const filterEventCommentByIds = (
+  comment: EventAttachmentUI,
+  searchTerm: string
+): EventAttachmentUI | null => {
+  const ids = Array.isArray(comment.eventId) ? comment.eventId : [comment.eventId];
+  const filteredIds = ids.filter((id: string) => id.includes(searchTerm));
+  if (filteredIds.length === 0) {
+    return null;
+  }
+  return {
+    ...comment,
+    eventId: filteredIds,
+  };
+};
+
+export const filterCaseAttachmentsBySearchTerm = (caseData: CaseUI, searchTerm: string): CaseUI => {
+  if (!searchTerm) {
+    return caseData;
+  }
+
+  return {
+    ...caseData,
+    comments: caseData.comments
+      .map((comment) => {
+        if (isAlertAttachment(comment)) {
+          return filterAlertCommentByIds(comment, searchTerm);
+        }
+        if (isEventAttachment(comment)) {
+          return filterEventCommentByIds(comment, searchTerm);
+        }
+        return comment;
+      })
+      .filter((comment): comment is AttachmentUI => comment !== null),
+  };
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/helpers.ts
@@ -30,7 +30,7 @@ const filterAlertCommentByIds = (
   searchTerm: string
 ): AlertAttachmentUI | null => {
   const ids = Array.isArray(comment.alertId) ? comment.alertId : [comment.alertId];
-  const filteredIds = ids.filter((id: string) => id.includes(searchTerm));
+  const filteredIds = ids.filter((id: string) => Boolean(id) && id.includes(searchTerm));
   if (filteredIds.length === 0) {
     return null;
   }
@@ -49,7 +49,7 @@ const filterEventCommentByIds = (
   searchTerm: string
 ): EventAttachmentUI | null => {
   const ids = Array.isArray(comment.eventId) ? comment.eventId : [comment.eventId];
-  const filteredIds = ids.filter((id: string) => id.includes(searchTerm));
+  const filteredIds = ids.filter((id: string) => Boolean(id) && id.includes(searchTerm));
   if (filteredIds.length === 0) {
     return null;
   }

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_attachment_tabs.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_attachment_tabs.test.tsx
@@ -70,7 +70,7 @@ describe('useCaseAttachmentTabs()', () => {
         "files",
       ]
     `);
-    expect(result.current.totalAttachments).toEqual(3);
+    expect(result.current.totalAttachments).toEqual(4);
   });
 
   it('returns attachment tabs based on enable features an license', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_attachment_tabs.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_attachment_tabs.test.tsx
@@ -70,7 +70,7 @@ describe('useCaseAttachmentTabs()', () => {
         "files",
       ]
     `);
-    expect(result.current.totalAttachments).toEqual(4);
+    expect(result.current.totalAttachments).toEqual(3);
   });
 
   it('returns attachment tabs based on enable features an license', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_observables.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_observables.test.ts
@@ -23,10 +23,18 @@ const mockCaseData = {
       updatedAt: '2024-12-02',
     },
     {
+      typeKey: 'type1',
+      value: 'Host1',
+      description: null,
+      id: '6d44e478-3b35-4c48-929a-b22e98bfe179',
+      createdAt: '2024-12-02',
+      updatedAt: '2024-12-02',
+    },
+    {
       typeKey: 'unknown-type',
       value: '127.0.0.1',
       description: null,
-      id: '6d44e478-3b35-4c48-929a-b22e98bfe178',
+      id: '6d44e478-3b35-4c48-929a-b22e98bfe180',
       createdAt: '2024-12-02',
       updatedAt: '2024-12-02',
     },
@@ -72,6 +80,14 @@ describe('useCaseObservables', () => {
           createdAt: '2024-12-02',
           updatedAt: '2024-12-02',
         },
+        {
+          typeKey: 'type1',
+          value: 'Host1',
+          description: null,
+          id: '6d44e478-3b35-4c48-929a-b22e98bfe179',
+          createdAt: '2024-12-02',
+          updatedAt: '2024-12-02',
+        },
       ],
       isLoading: false,
     });
@@ -90,5 +106,42 @@ describe('useCaseObservables', () => {
         OBSERVABLE_TYPES_BUILTIN_KEYS.includes(typeKey)
       )
     );
+  });
+
+  it('filters observables by searchTerm when provided', () => {
+    (useGetCaseConfiguration as jest.Mock).mockReturnValue({
+      data: { observableTypes: [{ key: 'type1' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useCaseObservables(mockCaseData, 'host'));
+
+    expect(result.current).toEqual({
+      observables: [
+        {
+          typeKey: 'type1',
+          value: 'Host1',
+          description: null,
+          id: '6d44e478-3b35-4c48-929a-b22e98bfe179',
+          createdAt: '2024-12-02',
+          updatedAt: '2024-12-02',
+        },
+      ],
+      isLoading: false,
+    });
+  });
+
+  it('returns empty array when searchTerm does not match any observable values', () => {
+    (useGetCaseConfiguration as jest.Mock).mockReturnValue({
+      data: { observableTypes: [{ key: 'type1' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useCaseObservables(mockCaseData, 'nonexistent'));
+
+    expect(result.current).toEqual({
+      observables: [],
+      isLoading: false,
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_observables.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_observables.ts
@@ -10,7 +10,7 @@ import { OBSERVABLE_TYPES_BUILTIN_KEYS } from '../../../common/constants';
 import type { CaseUI } from '../../../common';
 import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
 
-export const useCaseObservables = (caseData: CaseUI) => {
+export const useCaseObservables = (caseData: CaseUI, searchTerm?: string) => {
   const { data: currentConfiguration, isLoading: loadingCaseConfigure } = useGetCaseConfiguration();
 
   return useMemo(() => {
@@ -27,8 +27,17 @@ export const useCaseObservables = (caseData: CaseUI) => {
     ]);
 
     return {
-      observables: caseData.observables.filter(({ typeKey }) => availableTypesSet.has(typeKey)),
+      observables: caseData.observables.filter(
+        ({ typeKey, value }) =>
+          availableTypesSet.has(typeKey) &&
+          (!searchTerm || value.toLowerCase().includes(searchTerm.toLowerCase()))
+      ),
       isLoading: loadingCaseConfigure,
     };
-  }, [caseData.observables, currentConfiguration.observableTypes, loadingCaseConfigure]);
+  }, [
+    caseData.observables,
+    currentConfiguration.observableTypes,
+    loadingCaseConfigure,
+    searchTerm,
+  ]);
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/files/files_table.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/files/files_table.tsx
@@ -64,7 +64,6 @@ export const FilesTable = ({ caseId, items, pagination, onChange, isLoading }: F
     <>
       {pagination.totalItemCount > 0 && (
         <>
-          <EuiSpacer size="xl" />
           <EuiText size="xs" color="subdued" data-test-subj="cases-files-table-results-count">
             {i18n.SHOWING_FILES(items.length)}
           </EuiText>

--- a/x-pack/platform/plugins/shared/cases/public/components/files/files_utility_bar.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/files/files_utility_bar.test.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { useCreateAttachments } from '../../containers/use_create_attachments';
-import userEvent from '@testing-library/user-event';
 import { FilesUtilityBar } from './files_utility_bar';
 import { renderWithTestingProviders } from '../../common/mock';
 
@@ -26,7 +25,6 @@ useCreateAttachmentsMock.mockReturnValue({
 
 const defaultProps = {
   caseId: 'foobar',
-  onSearch: jest.fn(),
 };
 
 describe('FilesUtilityBar', () => {
@@ -37,14 +35,6 @@ describe('FilesUtilityBar', () => {
   it('renders correctly', async () => {
     renderWithTestingProviders(<FilesUtilityBar {...defaultProps} />);
 
-    expect(await screen.findByTestId('cases-files-search')).toBeInTheDocument();
     expect(await screen.findByTestId('cases-files-add')).toBeInTheDocument();
-  });
-
-  it('search text passed correctly to callback', async () => {
-    renderWithTestingProviders(<FilesUtilityBar {...defaultProps} />);
-
-    await userEvent.type(await screen.findByTestId('cases-files-search'), 'My search{enter}');
-    expect(defaultProps.onSearch).toBeCalledWith('My search');
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/files/files_utility_bar.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/files/files_utility_bar.tsx
@@ -6,29 +6,17 @@
  */
 import React from 'react';
 
-import { EuiFlexGroup, EuiFlexItem, EuiFieldSearch } from '@elastic/eui';
+import { EuiFlexGroup } from '@elastic/eui';
 import { AddFile } from './add_file';
-
-import * as i18n from './translations';
 
 interface FilesUtilityBarProps {
   caseId: string;
-  onSearch: (newSearch: string) => void;
 }
 
-export const FilesUtilityBar = ({ caseId, onSearch }: FilesUtilityBarProps) => {
+export const FilesUtilityBar = ({ caseId }: FilesUtilityBarProps) => {
   return (
-    <EuiFlexGroup alignItems="center">
+    <EuiFlexGroup alignItems="center" justifyContent="flexEnd" gutterSize="none">
       <AddFile caseId={caseId} />
-      <EuiFlexItem grow={false} style={{ minWidth: 400 }}>
-        <EuiFieldSearch
-          fullWidth
-          placeholder={i18n.SEARCH_PLACEHOLDER}
-          onSearch={onSearch}
-          incremental={false}
-          data-test-subj="cases-files-search"
-        />
-      </EuiFlexItem>
     </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/containers/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/constants.ts
@@ -29,7 +29,8 @@ export const casesQueriesKeys = {
   case: (id: string) => [...casesQueriesKeys.caseView(), id] as const,
   caseFiles: (id: string, params: unknown) =>
     [...casesQueriesKeys.case(id), 'files', params] as const,
-  caseFileStats: (id: string) => [...casesQueriesKeys.case(id), 'files', 'stats'] as const,
+  caseFileStats: (id: string, params?: unknown) =>
+    [...casesQueriesKeys.case(id), 'files', 'stats', params] as const,
   caseMetrics: (id: string, features: SingleCaseMetricsFeature[]) =>
     [...casesQueriesKeys.case(id), 'metrics', features] as const,
   caseConnectors: (id: string) => [...casesQueriesKeys.case(id), 'connectors'],

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_get_case_file_stats.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_get_case_file_stats.test.tsx
@@ -17,6 +17,7 @@ import { constructFileKindIdByOwner } from '../../common/files';
 
 jest.mock('../common/lib/kibana');
 
+const searchTerm = 'foobar';
 const hookParams = {
   caseId: basicCase.id,
 };
@@ -33,7 +34,7 @@ describe('useGetCaseFileStats', () => {
     jest.clearAllMocks();
   });
 
-  it('calls filesClient.list with correct arguments', async () => {
+  it('calls filesClient.list when searchTerm is not provided', async () => {
     const filesClient = createMockFilesClient();
 
     renderHook(() => useGetCaseFileStats(hookParams), {
@@ -41,6 +42,20 @@ describe('useGetCaseFileStats', () => {
     });
 
     await waitFor(() => expect(filesClient.list).toHaveBeenCalledWith(expectedCallParams));
+  });
+
+  it('calls filesClient.list with correct arguments when searchTerm is provided', async () => {
+    const filesClient = createMockFilesClient();
+    const hookParamsWithSearchTerm = { ...hookParams, searchTerm };
+    renderHook(() => useGetCaseFileStats(hookParamsWithSearchTerm), {
+      wrapper: (props) => <TestProviders {...props} filesClient={filesClient} />,
+    });
+    await waitFor(() =>
+      expect(filesClient.list).toHaveBeenCalledWith({
+        ...expectedCallParams,
+        name: `*${searchTerm}*`,
+      })
+    );
   });
 
   it('shows an error toast when filesClient.list throws', async () => {

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_get_case_file_stats.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_get_case_file_stats.tsx
@@ -27,20 +27,23 @@ const getTotalFromFileList = (data: { files: FileJSON[]; total: number }): { tot
 
 interface GetCaseFileStatsParams {
   caseId: string;
+  searchTerm?: string;
 }
 
 export const useGetCaseFileStats = ({
   caseId,
+  searchTerm,
 }: GetCaseFileStatsParams): UseQueryResult<{ total: number }> => {
   const { owner } = useCasesContext();
   const { showErrorToast } = useCasesToast();
   const { client: filesClient } = useFilesContext();
 
   return useQuery(
-    casesQueriesKeys.caseFileStats(caseId),
+    casesQueriesKeys.caseFileStats(caseId, { searchTerm }),
     () => {
       return filesClient.list({
         kind: constructFileKindIdByOwner(owner[0] as Owner),
+        ...(searchTerm && { name: `*${searchTerm}*` }),
         page: 1,
         perPage: 1,
         meta: { caseIds: [caseId] },


### PR DESCRIPTION
## Summary

Adds a search bar in attachment tab. Counts and table will reflect results based on search term. Supported search fields are:
- Alert id
- Event id
- Observables value
- File name



https://github.com/user-attachments/assets/57fead7e-7095-41bc-901a-2c4ebaa6efcf



### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

