### PR TITLE
[8.19] [APM] Replace `host.hostname` with `host.name` in Infrastructure tab (#246386)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/infrastructure/generate_data.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/infrastructure/generate_data.ts
@@ -34,7 +34,7 @@ export function generateData({ from, to }: { from: number; to: number }) {
         .transaction({ transactionName: 'GET /apple 🍎' })
         .defaults({
           'container.id': 'foo',
-          'host.hostname': 'bar',
+          'host.name': 'bar',
           'kubernetes.pod.name': 'baz',
         })
         .timestamp(timestamp)
@@ -43,13 +43,16 @@ export function generateData({ from, to }: { from: number; to: number }) {
       serviceInstance
         .transaction({ transactionName: 'GET /banana 🍌' })
         .defaults({
-          'host.hostname': 'bar',
+          'host.name': 'bar',
         })
         .timestamp(timestamp)
         .duration(1000)
         .success(),
       serviceNoInfraDataInstance
         .transaction({ transactionName: 'GET /banana 🍌' })
+        .overrides({
+          'host.name': undefined,
+        })
         .timestamp(timestamp)
         .duration(1000)
         .success(),

--- a/x-pack/solutions/observability/plugins/apm/server/routes/infrastructure/get_infrastructure_data.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/infrastructure/get_infrastructure_data.ts
@@ -11,8 +11,8 @@ import { environmentQuery } from '../../../common/utils/environment_query';
 import {
   SERVICE_NAME,
   CONTAINER_ID,
-  HOST_HOSTNAME,
   KUBERNETES_POD_NAME,
+  HOST_NAME,
 } from '../../../common/es_fields/apm';
 import type { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
 
@@ -57,7 +57,7 @@ export const getInfrastructureData = async ({
         },
         hostNames: {
           terms: {
-            field: HOST_HOSTNAME,
+            field: HOST_NAME,
             size: 500,
           },
         },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM] Replace `host.hostname` with `host.name` in Infrastructure tab (#246386)](https://github.com/elastic/kibana/pull/246386)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-12-16T16:12:57Z","message":"[APM] Replace `host.hostname` with `host.name` in Infrastructure tab (#246386)\n\n## Summary\n\nCloses #246375\n\nThis PR solves a bug by replacing the old and deprecated `host.hostname`\nfield by `host.name` in `get_infrastructure_data.ts`, endpoint required\nfor the Infrastructure tab in APM Service detail view\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"aae10fafb472fbe3701e30463aa729b1be8ae2f1","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.3.0","ci:beta-faster-pr-build","Team:obs-presentation","v9.1.9","v8.19.9","v9.2.4"],"title":"[APM] Replace `host.hostname` with `host.name` in Infrastructure tab","number":246386,"url":"https://github.com/elastic/kibana/pull/246386","mergeCommit":{"message":"[APM] Replace `host.hostname` with `host.name` in Infrastructure tab (#246386)\n\n## Summary\n\nCloses #246375\n\nThis PR solves a bug by replacing the old and deprecated `host.hostname`\nfield by `host.name` in `get_infrastructure_data.ts`, endpoint required\nfor the Infrastructure tab in APM Service detail view\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"aae10fafb472fbe3701e30463aa729b1be8ae2f1"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246386","number":246386,"mergeCommit":{"message":"[APM] Replace `host.hostname` with `host.name` in Infrastructure tab (#246386)\n\n## Summary\n\nCloses #246375\n\nThis PR solves a bug by replacing the old and deprecated `host.hostname`\nfield by `host.name` in `get_infrastructure_data.ts`, endpoint required\nfor the Infrastructure tab in APM Service detail view\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"aae10fafb472fbe3701e30463aa729b1be8ae2f1"}},{"branch":"9.1","label":"v9.1.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/246597","number":246597,"state":"OPEN"},{"branch":"8.19","label":"v8.19.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/246598","number":246598,"state":"OPEN"}]}] BACKPORT-->