### PR TITLE
[9.2] skip endpoint_alerts.cy.ts test manually

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/endpoint_alerts.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/endpoint_alerts.cy.ts
@@ -16,7 +16,8 @@ import type { PolicyData } from '../../../../common/endpoint/types';
 import type { CreateAndEnrollEndpointHostResponse } from '../../../../scripts/endpoint/common/endpoint_host_services';
 import { login, ROLE } from '../tasks/login';
 
-describe('Endpoint generated alerts', { tags: ['@ess', '@serverless'] }, () => {
+// Failing: See https://github.com/elastic/kibana/issues/207529
+describe.skip('Endpoint generated alerts', { tags: ['@ess', '@serverless'] }, () => {
   let indexedPolicy: IndexedFleetEndpointPolicyResponse;
   let policy: PolicyData;
   let createdHost: CreateAndEnrollEndpointHostResponse;


### PR DESCRIPTION
## Summary
Manually skipping the test, it's failing @9.2 - https://github.com/elastic/kibana/issues/207529