### PR TITLE
Retry on "all shards failed" from ES

### DIFF
--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.test.ts
@@ -86,7 +86,7 @@ describe('catchRetryableEsClientErrors', () => {
 });
 
 describe('catchRetryableSearchPhaseExecutionException', () => {
-  it('retries search phase execution exception ', async () => {
+  it('retries search phase execution exception', async () => {
     const error = new esErrors.ResponseError(
       elasticsearchClientMock.createApiResponse({
         body: {
@@ -111,6 +111,34 @@ describe('catchRetryableSearchPhaseExecutionException', () => {
         "message": "search_phase_execution_exception
       	Caused by:
       		search_phase_execution_exception: Search rejected due to missing shards [.kibana]. Consider using \`allow_partial_search_results\` setting to bypass this error.",
+        "type": "retryable_es_client_error",
+      }
+    `);
+  });
+  it('retries search phase execution exception for "all shards failed"', async () => {
+    const error = new esErrors.ResponseError(
+      elasticsearchClientMock.createApiResponse({
+        body: {
+          error: {
+            type: 'search_phase_execution_exception',
+            caused_by: {
+              type: 'search_phase_execution_exception',
+              reason: 'all shards failed',
+            },
+          },
+        },
+      })
+    );
+    expect(
+      ((await Promise.reject(error).catch(catchRetryableSearchPhaseExecutionException)) as any).left
+    ).toMatchInlineSnapshot(`
+      Object {
+        "error": [ResponseError: search_phase_execution_exception
+      	Caused by:
+      		search_phase_execution_exception: all shards failed],
+        "message": "search_phase_execution_exception
+      	Caused by:
+      		search_phase_execution_exception: all shards failed",
         "type": "retryable_es_client_error",
       }
     `);


### PR DESCRIPTION
## Summary

We are observing Pod restarts on Serverless during Kibana bootstrap (migration) process, with the following error:

```
Reason: Unable to complete saved object migrations for the [.kibana] index. Error: pickupUpdatedMappings task failed with the following error:
{"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":".kibana_1","node":"iu4ANm6gTQO8eQyvnWGdkw","reason":{"type":"no_shard_available_action_exception","reason":"[es-es-search-6b8cf96d57-rvnz4][100.66.190.214:9300][indices:data/read/search[phase/query]]"}}]}
```

It seems that the Kibana Pods bootstrap normally after the restart, so we can assume that the `all shards failed` is a temporary condition of ES upon which we can retry.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->