### PR TITLE
[SLO] Unskip SLO find definition test on MKI

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/find_slo_definition.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/find_slo_definition.ts
@@ -26,9 +26,6 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   let adminRoleAuthc: RoleCredentials;
 
   describe('Find SLOs by outdated status and tags', function () {
-    // failsOnMKI, see https://github.com/elastic/kibana/issues/246127
-    this.tags(['failsOnMKI']);
-
     before(async () => {
       adminRoleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('admin');
 


### PR DESCRIPTION
## Summary

In this [PR](https://github.com/elastic/kibana/pull/246130) the find SLOs test suite for MKI was skipped. In current PR we remove the skip.