### PR TITLE
chore: enable OTel collector profiles feature gate for OTel Host Onboarding

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
@@ -116,7 +116,7 @@ export const OtelLogsPanel: React.FC = () => {
             agentVersion: setupData.elasticAgentVersionInfo.agentVersion,
           })
         : '',
-      start: 'sudo ./otelcol --config otel.yml',
+      start: 'sudo ./otelcol --config otel.yml --feature-gates=service.profilesSupport',
       type: 'copy',
     },
     {


### PR DESCRIPTION
## Summary

This PR enables the profiling feature gate for the EDOT Collector in the Hosts OpenTelemetry Onboarding. This is required in order to enable the [profiling]() receiver because of its `development` stability.
The goal is to enable the [profiling](https://github.com/open-telemetry/opentelemetry-ebpf-profiler) receiver + the [profilingmetrics](https://github.com/elastic/opentelemetry-collector-components/tree/main/connector/profilingmetricsconnector) connector by default in the onboarding, starting with the Host one. Note that profiles will be dropped after the `profilingmetrics` connector generates the corresponding metrics.

Enablement of profiling in the `elastic-agent` configurations used in this onboarding: https://github.com/elastic/elastic-agent/pull/11849

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



