### PR TITLE
[9.2] [Fleet] Improve agent status task to only fetch relevant agents (#246246)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.ts
@@ -442,7 +442,10 @@ export async function getAllAgentsByKuery(
 export async function fetchAllAgentsByKuery(
   esClient: ElasticsearchClient,
   soClient: SavedObjectsClientContract,
-  options: ListWithKuery & { spaceId?: string }
+  options: ListWithKuery & {
+    spaceId?: string;
+    runtimeFields?: estypes.SearchRequest['runtime_mappings'];
+  }
 ): Promise<AsyncIterable<Agent[]>> {
   const {
     kuery = '',
@@ -458,7 +461,11 @@ export async function fetchAllAgentsByKuery(
   }
   const kueryNode = _joinFilters(filters);
   const query = kueryNode ? { query: toElasticsearchQuery(kueryNode) } : {};
-  const runtimeFields = await buildAgentStatusRuntimeField(soClient);
+  const runtimeFields = Object.assign(
+    await buildAgentStatusRuntimeField(soClient),
+    options.runtimeFields
+  );
+
   const sort = getSortConfig(sortField, sortOrder);
 
   try {

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/agent_status_change_task.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/agent_status_change_task.test.ts
@@ -158,18 +158,6 @@ describe('AgentStatusChangeTask', () => {
           },
           last_known_status: 'offline',
         },
-        {
-          id: 'agent-3',
-          policy_id: 'agent-policy-3',
-          status: 'online',
-          namespaces: ['default'],
-          local_metadata: {
-            host: {
-              hostname: 'host3',
-            },
-          },
-          last_known_status: 'online',
-        },
       ] as unknown as Agent[];
       mockedFetchAllAgentsByKuery
         .mockResolvedValueOnce(getMockFetchAllAgentsByKuery(agents))
@@ -236,20 +224,7 @@ describe('AgentStatusChangeTask', () => {
     });
 
     it('should do nothing when no agents changed status', async () => {
-      const agents = [
-        {
-          id: 'agent-3',
-          policy_id: 'agent-policy-3',
-          status: 'online',
-          namespaces: ['default'],
-          local_metadata: {
-            host: {
-              hostname: 'host3',
-            },
-          },
-          last_known_status: 'online',
-        },
-      ] as unknown as Agent[];
+      const agents = [] as unknown as Agent[];
       mockedFetchAllAgentsByKuery
         .mockResolvedValueOnce(getMockFetchAllAgentsByKuery(agents))
         .mockResolvedValue(getMockFetchAllAgentsByKuery([]));

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/agent_status_change_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/agent_status_change_task.ts
@@ -18,7 +18,7 @@ import type {
 } from '@kbn/task-manager-plugin/server';
 import { getDeleteTaskRunResult } from '@kbn/task-manager-plugin/server/task';
 import type { LoggerFactory, SavedObjectsClientContract } from '@kbn/core/server';
-import { errors } from '@elastic/elasticsearch';
+import { errors, type estypes } from '@elastic/elasticsearch';
 
 import { agentPolicyService, appContextService } from '../services';
 import { bulkUpdateAgents, fetchAllAgentsByKuery } from '../services/agents';
@@ -39,6 +39,17 @@ const AGENT_STATUS_CHANGE_DATA_STREAM = {
   namespace: 'default',
 };
 const AGENT_STATUS_CHANGE_DATA_STREAM_NAME = `${AGENT_STATUS_CHANGE_DATA_STREAM.type}-${AGENT_STATUS_CHANGE_DATA_STREAM.dataset}-${AGENT_STATUS_CHANGE_DATA_STREAM.namespace}`;
+
+export const HAS_CHANGED_RUNTIME_FIELD: estypes.SearchRequest['runtime_mappings'] = {
+  hasChanged: {
+    type: 'boolean',
+    script: {
+      lang: 'painless',
+      source:
+        "emit(doc['last_known_status'].size() == 0 || doc['status'].size() == 0 || doc['last_known_status'].value != doc['status'].value );",
+    },
+  },
+};
 
 interface AgentStatusChangeTaskConfig {
   taskInterval?: string;
@@ -172,6 +183,8 @@ export class AgentStatusChangeTask {
     let agentlessPolicies: string[] | undefined;
     const agentsFetcher = await fetchAllAgentsByKuery(esClient, soClient, {
       perPage: AGENTS_BATCHSIZE,
+      kuery: 'hasChanged:true',
+      runtimeFields: HAS_CHANGED_RUNTIME_FIELD,
     });
     for await (const agentPageResults of agentsFetcher) {
       if (!agentPageResults.length) {
@@ -180,15 +193,9 @@ export class AgentStatusChangeTask {
       }
 
       const updateErrors = {};
-      const agentsToUpdate = [];
 
-      for (const agent of agentPageResults) {
-        this.throwIfAborted(abortController);
-
-        if (agent.status !== agent.last_known_status) {
-          agentsToUpdate.push(agent);
-        }
-      }
+      const agentsToUpdate = agentPageResults;
+      this.throwIfAborted(abortController);
 
       if (agentsToUpdate.length === 0) {
         continue;

--- a/x-pack/platform/test/fleet_api_integration/apis/agents/index.js
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/index.js
@@ -29,5 +29,6 @@ export default function loadTests({ loadTestFile, getService }) {
     loadTestFile(require.resolve('./privileges'));
     loadTestFile(require.resolve('./migrate'));
     loadTestFile(require.resolve('./privilege_level_change'));
+    loadTestFile(require.resolve('./last_known_status'));
   });
 }

--- a/x-pack/platform/test/fleet_api_integration/apis/agents/last_known_status.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agents/last_known_status.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+
+import { HAS_CHANGED_RUNTIME_FIELD } from '@kbn/fleet-plugin/server/tasks/agent_status_change_task';
+import { _buildStatusRuntimeField } from '@kbn/fleet-plugin/server/services/agents/build_status_runtime_field';
+import { AGENTS_INDEX } from '@kbn/fleet-plugin/common';
+
+import type { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { cleanFleetAgents, createFleetAgent } from '../space_awareness/helpers';
+
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+  const es = getService('es');
+
+  describe('fleet_last_known_status_task', () => {
+    beforeEach(async () => {
+      await cleanFleetAgents(es);
+    });
+    afterEach(async () => {
+      await cleanFleetAgents(es);
+    });
+
+    describe('hasChanged runtime fields', () => {
+      const runtimeFields = Object.assign(
+        {},
+        _buildStatusRuntimeField({
+          inactivityTimeouts: [],
+          logger: undefined,
+        }),
+        HAS_CHANGED_RUNTIME_FIELD
+      );
+
+      const SCENARIOS = [
+        {
+          name: 'should return hasChanged:true for an online agent without last_known_status',
+          agentAttrs: {}, // Create an online agent
+          expectedHasChanged: true,
+        },
+        {
+          name: 'should return hasChanged:true for an online agent with last_known_status:offline',
+          agentAttrs: { last_known_status: 'offline' },
+          expectedHasChanged: true,
+        },
+        {
+          name: 'should return hasChanged:false for an online agent with last_known_status:online',
+          agentAttrs: { last_known_status: 'online' },
+          expectedHasChanged: false,
+        },
+      ];
+
+      for (const scenario of SCENARIOS) {
+        it(scenario.name, async () => {
+          const agent = await createFleetAgent(es, 'test', undefined, scenario.agentAttrs as any);
+
+          const res = await es.search({
+            index: AGENTS_INDEX,
+            runtime_mappings: runtimeFields,
+            fields: Object.keys(runtimeFields),
+          });
+
+          const agentDoc = res.hits.hits.find((hit) => hit._id === agent);
+          expect(agentDoc).not.to.be(undefined);
+          expect(agentDoc).not.to.be(undefined);
+          expect(agentDoc!.fields).not.to.be(undefined);
+          expect(agentDoc!.fields!.hasChanged[0]).to.be(scenario.expectedHasChanged);
+        });
+      }
+    });
+  });
+}

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/helpers.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/helpers.ts
@@ -130,27 +130,35 @@ export async function cleanFleetActionIndices(esClient: Client) {
   }
 }
 
-export async function createFleetAgent(esClient: Client, agentPolicyId: string, spaceId?: string) {
+export async function createFleetAgent(
+  esClient: Client,
+  agentPolicyId: string,
+  spaceId?: string,
+  data?: Partial<FleetServerAgent>
+) {
   const agentResponse = await esClient.index({
     index: '.fleet-agents',
     refresh: true,
-    document: {
-      access_api_key_id: 'api-key-3',
-      active: true,
-      policy_id: agentPolicyId,
-      policy_revision_idx: 1,
-      last_checkin_status: 'online',
-      type: 'PERMANENT',
-      local_metadata: {
-        host: { hostname: 'host123' },
-        elastic: { agent: { version: '8.15.0' } },
+    document: Object.assign(
+      {
+        access_api_key_id: 'api-key-3',
+        active: true,
+        policy_id: agentPolicyId,
+        policy_revision_idx: 1,
+        last_checkin_status: 'online',
+        type: 'PERMANENT',
+        local_metadata: {
+          host: { hostname: 'host123' },
+          elastic: { agent: { version: '8.15.0' } },
+        },
+        user_provided_metadata: {},
+        enrolled_at: new Date().toISOString(),
+        last_checkin: new Date().toISOString(),
+        tags: ['tag1'],
+        namespaces: spaceId ? [spaceId] : undefined,
       },
-      user_provided_metadata: {},
-      enrolled_at: new Date().toISOString(),
-      last_checkin: new Date().toISOString(),
-      tags: ['tag1'],
-      namespaces: spaceId ? [spaceId] : undefined,
-    },
+      data ?? {}
+    ),
   });
 
   return agentResponse._id;

--- a/x-pack/platform/test/fleet_api_integration/config.base.ts
+++ b/x-pack/platform/test/fleet_api_integration/config.base.ts
@@ -110,6 +110,9 @@ export default async function ({ readConfigFile, log }: FtrConfigProviderContext
             appenders: ['default'],
           },
         ])}`,
+        `--xpack.task_manager.unsafe.exclude_task_types=${JSON.stringify([
+          'fleet:agent-status-change-task',
+        ])} `,
       ],
     },
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Fleet] Improve agent status task to only fetch relevant agents (#246246)](https://github.com/elastic/kibana/pull/246246)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2025-12-15T03:46:05Z","message":"[Fleet] Improve agent status task to only fetch relevant agents (#246246)","sha":"e5ac5e26fe23f99c8c11061ebe55359b911617ea","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.3.0","v9.2.4"],"title":"[Fleet] Improve agent status task to only fetch relevant agents","number":246246,"url":"https://github.com/elastic/kibana/pull/246246","mergeCommit":{"message":"[Fleet] Improve agent status task to only fetch relevant agents (#246246)","sha":"e5ac5e26fe23f99c8c11061ebe55359b911617ea"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246246","number":246246,"mergeCommit":{"message":"[Fleet] Improve agent status task to only fetch relevant agents (#246246)","sha":"e5ac5e26fe23f99c8c11061ebe55359b911617ea"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->