### PR TITLE
[Metrics in Discover] Unskip metrics api test

### DIFF
--- a/src/platform/test/api_integration/apis/metrics_experience/fields.ts
+++ b/src/platform/test/api_integration/apis/metrics_experience/fields.ts
@@ -172,8 +172,7 @@ export default function ({ getService }: FtrProviderContext) {
         expect(body.page).to.be(1);
       });
 
-      // TODO: see https://github.com/elastic/kibana/pull/243499
-      it.skip('should return empty results if no fields match the filters', async () => {
+      it('should return empty results if no fields match the filters', async () => {
         const { body, status } = await sendSearchRequest({
           index: 'fieldsense-station-metrics',
           from: timerange.min,


### PR DESCRIPTION
Closes [#244709](https://github.com/elastic/kibana/issues/244709)

## Summary

This PR unskips the failed test, which was fixed after the issue skipped it. The test passed multiple times locally.

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed: [Pased](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10112) ✔️ 




