### PR TITLE
[Agent Builder] Simple FTR test for renaming a conversation

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/rename_conversation_input.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/rename_conversation_input.tsx
@@ -110,9 +110,14 @@ export const RenameConversationInput: React.FC<RenameConversationInputProps> = (
       editModeProps={{
         inputProps: {
           inputRef: inputRefCallback,
+          'data-test-subj': 'renameConversationInputField',
         },
         saveButtonProps: {
           isDisabled: !isFormDirty || newTitle.trim() === '',
+          'data-test-subj': 'renameConversationSaveButton',
+        },
+        cancelButtonProps: {
+          'data-test-subj': 'renameConversationCancelButton',
         },
       }}
       data-test-subj="renameConversationInput"

--- a/x-pack/platform/test/functional/page_objects/onechat_page.ts
+++ b/x-pack/platform/test/functional/page_objects/onechat_page.ts
@@ -244,6 +244,47 @@ export class OneChatPageObject extends FtrService {
   }
 
   /**
+   * Get the current conversation title text
+   */
+  async getConversationTitle(): Promise<string> {
+    const titleElement = await this.testSubjects.find('agentBuilderConversationTitle');
+    return await titleElement.getVisibleText();
+  }
+
+  /**
+   * Rename a conversation by hovering over the title, clicking the pencil icon,
+   * entering the new name, and submitting
+   */
+  async renameConversation(newTitle: string): Promise<string> {
+    // Hover over the conversation title to reveal the pencil icon
+    const titleElement = await this.testSubjects.find('agentBuilderConversationTitle');
+    await titleElement.moveMouseTo();
+
+    // Click the pencil icon to enter edit mode
+    const renameButton = await this.testSubjects.find('agentBuilderConversationRenameButton');
+    await renameButton.click();
+
+    // Wait for the inline edit input to appear and clear + type new name
+    const inputElement = await this.testSubjects.find('renameConversationInputField');
+    await inputElement.clearValueWithKeyboard();
+    await inputElement.type(newTitle);
+
+    // Click the save button (checkmark icon)
+    const saveButton = await this.testSubjects.find('renameConversationSaveButton');
+    await saveButton.click();
+
+    // Wait for the title to update
+    await this.retry.try(async () => {
+      const updatedTitle = await this.getConversationTitle();
+      if (updatedTitle !== newTitle) {
+        throw new Error(`Title not yet updated: expected "${newTitle}", got "${updatedTitle}"`);
+      }
+    });
+
+    return newTitle;
+  }
+
+  /**
    * Get the thinking details text
    */
   async getThinkingDetails() {

--- a/x-pack/platform/test/onechat_functional/tests/converse/conversation_history.ts
+++ b/x-pack/platform/test/onechat_functional/tests/converse/conversation_history.ts
@@ -146,6 +146,25 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       expect(await onechat.isConversationInHistory(conversationIds[2])).to.be(true);
     });
 
+    it('can rename a conversation and the title updates correctly', async () => {
+      const conversationIdToRename = conversationIds[1];
+      const newTitle = 'Renamed Conversation Title';
+
+      // Navigate to the conversation
+      await onechat.navigateToConversationViaHistory(conversationIdToRename);
+
+      // Wait for conversation content to load
+      await retry.try(async () => {
+        await testSubjects.find('agentBuilderRoundResponse');
+      });
+
+      // Rename the conversation
+      const updatedTitle = await onechat.renameConversation(newTitle);
+
+      // Assert the title was updated correctly
+      expect(updatedTitle).to.be(newTitle);
+    });
+
     it.skip('does not allow continuing to chat if the agent cannot be found', async () => {
       // 1. Add new agent
       // 2. Create new conversation with that agent


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/search-team/issues/12180

- [ ] Adds an FTR test for renaming a conversation following the existing format we've been using for our FTR tests



