### PR TITLE
[Search Playground] Fix the issue related to token count

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/public/utils/api.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/api.test.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { parseDataStream } from './api';
+import { MessageRole } from '../types';
+
+interface MockChunk {
+  type: string;
+  data?: unknown[];
+  delta?: string;
+  id?: string;
+  errorText?: string;
+}
+
+// Helper to create a mock reader that yields chunks in sequence
+function createMockReader(chunks: MockChunk[]): ReadableStreamDefaultReader<Uint8Array> {
+  let index = 0;
+  const encoder = new TextEncoder();
+
+  return {
+    read: jest.fn().mockImplementation(async () => {
+      if (index >= chunks.length) {
+        return { done: true, value: undefined };
+      }
+      const chunk = chunks[index];
+      index += 1;
+      const sseData = `data: ${JSON.stringify(chunk)}\n\n`;
+      return { done: false, value: encoder.encode(sseData) };
+    }),
+    releaseLock: jest.fn(),
+    cancel: jest.fn(),
+    closed: Promise.resolve(undefined),
+  } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+}
+
+describe('parseDataStream', () => {
+  const mockDate = new Date('2024-01-01T00:00:00.000Z');
+  const mockId = 'test-id';
+
+  describe('annotations handling', () => {
+    it('should preserve annotations received before text-start chunk', async () => {
+      // This test verifies the fix for the NaN token count bug.
+      // In AI SDK v5, annotations are sent BEFORE text-start, so they must persist.
+      const chunks: MockChunk[] = [
+        // Annotations come first (AI SDK v5 behavior)
+        {
+          type: 'data-message_annotations',
+          data: [
+            { type: 'context_token_count', count: 100 },
+            { type: 'prompt_token_count', count: 200 },
+          ],
+        },
+        // Then text-start arrives
+        { type: 'text-start' },
+        // Then text content streams in
+        { type: 'text-delta', delta: 'Hello' },
+        { type: 'text-delta', delta: ' world' },
+      ];
+
+      const reader = createMockReader(chunks);
+      const updateMock = jest.fn();
+      const handleFailureMock = jest.fn();
+
+      const result = await parseDataStream({
+        reader,
+        update: updateMock,
+        handleFailure: handleFailureMock,
+        generateId: () => mockId,
+        getCurrentDate: () => mockDate,
+      });
+
+      // Verify the final message has annotations attached
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].annotations).toBeDefined();
+      expect(result.messages[0].annotations).toEqual([
+        { type: 'context_token_count', count: 100 },
+        { type: 'prompt_token_count', count: 200 },
+      ]);
+      expect(result.messages[0].content).toBe('Hello world');
+      expect(result.messages[0].role).toBe(MessageRole.assistant);
+    });
+
+    it('should accumulate multiple annotation chunks', async () => {
+      const chunks: MockChunk[] = [
+        {
+          type: 'data-message_annotations',
+          data: [{ type: 'context_token_count', count: 100 }],
+        },
+        {
+          type: 'data-message_annotations',
+          data: [{ type: 'prompt_token_count', count: 200 }],
+        },
+        { type: 'text-start' },
+        { type: 'text-delta', delta: 'Response' },
+      ];
+
+      const reader = createMockReader(chunks);
+      const updateMock = jest.fn();
+      const handleFailureMock = jest.fn();
+
+      const result = await parseDataStream({
+        reader,
+        update: updateMock,
+        handleFailure: handleFailureMock,
+        generateId: () => mockId,
+        getCurrentDate: () => mockDate,
+      });
+
+      expect(result.messages[0].annotations).toHaveLength(2);
+      expect(result.messages[0].annotations).toContainEqual({
+        type: 'context_token_count',
+        count: 100,
+      });
+      expect(result.messages[0].annotations).toContainEqual({
+        type: 'prompt_token_count',
+        count: 200,
+      });
+    });
+
+    it('should handle annotations with retrieved docs and citations', async () => {
+      const mockDoc = {
+        metadata: { _id: 'doc1', _index: 'test-index', _score: 1 },
+        pageContent: 'Test content',
+      };
+
+      const chunks: MockChunk[] = [
+        {
+          type: 'data-message_annotations',
+          data: [{ type: 'retrieved_docs', documents: [mockDoc] }],
+        },
+        {
+          type: 'data-message_annotations',
+          data: [{ type: 'context_token_count', count: 50 }],
+        },
+        { type: 'text-start' },
+        { type: 'text-delta', delta: 'Based on the documents...' },
+        {
+          type: 'data-message_annotations',
+          data: [{ type: 'citations', documents: [mockDoc] }],
+        },
+      ];
+
+      const reader = createMockReader(chunks);
+      const updateMock = jest.fn();
+      const handleFailureMock = jest.fn();
+
+      const result = await parseDataStream({
+        reader,
+        update: updateMock,
+        handleFailure: handleFailureMock,
+        generateId: () => mockId,
+        getCurrentDate: () => mockDate,
+      });
+
+      expect(result.messages[0].annotations).toHaveLength(3);
+      expect(result.messages[0].annotations).toContainEqual({
+        type: 'retrieved_docs',
+        documents: [mockDoc],
+      });
+      expect(result.messages[0].annotations).toContainEqual({
+        type: 'context_token_count',
+        count: 50,
+      });
+      expect(result.messages[0].annotations).toContainEqual({
+        type: 'citations',
+        documents: [mockDoc],
+      });
+    });
+  });
+
+  describe('text streaming', () => {
+    it('should correctly assemble text from multiple delta chunks', async () => {
+      const chunks: MockChunk[] = [
+        { type: 'text-start' },
+        { type: 'text-delta', delta: 'The ' },
+        { type: 'text-delta', delta: 'quick ' },
+        { type: 'text-delta', delta: 'brown ' },
+        { type: 'text-delta', delta: 'fox' },
+      ];
+
+      const reader = createMockReader(chunks);
+      const updateMock = jest.fn();
+      const handleFailureMock = jest.fn();
+
+      const result = await parseDataStream({
+        reader,
+        update: updateMock,
+        handleFailure: handleFailureMock,
+        generateId: () => mockId,
+        getCurrentDate: () => mockDate,
+      });
+
+      expect(result.messages[0].content).toBe('The quick brown fox');
+    });
+
+    it('should call update callback for each chunk', async () => {
+      const chunks: MockChunk[] = [
+        { type: 'text-start' },
+        { type: 'text-delta', delta: 'A' },
+        { type: 'text-delta', delta: 'B' },
+        { type: 'text-delta', delta: 'C' },
+      ];
+
+      const reader = createMockReader(chunks);
+      const updateMock = jest.fn();
+      const handleFailureMock = jest.fn();
+
+      await parseDataStream({
+        reader,
+        update: updateMock,
+        handleFailure: handleFailureMock,
+        generateId: () => mockId,
+        getCurrentDate: () => mockDate,
+      });
+
+      // Update should be called for each text-delta chunk
+      expect(updateMock).toHaveBeenCalledTimes(3);
+      // Last call should have the complete message
+      const lastCall = updateMock.mock.calls[2][0];
+      expect(lastCall[0].content).toBe('ABC');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should call handleFailure on error chunk', async () => {
+      const chunks: MockChunk[] = [
+        { type: 'text-start' },
+        { type: 'text-delta', delta: 'Starting...' },
+        { type: 'error', errorText: 'Something went wrong' },
+      ];
+
+      const reader = createMockReader(chunks);
+      const updateMock = jest.fn();
+      const handleFailureMock = jest.fn();
+
+      await parseDataStream({
+        reader,
+        update: updateMock,
+        handleFailure: handleFailureMock,
+        generateId: () => mockId,
+        getCurrentDate: () => mockDate,
+      });
+
+      expect(handleFailureMock).toHaveBeenCalledWith('Something went wrong');
+    });
+  });
+});

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/api.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/api.ts
@@ -119,7 +119,6 @@ export async function parseDataStream({
       responseMessageId =
         'id' in chunk && chunk.id ? allocateResponseId(chunk.id) : allocateResponseId();
       prefixMap.text = undefined;
-      messageAnnotations = undefined;
       continue;
     } else if (type === 'text-delta' && 'delta' in chunk && typeof chunk.delta === 'string') {
       if (prefixMap.text) {


### PR DESCRIPTION
## Summary

Fixes token count display showing "NaN / 200,000 tokens sent" in the Search Playground after the AI SDK v5 upgrade.

The issue was on the client-side in `parseDataStream` (`api.ts`), where `messageAnnotations` was being reset to `undefined` when a `text-start` chunk was received. In AI SDK v5, annotations (including token counts) are sent *before* the `text-start` chunk, so this reset was clearing the already-collected token data. This PR removes that reset to preserve annotations across the stream, ensuring token counts are correctly attached to the final message and displayed in the UI.


### Before
<img width="865" height="502" alt="Screenshot 2025-12-16 at 10 39 42 AM" src="https://github.com/user-attachments/assets/331d3c7c-1b3e-455e-b8d7-561e2832054c" />


### After
<img width="1008" height="519" alt="Screenshot 2025-12-16 at 9 56 13 AM" src="https://github.com/user-attachments/assets/ec507093-e382-4320-b610-cc3d53a74c3b" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


## Release note
Fixes token count display showing "NaN" in Search Playground by preserving message annotations across the AI SDK v5 stream.


<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->