### PR TITLE
[Security Solution][Endpoint] Add server configuration setting for disabling the auto install of endpoint rule on policy create

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/config.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/config.mock.ts
@@ -32,6 +32,7 @@ export const createMockConfig = (): ConfigType => {
     alertIgnoreFields: [],
     maxUploadResponseActionFileBytes: 26214400,
     maxEndpointScriptFileSize: 26214400,
+    disableEndpointRuleAutoInstall: false,
     settings: getDefaultConfigSettings(),
     experimentalFeatures: parseExperimentalConfigValue(enableExperimental).features,
     enabled: true,

--- a/x-pack/solutions/security/plugins/security_solution/server/config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/config.ts
@@ -164,6 +164,14 @@ export const configSchema = schema.object({
   }),
 
   /**
+   * Disables the auto-install/enable of the Elastic Defend SIEM rule.
+   * Whenever a Policy is created via Fleet's API, we check if the corresponding Elastic Defend SIEM
+   * rule is installed/enabled in the active space, and if not, we auto-install it. Set this configuration
+   * setting to `false` to disable that behavior
+   */
+  disableEndpointRuleAutoInstall: schema.boolean({ defaultValue: false }),
+
+  /**
    * Defines the settings for a specific offering of the Security Solution app.
    * They override the default values.
    * @example

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -479,7 +479,7 @@ export class EndpointAppContextService {
       throw new EndpointAppContentServicesNotStartedError();
     }
 
-    if (!this.startDependencies.config[key]) {
+    if (!Object.prototype.hasOwnProperty.call(this.startDependencies.config, key)) {
       throw new EndpointError(`Missing config value for key: ${key}`);
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
@@ -32,7 +32,7 @@ import {
   getPackagePolicyPostCreateCallback,
   getPackagePolicyUpdateCallback,
 } from './fleet_integration';
-import type { KibanaRequest, Logger } from '@kbn/core/server';
+import type { KibanaRequest, Logger, RequestHandlerContext } from '@kbn/core/server';
 import {
   ALL_PRODUCT_FEATURE_KEYS,
   ProductFeatureSecurityKey,
@@ -90,6 +90,26 @@ import { RESPONSE_ACTIONS_SUPPORTED_INTEGRATION_TYPES } from '../../common/endpo
 import { pick } from 'lodash';
 import { ENDPOINT_ACTIONS_INDEX } from '../../common/endpoint/constants';
 import type { ExperimentalFeatures } from '../../common';
+import type { IRequestContextFactory } from '../request_context_factory';
+import { installEndpointSecurityPrebuiltRule as _installEndpointSecurityPrebuiltRule } from '../lib/detection_engine/prebuilt_rules/logic/integrations/install_endpoint_security_prebuilt_rule';
+
+const installEndpointSecurityPrebuiltRuleMock = _installEndpointSecurityPrebuiltRule as jest.Mock;
+
+jest.mock(
+  '../lib/detection_engine/prebuilt_rules/logic/integrations/install_endpoint_security_prebuilt_rule',
+  () => {
+    const actualModule = jest.requireActual(
+      '../lib/detection_engine/prebuilt_rules/logic/integrations/install_endpoint_security_prebuilt_rule'
+    );
+
+    return {
+      ...actualModule,
+      installEndpointSecurityPrebuiltRule: jest.fn(
+        actualModule.installEndpointSecurityPrebuiltRule
+      ),
+    };
+  }
+);
 
 jest.mock('uuid', () => ({
   v4: (): string => 'NEW_UUID',
@@ -159,47 +179,17 @@ describe('Fleet integrations', () => {
     jest.clearAllMocks();
   });
 
-  describe('package policy init callback (atifacts manifest initialisation tests)', () => {
-    const soClient = savedObjectsClientMock.create();
-    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
-
-    const createNewEndpointPolicyInput = (
-      manifest: ManifestSchema,
-      license = 'platinum',
-      cloud = cloudService.isCloudEnabled,
-      licenseUuid = 'updated-uid',
-      clusterUuid = '',
-      clusterName = '',
-      isServerlessEnabled = cloudService.isServerlessEnabled,
-      isTelemetryEnabled = true
-    ) => ({
-      type: 'endpoint',
-      enabled: true,
-      streams: [],
-      config: {
-        integration_config: {},
-        policy: {
-          value: disableProtections(
-            policyFactory({
-              license,
-              cloud,
-              licenseUuid,
-              clusterUuid,
-              clusterName,
-              serverless: isServerlessEnabled,
-              isGlobalTelemetryEnabled: isTelemetryEnabled,
-            })
-          ),
-        },
-        artifact_manifest: { value: manifest },
-      },
-    });
+  describe('package policy create callback', () => {
+    let soClient: ReturnType<typeof savedObjectsClientMock.create>;
+    let esClient: ReturnType<typeof elasticsearchServiceMock.createClusterClient>['asInternalUser'];
+    let securitySolutionRequestContextFactory: jest.Mocked<IRequestContextFactory>;
+    let endpointServicesMock: ReturnType<typeof createMockEndpointAppContextService>;
 
     const invokeCallback = async (manifestManager: ManifestManager): Promise<NewPackagePolicy> => {
       const callback = getPackagePolicyCreateCallback(
         logger,
         manifestManager,
-        requestContextFactoryMock.create(),
+        securitySolutionRequestContextFactory,
         endpointAppContextStartContract.alerting,
         licenseService,
         cloudService,
@@ -217,192 +207,254 @@ describe('Fleet integrations', () => {
       );
     };
 
-    const TEST_POLICY_ID_1 = 'c6d16e42-c32d-4dce-8a88-113cfe276ad1';
-    const TEST_POLICY_ID_2 = '93c46720-c217-11ea-9906-b5b8a21b268e';
-    const ARTIFACT_NAME_EXCEPTIONS_MACOS = 'endpoint-exceptionlist-macos-v1';
-    const ARTIFACT_NAME_TRUSTED_APPS_MACOS = 'endpoint-trustlist-macos-v1';
-    const ARTIFACT_NAME_TRUSTED_APPS_WINDOWS = 'endpoint-trustlist-windows-v1';
-    let ARTIFACT_EXCEPTIONS_MACOS: InternalArtifactCompleteSchema;
-    let ARTIFACT_EXCEPTIONS_WINDOWS: InternalArtifactCompleteSchema;
-    let ARTIFACT_TRUSTED_APPS_MACOS: InternalArtifactCompleteSchema;
-    let ARTIFACT_TRUSTED_APPS_WINDOWS: InternalArtifactCompleteSchema;
-
-    beforeAll(async () => {
-      const artifacts = await getMockArtifacts();
-      ARTIFACT_EXCEPTIONS_MACOS = artifacts[0];
-      ARTIFACT_EXCEPTIONS_WINDOWS = artifacts[1];
-      ARTIFACT_TRUSTED_APPS_MACOS = artifacts[3];
-      ARTIFACT_TRUSTED_APPS_WINDOWS = artifacts[4];
+    beforeEach(async () => {
+      soClient = savedObjectsClientMock.create();
+      esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      endpointServicesMock = createMockEndpointAppContextService();
+      securitySolutionRequestContextFactory = requestContextFactoryMock.create();
+      const reqContextMock = await securitySolutionRequestContextFactory.create(
+        ctx as unknown as RequestHandlerContext,
+        req
+      );
+      (reqContextMock.getEndpointService as jest.Mock).mockReturnValue(endpointServicesMock);
+      securitySolutionRequestContextFactory.create.mockReturnValue(Promise.resolve(reqContextMock));
     });
 
-    beforeEach(() => {
-      licenseEmitter.next(Platinum); // set license level to platinum
+    describe('SIEM rule install', () => {
+      it('should call utility to install SIEM prebuilt rule', async () => {
+        await invokeCallback(buildManifestManagerMock());
+
+        expect(installEndpointSecurityPrebuiltRuleMock).toHaveBeenCalled();
+      });
+
+      it('should not call utility to install SIEM prebuilt rule when server config setting is enabled', async () => {
+        (endpointServicesMock.getServerConfigValue as jest.Mock).mockReturnValue(true);
+        await invokeCallback(buildManifestManagerMock());
+
+        expect(installEndpointSecurityPrebuiltRuleMock).not.toHaveBeenCalled();
+      });
     });
 
-    test('default manifest is taken when there is none and there are errors building new one', async () => {
-      const manifestManager = buildManifestManagerMock();
-      manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
-      manifestManager.buildNewManifest = jest.fn().mockRejectedValue(new Error());
+    describe('Artifacts manifest initialisation', () => {
+      const createNewEndpointPolicyInput = (
+        manifest: ManifestSchema,
+        license = 'platinum',
+        cloud = cloudService.isCloudEnabled,
+        licenseUuid = 'updated-uid',
+        clusterUuid = '',
+        clusterName = '',
+        isServerlessEnabled = cloudService.isServerlessEnabled,
+        isTelemetryEnabled = true
+      ) => ({
+        type: 'endpoint',
+        enabled: true,
+        streams: [],
+        config: {
+          integration_config: {},
+          policy: {
+            value: disableProtections(
+              policyFactory({
+                license,
+                cloud,
+                licenseUuid,
+                clusterUuid,
+                clusterName,
+                serverless: isServerlessEnabled,
+                isGlobalTelemetryEnabled: isTelemetryEnabled,
+              })
+            ),
+          },
+          artifact_manifest: { value: manifest },
+        },
+      });
 
-      expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
-        createNewEndpointPolicyInput({
-          artifacts: {},
-          manifest_version: '1.0.0',
-          schema_version: 'v1',
-        })
-      );
+      const TEST_POLICY_ID_1 = 'c6d16e42-c32d-4dce-8a88-113cfe276ad1';
+      const TEST_POLICY_ID_2 = '93c46720-c217-11ea-9906-b5b8a21b268e';
+      const ARTIFACT_NAME_EXCEPTIONS_MACOS = 'endpoint-exceptionlist-macos-v1';
+      const ARTIFACT_NAME_TRUSTED_APPS_MACOS = 'endpoint-trustlist-macos-v1';
+      const ARTIFACT_NAME_TRUSTED_APPS_WINDOWS = 'endpoint-trustlist-windows-v1';
+      let ARTIFACT_EXCEPTIONS_MACOS: InternalArtifactCompleteSchema;
+      let ARTIFACT_EXCEPTIONS_WINDOWS: InternalArtifactCompleteSchema;
+      let ARTIFACT_TRUSTED_APPS_MACOS: InternalArtifactCompleteSchema;
+      let ARTIFACT_TRUSTED_APPS_WINDOWS: InternalArtifactCompleteSchema;
 
-      expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
-      expect(manifestManager.pushArtifacts).not.toHaveBeenCalled();
-      expect(manifestManager.commit).not.toHaveBeenCalled();
-    });
+      beforeAll(async () => {
+        const artifacts = await getMockArtifacts();
+        ARTIFACT_EXCEPTIONS_MACOS = artifacts[0];
+        ARTIFACT_EXCEPTIONS_WINDOWS = artifacts[1];
+        ARTIFACT_TRUSTED_APPS_MACOS = artifacts[3];
+        ARTIFACT_TRUSTED_APPS_WINDOWS = artifacts[4];
+      });
 
-    test('default manifest is taken when there is none and there are errors pushing artifacts', async () => {
-      const newManifest = ManifestManager.createDefaultManifest();
-      newManifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
+      beforeEach(() => {
+        licenseEmitter.next(Platinum); // set license level to platinum
+      });
 
-      const manifestManager = buildManifestManagerMock();
-      manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
-      manifestManager.buildNewManifest = jest.fn().mockResolvedValue(newManifest);
-      manifestManager.pushArtifacts = jest.fn().mockResolvedValue([new Error()]);
-
-      expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
-        createNewEndpointPolicyInput({
-          artifacts: {},
-          manifest_version: '1.0.0',
-          schema_version: 'v1',
-        })
-      );
-
-      expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
-      expect(manifestManager.pushArtifacts).toHaveBeenCalledWith(
-        [ARTIFACT_EXCEPTIONS_MACOS],
-        newManifest
-      );
-      expect(manifestManager.commit).not.toHaveBeenCalled();
-    });
-
-    test('default manifest is taken when there is none and there are errors commiting manifest', async () => {
-      const newManifest = ManifestManager.createDefaultManifest();
-      newManifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
-
-      const manifestManager = buildManifestManagerMock();
-      manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
-      manifestManager.buildNewManifest = jest.fn().mockResolvedValue(newManifest);
-      manifestManager.pushArtifacts = jest.fn().mockResolvedValue([]);
-      manifestManager.commit = jest.fn().mockRejectedValue(new Error());
-
-      expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
-        createNewEndpointPolicyInput({
-          artifacts: {},
-          manifest_version: '1.0.0',
-          schema_version: 'v1',
-        })
-      );
-
-      expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
-      expect(manifestManager.pushArtifacts).toHaveBeenCalledWith(
-        [ARTIFACT_EXCEPTIONS_MACOS],
-        newManifest
-      );
-      expect(manifestManager.commit).toHaveBeenCalledWith(newManifest);
-    });
-
-    test('manifest is created successfuly when there is none', async () => {
-      const newManifest = ManifestManager.createDefaultManifest();
-      newManifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
-      newManifest.addEntry(ARTIFACT_TRUSTED_APPS_MACOS);
-
-      const manifestManager = buildManifestManagerMock();
-      manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
-      manifestManager.buildNewManifest = jest.fn().mockResolvedValue(newManifest);
-      manifestManager.pushArtifacts = jest.fn().mockResolvedValue([]);
-      manifestManager.commit = jest.fn().mockResolvedValue(null);
-
-      expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
-        createNewEndpointPolicyInput({
-          artifacts: toArtifactRecords({
-            [ARTIFACT_NAME_EXCEPTIONS_MACOS]: ARTIFACT_EXCEPTIONS_MACOS,
-            [ARTIFACT_NAME_TRUSTED_APPS_MACOS]: ARTIFACT_TRUSTED_APPS_MACOS,
-          }),
-          manifest_version: '1.0.0',
-          schema_version: 'v1',
-        })
-      );
-
-      expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
-      expect(manifestManager.pushArtifacts).toHaveBeenCalledWith(
-        [ARTIFACT_EXCEPTIONS_MACOS, ARTIFACT_TRUSTED_APPS_MACOS],
-        newManifest
-      );
-      expect(manifestManager.commit).toHaveBeenCalledWith(newManifest);
-    });
-
-    test('policy is updated with only default entries from manifest', async () => {
-      const manifest = new Manifest({ soVersion: '1.0.1', semanticVersion: '1.0.1' });
-      manifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
-      manifest.addEntry(ARTIFACT_EXCEPTIONS_WINDOWS, TEST_POLICY_ID_1);
-      manifest.addEntry(ARTIFACT_TRUSTED_APPS_MACOS, TEST_POLICY_ID_2);
-      manifest.addEntry(ARTIFACT_TRUSTED_APPS_WINDOWS);
-
-      const manifestManager = buildManifestManagerMock();
-      manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(manifest);
-
-      expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
-        createNewEndpointPolicyInput({
-          artifacts: toArtifactRecords({
-            [ARTIFACT_NAME_EXCEPTIONS_MACOS]: ARTIFACT_EXCEPTIONS_MACOS,
-            [ARTIFACT_NAME_TRUSTED_APPS_WINDOWS]: ARTIFACT_TRUSTED_APPS_WINDOWS,
-          }),
-          manifest_version: '1.0.1',
-          schema_version: 'v1',
-        })
-      );
-
-      expect(manifestManager.buildNewManifest).not.toHaveBeenCalled();
-      expect(manifestManager.pushArtifacts).not.toHaveBeenCalled();
-      expect(manifestManager.commit).not.toHaveBeenCalled();
-    });
-
-    it('should correctly set meta.billable', async () => {
-      const isBillablePolicySpy = jest.spyOn(PolicyConfigHelpers, 'isBillablePolicy');
-      isBillablePolicySpy.mockReturnValue(false);
-      const manifestManager = buildManifestManagerMock();
-
-      let packagePolicy = await invokeCallback(manifestManager);
-      expect(isBillablePolicySpy).toHaveBeenCalled();
-      expect(packagePolicy.inputs[0].config!.policy.value.meta.billable).toBe(false);
-
-      isBillablePolicySpy.mockReset();
-      isBillablePolicySpy.mockReturnValue(true);
-      packagePolicy = await invokeCallback(manifestManager);
-      expect(isBillablePolicySpy).toHaveBeenCalled();
-      expect(packagePolicy.inputs[0].config!.policy.value.meta.billable).toBe(true);
-
-      isBillablePolicySpy.mockRestore();
-    });
-
-    it.each([false, true])(
-      'should correctly set `global_telemetry_enabled` to %s',
-      async (targetValue) => {
+      test('default manifest is taken when there is none and there are errors building new one', async () => {
         const manifestManager = buildManifestManagerMock();
-        telemetryConfigProviderMock.getIsOptedIn.mockReturnValue(targetValue);
+        manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
+        manifestManager.buildNewManifest = jest.fn().mockRejectedValue(new Error());
+
+        expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
+          createNewEndpointPolicyInput({
+            artifacts: {},
+            manifest_version: '1.0.0',
+            schema_version: 'v1',
+          })
+        );
+
+        expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
+        expect(manifestManager.pushArtifacts).not.toHaveBeenCalled();
+        expect(manifestManager.commit).not.toHaveBeenCalled();
+      });
+
+      test('default manifest is taken when there is none and there are errors pushing artifacts', async () => {
+        const newManifest = ManifestManager.createDefaultManifest();
+        newManifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
+
+        const manifestManager = buildManifestManagerMock();
+        manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
+        manifestManager.buildNewManifest = jest.fn().mockResolvedValue(newManifest);
+        manifestManager.pushArtifacts = jest.fn().mockResolvedValue([new Error()]);
+
+        expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
+          createNewEndpointPolicyInput({
+            artifacts: {},
+            manifest_version: '1.0.0',
+            schema_version: 'v1',
+          })
+        );
+
+        expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
+        expect(manifestManager.pushArtifacts).toHaveBeenCalledWith(
+          [ARTIFACT_EXCEPTIONS_MACOS],
+          newManifest
+        );
+        expect(manifestManager.commit).not.toHaveBeenCalled();
+      });
+
+      test('default manifest is taken when there is none and there are errors commiting manifest', async () => {
+        const newManifest = ManifestManager.createDefaultManifest();
+        newManifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
+
+        const manifestManager = buildManifestManagerMock();
+        manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
+        manifestManager.buildNewManifest = jest.fn().mockResolvedValue(newManifest);
+        manifestManager.pushArtifacts = jest.fn().mockResolvedValue([]);
+        manifestManager.commit = jest.fn().mockRejectedValue(new Error());
+
+        expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
+          createNewEndpointPolicyInput({
+            artifacts: {},
+            manifest_version: '1.0.0',
+            schema_version: 'v1',
+          })
+        );
+
+        expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
+        expect(manifestManager.pushArtifacts).toHaveBeenCalledWith(
+          [ARTIFACT_EXCEPTIONS_MACOS],
+          newManifest
+        );
+        expect(manifestManager.commit).toHaveBeenCalledWith(newManifest);
+      });
+
+      test('manifest is created successfuly when there is none', async () => {
+        const newManifest = ManifestManager.createDefaultManifest();
+        newManifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
+        newManifest.addEntry(ARTIFACT_TRUSTED_APPS_MACOS);
+
+        const manifestManager = buildManifestManagerMock();
+        manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
+        manifestManager.buildNewManifest = jest.fn().mockResolvedValue(newManifest);
+        manifestManager.pushArtifacts = jest.fn().mockResolvedValue([]);
+        manifestManager.commit = jest.fn().mockResolvedValue(null);
+
+        expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
+          createNewEndpointPolicyInput({
+            artifacts: toArtifactRecords({
+              [ARTIFACT_NAME_EXCEPTIONS_MACOS]: ARTIFACT_EXCEPTIONS_MACOS,
+              [ARTIFACT_NAME_TRUSTED_APPS_MACOS]: ARTIFACT_TRUSTED_APPS_MACOS,
+            }),
+            manifest_version: '1.0.0',
+            schema_version: 'v1',
+          })
+        );
+
+        expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
+        expect(manifestManager.pushArtifacts).toHaveBeenCalledWith(
+          [ARTIFACT_EXCEPTIONS_MACOS, ARTIFACT_TRUSTED_APPS_MACOS],
+          newManifest
+        );
+        expect(manifestManager.commit).toHaveBeenCalledWith(newManifest);
+      });
+
+      test('policy is updated with only default entries from manifest', async () => {
+        const manifest = new Manifest({ soVersion: '1.0.1', semanticVersion: '1.0.1' });
+        manifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
+        manifest.addEntry(ARTIFACT_EXCEPTIONS_WINDOWS, TEST_POLICY_ID_1);
+        manifest.addEntry(ARTIFACT_TRUSTED_APPS_MACOS, TEST_POLICY_ID_2);
+        manifest.addEntry(ARTIFACT_TRUSTED_APPS_WINDOWS);
+
+        const manifestManager = buildManifestManagerMock();
+        manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(manifest);
+
+        expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
+          createNewEndpointPolicyInput({
+            artifacts: toArtifactRecords({
+              [ARTIFACT_NAME_EXCEPTIONS_MACOS]: ARTIFACT_EXCEPTIONS_MACOS,
+              [ARTIFACT_NAME_TRUSTED_APPS_WINDOWS]: ARTIFACT_TRUSTED_APPS_WINDOWS,
+            }),
+            manifest_version: '1.0.1',
+            schema_version: 'v1',
+          })
+        );
+
+        expect(manifestManager.buildNewManifest).not.toHaveBeenCalled();
+        expect(manifestManager.pushArtifacts).not.toHaveBeenCalled();
+        expect(manifestManager.commit).not.toHaveBeenCalled();
+      });
+
+      it('should correctly set meta.billable', async () => {
+        const isBillablePolicySpy = jest.spyOn(PolicyConfigHelpers, 'isBillablePolicy');
+        isBillablePolicySpy.mockReturnValue(false);
+        const manifestManager = buildManifestManagerMock();
+
+        let packagePolicy = await invokeCallback(manifestManager);
+        expect(isBillablePolicySpy).toHaveBeenCalled();
+        expect(packagePolicy.inputs[0].config!.policy.value.meta.billable).toBe(false);
+
+        isBillablePolicySpy.mockReset();
+        isBillablePolicySpy.mockReturnValue(true);
+        packagePolicy = await invokeCallback(manifestManager);
+        expect(isBillablePolicySpy).toHaveBeenCalled();
+        expect(packagePolicy.inputs[0].config!.policy.value.meta.billable).toBe(true);
+
+        isBillablePolicySpy.mockRestore();
+      });
+
+      it.each([false, true])(
+        'should correctly set `global_telemetry_enabled` to %s',
+        async (targetValue) => {
+          const manifestManager = buildManifestManagerMock();
+          telemetryConfigProviderMock.getIsOptedIn.mockReturnValue(targetValue);
+
+          const packagePolicy = await invokeCallback(manifestManager);
+
+          const policyConfig: PolicyConfig = packagePolicy.inputs[0].config!.policy.value;
+          expect(policyConfig.global_telemetry_enabled).toBe(targetValue);
+        }
+      );
+
+      it('should remove Linux DNS events when linuxDnsEvents feature flag is disabled', async () => {
+        // @ts-expect-error write to readonly property for testing
+        experimentalFeatures.linuxDnsEvents = false;
+        const manifestManager = buildManifestManagerMock();
 
         const packagePolicy = await invokeCallback(manifestManager);
 
-        const policyConfig: PolicyConfig = packagePolicy.inputs[0].config!.policy.value;
-        expect(policyConfig.global_telemetry_enabled).toBe(targetValue);
-      }
-    );
-
-    it('should remove Linux DNS events when linuxDnsEvents feature flag is disabled', async () => {
-      // @ts-expect-error write to readonly property for testing
-      experimentalFeatures.linuxDnsEvents = false;
-      const manifestManager = buildManifestManagerMock();
-
-      const packagePolicy = await invokeCallback(manifestManager);
-
-      expect(packagePolicy.inputs[0].config!.policy.value.linux.events.dns).toBeUndefined();
+        expect(packagePolicy.inputs[0].config!.policy.value.linux.events.dns).toBeUndefined();
+      });
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.ts
@@ -174,7 +174,7 @@ export const getPackagePolicyCreateCallback = (
 
     // perform these operations in parallel in order to help in not delaying the API response too much
     const [, manifestValue] = await Promise.all([
-      async () => {
+      (async () => {
         // In this callback we are handling an HTTP request to the fleet plugin. Since we use
         // code from the security_solution plugin to handle it (installPrepackagedRules),
         // we need to build the context that is native to security_solution and pass it there.
@@ -202,7 +202,7 @@ export const getPackagePolicyCreateCallback = (
             `Server setting 'disableEndpointRuleAutoInstall' is 'true' - skipping the install of Endpoint Security prebuilt rule`
           );
         }
-      },
+      })(),
 
       // create the Artifact Manifest for this policy
       createPolicyArtifactManifest(logger, manifestManager),

--- a/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.ts
@@ -172,37 +172,39 @@ export const getPackagePolicyCreateCallback = (
       validateIntegrationConfig(endpointIntegrationConfig, logger);
     }
 
+    const conditionallyInstallEndpointSecurityPrebuiltRule = async () => {
+      // In this callback we are handling an HTTP request to the fleet plugin. Since we use
+      // code from the security_solution plugin to handle it (installPrepackagedRules),
+      // we need to build the context that is native to security_solution and pass it there.
+      const securitySolutionContext = await securitySolutionRequestContextFactory.create(
+        context,
+        request
+      );
+
+      if (
+        !securitySolutionContext
+          .getEndpointService()
+          .getServerConfigValue('disableEndpointRuleAutoInstall')
+      ) {
+        logger.debug(`Checking if Endpoint Security prebuilt rule is installed/enabled...`);
+
+        return installEndpointSecurityPrebuiltRule({
+          logger,
+          context: securitySolutionContext,
+          request,
+          alerts,
+          soClient,
+        });
+      } else {
+        logger.debug(
+          `Server setting 'disableEndpointRuleAutoInstall' is 'true' - skipping the install of Endpoint Security prebuilt rule`
+        );
+      }
+    };
+
     // perform these operations in parallel in order to help in not delaying the API response too much
     const [, manifestValue] = await Promise.all([
-      (async () => {
-        // In this callback we are handling an HTTP request to the fleet plugin. Since we use
-        // code from the security_solution plugin to handle it (installPrepackagedRules),
-        // we need to build the context that is native to security_solution and pass it there.
-        const securitySolutionContext = await securitySolutionRequestContextFactory.create(
-          context,
-          request
-        );
-
-        if (
-          !securitySolutionContext
-            .getEndpointService()
-            .getServerConfigValue('disableEndpointRuleAutoInstall')
-        ) {
-          logger.debug(`Checking if Endpoint Security prebuilt rule is installed/enabled...`);
-
-          return installEndpointSecurityPrebuiltRule({
-            logger,
-            context: securitySolutionContext,
-            request,
-            alerts,
-            soClient,
-          });
-        } else {
-          logger.debug(
-            `Server setting 'disableEndpointRuleAutoInstall' is 'true' - skipping the install of Endpoint Security prebuilt rule`
-          );
-        }
-      })(),
+      conditionallyInstallEndpointSecurityPrebuiltRule(),
 
       // create the Artifact Manifest for this policy
       createPolicyArtifactManifest(logger, manifestManager),

--- a/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.ts
@@ -172,23 +172,37 @@ export const getPackagePolicyCreateCallback = (
       validateIntegrationConfig(endpointIntegrationConfig, logger);
     }
 
-    // In this callback we are handling an HTTP request to the fleet plugin. Since we use
-    // code from the security_solution plugin to handle it (installPrepackagedRules),
-    // we need to build the context that is native to security_solution and pass it there.
-    const securitySolutionContext = await securitySolutionRequestContextFactory.create(
-      context,
-      request
-    );
-
     // perform these operations in parallel in order to help in not delaying the API response too much
     const [, manifestValue] = await Promise.all([
-      installEndpointSecurityPrebuiltRule({
-        logger,
-        context: securitySolutionContext,
-        request,
-        alerts,
-        soClient,
-      }),
+      async () => {
+        // In this callback we are handling an HTTP request to the fleet plugin. Since we use
+        // code from the security_solution plugin to handle it (installPrepackagedRules),
+        // we need to build the context that is native to security_solution and pass it there.
+        const securitySolutionContext = await securitySolutionRequestContextFactory.create(
+          context,
+          request
+        );
+
+        if (
+          !securitySolutionContext
+            .getEndpointService()
+            .getServerConfigValue('disableEndpointRuleAutoInstall')
+        ) {
+          logger.debug(`Checking if Endpoint Security prebuilt rule is installed/enabled...`);
+
+          return installEndpointSecurityPrebuiltRule({
+            logger,
+            context: securitySolutionContext,
+            request,
+            alerts,
+            soClient,
+          });
+        } else {
+          logger.debug(
+            `Server setting 'disableEndpointRuleAutoInstall' is 'true' - skipping the install of Endpoint Security prebuilt rule`
+          );
+        }
+      },
 
       // create the Artifact Manifest for this policy
       createPolicyArtifactManifest(logger, manifestManager),


### PR DESCRIPTION
## Summary

- Add a new server configuration setting: `xpack.securitySolution.disableEndpointRuleAutoInstall`
    - When set to `true`, the Elastic Defend SIEM rule will NOT be auto-installed/enabled when the first Elastic Defend Integration policy is created
    - Default value is `false` - thus backwards compatible: we will continue to auto-install/enable the Elastic Defend SIEM rule when an Elastic Defend integration policy is created


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->

####Summary

####Requester
Cody
####PM-comment

####Release-vehicle

####Customer-Priority
high