### PR TITLE
[Reporting] Cap browser zoom and allow downscaling for large screenshots

### DIFF
--- a/x-pack/platform/plugins/shared/screenshotting/server/layouts/preserve_layout.test.ts
+++ b/x-pack/platform/plugins/shared/screenshotting/server/layouts/preserve_layout.test.ts
@@ -58,3 +58,19 @@ it('preserve layout allows customizable selectors', () => {
     }
   `);
 });
+
+it('preserve layout caps browser zoom for extremely large screenshots to avoid Chromium artifacts', () => {
+  // A very tall layout would exceed common graphics limits at zoom=2.
+  // (height * 2) would be 53608 which is > 32767.
+  const testPreserveLayout = new PreserveLayout({ width: 1727, height: 26804 });
+
+  // The zoom should be reduced so that output height stays <= 32767 pixels.
+  expect(testPreserveLayout.getBrowserZoom()).toBeLessThan(2);
+  expect(testPreserveLayout.getBrowserViewport().height).toBeLessThanOrEqual(32767);
+});
+
+it('preserve layout allows downscaling for very large dimensions', () => {
+  const testPreserveLayout = new PreserveLayout({ width: 1000, height: 200000 });
+  expect(testPreserveLayout.getBrowserZoom()).toBeGreaterThan(0);
+  expect(testPreserveLayout.getBrowserViewport().height).toBeLessThanOrEqual(32767);
+});


### PR DESCRIPTION
## Summary



### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
