### PR TITLE
Add LLM Proxy Test Helper Package

### DIFF
--- a/.buildkite/ftr_security_stateful_configs.yml
+++ b/.buildkite/ftr_security_stateful_configs.yml
@@ -29,9 +29,6 @@ disabled:
   # Gen AI Evals run weekly via their own pipeline
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/evaluations/trial_license_complete_tier/configs/ess.config.ts
 
-  # LLM Proxy Example - Reference/documentation test, run manually
-  - x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/llm_proxy_example/trial_license_complete_tier/configs/ess.config.ts
-
   # Detection Rules Management base configs
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.basic.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.trial.config.ts

--- a/.buildkite/ftr_security_stateful_configs.yml
+++ b/.buildkite/ftr_security_stateful_configs.yml
@@ -29,6 +29,9 @@ disabled:
   # Gen AI Evals run weekly via their own pipeline
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/evaluations/trial_license_complete_tier/configs/ess.config.ts
 
+  # LLM Proxy Example - Reference/documentation test, run manually
+  - x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/llm_proxy_example/trial_license_complete_tier/configs/ess.config.ts
+
   # Detection Rules Management base configs
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.basic.config.ts
   - x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/configs/ess/rules_management.trial.config.ts

--- a/package.json
+++ b/package.json
@@ -1650,6 +1650,7 @@
     "@kbn/lazy-object": "link:src/platform/packages/shared/kbn-lazy-object",
     "@kbn/lint-packages-cli": "link:packages/kbn-lint-packages-cli",
     "@kbn/lint-ts-projects-cli": "link:packages/kbn-lint-ts-projects-cli",
+    "@kbn/llm-proxy-test-helper": "link:src/platform/packages/shared/kbn-llm-proxy-test-helper",
     "@kbn/managed-vscode-config": "link:packages/kbn-managed-vscode-config",
     "@kbn/managed-vscode-config-cli": "link:packages/kbn-managed-vscode-config-cli",
     "@kbn/management-storybook-config": "link:src/platform/packages/shared/kbn-management/storybook/config",

--- a/src/platform/packages/shared/kbn-llm-proxy-test-helper/index.ts
+++ b/src/platform/packages/shared/kbn-llm-proxy-test-helper/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { createLlmProxy, LlmProxy } from './src/proxy';
+export { LlmSimulator, sseEvent } from './src/llm_simulator';
+export { createToolCallMessage } from './src/tool_call_helpers';
+export { createOpenAiChunk } from './src/create_openai_chunk';
+export { createLlmProxyConnector, deleteLlmProxyConnector } from './src/create_llm_proxy_connector';
+export type { LLMMessage, ToolMessage, HttpRequest, HttpResponse } from './src/types';

--- a/src/platform/packages/shared/kbn-llm-proxy-test-helper/jest.config.js
+++ b/src/platform/packages/shared/kbn-llm-proxy-test-helper/jest.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/src/platform/packages/shared/kbn-llm-proxy-test-helper'],
+};

--- a/src/platform/packages/shared/kbn-llm-proxy-test-helper/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-llm-proxy-test-helper/kibana.jsonc
@@ -1,0 +1,10 @@
+{
+  "type": "test-helper",
+  "id": "@kbn/llm-proxy-test-helper",
+  "owner": [
+    "@elastic/security-generative-ai"
+  ],
+  "group": "platform",
+  "visibility": "shared",
+  "devOnly": true
+}

--- a/src/platform/packages/shared/kbn-llm-proxy-test-helper/package.json
+++ b/src/platform/packages/shared/kbn-llm-proxy-test-helper/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/llm-proxy-test-helper",
+  "version": "1.0.0",
+  "private": true,
+  "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0"
+}

--- a/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/create_llm_proxy_connector.ts
+++ b/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/create_llm_proxy_connector.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { LlmProxy } from './proxy';
+
+interface SuperTestLike {
+  post(url: string): SuperTestLike;
+  delete(url: string): SuperTestLike;
+  set(key: string, value: string): SuperTestLike;
+  send(body: unknown): SuperTestLike;
+  expect(status: number): Promise<{ body: { id: string } }>;
+}
+
+/**
+ * Creates a .gen-ai connector that points to the LLM proxy server.
+ * This allows tests to intercept and mock LLM responses.
+ *
+ * @param supertest - The supertest agent to use for API calls
+ * @param proxy - The LLM proxy instance
+ * @param name - Optional name for the connector (defaults to 'LLM Proxy Connector')
+ * @returns The connector ID
+ */
+export async function createLlmProxyConnector({
+  supertest,
+  proxy,
+  name = 'LLM Proxy Connector',
+}: {
+  supertest: SuperTestLike;
+  proxy: LlmProxy;
+  name?: string;
+}): Promise<string> {
+  const { body } = await supertest
+    .post('/api/actions/connector')
+    .set('kbn-xsrf', 'true')
+    .send({
+      name,
+      connector_type_id: '.gen-ai',
+      config: {
+        apiProvider: 'OpenAI',
+        apiUrl: `http://localhost:${proxy.getPort()}`,
+      },
+      secrets: {
+        apiKey: 'fake-api-key',
+      },
+    })
+    .expect(200);
+
+  return body.id;
+}
+
+/**
+ * Deletes a connector by ID.
+ *
+ * @param supertest - The supertest agent to use for API calls
+ * @param connectorId - The ID of the connector to delete
+ */
+export async function deleteLlmProxyConnector({
+  supertest,
+  connectorId,
+}: {
+  supertest: SuperTestLike;
+  connectorId: string;
+}): Promise<void> {
+  await supertest
+    .delete(`/api/actions/connector/${connectorId}`)
+    .set('kbn-xsrf', 'true')
+    .expect(204);
+}

--- a/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/create_openai_chunk.ts
+++ b/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/create_openai_chunk.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { v4 } from 'uuid';
+import type OpenAI from 'openai';
+import type { ToolMessage } from './types';
+
+export function createOpenAiChunk(msg: string | ToolMessage): OpenAI.ChatCompletionChunk {
+  let delta: OpenAI.ChatCompletionChunk.Choice.Delta;
+  if (typeof msg === 'string') {
+    delta = { role: 'user', content: msg };
+  } else {
+    delta = {
+      role: msg.role,
+      content: msg.content,
+      tool_calls: msg.tool_calls?.map((tc) => ({ ...tc, index: 0 })),
+    };
+  }
+
+  return {
+    id: v4(),
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: 'gpt-4',
+    choices: [
+      {
+        delta,
+        index: 0,
+        finish_reason: null,
+      },
+    ],
+  };
+}

