### PR TITLE
[fix] Ignore typescript error

### DIFF
--- a/x-pack/solutions/chat/packages/wci-server/src/utils/create_external_client.ts
+++ b/x-pack/solutions/chat/packages/wci-server/src/utils/create_external_client.ts
@@ -32,11 +32,7 @@ export const getConnectToExternalServer = ({
         version: '1.0.0',
       },
       {
-        capabilities: {
-          prompts: {},
-          resources: {},
-          tools: {},
-        },
+        capabilities: {},
       }
     );
 


### PR DESCRIPTION
## Summary
This probably went unnoticed because of the typescript cache got stuck, and only started to show up after a few days of not having the type archives available.

Errors show up like:
```
proc [tsc] x-pack/solutions/chat/packages/wci-server/src/utils/create_external_client.ts:36:11 - error TS2353: Object literal may only specify known properties, and 'prompts' does not exist in type '{ experimental?: { [x: string]: object; } \| undefined; sampling?: { context?: object \| undefined; tools?: object \| undefined; } \| undefined; elicitation?: { [x: string]: unknown; form?: { [x: string]: unknown; applyDefaults?: boolean \| undefined; } \| undefined; url?: object \| undefined; } \| undefined; roots?: { ...;...'.
--
proc [tsc]
proc [tsc] 36           prompts: {},
proc [tsc]              ~~~~~~~
proc [tsc]
```