### PR TITLE
[Search] Add the update ELSER to ELSER on EIS callout to the index details overview tab

### DIFF
--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_update_callout.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_update_callout.tsx
@@ -29,6 +29,7 @@ export interface EisUpdateCalloutProps {
   handleOnClick: () => void;
   direction: 'row' | 'column';
   hasUpdatePrivileges: boolean | undefined;
+  addSpacer?: 'top' | 'bottom';
 }
 
 export const EisUpdateCallout = ({
@@ -38,6 +39,7 @@ export const EisUpdateCallout = ({
   handleOnClick,
   direction,
   hasUpdatePrivileges,
+  addSpacer,
 }: EisUpdateCalloutProps) => {
   const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
     promoId: `${promoId}UpdateCallout`,
@@ -50,50 +52,54 @@ export const EisUpdateCallout = ({
   }
 
   return (
-    <EuiCallOut
-      data-telemetry-id={dataId}
-      data-test-subj={dataId}
-      css={({ euiTheme }) => ({
-        color: euiTheme.colors.primaryText,
-        backgroundColor: `${euiTheme.colors.backgroundBaseSubdued}`,
-        border: `${euiTheme.border.thin}`,
-        borderRadius: `${euiTheme.border.radius.medium}`,
-      })}
-      onDismiss={onDismissTour}
-    >
-      <EuiFlexGroup direction={direction} alignItems="flexStart">
-        <EuiImage src={searchRocketIcon} alt="" size="original" />
-        <div>
-          <EuiTitle>
-            <h4>{i18n.EIS_CALLOUT_TITLE}</h4>
-          </EuiTitle>
-          <EuiText color="subdued" size="s">
-            <p>{i18n.EIS_UPDATE_CALLOUT_DESCRIPTION}</p>
-          </EuiText>
-          <EuiSpacer size="m" />
-          <EuiFlexGroup direction="row" gutterSize="m" alignItems="center">
-            <EuiButton
-              fullWidth={false}
-              color="text"
-              size="s"
-              onClick={handleOnClick}
-              data-test-subj="eisUpdateCalloutCtaBtn"
-              data-telemetry-id={`${dataId}-cta-btn`}
-            >
-              {i18n.EIS_UPDATE_CALLOUT_CTA}
-            </EuiButton>
-            <EuiLink
-              href={ctaLink}
-              target="_blank"
-              external
-              color="text"
-              data-telemetry-id={`${dataId}-docs-btn`}
-            >
-              {i18n.EIS_CALLOUT_DOCUMENTATION_BTN}
-            </EuiLink>
-          </EuiFlexGroup>
-        </div>
-      </EuiFlexGroup>
-    </EuiCallOut>
+    <>
+      {addSpacer === 'top' && <EuiSpacer size="l" />}
+      <EuiCallOut
+        data-telemetry-id={dataId}
+        data-test-subj={dataId}
+        css={({ euiTheme }) => ({
+          color: euiTheme.colors.primaryText,
+          backgroundColor: `${euiTheme.colors.backgroundBaseSubdued}`,
+          border: `${euiTheme.border.thin}`,
+          borderRadius: `${euiTheme.border.radius.medium}`,
+        })}
+        onDismiss={onDismissTour}
+      >
+        <EuiFlexGroup direction={direction} alignItems="flexStart">
+          <EuiImage src={searchRocketIcon} alt="" size="original" />
+          <div>
+            <EuiTitle>
+              <h4>{i18n.EIS_CALLOUT_TITLE}</h4>
+            </EuiTitle>
+            <EuiText color="subdued" size="s">
+              <p>{i18n.EIS_UPDATE_CALLOUT_DESCRIPTION}</p>
+            </EuiText>
+            <EuiSpacer size="m" />
+            <EuiFlexGroup direction="row" gutterSize="m" alignItems="center">
+              <EuiButton
+                fullWidth={false}
+                color="text"
+                size="s"
+                onClick={handleOnClick}
+                data-test-subj="eisUpdateCalloutCtaBtn"
+                data-telemetry-id={`${dataId}-cta-btn`}
+              >
+                {i18n.EIS_UPDATE_CALLOUT_CTA}
+              </EuiButton>
+              <EuiLink
+                href={ctaLink}
+                target="_blank"
+                external
+                color="text"
+                data-telemetry-id={`${dataId}-docs-btn`}
+              >
+                {i18n.EIS_CALLOUT_DOCUMENTATION_BTN}
+              </EuiLink>
+            </EuiFlexGroup>
+          </div>
+        </EuiFlexGroup>
+      </EuiCallOut>
+      {addSpacer === 'bottom' && <EuiSpacer size="l" />}
+    </>
   );
 };

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/index_details_page.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/index_details_page.test.tsx
@@ -116,16 +116,16 @@ describe('<IndexDetailsPage />', () => {
     });
 
     it('resends a request when reload button is clicked', async () => {
-      // already sent 4 requests while setting up the component
-      const numberOfRequests = 4;
+      // already sent 5 requests while setting up the component
+      const numberOfRequests = 5;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
       await testBed.actions.errorSection.clickReloadButton();
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests + 1);
     });
 
     it('renders an error section when no index name is provided', async () => {
-      // already sent 2 requests while setting up the component
-      const numberOfRequests = 4;
+      // already sent 5 requests while setting up the component
+      const numberOfRequests = 5;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
       await act(async () => {
         testBed = await setup({ httpSetup, initialEntry: '/indices/index_details' });
@@ -295,8 +295,8 @@ describe('<IndexDetailsPage />', () => {
       });
 
       it('resends a request when reload button is clicked', async () => {
-        // already sent 7 requests while setting up the component
-        const numberOfRequests = 7;
+        // already sent 9 requests while setting up the component
+        const numberOfRequests = 9;
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
         await testBed.actions.stats.clickErrorReloadButton();
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests + 1);
@@ -468,8 +468,8 @@ describe('<IndexDetailsPage />', () => {
           `Data streamUnable to load data stream detailsReloadLast update`
         );
 
-        // already sent 7 requests while setting up the component
-        const numberOfRequests = 7;
+        // already sent 9 requests while setting up the component
+        const numberOfRequests = 9;
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
         await testBed.actions.overview.reloadDataStreamDetails();
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests + 1);
@@ -785,7 +785,7 @@ describe('<IndexDetailsPage />', () => {
           body: '{"name":{"type":"text"}}',
         });
 
-        expect(httpSetup.get).toHaveBeenCalledTimes(9);
+        expect(httpSetup.get).toHaveBeenCalledTimes(11);
         expect(httpSetup.get).toHaveBeenLastCalledWith(
           `${API_BASE_PATH}/mapping/${testIndexName}`,
           requestOptions
@@ -987,8 +987,8 @@ describe('<IndexDetailsPage />', () => {
       });
 
       it('resends a request when reload button is clicked', async () => {
-        // already sent 8 requests while setting up the component
-        const numberOfRequests = 8;
+        // already sent 10 requests while setting up the component
+        const numberOfRequests = 10;
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
         await testBed.actions.mappings.clickErrorReloadButton();
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests + 1);
@@ -1061,8 +1061,8 @@ describe('<IndexDetailsPage />', () => {
       });
 
       it('resends a request when reload button is clicked', async () => {
-        // already sent 7 requests while setting up the component
-        const numberOfRequests = 7;
+        // already sent 9 requests while setting up the component
+        const numberOfRequests = 9;
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
         await testBed.actions.settings.clickErrorReloadButton();
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests + 1);
@@ -1113,7 +1113,7 @@ describe('<IndexDetailsPage />', () => {
       });
 
       it('reloads the settings after an update', async () => {
-        const numberOfRequests = 4;
+        const numberOfRequests = 5;
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
         const updatedSettings = { ...testIndexEditableSettingsAll, 'index.priority': '2' };
         await testBed.actions.settings.updateCodeEditorContent(JSON.stringify(updatedSettings));
@@ -1175,8 +1175,8 @@ describe('<IndexDetailsPage />', () => {
     });
 
     it('closes an index', async () => {
-      // already sent 3 requests while setting up the component
-      const numberOfRequests = 3;
+      // already sent 4 requests while setting up the component
+      const numberOfRequests = 4;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1198,8 +1198,8 @@ describe('<IndexDetailsPage />', () => {
       });
       testBed.component.update();
 
-      // already sent 6 requests while setting up the component
-      const numberOfRequests = 6;
+      // already sent 8 requests while setting up the component
+      const numberOfRequests = 8;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1211,8 +1211,8 @@ describe('<IndexDetailsPage />', () => {
     });
 
     it('forcemerges an index', async () => {
-      // already sent 3 request while setting up the component
-      const numberOfRequests = 3;
+      // already sent 4 requests while setting up the component
+      const numberOfRequests = 4;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1225,8 +1225,8 @@ describe('<IndexDetailsPage />', () => {
     });
 
     it('refreshes an index', async () => {
-      // already sent 3 request while setting up the component
-      const numberOfRequests = 3;
+      // already sent 4 requests while setting up the component
+      const numberOfRequests = 4;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1238,8 +1238,8 @@ describe('<IndexDetailsPage />', () => {
     });
 
     it(`clears an index's cache`, async () => {
-      // already sent 3 request while setting up the component
-      const numberOfRequests = 3;
+      // already sent 4 requests while setting up the component
+      const numberOfRequests = 4;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1251,8 +1251,8 @@ describe('<IndexDetailsPage />', () => {
     });
 
     it(`flushes an index`, async () => {
-      // already sent 3 requests while setting up the component
-      const numberOfRequests = 3;
+      // already sent 4 requests while setting up the component
+      const numberOfRequests = 4;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1265,8 +1265,8 @@ describe('<IndexDetailsPage />', () => {
 
     it(`deletes an index`, async () => {
       jest.spyOn(testBed.routerMock.history, 'push');
-      // already sent 1 request while setting up the component
-      const numberOfRequests = 3;
+      // already sent 4 requests while setting up the component
+      const numberOfRequests = 4;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
@@ -28,17 +28,24 @@ import {
   getLanguageDefinitionCodeSnippet,
   getConsoleRequest,
   EisCloudConnectPromoCallout,
+  EisUpdateCallout,
 } from '@kbn/search-api-panels';
 import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 import type { Index } from '../../../../../../../common';
 import { useAppContext } from '../../../../../app_context';
-import { documentationService } from '../../../../../services';
+import { documentationService, useLoadIndexMappings } from '../../../../../services';
 import { languageDefinitions, curlDefinition } from './languages';
 import { StatusDetails } from './status_details';
 import { DataStreamDetails } from './data_stream_details';
 import { StorageDetails } from './storage_details';
 import { AliasesDetails } from './aliases_details';
 import { SizeDocCountDetails } from './size_doc_count_details';
+
+import { UpdateElserMappingsModal } from '../update_elser_mappings/update_elser_mappings_modal';
+import { useMappingsState } from '../../../../../components/mappings_editor/mappings_state_context';
+import { hasElserOnMlNodeSemanticTextField } from '../../../../../components/mappings_editor/lib/utils';
+import { useMappingsStateListener } from '../../../../../components/mappings_editor/use_state_listener';
+import { parseMappings } from '../../../../../shared/parse_mappings';
 
 interface Props {
   indexDetails: Index;
@@ -60,19 +67,21 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
   } = indexDetails;
   const {
     core,
-    plugins,
+    plugins: { cloud, share },
     services: { extensionsService },
   } = useAppContext();
+  const state = useMappingsState();
+  const { data: mappingsData, resendRequest } = useLoadIndexMappings(name || '');
 
   const [selectedLanguage, setSelectedLanguage] = useState<LanguageDefinition>(curlDefinition);
-
   const [elasticsearchUrl, setElasticsearchUrl] = useState<string>('');
+  const hasElserOnMlNodeSemanticText = hasElserOnMlNodeSemanticTextField(state.mappingViewFields);
+  const [isUpdatingElserMappings, setIsUpdatingElserMappings] = useState<boolean>(false);
 
-  useEffect(() => {
-    plugins.cloud?.fetchElasticsearchConfig().then((config) => {
-      setElasticsearchUrl(config.elasticsearchUrl || 'https://your_deployment_url');
-    });
-  }, [plugins.cloud]);
+  // Setting undefined here because we don't have user privileges data in index management
+  // If the user doesn't have update mappings privileges we let the api handle the error
+  // TODO: Add route and api to get user privileges data in index management plugin
+  const hasUpdateMappingsPrivileges = undefined;
 
   const codeSnippetArguments: LanguageDefinitionSnippetArguments = {
     url: elasticsearchUrl,
@@ -82,15 +91,48 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
 
   const isLarge = useIsWithinBreakpoints(['xl']);
 
+  const { parsedDefaultValue } = useMemo(
+    () => parseMappings(mappingsData ?? undefined),
+    [mappingsData]
+  );
+
+  useMappingsStateListener({ value: parsedDefaultValue, status: 'disabled' });
+
+  useEffect(() => {
+    cloud?.fetchElasticsearchConfig().then((config) => {
+      setElasticsearchUrl(config.elasticsearchUrl || 'https://your_deployment_url');
+    });
+  }, [cloud]);
+
   return (
     <>
       <EisCloudConnectPromoCallout
         promoId="indexDetailsOverview"
-        isSelfManaged={!plugins.cloud?.isCloudEnabled}
+        isSelfManaged={!cloud?.isCloudEnabled}
         direction="row"
         navigateToApp={() => core.application.navigateToApp(CLOUD_CONNECT_NAV_ID)}
         addSpacer="bottom"
       />
+      {hasElserOnMlNodeSemanticText && (
+        <EisUpdateCallout
+          ctaLink={documentationService.docLinks.enterpriseSearch.elasticInferenceService}
+          promoId="indexDetailsOverview"
+          isCloudEnabled={cloud?.isCloudEnabled ?? false}
+          handleOnClick={() => setIsUpdatingElserMappings(true)}
+          direction="row"
+          hasUpdatePrivileges={hasUpdateMappingsPrivileges}
+          addSpacer="bottom"
+        />
+      )}
+      {isUpdatingElserMappings && (
+        <UpdateElserMappingsModal
+          indexName={name}
+          refetchMapping={resendRequest}
+          setIsModalOpen={setIsUpdatingElserMappings}
+          hasUpdatePrivileges={hasUpdateMappingsPrivileges}
+        />
+      )}
+
       <EuiFlexGrid columns={isLarge ? 3 : 1}>
         <StorageDetails size={size} primarySize={primarySize} primary={primary} replica={replica} />
 
@@ -161,7 +203,7 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
               selectedLanguage={selectedLanguage}
               setSelectedLanguage={setSelectedLanguage}
               assetBasePath={core.http.basePath.prepend(`/plugins/indexManagement/assets`)}
-              sharePlugin={plugins.share}
+              sharePlugin={share}
               application={core.application}
               consoleRequest={getConsoleRequest('ingestDataIndex', codeSnippetArguments)}
             />


### PR DESCRIPTION
## Summary

This PR adds the update ELSER to ELSER on EIS callout to the overview tab of the index details page. 

### Acceptance criteria
The callout should:
- [ ] appear in the overview tab of the index details page (classic nav view)
- [ ] only be shown for cloud users (although the overview tab is only used on ECH)
- [ ] only show if the user has semantic text field mappings with the `.elser-2-elasticsearch` inference endpoint
- [ ] allow the user the select the fields they want to update, and on applying the update, only the selected fields should be updated
- [ ] disappear when there are no more semantic text field mappings with the `.elser-2-elasticsearch` inference endpoint

### Testing

To can mock an ECH environment locally you'll need add the following to your `kibana.dev.yml`:

```
xpack.cloud:
  id: 'LOCAL_DEV:ZmFrZS5lbHN0Yy5jbyRsb2NhbF9kZXYuZXMkbG9jYWxfZGV2LmtiCg=='
  base_url: 'https://fake-cloud.elastic.co'
```

You will also need to have EIS running locally. You can find instructions on how to do this in the [Inference team FAQs](https://docs.elastic.dev/search-team/teams/inference/faq#how-can-i-run-eis-locally-in-kibana).

**Note**: In those instructions there's an example command for running Elasticsearch. Use this command: `yarn es snapshot --license trial -E xpack.inference.elastic.url=https://localhost:8443 -E xpack.inference.elastic.http.ssl.verification_mode=none`

Once you have Kibana running with EIS, the following command can be run in the Kibana console to quickly create an index with `.elser-2-elasticsearch` semantic text mappings:

```
PUT /update_elser_to_eis
{
  "mappings": {
    "properties": {
      "name": {
        "type": "semantic_text",
        "inference_id": ".elser-2-elasticsearch"
      },
      "address": {
        "type": "semantic_text",
        "inference_id": ".elser-2-elastic"
      },
    }
  }
}
```
Once you have your environment set up and your index created, make sure you are viewing Kibana in a `Classic` space. This should be the default, so you probably won't need to do anything. Navigate to the Index Management page. It will load on the Overview tab, which is where you can test the acceptance criteria.

### Screenshot
<img width="1508" height="827" alt="Screenshot 2025-12-16 at 10 24 52" src="https://github.com/user-attachments/assets/620d2131-795b-48aa-8e4d-614e2e8e581d" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines]~(https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~


