### PR TITLE
[Agent Builder] Create visualization tool: Fix Bedrock

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/create_visualization/prompts.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/create_visualization/prompts.ts
@@ -35,14 +35,14 @@ ${JSON.stringify(schema, null, 2)}
 
 ${
   existingConfig
-    ? `Existing configuration to modify: 
+    ? `Existing configuration to modify:
   <existing_configuration>
   ${existingConfig}
   </existing_configuration>
   `
     : ''
 }
-  
+
 ${existingConfig ? `Existing configuration to modify: ${existingConfig}` : ''}
 
 ${additionalInstructions}
@@ -64,5 +64,6 @@ IMPORTANT: Return ONLY the JSON configuration wrapped in a markdown code block l
 
 ${additionalContext}`,
     ],
+    ['human', 'Generate the visualization configuration.'],
   ];
 };

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/create_visualization/prompts.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/create_visualization/prompts.ts
@@ -64,6 +64,7 @@ IMPORTANT: Return ONLY the JSON configuration wrapped in a markdown code block l
 
 ${additionalContext}`,
     ],
+    // Human message required for Bedrock to work properly
     ['human', 'Generate the visualization configuration.'],
   ];
 };


### PR DESCRIPTION
## Summary

Bedrock rejects calls where the first chat message isn't from the user. Our `create_visualization` prompt was system-only, and our adapter sends system prompts separately, so Bedrock saw no user message which caused errors.

Before:

console: 
```
Error calling connector: Status code: 400. Message: API Error: Bad Request - A conversation must start with a user message. Try again with a conversation that starts with a user message.
```

<img width="1315" height="845" alt="image" src="https://github.com/user-attachments/assets/f33b119c-b8c4-4f7d-88cd-4d411c949c9f" />


After:

<img width="2212" height="1942" alt="image" src="https://github.com/user-attachments/assets/3e983adf-ebdc-42a8-b3da-a30d87969f80" />