--- a/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/interceptors.ts
+++ b/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/interceptors.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ChatCompletionStreamParams } from 'openai/lib/ChatCompletionStream';
+import { last } from 'lodash';
+import type { LlmProxy } from './proxy';
+import type { ToolMessage } from './types';
+
+type LLMMessage = string[] | ToolMessage | string | undefined;
+type LLMResponseFnOrString = LLMMessage | ((body: ChatCompletionStreamParams) => LLMMessage);
+
+export function createInterceptors(proxy: LlmProxy) {
+  return {
+    toolChoice: ({ name, response }: { name: string; response: LLMResponseFnOrString }) =>
+      proxy
+        .intercept({
+          name: `toolChoice: "${name}"`,
+          // @ts-expect-error
+          when: (body) => body.tool_choice?.function?.name === name,
+          responseMock: response,
+        })
+        .completeAfterIntercept(),
+
+    userMessage: ({
+      name,
+      response,
+      when,
+    }: {
+      name?: string;
+      response: LLMResponseFnOrString;
+      when?: (body: ChatCompletionStreamParams) => boolean;
+    }) =>
+      proxy
+        .intercept({
+          name: name ?? `userMessage`,
+          when: (body) => {
+            const isUserMessage = last(body.messages)?.role === 'user';
+            if (when) {
+              return isUserMessage && when(body);
+            }
+            return isUserMessage;
+          },
+          responseMock: response,
+        })
+        .completeAfterIntercept(),
+
+    toolMessage: ({
+      name,
+      response,
+      when,
+    }: {
+      name?: string;
+      response: LLMResponseFnOrString;
+      when?: (body: ChatCompletionStreamParams) => boolean;
+    }) =>
+      proxy
+        .intercept({
+          name: name ?? `toolMessage`,
+          when: (body) => {
+            const isToolMessage = last(body.messages)?.role === 'tool';
+            if (when) {
+              return isToolMessage && when(body);
+            }
+            return isToolMessage;
+          },
+          responseMock: response,
+        })
+        .completeAfterIntercept(),
+  };
+}

--- a/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/llm_simulator.ts
+++ b/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/llm_simulator.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { once } from 'lodash';
+import type { ChatCompletionStreamParams } from 'openai/lib/ChatCompletionStream';
+import type { ToolingLog } from '@kbn/tooling-log';
+import { createOpenAiChunk } from './create_openai_chunk';
+import type { HttpResponse, ToolMessage } from './types';
+
+/**
+ * Formats a chunk for Server-Sent Events (SSE)
+ */
+export function sseEvent(chunk: unknown) {
+  return `data: ${JSON.stringify(chunk)}\n\n`;
+}
+
+export class LlmSimulator {
+  constructor(
+    public readonly requestBody: ChatCompletionStreamParams,
+    private readonly response: HttpResponse,
+    private readonly log: ToolingLog,
+    private readonly name: string
+  ) {}
+
+  async writeChunk(msg: string | ToolMessage): Promise<void> {
+    this.status(200);
+    const chunk = createOpenAiChunk(msg);
+    return this.write(sseEvent(chunk));
+  }
+
+  async complete(): Promise<void> {
+    this.log.debug(`Completed intercept for "${this.name}"`);
+    await this.write('data: [DONE]\n\n');
+    await this.end();
+  }
+
+  async writeErrorChunk(code: number, error: Record<string, unknown>): Promise<void> {
+    this.status(code);
+    await this.write(sseEvent(error));
+    await this.end();
+  }
+
+  status = once((code: number) => {
+    this.response.writeHead(code, {
+      'Elastic-Interceptor': this.name.replace(/[^\x20-\x7E]/g, ' '), // Keeps only alphanumeric characters and spaces
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+  });
+
+  private write(chunk: string): Promise<void> {
+    return new Promise<void>((resolve) => this.response.write(chunk, () => resolve()));
+  }
+
+  private end(): Promise<void> {
+    return new Promise<void>((resolve) => this.response.end(resolve));
+  }
+}

--- a/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/proxy.ts
+++ b/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/proxy.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ToolingLog } from '@kbn/tooling-log';
+import getPort from 'get-port';
+import http, { type Server } from 'http';
+import { isString, pull, isFunction } from 'lodash';
+import pRetry from 'p-retry';
+import type { ChatCompletionStreamParams } from 'openai/lib/ChatCompletionStream';
+import { createInterceptors } from './interceptors';
+import { LlmSimulator } from './llm_simulator';
+import type { HttpRequest, HttpResponse, LLMMessage, ToolMessage } from './types';
+
+type RequestHandler = (
+  request: HttpRequest,
+  response: HttpResponse,
+  requestBody: ChatCompletionStreamParams
+) => LLMMessage;
+
+interface RequestInterceptor {
+  name: string;
+  when: (body: ChatCompletionStreamParams) => boolean;
+}
+
+export class LlmProxy {
+  server: Server;
+  interval: NodeJS.Timeout;
+  private requestInterceptors: Array<RequestInterceptor & { handle: RequestHandler }> = [];
+  // Public interceptor helper API
+  interceptors: ReturnType<typeof createInterceptors>;
+  interceptedRequests: Array<{
+    requestBody: ChatCompletionStreamParams;
+    matchingInterceptorName: string | undefined;
+  }> = [];
+
+  constructor(private readonly port: number, private readonly log: ToolingLog) {
+    this.interval = setInterval(() => this.log.debug(`LLM proxy listening on port ${port}`), 5000);
+
+    this.server = http
+      .createServer()
+      .on('request', async (request, response) => {
+        const requestBody = await getRequestBody(request);
+
+        const matchingInterceptor = this.requestInterceptors.find(({ when }) => when(requestBody));
+        this.interceptedRequests.push({
+          requestBody,
+          matchingInterceptorName: matchingInterceptor?.name,
+        });
+
+        const compressedConversation = requestBody.messages.map((m) => {
+          return { ...m, content: m.role === 'system' ? m.content?.slice(0, 200) : m.content };
+        });
+
+        // @ts-expect-error
+        const toolChoice = requestBody.tool_choice?.function.name;
+        const availableToolNames = requestBody.tools?.map(({ function: fn }) => fn.name);
+
+        this.log.info(`Outgoing conversation "${JSON.stringify(compressedConversation, null, 2)}"`);
+        this.log.info(`Tools: ${JSON.stringify(availableToolNames, null, 2)}`);
+        if (toolChoice) {
+          this.log.info(`Tool choice: ${toolChoice}`);
+        }
+
+        if (matchingInterceptor) {
+          const mockedLlmResponse = matchingInterceptor.handle(request, response, requestBody);
+          this.log.info(`Mocked LLM response: ${JSON.stringify(mockedLlmResponse, null, 2)}`);
+          pull(this.requestInterceptors, matchingInterceptor);
+          return;
+        }
+
+        const errorMessage = `No interceptors found to handle request`;
+        this.log.warning(errorMessage);
+        this.log.warning(
+          `Available interceptors: ${JSON.stringify(
+            this.requestInterceptors.map(({ name, when }) => ({
+              name,
+              when: when.toString(),
+            })),
+            null,
+            2
+          )}`
+        );
+
+        const simulator = new LlmSimulator(requestBody, response, this.log, 'No interceptor found');
+        await simulator.writeErrorChunk(404, {
+          errorMessage,
+          availableInterceptors: this.requestInterceptors.map(({ name }) => name),
+        });
+      })
+      .on('error', (error) => {
+        this.log.error(`LLM proxy encountered an error: ${error}`);
+      })
+      .listen(port);
+
+    // Initialize helper API
+    this.interceptors = createInterceptors(this);
+  }
+
+  getPort() {
+    return this.port;
+  }
+
+  clear() {
+    this.requestInterceptors = [];
+    this.interceptedRequests = [];
+  }
+
+  close() {
+    this.log.debug(`Closing LLM Proxy on port ${this.port}`);
+    clearInterval(this.interval);
+    this.server.close();
+    this.clear();
+  }
+
+  waitForAllInterceptorsToHaveBeenCalled() {
+    return pRetry(
+      async () => {
+        if (this.requestInterceptors.length === 0) {
+          return;
+        }
+
+        const interceptorNames = this.requestInterceptors.map(({ name }) => name);
+        this.log.debug(
+          `Waiting for the following interceptors to be called: ${JSON.stringify(interceptorNames)}`
+        );
+
+        throw new Error(
+          `Interceptors were not called: ${interceptorNames.map((name) => `\n - ${name}`)}\n`
+        );
+      },
+      { retries: 5, maxTimeout: 1000 }
+    ).catch((error) => {
+      this.clear();
+      throw error;
+    });
+  }
+
+  intercept({
+    name,
+    when,
+    responseMock,
+  }: {
+    name: string;
+    when: RequestInterceptor['when'];
+    responseMock?: LLMMessage | ((body: ChatCompletionStreamParams) => LLMMessage);
+  }): {
+    waitForIntercept: () => Promise<LlmSimulator>;
+    completeAfterIntercept: () => Promise<LlmSimulator>;
+  } {
+    const getMockedLlmMessage = (body: ChatCompletionStreamParams): LLMMessage | undefined => {
+      if (isFunction(responseMock)) {
+        return responseMock(body);
+      }
+
+      return responseMock;
+    };
+
+    const waitForInterceptPromise = withTimeout(
+      new Promise<LlmSimulator>((outerResolve) => {
+        this.requestInterceptors.push({
+          name,
+          when,
+          handle: (request, response, requestBody) => {
+            const simulator = new LlmSimulator(requestBody, response, this.log, name);
+            const llmMessage = getMockedLlmMessage(requestBody);
+            outerResolve(simulator);
+
+            return llmMessage;
+          },
+        });
+      }),
+      30000,
+      `Interceptor "${name}" timed out after 30000ms`
+    );
+
+    return {
+      waitForIntercept: () => waitForInterceptPromise,
+      completeAfterIntercept: async () => {
+        const simulator = await waitForInterceptPromise;
+
+        function getParsedChunks(): Array<string | ToolMessage> {
+          const llmMessage = getMockedLlmMessage(simulator.requestBody);
+          if (!llmMessage) {
+            return [];
+          }
+
+          if (Array.isArray(llmMessage)) {
+            return llmMessage;
+          }
+
+          if (isString(llmMessage)) {
+            return llmMessage.split(' ').map((token, i) => (i === 0 ? token : ` ${token}`));
+          }
+
+          return [llmMessage];
+        }
+
+        const parsedChunks = getParsedChunks();
+        for (const chunk of parsedChunks) {
+          await simulator.writeChunk(chunk);
+        }
+
+        await simulator.complete();
+        return simulator;
+      },
+    } as {
+      waitForIntercept: () => Promise<LlmSimulator>;
+      completeAfterIntercept: () => Promise<LlmSimulator>;
+    };
+  }
+}
+
+export async function createLlmProxy(log: ToolingLog) {
+  const port = await getPort({ port: getPort.makeRange(9000, 9100) });
+  log.debug(`Starting LLM Proxy on port ${port}`);
+  return new LlmProxy(port, log);
+}
+
+async function getRequestBody(request: http.IncomingMessage): Promise<ChatCompletionStreamParams> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+
+    request.on('data', (chunk) => {
+      data += chunk.toString();
+    });
+
+    request.on('end', () => {
+      try {
+        resolve(JSON.parse(data));
+      } catch (error) {
+        reject(`Failed to parse request body: ${error}`);
+      }
+    });
+
+    request.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
+
+function withTimeout<T>(promise: Promise<T>, timeout: number, message: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(() => reject(new Error(message)), timeout);
+    }),
+  ]);
+}

