### PR TITLE
unconditionally register intercept saved objects

### DIFF
--- a/x-pack/platform/plugins/private/intercepts/server/plugin.test.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/plugin.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { coreMock } from '@kbn/core/server/mocks';
+import { createUsageCollectionSetupMock } from '@kbn/usage-collection-plugin/server/mocks';
+import { InterceptsServerPlugin } from './plugin';
+import {
+  interceptTriggerRecordSavedObject,
+  interceptInteractionUserRecordSavedObject,
+} from './saved_objects';
+
+describe('InterceptsServerPlugin', () => {
+  let interceptsPlugin: InterceptsServerPlugin;
+  let coreSetupMock: ReturnType<typeof coreMock.createSetup>;
+  const usageCollectionSetupMock = createUsageCollectionSetupMock();
+  const initContext = coreMock.createPluginInitializerContext();
+
+  beforeEach(() => {
+    interceptsPlugin = new InterceptsServerPlugin(initContext);
+  });
+
+  describe('setup', () => {
+    it('should register the backing saved object types for the intercept plugin', () => {
+      coreSetupMock = coreMock.createSetup();
+
+      interceptsPlugin.setup(coreSetupMock, { usageCollection: usageCollectionSetupMock });
+
+      expect(coreSetupMock.savedObjects.registerType).toHaveBeenCalledWith(
+        interceptTriggerRecordSavedObject
+      );
+
+      expect(coreSetupMock.savedObjects.registerType).toHaveBeenCalledWith(
+        interceptInteractionUserRecordSavedObject
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/private/intercepts/server/plugin.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/plugin.ts
@@ -15,6 +15,10 @@ import {
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import { InterceptsTriggerOrchestrator } from './orchestrator';
 import type { ServerConfigSchema } from '../common/config';
+import {
+  interceptTriggerRecordSavedObject,
+  interceptInteractionUserRecordSavedObject,
+} from './saved_objects';
 
 interface InterceptsServerSetupDeps {
   usageCollection?: UsageCollectionSetup;
@@ -37,6 +41,11 @@ export class InterceptsServerPlugin
   }
 
   public setup(core: CoreSetup, { usageCollection }: InterceptsServerSetupDeps) {
+    // Always register saved objects unconditionally to ensure mappings are created
+    // during setup, regardless of plugin configuration or node roles
+    core.savedObjects.registerType(interceptTriggerRecordSavedObject);
+    core.savedObjects.registerType(interceptInteractionUserRecordSavedObject);
+
     this.interceptsOrchestrator?.setup(core, {
       logger: this.logger,
       kibanaVersion: this.initContext.env.packageInfo.version,

--- a/x-pack/platform/plugins/private/intercepts/server/services/intercept_trigger.test.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/services/intercept_trigger.test.ts
@@ -18,24 +18,6 @@ const usageCollectionSetupMock = createUsageCollectionSetupMock();
 describe('InterceptTriggerService', () => {
   const usageCounter = usageCollectionSetupMock.createUsageCounter('interceptsTriggerTest');
 
-  describe('#setup', () => {
-    it('invoking setup registers the backing saved object', () => {
-      const interceptTrigger = new InterceptTriggerService();
-
-      const coreSetupMock = coreMock.createSetup();
-
-      interceptTrigger.setup(coreSetupMock, {
-        logger: loggerMock.create(),
-        kibanaVersion: '9.1.0',
-        usageCollector: usageCounter,
-      });
-
-      expect(coreSetupMock.savedObjects.registerType).toHaveBeenCalledWith(
-        interceptTriggerRecordSavedObject
-      );
-    });
-  });
-
   describe('#start', () => {
     it('should return a specific of properties', () => {
       const interceptTrigger = new InterceptTriggerService();

--- a/x-pack/platform/plugins/private/intercepts/server/services/intercept_trigger.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/services/intercept_trigger.ts
@@ -39,8 +39,6 @@ export class InterceptTriggerService {
     this.kibanaVersion = kibanaVersion;
     this.counter = getCounters(usageCollector);
 
-    core.savedObjects.registerType(this.savedObjectRef);
-
     return {
       fetchRegisteredTask: this.fetchRegisteredTask.bind(this),
     };

--- a/x-pack/platform/plugins/private/intercepts/server/services/intercept_user_interaction.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/services/intercept_user_interaction.ts
@@ -26,8 +26,6 @@ export class InterceptUserInteractionService {
   private savedObjectRef = interceptInteractionUserRecordSavedObject;
 
   setup(core: CoreSetup, logger: Logger) {
-    core.savedObjects.registerType(this.savedObjectRef);
-
     const router = core.http.createRouter<RequestHandlerContext>();
 
     router.get(

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/intercepts/interaction_apis.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/intercepts/interaction_apis.ts
@@ -13,9 +13,6 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   const roleScopedSupertest = getService('roleScopedSupertest');
 
   describe('Intercept User Interaction APIs', function () {
-    // failsOnMKI, see https://github.com/elastic/kibana/issues/246120
-    this.tags(['failsOnMKI']);
-
     describe(`GET ${TRIGGER_USER_INTERACTION_METADATA_API_ROUTE}`, () => {
       it('should return 200 with empty object when no interaction exists', async () => {
         const supertest = await roleScopedSupertest.getSupertestWithRoleScope('viewer', {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/intercepts/trigger_apis.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/intercepts/trigger_apis.ts
@@ -15,9 +15,6 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
 
   describe('Intercept Trigger APIs', function () {
-    // failsOnMKI, see https://github.com/elastic/kibana/issues/246120
-    this.tags(['failsOnMKI']);
-
     before(async () => {
       await kibanaServer.savedObjects.clean({
         types: [interceptTriggerRecordSavedObject.name],


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/246120

What resulted in test failures? 

https://github.com/elastic/kibana/pull/242358 introduced changes that setup intercepts conditionally ([see](https://github.com/elastic/kibana/pull/242358/files#diff-e5efcd489d0ec57f80904c6e96f87183e43757661455bbd0561cc8cfe4dd3d88R34)), and we had test that were directly trying to create a record for these saved object types that were expected to have been registered hence the error we saw, we typically wouldn't get this issue for real users, because in UI nodes the saved object would have been registered. 

This PR makes it so that the backing saved object are always registered regardless of the node type, however for nodes other than the UI node we still keep it such that the intercept doesn't get instantiated.


## How to verify that this change resolves the failing test on MKI locally

The following steps assumes you have qaf configured, with a user having the `viewer` role in the qa environment

- create a project with qaf like so;
	```
	KIBANA_DOCKER_IMAGE=docker.elastic.co/kibana-ci/kibana-serverless:pr-246512-2f19a7d78cc8 \
	qaf elastic-cloud projects create \
	  --project-type elasticsearch \
	  --project-name custom-kibana-pr-246512 \
	  --environment qa \
	  --region aws-eu-west-1 \
	  --es-docker-image current-dev
	```

- When this completes, run the command below to ascertain that no intercept tests fail;
	```
	KIBANA_REPO_ROOT=. qaf kibana ftr run-config \
	  --ec-project-name custom-kibana-pr-246512 \
	   x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/search.serverless.config.ts
	```

<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->