### PR TITLE
[Agent Builder] Fix condition for showing conversation title + external menu link items

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_title.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/conversation_title.tsx
@@ -43,7 +43,7 @@ export const ConversationTitle: React.FC<ConversationTitleProps> = ({
   const [currentText, setCurrentText] = useState('');
 
   useEffect(() => {
-    if (isLoading) return;
+    if (isLoading || !hasActiveConversation) return;
 
     const fullText = title || labels.newConversation;
 
@@ -65,7 +65,7 @@ export const ConversationTitle: React.FC<ConversationTitleProps> = ({
 
     // Always track the previous title
     setPreviousTitle(fullText);
-  }, [title, currentText, isLoading, previousTitle]);
+  }, [title, currentText, isLoading, previousTitle, hasActiveConversation]);
 
   const displayedTitle = currentText || previousTitle;
 
@@ -78,7 +78,7 @@ export const ConversationTitle: React.FC<ConversationTitleProps> = ({
     setIsEditing(false);
   };
 
-  const shouldShowTitle = !isLoading;
+  const shouldShowTitle = hasActiveConversation;
   if (!shouldShowTitle) {
     return null;
   }

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/more_actions_button.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/conversations/conversation_header/more_actions_button.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { IconType } from '@elastic/eui';
 import {
   EuiContextMenuItem,
   EuiButtonIcon,
@@ -14,10 +13,7 @@ import {
   EuiContextMenuPanel,
   EuiTitle,
   EuiSpacer,
-  EuiIcon,
   useEuiTheme,
-  EuiFlexItem,
-  EuiFlexGroup,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
@@ -103,60 +99,6 @@ const MenuSectionTitle = ({ title }: { title: string }) => {
       </EuiTitle>
       <EuiSpacer size="s" />
     </>
-  );
-};
-
-interface ExternalLinkProps {
-  href: string;
-  icon: IconType;
-  children: React.ReactNode;
-  dataTestSubj: string;
-  onClick: () => void;
-}
-const ExternalLink = ({ href, icon, children, dataTestSubj, onClick }: ExternalLinkProps) => {
-  const { euiTheme } = useEuiTheme();
-
-  const containerStyles = css`
-    justify-content: space-between;
-    padding-left: ${euiTheme.size.s};
-
-    .externalLinkIcon {
-      opacity: 0;
-      transition: opacity ${euiTheme.animation.normal};
-    }
-
-    &:hover .externalLinkIcon {
-      opacity: 1;
-    }
-  `;
-
-  return (
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="s"
-      direction="row"
-      responsive={false}
-      css={containerStyles}
-      data-test-subj={dataTestSubj}
-    >
-      <EuiFlexGroup direction="row" gutterSize="s" responsive={false}>
-        <EuiIcon type={icon} color="text" size="m" />
-        {children}
-      </EuiFlexGroup>
-      <EuiFlexItem grow={false}>
-        <EuiButtonIcon
-          className="externalLinkIcon"
-          target="_blank"
-          rel="noopener noreferrer"
-          iconType="popout"
-          color="text"
-          size="m"
-          href={href}
-          aria-label={fullscreenLabels.externalLinkAriaLabel}
-          onClick={onClick}
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
   );
 };
 
@@ -252,35 +194,35 @@ export const MoreActionsButton: React.FC<MoreActionsButtonProps> = ({ onRenameCo
       key="management-title"
       title={fullscreenLabels.conversationManagementLabel}
     />,
-    <ExternalLink
+    <EuiContextMenuItem
       key="agents"
-      icon={() => <RobotIcon />}
+      icon={<RobotIcon />}
       onClick={closePopover}
       href={createOnechatUrl(appPaths.agents.list)}
-      dataTestSubj="onechatActionsAgents"
+      data-test-subj="onechatActionsAgents"
     >
       {fullscreenLabels.agents}
-    </ExternalLink>,
-    <ExternalLink
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem
       key="tools"
       icon="wrench"
       onClick={closePopover}
       href={createOnechatUrl(appPaths.tools.list)}
-      dataTestSubj="onechatActionsTools"
+      data-test-subj="onechatActionsTools"
     >
       {fullscreenLabels.tools}
-    </ExternalLink>,
+    </EuiContextMenuItem>,
     ...(hasAccessToGenAiSettings
       ? [
-          <ExternalLink
+          <EuiContextMenuItem
             key="agentBuilderSettings"
             icon="gear"
             onClick={closePopover}
             href={application.getUrlForApp('management', { path: '/ai/genAiSettings' })}
-            dataTestSubj="agentBuilderGenAiSettingsButton"
+            data-test-subj="agentBuilderGenAiSettingsButton"
           >
             {fullscreenLabels.genAiSettings}
-          </ExternalLink>,
+          </EuiContextMenuItem>,
         ]
       : []),
   ];


### PR DESCRIPTION
## Summary

- [x] Removes the external link option from items in the more actions button - we should not link externally, confirmed by Julian yesterday
<img width="252" height="309" alt="image" src="https://github.com/user-attachments/assets/a86265e7-5033-420a-9107-ed7bfdbb3a87" />

- [x] Updates the condition for when the conversation header is shown, it was incorrectly showing up "New conversation" before on the `/new` route if you changed the Agent selector as this adds an optimistic round



