### PR TITLE
[ResponseOps][Core][SavedObjects] Fix SO getFieldsByQueryType not detecting deeply nested fields

### DIFF
--- a/src/core/packages/saved-objects/api-server-internal/src/lib/search/search_dsl/query_params.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/search/search_dsl/query_params.test.ts
@@ -727,6 +727,9 @@ describe('#getQueryParams', () => {
                 key: {
                   type: 'keyword',
                 },
+                deep: {
+                  type: 'flattened',
+                },
               },
             },
           },
@@ -765,6 +768,26 @@ describe('#getQueryParams', () => {
         expect(nestedQueryClause.query.simple_query_string.query).toBe('foo');
         expect(nestedQueryClause.query.simple_query_string.fields).toEqual([
           'nestedtype.title.value',
+        ]);
+      });
+
+      it('supports deeply nested fields', () => {
+        const result = getQueryParams({
+          registry,
+          search: 'foo',
+          searchFields: ['title.deep.someField'],
+          type: ['nestedtype'],
+          mappings: nestedFieldMappings,
+        });
+
+        const mustClause = result.query.bool.must;
+        expect(mustClause.length).toBe(1);
+        const nestedQueryClause = mustClause[0].nested;
+
+        expect(nestedQueryClause.path).toBe('nestedtype.title');
+        expect(nestedQueryClause.query.simple_query_string.query).toBe('foo');
+        expect(nestedQueryClause.query.simple_query_string.fields).toEqual([
+          'nestedtype.title.deep.someField',
         ]);
       });
 


### PR DESCRIPTION
## 📄 Summary

- Fixes the `nested` mapped fields detection in the Saved Objects find query generation not considering deeply nested fields.
- Adds test coverage for deeply nested fields queries.

<details>
<summary>

## 🧪 Verification steps

</summary>

1. Create SOs with a nested field with deep subfields, for example alerting rules having actions with specific parameters (i.e. email connector with a `To` recipient email).
2. Query those SOs by deeply nested fields. I.E.:
  ```
  GET kbn:/api/alerting/rules/_find?search=<email_recipient>&search_fields=actions.params.to
  ```
3. Check that the search result matches the correct SO

</details>

## ⏪ Backport rationale

Backporting since this is a bug fix

## 🔗 References

Issue https://github.com/elastic/kibana/issues/246513

## Release Notes

## ☑️ Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.