### PR TITLE
[Synthetics] Fix SyncGlobalParamsSpaces flaky test

### DIFF
--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/services/private_location_test_service.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/services/private_location_test_service.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import expect from '@kbn/expect/expect';
+import expect from '@kbn/expect';
 import type { PrivateLocation } from '@kbn/synthetics-plugin/common/runtime_types';
 import type { KibanaSupertestProvider, RetryService } from '@kbn/ftr-common-functional-services';
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/services/private_location_test_service.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/services/private_location_test_service.ts
@@ -6,7 +6,7 @@
  */
 import expect from '@kbn/expect';
 import type { PrivateLocation } from '@kbn/synthetics-plugin/common/runtime_types';
-import type { KibanaSupertestProvider, RetryService } from '@kbn/ftr-common-functional-services';
+import type { KibanaSupertestProvider } from '@kbn/ftr-common-functional-services';
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
 import {
   legacyPrivateLocationsSavedObjectId,
@@ -21,12 +21,10 @@ export const INSTALLED_VERSION = '1.4.2';
 export class PrivateLocationTestService {
   private supertest: ReturnType<typeof KibanaSupertestProvider>;
   private readonly getService: FtrProviderContext['getService'];
-  private readonly retry: RetryService;
 
   constructor(getService: FtrProviderContext['getService']) {
     this.supertest = getService('supertest');
     this.getService = getService;
-    this.retry = getService('retry');
   }
 
   async cleanupFleetPolicies() {
@@ -64,22 +62,14 @@ export class PrivateLocationTestService {
   }
 
   async installSyntheticsPackage() {
-    await this.retry.try(async () => {
-      const setupRes = await this.supertest.post('/api/fleet/setup').set('kbn-xsrf', 'true').send();
-
-      expect(setupRes.status).to.eql(200, JSON.stringify(setupRes.body));
-      expect(setupRes.body.isInitialized).to.eql(true, JSON.stringify(setupRes.body));
-
-      // Attempt to delete any existing package so we can install a specific version
-      await this.supertest.delete(`/api/fleet/epm/packages/synthetics`).set('kbn-xsrf', 'true');
-
-      const installRes = await this.supertest
-        .post(`/api/fleet/epm/packages/synthetics/${INSTALLED_VERSION}`)
-        .set('kbn-xsrf', 'true')
-        .send({ force: true });
-
-      expect(installRes.status).to.eql(200, JSON.stringify(installRes.body));
-    });
+    await this.supertest.post('/api/fleet/setup').set('kbn-xsrf', 'true').send().expect(200);
+    // Attempt to delete any existing package so we can install a specific version
+    await this.supertest.delete(`/api/fleet/epm/packages/synthetics`).set('kbn-xsrf', 'true');
+    await this.supertest
+      .post(`/api/fleet/epm/packages/synthetics/${INSTALLED_VERSION}`)
+      .set('kbn-xsrf', 'true')
+      .send({ force: true })
+      .expect(200);
   }
 
   async addFleetPolicy(name?: string) {

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_global_params_spaces.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_global_params_spaces.ts
@@ -11,7 +11,7 @@ import type {
 } from '@kbn/synthetics-plugin/common/runtime_types';
 import { ConfigKey } from '@kbn/synthetics-plugin/common/runtime_types';
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
-import expect from '@kbn/expect/expect';
+import expect from '@kbn/expect';
 import { omit } from 'lodash';
 import { SyntheticsMonitorTestService } from './services/synthetics_monitor_test_service';
 import type { FtrProviderContext } from '../../ftr_provider_context';

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_global_params_spaces.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_global_params_spaces.ts
@@ -11,7 +11,7 @@ import type {
 } from '@kbn/synthetics-plugin/common/runtime_types';
 import { ConfigKey } from '@kbn/synthetics-plugin/common/runtime_types';
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
-import expect from '@kbn/expect';
+import expect from '@kbn/expect/expect';
 import { omit } from 'lodash';
 import { SyntheticsMonitorTestService } from './services/synthetics_monitor_test_service';
 import type { FtrProviderContext } from '../../ftr_provider_context';
@@ -40,6 +40,7 @@ export default function ({ getService }: FtrProviderContext) {
     const params: Record<string, string> = {};
 
     before(async () => {
+      await testPrivateLocations.cleanupFleetPolicies();
       await kServer.savedObjects.cleanStandardList();
       await testPrivateLocations.installSyntheticsPackage();
       _browserMonitorJson = getFixtureJson('browser_monitor');


### PR DESCRIPTION
It closes https://github.com/elastic/kibana/issues/241106

This PR addresses flaky test failures in the synthetics API integration tests by improving clean up of fleet related data.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->