### PR TITLE
[CPS][Maps] Support CPS Picker in Maps 

### DIFF
--- a/x-pack/platform/plugins/shared/maps/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/maps/kibana.jsonc
@@ -37,6 +37,7 @@
     ],
     "optionalPlugins": [
       "cloud",
+      "cps",
       "customIntegrations",
       "embeddableEnhanced",
       "home",

--- a/x-pack/platform/plugins/shared/maps/moon.yml
+++ b/x-pack/platform/plugins/shared/maps/moon.yml
@@ -106,6 +106,7 @@ dependsOn:
   - '@kbn/visualizations-common'
   - '@kbn/lens-common'
   - '@kbn/crypto-browser'
+  - '@kbn/cps'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/maps/public/actions/map_actions.ts
+++ b/x-pack/platform/plugins/shared/maps/public/actions/map_actions.ts
@@ -341,7 +341,7 @@ export function setQuery({
       filters: filters ? filters : getFilters(getState()),
       searchSessionId: searchSessionId ? searchSessionId : getSearchSessionId(getState()),
       searchSessionMapBuffer,
-      projectRouting,
+      projectRouting: projectRouting ?? getProjectRouting(getState()),
     };
 
     const prevQueryContext = {

--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/esql_source/esql_source.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/esql_source/esql_source.tsx
@@ -21,7 +21,7 @@ import {
   getStartEndParams,
   hasStartEndParams,
 } from '@kbn/esql-utils';
-import { buildEsQuery } from '@kbn/es-query';
+import { buildEsQuery, sanitizeProjectRoutingForES } from '@kbn/es-query';
 import type { Filter, Query } from '@kbn/es-query';
 import type { ESQLSearchParams, ESQLSearchResponse } from '@kbn/es-types';
 import { getEsQueryConfig } from '@kbn/data-service/src/es_query';
@@ -263,6 +263,10 @@ export class ESQLSource
     }
 
     params.filter = buildEsQuery(undefined, query, filters, getEsQueryConfig(getUiSettings()));
+
+    if (requestMeta.projectRouting) {
+      params.project_routing = sanitizeProjectRoutingForES(requestMeta.projectRouting);
+    }
 
     const requestResponder = inspectorAdapters.requests!.start(
       getLayerFeaturesRequestName(layerName),

--- a/x-pack/platform/plugins/shared/maps/public/kibana_services.ts
+++ b/x-pack/platform/plugins/shared/maps/public/kibana_services.ts
@@ -134,3 +134,4 @@ export const getEmsTileLayerId = () => {
 };
 
 export const getShareService = () => pluginsStart.share;
+export const getCps = () => pluginsStart.cps;

--- a/x-pack/platform/plugins/shared/maps/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/maps/public/plugin.ts
@@ -43,6 +43,7 @@ import type {
   ContentManagementPublicStart,
 } from '@kbn/content-management-plugin/public';
 import type { ServerlessPluginStart } from '@kbn/serverless/public';
+import type { CPSPluginStart } from '@kbn/cps/public';
 
 import {
   createRegionMapFn,
@@ -100,6 +101,7 @@ export interface MapsPluginSetupDependencies {
 
 export interface MapsPluginStartDependencies {
   charts: ChartsPluginStart;
+  cps?: CPSPluginStart;
   data: DataPublicPluginStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
   embeddable: EmbeddableStart;

--- a/x-pack/platform/plugins/shared/maps/public/routes/map_page/map_app/index.ts
+++ b/x-pack/platform/plugins/shared/maps/public/routes/map_page/map_app/index.ts
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import type { ThunkDispatch } from 'redux-thunk';
 import type { AnyAction } from 'redux';
 import type { KibanaExecutionContext } from '@kbn/core/public';
-import type { Filter } from '@kbn/es-query';
+import type { Filter, ProjectRouting } from '@kbn/es-query';
 import type { Query, TimeRange } from '@kbn/es-query';
 import { MapApp } from './map_app';
 import { getFlyoutDisplay, getIsFullScreen } from '../../../selectors/ui_selectors';
@@ -47,12 +47,14 @@ function mapDispatchToProps(dispatch: ThunkDispatch<MapStoreState, void, AnyActi
       query,
       timeFilters,
       searchSessionId,
+      projectRouting,
     }: {
       filters?: Filter[];
       query?: Query;
       timeFilters?: TimeRange;
       forceRefresh?: boolean;
       searchSessionId?: string;
+      projectRouting?: ProjectRouting;
     }) => {
       dispatch(
         setQuery({
@@ -61,6 +63,7 @@ function mapDispatchToProps(dispatch: ThunkDispatch<MapStoreState, void, AnyActi
           timeFilters,
           forceRefresh,
           searchSessionId,
+          projectRouting,
         })
       );
     },

--- a/x-pack/platform/plugins/shared/maps/public/routes/map_page/map_app/map_app.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/routes/map_page/map_app/map_app.tsx
@@ -18,7 +18,13 @@ import type {
 import { kbnFullBodyHeightCss } from '@kbn/css-utils/public/full_body_height_css';
 import type { Adapters } from '@kbn/inspector-plugin/public';
 import type { Subscription } from 'rxjs';
-import { type Filter, FilterStateStore, type Query, type TimeRange } from '@kbn/es-query';
+import {
+  type Filter,
+  FilterStateStore,
+  type ProjectRouting,
+  type Query,
+  type TimeRange,
+} from '@kbn/es-query';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
 import type { DataView } from '@kbn/data-plugin/common';
 import type {
@@ -43,6 +49,7 @@ import {
   getTimeFilter,
   getToasts,
 } from '../../../kibana_services';
+import { initializeProjectRoutingManager } from '../../use_project_routing';
 import { AppStateManager, startAppStateSyncing } from '../url_state';
 import { MapContainer } from '../../../connected_components/map_container';
 import { getIndexPatternsFromIds } from '../../../index_pattern_util';
@@ -98,12 +105,14 @@ export interface Props {
     query,
     timeFilters,
     searchSessionId,
+    projectRouting,
   }: {
     filters?: Filter[];
     query?: Query;
     timeFilters?: TimeRange;
     forceRefresh?: boolean;
     searchSessionId?: string;
+    projectRouting?: ProjectRouting;
   }) => void;
   timeFilters: TimeRange;
   isSaveDisabled: boolean;
@@ -126,6 +135,7 @@ export class MapApp extends React.Component<Props, State> {
   _globalSyncUnsubscribe: (() => void) | null = null;
   _globalSyncChangeMonitorSubscription: Subscription | null = null;
   _appSyncUnsubscribe: (() => void) | null = null;
+  _projectRoutingUnsubscribe: (() => void) | undefined = undefined;
   _appStateManager = new AppStateManager();
   _prevIndexPatternIds: string[] | null = null;
   _isMounted: boolean = false;
@@ -186,6 +196,13 @@ export class MapApp extends React.Component<Props, State> {
       this._updateFromGlobalState
     );
 
+    // Initialize project routing manager for CPS support
+    this._projectRoutingUnsubscribe = initializeProjectRoutingManager({
+      onProjectRoutingChange: (projectRouting) => {
+        this.props.setQuery({ projectRouting });
+      },
+    });
+
     // savedQuery must be fetched from savedQueryId
     // const initialSavedQuery = this._appStateManager.getAppState().savedQuery;
     // if (initialSavedQuery) {
@@ -220,6 +237,9 @@ export class MapApp extends React.Component<Props, State> {
     }
     if (this._globalSyncChangeMonitorSubscription) {
       this._globalSyncChangeMonitorSubscription.unsubscribe();
+    }
+    if (this._projectRoutingUnsubscribe) {
+      this._projectRoutingUnsubscribe();
     }
 
     this.props.onAppLeave((actions) => {

--- a/x-pack/platform/plugins/shared/maps/public/routes/map_page/map_app/map_app.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/routes/map_page/map_app/map_app.tsx
@@ -49,7 +49,7 @@ import {
   getTimeFilter,
   getToasts,
 } from '../../../kibana_services';
-import { initializeProjectRoutingManager } from '../../use_project_routing';
+import { initializeProjectRoutingManager } from '../../project_routing_manager';
 import { AppStateManager, startAppStateSyncing } from '../url_state';
 import { MapContainer } from '../../../connected_components/map_container';
 import { getIndexPatternsFromIds } from '../../../index_pattern_util';

--- a/x-pack/platform/plugins/shared/maps/public/routes/use_project_routing.ts
+++ b/x-pack/platform/plugins/shared/maps/public/routes/use_project_routing.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ProjectRouting } from '@kbn/es-query';
+import { BehaviorSubject } from 'rxjs';
+import { getCps } from '../kibana_services';
+
+/**
+ * Initializes project routing manager for Maps app.
+ * Handles subscription to CPS project picker changes and project routing overrides.
+ *
+ * @param onProjectRoutingChange - Callback invoked when project routing changes
+ * @returns Cleanup function to unsubscribe and cleanup resources
+ */
+export function initializeProjectRoutingManager({
+  onProjectRoutingChange,
+}: {
+  onProjectRoutingChange: (projectRouting: ProjectRouting) => void;
+}) {
+  const cpsManager = getCps()?.cpsManager;
+
+  if (!cpsManager || cpsManager.getProjectPickerAccess() === 'disabled') {
+    return;
+  }
+
+  const initialProjectRouting = cpsManager.getProjectRouting();
+  const projectRouting$ = new BehaviorSubject<ProjectRouting | undefined>(initialProjectRouting);
+
+  if (initialProjectRouting) {
+    onProjectRoutingChange(initialProjectRouting);
+  }
+
+  const cpsProjectRoutingSubscription = cpsManager
+    .getProjectRouting$()
+    .subscribe((cpsProjectRouting: ProjectRouting | undefined) => {
+      if (cpsProjectRouting !== projectRouting$.value) {
+        projectRouting$.next(cpsProjectRouting);
+        onProjectRoutingChange(cpsProjectRouting);
+      }
+    });
+
+  return () => {
+    cpsProjectRoutingSubscription?.unsubscribe();
+    projectRouting$.complete();
+  };
+}

--- a/x-pack/platform/plugins/shared/maps/tsconfig.json
+++ b/x-pack/platform/plugins/shared/maps/tsconfig.json
@@ -102,6 +102,7 @@
     "@kbn/visualizations-common",
     "@kbn/lens-common",
     "@kbn/crypto-browser",
+    "@kbn/cps",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Supports CPS project picker in Maps. When changing the picker setting, maps refetch the data with the correct `project_routing` parameter.
*Note*: This does NOT allow yet saving the project routing setting to the maps saved object 

Also fixes the fact I forgot to pass `project_routing` to esql source.

#### To test: 
1. Navigate to Maps and create a new map
  2. Add a few layers with Elasticsearch data sources (e.g., documents, clusters, heatmap)
  3. Open browser DevTools Network tab (optionally, filter for search requests)
  4. Click the CPS picker and change the project routing setting
  5. Verify that:
    - Maps layers refetch data automatically
    - Search requests include `project_routing` parameter in the request body
    - Different CPS settings result in different project_routing values in requests (none for All projects)

https://github.com/user-attachments/assets/8cbd4348-e2b0-445b-b260-64d5b1a3077f


