### PR TITLE
[CPS] replace ALL project_routing value to alias:*

### DIFF
--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker.test.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker.test.tsx
@@ -103,7 +103,7 @@ describe('ProjectPicker', () => {
   });
 
   describe('projectRouting change events', () => {
-    it('should call onProjectRoutingChange with ALL when "All projects" is clicked', async () => {
+    it('should call onProjectRoutingChange with PROJECT_ROUTING.ALL when "All projects" is clicked', async () => {
       const onProjectRoutingChange = jest.fn();
       await renderProjectPicker({
         projectRouting: PROJECT_ROUTING.ORIGIN,

--- a/src/platform/packages/shared/kbn-cps-utils/constants.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/constants.ts
@@ -13,7 +13,7 @@
  */
 export const PROJECT_ROUTING = {
   /** Search across all linked projects */
-  ALL: 'ALL',
+  ALL: '_alias:*',
   /** Search only the origin project */
   ORIGIN: '_alias:_origin',
 } as const;

--- a/src/platform/packages/shared/kbn-cps-utils/types.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/types.ts
@@ -50,4 +50,5 @@ export interface ICPSManager {
   getProjectRouting(): ProjectRouting | undefined;
   getDefaultProjectRouting(): ProjectRouting;
   getProjectPickerAccess$(): Observable<ProjectRoutingAccess>;
+  getProjectPickerAccess(): ProjectRoutingAccess;
 }

--- a/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.test.ts
+++ b/src/platform/plugins/private/vis_types/vega/public/data_model/search_api.test.ts
@@ -138,8 +138,4 @@ describe('SearchAPI projectRouting', () => {
   test('should not include project_routing in ES params when projectRouting is undefined', (done) => {
     testProjectRouting(undefined, undefined, done);
   });
-
-  test('should sanitize ALL projectRouting value', (done) => {
-    testProjectRouting('ALL', undefined, done);
-  });
 });

--- a/src/platform/plugins/shared/cps/public/services/access_control.test.ts
+++ b/src/platform/plugins/shared/cps/public/services/access_control.test.ts
@@ -8,11 +8,7 @@
  */
 
 import { ProjectRoutingAccess } from '@kbn/cps-utils';
-import {
-  getProjectRoutingAccess,
-  DEFAULT_ACCESS_CONTROL_CONFIG,
-  type AccessControlConfig,
-} from './access_control';
+import { ACCESS_CONTROL_CONFIG, getProjectRoutingAccess } from './access_control';
 
 describe('Access Control Configuration', () => {
   describe('getProjectRoutingAccess', () => {
@@ -65,85 +61,33 @@ describe('Access Control Configuration', () => {
       });
     });
 
-    describe('with custom configuration', () => {
-      const customConfig: AccessControlConfig = {
-        myApp: {
-          defaultAccess: ProjectRoutingAccess.EDITABLE,
-        },
-        customApp: {
-          defaultAccess: ProjectRoutingAccess.DISABLED,
-          routeRules: [
-            {
-              pattern: /^#\/special/,
-              access: ProjectRoutingAccess.EDITABLE,
-            },
-          ],
-        },
-      };
-
-      it('should use custom app configuration', () => {
-        expect(getProjectRoutingAccess('myApp', '#/anything', customConfig)).toBe(
-          ProjectRoutingAccess.EDITABLE
-        );
-      });
-
-      it('should match route rules before defaultAccess', () => {
-        expect(getProjectRoutingAccess('customApp', '#/special/page', customConfig)).toBe(
-          ProjectRoutingAccess.EDITABLE
-        );
-        expect(getProjectRoutingAccess('customApp', '#/normal/page', customConfig)).toBe(
-          ProjectRoutingAccess.DISABLED
-        );
-      });
-
-      it('should return DISABLED for unconfigured apps', () => {
-        expect(getProjectRoutingAccess('unknownApp', '#/', customConfig)).toBe(
-          ProjectRoutingAccess.DISABLED
-        );
-      });
-    });
-
     describe('route rule priority', () => {
-      const config: AccessControlConfig = {
-        testApp: {
-          defaultAccess: ProjectRoutingAccess.DISABLED,
-          routeRules: [
-            {
-              pattern: /^#\/admin/,
-              access: ProjectRoutingAccess.READONLY,
-            },
-            {
-              pattern: /^#\/edit/,
-              access: ProjectRoutingAccess.EDITABLE,
-            },
-          ],
-        },
-      };
-
-      it('should check rules in order', () => {
-        expect(getProjectRoutingAccess('testApp', '#/admin/settings', config)).toBe(
-          ProjectRoutingAccess.READONLY
-        );
-        expect(getProjectRoutingAccess('testApp', '#/edit/document', config)).toBe(
+      it('should check rules in order and match pattern before defaulting', () => {
+        // Rule matches: type:vega pattern -> EDITABLE (overrides DISABLED default)
+        expect(getProjectRoutingAccess('visualize', '#/edit/123?type:vega')).toBe(
           ProjectRoutingAccess.EDITABLE
         );
-        expect(getProjectRoutingAccess('testApp', '#/view/document', config)).toBe(
+        // No rule match: falls back to defaultAccess -> DISABLED
+        expect(getProjectRoutingAccess('visualize', '#/edit/456?type:lens')).toBe(
+          ProjectRoutingAccess.DISABLED
+        );
+        expect(getProjectRoutingAccess('visualize', '#/create')).toBe(
           ProjectRoutingAccess.DISABLED
         );
       });
     });
   });
 
-  describe('DEFAULT_ACCESS_CONTROL_CONFIG', () => {
+  describe('ACCESS_CONTROL_CONFIG', () => {
     it('should have configuration for expected apps', () => {
-      expect(DEFAULT_ACCESS_CONTROL_CONFIG).toHaveProperty('dashboards');
-      expect(DEFAULT_ACCESS_CONTROL_CONFIG).toHaveProperty('discover');
-      expect(DEFAULT_ACCESS_CONTROL_CONFIG).toHaveProperty('visualize');
-      expect(DEFAULT_ACCESS_CONTROL_CONFIG).toHaveProperty('lens');
+      expect(ACCESS_CONTROL_CONFIG).toHaveProperty('dashboards');
+      expect(ACCESS_CONTROL_CONFIG).toHaveProperty('discover');
+      expect(ACCESS_CONTROL_CONFIG).toHaveProperty('visualize');
+      expect(ACCESS_CONTROL_CONFIG).toHaveProperty('lens');
     });
 
     it('should have route rules for dashboards', () => {
-      expect(DEFAULT_ACCESS_CONTROL_CONFIG.dashboards.routeRules).toHaveLength(1);
+      expect(ACCESS_CONTROL_CONFIG.dashboards.routeRules).toHaveLength(1);
     });
   });
 });

--- a/src/platform/plugins/shared/cps/public/services/access_control.ts
+++ b/src/platform/plugins/shared/cps/public/services/access_control.ts
@@ -45,20 +45,8 @@ export type AccessControlConfig = Record<string, AppAccessConfig>;
  * - READONLY: View-only mode - shows current scope but prevents changes
  * - DISABLED: Picker is completely disabled
  *
- * Default Configuration:
- *
- * | App        | Route                  | Access Level | Notes                              |
- * |------------|------------------------|--------------|-------------------------------------|
- * | dashboards | all routes except list | EDITABLE     | All dashboard pages except listing  |
- * | dashboards | #/list                 | DISABLED     | List page only                     |
- * | discover   | all routes             | EDITABLE     | All discover pages                 |
- * | visualize  | type:vega in route     | EDITABLE     | Vega visualizations only           |
- * | visualize  | other routes           | DISABLED     | Other visualization types          |
- * | lens       | all routes             | EDITABLE     | All lens pages       |
- * | maps       | all routes             | EDITABLE     | All maps pages
- * | all others | all routes             | DISABLED     | Default behavior for unknown apps  |
  */
-export const DEFAULT_ACCESS_CONTROL_CONFIG: AccessControlConfig = {
+export const ACCESS_CONTROL_CONFIG: AccessControlConfig = {
   dashboards: {
     defaultAccess: ProjectRoutingAccess.EDITABLE,
     routeRules: [
@@ -93,10 +81,9 @@ export const DEFAULT_ACCESS_CONTROL_CONFIG: AccessControlConfig = {
  */
 export const getProjectRoutingAccess = (
   currentAppId: string,
-  hash: string,
-  config: AccessControlConfig = DEFAULT_ACCESS_CONTROL_CONFIG
+  hash: string
 ): ProjectRoutingAccess => {
-  const appConfig = config[currentAppId];
+  const appConfig = ACCESS_CONTROL_CONFIG[currentAppId];
   if (!appConfig) {
     return ProjectRoutingAccess.DISABLED;
   }

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/project_routing_manager.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/project_routing_manager.test.ts
@@ -67,30 +67,30 @@ describe('projectRouting', () => {
     expect(manager!.api.projectRouting$.value).toBe('_alias:_origin');
 
     manager!.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
-      // When projectRoutingRestore is true, changing to 'ALL' is detected
+      // When projectRoutingRestore is true, changing to '_alias:*' is detected
       expect(changes).toEqual({
-        project_routing: 'ALL',
+        project_routing: '_alias:*',
       });
       done();
     });
 
-    manager!.api.setProjectRouting('ALL');
+    manager!.api.setProjectRouting('_alias:*');
   });
 
-  test('Should detect change when setting projectRouting to ALL from undefined', (done) => {
+  test('Should detect change when setting projectRouting to _alias:* from undefined', (done) => {
     const { manager } = initManager(true);
     const lastSavedState$ = createLastSavedState();
 
     manager!.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
-      // When projectRoutingRestore is true, setting to 'ALL' should be detected as a change
+      // When projectRoutingRestore is true, setting to '_alias:*' should be detected as a change
       expect(changes).toEqual({
-        project_routing: 'ALL',
+        project_routing: '_alias:*',
       });
       done();
     });
 
-    // Setting to 'ALL' when projectRoutingRestore is true should be detected
-    manager!.api.setProjectRouting('ALL');
+    // Setting to '_alias:*' when projectRoutingRestore is true should be detected
+    manager!.api.setProjectRouting('_alias:*');
   });
 
   test('Should restore projectRouting in reset', () => {
@@ -143,28 +143,28 @@ describe('projectRouting', () => {
   test('Should save current routing when projectRoutingRestore is true', () => {
     const { manager } = initManager(true);
 
-    // Set projectRouting to 'ALL'
-    manager!.api.setProjectRouting('ALL');
+    // Set projectRouting to '_alias:*'
+    manager!.api.setProjectRouting('_alias:*');
     const state = manager!.internalApi.getState();
 
-    // projectRouting should be saved as 'ALL' when projectRoutingRestore is true
-    expect(state.project_routing).toBe('ALL');
+    // projectRouting should be saved as '_alias:*' when projectRoutingRestore is true
+    expect(state.project_routing).toBe('_alias:*');
   });
 
   test('Should distinguish between ALL (saved with all projects) and undefined (not saved)', () => {
-    const { manager } = initManager(true, 'ALL');
+    const { manager } = initManager(true, '_alias:*');
 
-    // Should initialize with 'ALL' from saved state
-    expect(manager!.api.projectRouting$.value).toBe('ALL');
+    // Should initialize with '_alias:*' from saved state
+    expect(manager!.api.projectRouting$.value).toBe('_alias:*');
 
     const state = manager!.internalApi.getState();
-    // getState should return 'ALL' when projectRouting is 'ALL'
-    expect(state.project_routing).toBe('ALL');
+    // getState should return '_alias:*' when projectRouting is '_alias:*'
+    expect(state.project_routing).toBe('_alias:*');
   });
 
   test('Should not detect change when projectRouting remains the same', (done) => {
-    const { manager } = initManager(true, 'ALL');
-    const lastSavedState$ = createLastSavedState('ALL');
+    const { manager } = initManager(true, '_alias:*');
+    const lastSavedState$ = createLastSavedState('_alias:*');
 
     manager!.internalApi.startComparing$(lastSavedState$).subscribe((changes) => {
       // When projectRouting is set to the same value as saved, no change detected
@@ -173,7 +173,7 @@ describe('projectRouting', () => {
     });
 
     // Set to same value as saved state - should not detect a change
-    manager!.api.setProjectRouting('ALL');
+    manager!.api.setProjectRouting('_alias:*');
   });
 
   test('Should return undefined when CPS is not enabled', () => {

--- a/src/platform/plugins/shared/visualizations/public/embeddable/get_expression_renderer_props.test.ts
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/get_expression_renderer_props.test.ts
@@ -109,7 +109,7 @@ describe('getExpressionRendererProps', () => {
           query: { query: '', language: 'kuery' },
           filters: [],
         },
-        projectRouting: 'ALL',
+        projectRouting: '_alias:*',
         timeRange: { from: 'now-15m', to: 'now' },
         disableTriggers: false,
         settings: {
@@ -126,7 +126,7 @@ describe('getExpressionRendererProps', () => {
       expect(result.params).toBeDefined();
       expect(result.params?.searchContext).toEqual(
         expect.objectContaining({
-          projectRouting: 'ALL',
+          projectRouting: '_alias:*',
         })
       );
     });


### PR DESCRIPTION
## Summary

**1. Replaced special runtime value sanitization**

Changed the `ALL` const to `_alias:*` - it is a correct value for ES `project_routing` param. Even though it ultimately gets sanitized to `undefined` and isn’t sent, maintaining this parity is safer. 

**2. Removed some unnecessary comments and complexity for cps access (no need to be able to pass a custom config)**
**3. Exposing `getProjectPickerAccess` externally**
