### PR TITLE
[ES|QL] Build function arguments suggestions from hints

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/generated/scalar_functions.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/generated/scalar_functions.ts
@@ -16595,6 +16595,12 @@ const textEmbeddingDefinition: FunctionDefinition = {
           optional: false,
           description:
             'Identifier of an existing inference endpoint the that will generate the embeddings. The inference endpoint must have the `text_embedding` task type and should use the same model that was used to embed your indexed data.',
+          hint: {
+            entityType: 'inference_endpoint',
+            constraints: {
+              task_type: 'text_embedding',
+            },
+          },
         },
       ],
       returnType: 'dense_vector',
@@ -16614,8 +16620,6 @@ const textEmbeddingDefinition: FunctionDefinition = {
     Location.JOIN,
   ],
   examples: [
-    'ROW input="Who is Victor Hugo?"\n| EVAL embedding = TEXT_EMBEDDING("Who is Victor Hugo?", "test_dense_inference")',
-    'FROM dense_vector_text METADATA _score\n| EVAL query_embedding = TEXT_EMBEDDING("be excellent to each other", "test_dense_inference")\n| WHERE KNN(text_embedding_field, query_embedding)',
     'FROM dense_vector_text METADATA _score\n| WHERE KNN(text_embedding_field, TEXT_EMBEDDING("be excellent to each other", "test_dense_inference"))',
   ],
 };
@@ -19439,6 +19443,7 @@ const topSnippetsDefinition: FunctionDefinition = {
     Location.JOIN,
   ],
   examples: [
+    'FROM books\n| EVAL snippets = TOP_SNIPPETS(description, "Tolkien")',
     'FROM books\n| WHERE MATCH(title, "Return")\n| EVAL snippets = TOP_SNIPPETS(description, "Tolkien", { "num_snippets": 3, "num_words": 25 })',
   ],
 };
