### PR TITLE
[9.2] [Observability:Streams] Manual ingest pipeline script validation (#245439)

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/validate_fields.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/validate_fields.ts
@@ -5,10 +5,14 @@
  * 2.0.
  */
 
+import type { IngestSimulateRequest } from '@elastic/elasticsearch/lib/api/types';
+import { transpileIngestPipeline } from '@kbn/streamlang';
 import type { FieldDefinition, Streams } from '@kbn/streams-schema';
 import { isRoot, keepFields, namespacePrefixes } from '@kbn/streams-schema';
-import { MalformedFieldsError } from '../errors/malformed_fields_error';
+import type { IScopedClusterClient } from '@kbn/core/server';
+import { executePipelineSimulation } from '../../../routes/internal/streams/processing/simulation_handler';
 import { baseMappings } from '../component_templates/logs_layer';
+import { MalformedFieldsError } from '../errors/malformed_fields_error';
 
 export function validateAncestorFields({
   ancestors,
@@ -83,6 +87,30 @@ export function validateClassicFields(definition: Streams.ClassicStream.Definiti
     throw new MalformedFieldsError(
       `Stream ${definition.name} is not allowed to have system fields`
     );
+  }
+}
+
+export async function validateSimulation(
+  definition: Streams.ClassicStream.Definition | Streams.WiredStream.Definition,
+  scopedClusterClient: IScopedClusterClient
+) {
+  if (definition.ingest.processing.steps.length === 0) {
+    return;
+  }
+
+  const simulationBody: IngestSimulateRequest = {
+    docs: [
+      {
+        _source: {},
+      },
+    ],
+    pipeline: {
+      processors: transpileIngestPipeline(definition.ingest.processing).processors,
+    },
+  };
+  const simulationResult = await executePipelineSimulation(scopedClusterClient, simulationBody);
+  if (simulationResult.status === 'failure') {
+    throw new MalformedFieldsError(simulationResult.error.message);
   }
 }
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/classic_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/classic_stream.ts
@@ -10,10 +10,7 @@ import type {
   IngestProcessorContainer,
 } from '@elastic/elasticsearch/lib/api/types';
 import { isNotFoundError } from '@kbn/es-errors';
-import type {
-  IngestStreamLifecycle,
-  IngestStreamSettings
-} from '@kbn/streams-schema';
+import type { IngestStreamLifecycle, IngestStreamSettings } from '@kbn/streams-schema';
 import { isIlmLifecycle, isInheritLifecycle, Streams } from '@kbn/streams-schema';
 import { isMappingProperties } from '@kbn/streams-schema/src/fields';
 import _, { cloneDeep } from 'lodash';

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
@@ -33,6 +33,7 @@ import { StatusError } from '../../errors/status_error';
 import {
   validateAncestorFields,
   validateDescendantFields,
+  validateSimulation,
   validateSystemFields,
 } from '../../helpers/validate_fields';
 import {
@@ -439,6 +440,8 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
     }
 
     validateSettings(this._definition, this.dependencies.isServerless);
+
+    await validateSimulation(this._definition, this.dependencies.scopedClusterClient);
 
     return { isValid: true, errors: [] };
   }

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -187,18 +187,18 @@ export class StreamsPlugin
             coreStart.uiSettings.asScopedToClient(coreStart.savedObjects.getScopedClient(request)),
           ]);
 
+          const scopedClusterClient = coreStart.elasticsearch.client.asScoped(request);
+          const soClient = coreStart.savedObjects.getScopedClient(request);
+          const inferenceClient = pluginsStart.inference.getClient({ request });
+          const licensing = pluginsStart.licensing;
+          const fieldsMetadataClient = await pluginsStart.fieldsMetadata.getClient(request);
+
           const streamsClient = await streamsService.getClientWithRequest({
             request,
             assetClient,
             queryClient,
             featureClient,
           });
