### PR TITLE
[9.1][ci] Fix type error, remove ts cache

### DIFF
--- a/.buildkite/scripts/steps/typecheck/check_types.sh
+++ b/.buildkite/scripts/steps/typecheck/check_types.sh
@@ -7,5 +7,4 @@ source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
 
 echo --- Check Types
-set +e
-node scripts/type_check --with-archive
+node scripts/type_check

--- a/x-pack/solutions/chat/packages/wci-server/src/utils/create_external_client.ts
+++ b/x-pack/solutions/chat/packages/wci-server/src/utils/create_external_client.ts
@@ -32,11 +32,7 @@ export const getConnectToExternalServer = ({
         version: '1.0.0',
       },
       {
-        capabilities: {
-          prompts: {},
-          resources: {},
-          tools: {},
-        },
+        capabilities: {},
       }
     );
 


### PR DESCRIPTION
Fixes a type error that became visible only after the cache expired.  Also disables the cache.