### PR TITLE
[9.2] Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook·ts - alerting api integration security and spaces enabled - Group 2 testtest Connectors webhook action OAuth2 client credentials should refresh the token once the previous one has expired (#246072)

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
@@ -2129,7 +2129,7 @@ describe('TaskManagerRunner', () => {
         expect(onTaskEvent).toHaveBeenCalledTimes(2);
       });
 
-      test('testtest emits TaskEvent when an ad-hoc task run throws an error due to timeout', async () => {
+      test('emits TaskEvent when an ad-hoc task run throws an error due to timeout', async () => {
         jest.setSystemTime(new Date(2023, 1, 1, 0, 0, 0, 0));
         const id = _.random(1, 20).toString();
         const error = new Error('Task was cancelled');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook·ts - alerting api integration security and spaces enabled - Group 2 testtest Connectors webhook action OAuth2 client credentials should refresh the token once the previous one has expired (#246072)](https://github.com/elastic/kibana/pull/246072)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-12-12T14:11:16Z","message":"Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook·ts - alerting api integration security and spaces enabled - Group 2 testtest Connectors webhook action OAuth2 client credentials should refresh the token once the previous one has expired (#246072)\n\nResolves https://github.com/elastic/kibana/issues/240923\n\n## Summary\n\nThis tests that another call was made to retrieve a token after the\nprevious one had expired. It waited the exact length of the token\nexpiration (1 second) before calling the webhook connector again. It\nseems like it would occassionaly fail because a second call to retrieve\na token was not made. I updated to wait a little longer (2 seconds)\nbefore trying to call the connector to ensure the expiration period had\npassed.\n\n## Flaky test runner\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10061\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10063","sha":"3b605a3246008a04e4ff0082cd6187528abb4475","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Actions","Team:ResponseOps","backport:version","v9.3.0","v9.2.3"],"title":"Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook·ts - alerting api integration security and spaces enabled - Group 2 testtest Connectors webhook action OAuth2 client credentials should refresh the token once the previous one has expired","number":246072,"url":"https://github.com/elastic/kibana/pull/246072","mergeCommit":{"message":"Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook·ts - alerting api integration security and spaces enabled - Group 2 testtest Connectors webhook action OAuth2 client credentials should refresh the token once the previous one has expired (#246072)\n\nResolves https://github.com/elastic/kibana/issues/240923\n\n## Summary\n\nThis tests that another call was made to retrieve a token after the\nprevious one had expired. It waited the exact length of the token\nexpiration (1 second) before calling the webhook connector again. It\nseems like it would occassionaly fail because a second call to retrieve\na token was not made. I updated to wait a little longer (2 seconds)\nbefore trying to call the connector to ensure the expiration period had\npassed.\n\n## Flaky test runner\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10061\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10063","sha":"3b605a3246008a04e4ff0082cd6187528abb4475"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246072","number":246072,"mergeCommit":{"message":"Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook·ts - alerting api integration security and spaces enabled - Group 2 testtest Connectors webhook action OAuth2 client credentials should refresh the token once the previous one has expired (#246072)\n\nResolves https://github.com/elastic/kibana/issues/240923\n\n## Summary\n\nThis tests that another call was made to retrieve a token after the\nprevious one had expired. It waited the exact length of the token\nexpiration (1 second) before calling the webhook connector again. It\nseems like it would occassionaly fail because a second call to retrieve\na token was not made. I updated to wait a little longer (2 seconds)\nbefore trying to call the connector to ensure the expiration period had\npassed.\n\n## Flaky test runner\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10061\n-\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10063","sha":"3b605a3246008a04e4ff0082cd6187528abb4475"}},{"branch":"9.2","label":"v9.2.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->