### PR TITLE
[AI Infra] Chat Experience: make Agent default in Elasticsearch Serverless and Solution view

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -107,6 +107,7 @@ xpack.searchAssistant.enabled: true
 xpack.searchAssistant.ui.enabled: true
 xpack.observabilityAIAssistant.scope: "search"
 aiAssistantManagementSelection.preferredAIAssistantType: "observability"
+aiAssistantManagementSelection.preferredChatExperience: "agent"
 
 # Query Rules UI
 xpack.searchQueryRules.enabled: true

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -298,6 +298,9 @@ xpack.genAiSettings:
   showSpacesIntegration: false
   showAiAssistantsVisibilitySetting: false
 
+# AI Assistant Management Selection plugin
+aiAssistantManagementSelection.preferredChatExperience: 'classic'
+
 # Cross Project Search
 cps.enabled: true
 cps.cpsEnabled: false

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -298,9 +298,6 @@ xpack.genAiSettings:
   showSpacesIntegration: false
   showAiAssistantsVisibilitySetting: false
 
-# AI Assistant Management Selection plugin
-aiAssistantManagementSelection.preferredChatExperience: 'classic'
-
 # Cross Project Search
 cps.enabled: true
 cps.cpsEnabled: false

--- a/src/platform/plugins/shared/ai_assistant_management/selection/public/hooks/use_is_nav_control_visible.tsx
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/public/hooks/use_is_nav_control_visible.tsx
@@ -62,8 +62,7 @@ export function useIsNavControlVisible(coreStart: CoreStart, spaces?: SpacesPlug
   );
 
   const chatExperience$ = coreStart.settings.client.get$<AIChatExperience>(
-    PREFERRED_CHAT_EXPERIENCE_SETTING_KEY,
-    AIChatExperience.Classic
+    PREFERRED_CHAT_EXPERIENCE_SETTING_KEY
   );
 
   const activeSpace$ = useMemo(

--- a/src/platform/plugins/shared/ai_assistant_management/selection/public/plugin.tsx
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/public/plugin.tsx
@@ -183,10 +183,7 @@ export class AIAssistantManagementPlugin
     if (!this.isServerless && licensing) {
       this.managementAppVisibilitySubscription = combineLatest([
         licensing.license$,
-        coreStart.settings.client.get$<AIChatExperience>(
-          PREFERRED_CHAT_EXPERIENCE_SETTING_KEY,
-          AIChatExperience.Classic
-        ),
+        coreStart.settings.client.get$<AIChatExperience>(PREFERRED_CHAT_EXPERIENCE_SETTING_KEY),
       ]).subscribe(([license, chatExperience]) => {
         const isEnterprise = license?.hasAtLeast('enterprise');
 

--- a/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.test.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.test.ts
@@ -48,11 +48,21 @@ describe('plugin', () => {
 
   const setupPlugin = (
     plugin: AIAssistantManagementSelectionPlugin,
-    options: { spaces?: ReturnType<typeof spacesMock.createStart> } = {}
+    options: {
+      spaces?: ReturnType<typeof spacesMock.createStart>;
+      coreStart?: Partial<{ security: { authc: { getCurrentUser: jest.Mock } } }>;
+    } = {}
   ) => {
     const coreSetup = coreMock.createSetup();
     const spaces = options.spaces ?? spacesMock.createStart();
-    coreSetup.getStartServices.mockResolvedValue([{} as any, { spaces }, {} as any]);
+    const coreStart = options.coreStart ?? {
+      security: {
+        authc: {
+          getCurrentUser: jest.fn().mockReturnValue({ username: 'test-user' }),
+        },
+      },
+    };
+    coreSetup.getStartServices.mockResolvedValue([coreStart as any, { spaces }, {} as any]);
 
     const setupDeps = {
       management: {

--- a/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.test.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.test.ts
@@ -7,8 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { PluginInitializerContext, CoreSetup } from '@kbn/core/server';
-import type { AIAssistantManagementSelectionPluginServerDependenciesSetup } from './types';
+import type { PluginInitializerContext } from '@kbn/core/server';
+import { coreMock } from '@kbn/core/server/mocks';
+import { spacesMock } from '@kbn/spaces-plugin/server/mocks';
+import type { Space } from '@kbn/spaces-plugin/common';
+import type { AIAssistantManagementSelectionConfig } from './config';
 import { AIChatExperience } from '@kbn/ai-assistant-common';
 import { AIAssistantType } from '../common/ai_assistant_type';
 import {
@@ -24,43 +27,59 @@ describe('plugin', () => {
     jest.clearAllMocks();
   });
 
+  const createPlugin = (config: Partial<AIAssistantManagementSelectionConfig> = {}) => {
+    const initializerContext = {
+      env: {
+        packageInfo: {
+          buildFlavor: 'classic',
+        },
+      },
+      config: {
+        get: jest.fn().mockReturnValue(config),
+      },
+      logger: {
+        get: jest.fn().mockReturnValue({
+          error: jest.fn(),
+        }),
+      },
+    } as unknown as PluginInitializerContext;
+    return new AIAssistantManagementSelectionPlugin(initializerContext);
+  };
+
+  const setupPlugin = (
+    plugin: AIAssistantManagementSelectionPlugin,
+    options: { spaces?: ReturnType<typeof spacesMock.createStart> } = {}
+  ) => {
+    const coreSetup = coreMock.createSetup();
+    const spaces = options.spaces ?? spacesMock.createStart();
+    coreSetup.getStartServices.mockResolvedValue([{} as any, { spaces }, {} as any]);
+
+    const setupDeps = {
+      management: {
+        sections: {
+          getSection: jest.fn(),
+        },
+      },
+    } as any;
+
+    plugin.setup(coreSetup, setupDeps);
+    return { coreSetup, spaces };
+  };
+
+  const getChatExperienceGetValue = (coreSetup: ReturnType<typeof coreMock.createSetup>) => {
+    const registeredSettings = coreSetup.uiSettings.register.mock.calls.find(
+      (call) => call[0][PREFERRED_CHAT_EXPERIENCE_SETTING_KEY]
+    );
+    return registeredSettings![0][PREFERRED_CHAT_EXPERIENCE_SETTING_KEY].getValue;
+  };
+
   describe('stateful', () => {
-    it('uses the correct setting keys to register both AI assistant type and chat experience settings', async () => {
-      const initializerContext = {
-        env: {
-          packageInfo: {
-            buildFlavor: 'classic',
-          },
-        },
-        config: {
-          get: jest.fn().mockReturnValue({
-            preferredAIAssistantType: AIAssistantType.Observability,
-            preferredChatExperience: AIChatExperience.Classic,
-          }),
-        },
-      } as unknown as PluginInitializerContext;
-      const aiAssistantManagementSelectionPlugin = new AIAssistantManagementSelectionPlugin(
-        initializerContext
-      );
-
-      const coreSetup = {
-        uiSettings: {
-          register: jest.fn(),
-        },
-        capabilities: {
-          registerProvider: jest.fn(),
-        },
-      } as unknown as CoreSetup;
-
-      const setupDeps = {
-        management: {
-          sections: {
-            getSection: jest.fn(),
-          },
-        },
-      } as unknown as AIAssistantManagementSelectionPluginServerDependenciesSetup;
-
-      aiAssistantManagementSelectionPlugin.setup(coreSetup, setupDeps);
+    it('registers both AI assistant type and chat experience settings', async () => {
+      const plugin = createPlugin({
+        preferredAIAssistantType: AIAssistantType.Observability,
+        preferredChatExperience: AIChatExperience.Classic,
+      });
+      const { coreSetup } = setupPlugin(plugin);
 
       expect(coreSetup.uiSettings.register).toHaveBeenCalledTimes(2);
 
@@ -72,12 +91,71 @@ describe('plugin', () => {
         },
       });
 
-      // Second call: Chat Experience setting
-      expect(coreSetup.uiSettings.register).toHaveBeenNthCalledWith(2, {
-        [PREFERRED_CHAT_EXPERIENCE_SETTING_KEY]: {
-          ...chatExperienceSetting,
-          value: AIChatExperience.Classic,
-        },
+      // Second call: Chat Experience setting - should have getValue function
+      const chatExperienceSettingDef =
+        coreSetup.uiSettings.register.mock.calls[1][0][PREFERRED_CHAT_EXPERIENCE_SETTING_KEY];
+      expect(chatExperienceSettingDef).toMatchObject({
+        name: chatExperienceSetting.name,
+        options: chatExperienceSetting.options,
+        type: chatExperienceSetting.type,
+      });
+      expect(chatExperienceSettingDef.getValue).toBeDefined();
+      expect(typeof chatExperienceSettingDef.getValue).toBe('function');
+      expect(chatExperienceSettingDef).not.toHaveProperty('value');
+    });
+
+    describe('chat experience getValue()', () => {
+      it('should return config value when provided', async () => {
+        const plugin = createPlugin({ preferredChatExperience: AIChatExperience.Agent });
+        const { coreSetup } = setupPlugin(plugin);
+        const getValue = getChatExperienceGetValue(coreSetup);
+
+        await expect(getValue!({ request: {} as any })).resolves.toBe(AIChatExperience.Agent);
+      });
+
+      it('should return Classic when no request is provided', async () => {
+        const plugin = createPlugin();
+        const { coreSetup } = setupPlugin(plugin);
+        const getValue = getChatExperienceGetValue(coreSetup);
+
+        await expect(getValue!()).resolves.toBe(AIChatExperience.Classic);
+      });
+
+      it.each([
+        { solution: 'es', expected: AIChatExperience.Agent },
+        { solution: 'oblt', expected: AIChatExperience.Classic },
+        { solution: 'security', expected: AIChatExperience.Classic },
+        { solution: 'classic', expected: AIChatExperience.Classic },
+      ])(
+        'should return $expected when active space solution is "$solution"',
+        async ({ solution, expected }) => {
+          const plugin = createPlugin();
+          const spaces = spacesMock.createStart();
+          const mockSpace: Pick<Space, 'solution'> = { solution: solution as any };
+          spaces.spacesService.getActiveSpace.mockResolvedValue(mockSpace as Space);
+          const { coreSetup } = setupPlugin(plugin, { spaces });
+          const getValue = getChatExperienceGetValue(coreSetup);
+
+          const requestMock = {
+            auth: { isAuthenticated: true },
+          };
+          await expect(getValue!({ request: requestMock as any })).resolves.toBe(expected);
+        }
+      );
+
+      it('should handle error and fallback to Classic', async () => {
+        const plugin = createPlugin();
+        const spaces = spacesMock.createStart();
+        spaces.spacesService.getActiveSpace.mockRejectedValue(new Error('something went wrong'));
+        const { coreSetup } = setupPlugin(plugin, { spaces });
+        const getValue = getChatExperienceGetValue(coreSetup);
+
+        const requestMock = {
+          auth: { isAuthenticated: true },
+        };
+        await expect(getValue!({ request: requestMock as any })).resolves.toBe(
+          AIChatExperience.Classic
+        );
       });
     });
   });

--- a/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.ts
@@ -89,10 +89,13 @@ export class AIAssistantManagementSelectionPlugin
           getValue: async ({ request }: { request?: KibanaRequest } = {}) => {
             if (request) {
               try {
-                const [, startServices] = await core.getStartServices();
-                const spaces = startServices.spaces;
-                if (spaces) {
-                  const activeSpace = await spaces.spacesService.getActiveSpace(request);
+                const [coreStart, startServices] = await core.getStartServices();
+                // Avoid security exceptions before login
+                const user = coreStart.security.authc.getCurrentUser(request);
+                if (startServices.spaces && user) {
+                  const activeSpace = await startServices.spaces.spacesService.getActiveSpace(
+                    request
+                  );
                   if (activeSpace?.solution === 'es') {
                     return AIChatExperience.Agent;
                   }

--- a/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/server/plugin.ts
@@ -15,7 +15,6 @@ import type {
   KibanaRequest,
   Logger,
 } from '@kbn/core/server';
-import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import { AIChatExperience } from '@kbn/ai-assistant-common';
 import type { AIAssistantManagementSelectionConfig } from './config';
 import type {
@@ -50,7 +49,10 @@ export class AIAssistantManagementSelectionPlugin
   }
 
   public setup(
-    core: CoreSetup,
+    core: CoreSetup<
+      AIAssistantManagementSelectionPluginServerDependenciesStart,
+      AIAssistantManagementSelectionPluginServerStart
+    >,
     plugins: AIAssistantManagementSelectionPluginServerDependenciesSetup
   ) {
     this.registerUiSettings(core, plugins);
@@ -59,7 +61,10 @@ export class AIAssistantManagementSelectionPlugin
   }
 
   private registerUiSettings(
-    core: CoreSetup,
+    core: CoreSetup<
+      AIAssistantManagementSelectionPluginServerDependenciesStart,
+      AIAssistantManagementSelectionPluginServerStart
+    >,
     plugins: AIAssistantManagementSelectionPluginServerDependenciesSetup
   ) {
     const { cloud } = plugins;
@@ -85,7 +90,7 @@ export class AIAssistantManagementSelectionPlugin
             if (request) {
               try {
                 const [, startServices] = await core.getStartServices();
-                const spaces = (startServices as { spaces?: SpacesPluginStart }).spaces;
+                const spaces = startServices.spaces;
                 if (spaces) {
                   const activeSpace = await spaces.spacesService.getActiveSpace(request);
                   if (activeSpace?.solution === 'es') {

--- a/src/platform/plugins/shared/ai_assistant_management/selection/server/types.ts
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/server/types.ts
@@ -9,9 +9,11 @@
 
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface AIAssistantManagementSelectionPluginServerDependenciesStart {}
+export interface AIAssistantManagementSelectionPluginServerDependenciesStart {
+  spaces?: SpacesPluginStart;
+}
 
 export interface AIAssistantManagementSelectionPluginServerDependenciesSetup {
   features?: FeaturesPluginSetup;

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/gen_ai_settings_app.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/gen_ai_settings_app.tsx
@@ -61,6 +61,7 @@ export const GenAiSettingsApp: React.FC<GenAiSettingsAppProps> = ({ setBreadcrum
   const currentChatExperience =
     unsavedChanges[AI_CHAT_EXPERIENCE_TYPE]?.unsavedValue ??
     chatExperienceField?.savedValue ??
+    chatExperienceField?.defaultValue ??
     AIChatExperience.Classic;
   const isAgentExperience = currentChatExperience === AIChatExperience.Agent;
 

--- a/x-pack/platform/plugins/shared/onechat/public/components/nav_control/lazy_onechat_nav_control.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/components/nav_control/lazy_onechat_nav_control.tsx
@@ -34,7 +34,7 @@ export const OnechatNavControlInitiator = ({
 
   useEffect(() => {
     const sub = coreStart.settings.client
-      .get$<AIChatExperience>(AI_CHAT_EXPERIENCE_TYPE, AIChatExperience.Classic)
+      .get$<AIChatExperience>(AI_CHAT_EXPERIENCE_TYPE)
       .subscribe((chatExperience) => {
         setIsAgentsExperience(chatExperience === AIChatExperience.Agent);
       });

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/hooks/is_nav_control_visible.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/hooks/is_nav_control_visible.tsx
@@ -69,10 +69,8 @@ export function useIsNavControlVisible({
   const space$ = spaces.getActiveSpace$();
 
   useEffect(() => {
-    const chatExperience$ = coreStart.settings.client.get$<AIChatExperience>(
-      AI_CHAT_EXPERIENCE_TYPE,
-      AIChatExperience.Classic
-    );
+    const chatExperience$ =
+      coreStart.settings.client.get$<AIChatExperience>(AI_CHAT_EXPERIENCE_TYPE);
 
     const appSubscription = combineLatest([
       currentAppId$,

--- a/x-pack/solutions/search/plugins/search_assistant/public/components/nav_control/lazy_nav_control.tsx
+++ b/x-pack/solutions/search/plugins/search_assistant/public/components/nav_control/lazy_nav_control.tsx
@@ -28,7 +28,7 @@ export const NavControlInitiator = ({ coreStart, pluginsStart }: NavControlIniti
 
   useEffect(() => {
     const sub = coreStart.settings.client
-      .get$<AIChatExperience>(AI_CHAT_EXPERIENCE_TYPE, AIChatExperience.Classic)
+      .get$<AIChatExperience>(AI_CHAT_EXPERIENCE_TYPE)
       .subscribe((chatExperience) => {
         setIsClassicExperience(chatExperience === AIChatExperience.Classic);
       });

--- a/x-pack/solutions/security/plugins/elastic_assistant/public/src/hooks/is_nav_control_visible/use_is_nav_control_visible.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/public/src/hooks/is_nav_control_visible/use_is_nav_control_visible.ts
@@ -60,10 +60,7 @@ export function useIsNavControlVisible(isServerless?: boolean) {
   const space$ = spaces.getActiveSpace$();
 
   useEffect(() => {
-    const chatExperience$ = settings.client.get$<AIChatExperience>(
-      AI_CHAT_EXPERIENCE_TYPE,
-      AIChatExperience.Classic
-    );
+    const chatExperience$ = settings.client.get$<AIChatExperience>(AI_CHAT_EXPERIENCE_TYPE);
 
     const appSubscription = combineLatest([
       currentAppId$,


### PR DESCRIPTION
## Summary

Implements: https://github.com/elastic/ml-team/issues/1755
Follow up to: https://github.com/elastic/kibana/pull/244532

The goal of this PR is to make Chat Experience in Elasticsearch serverless/solution view default to Agent instead of Classic Assistants.

Implementation details:

- Serverless is configured via `serverless.es.yml` file
- Second argument in `coreStart.settings.client.get$<AIChatExperience>` was removed as it was overriding provided configuration.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



