### PR TITLE
[Obs AI] Query all environments if service environment is empty for downstream dependencies

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/data_provider/register_data_providers.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/data_provider/register_data_providers.ts
@@ -78,7 +78,7 @@ export function registerDataProviders({
         randomSampler,
         arguments: {
           serviceName,
-          serviceEnvironment,
+          serviceEnvironment: serviceEnvironment ? serviceEnvironment : ENVIRONMENT_ALL.value,
           start,
           end,
         },

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/common/constants.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/common/constants.ts
@@ -9,3 +9,6 @@
 export const OBSERVABILITY_AI_INSIGHT_ATTACHMENT_TYPE_ID = 'observability.ai_insight';
 export const OBSERVABILITY_ERROR_ATTACHMENT_TYPE_ID = 'observability.error';
 export const OBSERVABILITY_ALERT_ATTACHMENT_TYPE_ID = 'observability.alert';
+
+// Environment name to "query across all environments" (i.e. don't apply an environment filter)
+export const ENVIRONMENT_ALL = 'ENVIRONMENT_ALL';

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/common/constants.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/common/constants.ts
@@ -9,6 +9,3 @@
 export const OBSERVABILITY_AI_INSIGHT_ATTACHMENT_TYPE_ID = 'observability.ai_insight';
 export const OBSERVABILITY_ERROR_ATTACHMENT_TYPE_ID = 'observability.error';
 export const OBSERVABILITY_ALERT_ATTACHMENT_TYPE_ID = 'observability.alert';
-
-// Environment name to "query across all environments" (i.e. don't apply an environment filter)
-export const ENVIRONMENT_ALL = 'ENVIRONMENT_ALL';

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/apm_error/fetch_apm_error_context.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/apm_error/fetch_apm_error_context.ts
@@ -9,6 +9,7 @@ import dedent from 'dedent';
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { CoreSetup } from '@kbn/core/server';
+import { ENVIRONMENT_ALL } from '../../../../common/constants';
 import { termFilter } from '../../../utils/dsl_filters';
 import type { ObservabilityAgentBuilderDataRegistry } from '../../../data_registry/data_registry';
 import type {
@@ -95,7 +96,7 @@ export async function fetchApmErrorContext({
         dataRegistry.getData('apmDownstreamDependencies', {
           request,
           serviceName,
-          serviceEnvironment: environment ?? '',
+          serviceEnvironment: environment ?? ENVIRONMENT_ALL,
           start,
           end,
         }),

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/apm_error/fetch_apm_error_context.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/apm_error/fetch_apm_error_context.ts
@@ -9,7 +9,6 @@ import dedent from 'dedent';
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { CoreSetup } from '@kbn/core/server';
-import { ENVIRONMENT_ALL } from '../../../../common/constants';
 import { termFilter } from '../../../utils/dsl_filters';
 import type { ObservabilityAgentBuilderDataRegistry } from '../../../data_registry/data_registry';
 import type {
@@ -96,7 +95,7 @@ export async function fetchApmErrorContext({
         dataRegistry.getData('apmDownstreamDependencies', {
           request,
           serviceName,
-          serviceEnvironment: environment ?? ENVIRONMENT_ALL,
+          serviceEnvironment: environment ?? '',
           start,
           end,
         }),

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/get_alert_ai_insights.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/get_alert_ai_insights.ts
@@ -11,6 +11,7 @@ import { MessageRole } from '@kbn/inference-common';
 import dedent from 'dedent';
 import { isEmpty } from 'lodash';
 import moment from 'moment';
+import { ENVIRONMENT_ALL } from '../../../common/constants';
 import type { ObservabilityAgentBuilderDataRegistry } from '../../data_registry/data_registry';
 
 /**
@@ -84,7 +85,7 @@ async function fetchAlertContext({
   'alertDoc' | 'dataRegistry' | 'request' | 'logger'
 >): Promise<string> {
   const serviceName = alertDoc?.['service.name'] ?? '';
-  const serviceEnvironment = alertDoc?.['service.environment'] ?? '';
+  const serviceEnvironment = alertDoc?.['service.environment'] || ENVIRONMENT_ALL;
   const transactionType = alertDoc?.['transaction.type'];
   const transactionName = alertDoc?.['transaction.name'];
 

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/get_alert_ai_insights.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/routes/ai_insights/get_alert_ai_insights.ts
@@ -11,7 +11,6 @@ import { MessageRole } from '@kbn/inference-common';
 import dedent from 'dedent';
 import { isEmpty } from 'lodash';
 import moment from 'moment';
-import { ENVIRONMENT_ALL } from '../../../common/constants';
 import type { ObservabilityAgentBuilderDataRegistry } from '../../data_registry/data_registry';
 
 /**
@@ -85,7 +84,7 @@ async function fetchAlertContext({
   'alertDoc' | 'dataRegistry' | 'request' | 'logger'
 >): Promise<string> {
   const serviceName = alertDoc?.['service.name'] ?? '';
-  const serviceEnvironment = alertDoc?.['service.environment'] || ENVIRONMENT_ALL;
+  const serviceEnvironment = alertDoc?.['service.environment'] ?? '';
   const transactionType = alertDoc?.['transaction.type'];
   const transactionName = alertDoc?.['transaction.name'];
 

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_downstream_dependencies/get_downstream_dependencies.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_downstream_dependencies/get_downstream_dependencies.ts
@@ -10,7 +10,6 @@ import type { CoreSetup, Logger } from '@kbn/core/server';
 import type { BuiltinToolDefinition, StaticToolRegistration } from '@kbn/onechat-server';
 import { ToolType } from '@kbn/onechat-common';
 import { ToolResultType } from '@kbn/onechat-common/tools/tool_result';
-import { ENVIRONMENT_ALL } from '../../../common/constants';
 import type {
   ObservabilityAgentBuilderPluginStart,
   ObservabilityAgentBuilderPluginStartDependencies,
@@ -65,7 +64,7 @@ export function createDownstreamDependenciesTool({
         const dependencies = await dataRegistry.getData('apmDownstreamDependencies', {
           request,
           serviceName: args.serviceName,
-          serviceEnvironment: args.serviceEnvironment ?? ENVIRONMENT_ALL,
+          serviceEnvironment: args.serviceEnvironment ?? '',
           start: args.start,
           end: args.end,
         });

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_downstream_dependencies/get_downstream_dependencies.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_downstream_dependencies/get_downstream_dependencies.ts
@@ -10,6 +10,7 @@ import type { CoreSetup, Logger } from '@kbn/core/server';
 import type { BuiltinToolDefinition, StaticToolRegistration } from '@kbn/onechat-server';
 import { ToolType } from '@kbn/onechat-common';
 import { ToolResultType } from '@kbn/onechat-common/tools/tool_result';
+import { ENVIRONMENT_ALL } from '../../../common/constants';
 import type {
   ObservabilityAgentBuilderPluginStart,
   ObservabilityAgentBuilderPluginStartDependencies,
@@ -64,7 +65,7 @@ export function createDownstreamDependenciesTool({
         const dependencies = await dataRegistry.getData('apmDownstreamDependencies', {
           request,
           serviceName: args.serviceName,
-          serviceEnvironment: args.serviceEnvironment ?? '',
+          serviceEnvironment: args.serviceEnvironment ?? ENVIRONMENT_ALL,
           start: args.start,
           end: args.end,
         });


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-team/issues/441

## Summary

For downstream dependencies, an empty array is returned if the service environment is not passed. Since the service environment is an optional parameter, we should query all environments if the service environment is not passed. 

### After the fix

<img width="1014" height="707" alt="image" src="https://github.com/user-attachments/assets/c24cde14-de9e-4b80-a901-ff2bc243a5e2" />


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


