### PR TITLE
[Obs AI] Remove the beta badge in the AI Agent tour callout

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/tour_callout/ai_agent_tour_callout.tsx
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/tour_callout/ai_agent_tour_callout.tsx
@@ -8,12 +8,12 @@
 import type { ReactElement } from 'react';
 import React, { useCallback } from 'react';
 import {
-  EuiBetaBadge,
   EuiButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLink,
+  EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -66,22 +66,13 @@ export const AIAgentTourCallout = ({
     <>
       <TourCallout
         title={
-          <EuiFlexGroup gutterSize="s" responsive={false}>
-            <EuiFlexItem grow={false}>
+          <EuiTitle size="xs">
+            <span>
               {i18n.translate('xpack.observabilityAiAssistant.agentTour.title', {
                 defaultMessage: 'Try the new AI Agent',
               })}
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiBetaBadge
-                label={i18n.translate('xpack.observabilityAiAssistant.agentTour.betaBadge', {
-                  defaultMessage: 'BETA',
-                })}
-                size="s"
-                color="hollow"
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
+            </span>
+          </EuiTitle>
         }
         content={
           <FormattedMessage


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-team/issues/442

## Summary

This PR removes the beta badge of the AI Agent tour callout in the Obs AI Assistant.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

