### PR TITLE
[ES|QL] [Index editor] Limits the update operations to 1000

### DIFF
--- a/src/platform/plugins/shared/esql/server/routes/lookup_index.ts
+++ b/src/platform/plugins/shared/esql/server/routes/lookup_index.ts
@@ -29,8 +29,8 @@ export const registerLookupIndexRoutes = (
           indexName: schema.string(),
         }),
         body: schema.object({
-          // maxSize fixes: Unbounded array in schema validation vulnerability,
-          operations: schema.arrayOf(schema.any(), { maxSize: 10000 }),
+          // maxSize is added here to prevent DoS vulnerabilities https://github.com/elastic/kibana/pull/245533,
+          operations: schema.arrayOf(schema.any(), { maxSize: 1000 }),
         }),
       },
       security: {


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/245533

After discussion with the elastic security team we decided to decrease the number to 1000. It seems as a reasonable number which doesnt degrade the feature



