### PR TITLE
[AI Infra] Add `docLinks` to GenAI Settings Documentation section

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -40,6 +40,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
 
   return deepFreeze({
     settings: `${ELASTIC_DOCS}reference/kibana/configuration-reference`,
+    aiAssistantSettings: `${ELASTIC_DOCS}reference/kibana/configuration-reference/ai-assistant-settings`,
     elasticStackGetStarted: isServerless
       ? `${ELASTIC_DOCS}deploy-manage/deploy/elastic-cloud/serverless`
       : `${ELASTIC_DOCS}get-started`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -25,6 +25,7 @@ export interface DocLinksMeta {
  */
 export interface DocLinks {
   readonly settings: string;
+  readonly aiAssistantSettings: string;
   readonly elasticStackGetStarted: string;
   readonly apiReference: string;
   readonly serverlessReleaseNotes: string;

--- a/x-pack/platform/plugins/private/gen_ai_settings/moon.yml
+++ b/x-pack/platform/plugins/private/gen_ai_settings/moon.yml
@@ -47,6 +47,7 @@ dependsOn:
   - '@kbn/ai-assistant-common'
   - '@kbn/ai-agent-confirmation-modal'
   - '@kbn/product-doc-common'
+  - '@kbn/react-kibana-mount'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/documentation/documentation_section.tsx
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/documentation/documentation_section.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
+  EuiLink,
   EuiSplitPanel,
   EuiSpacer,
   EuiText,
@@ -23,6 +24,7 @@ import {
 } from '@elastic/eui';
 import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import { ResourceTypes } from '@kbn/product-doc-common';
+import { toMountPoint } from '@kbn/react-kibana-mount';
 import {
   useProductDocStatus,
   useInstallProductDoc,
@@ -40,7 +42,7 @@ interface DocumentationSectionProps {
 
 export const DocumentationSection: React.FC<DocumentationSectionProps> = ({ productDocBase }) => {
   const { services } = useKibana();
-  const { notifications, application } = services;
+  const { notifications, application, rendering, docLinks } = services;
 
   // Check if user has Agent Builder 'All' privileges (manageAgents capability)
   const hasManagePrivilege = application.capabilities.agentBuilder?.manageAgents === true;
@@ -72,8 +74,21 @@ export const DocumentationSection: React.FC<DocumentationSectionProps> = ({ prod
       notifications.toasts.addSuccess({ title: i18n.INSTALL_SUCCESS });
     },
     onError: (error) => {
-      notifications.toasts.addError(new Error(error.body?.message ?? error.message), {
+      const message = error.body?.message ?? error.message;
+      notifications.toasts.addDanger({
         title: i18n.INSTALL_ERROR,
+        text: toMountPoint(
+          <EuiText size="s">
+            <p>{message}</p>
+            <p>{i18n.AIR_GAPPED_HINT}</p>
+            <p>
+              <EuiLink href={docLinks.links.aiAssistantSettings} target="_blank" external>
+                {i18n.LEARN_MORE}
+              </EuiLink>
+            </p>
+          </EuiText>,
+          rendering
+        ),
       });
     },
   });
@@ -418,7 +433,10 @@ export const DocumentationSection: React.FC<DocumentationSectionProps> = ({ prod
       </EuiSplitPanel.Inner>
       <EuiSplitPanel.Inner>
         <EuiText size="s" color="subdued">
-          {i18n.DOCUMENTATION_DESCRIPTION}
+          {i18n.DOCUMENTATION_DESCRIPTION}{' '}
+          <EuiLink href={docLinks.links.aiAssistantSettings} target="_blank" external>
+            {i18n.LEARN_MORE}
+          </EuiLink>
         </EuiText>
         <EuiSpacer size="m" />
         <EuiText size="xs" color="subdued">

--- a/x-pack/platform/plugins/private/gen_ai_settings/public/components/documentation/translations.ts
+++ b/x-pack/platform/plugins/private/gen_ai_settings/public/components/documentation/translations.ts
@@ -16,6 +16,15 @@ export const DOCUMENTATION_DESCRIPTION = i18n.translate('genAiSettings.documenta
     'Help improve Agent Builder responses to your prompts by installing product documentation. All entries are global to the cluster.',
 });
 
+export const LEARN_MORE = i18n.translate('genAiSettings.documentation.learnMore', {
+  defaultMessage: 'Learn more',
+});
+
+export const AIR_GAPPED_HINT = i18n.translate('genAiSettings.documentation.airGappedHint', {
+  defaultMessage:
+    'If your environment has no internet access, you can host these artifacts yourself.',
+});
+
 export const ELASTIC_DOCS_NAME = i18n.translate('genAiSettings.documentation.elasticDocs.name', {
   defaultMessage: 'Elastic documentation',
 });

--- a/x-pack/platform/plugins/private/gen_ai_settings/tsconfig.json
+++ b/x-pack/platform/plugins/private/gen_ai_settings/tsconfig.json
@@ -33,7 +33,8 @@
     "@kbn/product-doc-base-plugin",
     "@kbn/ai-assistant-common",
     "@kbn/ai-agent-confirmation-modal",
-    "@kbn/product-doc-common"
+    "@kbn/product-doc-common",
+    "@kbn/react-kibana-mount"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

As a follow-up to https://github.com/elastic/kibana/pull/246099 and https://github.com/elastic/kibana/pull/246334, this PR adds `docLinks` off to the [AI Assistant Settings Docs](https://www.elastic.co/docs/reference/kibana/configuration-reference/ai-assistant-settings) to both the `Documentation` panel and error toasts when the artifact fails to install (in aid of those in air-gapped environments).

Note: Yes, air-gapped deployments won't be able to load the documentation link, but they'll at least have the URL they need to get further information.

<p align="center">
  <img width="700" src="https://github.com/user-attachments/assets/c15afd58-31b4-4f03-a489-ad21a983b6cf" />
</p> 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [X] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


_PR developed with Cursor + GPT 5.2_
