### PR TITLE
[9.1] [Infra] Fix legacy Infra search client to respect the frozen tier setting (#246438)

### DIFF
--- a/x-pack/platform/plugins/shared/logs_shared/public/services/log_views/exclude_tiers_query.ts
+++ b/x-pack/platform/plugins/shared/logs_shared/public/services/log_views/exclude_tiers_query.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+
+export function excludeTiersQuery(
+  excludedDataTiers: Array<'data_frozen' | 'data_cold' | 'data_warm' | 'data_hot'>
+): estypes.QueryDslQueryContainer[] {
+  return [
+    {
+      bool: {
+        must_not: [
+          {
+            terms: {
+              _tier: excludedDataTiers,
+            },
+          },
+        ],
+      },
+    },
+  ];
+}

--- a/x-pack/platform/plugins/shared/logs_shared/public/services/log_views/types.ts
+++ b/x-pack/platform/plugins/shared/logs_shared/public/services/log_views/types.ts
@@ -10,7 +10,8 @@ import { ISearchStart } from '@kbn/data-plugin/public';
 import { DataViewsContract } from '@kbn/data-views-plugin/public';
 import { LogSourcesService } from '@kbn/logs-data-access-plugin/common/types';
 import type { DataView, DataViewLazy } from '@kbn/data-views-plugin/common';
-import {
+import type { IUiSettingsClient } from '@kbn/core/public';
+import type {
   LogView,
   LogViewAttributes,
   LogViewReference,
@@ -36,7 +37,10 @@ export interface LogViewsServiceStartDeps {
 
 export interface ILogViewsClient {
   getLogView(logViewReference: LogViewReference): Promise<LogView>;
-  getResolvedLogViewStatus(resolvedLogView: ResolvedLogView<DataView>): Promise<LogViewStatus>;
+  getResolvedLogViewStatus(
+    resolvedLogView: ResolvedLogView<DataView>,
+    uiSettings?: IUiSettingsClient
+  ): Promise<LogViewStatus>;
   getResolvedLogView(logViewReference: LogViewReference): Promise<ResolvedLogView<DataView>>;
   putLogView(
     logViewReference: LogViewReference,

--- a/x-pack/solutions/observability/plugins/infra/public/utils/logs_overview_fetchers.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/utils/logs_overview_fetchers.ts
@@ -13,6 +13,8 @@ import type {
 } from '@kbn/observability-plugin/public';
 import { DEFAULT_LOG_VIEW, getLogsLocatorFromUrlService } from '@kbn/logs-shared-plugin/common';
 import moment from 'moment';
+import type { IUiSettingsClient } from '@kbn/core/public';
+import type { DataTier } from '@kbn/observability-shared-plugin/common';
 import { TIMESTAMP_FIELD } from '../../common/constants';
 import type { InfraClientStartDeps, InfraClientStartServicesAccessor } from '../types';
 
@@ -38,10 +40,11 @@ type StatsAndSeries = Pick<LogsFetchDataResponse, 'stats' | 'series'>;
 
 export function getLogsHasDataFetcher(getStartServices: InfraClientStartServicesAccessor) {
   return async () => {
-    const [, { logsShared }] = await getStartServices();
+    const [coreStart, { logsShared }] = await getStartServices();
     const resolvedLogView = await logsShared.logViews.client.getResolvedLogView(DEFAULT_LOG_VIEW);
     const logViewStatus = await logsShared.logViews.client.getResolvedLogViewStatus(
-      resolvedLogView
+      resolvedLogView,
+      coreStart.uiSettings
     );
 
     const hasData = logViewStatus.index === 'available';
@@ -58,7 +61,7 @@ export function getLogsOverviewDataFetcher(
   getStartServices: InfraClientStartServicesAccessor
 ): FetchData<LogsFetchDataResponse> {
   return async (params) => {
-    const [, { data, logsShared, share }] = await getStartServices();
+    const [coreStart, { data, logsShared, share }] = await getStartServices();
     const resolvedLogView = await logsShared.logViews.client.getResolvedLogView(DEFAULT_LOG_VIEW);
 
     const { stats, series } = await fetchLogsOverview(
@@ -66,7 +69,8 @@ export function getLogsOverviewDataFetcher(
         index: resolvedLogView.indices,
       },
       params,
-      data
+      data,
+      coreStart.uiSettings
     );
     const logsLocator = getLogsLocatorFromUrlService(share.url)!;
     const timeSpanInMinutes = (params.absoluteTime.end - params.absoluteTime.start) / (1000 * 60);
@@ -89,8 +93,12 @@ export function getLogsOverviewDataFetcher(
 async function fetchLogsOverview(
   logParams: LogParams,
   params: FetchDataParams,
-  dataPlugin: InfraClientStartDeps['data']
+  dataPlugin: InfraClientStartDeps['data'],
+  uiSettings: IUiSettingsClient
 ): Promise<StatsAndSeries> {
+  const excludedDataTiers =
+    uiSettings?.get<DataTier[]>('observability:searchExcludedDataTiers') ?? [];
+
   return new Promise((resolve, reject) => {
     let esResponse: estypes.SearchResponse<any> | undefined;
 
@@ -100,7 +108,7 @@ async function fetchLogsOverview(
           index: logParams.index,
           body: {
             size: 0,
-            query: buildLogOverviewQuery(logParams, params),
+            query: buildLogOverviewQuery(params, excludedDataTiers),
             aggs: buildLogOverviewAggregations(logParams, params),
           },
         },
@@ -119,14 +127,21 @@ async function fetchLogsOverview(
   });
 }
 
-function buildLogOverviewQuery(logParams: LogParams, params: FetchDataParams) {
+function buildLogOverviewQuery(params: FetchDataParams, excludedDataTiers: DataTier[]) {
   return {
-    range: {
-      [TIMESTAMP_FIELD]: {
-        gt: new Date(params.absoluteTime.start).toISOString(),
-        lte: new Date(params.absoluteTime.end).toISOString(),
-        format: 'strict_date_optional_time',
-      },
+    bool: {
+      must: [
+        {
+          range: {
+            [TIMESTAMP_FIELD]: {
+              gt: new Date(params.absoluteTime.start).toISOString(),
+              lte: new Date(params.absoluteTime.end).toISOString(),
+              format: 'strict_date_optional_time',
+            },
+          },
+        },
+      ],
+      must_not: excludedDataTiers.length ? [{ terms: { _tier: excludedDataTiers } }] : undefined,
     },
   };
 }

--- a/x-pack/solutions/observability/plugins/infra/server/lib/create_search_client.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/create_search_client.ts
@@ -6,6 +6,9 @@
  */
 
 import type { KibanaRequest } from '@kbn/core/server';
+import { searchExcludedDataTiers } from '@kbn/observability-plugin/common/ui_settings_keys';
+import type { DataTier } from '@kbn/observability-shared-plugin/common';
+import { excludeTiersQuery } from '@kbn/observability-utils-common/es/queries/exclude_tiers_query';
 import type { InfraPluginRequestHandlerContext } from '../types';
 import type { CallWithRequestParams, InfraDatabaseSearchResponse } from './adapters/framework';
 import type { KibanaFramework } from './adapters/framework/kibana_framework_adapter';
@@ -16,7 +19,32 @@ export const createSearchClient =
     framework: KibanaFramework,
     request?: KibanaRequest
   ) =>
-  <Hit = {}, Aggregation = undefined>(
+  async <Hit = {}, Aggregation = undefined>(
     opts: CallWithRequestParams
-  ): Promise<InfraDatabaseSearchResponse<Hit, Aggregation>> =>
-    framework.callWithRequest(requestContext, 'search', opts, request);
+  ): Promise<InfraDatabaseSearchResponse<Hit, Aggregation>> => {
+    const { uiSettings } = await requestContext.core;
+
+    const excludedDataTiers = await uiSettings.client.get<DataTier[]>(searchExcludedDataTiers);
+
+    const excludedQuery = excludedDataTiers.length
+      ? excludeTiersQuery(excludedDataTiers)
+      : undefined;
+
+    return framework.callWithRequest(
+      requestContext,
+      'search',
+      {
+        ...opts,
+        body: {
+          ...(opts.body ?? {}),
+          query: {
+            bool: {
+              ...(opts.body?.query ? { must: [opts.body?.query] } : {}),
+              filter: excludedQuery,
+            },
+          },
+        },
+      },
+      request
+    );
+  };

--- a/x-pack/solutions/observability/plugins/infra/server/routes/metrics_sources/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/metrics_sources/index.ts
@@ -186,7 +186,7 @@ export const initMetricsSourceConfigurationRoutes = (libs: InfraBackendLibs) => 
     async (requestContext, request, response) => {
       const { sourceId } = request.params;
 
-      const client = createSearchClient(requestContext, framework);
+      const client = await createSearchClient(requestContext, framework);
       const soClient = (await requestContext.core).savedObjects.client;
       const source = await libs.sources.getSourceConfiguration(soClient, sourceId);
 

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/index.ts
@@ -23,7 +23,7 @@ export const initOverviewRoute = (libs: InfraBackendLibs) => {
     },
     async (requestContext, request, response) => {
       const options = request.body;
-      const client = createSearchClient(requestContext, framework);
+      const client = await createSearchClient(requestContext, framework);
       const soClient = (await requestContext.core).savedObjects.client;
       const source = await libs.sources.getSourceConfiguration(soClient, options.sourceId);
 

--- a/x-pack/solutions/observability/plugins/infra/server/routes/snapshot/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/snapshot/index.ts
@@ -57,7 +57,7 @@ export const initSnapshotRoute = (libs: InfraBackendLibs) => {
           );
 
         UsageCollector.countNode(snapshotRequest.nodeType);
-        const client = createSearchClient(requestContext, framework, request);
+        const client = await createSearchClient(requestContext, framework, request);
 
         const snapshotResponse = await getNodes(
           client,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/server/lib/create_search_client.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/server/lib/create_search_client.ts
@@ -6,12 +6,36 @@
  */
 
 import type { RequestHandlerContext } from '@kbn/core/server';
-import type { CallWithRequestParams, InfraDatabaseSearchResponse } from './adapters/framework';
+import type { DataTier } from '@kbn/observability-shared-plugin/common';
+import { excludeTiersQuery } from '@kbn/observability-utils-common/es/queries/exclude_tiers_query';
 import type { KibanaFramework } from './adapters/framework/kibana_framework_adapter';
+import type { CallWithRequestParams, InfraDatabaseSearchResponse } from './adapters/framework';
 
 export const createSearchClient =
   (requestContext: RequestHandlerContext, framework: KibanaFramework) =>
-  <Hit = {}, Aggregation = undefined>(
+  async <Hit = {}, Aggregation = undefined>(
     opts: CallWithRequestParams
-  ): Promise<InfraDatabaseSearchResponse<Hit, Aggregation>> =>
-    framework.callWithRequest(requestContext, 'search', opts);
+  ): Promise<InfraDatabaseSearchResponse<Hit, Aggregation>> => {
+    const { uiSettings } = await requestContext.core;
+
+    const excludedDataTiers = await uiSettings.client.get<DataTier[]>(
+      'observability:searchExcludedDataTiers'
+    );
+
+    const excludedQuery = excludedDataTiers.length
+      ? excludeTiersQuery(excludedDataTiers)
+      : undefined;
+
+    return framework.callWithRequest(requestContext, 'search', {
+      ...opts,
+      body: {
+        ...(opts.body ?? {}),
+        query: {
+          bool: {
+            ...(opts.body?.query ? { must: [opts.body?.query] } : {}),
+            filter: excludedQuery,
+          },
+        },
+      },
+    });
+  };

--- a/x-pack/solutions/observability/plugins/metrics_data_access/server/routes/metrics_explorer/index.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/server/routes/metrics_explorer/index.ts
@@ -41,7 +41,7 @@ export const initMetricExplorerRoute = (framework: KibanaFramework) => {
           );
         }
 
-        const client = createSearchClient(requestContext, framework);
+        const client = await createSearchClient(requestContext, framework);
         const interval = await findIntervalForMetrics(client, options);
 
         const optionsWithInterval = options.forceInterval

--- a/x-pack/solutions/observability/plugins/metrics_data_access/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/tsconfig.json
@@ -35,6 +35,7 @@
     "@kbn/lens-embeddable-utils",
     "@kbn/react-kibana-context-render",
     "@kbn/react-kibana-context-theme",
-    "@kbn/router-utils"
+    "@kbn/router-utils",
+    "@kbn/observability-utils-common"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Infra] Fix legacy Infra search client to respect the frozen tier setting (#246438)](https://github.com/elastic/kibana/pull/246438)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-16T15:25:48Z","message":"[Infra] Fix legacy Infra search client to respect the frozen tier setting (#246438)\n\n## Summary\n\nBasically what this https://github.com/elastic/kibana/pull/245224 does,\nbut focusing only on the Infra plugin changes\n\n`has_data` endpoint will run this when the setting is not set\n\n```json\n{\n  \"index\": \"remote_cluster:metrics-*,remote_cluster:metricbeat-*\",\n  \"allow_no_indices\": true,\n  \"terminate_after\": 1,\n  \"ignore_unavailable\": true,\n  \"body\": {\n    \"size\": 0,\n    \"query\": {\n      \"bool\": {}\n    }\n  }\n}\n```\n\nand this when the setting is set\n\n```json\nparams {\n  \"index\": \"remote_cluster:metrics-*,remote_cluster:metricbeat-*\",\n  \"allow_no_indices\": true,\n  \"terminate_after\": 1,\n  \"ignore_unavailable\": true,\n  \"body\": {\n    \"size\": 0,\n    \"query\": {\n      \"bool\": {\n        \"filter\": [\n          {\n            \"bool\": {\n              \"must_not\": [\n                {\n                  \"terms\": {\n                    \"_tier\": [\n                      \"data_frozen\"\n                    ]\n                  }\n                }\n              ]\n            }\n          }\n        ]\n      }\n    }\n  }\n}\n```\n\nOther pages are affected by this change, but are not a source for the\nfrozen tier being hit because they don't run unbounded queries\n\n- Infra Inventory UI\n```json\nparams {\n  \"allow_no_indices\": true,\n  \"ignore_unavailable\": true,\n  \"index\": \"remote_cluster:metrics-*,remote_cluster:metricbeat-*\",\n  \"body\": {\n    \"size\": 0,\n    \"query\": {\n      \"bool\": {\n        \"must\": [\n          {\n            \"bool\": {\n              \"filter\": [\n                {\n                  \"bool\": {\n                    \"filter\": [\n                      {\n                        \"bool\": {\n                          \"filter\": [\n                            {\n                              \"term\": {\n                                \"data_stream.dataset\": \"hostmetricsreceiver.otel\"\n                              }\n                            }\n                          ]\n                        }\n                      }\n                    ]\n                  }\n                },\n                {\n                  \"range\": {\n                    \"@timestamp\": {\n                      \"gte\": 1765824423511,\n                      \"lte\": 1765824723511,\n                      \"format\": \"epoch_millis\"\n                    }\n                  }\n                },\n                {\n                  \"exists\": {\n                    \"field\": \"host.name\"\n                  }\n                }\n              ]\n            }\n          }\n        ],\n        \"filter\": [\n          {\n            \"bool\": {\n              \"must_not\": [\n                {\n                  \"terms\": {\n                    \"_tier\": [\n                      \"data_frozen\"\n                    ]\n                  }\n                }\n              ]\n            }\n          }\n        ]\n      }\n    },\n    \"aggs\": {\n      \"groupings\": {\n        \"composite\": {\n          \"size\": 2000,\n          \"sources\": [\n            {\n              \"groupBy0\": {\n                \"terms\": {\n                  \"field\": \"host.name\"\n                }\n              }\n            }\n          ]\n        },\n        \"aggs\": {\n          \"histogram\": {\n            \"date_histogram\": {\n              \"field\": \"@timestamp\",\n              \"fixed_interval\": \"60s\",\n              \"offset\": \"-57511ms\",\n              \"extended_bounds\": {\n                \"min\": 1765824423511,\n                \"max\": 1765824723511\n              }\n            },\n            \"aggregations\": {\n              \"cpu_idle\": {\n                \"terms\": {\n                  \"field\": \"state\",\n                  \"include\": [\n                    \"idle\",\n                    \"wait\"\n                  ]\n                },\n                \"aggs\": {\n                  \"avg\": {\n                    \"avg\": {\n                      \"field\": \"system.cpu.utilization\"\n                    }\n                  }\n                }\n              },\n              \"cpu_idle_total\": {\n                \"sum_bucket\": {\n                  \"buckets_path\": \"cpu_idle.avg\"\n                }\n              },\n              \"cpuV2\": {\n                \"bucket_script\": {\n                  \"buckets_path\": {\n                    \"cpuIdleTotal\": \"cpu_idle_total\"\n                  },\n                  \"script\": \"1 - params.cpuIdleTotal\",\n                  \"gap_policy\": \"skip\"\n                }\n              },\n              \"__metadata__\": {\n                \"top_metrics\": {\n                  \"size\": 1,\n                  \"metrics\": [\n                    {\n                      \"field\": \"host.name\"\n                    },\n                    {\n                      \"field\": \"host.ip\"\n                    },\n                    {\n                      \"field\": \"host.os.name\"\n                    },\n                    {\n                      \"field\": \"cloud.provider\"\n                    }\n                  ],\n                  \"sort\": {\n                    \"@timestamp\": \"desc\"\n                  }\n                }\n              }\n            }\n          },\n          \"metricsets\": {\n            \"terms\": {\n              \"field\": \"metricset.name\"\n            }\n          }\n        }\n      }\n    }\n  }\n}\n```\n- Metrics Explorer\n\n```json\n{\n  \"allow_no_indices\": true,\n  \"ignore_unavailable\": true,\n  \"index\": \"remote_cluster:metrics-*,remote_cluster:metricbeat-*\",\n  \"body\": {\n    \"size\": 0,\n    \"query\": {\n      \"bool\": {\n        \"must\": [\n          {\n            \"bool\": {\n              \"filter\": [\n                null,\n                {\n                  \"range\": {\n                    \"@timestamp\": {\n                      \"gte\": 1765821298325,\n                      \"lte\": 1765824898325,\n                      \"format\": \"epoch_millis\"\n                    }\n                  }\n                }\n              ]\n            }\n          }\n        ],\n        \"filter\": [\n          {\n            \"bool\": {\n              \"must_not\": [\n                {\n                  \"terms\": {\n                    \"_tier\": [\n                      \"data_frozen\"\n                    ]\n                  }\n                }\n              ]\n            }\n          }\n        ]\n      }\n    },\n    \"aggs\": {\n      \"histogram\": {\n        \"date_histogram\": {\n          \"field\": \"@timestamp\",\n          \"fixed_interval\": \"30s\",\n          \"offset\": \"0s\",\n          \"extended_bounds\": {\n            \"min\": 1765821298325,\n            \"max\": 1765824898325\n          }\n        },\n        \"aggregations\": {\n          \"metric_0\": {\n            \"avg\": {\n              \"field\": \"system.cpu.total.norm.pct\"\n            }\n          },\n          \"metric_1\": {\n            \"avg\": {\n              \"field\": \"kubernetes.pod.cpu.usage.node.pct\"\n            }\n          },\n          \"metric_2\": {\n            \"avg\": {\n              \"field\": \"docker.cpu.total.pct\"\n            }\n          }\n        }\n      },\n      \"metricsets\": {\n        \"terms\": {\n          \"field\": \"metricset.name\"\n        }\n      }\n    }\n  }\n}\n```\n\n---------\n\nCo-authored-by: Nathan L Smith <nathan.smith@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Caue Marcondes <caue.marcondes@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Coen Warmer <coen.warmer@gmail.com>","sha":"aedfb94b2118c1e925e5678c585ab2093b04ed12","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.1.0","v8.19.0","v9.2.0","v9.3.0","ci:beta-faster-pr-build","Team:obs-presentation","v9.1.9"],"title":"[Infra] Fix legacy Infra search client to respect the frozen tier setting","number":246438,"url":"https://github.com/elastic/kibana/pull/246438","mergeCommit":{"message":"[Infra] Fix legacy Infra search client to respect the frozen tier setting (#246438)\n\n## Summary\n\nBasically what this https://github.com/elastic/kibana/pull/245224 does,\nbut focusing only on the Infra plugin changes\n\n`has_data` endpoint will run this when the setting is not set\n\n```json\n{\n  \"index\": \"remote_cluster:metrics-*,remote_cluster:metricbeat-*\",\n  \"allow_no_indices\": true,\n  \"terminate_after\": 1,\n  \"ignore_unavailable\": true,\n  \"body\": {\n    \"size\": 0,\n    \"query\": {\n      \"bool\": {}\n    }\n  }\n}\n```\n\nand this when the setting is set\n\n```json\nparams {\n  \"index\": \"remote_cluster:metrics-*,remote_cluster:metricbeat-*\",\n  \"allow_no_indices\": true,\n  \"terminate_after\": 1,\n  \"ignore_unavailable\": true,\n  \"body\": {\n    \"size\": 0,\n    \"query\": {\n      \"bool\": {\n        \"filter\": [\n          {\n            \"bool\": {\n              \"must_not\": [\n                {\n                  \"terms\": {\n                    \"_tier\": [\n                      \"data_frozen\"\n                    ]\n                  }\n                }\n              ]\n            }\n          }\n        ]\n      }\n    }\n  }\n}\n```\n\nOther pages are affected by this change, but are not a source for the\nfrozen tier being hit because they don't run unbounded queries\n\n- Infra Inventory UI\n```json\nparams {\n  \"allow_no_indices\": true,\n  \"ignore_unavailable\": true,\n  \"index\": \"remote_cluster:metrics-*,remote_cluster:metricbeat-*\",\n  \"body\": {\n    \"size\": 0,\n    \"query\": {\n      \"bool\": {\n        \"must\": [\n          {\n            \"bool\": {\n              \"filter\": [\n                {\n                  \"bool\": {\n                    \"filter\": [\n                      {\n                        \"bool\": {\n                          \"filter\": [\n                            {\n                              \"term\": {\n                                \"data_stream.dataset\": \"hostmetricsreceiver.otel\"\n                              }\n                            }\n                          ]\n                        }\n                      }\n                    ]\n                  }\n                },\n                {\n                  \"range\": {\n                    \"@timestamp\": {\n                      \"gte\": 1765824423511,\n                      \"lte\": 1765824723511,\n                      \"format\": \"epoch_millis\"\n                    }\n                  }\n                },\n                {\n                  \"exists\": {\n                    \"field\": \"host.name\"\n                  }\n                }\n              ]\n            }\n          }\n        ],\n        \"filter\": [\n          {\n            \"bool\": {\n              \"must_not\": [\n                {\n                  \"terms\": {\n                    \"_tier\": [\n                      \"data_frozen\"\n                    ]\n                  }\n                }\n              ]\n            }\n          }\n        ]\n      }\n    },\n    \"aggs\": {\n      \"groupings\": {\n        \"composite\": {\n          \"size\": 2000,\n          \"sources\": [\n            {\n              \"groupBy0\": {\n                \"terms\": {\n                  \"field\": \"host.name\"\n                }\n              }\n            }\n          ]\n        },\n        \"aggs\": {\n          \"histogram\": {\n            \"date_histogram\": {\n              \"field\": \"@timestamp\",\n              \"fixed_interval\": \"60s\",\n              \"offset\": \"-57511ms\",\n              \"extended_bounds\": {\n                \"min\": 1765824423511,\n                \"max\": 1765824723511\n              }\n            },\n            \"aggregations\": {\n              \"cpu_idle\": {\n                \"terms\": {\n                  \"field\": \"state\",\n                  \"include\": [\n                    \"idle\",\n                    \"wait\"\n                  ]\n                },\n                \"aggs\": {\n                  \"avg\": {\n                    \"avg\": {\n                      \"field\": \"system.cpu.utilization\"\n                    }\n                  }\n                }\n              },\n              \"cpu_idle_total\": {\n                \"sum_bucket\": {\n                  \"buckets_path\": \"cpu_idle.avg\"\n                }\n              },\n              \"cpuV2\": {\n                \"bucket_script\": {\n                  \"buckets_path\": {\n                    \"cpuIdleTotal\": \"cpu_idle_total\"\n                  },\n                  \"script\": \"1 - params.cpuIdleTotal\",\n                  \"gap_policy\": \"skip\"\n                }\n              },\n              \"__metadata__\": {\n                \"top_metrics\": {\n                  \"size\": 1,\n                  \"metrics\": [\n                    {\n                      \"field\": \"host.name\"\n                    },\n                    {\n                      \"field\": \"host.ip\"\n                    },\n                    {\n                      \"field\": \"host.os.name\"\n                    },\n                    {\n                      \"field\": \"cloud.provider\"\n                    }\n                  ],\n                  \"sort\": {\n                    \"@timestamp\": \"desc\"\n                  }\n                }\n              }\n            }\n          },\n          \"metricsets\": {\n            \"terms\": {\n              \"field\": \"metricset.name\"\n            }\n          }\n        }\n      }\n    }\n  }\n}\n```\n- Metrics Explorer\n\n```json\n{\n  \"allow_no_indices\": true,\n  \"ignore_unavailable\": true,\n  \"index\": \"remote_cluster:metrics-*,remote_cluster:metricbeat-*\",\n  \"body\": {\n    \"size\": 0,\n    \"query\": {\n      \"bool\": {\n        \"must\": [\n          {\n            \"bool\": {\n              \"filter\": [\n                null,\n                {\n                  \"range\": {\n                    \"@timestamp\": {\n                      \"gte\": 1765821298325,\n                      \"lte\": 1765824898325,\n                      \"format\": \"epoch_millis\"\n                    }\n                  }\n                }\n              ]\n            }\n          }\n        ],\n        \"filter\": [\n          {\n            \"bool\": {\n              \"must_not\": [\n                {\n                  \"terms\": {\n                    \"_tier\": [\n                      \"data_frozen\"\n                    ]\n                  }\n                }\n              ]\n            }\n          }\n        ]\n      }\n    },\n    \"aggs\": {\n      \"histogram\": {\n        \"date_histogram\": {\n          \"field\": \"@timestamp\",\n          \"fixed_interval\": \"30s\",\n          \"offset\": \"0s\",\n          \"extended_bounds\": {\n            \"min\": 1765821298325,\n            \"max\": 1765824898325\n          }\n        },\n        \"aggregations\": {\n          \"metric_0\": {\n            \"avg\": {\n              \"field\": \"system.cpu.total.norm.pct\"\n            }\n          },\n          \"metric_1\": {\n            \"avg\": {\n              \"field\": \"kubernetes.pod.cpu.usage.node.pct\"\n            }\n          },\n          \"metric_2\": {\n            \"avg\": {\n              \"field\": \"docker.cpu.total.pct\"\n            }\n          }\n        }\n      },\n      \"metricsets\": {\n        \"terms\": {\n          \"field\": \"metricset.name\"\n        }\n      }\n    }\n  }\n}\n```\n\n---------\n\nCo-authored-by: Nathan L Smith <nathan.smith@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Caue Marcondes <caue.marcondes@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Coen Warmer <coen.warmer@gmail.com>","sha":"aedfb94b2118c1e925e5678c585ab2093b04ed12"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19","9.2"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246438","number":246438,"mergeCommit":{"message":"[Infra] Fix legacy Infra search client to respect the frozen tier setting (#246438)\n\n## Summary\n\nBasically what this https://github.com/elastic/kibana/pull/245224 does,\nbut focusing only on the Infra plugin changes\n\n`has_data` endpoint will run this when the setting is not set\n\n```json\n{\n  \"index\": \"remote_cluster:metrics-*,remote_cluster:metricbeat-*\",\n  \"allow_no_indices\": true,\n  \"terminate_after\": 1,\n  \"ignore_unavailable\": true,\n  \"body\": {\n    \"size\": 0,\n    \"query\": {\n      \"bool\": {}\n    }\n  }\n}\n```\n\nand this when the setting is set\n\n```json\nparams {\n  \"index\": \"remote_cluster:metrics-*,remote_cluster:metricbeat-*\",\n  \"allow_no_indices\": true,\n  \"terminate_after\": 1,\n  \"ignore_unavailable\": true,\n  \"body\": {\n    \"size\": 0,\n    \"query\": {\n      \"bool\": {\n        \"filter\": [\n          {\n            \"bool\": {\n              \"must_not\": [\n                {\n                  \"terms\": {\n                    \"_tier\": [\n                      \"data_frozen\"\n                    ]\n                  }\n                }\n              ]\n            }\n          }\n        ]\n      }\n    }\n  }\n}\n```\n\nOther pages are affected by this change, but are not a source for the\nfrozen tier being hit because they don't run unbounded queries\n\n- Infra Inventory UI\n```json\nparams {\n  \"allow_no_indices\": true,\n  \"ignore_unavailable\": true,\n  \"index\": \"remote_cluster:metrics-*,remote_cluster:metricbeat-*\",\n  \"body\": {\n    \"size\": 0,\n    \"query\": {\n      \"bool\": {\n        \"must\": [\n          {\n            \"bool\": {\n              \"filter\": [\n                {\n                  \"bool\": {\n                    \"filter\": [\n                      {\n                        \"bool\": {\n                          \"filter\": [\n                            {\n                              \"term\": {\n                                \"data_stream.dataset\": \"hostmetricsreceiver.otel\"\n                              }\n                            }\n                          ]\n                        }\n                      }\n                    ]\n                  }\n                },\n                {\n                  \"range\": {\n                    \"@timestamp\": {\n                      \"gte\": 1765824423511,\n                      \"lte\": 1765824723511,\n                      \"format\": \"epoch_millis\"\n                    }\n                  }\n                },\n                {\n                  \"exists\": {\n                    \"field\": \"host.name\"\n                  }\n                }\n              ]\n            }\n          }\n        ],\n        \"filter\": [\n          {\n            \"bool\": {\n              \"must_not\": [\n                {\n                  \"terms\": {\n                    \"_tier\": [\n                      \"data_frozen\"\n                    ]\n                  }\n                }\n              ]\n            }\n          }\n        ]\n      }\n    },\n    \"aggs\": {\n      \"groupings\": {\n        \"composite\": {\n          \"size\": 2000,\n          \"sources\": [\n            {\n              \"groupBy0\": {\n                \"terms\": {\n                  \"field\": \"host.name\"\n                }\n              }\n            }\n          ]\n        },\n        \"aggs\": {\n          \"histogram\": {\n            \"date_histogram\": {\n              \"field\": \"@timestamp\",\n              \"fixed_interval\": \"60s\",\n              \"offset\": \"-57511ms\",\n              \"extended_bounds\": {\n                \"min\": 1765824423511,\n                \"max\": 1765824723511\n              }\n            },\n            \"aggregations\": {\n              \"cpu_idle\": {\n                \"terms\": {\n                  \"field\": \"state\",\n                  \"include\": [\n                    \"idle\",\n                    \"wait\"\n                  ]\n                },\n                \"aggs\": {\n                  \"avg\": {\n                    \"avg\": {\n                      \"field\": \"system.cpu.utilization\"\n                    }\n                  }\n                }\n              },\n              \"cpu_idle_total\": {\n                \"sum_bucket\": {\n                  \"buckets_path\": \"cpu_idle.avg\"\n                }\n              },\n              \"cpuV2\": {\n                \"bucket_script\": {\n                  \"buckets_path\": {\n                    \"cpuIdleTotal\": \"cpu_idle_total\"\n                  },\n                  \"script\": \"1 - params.cpuIdleTotal\",\n                  \"gap_policy\": \"skip\"\n                }\n              },\n              \"__metadata__\": {\n                \"top_metrics\": {\n                  \"size\": 1,\n                  \"metrics\": [\n                    {\n                      \"field\": \"host.name\"\n                    },\n                    {\n                      \"field\": \"host.ip\"\n                    },\n                    {\n                      \"field\": \"host.os.name\"\n                    },\n                    {\n                      \"field\": \"cloud.provider\"\n                    }\n                  ],\n                  \"sort\": {\n                    \"@timestamp\": \"desc\"\n                  }\n                }\n              }\n            }\n          },\n          \"metricsets\": {\n            \"terms\": {\n              \"field\": \"metricset.name\"\n            }\n          }\n        }\n      }\n    }\n  }\n}\n```\n- Metrics Explorer\n\n```json\n{\n  \"allow_no_indices\": true,\n  \"ignore_unavailable\": true,\n  \"index\": \"remote_cluster:metrics-*,remote_cluster:metricbeat-*\",\n  \"body\": {\n    \"size\": 0,\n    \"query\": {\n      \"bool\": {\n        \"must\": [\n          {\n            \"bool\": {\n              \"filter\": [\n                null,\n                {\n                  \"range\": {\n                    \"@timestamp\": {\n                      \"gte\": 1765821298325,\n                      \"lte\": 1765824898325,\n                      \"format\": \"epoch_millis\"\n                    }\n                  }\n                }\n              ]\n            }\n          }\n        ],\n        \"filter\": [\n          {\n            \"bool\": {\n              \"must_not\": [\n                {\n                  \"terms\": {\n                    \"_tier\": [\n                      \"data_frozen\"\n                    ]\n                  }\n                }\n              ]\n            }\n          }\n        ]\n      }\n    },\n    \"aggs\": {\n      \"histogram\": {\n        \"date_histogram\": {\n          \"field\": \"@timestamp\",\n          \"fixed_interval\": \"30s\",\n          \"offset\": \"0s\",\n          \"extended_bounds\": {\n            \"min\": 1765821298325,\n            \"max\": 1765824898325\n          }\n        },\n        \"aggregations\": {\n          \"metric_0\": {\n            \"avg\": {\n              \"field\": \"system.cpu.total.norm.pct\"\n            }\n          },\n          \"metric_1\": {\n            \"avg\": {\n              \"field\": \"kubernetes.pod.cpu.usage.node.pct\"\n            }\n          },\n          \"metric_2\": {\n            \"avg\": {\n              \"field\": \"docker.cpu.total.pct\"\n            }\n          }\n        }\n      },\n      \"metricsets\": {\n        \"terms\": {\n          \"field\": \"metricset.name\"\n        }\n      }\n    }\n  }\n}\n```\n\n---------\n\nCo-authored-by: Nathan L Smith <nathan.smith@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Caue Marcondes <caue.marcondes@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Coen Warmer <coen.warmer@gmail.com>","sha":"aedfb94b2118c1e925e5678c585ab2093b04ed12"}}]}] BACKPORT-->