--- a/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/tool_call_helpers.ts
+++ b/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/tool_call_helpers.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { ChatCompletionMessage } from 'openai/resources/chat/completions';
+
+export function createToolCallMessage(
+  toolName: string,
+  toolArg: Record<string, unknown>
+): Omit<ChatCompletionMessage, 'refusal'> {
+  return {
+    role: 'assistant' as const,
+    content: '',
+    tool_calls: [
+      {
+        function: {
+          name: toolName,
+          arguments: JSON.stringify(toolArg),
+        },
+        id: `call_${uuidv4()}`,
+        type: 'function',
+      },
+    ],
+  };
+}

--- a/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/types.ts
+++ b/src/platform/packages/shared/kbn-llm-proxy-test-helper/src/types.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type http from 'http';
+import type { ChatCompletionMessage } from 'openai/resources';
+
+export type HttpRequest = http.IncomingMessage;
+export type HttpResponse = http.ServerResponse<http.IncomingMessage>;
+
+export type LLMMessage = string[] | ToolMessage | string | undefined;
+
+export type ToolMessage = Omit<ChatCompletionMessage, 'refusal'>;

--- a/src/platform/packages/shared/kbn-llm-proxy-test-helper/tsconfig.json
+++ b/src/platform/packages/shared/kbn-llm-proxy-test-helper/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "kbn_references": [
+    "@kbn/tooling-log"
+  ],
+  "exclude": [
+    "target/**/*"
+  ]
+}
+
+

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1366,6 +1366,8 @@
       "@kbn/lint-ts-projects-cli/*": ["packages/kbn-lint-ts-projects-cli/*"],
       "@kbn/lists-plugin": ["x-pack/solutions/security/plugins/lists"],
       "@kbn/lists-plugin/*": ["x-pack/solutions/security/plugins/lists/*"],
