### PR TITLE
Skip Tests for FIPS Runs

### DIFF
--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/apis/spaces/access_control_objects.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/apis/spaces/access_control_objects.ts
@@ -272,7 +272,9 @@ export default function ({ getService }: FtrProviderContext) {
         expect(createResponse.body.accessControl).to.have.property('owner', adminUid);
       });
 
-      it('should reject when attempting to overwrite an object owned by another user if not admin', async () => {
+      it('should reject when attempting to overwrite an object owned by another user if not admin', async function () {
+        this.tags('skipFIPS');
+
         const { cookie: objectOwnerCookie, profileUid: adminUid } = await loginAsKibanaAdmin();
         const createResponse = await supertestWithoutAuth
           .post('/access_control_objects/create')
@@ -487,8 +489,10 @@ export default function ({ getService }: FtrProviderContext) {
         });
       });
 
-      describe('failure modes', () => {
-        it('rejects when overwriting and all objects are write-restricted and inaccessible', async () => {
+      describe('failure modes', function () {
+        this.tags('skipFIPS');
+
+        it('rejects when overwriting and all objects are write-restricted and inaccessible', async function () {
           const { cookie: adminCookie, profileUid: adminProfileUid } = await loginAsKibanaAdmin();
 
           const firstObject = await supertestWithoutAuth
@@ -794,7 +798,9 @@ export default function ({ getService }: FtrProviderContext) {
         );
       });
 
-      it('should throw when updating write-restricted objects owned by a different user when not admin', async () => {
+      it('should throw when updating write-restricted objects owned by a different user when not admin', async function () {
+        this.tags('skipFIPS');
+
         const { cookie: adminCookie, profileUid: adminProfileUid } = await loginAsKibanaAdmin();
         const createResponse = await supertestWithoutAuth
           .post('/access_control_objects/create')
@@ -1334,7 +1340,9 @@ export default function ({ getService }: FtrProviderContext) {
         );
       });
 
-      it('throws when trying to delete write-restricted object owned by a different user when not admin', async () => {
+      it('throws when trying to delete write-restricted object owned by a different user when not admin', async function () {
+        this.tags('skipFIPS');
+
         const { cookie: adminCookie, profileUid: adminProfileUid } = await loginAsKibanaAdmin();
         const createResponse = await supertestWithoutAuth
           .post('/access_control_objects/create')
@@ -1996,7 +2004,9 @@ export default function ({ getService }: FtrProviderContext) {
         expect(getResponse.body.accessControl).to.have.property('owner', simpleUserProfileUid);
       });
 
-      it('should throw when transferring ownership of object owned by a different user and not admin', async () => {
+      it('should throw when transferring ownership of object owned by a different user and not admin', async function () {
+        this.tags('skipFIPS');
+
         const { profileUid: simpleUserProfileUid } = await activateSimpleUserProfile();
         const { cookie: adminCookie, profileUid: adminProfileUid } = await loginAsKibanaAdmin();
         const createResponse = await supertestWithoutAuth

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/apis/spaces/import_export.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/apis/spaces/import_export.ts
@@ -366,7 +366,9 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       describe('ovewriting objects', () => {
-        it('should disallow overwrite of owned objects if not owned by the current user', async () => {
+        it('should disallow overwrite of owned objects if not owned by the current user', async function () {
+          this.tags('skipFIPS');
+
           const { cookie: adminCookie, profileUid: adminProfileId } = await loginAsKibanaAdmin();
 
           let createResponse = await supertestWithoutAuth
@@ -485,7 +487,9 @@ export default function ({ getService }: FtrProviderContext) {
           ]);
         });
 
-        it('should throw if the import only contains objects are not overwritable by the current user', async () => {
+        it('should throw if the import only contains objects are not overwritable by the current user', async function () {
+          this.tags('skipFIPS');
+
           const { cookie: adminCookie, profileUid: adminProfileId } = await loginAsKibanaAdmin();
 
           let createResponse = await supertestWithoutAuth
@@ -1135,7 +1139,9 @@ export default function ({ getService }: FtrProviderContext) {
         ]);
       });
 
-      it('should disallow create new retry with same ID for write-restricted objects not owned by the current user', async () => {
+      it('should disallow create new retry with same ID for write-restricted objects not owned by the current user', async function () {
+        this.tags('skipFIPS');
+
         const { cookie: adminCookie, profileUid: adminProfileId } = await loginAsKibanaAdmin();
 
         let createResponse = await supertestWithoutAuth


### PR DESCRIPTION
temporarily skipping negative tests for FIPS runs in spaces_api_integration/access_control_objects functional tests.

I will create a chore to rework these tests to work in FIPS mode