### PR TITLE
[CPS][Discover] Support CPS project picker 

### DIFF
--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker.test.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker.test.tsx
@@ -103,7 +103,7 @@ describe('ProjectPicker', () => {
   });
 
   describe('projectRouting change events', () => {
-    it('should call onProjectRoutingChange with ALL when "All projects" is clicked', async () => {
+    it('should call onProjectRoutingChange with PROJECT_ROUTING.ALL when "All projects" is clicked', async () => {
       const onProjectRoutingChange = jest.fn();
       await renderProjectPicker({
         projectRouting: PROJECT_ROUTING.ORIGIN,

--- a/src/platform/packages/shared/kbn-cps-utils/constants.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/constants.ts
@@ -13,7 +13,7 @@
  */
 export const PROJECT_ROUTING = {
   /** Search across all linked projects */
-  ALL: 'ALL',
+  ALL: '_alias:*',
   /** Search only the origin project */
   ORIGIN: '_alias:_origin',
 } as const;

--- a/src/platform/packages/shared/kbn-cps-utils/types.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/types.ts
@@ -50,4 +50,5 @@ export interface ICPSManager {
   getProjectRouting(): ProjectRouting | undefined;
   getDefaultProjectRouting(): ProjectRouting;
   getProjectPickerAccess$(): Observable<ProjectRoutingAccess>;
+  getProjectPickerAccess(): ProjectRoutingAccess;
 }

--- a/src/platform/packages/shared/kbn-es-query/src/project_routing/index.ts
+++ b/src/platform/packages/shared/kbn-es-query/src/project_routing/index.ts
@@ -14,6 +14,7 @@
  *
  * Examples:
  * - undefined - Search across all projects (default)
+ * - '_alias:*' - Search across all projects
  * - '_alias:_origin' - Search only in the current project
  *
  * @public
@@ -22,9 +23,6 @@ export type ProjectRouting = string | undefined;
 
 /**
  * Sanitizes project routing value for Elasticsearch API calls.
- *
- * Application-level code may use special values like 'ALL' to represent "all projects"
- * with explicit state, but Elasticsearch only accepts specific routing values.
  *
  * @param value - The project routing value from application state
  * @returns The sanitized value for Elasticsearch, or undefined to search all projects

--- a/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.test.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.test.ts
@@ -138,8 +138,4 @@ describe('SearchAPI projectRouting', () => {
   test('should not include project_routing in ES params when projectRouting is undefined', (done) => {
     testProjectRouting(undefined, undefined, done);
   });
-
-  test('should sanitize ALL projectRouting value', (done) => {
-    testProjectRouting('ALL', undefined, done);
-  });
 });

--- a/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.ts
@@ -17,7 +17,6 @@ import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { search as dataPluginSearch } from '@kbn/data-plugin/public';
 import type { RequestResponder } from '@kbn/inspector-plugin/public';
 import type { ProjectRouting } from '@kbn/es-query';
-import { sanitizeProjectRoutingForES } from '@kbn/es-query';
 import type { VegaInspectorAdapters } from '../vega_inspector';
 
 /** @internal **/
@@ -87,10 +86,9 @@ export class SearchAPI {
             }
           }),
           switchMap((params) => {
-            const sanitizedRouting = sanitizeProjectRoutingForES(this.projectRouting);
-            if (sanitizedRouting) {
+            if (this.projectRouting) {
               // @ts-ignore it will not throw ts error once ES client supports it
-              params.body.project_routing = sanitizedRouting;
+              params.body.project_routing = this.projectRouting;
             }
 
             return search

--- a/src/platform/plugins/shared/cps/public/services/access_control.test.ts
+++ b/src/platform/plugins/shared/cps/public/services/access_control.test.ts
@@ -8,11 +8,7 @@
  */
 
 import { ProjectRoutingAccess } from '@kbn/cps-utils';
-import {
-  getProjectRoutingAccess,
-  DEFAULT_ACCESS_CONTROL_CONFIG,
-  type AccessControlConfig,
-} from './access_control';
+import { ACCESS_CONTROL_CONFIG, getProjectRoutingAccess } from './access_control';
 
 describe('Access Control Configuration', () => {
   describe('getProjectRoutingAccess', () => {
@@ -65,85 +61,33 @@ describe('Access Control Configuration', () => {
       });
     });
 
-    describe('with custom configuration', () => {
-      const customConfig: AccessControlConfig = {
-        myApp: {
-          defaultAccess: ProjectRoutingAccess.EDITABLE,
-        },
-        customApp: {
-          defaultAccess: ProjectRoutingAccess.DISABLED,
-          routeRules: [
-            {
-              pattern: /^#\/special/,
-              access: ProjectRoutingAccess.EDITABLE,
-            },
-          ],
-        },
-      };
-
-      it('should use custom app configuration', () => {
-        expect(getProjectRoutingAccess('myApp', '#/anything', customConfig)).toBe(
-          ProjectRoutingAccess.EDITABLE
-        );
-      });
-
-      it('should match route rules before defaultAccess', () => {
-        expect(getProjectRoutingAccess('customApp', '#/special/page', customConfig)).toBe(
-          ProjectRoutingAccess.EDITABLE
-        );
-        expect(getProjectRoutingAccess('customApp', '#/normal/page', customConfig)).toBe(
-          ProjectRoutingAccess.DISABLED
-        );
-      });
-
-      it('should return DISABLED for unconfigured apps', () => {
-        expect(getProjectRoutingAccess('unknownApp', '#/', customConfig)).toBe(
-          ProjectRoutingAccess.DISABLED
-        );
-      });
-    });
-
     describe('route rule priority', () => {
-      const config: AccessControlConfig = {
-        testApp: {
-          defaultAccess: ProjectRoutingAccess.DISABLED,
-          routeRules: [
-            {
-              pattern: /^#\/admin/,
-              access: ProjectRoutingAccess.READONLY,
-            },
-            {
-              pattern: /^#\/edit/,
-              access: ProjectRoutingAccess.EDITABLE,
-            },
-          ],
-        },
-      };
-
-      it('should check rules in order', () => {
-        expect(getProjectRoutingAccess('testApp', '#/admin/settings', config)).toBe(
-          ProjectRoutingAccess.READONLY
-        );
-        expect(getProjectRoutingAccess('testApp', '#/edit/document', config)).toBe(
+      it('should check rules in order and match pattern before defaulting', () => {
+        // Rule matches: type:vega pattern -> EDITABLE (overrides DISABLED default)
+        expect(getProjectRoutingAccess('visualize', '#/edit/123?type:vega')).toBe(
           ProjectRoutingAccess.EDITABLE
         );
-        expect(getProjectRoutingAccess('testApp', '#/view/document', config)).toBe(
+        // No rule match: falls back to defaultAccess -> DISABLED
+        expect(getProjectRoutingAccess('visualize', '#/edit/456?type:lens')).toBe(
+          ProjectRoutingAccess.DISABLED
+        );
+        expect(getProjectRoutingAccess('visualize', '#/create')).toBe(
           ProjectRoutingAccess.DISABLED
         );
       });
     });
   });
 
-  describe('DEFAULT_ACCESS_CONTROL_CONFIG', () => {
+  describe('ACCESS_CONTROL_CONFIG', () => {
     it('should have configuration for expected apps', () => {
-      expect(DEFAULT_ACCESS_CONTROL_CONFIG).toHaveProperty('dashboards');
-      expect(DEFAULT_ACCESS_CONTROL_CONFIG).toHaveProperty('discover');
-      expect(DEFAULT_ACCESS_CONTROL_CONFIG).toHaveProperty('visualize');
-      expect(DEFAULT_ACCESS_CONTROL_CONFIG).toHaveProperty('lens');
+      expect(ACCESS_CONTROL_CONFIG).toHaveProperty('dashboards');
+      expect(ACCESS_CONTROL_CONFIG).toHaveProperty('discover');
+      expect(ACCESS_CONTROL_CONFIG).toHaveProperty('visualize');
+      expect(ACCESS_CONTROL_CONFIG).toHaveProperty('lens');
     });
 
     it('should have route rules for dashboards', () => {
-      expect(DEFAULT_ACCESS_CONTROL_CONFIG.dashboards.routeRules).toHaveLength(1);
+      expect(ACCESS_CONTROL_CONFIG.dashboards.routeRules).toHaveLength(1);
     });
   });
 });

--- a/src/platform/plugins/shared/cps/public/services/access_control.ts
+++ b/src/platform/plugins/shared/cps/public/services/access_control.ts
@@ -45,20 +45,8 @@ export type AccessControlConfig = Record<string, AppAccessConfig>;
  * - READONLY: View-only mode - shows current scope but prevents changes
  * - DISABLED: Picker is completely disabled
  *
- * Default Configuration:
- *
- * | App        | Route                  | Access Level | Notes                              |
- * |------------|------------------------|--------------|-------------------------------------|
- * | dashboards | all routes except list | EDITABLE     | All dashboard pages except listing  |
- * | dashboards | #/list                 | DISABLED     | List page only                     |
- * | discover   | all routes             | EDITABLE     | All discover pages                 |
- * | visualize  | type:vega in route     | EDITABLE     | Vega visualizations only           |
- * | visualize  | other routes           | DISABLED     | Other visualization types          |
- * | lens       | all routes             | EDITABLE     | All lens pages       |
- * | maps       | all routes             | EDITABLE     | All maps pages
- * | all others | all routes             | DISABLED     | Default behavior for unknown apps  |
  */
-export const DEFAULT_ACCESS_CONTROL_CONFIG: AccessControlConfig = {
+export const ACCESS_CONTROL_CONFIG: AccessControlConfig = {
   dashboards: {
     defaultAccess: ProjectRoutingAccess.EDITABLE,
     routeRules: [
@@ -93,10 +81,9 @@ export const DEFAULT_ACCESS_CONTROL_CONFIG: AccessControlConfig = {
  */
 export const getProjectRoutingAccess = (
   currentAppId: string,
-  hash: string,
-  config: AccessControlConfig = DEFAULT_ACCESS_CONTROL_CONFIG
+  hash: string
 ): ProjectRoutingAccess => {
-  const appConfig = config[currentAppId];
+  const appConfig = ACCESS_CONTROL_CONFIG[currentAppId];
   if (!appConfig) {
     return ProjectRoutingAccess.DISABLED;
   }

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/project_routing_manager.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/project_routing_manager.test.ts
@@ -67,30 +67,30 @@ describe('projectRouting', () => {
     expect(manager!.api.projectRouting$.value).toBe('_alias:_origin');
 
     manager!.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
-      // When projectRoutingRestore is true, changing to 'ALL' is detected
+      // When projectRoutingRestore is true, changing to '_alias:*' is detected
       expect(changes).toEqual({
-        project_routing: 'ALL',
+        project_routing: '_alias:*',
       });
       done();
     });
 
-    manager!.api.setProjectRouting('ALL');
+    manager!.api.setProjectRouting('_alias:*');
   });
 
-  test('Should detect change when setting projectRouting to ALL from undefined', (done) => {
+  test('Should detect change when setting projectRouting to _alias:* from undefined', (done) => {
     const { manager } = initManager(true);
     const lastSavedState$ = createLastSavedState();
 
     manager!.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
-      // When projectRoutingRestore is true, setting to 'ALL' should be detected as a change
+      // When projectRoutingRestore is true, setting to '_alias:*' should be detected as a change
       expect(changes).toEqual({
-        project_routing: 'ALL',
+        project_routing: '_alias:*',
       });
       done();
     });
 
-    // Setting to 'ALL' when projectRoutingRestore is true should be detected
-    manager!.api.setProjectRouting('ALL');
+    // Setting to '_alias:*' when projectRoutingRestore is true should be detected
+    manager!.api.setProjectRouting('_alias:*');
   });
 
   test('Should restore projectRouting in reset', () => {
@@ -143,28 +143,28 @@ describe('projectRouting', () => {
   test('Should save current routing when projectRoutingRestore is true', () => {
     const { manager } = initManager(true);
 
-    // Set projectRouting to 'ALL'
-    manager!.api.setProjectRouting('ALL');
+    // Set projectRouting to '_alias:*'
+    manager!.api.setProjectRouting('_alias:*');
     const state = manager!.internalApi.getState();
 
-    // projectRouting should be saved as 'ALL' when projectRoutingRestore is true
-    expect(state.project_routing).toBe('ALL');
+    // projectRouting should be saved as '_alias:*' when projectRoutingRestore is true
+    expect(state.project_routing).toBe('_alias:*');
   });
 
   test('Should distinguish between ALL (saved with all projects) and undefined (not saved)', () => {
-    const { manager } = initManager(true, 'ALL');
+    const { manager } = initManager(true, '_alias:*');
 
-    // Should initialize with 'ALL' from saved state
-    expect(manager!.api.projectRouting$.value).toBe('ALL');
+    // Should initialize with '_alias:*' from saved state
+    expect(manager!.api.projectRouting$.value).toBe('_alias:*');
 
     const state = manager!.internalApi.getState();
-    // getState should return 'ALL' when projectRouting is 'ALL'
-    expect(state.project_routing).toBe('ALL');
+    // getState should return '_alias:*' when projectRouting is '_alias:*'
+    expect(state.project_routing).toBe('_alias:*');
   });
 
   test('Should not detect change when projectRouting remains the same', (done) => {
-    const { manager } = initManager(true, 'ALL');
-    const lastSavedState$ = createLastSavedState('ALL');
+    const { manager } = initManager(true, '_alias:*');
+    const lastSavedState$ = createLastSavedState('_alias:*');
 
     manager!.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
       // When projectRouting is set to the same value as saved, no change detected
@@ -173,7 +173,7 @@ describe('projectRouting', () => {
     });
 
     // Set to same value as saved state - should not detect a change
-    manager!.api.setProjectRouting('ALL');
+    manager!.api.setProjectRouting('_alias:*');
   });
 
   test('Should return undefined when CPS is not enabled', () => {

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.ts
@@ -26,7 +26,7 @@ import { getIndexPatternFromESQLQuery, fixESQLQueryWithVariables } from '@kbn/es
 import { zipObject } from 'lodash';
 import type { Observable } from 'rxjs';
 import { catchError, defer, map, switchMap, tap, throwError } from 'rxjs';
-import { buildEsQuery, sanitizeProjectRoutingForES, type Filter } from '@kbn/es-query';
+import { buildEsQuery, type Filter } from '@kbn/es-query';
 import type { ESQLSearchParams, ESQLSearchResponse } from '@kbn/es-types';
 import DateMath from '@kbn/datemath';
 import { getEsQueryConfig } from '../../es_query';
@@ -241,10 +241,8 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
             params.filter = buildEsQuery(undefined, input.query || [], filters, esQueryConfigs);
 
             if (input.projectRouting) {
-              const sanitizedProjectRouting = sanitizeProjectRoutingForES(input.projectRouting);
-              if (sanitizedProjectRouting) {
-                params.project_routing = sanitizedProjectRouting;
-              }
+              // Don't sanitize here - search_interceptor needs the raw value to distinguish explicit 'ALL' from missing value
+              params.project_routing = input.projectRouting;
             }
           }
 

--- a/src/platform/plugins/shared/data/common/search/search_source/search_source.test.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/search_source.test.ts
@@ -1133,14 +1133,6 @@ describe('SearchSource', () => {
       expect(request.project_routing).toBe('_alias:_origin');
     });
 
-    test('should not include project_routing in ES request body when projectRouting is set to ALL (sanitized)', () => {
-      searchSource.setField('index', indexPattern);
-      searchSource.setField('projectRouting', 'ALL');
-      const request = searchSource.getSearchRequestBody();
-      // 'ALL' gets sanitized to undefined since it means "search all projects" which is the default
-      expect(request.project_routing).toBeUndefined();
-    });
-
     test('should not include project_routing in ES request body when projectRouting is undefined', () => {
       searchSource.setField('index', indexPattern);
       searchSource.setField('projectRouting', undefined);

--- a/src/platform/plugins/shared/data/common/search/search_source/search_source.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/search_source.ts
@@ -77,13 +77,7 @@ import { catchError, finalize, first, last, map, shareReplay, switchMap, tap } f
 import { defer, EMPTY, from, lastValueFrom, Observable } from 'rxjs';
 import type { estypes } from '@elastic/elasticsearch';
 import type { Filter } from '@kbn/es-query';
-import {
-  buildEsQuery,
-  isOfQueryType,
-  isPhraseFilter,
-  isPhrasesFilter,
-  sanitizeProjectRoutingForES,
-} from '@kbn/es-query';
+import { buildEsQuery, isOfQueryType, isPhraseFilter, isPhrasesFilter } from '@kbn/es-query';
 import { fieldWildcardFilter } from '@kbn/kibana-utils-plugin/common';
 import { getHighlightRequest } from '@kbn/field-formats-plugin/common';
 import type { DataView, DataViewLazy, DataViewsContract } from '@kbn/data-views-plugin/common';
@@ -689,11 +683,7 @@ export class SearchSource {
       case 'pit':
         return addToRoot(key, val);
       case 'projectRouting':
-        const sanitizedProjectRouting = sanitizeProjectRoutingForES(val);
-        if (sanitizedProjectRouting) {
-          return addToBody('project_routing', sanitizedProjectRouting);
-        }
-        return;
+        return addToBody('project_routing', val);
       case 'aggs':
         if ((val as unknown) instanceof AggConfigs) {
           return addToBody('aggs', val.toDsl());

--- a/src/platform/plugins/shared/data/kibana.jsonc
+++ b/src/platform/plugins/shared/data/kibana.jsonc
@@ -28,7 +28,8 @@
       "management"
     ],
     "optionalPlugins": [
-      "usageCollection"
+      "usageCollection",
+      "cps"
     ],
     "requiredBundles": [
       "kibanaUtils",

--- a/src/platform/plugins/shared/data/moon.yml
+++ b/src/platform/plugins/shared/data/moon.yml
@@ -65,6 +65,8 @@ dependsOn:
   - '@kbn/data-service-server'
   - '@kbn/core-elasticsearch-client-server-mocks'
   - '@kbn/field-formats-common'
+  - '@kbn/cps'
+  - '@kbn/cps-utils'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/data/public/plugin.ts
+++ b/src/platform/plugins/shared/data/public/plugin.ts
@@ -138,7 +138,15 @@ export class DataPublicPlugin
 
   public start(
     core: CoreStart,
-    { uiActions, fieldFormats, dataViews, inspector, screenshotMode, share }: DataStartDependencies
+    {
+      uiActions,
+      fieldFormats,
+      dataViews,
+      inspector,
+      screenshotMode,
+      share,
+      cps,
+    }: DataStartDependencies
   ): DataPublicPluginStart {
     const { uiSettings, overlays } = core;
     setOverlays(overlays);
@@ -158,6 +166,7 @@ export class DataPublicPlugin
       screenshotMode,
       share,
       scriptedFieldsEnabled: dataViews.scriptedFieldsEnabled,
+      cps,
     });
     setSearchService(search);
 

--- a/src/platform/plugins/shared/data/public/query/state_sync/types.ts
+++ b/src/platform/plugins/shared/data/public/query/state_sync/types.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Filter, ProjectRouting } from '@kbn/es-query';
+import type { Filter } from '@kbn/es-query';
 import type { RefreshInterval } from '@kbn/data-service-server';
 import type { QueryState } from '../query_state';
 import type { TimeRange } from '../../../common/types';
@@ -28,5 +28,4 @@ export interface GlobalQueryStateFromUrl {
   time?: TimeRange;
   refreshInterval?: RefreshInterval;
   filters?: Filter[];
-  projectRouting?: ProjectRouting;
 }

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.test.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.test.ts
@@ -15,14 +15,19 @@ import { type IKibanaSearchResponse } from '@kbn/search-types';
 import { SearchInterceptor } from './search_interceptor';
 import { AbortError } from '@kbn/kibana-utils-plugin/public';
 import { EsError, type IEsError } from '@kbn/search-errors';
-import type { ISessionService } from '..';
+import type { ISessionService, SearchInterceptorDeps } from '..';
 import { SearchSessionState } from '..';
+import { ProjectRoutingAccess, type ICPSManager } from '@kbn/cps-utils';
 
 import * as searchPhaseException from '../../../common/search/test_data/search_phase_execution_exception.json';
 import * as resourceNotFoundException from '../../../common/search/test_data/resource_not_found_exception.json';
 import { BehaviorSubject } from 'rxjs';
 import { dataPluginMock } from '../../mocks';
-import { ESQL_ASYNC_SEARCH_STRATEGY, UI_SETTINGS } from '../../../common';
+import {
+  ENHANCED_ES_SEARCH_STRATEGY,
+  ESQL_ASYNC_SEARCH_STRATEGY,
+  UI_SETTINGS,
+} from '../../../common';
 import type { SearchServiceStartDependencies } from '../search_service';
 import type { Start as InspectorStart } from '@kbn/inspector-plugin/public';
 import { SearchTimeoutError, TimeoutErrorMode } from './timeout_error';
@@ -2127,6 +2132,257 @@ describe('SearchInterceptor', () => {
         });
 
         response.subscribe({ error });
+      });
+    });
+  });
+
+  describe('project_routing parameter handling', () => {
+    const createMockCPSManager = (
+      projectRouting: string | undefined,
+      access: ProjectRoutingAccess = ProjectRoutingAccess.EDITABLE
+    ): ICPSManager =>
+      ({
+        getProjectRouting: jest.fn().mockReturnValue(projectRouting),
+        getProjectPickerAccess: jest.fn().mockReturnValue(access),
+      } as unknown as ICPSManager);
+
+    const getSearchInterceptor = (overrides?: Partial<SearchInterceptorDeps>) => {
+      return new SearchInterceptor({
+        toasts: mockCoreSetup.notifications.toasts,
+        startServices: new Promise((resolve) => {
+          resolve([
+            mockCoreStart,
+            {
+              inspector: {} as unknown as InspectorStart,
+            } as unknown as SearchServiceStartDependencies,
+            {},
+          ]);
+        }),
+        uiSettings: mockCoreSetup.uiSettings,
+        http: mockCoreSetup.http,
+        executionContext: mockCoreSetup.executionContext,
+        session: sessionService,
+        searchConfig: getMockSearchConfig({}),
+        ...overrides,
+      });
+    };
+    beforeEach(() => {
+      mockCoreSetup.http.post.mockResolvedValue(getMockSearchResponse());
+    });
+
+    describe('ESQL_ASYNC_SEARCH_STRATEGY', () => {
+      test('User passes "_alias:*" with global "_alias:_origin" - does not send to ES', async () => {
+        searchInterceptor = getSearchInterceptor({
+          getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:_origin')),
+        });
+
+        await searchInterceptor
+          .search(
+            { params: { project_routing: '_alias:*' } },
+            { strategy: ESQL_ASYNC_SEARCH_STRATEGY }
+          )
+          .toPromise();
+
+        const requestOptions = (
+          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
+        )[1];
+        const requestBody = JSON.parse(requestOptions.body as string);
+        expect(requestBody.params.project_routing).toBeUndefined();
+      });
+
+      test('User passes "_alias:*" with global "_alias:*" - does not send to ES', async () => {
+        searchInterceptor = getSearchInterceptor({
+          getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:*')),
+        });
+
+        await searchInterceptor
+          .search(
+            { params: { project_routing: '_alias:*' } },
+            { strategy: ESQL_ASYNC_SEARCH_STRATEGY }
+          )
+          .toPromise();
+
+        const requestOptions = (
+          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
+        )[1];
+        const requestBody = JSON.parse(requestOptions.body as string);
+        expect(requestBody.params.project_routing).toBeUndefined();
+      });
+
+      test('User passes "_alias:_origin" with global "_alias:_origin" - sends to ES', async () => {
+        searchInterceptor = getSearchInterceptor({
+          getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:_origin')),
+        });
+
+        await searchInterceptor
+          .search(
+            { params: { project_routing: '_alias:_origin' } },
+            { strategy: ESQL_ASYNC_SEARCH_STRATEGY }
+          )
+          .toPromise();
+
+        const requestOptions = (
+          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
+        )[1];
+        const requestBody = JSON.parse(requestOptions.body as string);
+        expect(requestBody.params.project_routing).toBe('_alias:_origin');
+      });
+
+      test('User passes "_alias:_origin" with global "_alias:*" - sends to ES', async () => {
+        searchInterceptor = getSearchInterceptor({
+          getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:*')),
+        });
+
+        await searchInterceptor
+          .search(
+            { params: { project_routing: '_alias:_origin' } },
+            { strategy: ESQL_ASYNC_SEARCH_STRATEGY }
+          )
+          .toPromise();
+
+        const requestOptions = (
+          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
+        )[1];
+        const requestBody = JSON.parse(requestOptions.body as string);
+        expect(requestBody.params.project_routing).toBe('_alias:_origin');
+      });
+
+      test('User passes nothing with global "_alias:_origin" - sends global to ES', async () => {
+        searchInterceptor = getSearchInterceptor({
+          getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:_origin')),
+        });
+
+        await searchInterceptor
+          .search({ params: {} }, { strategy: ESQL_ASYNC_SEARCH_STRATEGY })
+          .toPromise();
+
+        const requestOptions = (
+          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
+        )[1];
+        const requestBody = JSON.parse(requestOptions.body as string);
+        expect(requestBody.params.project_routing).toBe('_alias:_origin');
+      });
+
+      test('User passes nothing with global "_alias:*" - does not send to ES', async () => {
+        searchInterceptor = getSearchInterceptor({
+          getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:*')),
+        });
+
+        await searchInterceptor
+          .search({ params: {} }, { strategy: ESQL_ASYNC_SEARCH_STRATEGY })
+          .toPromise();
+
+        const requestOptions = (
+          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
+        )[1];
+        const requestBody = JSON.parse(requestOptions.body as string);
+        expect(requestBody.params.project_routing).toBeUndefined();
+      });
+
+      test('User passes nothing with global undefined - does not send to ES', async () => {
+        searchInterceptor = getSearchInterceptor({
+          getCPSManager: jest.fn().mockReturnValue(createMockCPSManager(undefined)),
+        });
+
+        await searchInterceptor
+          .search({ params: {} }, { strategy: ESQL_ASYNC_SEARCH_STRATEGY })
+          .toPromise();
+
+        const requestOptions = (
+          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
+        )[1];
+        const requestBody = JSON.parse(requestOptions.body as string);
+        expect(requestBody.params.project_routing).toBeUndefined();
+      });
+
+      test('CPS unavailable - does not send to ES', async () => {
+        searchInterceptor = getSearchInterceptor({ getCPSManager: undefined });
+
+        await searchInterceptor
+          .search(
+            { params: { project_routing: '_alias:_origin' } },
+            { strategy: ESQL_ASYNC_SEARCH_STRATEGY }
+          )
+          .toPromise();
+
+        const requestOptions = (
+          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
+        )[1];
+        const requestBody = JSON.parse(requestOptions.body as string);
+        expect(requestBody.params.project_routing).toBeUndefined();
+      });
+    });
+
+    describe('ENHANCED_ES_SEARCH_STRATEGY', () => {
+      test('User passes "_alias:*" with global "_alias:_origin" - does not send to ES', async () => {
+        searchInterceptor = getSearchInterceptor({
+          getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:_origin')),
+        });
+
+        await searchInterceptor
+          .search(
+            { params: { body: { project_routing: '_alias:*' } } },
+            { strategy: ENHANCED_ES_SEARCH_STRATEGY }
+          )
+          .toPromise();
+
+        const requestOptions = (
+          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
+        )[1];
+        const requestBody = JSON.parse(requestOptions.body as string);
+        expect(requestBody.params.body.project_routing).toBeUndefined();
+      });
+
+      test('User passes "_alias:_origin" with global "_alias:*" - sends to ES', async () => {
+        searchInterceptor = getSearchInterceptor({
+          getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:*')),
+        });
+
+        await searchInterceptor
+          .search(
+            { params: { body: { project_routing: '_alias:_origin' } } },
+            { strategy: ENHANCED_ES_SEARCH_STRATEGY }
+          )
+          .toPromise();
+
+        const requestOptions = (
+          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
+        )[1];
+        const requestBody = JSON.parse(requestOptions.body as string);
+        expect(requestBody.params.body.project_routing).toBe('_alias:_origin');
+      });
+
+      test('User passes nothing with global "_alias:_origin" - sends global to ES', async () => {
+        searchInterceptor = getSearchInterceptor({
+          getCPSManager: jest.fn().mockReturnValue(createMockCPSManager('_alias:_origin')),
+        });
+
+        await searchInterceptor
+          .search({ params: { body: {} } }, { strategy: ENHANCED_ES_SEARCH_STRATEGY })
+          .toPromise();
+
+        const requestOptions = (
+          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
+        )[1];
+        const requestBody = JSON.parse(requestOptions.body as string);
+        expect(requestBody.params.body.project_routing).toBe('_alias:_origin');
+      });
+
+      test('CPS unavailable - does not send to ES', async () => {
+        searchInterceptor = getSearchInterceptor({ getCPSManager: undefined });
+
+        await searchInterceptor
+          .search(
+            { params: { body: { project_routing: '_alias:_origin' } } },
+            { strategy: ENHANCED_ES_SEARCH_STRATEGY }
+          )
+          .toPromise();
+
+        const requestOptions = (
+          mockCoreSetup.http.post.mock.calls[0] as unknown as [string, HttpFetchOptions]
+        )[1];
+        const requestBody = JSON.parse(requestOptions.body as string);
+        expect(requestBody.params.body.project_routing).toBeUndefined();
       });
     });
   });

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -58,6 +58,9 @@ import type {
 import { createEsError, isEsError, renderSearchError } from '@kbn/search-errors';
 import type { IKibanaSearchResponse, ISearchOptions } from '@kbn/search-types';
 import { defaultFreeze } from '@kbn/kibana-utils-plugin/common';
+import { sanitizeProjectRoutingForES } from '@kbn/es-query';
+import { ProjectRoutingAccess } from '@kbn/cps-utils';
+import type { ICPSManager } from '@kbn/cps-utils';
 import {
   EVENT_TYPE_DATA_SEARCH_TIMEOUT,
   EVENT_PROPERTY_SEARCH_TIMEOUT_MS,
@@ -97,6 +100,7 @@ export interface SearchInterceptorDeps {
   usageCollector?: SearchUsageCollector;
   session: ISessionService;
   searchConfig: SearchConfigSchema;
+  getCPSManager?: () => ICPSManager | undefined;
 }
 
 const MAX_CACHE_ITEMS = 50;
@@ -453,6 +457,29 @@ export class SearchInterceptor {
     const requestHash = params ? createRequestHashForBackgroundSearches(params) : undefined;
 
     const { executionContext, strategy, ...searchOptions } = this.getSerializableOptions(options);
+
+    if (!request.id && params) {
+      const cpsManager = this.deps.getCPSManager?.();
+      if (cpsManager && cpsManager.getProjectPickerAccess() !== ProjectRoutingAccess.DISABLED) {
+        // - If params.body exists → params.body.project_routing (SearchSource, Vega with body)
+        // - If no body → params.project_routing (ESQL, enhanced search)
+        if (params.body) {
+          params.body.project_routing = sanitizeProjectRoutingForES(
+            params.body.project_routing ?? cpsManager.getProjectRouting()
+          );
+        } else {
+          params.project_routing = sanitizeProjectRoutingForES(
+            params.project_routing ?? cpsManager.getProjectRouting()
+          );
+        }
+      } else {
+        // Remove project_routing if CPS is disabled to avoid ES errors
+        delete params.project_routing;
+        if (params.body) {
+          delete params.body.project_routing;
+        }
+      }
+    }
 
     // FIXME: the dropNullColumns param shouldn't be needed during polling
     // once https://github.com/elastic/elasticsearch/issues/138439 is resolved

--- a/src/platform/plugins/shared/data/public/search/search_service.ts
+++ b/src/platform/plugins/shared/data/public/search/search_service.ts
@@ -17,6 +17,7 @@ import type {
   PluginInitializerContext,
   StartServicesAccessor,
 } from '@kbn/core/public';
+import type { CPSPluginStart } from '@kbn/cps/public';
 import type { ISearchGeneric } from '@kbn/search-types';
 import { RequestAdapter } from '@kbn/inspector-plugin/common/adapters/request';
 import type { DataViewsContract } from '@kbn/data-views-plugin/common';
@@ -28,6 +29,7 @@ import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
 import type { Start as InspectorStartContract } from '@kbn/inspector-plugin/public';
 import { BehaviorSubject } from 'rxjs';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
+import type { ICPSManager } from '@kbn/cps-utils';
 import type { SearchSourceDependencies } from '../../common/search';
 import {
   cidrFunction,
@@ -95,6 +97,7 @@ export interface SearchServiceStartDependencies {
   screenshotMode: ScreenshotModePluginStart;
   share: SharePluginStart;
   scriptedFieldsEnabled: boolean;
+  cps?: CPSPluginStart;
 }
 
 export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
@@ -105,6 +108,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
   private sessionService!: ISessionService;
   private sessionsClient!: ISessionsClient;
   private searchSessionEBTManager!: ISearchSessionEBTManager;
+  private cpsManager?: ICPSManager;
 
   constructor(private initializerContext: PluginInitializerContext<ConfigSchema>) {}
 
@@ -144,6 +148,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
       usageCollector: this.usageCollector!,
       session: this.sessionService,
       searchConfig: this.initializerContext.config.get().search,
+      getCPSManager: () => this.cpsManager,
     });
 
     expressions.registerFunction(
@@ -241,6 +246,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
       screenshotMode,
       scriptedFieldsEnabled,
       share,
+      cps,
     }: SearchServiceStartDependencies
   ): ISearchStart {
     const { http, uiSettings, chrome, application, notifications, ...startServices } = coreStart;
@@ -259,6 +265,8 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
       notifications,
       ...startServices,
     };
+
+    this.cpsManager = cps?.cpsManager;
 
     const searchSourceDependencies: SearchSourceDependencies = {
       aggs,

--- a/src/platform/plugins/shared/data/public/types.ts
+++ b/src/platform/plugins/shared/data/public/types.ts
@@ -21,6 +21,7 @@ import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { ManagementSetup } from '@kbn/management-plugin/public';
 import type { Filter } from '@kbn/es-query';
 import type { DataViewsContract } from '@kbn/data-views-plugin/public';
+import type { CPSPluginStart } from '@kbn/cps/public';
 import type { DatatableUtilitiesService } from '../common';
 import type { ISearchSetup, ISearchStart } from './search';
 import type { QuerySetup, QueryStart } from './query';
@@ -47,6 +48,7 @@ export interface DataStartDependencies {
   inspector: InspectorStartContract;
   screenshotMode: ScreenshotModePluginStart;
   share: SharePluginStart;
+  cps?: CPSPluginStart;
 }
 
 /**

--- a/src/platform/plugins/shared/data/tsconfig.json
+++ b/src/platform/plugins/shared/data/tsconfig.json
@@ -60,6 +60,8 @@
     "@kbn/data-service-server",
     "@kbn/core-elasticsearch-client-server-mocks",
     "@kbn/field-formats-common",
+    "@kbn/cps",
+    "@kbn/cps-utils",
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/discover/kibana.jsonc
+++ b/src/platform/plugins/shared/discover/kibana.jsonc
@@ -51,7 +51,8 @@
       "embeddableEnhanced",
       "apmSourcesAccess",
       "fileUpload",
-      "metricsExperience"
+      "metricsExperience",
+      "cps"
     ],
     "requiredBundles": [
       "kibanaUtils",

--- a/src/platform/plugins/shared/discover/moon.yml
+++ b/src/platform/plugins/shared/discover/moon.yml
@@ -127,6 +127,7 @@ dependsOn:
   - '@kbn/unified-metrics-grid'
   - '@kbn/shared-ux-link-redirect-app'
   - '@kbn/react-query'
+  - '@kbn/cps'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_state.ts
@@ -568,6 +568,16 @@ export function getDiscoverStateContainer({
       }
     );
 
+    // Subscribe to CPS projectRouting changes (global subscription affects all tabs)
+    // When projectRouting changes, mark non-active tabs for refetch and trigger data fetch
+    const cpsProjectRoutingSubscription = services.cps?.cpsManager
+      ?.getProjectRouting$()
+      .subscribe(() => {
+        internalState.dispatch(internalStateActions.markNonActiveTabsForRefetch());
+        addLog('[getDiscoverStateContainer] projectRouting changes triggers data fetching');
+        fetchData();
+      });
+
     const { start: startSyncingGlobalStateWithUrl, stop: stopSyncingGlobalStateWithUrl } =
       syncState({
         storageKey: GLOBAL_STATE_URL_KEY,
@@ -588,6 +598,7 @@ export function getDiscoverStateContainer({
       stopSyncingQueryGlobalStateWithStateContainer();
       stopSyncingAppStateWithUrl();
       stopSyncingGlobalStateWithUrl();
+      cpsProjectRoutingSubscription?.unsubscribe();
     };
   };
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -152,6 +152,17 @@ export const internalStateSlice = createSlice({
       state.tabsBarVisibility = action.payload;
     },
 
+    markNonActiveTabsForRefetch: (state) => {
+      // Mark all non-active tabs to refetch on selection
+      // Used when projectRouting changes in CPS Manager
+      const currentTabId = state.tabs.unsafeCurrentId;
+      state.tabs.allIds.forEach((tabId) => {
+        if (tabId !== currentTabId && state.tabs.byId[tabId]) {
+          state.tabs.byId[tabId].forceFetchOnSelect = true;
+        }
+      });
+    },
+
     setExpandedDoc: (
       state,
       action: PayloadAction<{

--- a/src/platform/plugins/shared/discover/public/build_services.ts
+++ b/src/platform/plugins/shared/discover/public/build_services.ts
@@ -64,6 +64,7 @@ import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/publ
 import type { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/public';
 import type { DiscoverSharedPublicStart } from '@kbn/discover-shared-plugin/public';
 import type { EmbeddableEnhancedPluginStart } from '@kbn/embeddable-enhanced-plugin/public';
+import type { CPSPluginStart } from '@kbn/cps/public';
 import type { DiscoverStartPlugins } from './types';
 import type { DiscoverContextAppLocator } from './application/context/services/locator';
 import type { DiscoverSingleDocLocator } from './application/doc/locator';
@@ -150,6 +151,7 @@ export interface DiscoverServices {
   fieldsMetadata?: FieldsMetadataPublicStart;
   logsDataAccess?: LogsDataAccessPluginStart;
   embeddableEnhanced?: EmbeddableEnhancedPluginStart;
+  cps?: CPSPluginStart;
 }
 
 export const buildServices = ({
@@ -247,5 +249,6 @@ export const buildServices = ({
     fieldsMetadata: plugins.fieldsMetadata,
     logsDataAccess: plugins.logsDataAccess,
     embeddableEnhanced: plugins.embeddableEnhanced,
+    cps: plugins.cps,
   };
 };

--- a/src/platform/plugins/shared/discover/public/types.ts
+++ b/src/platform/plugins/shared/discover/public/types.ts
@@ -48,6 +48,7 @@ import type { ApmSourceAccessPluginStart } from '@kbn/apm-sources-access-plugin/
 import type { Setup as InspectorPublicPluginSetup } from '@kbn/inspector-plugin/public/plugin';
 import type { FileUploadPluginStart } from '@kbn/file-upload-plugin/public';
 import type { MetricsExperiencePluginStart } from '@kbn/metrics-experience-plugin/public';
+import type { CPSPluginStart } from '@kbn/cps/public';
 import type { DiscoverAppLocator } from '../common';
 import type { DiscoverContainerProps } from './components/discover_container';
 
@@ -183,4 +184,5 @@ export interface DiscoverStartPlugins {
   apmSourcesAccess?: ApmSourceAccessPluginStart;
   fileUpload?: FileUploadPluginStart;
   metricsExperience?: MetricsExperiencePluginStart;
+  cps?: CPSPluginStart;
 }

--- a/src/platform/plugins/shared/discover/tsconfig.json
+++ b/src/platform/plugins/shared/discover/tsconfig.json
@@ -119,7 +119,8 @@
     "@kbn/metrics-experience-plugin",
     "@kbn/unified-metrics-grid",
     "@kbn/shared-ux-link-redirect-app",
-    "@kbn/react-query"
+    "@kbn/react-query",
+    "@kbn/cps"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/visualizations/public/embeddable/get_expression_renderer_props.test.ts
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/get_expression_renderer_props.test.ts
@@ -109,7 +109,7 @@ describe('getExpressionRendererProps', () => {
           query: { query: '', language: 'kuery' },
           filters: [],
         },
-        projectRouting: 'ALL',
+        projectRouting: '_alias:*',
         timeRange: { from: 'now-15m', to: 'now' },
         disableTriggers: false,
         settings: {
@@ -126,7 +126,7 @@ describe('getExpressionRendererProps', () => {
       expect(result.params).toBeDefined();
       expect(result.params?.searchContext).toEqual(
         expect.objectContaining({
-          projectRouting: 'ALL',
+          projectRouting: '_alias:*',
         })
       );
     });


### PR DESCRIPTION
## Summary

Adds CPS functionality to Discover, enabling Discover app to react to changes in CPS project picker.
<img width="1058" height="591" alt="Screenshot 2025-12-03 at 15 01 09" src="https://github.com/user-attachments/assets/420c725e-9574-4b67-b6e4-13a1542cc8a8" />

### Discover app
1. When going to Discover, project routing is set to default spaces setting (for now hardcoded).
2. When moving to another app or reloading Discover page, the setting is reset.
3. Project routing is not persisted in URL.


