### PR TITLE
[Hardening] Added check for set function with string array path

### DIFF
--- a/src/platform/packages/shared/kbn-safer-lodash-set/lodash/_baseSet.js
+++ b/src/platform/packages/shared/kbn-safer-lodash-set/lodash/_baseSet.js
@@ -43,6 +43,10 @@ function baseSet(object, path, value, customizer) {
       throw new Error('Illegal access of function prototype')
     }
 
+    if (key == 'prototype' && index > 0 && path[index - 1] == 'constructor') {
+      throw new Error('Illegal access of constructor.prototype')
+    }
+
     if (index != lastIndex) {
       var objValue = hasOwnProperty.call(nested, key) ? nested[key] : undefined
       newValue = customizer ? customizer(objValue, key, nested) : undefined;

--- a/src/platform/packages/shared/kbn-safer-lodash-set/lodash/_baseSet.js
+++ b/src/platform/packages/shared/kbn-safer-lodash-set/lodash/_baseSet.js
@@ -44,6 +44,7 @@ function baseSet(object, path, value, customizer) {
     }
 
     if (key == 'prototype' && index > 0 && path[index - 1] == 'constructor') {
+      console.log('Illegal access of constructor.prototype', key, index, path[index - 1]);
       throw new Error('Illegal access of constructor.prototype')
     }
 

--- a/src/platform/packages/shared/kbn-safer-lodash-set/test/fp_patch_test.js
+++ b/src/platform/packages/shared/kbn-safer-lodash-set/test/fp_patch_test.js
@@ -153,10 +153,10 @@ setFunctions.forEach(([testPermutations, set, testName]) => {
     ['o.prototype', { o: { prototype: 'foo' } }],
     ['a[0].prototype', { a: [{ prototype: 'foo' }] }],
 
-    ['constructor.prototype', { constructor: { prototype: 'foo' } }],
-    ['.constructor.prototype', { '': { constructor: { prototype: 'foo' } } }],
-    ['o.constructor.prototype', { o: { constructor: { prototype: 'foo' } } }],
-    ['a[0].constructor.prototype', { a: [{ constructor: { prototype: 'foo' } }] }],
+    // ['constructor.prototype', { constructor: { prototype: 'foo' } }],
+    // ['.constructor.prototype', { '': { constructor: { prototype: 'foo' } } }],
+    // ['o.constructor.prototype', { o: { constructor: { prototype: 'foo' } } }],
+    // ['a[0].constructor.prototype', { a: [{ constructor: { prototype: 'foo' } }] }],
 
     ['constructor.something.prototype', { constructor: { something: { prototype: 'foo' } } }],
     [

--- a/src/platform/packages/shared/kbn-safer-lodash-set/test/patch_test.js
+++ b/src/platform/packages/shared/kbn-safer-lodash-set/test/patch_test.js
@@ -83,11 +83,6 @@ setAndSetWithFunctions.forEach(([set, testName]) => {
     ['o.prototype', { o: { prototype: 'foo' } }],
     ['a[0].prototype', { a: [{ prototype: 'foo' }] }],
 
-    ['constructor.prototype', { constructor: { prototype: 'foo' } }],
-    ['.constructor.prototype', { '': { constructor: { prototype: 'foo' } } }],
-    ['o.constructor.prototype', { o: { constructor: { prototype: 'foo' } } }],
-    ['a[0].constructor.prototype', { a: [{ constructor: { prototype: 'foo' } }] }],
-
     ['constructor.something.prototype', { constructor: { something: { prototype: 'foo' } } }],
     [
       '.constructor.something.prototype',
@@ -140,6 +135,10 @@ setAndSetWithFunctions.forEach(([set, testName]) => {
       [['constructor', 'prototype'], 'foo'],
       [['a', 'constructor', 'prototype'], 'foo'],
       [['a', 'b', 'constructor', 'prototype'], 'polluted'],
+      ['constructor.prototype', { constructor: { prototype: 'foo' } }],
+      ['.constructor.prototype', { '': { constructor: { prototype: 'foo' } } }],
+      ['o.constructor.prototype', { o: { constructor: { prototype: 'foo' } } }],
+      ['a[0].constructor.prototype', { a: [{ constructor: { prototype: 'foo' } }] }],
     ];
     constructorPrototypeTestCases.forEach(([path, value]) => {
       t.throws(() => set({}, path, value), /Illegal access of constructor\.prototype/);

--- a/src/platform/packages/shared/kbn-safer-lodash-set/test/patch_test.js
+++ b/src/platform/packages/shared/kbn-safer-lodash-set/test/patch_test.js
@@ -134,6 +134,18 @@ setAndSetWithFunctions.forEach(([set, testName]) => {
     });
     t.end();
   });
+
+  test(`${testName}: constructor.prototype pollution protection`, (t) => {
+    const constructorPrototypeTestCases = [
+      [['constructor', 'prototype'], 'foo'],
+      [['a', 'constructor', 'prototype'], 'foo'],
+      [['a', 'b', 'constructor', 'prototype'], 'polluted'],
+    ];
+    constructorPrototypeTestCases.forEach(([path, value]) => {
+      t.throws(() => set({}, path, value), /Illegal access of constructor\.prototype/);
+    });
+    t.end();
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

Handles cases when path is a string array


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



