### PR TITLE
[Security Solution][Entity Analytics][Risk Score] AI to consider privmon contribution while answering questions to risk score

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/ask_ai_assistant.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/ask_ai_assistant.tsx
@@ -62,7 +62,7 @@ export const AskAiAssistant = <T extends EntityType>({
   const { showAssistantOverlay, disabled: aiAssistantDisable } = useAskAiAssistant({
     title: `Explain ${entityType} '${entityName}' Risk Score`,
     description: `Entity: ${entityName}`,
-    suggestedPrompt: `Explain how inputs contributed to the risk score. Additionally, outline the recommended next steps for investigating or mitigating the risk if the entity is deemed risky.\nTo answer risk score questions, fetch the risk score information and take into consideration the risk score inputs.`,
+    suggestedPrompt: `Explain how inputs contributed to the risk score, including any risk modifiers such as asset criticality or privileged user monitoring status. Additionally, outline the recommended next steps for investigating or mitigating the risk if the entity is deemed risky.\nTo answer risk score questions, fetch the risk score information and take into consideration both the risk score inputs and any modifiers that adjusted the final score.`,
     getPromptContext,
     replacements,
   });
@@ -74,7 +74,7 @@ export const AskAiAssistant = <T extends EntityType>({
         identifier: entityName,
         attachmentLabel: `${entityType}: ${entityName}`,
       },
-      attachmentPrompt: `Explain how inputs contributed to the risk score. Additionally, outline the recommended next steps for investigating or mitigating the risk if the entity is deemed risky.\nTo answer risk score questions, fetch the risk score information and take into consideration the risk score inputs.`,
+      attachmentPrompt: `Explain how inputs contributed to the risk score, including any risk modifiers such as asset criticality or privileged user monitoring status. Additionally, outline the recommended next steps for investigating or mitigating the risk if the entity is deemed risky.\nTo answer risk score questions, fetch the risk score information and take into consideration both the risk score inputs and any modifiers that adjusted the final score.`,
     }),
     [entityName, entityType]
   );

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_risk_score_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_risk_score_tool.ts
@@ -131,7 +131,7 @@ export const entityRiskScoreTool = (
   return {
     id: SECURITY_ENTITY_RISK_SCORE_TOOL_ID,
     type: ToolType.builtin,
-    description: `Call this tool to get the latest entity risk score and the inputs that contributed to the calculation for a specific entity (host, user, service, or generic). Use identifier "*" to get all entities of the specified type sorted by risk score. IMPORTANT: Always use 'calculated_score_norm' (0-100) when reporting risk scores, NOT 'calculated_score' which is a raw value. The 'calculated_score_norm' field is the normalized score suitable for comparison between entities.`,
+    description: `Call this tool to get the latest entity risk score and the inputs that contributed to the calculation for a specific entity (host, user, service, or generic). Use identifier "*" to get all entities of the specified type sorted by risk score. IMPORTANT: Always use 'calculated_score_norm' (0-100) when reporting risk scores, NOT 'calculated_score' which is a raw value. The 'calculated_score_norm' field is the normalized score suitable for comparison between entities. The 'modifiers' array contains risk adjustments such as asset criticality and privileged user monitoring (watchlist/privmon type).`,
     schema: entityRiskScoreSchema,
     availability: {
       cacheMode: 'space',

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/entity_risk_score/entity_risk_score.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/entity_risk_score/entity_risk_score.ts
@@ -30,7 +30,7 @@ export type EntityRiskScoreToolParams = Require<
   'alertsIndexPattern' | 'size' | 'assistantContext'
 >;
 
-export const ENTITY_RISK_SCORE_TOOL_DESCRIPTION = `Call this for knowledge about the latest entity risk score and the inputs that contributed to the calculation (sorted by 'kibana.alert.risk_score') in the environment, or when answering questions about how critical or risky an entity is. When informing the risk score value for a entity you must use the normalized field 'calculated_score_norm'.`;
+export const ENTITY_RISK_SCORE_TOOL_DESCRIPTION = `Call this for knowledge about the latest entity risk score and the inputs that contributed to the calculation (sorted by 'kibana.alert.risk_score') in the environment, or when answering questions about how critical or risky an entity is. When informing the risk score value for a entity you must use the normalized field 'calculated_score_norm'. The 'modifiers' array contains risk adjustments including asset criticality and privileged user monitoring (watchlist/privmon).`;
 
 export const ENTITY_RISK_SCORE_TOOL_ID = 'entity-risk-score-tool';
 
@@ -131,7 +131,12 @@ export const ENTITY_RISK_SCORE_TOOL: AssistantTool = {
           }))
         );
 