-
-          const scopedClusterClient = coreStart.elasticsearch.client.asScoped(request);
-          const soClient = coreStart.savedObjects.getScopedClient(request);
-          const inferenceClient = pluginsStart.inference.getClient({ request });
-          const licensing = pluginsStart.licensing;
-          const fieldsMetadataClient = await pluginsStart.fieldsMetadata.getClient(request);
 
           return {
             scopedClusterClient,

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
@@ -399,7 +399,7 @@ const prepareIngestSimulationBody = (
  * If the simulation fails, we won't be able to extract the documents reports and the processor metrics.
  * In case any other error occurs, we delegate the error handling to currently in draft processor.
  */
-const executePipelineSimulation = async (
+export const executePipelineSimulation = async (
   scopedClusterClient: IScopedClusterClient,
   simulationBody: IngestSimulateRequest
 ): Promise<PipelineSimulationResult> => {
@@ -414,12 +414,12 @@ const executePipelineSimulation = async (
     };
   } catch (error) {
     if (error instanceof esErrors.ResponseError) {
-      const { processor_tag, reason } = error.body?.error;
+      const { processor_tag } = error.body?.error;
 
       return {
         status: 'failure',
         error: {
-          message: reason,
+          message: error.message,
           processor_id: processor_tag,
           type: 'generic_simulation_failure',
         },

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/classic.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/classic.ts
@@ -269,12 +269,51 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           apiClient,
           'logs-invalid_pipeline-default',
           body,
-          500
+          400
         );
-
-        expect((streamsResponse as any).message).to.contain('Failed to change state:');
         expect((streamsResponse as any).message).to.contain(
-          `The stream state may be inconsistent. Revert your last change, or use the resync API to restore a consistent state.`
+          'Desired stream state is invalid: parse_exception'
+        );
+        expect((streamsResponse as any).message).to.contain(
+          "processor [set] doesn't support one or more provided configuration parameters [fail]"
+        );
+      });
+
+      it('fails to store invalid ingest pipeline script', async () => {
+        const body: Streams.ClassicStream.UpsertRequest = {
+          ...emptyAssets,
+          stream: {
+            description: '',
+            ingest: {
+              lifecycle: { inherit: {} },
+              settings: {},
+              processing: {
+                steps: [
+                  {
+                    action: 'manual_ingest_pipeline',
+                    processors: [
+                      {
+                        script: {
+                          source: 'ctx.age = ', // invalid painless script
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              classic: {
+                field_overrides: {},
+              },
+              failure_store: { inherit: {} },
+            },
+          },
+        };
+        const streamsResponse = await putStream(apiClient, TEST_STREAM_NAME, body, 400);
+        expect((streamsResponse as any).message).to.contain(
+          'Desired stream state is invalid: script_exception'
+        );
+        expect((streamsResponse as any).message).to.contain(
+          'illegal_argument_exception: unexpected end of script'
         );
       });
     });

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/processing_simulate.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/processing_simulate.ts
@@ -417,7 +417,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             processor_id: 'draft',
             type: 'generic_simulation_failure',
             message:
-              "[patterns] Invalid regex pattern found in: [%{INVALID_PATTERN:field}]. Unable to find pattern [INVALID_PATTERN] in Grok's pattern dictionary",
+              "parse_exception\n\tRoot causes:\n\t\tparse_exception: [patterns] Invalid regex pattern found in: [%{INVALID_PATTERN:field}]. Unable to find pattern [INVALID_PATTERN] in Grok's pattern dictionary",
           },
         ]);
       });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Observability:Streams] Manual ingest pipeline script validation (#245439)](https://github.com/elastic/kibana/pull/245439)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Quentin Couvelaire","email":"98294366+couvq@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-15T13:34:15Z","message":"[Observability:Streams] Manual ingest pipeline script validation (#245439)\n\nCloses https://github.com/elastic/observability-error-backlog/issues/314\nCloses https://github.com/elastic/observability-error-backlog/issues/315\nCloses https://github.com/elastic/observability-error-backlog/issues/317\nCloses https://github.com/elastic/observability-error-backlog/issues/320\n\n## Description\n* There are several Kibana error logs that are caused by script\nvalidation errors when making a direct call to the backend, we have been\nrelying on elasticsearch to validate these up until this point, which\nleads to an error on the Kibana side. This PR adds a validation layer to\nour API and uses the simulation api to catch these validation errors\nbefore hitting elasticsearch. It also makes a change to our simulation\nhandler to return a full error message so the UI includes a reason for\nfailure to be more descriptive.\n\n## Screen recordings showing new behavior\n### UI\n\nhttps://github.com/user-attachments/assets/ebe82ab4-ac0c-465e-a8fa-cd6f96374f3e\n\n### API\n\nhttps://github.com/user-attachments/assets/46520026-dc55-49fc-9d23-902b461942ae\n\n---------\n\nCo-authored-by: Joe Reuter <johannes.reuter@elastic.co>","sha":"d9a067544b781debea829259e41b80d58ebf9f3b","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:obs-onboarding","backport:version","Feature:Streams","v9.3.0","v9.2.4"],"title":"[Observability:Streams] Manual ingest pipeline script validation","number":245439,"url":"https://github.com/elastic/kibana/pull/245439","mergeCommit":{"message":"[Observability:Streams] Manual ingest pipeline script validation (#245439)\n\nCloses https://github.com/elastic/observability-error-backlog/issues/314\nCloses https://github.com/elastic/observability-error-backlog/issues/315\nCloses https://github.com/elastic/observability-error-backlog/issues/317\nCloses https://github.com/elastic/observability-error-backlog/issues/320\n\n## Description\n* There are several Kibana error logs that are caused by script\nvalidation errors when making a direct call to the backend, we have been\nrelying on elasticsearch to validate these up until this point, which\nleads to an error on the Kibana side. This PR adds a validation layer to\nour API and uses the simulation api to catch these validation errors\nbefore hitting elasticsearch. It also makes a change to our simulation\nhandler to return a full error message so the UI includes a reason for\nfailure to be more descriptive.\n\n## Screen recordings showing new behavior\n### UI\n\nhttps://github.com/user-attachments/assets/ebe82ab4-ac0c-465e-a8fa-cd6f96374f3e\n\n### API\n\nhttps://github.com/user-attachments/assets/46520026-dc55-49fc-9d23-902b461942ae\n\n---------\n\nCo-authored-by: Joe Reuter <johannes.reuter@elastic.co>","sha":"d9a067544b781debea829259e41b80d58ebf9f3b"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245439","number":245439,"mergeCommit":{"message":"[Observability:Streams] Manual ingest pipeline script validation (#245439)\n\nCloses https://github.com/elastic/observability-error-backlog/issues/314\nCloses https://github.com/elastic/observability-error-backlog/issues/315\nCloses https://github.com/elastic/observability-error-backlog/issues/317\nCloses https://github.com/elastic/observability-error-backlog/issues/320\n\n## Description\n* There are several Kibana error logs that are caused by script\nvalidation errors when making a direct call to the backend, we have been\nrelying on elasticsearch to validate these up until this point, which\nleads to an error on the Kibana side. This PR adds a validation layer to\nour API and uses the simulation api to catch these validation errors\nbefore hitting elasticsearch. It also makes a change to our simulation\nhandler to return a full error message so the UI includes a reason for\nfailure to be more descriptive.\n\n## Screen recordings showing new behavior\n### UI\n\nhttps://github.com/user-attachments/assets/ebe82ab4-ac0c-465e-a8fa-cd6f96374f3e\n\n### API\n\nhttps://github.com/user-attachments/assets/46520026-dc55-49fc-9d23-902b461942ae\n\n---------\n\nCo-authored-by: Joe Reuter <johannes.reuter@elastic.co>","sha":"d9a067544b781debea829259e41b80d58ebf9f3b"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->