### PR TITLE
[Discover] Use the updated label-board mappings for Github actions

### DIFF
--- a/.github/workflows/pm-map-labels-to-fields.yml
+++ b/.github/workflows/pm-map-labels-to-fields.yml
@@ -43,6 +43,7 @@ jobs:
           all: 'true'
           project-number: 787
           owner: 'elastic'
+          mapping: 'mapping-sizes-and-impact-p787.json'
 
       - name: Update every issue in project 859 (https://github.com/orgs/elastic/projects/859)
         uses: ./actions/github-projects/map-labels


### PR DESCRIPTION
## Summary

Follow up for https://github.com/elastic/kibana-github-actions/pull/65
I think this separate configuration was not applied before.





