### PR TITLE
[streams][prompts] only override prompts with value

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/saved_objects/significant_events/promps_config_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/saved_objects/significant_events/promps_config_service.ts
@@ -48,7 +48,7 @@ export class PromptsConfigService {
       {
         ...defaultsPrompts,
         ...existing,
-        ...attributes,
+        ...Object.fromEntries(Object.entries(attributes).filter(([, value]) => Boolean(value))),
       },
       {
         ...(options ?? {}),

--- a/x-pack/platform/plugins/shared/streams/server/lib/saved_objects/significant_events/prompts_config_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/saved_objects/significant_events/prompts_config_service.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { isUndefined, omitBy } from 'lodash';
 import type {
   Logger,
   SavedObjectsClientContract,
@@ -48,7 +49,7 @@ export class PromptsConfigService {
       {
         ...defaultsPrompts,
         ...existing,
-        ...Object.fromEntries(Object.entries(attributes).filter(([, value]) => Boolean(value))),
+        ...omitBy(attributes, isUndefined),
       },
       {
         ...(options ?? {}),

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/features/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/features/route.ts
@@ -20,7 +20,7 @@ import type {
 import { generateStreamDescription, sumTokens } from '@kbn/streams-ai';
 import type { Observable } from 'rxjs';
 import { from, map } from 'rxjs';
-import { PromptsConfigService } from '../../../../lib/saved_objects/significant_events/promps_config_service';
+import { PromptsConfigService } from '../../../../lib/saved_objects/significant_events/prompts_config_service';
 import { StatusError } from '../../../../lib/streams/errors/status_error';
 import { getDefaultFeatureRegistry } from '../../../../lib/streams/feature/feature_type_registry';
 import { createServerRoute } from '../../../create_server_route';

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/prompts/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/prompts/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { z } from '@kbn/zod';
-import type { PromptsConfigAttributes } from '../../../../lib/saved_objects/significant_events/promps_config_service';
+import type { PromptsConfigAttributes } from '../../../../lib/saved_objects/significant_events/prompts_config_service';
 import { PromptsConfigService } from '../../../../lib/saved_objects/significant_events/prompts_config_service';
 import { StatusError } from '../../../../lib/streams/errors/status_error';
 import { createServerRoute } from '../../../create_server_route';

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/prompts/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/prompts/route.ts
@@ -7,7 +7,7 @@
 
 import { z } from '@kbn/zod';
 import type { PromptsConfigAttributes } from '../../../../lib/saved_objects/significant_events/promps_config_service';
-import { PromptsConfigService } from '../../../../lib/saved_objects/significant_events/promps_config_service';
+import { PromptsConfigService } from '../../../../lib/saved_objects/significant_events/prompts_config_service';
 import { StatusError } from '../../../../lib/streams/errors/status_error';
 import { createServerRoute } from '../../../create_server_route';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/significant_events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/significant_events/route.ts
@@ -14,7 +14,7 @@ import {
 import { z } from '@kbn/zod';
 import { conditionSchema } from '@kbn/streamlang';
 import { from as fromRxjs, map } from 'rxjs';
-import { PromptsConfigService } from '../../../lib/saved_objects/significant_events/promps_config_service';
+import { PromptsConfigService } from '../../../lib/saved_objects/significant_events/prompts_config_service';
 import { STREAMS_API_PRIVILEGES } from '../../../../common/constants';
 import { generateSignificantEventDefinitions } from '../../../lib/significant_events/generate_significant_events';
 import { previewSignificantEvents } from '../../../lib/significant_events/preview_significant_events';


### PR DESCRIPTION
## Summary

If one only overrides one prompt, the current logic will apply undefined to any other prompts resulting in resetting them unexpectedly


