### PR TITLE
[skip] Skipping createIndex test in actions_suite_test.ts

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
@@ -1809,7 +1809,8 @@ export const runActionTestSuite = ({
     });
   });
 
-  describe('createIndex', () => {
+  // Fails on 9.1: https://github.com/elastic/kibana/issues/188962
+  describe.skip('createIndex', () => {
     afterEach(async () => {
       // Restore the default setting of 1000 shards per node
       await client.cluster.putSettings({ persistent: { cluster: { max_shards_per_node: null } } });


### PR DESCRIPTION
## Summary
Manually skipping a suite, the `/skip` command didn't seem to take effect
Relates to: https://github.com/elastic/kibana/issues/188962