### PR TITLE
[9.2] [CI] Fix typecheck cache invalidation (#246000)

### DIFF
--- a/.buildkite/scripts/steps/typecheck/check_types.sh
+++ b/.buildkite/scripts/steps/typecheck/check_types.sh
@@ -7,5 +7,9 @@ source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
 
 echo --- Check Types
-set +e
-node scripts/type_check --with-archive
+
+if is_pr; then
+  node scripts/type_check --with-archive
+else
+  node scripts/type_check
+fi

--- a/packages/kbn-ts-type-check-cli/src/archive/archive_ts_build_artifacts.test.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/archive_ts_build_artifacts.test.ts
@@ -102,6 +102,7 @@ describe('archiveTSBuildArtifacts', () => {
     expect(updateSpy).toHaveBeenCalledTimes(1);
     expect(updateSpy).toHaveBeenCalledWith({
       files,
+      cacheInvalidationFiles: ['yarn.lock', '.nvmrc', '.node-version'],
       prNumber: '789',
       sha: 'abc123',
     });

--- a/packages/kbn-ts-type-check-cli/src/archive/archive_ts_build_artifacts.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/archive_ts_build_artifacts.ts
@@ -9,7 +9,7 @@
 import { REPO_ROOT } from '@kbn/repo-info';
 import type { SomeDevLog } from '@kbn/some-dev-log';
 import globby from 'globby';
-import { CACHE_IGNORE_GLOBS, CACHE_MATCH_GLOBS } from './constants';
+import { CACHE_IGNORE_GLOBS, CACHE_MATCH_GLOBS, CACHE_INVALIDATION_FILES } from './constants';
 import { GcsFileSystem } from './file_system/gcs_file_system';
 import { LocalFileSystem } from './file_system/local_file_system';
 import {
@@ -46,7 +46,12 @@ export async function archiveTSBuildArtifacts(log: SomeDevLog) {
 
     const prNumber = getPullRequestNumber();
 
-    const options = { files: matches, sha: commitSha, prNumber };
+    const options = {
+      files: matches,
+      sha: commitSha,
+      prNumber,
+      cacheInvalidationFiles: CACHE_INVALIDATION_FILES,
+    };
 
     if (isCiEnvironment()) {
       await withGcsAuth(log, () => new GcsFileSystem(log).updateArchive(options));

--- a/packages/kbn-ts-type-check-cli/src/archive/constants.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/constants.ts
@@ -54,3 +54,9 @@ export const MAX_COMMITS_TO_CHECK = 50;
 
 export const TYPES_DIRECTORY_GLOB = '**/target/types';
 export const TYPE_CHECK_CONFIG_GLOB = '**/tsconfig*.type_check.json';
+
+/**
+ * Files that should be hashed and checked for cache invalidation.
+ * If any of these files change, the cache should be invalidated.
+ */
+export const CACHE_INVALIDATION_FILES = ['yarn.lock', '.nvmrc', '.node-version'];

--- a/packages/kbn-ts-type-check-cli/src/archive/file_system/abstract_file_system.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/file_system/abstract_file_system.ts
@@ -11,8 +11,8 @@ import Fs from 'fs';
 import type { SomeDevLog } from '@kbn/some-dev-log';
 import type { ArchiveMetadata } from './types';
 import { COMMITS_PATH, PULL_REQUESTS_PATH, TMP_DIR } from '../constants';
-import { join } from './utils';
-import { cleanTypeCheckArtifacts } from '../utils';
+import { doHashesMatch, join } from './utils';
+import { cleanTypeCheckArtifacts, calculateFileHashes } from '../utils';
 
 export abstract class AbstractFileSystem {
   constructor(protected readonly log: SomeDevLog) {}
@@ -20,11 +20,13 @@ export abstract class AbstractFileSystem {
   protected abstract getPath(archiveId: string): string;
 
   protected abstract readMetadata(metadataPath: string): Promise<ArchiveMetadata | undefined>;
+
   protected abstract writeMetadata(metadataPath: string, data: ArchiveMetadata): Promise<void>;
 
   protected abstract hasArchive(archivePath: string): Promise<boolean>;
 
   protected abstract extract(archivePath: string): Promise<void>;
+
   protected abstract archive(archivePath: string, fileListPath: string): Promise<void>;
 
   public abstract clean(): Promise<void>;
@@ -56,7 +58,11 @@ export abstract class AbstractFileSystem {
     return fileListPath;
   }
 
-  public async restoreArchive(options: { shas: string[]; prNumber?: string }) {
+  public async restoreArchive(options: {
+    shas: string[];
+    prNumber?: string;
+    cacheInvalidationFiles?: string[];
+  }) {
     const prArchiveId = options.prNumber ? join(PULL_REQUESTS_PATH, options.prNumber) : undefined;
 
     const prArchiveMetadata = prArchiveId
@@ -65,12 +71,31 @@ export abstract class AbstractFileSystem {
 
     const prSha = prArchiveMetadata?.commitSha;
 
+    // Calculate current file hashes if cache invalidation files are provided
+    const currentFileHashes =
+      options.cacheInvalidationFiles && options.cacheInvalidationFiles.length > 0
+        ? await calculateFileHashes(options.cacheInvalidationFiles)
+        : undefined;
+
     for (const sha of options.shas) {
       const archiveId = prSha && sha === prSha ? prArchiveId! : join(COMMITS_PATH, sha);
 
       const archivePath = this.getArchivePath(archiveId);
+      const metadata = await this.readMetadata(this.getMetadataPath(archiveId));
+      const storedFileHashes = metadata?.fileHashes;
 
       if (await this.hasArchive(archivePath)) {
+        const hashCheckResult = doHashesMatch({
+          currentFileHashes,
+          storedFileHashes,
+        });
+        if (!hashCheckResult.result) {
+          this.log.warning(
+            `Cached TypeScript build artifacts for ${sha} found, but cache invalidation files have changed:\n ${hashCheckResult.message}`
+          );
+          return undefined;
+        }
+
         await cleanTypeCheckArtifacts(this.log);
         this.log.info(`Extracting archive for ${sha}`);
         return await this.extract(archivePath);
@@ -82,14 +107,33 @@ export abstract class AbstractFileSystem {
     return undefined;
   }
 
-  public async updateArchive(options: { files: string[]; sha: string; prNumber?: string }) {
+  public async updateArchive(options: {
+    files: string[];
+    sha: string;
+    prNumber?: string;
+    cacheInvalidationFiles?: string[];
+  }) {
     const archiveId = options.prNumber
       ? join(PULL_REQUESTS_PATH, options.prNumber.toString())
       : join(COMMITS_PATH, options.sha);
 
+    // Calculate file hashes if cache invalidation files are provided
+    const fileHashes =
+      options.cacheInvalidationFiles && options.cacheInvalidationFiles.length > 0
+        ? await calculateFileHashes(options.cacheInvalidationFiles)
+        : undefined;
+
+    // Convert null values to undefined for JSON serialization
+    const fileHashesForMetadata: Record<string, string> | undefined = fileHashes
+      ? Object.fromEntries(
+          Object.entries(fileHashes).filter((entry): entry is [string, string] => entry[1] !== null)
+        )
+      : undefined;
+
     const metadata: ArchiveMetadata = {
       commitSha: options.sha,
       prNumber: options.prNumber,
+      fileHashes: fileHashesForMetadata,
     };
 
     const fileListPath = await this.writeFileList(options.files);

--- a/packages/kbn-ts-type-check-cli/src/archive/file_system/types.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/file_system/types.ts
@@ -12,6 +12,7 @@ export type WritableData = string | NodeJS.ArrayBufferView;
 export interface ArchiveMetadata {
   commitSha: string;
   prNumber?: string | null;
+  fileHashes?: Record<string, string>;
 }
 
 export interface PullRequestArchiveMetadata {

--- a/packages/kbn-ts-type-check-cli/src/archive/file_system/utils.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/file_system/utils.ts
@@ -63,3 +63,29 @@ export const resolveTarEnvironment = (): NodeJS.ProcessEnv => {
 
   return env;
 };
+
+export function doHashesMatch({
+  currentFileHashes,
+  storedFileHashes,
+}: {
+  currentFileHashes?: Record<string, string | null | undefined>;
+  storedFileHashes?: Record<string, string | null | undefined>;
+}): { result: boolean; message: string } {
+  if (!currentFileHashes || !storedFileHashes) {
+    return { result: true, message: 'No file hashes to compare.' };
+  }
+
+  const currentHashKeys = Object.keys(currentFileHashes);
+  const storedHashKeys = Object.keys(storedFileHashes);
+  const allKeys = new Set([...currentHashKeys, ...storedHashKeys]);
+
+  for (const key of allKeys) {
+    if (currentFileHashes[key] !== storedFileHashes[key]) {
+      return {
+        result: false,
+        message: `Hash mismatch for file "${key}": current hash is "${currentFileHashes[key]}", stored hash is "${storedFileHashes[key]}"`,
+      };
+    }
+  }
+  return { result: true, message: 'All file hashes match.' };
+}

--- a/packages/kbn-ts-type-check-cli/src/archive/restore_ts_build_artifacts.test.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/restore_ts_build_artifacts.test.ts
@@ -101,6 +101,7 @@ describe('restoreTSBuildArtifacts', () => {
 
     expect(restoreSpy).toHaveBeenCalledTimes(1);
     expect(restoreSpy).toHaveBeenCalledWith({
+      cacheInvalidationFiles: ['yarn.lock', '.nvmrc', '.node-version'],
       prNumber: '456',
       shas: candidateShas,
     });

--- a/packages/kbn-ts-type-check-cli/src/archive/restore_ts_build_artifacts.ts
+++ b/packages/kbn-ts-type-check-cli/src/archive/restore_ts_build_artifacts.ts
@@ -8,7 +8,7 @@
  */
 
 import type { SomeDevLog } from '@kbn/some-dev-log';
-import { MAX_COMMITS_TO_CHECK } from './constants';
+import { MAX_COMMITS_TO_CHECK, CACHE_INVALIDATION_FILES } from './constants';
 import { GcsFileSystem } from './file_system/gcs_file_system';
 import { LocalFileSystem } from './file_system/local_file_system';
 import {
@@ -36,10 +36,18 @@ export async function restoreTSBuildArtifacts(log: SomeDevLog) {
 
     if (isCiEnvironment()) {
       await withGcsAuth(log, async () => {
-        await new GcsFileSystem(log).restoreArchive({ shas: candidateShas, prNumber });
+        await new GcsFileSystem(log).restoreArchive({
+          shas: candidateShas,
+          prNumber,
+          cacheInvalidationFiles: CACHE_INVALIDATION_FILES,
+        });
       });
     } else {
-      await new LocalFileSystem(log).restoreArchive({ shas: candidateShas, prNumber });
+      await new LocalFileSystem(log).restoreArchive({
+        shas: candidateShas,
+        prNumber,
+        cacheInvalidationFiles: CACHE_INVALIDATION_FILES,
+      });
     }
   } catch (error) {
     const restoreErrorDetails = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[CI] Fix typecheck cache invalidation (#246000)](https://github.com/elastic/kibana/pull/246000)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2025-12-15T14:19:18Z","message":"[CI] Fix typecheck cache invalidation (#246000)\n\n## Summary\nThis pull request introduces cache invalidation for TypeScript build\nartifact archives by tracking file hashes (specifically for files like\n`yarn.lock`). If any of these tracked files change, cached build\nartifacts are considered invalid and will not be restored. The\nimplementation includes calculating, storing, and comparing file hashes\nas part of the archiving and restoration process.\n\nWe're currently invaldating on `yarn.lock` + node version changes -\nyarn.lock might be an overkill, it changes too often, and the\nnode-version changes too infrequently (and even @types/* changes might\nbreak it). Maybe we should design a bit more intelligent cache\ninvalidation calculation relying on parsed fields of yarn.lock?\n\n**Cache invalidation for build artifact archives:**\n\n* Added `CACHE_INVALIDATION_FILES` (currently `['yarn.lock']`) to\n`constants.ts`, and updated archiving and restoring logic to include\nthese files for cache invalidation checks.\n[[1]](diffhunk://#diff-12760cbc3b4f8e6127b80a5ccde24bbeafc16f447f6d7ae2daf19ff241b6c4a7R57-R62)\n[[2]](diffhunk://#diff-14030bc13e47e2af1ba4c1af435719cf33616428901ce7f8d25d852667ead9d8L12-R13)\n[[3]](diffhunk://#diff-14030bc13e47e2af1ba4c1af435719cf33616428901ce7f8d25d852667ead9d8L49-R55)\n[[4]](diffhunk://#diff-47f9dcd86e850ad5ad743c3f1c15167629e3c87eff95e832bd5a93b98b451e0eL11-R11)\n[[5]](diffhunk://#diff-47f9dcd86e850ad5ad743c3f1c15167629e3c87eff95e832bd5a93b98b451e0eL39-R50)\n* Updated `AbstractFileSystem` methods (`restoreArchive` and\n`updateArchive`) to calculate and store hashes for cache invalidation\nfiles, and to compare these hashes when restoring archives. If hashes do\nnot match, restoration is aborted and a warning is logged.\n[[1]](diffhunk://#diff-2a9bbd75fec835503245b319665aef6ad0a6020c5a743fbfc71487942f4131a6L59-R65)\n[[2]](diffhunk://#diff-2a9bbd75fec835503245b319665aef6ad0a6020c5a743fbfc71487942f4131a6R74-R98)\n[[3]](diffhunk://#diff-2a9bbd75fec835503245b319665aef6ad0a6020c5a743fbfc71487942f4131a6L85-R136)\n[[4]](diffhunk://#diff-eeb0d88f838614dcceb8f7d28e32fddbfb6e4861309e3a142e9801d611520f53R15)\n[[5]](diffhunk://#diff-cc536a00028321acf5d5626806490294f012f738c1d8d4e1d6c2a5b71fc6c419R66-R91)\n* Implemented utility functions `calculateFileHash`,\n`calculateFileHashes`, and `doHashesMatch` for hashing files and\ncomparing hash sets.\n[[1]](diffhunk://#diff-e7b190e8abc1da621f08d13eb9bc6d06760357b0210a5a1a09fac38b7ceb2fc9R10-R12)\n[[2]](diffhunk://#diff-e7b190e8abc1da621f08d13eb9bc6d06760357b0210a5a1a09fac38b7ceb2fc9R139-R170)\n[[3]](diffhunk://#diff-cc536a00028321acf5d5626806490294f012f738c1d8d4e1d6c2a5b71fc6c419R66-R91)\n\n**Pipeline integration:**\n\n* Modified `.buildkite/scripts/steps/typecheck/check_types.sh` to run\nthe type check with cache archiving for pull requests, ensuring cache\ninvalidation logic is applied in CI.\n\nIf this works OK for PRs (where we expect to gain most of fast\ntypechecks) we can then turn it back on for main.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"23218234ab0370297c11178033e9c526c6970764","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open","v9.3.0"],"title":"[CI] Fix typecheck cache invalidation","number":246000,"url":"https://github.com/elastic/kibana/pull/246000","mergeCommit":{"message":"[CI] Fix typecheck cache invalidation (#246000)\n\n## Summary\nThis pull request introduces cache invalidation for TypeScript build\nartifact archives by tracking file hashes (specifically for files like\n`yarn.lock`). If any of these tracked files change, cached build\nartifacts are considered invalid and will not be restored. The\nimplementation includes calculating, storing, and comparing file hashes\nas part of the archiving and restoration process.\n\nWe're currently invaldating on `yarn.lock` + node version changes -\nyarn.lock might be an overkill, it changes too often, and the\nnode-version changes too infrequently (and even @types/* changes might\nbreak it). Maybe we should design a bit more intelligent cache\ninvalidation calculation relying on parsed fields of yarn.lock?\n\n**Cache invalidation for build artifact archives:**\n\n* Added `CACHE_INVALIDATION_FILES` (currently `['yarn.lock']`) to\n`constants.ts`, and updated archiving and restoring logic to include\nthese files for cache invalidation checks.\n[[1]](diffhunk://#diff-12760cbc3b4f8e6127b80a5ccde24bbeafc16f447f6d7ae2daf19ff241b6c4a7R57-R62)\n[[2]](diffhunk://#diff-14030bc13e47e2af1ba4c1af435719cf33616428901ce7f8d25d852667ead9d8L12-R13)\n[[3]](diffhunk://#diff-14030bc13e47e2af1ba4c1af435719cf33616428901ce7f8d25d852667ead9d8L49-R55)\n[[4]](diffhunk://#diff-47f9dcd86e850ad5ad743c3f1c15167629e3c87eff95e832bd5a93b98b451e0eL11-R11)\n[[5]](diffhunk://#diff-47f9dcd86e850ad5ad743c3f1c15167629e3c87eff95e832bd5a93b98b451e0eL39-R50)\n* Updated `AbstractFileSystem` methods (`restoreArchive` and\n`updateArchive`) to calculate and store hashes for cache invalidation\nfiles, and to compare these hashes when restoring archives. If hashes do\nnot match, restoration is aborted and a warning is logged.\n[[1]](diffhunk://#diff-2a9bbd75fec835503245b319665aef6ad0a6020c5a743fbfc71487942f4131a6L59-R65)\n[[2]](diffhunk://#diff-2a9bbd75fec835503245b319665aef6ad0a6020c5a743fbfc71487942f4131a6R74-R98)\n[[3]](diffhunk://#diff-2a9bbd75fec835503245b319665aef6ad0a6020c5a743fbfc71487942f4131a6L85-R136)\n[[4]](diffhunk://#diff-eeb0d88f838614dcceb8f7d28e32fddbfb6e4861309e3a142e9801d611520f53R15)\n[[5]](diffhunk://#diff-cc536a00028321acf5d5626806490294f012f738c1d8d4e1d6c2a5b71fc6c419R66-R91)\n* Implemented utility functions `calculateFileHash`,\n`calculateFileHashes`, and `doHashesMatch` for hashing files and\ncomparing hash sets.\n[[1]](diffhunk://#diff-e7b190e8abc1da621f08d13eb9bc6d06760357b0210a5a1a09fac38b7ceb2fc9R10-R12)\n[[2]](diffhunk://#diff-e7b190e8abc1da621f08d13eb9bc6d06760357b0210a5a1a09fac38b7ceb2fc9R139-R170)\n[[3]](diffhunk://#diff-cc536a00028321acf5d5626806490294f012f738c1d8d4e1d6c2a5b71fc6c419R66-R91)\n\n**Pipeline integration:**\n\n* Modified `.buildkite/scripts/steps/typecheck/check_types.sh` to run\nthe type check with cache archiving for pull requests, ensuring cache\ninvalidation logic is applied in CI.\n\nIf this works OK for PRs (where we expect to gain most of fast\ntypechecks) we can then turn it back on for main.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"23218234ab0370297c11178033e9c526c6970764"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246000","number":246000,"mergeCommit":{"message":"[CI] Fix typecheck cache invalidation (#246000)\n\n## Summary\nThis pull request introduces cache invalidation for TypeScript build\nartifact archives by tracking file hashes (specifically for files like\n`yarn.lock`). If any of these tracked files change, cached build\nartifacts are considered invalid and will not be restored. The\nimplementation includes calculating, storing, and comparing file hashes\nas part of the archiving and restoration process.\n\nWe're currently invaldating on `yarn.lock` + node version changes -\nyarn.lock might be an overkill, it changes too often, and the\nnode-version changes too infrequently (and even @types/* changes might\nbreak it). Maybe we should design a bit more intelligent cache\ninvalidation calculation relying on parsed fields of yarn.lock?\n\n**Cache invalidation for build artifact archives:**\n\n* Added `CACHE_INVALIDATION_FILES` (currently `['yarn.lock']`) to\n`constants.ts`, and updated archiving and restoring logic to include\nthese files for cache invalidation checks.\n[[1]](diffhunk://#diff-12760cbc3b4f8e6127b80a5ccde24bbeafc16f447f6d7ae2daf19ff241b6c4a7R57-R62)\n[[2]](diffhunk://#diff-14030bc13e47e2af1ba4c1af435719cf33616428901ce7f8d25d852667ead9d8L12-R13)\n[[3]](diffhunk://#diff-14030bc13e47e2af1ba4c1af435719cf33616428901ce7f8d25d852667ead9d8L49-R55)\n[[4]](diffhunk://#diff-47f9dcd86e850ad5ad743c3f1c15167629e3c87eff95e832bd5a93b98b451e0eL11-R11)\n[[5]](diffhunk://#diff-47f9dcd86e850ad5ad743c3f1c15167629e3c87eff95e832bd5a93b98b451e0eL39-R50)\n* Updated `AbstractFileSystem` methods (`restoreArchive` and\n`updateArchive`) to calculate and store hashes for cache invalidation\nfiles, and to compare these hashes when restoring archives. If hashes do\nnot match, restoration is aborted and a warning is logged.\n[[1]](diffhunk://#diff-2a9bbd75fec835503245b319665aef6ad0a6020c5a743fbfc71487942f4131a6L59-R65)\n[[2]](diffhunk://#diff-2a9bbd75fec835503245b319665aef6ad0a6020c5a743fbfc71487942f4131a6R74-R98)\n[[3]](diffhunk://#diff-2a9bbd75fec835503245b319665aef6ad0a6020c5a743fbfc71487942f4131a6L85-R136)\n[[4]](diffhunk://#diff-eeb0d88f838614dcceb8f7d28e32fddbfb6e4861309e3a142e9801d611520f53R15)\n[[5]](diffhunk://#diff-cc536a00028321acf5d5626806490294f012f738c1d8d4e1d6c2a5b71fc6c419R66-R91)\n* Implemented utility functions `calculateFileHash`,\n`calculateFileHashes`, and `doHashesMatch` for hashing files and\ncomparing hash sets.\n[[1]](diffhunk://#diff-e7b190e8abc1da621f08d13eb9bc6d06760357b0210a5a1a09fac38b7ceb2fc9R10-R12)\n[[2]](diffhunk://#diff-e7b190e8abc1da621f08d13eb9bc6d06760357b0210a5a1a09fac38b7ceb2fc9R139-R170)\n[[3]](diffhunk://#diff-cc536a00028321acf5d5626806490294f012f738c1d8d4e1d6c2a5b71fc6c419R66-R91)\n\n**Pipeline integration:**\n\n* Modified `.buildkite/scripts/steps/typecheck/check_types.sh` to run\nthe type check with cache archiving for pull requests, ensuring cache\ninvalidation logic is applied in CI.\n\nIf this works OK for PRs (where we expect to gain most of fast\ntypechecks) we can then turn it back on for main.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"23218234ab0370297c11178033e9c526c6970764"}}]}] BACKPORT-->