@@ -19786,7 +19791,6 @@ const vCosineDefinition: FunctionDefinition = {
   description: i18n.translate('kbn-esql-ast.esql.definitions.v_cosine', {
     defaultMessage: 'Calculates the cosine similarity between two dense_vectors.',
   }),
-  ignoreAsSuggestion: true,
   preview: true,
   alias: undefined,
   signatures: [
@@ -19833,7 +19837,6 @@ const vDotProductDefinition: FunctionDefinition = {
   description: i18n.translate('kbn-esql-ast.esql.definitions.v_dot_product', {
     defaultMessage: 'Calculates the dot product between two dense_vectors.',
   }),
-  ignoreAsSuggestion: true,
   preview: true,
   alias: undefined,
   signatures: [
@@ -19880,7 +19883,6 @@ const vHammingDefinition: FunctionDefinition = {
   description: i18n.translate('kbn-esql-ast.esql.definitions.v_hamming', {
     defaultMessage: 'Calculates the Hamming distance between two dense vectors.',
   }),
-  ignoreAsSuggestion: true,
   preview: true,
   alias: undefined,
   signatures: [
@@ -19927,7 +19929,6 @@ const vL1NormDefinition: FunctionDefinition = {
   description: i18n.translate('kbn-esql-ast.esql.definitions.v_l1_norm', {
     defaultMessage: 'Calculates the l1 norm between two dense_vectors.',
   }),
-  ignoreAsSuggestion: true,
   preview: true,
   alias: undefined,
   signatures: [
@@ -19974,7 +19975,6 @@ const vL2NormDefinition: FunctionDefinition = {
   description: i18n.translate('kbn-esql-ast.esql.definitions.v_l2_norm', {
     defaultMessage: 'Calculates the l2 norm between two dense_vectors.',
   }),
-  ignoreAsSuggestion: true,
   preview: true,
   alias: undefined,
   signatures: [

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/generated/settings.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/generated/settings.ts
@@ -13,7 +13,7 @@ const projectRouting = {
   type: 'keyword',
   serverlessOnly: true,
   preview: true,
-  snapshotOnly: true,
+  snapshotOnly: false,
   description:
     'A project routing expression, used to define which projects to route the query to. Only supported if Cross-Project Search is enabled.',
   ignoreAsSuggestion: false,

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/types.ts
@@ -140,7 +140,7 @@ export interface FunctionParameter {
    * Provides information that is useful for getting parameter values from external sources.
    * For example, an inference endpoint
    */
-  hint: ParameterHint;
+  hint?: ParameterHint;
 }
 
 export interface ElasticsearchCommandDefinition {

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/types.ts
@@ -99,6 +99,13 @@ export const isParameterType = (str: string | undefined): str is FunctionParamet
 export const isReturnType = (str: string | FunctionParameterType): str is FunctionReturnType =>
   str !== 'unsupported' && (str === 'unknown' || str === 'any' || dataTypes.includes(str));
 
+export const parameterHintEntityTypes = ['inference_endpoint'] as const;
+export type ParameterHintEntityType = (typeof parameterHintEntityTypes)[number];
+export interface ParameterHint {
+  entityType: ParameterHintEntityType;
+  constraints?: Record<string, string>;
+}
+
 export interface FunctionParameter {
   name: string;
   type: FunctionParameterType;
@@ -128,6 +135,12 @@ export interface FunctionParameter {
    * This indicates that the parameter can accept multiple values, which will be passed as an array.
    */
   supportsMultiValues?: boolean;
+
+  /**
+   * Provides information that is useful for getting parameter values from external sources.
+   * For example, an inference endpoint
+   */
+  hint: ParameterHint;
 }
 
 export interface ElasticsearchCommandDefinition {

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
@@ -21,6 +21,7 @@ import type {
   FunctionDefinition,
   FunctionParameter,
   FunctionParameterType,
+  ParameterHint,
 } from '../../../../types';
 import { type ISuggestionItem } from '../../../../../registry/types';
 import { FULL_TEXT_SEARCH_FUNCTIONS } from '../../../../constants';
@@ -29,6 +30,7 @@ import {
   valuePlaceholderConstant,
   defaultValuePlaceholderConstant,
 } from '../../../../../registry/complete_items';
+import { parametersFromHintsMap } from '../../parameters_from_hints';
 
 type FunctionParamContext = NonNullable<ExpressionContext['options']['functionParameterContext']>;
 
@@ -383,9 +385,9 @@ async function buildSuggestionsFromHints(
   paramDefinitions: FunctionParameter[],
   ctx: ExpressionContext
 ): Promise<ISuggestionItem[]> {
-  const hints = paramDefinitions
+  const hints: ParameterHint[] = paramDefinitions
     .filter((param) => param.hint !== undefined)
-    .map((param) => param.hint);
+    .map((param) => param.hint!);
 
   if (hints.length > 0) {
     return (

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
@@ -8,7 +8,7 @@
  */
 
 import { ControlTriggerSource, ESQLVariableType } from '@kbn/esql-types';
-import { uniq } from 'lodash';
+import { isEqual, uniq, uniqWith } from 'lodash';
 import { matchesSpecialFunction } from '../utils';
 import { shouldSuggestComma, type CommaContext } from '../comma_decision_engine';
 import type { ExpressionContext } from '../types';
@@ -385,9 +385,11 @@ async function buildSuggestionsFromHints(
   paramDefinitions: FunctionParameter[],
   ctx: ExpressionContext
 ): Promise<ISuggestionItem[]> {
-  const hints: ParameterHint[] = paramDefinitions
-    .filter((param) => param.hint !== undefined)
-    .map((param) => param.hint!);
+  // Keep the hints that are unique by entityType + constraints
+  const hints: ParameterHint[] = uniqWith(
+    paramDefinitions.filter((param) => param.hint !== undefined).map((param) => param.hint!),
+    (a, b) => a.entityType === b.entityType && isEqual(a.constraints, b.constraints)
+  );
 
   if (hints.length > 0) {
     return (

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/autocomplete/parameters_from_hints.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/autocomplete/parameters_from_hints.ts
@@ -7,15 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "async Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
- */
-
 import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import { i18n } from '@kbn/i18n';
 import type { ParameterHint, ParameterHintEntityType } from '../../..';
@@ -23,7 +14,21 @@ import type { ISuggestionItem } from '../../../registry/types';
 import type { ExpressionContext } from './expressions/types';
 import { createInferenceEndpointToCompletionItem } from './helpers';
 
-const inferenceEndpointHandler = async (hint: ParameterHint, ctx: ExpressionContext) => {
+/**
+ * For some parameters, ES gives as hints about the nature of it, that we use to provide
+ * custom autocompletion handlers.
+ */
+export const parametersFromHintsMap: Record<
+  ParameterHintEntityType,
+  (hint: ParameterHint, ctx: ExpressionContext) => Promise<ISuggestionItem[]>
+> = {
+  ['inference_endpoint']: inferenceEndpointHandler,
+};
+
+async function inferenceEndpointHandler(
+  hint: ParameterHint,
+  ctx: ExpressionContext
+): Promise<ISuggestionItem[]> {
   if (hint.constraints?.task_type) {
     const inferenceEnpoints =
       (
@@ -43,15 +48,4 @@ const inferenceEndpointHandler = async (hint: ParameterHint, ctx: ExpressionCont
     });
   }
   return [];
-};
-
-/**
- * For some parameters, ES gives as hints about the nature of it, that we use to provide
- * custom autocompletion handlers.
- */
-export const parametersFromHintsMap: Record<
-  ParameterHintEntityType,
-  (hint: ParameterHint, ctx: ExpressionContext) => Promise<ISuggestionItem[]>
-> = {
-  ['inference_endpoint']: inferenceEndpointHandler,
-};
+}

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/autocomplete/parameters_from_hints.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/autocomplete/parameters_from_hints.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "async Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
+import { i18n } from '@kbn/i18n';
+import type { ParameterHint, ParameterHintEntityType } from '../../..';
+import type { ISuggestionItem } from '../../../registry/types';
+import type { ExpressionContext } from './expressions/types';
+import { createInferenceEndpointToCompletionItem } from './helpers';
+
+const inferenceEndpointHandler = async (hint: ParameterHint, ctx: ExpressionContext) => {
+  if (hint.constraints?.task_type) {
+    const inferenceEnpoints =
+      (
+        await ctx.callbacks?.getInferenceEndpoints?.(
+          hint.constraints?.task_type as InferenceTaskType
+        )
+      )?.inferenceEndpoints || [];
+
+    return inferenceEnpoints.map(createInferenceEndpointToCompletionItem).map((item) => {
+      return {
+        ...item,
+        detail: i18n.translate('kbn-esql-ast.esql.definitions.inferenceEndpointInFunction', {
+          defaultMessage: 'Inference endpoint used for this function',
+        }),
+        text: `"${item.text}"`,
+      };
+    });
+  }
+  return [];
+};
+
+/**
+ * For some parameters, ES gives as hints about the nature of it, that we use to provide
+ * custom autocompletion handlers.
+ */
+export const parametersFromHintsMap: Record<
+  ParameterHintEntityType,
+  (hint: ParameterHint, ctx: ExpressionContext) => Promise<ISuggestionItem[]>
+> = {
+  ['inference_endpoint']: inferenceEndpointHandler,
+};

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/types.ts
@@ -13,9 +13,11 @@ import type {
   ESQLControlVariable,
   ESQLSourceResult,
   ESQLFieldWithMetadata,
+  InferenceEndpointsAutocompleteResult,
 } from '@kbn/esql-types';
 import type { LicenseType } from '@kbn/licensing-types';
 import type { PricingProduct } from '@kbn/core-pricing-common/src/types';
+import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import type { ESQLLocation } from '../../types';
 import type { SupportedDataType } from '../definitions/types';
 import type { EditorExtensions } from './options/recommended_queries';
@@ -138,6 +140,9 @@ export interface ICommandCallbacks {
   getJoinIndices?: () => Promise<{ indices: IndexAutocompleteItem[] }>;
   canCreateLookupIndex?: (indexName: string) => Promise<boolean>;
   isServerless?: boolean;
+  getInferenceEndpoints?: (
+    taskType: InferenceTaskType
+  ) => Promise<InferenceEndpointsAutocompleteResult>;
 }
 
 export interface ICommandContext {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/functions.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/functions.test.ts
@@ -2010,4 +2010,14 @@ describe('functions arg suggestions', () => {
       expect(labels).not.toContain(',');
     });
   });
+
+  describe('function parameter built from hint', () => {
+    it('suggests inference endpoints for TEXT_EMBEDDING function', async () => {
+      const { suggest } = await setup();
+      const suggestions = await suggest('FROM index | EVAL result = TEXT_EMBEDDING("text", /');
+      const labels = suggestions.map(({ label }) => label);
+
+      expect(labels).toEqual(['inference_1']);
+    });
+  });
 });

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -273,6 +273,7 @@ async function getSuggestionsWithinCommandExpression(
       hasMinimumLicenseRequired,
       canCreateLookupIndex: callbacks?.canCreateLookupIndex,
       isServerless: callbacks?.isServerless,
+      getInferenceEndpoints: callbacks?.getInferenceEndpoints,
     },
     context,
     offset

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/get_command_context.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/get_command_context.ts
@@ -24,6 +24,11 @@ export const getCommandContext = async (
       return {
         inferenceEndpoints,
       };
+    case 'rerank':
+      return {
+        inferenceEndpoints:
+          (await callbacks?.getInferenceEndpoints?.('rerank'))?.inferenceEndpoints || [],
+      };
     case 'enrich':
       const policies = await helpers.getPolicies();
       const policiesMap = new Map(policies.map((policy) => [policy.name, policy]));

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/get_command_context.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/get_command_context.ts
@@ -24,11 +24,6 @@ export const getCommandContext = async (
       return {
         inferenceEndpoints,
       };
-    case 'rerank':
-      return {
-        inferenceEndpoints:
-          (await callbacks?.getInferenceEndpoints?.('rerank'))?.inferenceEndpoints || [],
-      };
     case 'enrich':
       const policies = await helpers.getPolicies();
       const policiesMap = new Map(policies.map((policy) => [policy.name, policy]));


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/237794

## Summary
For some special function arguments ES is now providing information about how to resolve them. For instance, functions that accepts inference endpoints.

<img width="1169" height="301" alt="image" src="https://github.com/user-attachments/assets/9d3e212c-11dd-4a84-abfc-324587ea7c50" />
<img width="1163" height="261" alt="image" src="https://github.com/user-attachments/assets/9900a836-f82c-4d03-9126-bd63156fd2b6" />

This PR adds support for the `inference_endpoint` hint, and an easy way to extend it to other hints.

