### PR TITLE
[Fleet] Add no data prompt new browse integration UX

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/no_data_prompt.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/no_data_prompt.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+
+import { EuiButton, EuiEmptyPrompt } from '@elastic/eui';
+
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { useLink } from '../../../../../../../hooks';
+
+export const NoDataPrompt: React.FC = () => {
+  const { getHref } = useLink();
+  const href = useMemo(() => getHref('integration_create'), [getHref]);
+
+  return (
+    <EuiEmptyPrompt
+      iconType="info"
+      titleSize="s"
+      title={
+        <h3>
+          <FormattedMessage
+            id="xpack.fleet.integrations.noDataPromptTitle"
+            defaultMessage="No integrations match your search criteria"
+          />
+        </h3>
+      }
+      body={
+        <>
+          <p>
+            <FormattedMessage
+              id="xpack.fleet.integrations.noDataPromptBody"
+              defaultMessage="Try adjusting your search or filters. {br}
+You can also create an integration tailored to your needs."
+              values={{ br: <br /> }}
+            />
+          </p>
+          <EuiButton fill href={href}>
+            <FormattedMessage
+              id="xpack.fleet.integrations.noDataPromptCreateButton"
+              defaultMessage="Create integration"
+            />
+          </EuiButton>
+        </>
+      }
+    />
+  );
+};

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/hooks/index.tsx
@@ -32,7 +32,7 @@ export function useBrowseIntegrationHook({
     eprPackageLoadingError,
     eprCategoryLoadingError,
     searchTerm,
-    setSearchTerm,
+    setSearchTerm: setSearchTermState,
     setUrlandPushHistory,
     setUrlandReplaceHistory,
     filteredCards: originalFilteredCards,
@@ -45,7 +45,7 @@ export function useBrowseIntegrationHook({
 
   const filteredCards = useMemo(() => {
     const searchResults = searchTerm
-      ? (localSearch?.search(searchTerm) as IntegrationCardItem[]).map(
+      ? (localSearch?.search(searchTerm) as IntegrationCardItem[])?.map(
           (match) => match[searchIdField]
         ) ?? []
       : [];
@@ -58,7 +58,7 @@ export function useBrowseIntegrationHook({
   const onCategoryChange = useCallback(
     ({ id }: { id: string }) => {
       setCategory(id as ExtendedIntegrationCategory);
-      setSearchTerm('');
+      setSearchTermState('');
       setSelectedSubCategory(undefined);
       setUrlandPushHistory({
         searchString: '',
@@ -67,7 +67,25 @@ export function useBrowseIntegrationHook({
         onlyAgentless: onlyAgentlessFilter,
       });
     },
-    [setCategory, setSearchTerm, setSelectedSubCategory, setUrlandPushHistory, onlyAgentlessFilter]
+    [
+      setCategory,
+      setSearchTermState,
+      setSelectedSubCategory,
+      setUrlandPushHistory,
+      onlyAgentlessFilter,
+    ]
+  );
+
+  const setSearchTerm = useCallback(
+    (term: string) => {
+      setSearchTermState(term);
+      setUrlandReplaceHistory({
+        searchString: term,
+        categoryId: selectedCategory,
+        subCategoryId: selectedSubCategory || '',
+      });
+    },
+    [setSearchTermState, selectedCategory, selectedSubCategory, setUrlandReplaceHistory]
   );
 
   return {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/index.tsx
@@ -16,6 +16,7 @@ import { PackageGrid } from './components/package_grid';
 import { SearchAndFiltersBar } from './components/search_and_filters_bar';
 import { Sidebar } from './components/side_bar';
 import { useBrowseIntegrationHook } from './hooks';
+import { NoDataPrompt } from './components/no_data_prompt';
 
 export const BrowseIntegrationsPage: React.FC<{ prereleaseIntegrationsEnabled: boolean }> = ({
   prereleaseIntegrationsEnabled,
@@ -89,12 +90,16 @@ export const BrowseIntegrationsPage: React.FC<{ prereleaseIntegrationsEnabled: b
               backgroundColor: euiTheme.euiTheme.colors.backgroundBasePlain,
             }}
           >
-            <PackageGrid
-              items={filteredCards}
-              isLoading={
-                isLoadingCategories || isLoadingAllPackages || isLoadingAppendCustomIntegrations
-              }
-            />
+            {filteredCards.length === 0 && !isLoading ? (
+              <NoDataPrompt />
+            ) : (
+              <PackageGrid
+                items={filteredCards}
+                isLoading={
+                  isLoadingCategories || isLoadingAllPackages || isLoadingAppendCustomIntegrations
+                }
+              />
+            )}
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/ingest-dev/issues/4787

Add a no data prompt when no packages match the search, that prompt redirect to the UI to create custom integration.

That PR also sync the search bar with the url search params.

## UI Changes 

<img width="800" alt="Screenshot 2025-12-17 at 9 06 02 AM" src="https://github.com/user-attachments/assets/d06bdac2-3493-4966-bf1b-0d6176052eb3" />


## Tests

You can manually test this by enabling the feature flag `newBrowseIntegrationUx` and check the browse integration page 