### PR TITLE
[9.1] [OAS] Validate last, then commit changes (#243779)

### DIFF
--- a/.buildkite/scripts/steps/checks/capture_oas_snapshot.sh
+++ b/.buildkite/scripts/steps/checks/capture_oas_snapshot.sh
@@ -34,8 +34,10 @@ run_check() {
 }
 
 retry 5 15 run_check
-
-check_for_changed_files "$cmd" true
-
+# Bundle hand written specs
 .buildkite/scripts/steps/openapi_bundling/security_solution_openapi_bundling.sh
 .buildkite/scripts/steps/openapi_bundling/final_merge.sh
+
+node ./scripts/validate_oas_docs.js --assert-no-error-increase --skip-printing-issues --update-baseline
+
+check_for_changed_files "capture_oas_snapshot.sh" true


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[OAS] Validate last, then commit changes (#243779)](https://github.com/elastic/kibana/pull/243779)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jean-Louis Leysens","email":"jeanlouis.leysens@elastic.co"},"sourceCommit":{"committedDate":"2025-12-12T09:25:17Z","message":"[OAS] Validate last, then commit changes (#243779)\n\n## Summary\n\nWith the current ordering PR authors can get blocked behind OAS error\nincreases bc the capture CI step does not update our YAML spec before\nrunning validations against them (effectively forcing authors to run\n`node ./scripts/capture_oas...` etc locally).\n\nThe fix here is:\n\n-> Capture spec from code\n-> Capture spec from hand-written\n-> Bundle all spec into final YAML\n-> Validate spec in final YAML: if errors have not increased, commit the\nresult, if errors have increased block the PR\n\nInstead of:\n\n-> Capture spec from code\n-> Capture spec from hand-written\n-> Validate spec in final YAML: if errors have not increased, commit the\nresult, if errors have increased block the PR\n-> Bundle all spec into final YAML\n\n\nThis enables PR authors to address issues, push the result and have the\nvalidation pass on subsequent CI runs.","sha":"ce1aad4b0a12b9ef1e2f20fc95bade8c2e3bb2f7","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport missing","backport:all-open","v9.3.0"],"title":"[OAS] Validate last, then commit changes","number":243779,"url":"https://github.com/elastic/kibana/pull/243779","mergeCommit":{"message":"[OAS] Validate last, then commit changes (#243779)\n\n## Summary\n\nWith the current ordering PR authors can get blocked behind OAS error\nincreases bc the capture CI step does not update our YAML spec before\nrunning validations against them (effectively forcing authors to run\n`node ./scripts/capture_oas...` etc locally).\n\nThe fix here is:\n\n-> Capture spec from code\n-> Capture spec from hand-written\n-> Bundle all spec into final YAML\n-> Validate spec in final YAML: if errors have not increased, commit the\nresult, if errors have increased block the PR\n\nInstead of:\n\n-> Capture spec from code\n-> Capture spec from hand-written\n-> Validate spec in final YAML: if errors have not increased, commit the\nresult, if errors have increased block the PR\n-> Bundle all spec into final YAML\n\n\nThis enables PR authors to address issues, push the result and have the\nvalidation pass on subsequent CI runs.","sha":"ce1aad4b0a12b9ef1e2f20fc95bade8c2e3bb2f7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243779","number":243779,"mergeCommit":{"message":"[OAS] Validate last, then commit changes (#243779)\n\n## Summary\n\nWith the current ordering PR authors can get blocked behind OAS error\nincreases bc the capture CI step does not update our YAML spec before\nrunning validations against them (effectively forcing authors to run\n`node ./scripts/capture_oas...` etc locally).\n\nThe fix here is:\n\n-> Capture spec from code\n-> Capture spec from hand-written\n-> Bundle all spec into final YAML\n-> Validate spec in final YAML: if errors have not increased, commit the\nresult, if errors have increased block the PR\n\nInstead of:\n\n-> Capture spec from code\n-> Capture spec from hand-written\n-> Validate spec in final YAML: if errors have not increased, commit the\nresult, if errors have increased block the PR\n-> Bundle all spec into final YAML\n\n\nThis enables PR authors to address issues, push the result and have the\nvalidation pass on subsequent CI runs.","sha":"ce1aad4b0a12b9ef1e2f20fc95bade8c2e3bb2f7"}}]}] BACKPORT-->