-        const data = { ...latestRiskScore, inputs: enhancedInputs, id_value: input.identifier }; // Replace id_value for the anonymized identifier to avoid leaking user data
+        const data = {
+          ...latestRiskScore,
+          // modifiers already in latestRiskScore from PR #244634
+          inputs: enhancedInputs,
+          id_value: input.identifier, // Replace id_value for the anonymized identifier to avoid leaking user data
+        };
 
         return JSON.stringify({
           riskScore: data,

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/entity_risk_score/entity_risk_score.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/entity_risk_score/entity_risk_score.ts
@@ -133,7 +133,6 @@ export const ENTITY_RISK_SCORE_TOOL: AssistantTool = {
 
         const data = {
           ...latestRiskScore,
-          // modifiers already in latestRiskScore from PR #244634
           inputs: enhancedInputs,
           id_value: input.identifier, // Replace id_value for the anonymized identifier to avoid leaking user data
         };


### PR DESCRIPTION
## Summary


This PR integrates privileged user monitoring (category_3) support into Kibana's AI assistant tools by enabling them to consume and interpret the `modifiers` array from risk score records. This allows AI assistants (Elastic Assistant and Agent Builder) to understand and communicate risk score adjustments from both **asset criticality** and **privileged user monitoring** when explaining entity risk scores to users.

**Changes**:
- Updated tool to pass the `modifiers` array directly from risk score records to the AI
- Updated tool description to explicitly mention "risk modifiers" and "privileged user monitoring"
- Simplified data construction by relying on the spread operator to include all risk score fields

## Testing

### Prerequisites

1. **Enable Experimental Feature**: Add to `kibana.dev.yml`:
   ```yaml
   xpack.securitySolution.enableExperimental:
     - riskScorePrivmonModifier
   ```

2. **Setup Required**:
   - Risk Engine must be enabled and running
   - At least one user with asset criticality assigned
   - At least one user marked as privileged (for testing privmon)

### Manual Testing with Elastic Assistant

1. Start Kibana with LLM connector configured
2. Navigate to AI Assistant.
3. Query: "What is the risk score for user [username]?"
4. Verify the AI response mentions:
   - Asset criticality (if assigned)
   - Privileged user monitoring (if user is privileged)
5. Check browser DevTools Network tab:
   - Find the connector execution request
   - Verify `modifiers` array is present in the tool response

### Manual Testing with Agent Builder

1. Open Agent Builder
2. Attach risk score data for an entity
3. Ask: "Explain this user's risk score"
4. Verify AI mentions modifiers in explanation


Screenshots to showcase AI tools considering modifiers contribution while calculating risk scores.


<img width="1888" height="666" alt="Screenshot 2025-12-15 at 4 08 17 PM" src="https://github.com/user-attachments/assets/72bafa24-d9aa-42f1-a1dd-be524eb52f93" />
<img width="1664" height="349" alt="Screenshot 2025-12-15 at 4 07 01 PM" src="https://github.com/user-attachments/assets/3dc165b4-29a5-4a30-af79-ca87b62a18c1" />
<img width="957" height="559" alt="Screenshot 2025-12-15 at 4 06 45 PM" src="https://github.com/user-attachments/assets/e0678a4e-b144-441b-a796-d20b280ba58f" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
