### PR TITLE
[Cases] Change nested field search to be case insensitive

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/services/cases/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/utils.test.ts
@@ -228,7 +228,7 @@ const searchFieldQuery: estypes.QueryDslQueryContainer[] = [
     nested: {
       path: 'cases.observables',
       query: {
-        term: { 'cases.observables.value': search },
+        term: { 'cases.observables.value': { value: search, case_insensitive: true } },
       },
     },
   },
@@ -236,7 +236,7 @@ const searchFieldQuery: estypes.QueryDslQueryContainer[] = [
     nested: {
       path: 'cases.customFields',
       query: {
-        term: { 'cases.customFields.value': search },
+        term: { 'cases.customFields.value': { value: search, case_insensitive: true } },
       },
     },
   },

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/utils.ts
@@ -119,7 +119,7 @@ export const constructSearchQuery = ({
             nested: {
               path,
               query: {
-                term: { [field]: search },
+                term: { [field]: { value: search, case_insensitive: true } },
               },
             },
           });


### PR DESCRIPTION
## Summary

Updated observables value and custom field search to be case insensitive. This would match how title, description and comments are currently being searched. 


Video demoing case insensitivity for title, comments and observables.

https://github.com/user-attachments/assets/75ed64f4-d6f6-419e-a967-8a9f8dd9c245


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