+      "@kbn/llm-proxy-test-helper": ["src/platform/packages/shared/kbn-llm-proxy-test-helper"],
+      "@kbn/llm-proxy-test-helper/*": ["src/platform/packages/shared/kbn-llm-proxy-test-helper/*"],
       "@kbn/llm-tasks-plugin": ["x-pack/platform/plugins/shared/ai_infra/llm_tasks"],
       "@kbn/llm-tasks-plugin/*": ["x-pack/platform/plugins/shared/ai_infra/llm_tasks/*"],
       "@kbn/locator-examples-plugin": ["examples/locator_examples"],

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/llm_proxy_example/trial_license_complete_tier/configs/ess.config.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/llm_proxy_example/trial_license_complete_tier/configs/ess.config.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+// Action types enabled for this test suite - includes .gen-ai for LLM proxy testing
+const enabledActionTypes = [
+  '.cases',
+  '.email',
+  '.index',
+  '.pagerduty',
+  '.swimlane',
+  '.server-log',
+  '.servicenow',
+  '.slack',
+  '.webhook',
+  '.gen-ai', // Required for LLM proxy testing
+  'test.authorization',
+  'test.failing',
+  'test.index-record',
+  'test.noop',
+  'test.rate-limit',
+];
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(
+    require.resolve('../../../../../config/ess/config.base.trial')
+  );
+
+  return {
+    ...functionalConfig.getAll(),
+    testFiles: [require.resolve('..')],
+    junit: {
+      reportName: 'GenAI LLM Proxy Example - ESS Integration Tests - Trial License',
+    },
+    kbnTestServer: {
+      ...functionalConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...functionalConfig
+          .get('kbnTestServer.serverArgs')
+          .filter((arg: string) => !arg.startsWith('--xpack.actions.enabledActionTypes')),
+        `--xpack.actions.enabledActionTypes=${JSON.stringify(enabledActionTypes)}`,
+      ],
+    },
+  };
+}

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/llm_proxy_example/trial_license_complete_tier/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/llm_proxy_example/trial_license_complete_tier/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('GenAI - LLM Proxy Example', () => {
+    loadTestFile(require.resolve('./llm_proxy_example'));
+  });
+}

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/llm_proxy_example/trial_license_complete_tier/llm_proxy_example.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/llm_proxy_example/trial_license_complete_tier/llm_proxy_example.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import {
+  createLlmProxy,
+  createLlmProxyConnector,
+  deleteLlmProxyConnector,
+  type LlmProxy,
+} from '@kbn/llm-proxy-test-helper';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+
+/**
+ * This is a sample test file demonstrating how to use the LLM proxy
+ * for testing AI features in Security Solution without requiring a real AI connector.
+ *
+ * The LLM proxy pattern allows you to:
+ * 1. Create a local HTTP server that mimics an OpenAI-compatible API
+ * 2. Create a real .gen-ai connector that points to the proxy
+ * 3. Intercept LLM requests and return predetermined responses
+ * 4. Assert on what was sent to the "LLM" (request body inspection)
+ *
+ * Note: Tests using the LLM proxy should be tagged with 'skipCloud' since
+ * the proxy runs on localhost and won't work in cloud environments.
+ */
+export default ({ getService }: FtrProviderContext) => {
+  const supertest = getService('supertest');
+  const log = getService('log');
+
+  // Skip this test in cloud environments since the LLM proxy runs on localhost
+  describe('@ess LLM Proxy Example', function () {
+    // The proxy runs on localhost so it won't work in cloud environments
+    this.tags(['skipCloud']);
+
+    let proxy: LlmProxy;
+    let connectorId: string;
+
+    before(async () => {
+      // 1. Create the LLM proxy server
+      proxy = await createLlmProxy(log);
+
+      // 2. Create a .gen-ai connector pointing to the proxy
+      connectorId = await createLlmProxyConnector({
+        supertest,
+        proxy,
+        name: 'Test LLM Proxy Connector',
+      });
+
+      log.info(`Created LLM proxy on port ${proxy.getPort()} with connector ID: ${connectorId}`);
+    });
+
+    after(async () => {
+      // Clean up: close proxy and delete connector
+      proxy?.close();
+      if (connectorId) {
+        await deleteLlmProxyConnector({ supertest, connectorId });
+      }
+    });
+
+    afterEach(() => {
+      // Clear interceptors and intercepted requests between tests
+      proxy.clear();
+    });
+
+    describe('Basic Usage Examples', () => {
+      it('should demonstrate how to intercept and mock a simple text response', async () => {
+        // Register an interceptor that matches any user message
+        const { completeAfterIntercept } = proxy.intercept({
+          name: 'simple-response',
+          when: (body) => body.messages.some((m) => m.role === 'user'),
+          responseMock: 'This is a mocked LLM response for testing purposes.',
+        });
+
+        // The completeAfterIntercept() returns a promise that resolves when
+        // the interceptor is called and the response is fully streamed
+        void completeAfterIntercept();
+
+        // At this point, you would call your API endpoint that uses the connector
+        // For example:
+        // await supertest.post('/api/your_ai_endpoint')
+        //   .send({ connectorId, prompt: 'Hello' });
+
+        // For demonstration, let's just verify the interceptor was registered
+        expect(proxy.interceptedRequests).toHaveLength(0); // No requests yet
+      });
+    });
+  });
+};

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/utils/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/genai/utils/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './auth';

--- a/x-pack/solutions/security/test/security_solution_api_integration/tsconfig.json
+++ b/x-pack/solutions/security/test/security_solution_api_integration/tsconfig.json
@@ -67,5 +67,6 @@
     "@kbn/cloud-security-posture-common",
     "@kbn/detections-response-ftr-services",
     "@kbn/connector-schemas",
+    "@kbn/llm-proxy-test-helper",
   ]
 }

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/cypress.config.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/cypress.config.ts
@@ -8,6 +8,7 @@
 import { defineCypressConfig } from '@kbn/cypress-config';
 import { esArchiver } from './support/es_archiver';
 import { esClient } from './support/es_client';
