### PR TITLE
remove kibanamachine as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2312,8 +2312,6 @@ x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/server/confi
 # Connector Specs
 src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts
 src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts
-src/platform/packages/shared/kbn-connector-specs/src/all_specs.ts @kibanamachine
-src/platform/packages/shared/kbn-connector-specs/src/connector_icons_map.ts @kibanamachine
 src/platform/packages/shared/kbn-connector-specs/src/specs/abuseipdb/** @elastic/workflows-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/alienvault_otx/** @elastic/workflows-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/greynoise/** @elastic/workflows-eng


### PR DESCRIPTION
Was supposed to be fixed in https://github.com/elastic/kibana/pull/246262, but looks like an "update branch" merge ruined it.


