### PR TITLE
[Fleet] Do not allow to edit agentless agent policy

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -590,7 +590,7 @@ export const updateAgentPolicyHandler: FleetRequestHandler<
       request.params.agentPolicyId,
       false
     );
-    if (existingAgentPolicy?.supports_agentless) {
+    if (existingAgentPolicy?.supports_agentless || data.supports_agentless) {
       throw new FleetError(
         'To update agentless agent policies, use the Fleet agentless policies API.'
       );

--- a/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/agent_policy/handlers.ts
@@ -562,6 +562,14 @@ export const updateAgentPolicyHandler: FleetRequestHandler<
   logger.debug(`updating policy [${request.params.agentPolicyId}] in space [${spaceId}]`);
 
   try {
+    if (
+      data.supports_agentless &&
+      appContextService.getExperimentalFeatures().disableAgentlessLegacyAPI
+    ) {
+      throw new FleetError(
+        'To update agentless agent policies, use the Fleet agentless policies API.'
+      );
+    }
     const authzFleetAgentsAll = fleetContext.authz.fleet.allAgents;
 
     const requestSpaceId = spaceId;

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -651,19 +651,8 @@ export default function (providerContext: FtrProviderContext) {
           })
           .expect(200);
 
-        const agentPolicyResponse = await supertest
-          .post(`/api/fleet/agent_policies?sys_monitoring=false`)
-          .set('kbn-xsrf', 'xxxx')
-          .send({
-            name: 'test-agentless-policy',
-            namespace: 'default',
-          })
-          .expect(200);
-
-        const agentPolicy = agentPolicyResponse.body.item;
-
         const response = await supertest
-          .put(`/api/fleet/agent_policies/${agentPolicy.id}`)
+          .post(`/api/fleet/agent_policies?sys_monitoring=false`)
           .set('kbn-xsrf', 'xxxx')
           .send({
             name: 'test-agentless-policy',
@@ -1807,19 +1796,8 @@ export default function (providerContext: FtrProviderContext) {
           })
           .expect(200);
 
-        const agentPolicyResponse = await supertest
-          .post(`/api/fleet/agent_policies?sys_monitoring=false`)
-          .set('kbn-xsrf', 'xxxx')
-          .send({
-            name: 'test-agentless-policy',
-            namespace: 'default',
-          })
-          .expect(200);
-
-        const agentPolicy = agentPolicyResponse.body.item;
-
         const response = await supertest
-          .put(`/api/fleet/agent_policies/${agentPolicy.id}`)
+          .post(`/api/fleet/agent_policies?sys_monitoring=false`)
           .set('kbn-xsrf', 'xxxx')
           .send({
             name: 'test-agentless-policy',

--- a/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
@@ -448,6 +448,54 @@ export default function (providerContext: FtrProviderContext) {
       });
     });
 
+    describe('Side effetcts', () => {
+      beforeEach(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+
+        await cleanFleetIndices(es);
+        await apiClient.setup();
+        const mockAgentlessApiService = setupMockServer();
+        mockApiServer = await mockAgentlessApiService.listen(8089); // Start the agentless api mock server on port 8089
+      });
+
+      afterEach(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+        await cleanFleetIndices(es);
+        mockApiServer.close();
+      });
+      it('should not allow to update related agent policy', async () => {
+        const agentlessPolicy = await apiClient.createAgentlessPolicy({
+          id: uuidv4(),
+          package: {
+            name: 'test_agentless',
+            version: '1.0.0',
+          },
+          name: `Test ${Date.now()}`,
+          description: 'test agentless policy',
+          namespace: 'default',
+          inputs: {
+            'sample-httpjson': {
+              enabled: true,
+              vars: {
+                api_key: 'TEST_VALUE_API_KEY',
+              },
+              streams: {},
+            },
+          },
+        });
+
+        await expectToRejectWithError(
+          () =>
+            apiClient.putAgentPolicy(agentlessPolicy.item.id, {
+              name: 'tata',
+              namespace: 'default',
+              description: 'tata',
+            }),
+          /400 "Bad Request" To update agentless agent policies, use the Fleet agentless policies API./
+        );
+      });
+    });
+
     describe.skip('Agentless Policy with Cloud Connectors', () => {
       // See individual tests for more details
       // Will be resolved in https://github.com/elastic/security-team/issues/14864

--- a/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agentless/agentless_policies.ts
@@ -448,7 +448,7 @@ export default function (providerContext: FtrProviderContext) {
       });
     });
 
-    describe('Side effetcts', () => {
+    describe('Side effects', () => {
       beforeEach(async () => {
         await kibanaServer.savedObjects.cleanStandardList();
 

--- a/x-pack/platform/test/fleet_api_integration/apis/package_policy/delete.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/package_policy/delete.ts
@@ -155,26 +155,6 @@ export default function (providerContext: FtrProviderContext) {
           .set('kbn-xsrf', 'xxxx')
           .expect(200);
       });
-
-      it('should delete agent policy with package policy if supports_agentless', async function () {
-        // update existing policy to supports_agentless
-        await supertest
-          .put(`/api/fleet/agent_policies/${agentPolicy.id}`)
-          .set('kbn-xsrf', 'xxxx')
-          .send({
-            name: agentPolicy.name,
-            namespace: agentPolicy.namespace,
-            supports_agentless: true,
-          })
-          .expect(200);
-
-        await supertest
-          .delete(`/api/fleet/package_policies/${packagePolicy.id}`)
-          .set('kbn-xsrf', 'xxxx')
-          .expect(200);
-
-        await supertest.get(`/api/fleet/agent_policies/${agentPolicy.id}`).expect(200);
-      });
     });
 
     // TODO: see https://github.com/elastic/kibana/pull/243499


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/217704

To avoid user updating agentless agent policy, we should disallow to update an agentless agent policy, that PR does that.

## Tests

I added API integration test to cover that.