+import { llmProxyPlugin } from './support/llm_proxy';
 
 export default defineCypressConfig({
   chromeWebSecurity: false,
@@ -33,6 +34,7 @@ export default defineCypressConfig({
     setupNodeEvents(on, config) {
       esArchiver(on, config);
       esClient(on, config);
+      llmProxyPlugin(on, config);
       on('before:browser:launch', (browser, launchOptions) => {
         if (browser.name === 'chrome' && browser.isHeadless) {
           launchOptions.args.push('--window-size=1920,1200');

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/llm_proxy_example.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai_assistant/llm_proxy_example.cy.ts
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { login } from '../../tasks/login';
+import { visitGetStartedPage } from '../../tasks/navigation';
+import { deleteConnectors } from '../../tasks/api_calls/common';
+import { deleteConversations } from '../../tasks/api_calls/assistant';
+import {
+  openAssistant,
+  closeAssistant,
+  selectConnector,
+  assertConnectorSelected,
+  assertMessageSent,
+  typeAndSendMessage,
+} from '../../tasks/assistant';
+import { CONVERSATION_MESSAGE } from '../../screens/ai_assistant';
+
+/**
+ * This test file demonstrates how to use the LLM proxy for testing AI features
+ * in Security Solution Cypress tests without requiring a real AI connector.
+ *
+ * The LLM proxy pattern allows you to:
+ * 1. Create a local HTTP server that mimics an OpenAI-compatible API
+ * 2. Create a real .gen-ai connector that points to the proxy
+ * 3. Intercept LLM requests and return predetermined responses
+ * 4. Assert on what was sent to the "LLM" (request body inspection)
+ *
+ * Note: Tests using the LLM proxy should be tagged with '@skipInServerless'
+ * since the proxy runs on localhost and won't work in cloud/serverless environments.
+ */
+
+const CONNECTOR_NAME = 'LLM Proxy Test Connector';
+
+describe(
+  '@ess @skipInServerless LLM Proxy E2E Example',
+  { tags: ['@ess', '@skipInServerless'] },
+  () => {
+    let connectorId: string;
+
+    before(() => {
+      // Login to authenticate API requests
+      login();
+
+      // Clean up any existing connectors and conversations
+      deleteConnectors();
+      deleteConversations();
+
+      // Start the LLM proxy server
+      cy.startLlmProxy().then((port) => {
+        cy.log(`LLM Proxy started on port ${port}`);
+
+        // Create a .gen-ai connector pointing to the proxy
+        cy.createLlmProxyConnector(port, CONNECTOR_NAME).then((id) => {
+          connectorId = id;
+          cy.log(`Created connector with ID: ${id}`);
+        });
+      });
+    });
+
+    after(() => {
+      // Clean up: delete connector and stop proxy
+      if (connectorId) {
+        cy.deleteLlmProxyConnector(connectorId);
+      }
+      cy.stopLlmProxy();
+    });
+
+    beforeEach(() => {
+      // Clear interceptors and intercepted requests between tests
+      cy.clearLlmProxy();
+      // Login before each test
+      login();
+    });
+
+    describe('Simple Conversation Flow', () => {
+      it('should send a message and receive a mocked response from the LLM proxy', () => {
+        // 1. Register a mock response that the proxy will return
+        const mockResponse = 'Hello! I am a mocked AI response for testing purposes.';
+        cy.registerLlmResponse('greeting-response', mockResponse);
+
+        // 2. Navigate to Security and open the AI Assistant
+        visitGetStartedPage();
+        openAssistant();
+
+        // 3. Select the LLM proxy connector
+        selectConnector(CONNECTOR_NAME);
+        assertConnectorSelected(CONNECTOR_NAME);
+
+        // 4. Send a message to the assistant
+        const userMessage = 'Hello, can you help me?';
+        typeAndSendMessage(userMessage);
+
+        // 5. Verify the user message was sent
+        assertMessageSent(userMessage);
+
+        // 6. Wait for and verify the mocked response appears
+        // The assistant should display the mock response from our proxy
+        cy.get(CONVERSATION_MESSAGE, { timeout: 30000 })
+          .should('have.length.at.least', 2) // User message + AI response
+          .last()
+          .should('contain', mockResponse);
+
+        // 7. Verify what was actually sent to the LLM proxy
+        cy.getLlmInterceptedRequests().then((requests) => {
+          expect(requests).to.have.length.at.least(1);
+
+          const lastRequest = requests[requests.length - 1];
+          const { requestBody } = lastRequest;
+
+          // Verify the request structure
+          expect(requestBody).to.have.property('messages');
+          expect(requestBody.messages).to.be.an('array');
+
+          // Find the user message in the request
+          const userMessageInRequest = requestBody.messages.find(
+            (msg: { role: string; content: string }) =>
+              msg.role === 'user' && msg.content?.includes(userMessage)
+          );
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(userMessageInRequest).to.not.be.undefined;
+
+          cy.log('Successfully verified LLM request payload');
+        });
+      });
+
+      it('should handle streaming responses with multiple chunks', () => {
+        // Register a streaming response (array of chunks)
+        const streamingChunks = [
+          'I am analyzing ',
+          'your security ',
+          'environment. ',
+          'Here are my findings: ',
+          'Everything looks secure!',
+        ];
+        cy.registerLlmResponse('streaming-response', streamingChunks);
+
+        visitGetStartedPage();
+        openAssistant();
+        selectConnector(CONNECTOR_NAME);
+
+        typeAndSendMessage('Analyze my security posture');
+
+        // The full response should be assembled from all chunks
+        const fullResponse = streamingChunks.join('');
+        cy.get(CONVERSATION_MESSAGE, { timeout: 30000 })
+          .last()
+          .should('contain', fullResponse.trim());
+      });
+
+      it('should demonstrate conditional responses based on user input', () => {
+        // Register different responses for different queries
+        cy.registerLlmResponseWithCondition(
+          'alerts-query',
+          'I found 5 critical alerts that need your attention.',
+          'alerts'
+        );
+
+        cy.registerLlmResponseWithCondition(
+          'rules-query',
+          'You have 42 detection rules currently active.',
+          'rules'
+        );
+
+        visitGetStartedPage();
+        openAssistant();
+        selectConnector(CONNECTOR_NAME);
+
+        // First query about alerts
+        typeAndSendMessage('Show me my alerts');
+        cy.get(CONVERSATION_MESSAGE, { timeout: 30000 })
+          .last()
+          .should('contain', '5 critical alerts');
+
+        // Close and reopen for a fresh conversation
+        closeAssistant();
+
+        // Clear for next test
+        cy.clearLlmProxy();
+        cy.registerLlmResponseWithCondition(
+          'rules-query-2',
+          'You have 42 detection rules currently active.',
+          'rules'
+        );
+
+        openAssistant();
+        selectConnector(CONNECTOR_NAME);
+
+        // Second query about rules
+        typeAndSendMessage('How many rules do I have?');
+        cy.get(CONVERSATION_MESSAGE, { timeout: 30000 })
+          .last()
+          .should('contain', '42 detection rules');
+      });
+    });
+
+    describe('Request Inspection', () => {
+      it('should allow inspection of system prompts and tools sent to the LLM', () => {
+        cy.registerLlmResponse('inspection-test', 'Test response for inspection.');
+
+        visitGetStartedPage();
+        openAssistant();
+        selectConnector(CONNECTOR_NAME);
+
+        typeAndSendMessage('Test message for inspection');
+
+        // Wait for the response
+        cy.get(CONVERSATION_MESSAGE, { timeout: 30000 }).last().should('contain', 'Test response');
+
+        // Inspect the request that was sent
+        cy.getLlmInterceptedRequests().then((requests) => {
+          expect(requests).to.have.length.at.least(1);
+
+          const { requestBody } = requests[requests.length - 1];
+
+          // Log the full request for debugging
+          cy.log('Request body:', JSON.stringify(requestBody, null, 2));
+
+          // Verify messages array exists
+          expect(requestBody.messages).to.be.an('array');
+          expect(requestBody.messages.length).to.be.greaterThan(0);
+
+          // Check for system message (if present)
+          const systemMessage = requestBody.messages.find(
+            (msg: { role: string }) => msg.role === 'system'
+          );
+          if (systemMessage) {
+            cy.log('System prompt found:', systemMessage.content?.substring(0, 200));
+          }
+
+          // Check for tools (if present)
+          if (requestBody.tools) {
+            const toolNames = requestBody.tools.map(
+              (t: { function: { name: string } }) => t.function.name
+            );
+            cy.log('Available tools:', toolNames.join(', '));
+          }
+
+          // Verify the model parameter
+          if (requestBody.model) {
+            cy.log('Model:', requestBody.model);
+          }
+        });
+      });
+    });
+  }
+);

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/support/e2e.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/support/e2e.ts
@@ -6,6 +6,7 @@
  */
 
 import './commands';
+import './llm_proxy_commands';
 import 'cypress-real-events/support';
 import registerCypressGrep from '@cypress/grep';
 import {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/support/index.d.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/support/index.d.ts
@@ -5,6 +5,37 @@
  * 2.0.
  */
 
+/**
+ * Interface for intercepted LLM request data returned by getLlmInterceptedRequests
+ */
+interface LlmInterceptedRequest {
+  requestBody: {
+    messages: Array<{
+      role: string;
+      content: string | null;
+      tool_calls?: Array<{
+        function: {
+          name: string;
+          arguments: string;
+        };
+        id: string;
+        type: string;
+      }>;
+    }>;
+    tools?: Array<{
+      function: {
+        name: string;
+        description: string;
+        parameters: unknown;
+      };
+    }>;
+    tool_choice?: unknown;
+    model?: string;
+    stream?: boolean;
+  };
+  matchingInterceptorName: string | undefined;
+}
+
 declare namespace Cypress {
   interface Chainable<Subject> {
     promisify(): Promise<Subject>;
@@ -28,6 +59,99 @@ declare namespace Cypress {
     getByTestSubjContains(
       ...args: Parameters<Cypress.Chainable['get']>
     ): Chainable<JQuery<HTMLElement>>;
+
+    // ==========================================
+    // LLM Proxy Commands
+    // ==========================================
+
+    /**
+     * Start the LLM proxy server.
+     * Returns the port number the proxy is listening on.
+     *
+     * @example
+     * cy.startLlmProxy().then((port) => {
+     *   cy.createLlmProxyConnector(port);
+     * });
+     */
+    startLlmProxy(): Chainable<number>;
+
+    /**
+     * Stop the LLM proxy server and clean up resources.
+     */
+    stopLlmProxy(): Chainable<null>;
+
+    /**
+     * Clear all interceptors and intercepted requests.
+     * Call this in beforeEach() to reset state between tests.
+     */
+    clearLlmProxy(): Chainable<null>;
+
+    /**
+     * Register an interceptor that will respond with the given mock response.
+     *
+     * @param name - Unique name for this interceptor (for debugging)
+     * @param responseMock - The response to return (string or array of strings for streaming)
+     *
+     * @example
+     * cy.registerLlmResponse('greeting', 'Hello! How can I help you?');
+     */
+    registerLlmResponse(name: string, responseMock: string | string[]): Chainable<null>;
+
+    /**
+     * Register an interceptor with a custom condition based on user message content.
+     *
+     * @param name - Unique name for this interceptor
+     * @param responseMock - The response to return
+     * @param matchUserMessage - Only match if the last user message contains this string
+     *
+     * @example
+     * cy.registerLlmResponseWithCondition('alerts-query', 'Found 5 alerts', 'show me alerts');
+     */
+    registerLlmResponseWithCondition(
+      name: string,
+      responseMock: string | string[],
+      matchUserMessage: string
+    ): Chainable<null>;
+
+    /**
+     * Get all intercepted requests for assertions.
+     * Returns an array of request objects containing the request body and matching interceptor name.
+     *
+     * @example
+     * cy.getLlmInterceptedRequests().then((requests) => {
+     *   expect(requests).to.have.length(1);
+     *   expect(requests[0].requestBody.messages[0].role).to.equal('system');
+     * });
+     */
+    getLlmInterceptedRequests(): Chainable<LlmInterceptedRequest[]>;
+
+    /**
+     * Get the current LLM proxy port, or null if not started.
+     */
+    getLlmProxyPort(): Chainable<number | null>;
+
+    /**
+     * Create a .gen-ai connector that points to the LLM proxy server.
+     *
+     * @param port - The port the LLM proxy is running on
+     * @param name - Optional name for the connector (defaults to 'LLM Proxy Connector')
+     * @returns The connector ID
+     *
+     * @example
+     * cy.startLlmProxy().then((port) => {
+     *   cy.createLlmProxyConnector(port).then((connectorId) => {
+     *     // Use connectorId in your tests
+     *   });
+     * });
+     */
+    createLlmProxyConnector(port: number, name?: string): Chainable<string>;
+
+    /**
+     * Delete a connector by ID.
+     *
+     * @param connectorId - The ID of the connector to delete
+     */
+    deleteLlmProxyConnector(connectorId: string): Chainable<Cypress.Response<unknown>>;
   }
 }
 

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/support/llm_proxy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/support/llm_proxy.ts
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createLlmProxy, type LlmProxy } from '@kbn/llm-proxy-test-helper';
+import type { ToolingLog } from '@kbn/tooling-log';
+
+// Singleton proxy instance - persists across test files
+let proxy: LlmProxy | null = null;
+
+// Clean up proxy on process exit to prevent dangling interceptors
+const cleanup = () => {
+  if (proxy) {
+    try {
+      proxy.clear();
+      proxy.close();
+    } catch {
+      // Ignore errors during cleanup
+    }
+    proxy = null;
+  }
+};
+
+process.on('exit', cleanup);
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+
+/**
+ * Creates a simple log adapter for Cypress that implements the ToolingLog interface
+ * required by the LLM proxy.
+ */
+function createLogAdapter(): ToolingLog {
+  return {
+    // eslint-disable-next-line no-console
+    info: (msg: string) => console.log(`[LLM Proxy INFO] ${msg}`),
+    // eslint-disable-next-line no-console
+    debug: (msg: string) => console.log(`[LLM Proxy DEBUG] ${msg}`),
+    // eslint-disable-next-line no-console
+    warning: (msg: string) => console.warn(`[LLM Proxy WARN] ${msg}`),
+    // eslint-disable-next-line no-console
+    error: (msg: string) => console.error(`[LLM Proxy ERROR] ${msg}`),
+    verbose: () => {},
+    success: () => {},
+    write: () => {},
+    indent: () => createLogAdapter(),
+    getWritten: () => ({ json: false, log: '', error: '' }),
+    getWriters: () => ({ log: process.stdout, error: process.stderr }),
+  } as unknown as ToolingLog;
+}
+
+/**
+ * Cypress plugin that enables LLM proxy functionality via cy.task().
+ *
+ * This allows Cypress tests to:
+ * - Start/stop a local HTTP server that mimics an OpenAI-compatible API
+ * - Register interceptors to return predetermined responses
+ * - Inspect what was sent to the "LLM" for assertions
+ *
+ * @example
+ * // In cypress.config.ts
+ * import { llmProxyPlugin } from './support/llm_proxy';
+ *
+ * export default defineCypressConfig({
+ *   e2e: {
+ *     setupNodeEvents(on, config) {
+ *       llmProxyPlugin(on, config);
+ *     },
+ *   },
+ * });
+ */
+export const llmProxyPlugin = (
+  on: Cypress.PluginEvents,
+  _config: Cypress.PluginConfigOptions
+): void => {
+  on('task', {
+    /**
+     * Start the LLM proxy server.
+     * Returns the port number the proxy is listening on.
+     *
+     * @example
+     * cy.task('startLlmProxy').then((port) => {
+     *   // Create connector pointing to http://localhost:${port}
+     * });
+     */
+    startLlmProxy: async (): Promise<number> => {
+      const log = createLogAdapter();
+
+      // If proxy exists, clean it up first to avoid stale interceptors
+      if (proxy) {
+        log.info('Cleaning up existing proxy before starting new one');
+        try {
+          proxy.clear(); // Clear any pending interceptors
+          proxy.close();
+        } catch (e) {
+          log.warning(`Error cleaning up existing proxy: ${e}`);
+        }
+        proxy = null;
+      }
+
+      proxy = await createLlmProxy(log);
+      log.info(`Started on port ${proxy.getPort()}`);
+      return proxy.getPort();
+    },
+
+    /**
+     * Stop the LLM proxy server and clean up.
+     */
+    stopLlmProxy: (): null => {
+      if (proxy) {
+        proxy.close();
+        proxy = null;
+      }
+      return null;
+    },
+
+    /**
+     * Register an interceptor that will respond with the given mock response.
+     * Uses fire-and-forget pattern - doesn't wait for the intercept to complete.
+     *
+     * @param options.name - Unique name for this interceptor (for debugging)
+     * @param options.responseMock - The response to return (string or array of strings for streaming)
+     *
+     * @example
+     * cy.task('registerLlmInterceptor', {
+     *   name: 'test-response',
+     *   responseMock: 'This is a mocked LLM response',
+     * });
+     */
+    registerLlmInterceptor: ({
+      name,
+      responseMock,
+    }: {
+      name: string;
+      responseMock: string | string[];
+    }): null => {
+      if (!proxy) {
+        throw new Error('LLM Proxy not started. Call cy.task("startLlmProxy") first.');
+      }
+
+      // Use completeAfterIntercept but don't await it - the response will be sent
+      // when a matching request comes in. We catch any errors to prevent crashes
+      // if the test ends before the interceptor is triggered.
+      proxy
+        .intercept({
+          name,
+          when: () => true, // Match all requests
+          responseMock,
+        })
+        .completeAfterIntercept()
+        .catch(() => {
+          // Silently ignore timeout errors - this happens when test ends
+          // before the interceptor is triggered, which is fine
+        });
+
+      return null;
+    },
+
+    /**
+     * Register an interceptor with a custom condition.
+     * Uses fire-and-forget pattern - doesn't wait for the intercept to complete.
+     *
+     * @param options.name - Unique name for this interceptor
+     * @param options.responseMock - The response to return
+     * @param options.matchUserMessage - If provided, only match requests where the last user message contains this string
+     */
+    registerLlmInterceptorWithCondition: ({
+      name,
+      responseMock,
+      matchUserMessage,
+    }: {
+      name: string;
+      responseMock: string | string[];
+      matchUserMessage?: string;
+    }): null => {
+      if (!proxy) {
+        throw new Error('LLM Proxy not started. Call cy.task("startLlmProxy") first.');
+      }
+
+      // Use completeAfterIntercept but don't await it - the response will be sent
+      // when a matching request comes in. We catch any errors to prevent crashes
+      // if the test ends before the interceptor is triggered.
+      proxy
+        .intercept({
+          name,
+          when: (body) => {
+            if (!matchUserMessage) return true;
+
+            const lastMessage = body.messages[body.messages.length - 1];
+            return (
+              lastMessage?.role === 'user' &&
+              (lastMessage?.content as string)?.includes(matchUserMessage)
+            );
+          },
+          responseMock,
+        })
+        .completeAfterIntercept()
+        .catch(() => {
+          // Silently ignore timeout errors - this happens when test ends
+          // before the interceptor is triggered, which is fine
+        });
+
+      return null;
+    },
+
+    /**
+     * Get all intercepted requests for assertions.
+     * Returns an array of request bodies that were sent to the proxy.
+     *
+     * @example
+     * cy.task('getLlmInterceptedRequests').then((requests) => {
+     *   expect(requests).to.have.length(1);
+     *   expect(requests[0].requestBody.messages[0].role).to.equal('system');
+     * });
+     */
+    getLlmInterceptedRequests: (): Array<{
+      requestBody: unknown;
+      matchingInterceptorName: string | undefined;
+    }> => {
+      if (!proxy) {
+        return [];
+      }
+      // Return a serializable copy of the intercepted requests
+      return proxy.interceptedRequests.map((req) => ({
+        requestBody: JSON.parse(JSON.stringify(req.requestBody)),
+        matchingInterceptorName: req.matchingInterceptorName,
+      }));
+    },
+
+    /**
+     * Clear all interceptors and intercepted requests.
+     * Call this in beforeEach() to reset state between tests.
+     */
+    clearLlmProxy: (): null => {
+      if (proxy) {
+        proxy.clear();
+      }
+      return null;
+    },
+
+    /**
+     * Get the current proxy port, or null if not started.
+     */
+    getLlmProxyPort: (): number | null => {
+      return proxy?.getPort() ?? null;
+    },
+  });
+};

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/support/llm_proxy_commands.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/support/llm_proxy_commands.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rootRequest } from '../tasks/api_calls/common';
+
+/**
+ * Custom Cypress commands for LLM proxy functionality.
+ *
+ * These commands provide a cleaner API for interacting with the LLM proxy
+ * in Cypress tests, wrapping the underlying cy.task() calls.
+ *
+ * @example
+ * // In your test
+ * describe('AI Assistant', () => {
+ *   let connectorId: string;
+ *
+ *   before(() => {
+ *     cy.startLlmProxy().then((port) => {
+ *       cy.createLlmProxyConnector(port).then((id) => {
+ *         connectorId = id;
+ *       });
+ *     });
+ *   });
+ *
+ *   after(() => {
+ *     cy.deleteLlmProxyConnector(connectorId);
+ *     cy.stopLlmProxy();
+ *   });
+ *
+ *   beforeEach(() => {
+ *     cy.clearLlmProxy();
+ *   });
+ *
+ *   it('should respond to user message', () => {
+ *     cy.registerLlmResponse('test', 'Hello from the AI!');
+ *     // ... interact with AI feature ...
+ *     cy.getLlmInterceptedRequests().then((requests) => {
+ *       expect(requests).to.have.length(1);
+ *     });
+ *   });
+ * });
+ */
+
+/**
+ * Start the LLM proxy server.
+ * Returns the port number the proxy is listening on.
+ */
+Cypress.Commands.add('startLlmProxy', () => {
+  return cy.task('startLlmProxy');
+});
+
+/**
+ * Stop the LLM proxy server and clean up resources.
+ */
+Cypress.Commands.add('stopLlmProxy', () => {
+  return cy.task('stopLlmProxy');
+});
+
+/**
+ * Clear all interceptors and intercepted requests.
+ * Call this in beforeEach() to reset state between tests.
+ */
+Cypress.Commands.add('clearLlmProxy', () => {
+  return cy.task('clearLlmProxy');
+});
+
+/**
+ * Register an interceptor that will respond with the given mock response.
+ *
+ * @param name - Unique name for this interceptor (for debugging)
+ * @param responseMock - The response to return (string or array of strings)
+ */
+Cypress.Commands.add('registerLlmResponse', (name: string, responseMock: string | string[]) => {
+  return cy.task('registerLlmInterceptor', { name, responseMock });
+});
+
+/**
+ * Register an interceptor with a custom condition based on user message content.
+ *
+ * @param name - Unique name for this interceptor
+ * @param responseMock - The response to return
+ * @param matchUserMessage - Only match if the last user message contains this string
+ */
+Cypress.Commands.add(
+  'registerLlmResponseWithCondition',
+  (name: string, responseMock: string | string[], matchUserMessage: string) => {
+    return cy.task('registerLlmInterceptorWithCondition', { name, responseMock, matchUserMessage });
+  }
+);
+
+/**
+ * Get all intercepted requests for assertions.
+ * Returns an array of request objects containing the request body and matching interceptor name.
+ */
+Cypress.Commands.add('getLlmInterceptedRequests', () => {
+  return cy.task('getLlmInterceptedRequests');
+});
+
+/**
+ * Get the current LLM proxy port, or null if not started.
+ */
+Cypress.Commands.add('getLlmProxyPort', () => {
+  return cy.task('getLlmProxyPort');
+});
+
+/**
+ * Create a .gen-ai connector that points to the LLM proxy server.
+ *
+ * @param port - The port the LLM proxy is running on
+ * @param name - Optional name for the connector
+ * @returns The connector ID
+ */
+Cypress.Commands.add(
+  'createLlmProxyConnector',
+  (port: number, name: string = 'LLM Proxy Connector') => {
+    return rootRequest<{ id: string }>({
+      method: 'POST',
+      url: '/api/actions/connector',
+      body: {
+        name,
+        connector_type_id: '.gen-ai',
+        config: {
+          apiProvider: 'OpenAI',
+          apiUrl: `http://localhost:${port}`,
+        },
+        secrets: {
+          apiKey: 'fake-api-key-for-testing',
+        },
+      },
+    }).then((response) => response.body.id);
+  }
+);
+
+/**
+ * Delete a connector by ID.
+ *
+ * @param connectorId - The ID of the connector to delete
+ */
+Cypress.Commands.add('deleteLlmProxyConnector', (connectorId: string) => {
+  return rootRequest({
+    method: 'DELETE',
+    url: `/api/actions/connector/${connectorId}`,
+    failOnStatusCode: false, // Don't fail if connector already deleted
+  });
+});

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tsconfig.json
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tsconfig.json
@@ -39,6 +39,7 @@
     "@kbn/cloud-security-posture-common",
     "@kbn/security-plugin-types-common",
     "@kbn/securitysolution-utils",
-    "@kbn/maintenance-windows-plugin"
+    "@kbn/maintenance-windows-plugin",
+    "@kbn/llm-proxy-test-helper"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,7 +2687,7 @@
   resolved "https://registry.yarnpkg.com/@elastic/filesaver/-/filesaver-1.1.2.tgz#1998ffb3cd89c9da4ec12a7793bfcae10e30c77a"
   integrity sha512-YZbSufYFBhAj+S2cJgiKALoxIJevqXN2MSr6Yqr42rJdaPuM31cj6pUDwflkql1oDjupqD9la+MfxPFjXI1JFQ==
 
-"@elastic/kibana-d3-color@npm:@elastic/kibana-d3-color@2.0.1", "d3-color@1 - 2", "d3-color@npm:@elastic/kibana-d3-color@2.0.1":
+"@elastic/kibana-d3-color@npm:@elastic/kibana-d3-color@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@elastic/kibana-d3-color/-/kibana-d3-color-2.0.1.tgz#f83b9c2fea09273a918659de04d5e8098c82f65c"
   integrity sha512-YZ8hV2bWNyYi833Yj3UWczmTxdHzmo/Xc2IVkNXr/ZqtkrTDlTLysCyJm7SfAt9iBy6EVRGWTn8cPz8QOY6Ixw==
@@ -7247,6 +7247,10 @@
   uid ""
 
 "@kbn/lists-plugin@link:x-pack/solutions/security/plugins/lists":
+  version "0.0.0"
+  uid ""
+
+"@kbn/llm-proxy-test-helper@link:src/platform/packages/shared/kbn-llm-proxy-test-helper":
   version "0.0.0"
   uid ""
 
@@ -18688,6 +18692,11 @@ d3-collection@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
+
+"d3-color@1 - 2", "d3-color@npm:@elastic/kibana-d3-color@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@elastic/kibana-d3-color/-/kibana-d3-color-2.0.1.tgz#f83b9c2fea09273a918659de04d5e8098c82f65c"
+  integrity sha512-YZ8hV2bWNyYi833Yj3UWczmTxdHzmo/Xc2IVkNXr/ZqtkrTDlTLysCyJm7SfAt9iBy6EVRGWTn8cPz8QOY6Ixw==
 
 "d3-color@1 - 3", d3-color@^3.1.0:
   version "3.1.0"
@@ -32027,7 +32036,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -32044,6 +32053,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -32137,7 +32155,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -32150,6 +32168,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -34962,7 +34987,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -34983,6 +35008,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -35118,7 +35152,7 @@ xpath@^0.0.33:
   resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.33.tgz#5136b6094227c5df92002e7c3a13516a5074eb07"
   integrity sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==
 
-"xstate5@npm:xstate@^5.19.2", xstate@^5.19.2:
+"xstate5@npm:xstate@^5.19.2":
   version "5.19.2"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.19.2.tgz#db3f1ee614bbb6a49ad3f0c96ddbf98562d456ba"
   integrity sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==
@@ -35127,6 +35161,11 @@ xstate@^4.38.3:
   version "4.38.3"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.38.3.tgz#4e15e7ad3aa0ca1eea2010548a5379966d8f1075"
   integrity sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==
+
+xstate@^5.19.2:
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.19.2.tgz#db3f1ee614bbb6a49ad3f0c96ddbf98562d456ba"
+  integrity sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
- Introduced a new package `@kbn/llm-proxy-test-helper` to facilitate testing of AI features in the Security Solution.
- Implemented a local HTTP server that mimics an OpenAI-compatible API, allowing for the creation of connectors and interception of LLM requests.
- Added various utilities for managing LLM proxies, including request interceptors and response mocking.
- Updated relevant configuration files and test suites to integrate the new package.
- Included Cypress commands for easier interaction with the LLM proxy in end-to-end tests.

This enhancement aims to streamline the testing process for AI functionalities without requiring a real AI connector, improving the overall development workflow.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



