### PR TITLE
[Agent Builder] Adds keyboard shortcut and toggle behavior to AI Agent button

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/components/nav_control/onechat_nav_control.test.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/components/nav_control/onechat_nav_control.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { BehaviorSubject } from 'rxjs';
 
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -34,7 +34,7 @@ describe('OnechatNavControl', () => {
 
   it('toggles the flyout when the nav button is clicked', () => {
     const toggleConversationFlyout = jest.fn();
-    const openChat$ = new BehaviorSubject(AIChatExperience.Assistant);
+    const openChat$ = new BehaviorSubject(AIChatExperience.Classic);
 
     mockUseUiPrivileges.mockReturnValue({ show: true } as any);
     mockUseKibana.mockReturnValue({
@@ -62,7 +62,7 @@ describe('OnechatNavControl', () => {
 
   it('toggles the flyout on Cmd/Ctrl+; keyboard shortcut', () => {
     const toggleConversationFlyout = jest.fn();
-    const openChat$ = new BehaviorSubject(AIChatExperience.Assistant);
+    const openChat$ = new BehaviorSubject(AIChatExperience.Classic);
 
     mockUseUiPrivileges.mockReturnValue({ show: true } as any);
     mockUseKibana.mockReturnValue({
@@ -87,5 +87,39 @@ describe('OnechatNavControl', () => {
     // Provide both ctrlKey and metaKey so the assertion is platform-independent
     fireEvent.keyDown(window, { key: ';', code: 'Semicolon', ctrlKey: true, metaKey: true });
     expect(toggleConversationFlyout).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the flyout when openChat$ emits Agent', () => {
+    const toggleConversationFlyout = jest.fn();
+    const openConversationFlyout = jest.fn();
+    const completeOpenChat = jest.fn();
+    const openChat$ = new BehaviorSubject(AIChatExperience.Classic);
+
+    mockUseUiPrivileges.mockReturnValue({ show: true } as any);
+    mockUseKibana.mockReturnValue({
+      services: {
+        onechat: {
+          toggleConversationFlyout,
+          openConversationFlyout,
+        },
+        aiAssistantManagementSelection: {
+          openChat$,
+          completeOpenChat,
+        },
+      },
+    } as any);
+
+    render(
+      <IntlProvider locale="en">
+        <OnechatNavControl />
+      </IntlProvider>
+    );
+
+    act(() => {
+      openChat$.next(AIChatExperience.Agent);
+    });
+
+    expect(openConversationFlyout).toHaveBeenCalledTimes(1);
+    expect(completeOpenChat).toHaveBeenCalledTimes(1);
   });
 });

--- a/x-pack/platform/plugins/shared/onechat/public/components/nav_control/onechat_nav_control.test.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/components/nav_control/onechat_nav_control.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BehaviorSubject } from 'rxjs';
+
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { AIChatExperience } from '@kbn/ai-assistant-common';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+import { useUiPrivileges } from '../../application/hooks/use_ui_privileges';
+import { OnechatNavControl } from './onechat_nav_control';
+
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useKibana: jest.fn(),
+}));
+
+jest.mock('../../application/hooks/use_ui_privileges', () => ({
+  useUiPrivileges: jest.fn(),
+}));
+
+const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
+const mockUseUiPrivileges = useUiPrivileges as jest.MockedFunction<typeof useUiPrivileges>;
+
+describe('OnechatNavControl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('toggles the flyout when the nav button is clicked', () => {
+    const toggleConversationFlyout = jest.fn();
+    const openChat$ = new BehaviorSubject(AIChatExperience.Assistant);
+
+    mockUseUiPrivileges.mockReturnValue({ show: true } as any);
+    mockUseKibana.mockReturnValue({
+      services: {
+        onechat: {
+          toggleConversationFlyout,
+          openConversationFlyout: jest.fn(),
+        },
+        aiAssistantManagementSelection: {
+          openChat$,
+          completeOpenChat: jest.fn(),
+        },
+      },
+    } as any);
+
+    render(
+      <IntlProvider locale="en">
+        <OnechatNavControl />
+      </IntlProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Agent Builder' }));
+    expect(toggleConversationFlyout).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles the flyout on Cmd/Ctrl+; keyboard shortcut', () => {
+    const toggleConversationFlyout = jest.fn();
+    const openChat$ = new BehaviorSubject(AIChatExperience.Assistant);
+
+    mockUseUiPrivileges.mockReturnValue({ show: true } as any);
+    mockUseKibana.mockReturnValue({
+      services: {
+        onechat: {
+          toggleConversationFlyout,
+          openConversationFlyout: jest.fn(),
+        },
+        aiAssistantManagementSelection: {
+          openChat$,
+          completeOpenChat: jest.fn(),
+        },
+      },
+    } as any);
+
+    render(
+      <IntlProvider locale="en">
+        <OnechatNavControl />
+      </IntlProvider>
+    );
+
+    // Provide both ctrlKey and metaKey so the assertion is platform-independent
+    fireEvent.keyDown(window, { key: ';', code: 'Semicolon', ctrlKey: true, metaKey: true });
+    expect(toggleConversationFlyout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/platform/plugins/shared/onechat/public/mocks.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/mocks.ts
@@ -19,6 +19,7 @@ const createStartContractMock = (): jest.Mocked<OnechatPluginStart> => {
     tools: {} as any,
     setConversationFlyoutActiveConfig: jest.fn(),
     clearConversationFlyoutActiveConfig: jest.fn(),
+    toggleConversationFlyout: jest.fn(),
     openConversationFlyout: jest
       .fn()
       .mockImplementation((options: OpenConversationFlyoutOptions) => {

--- a/x-pack/platform/plugins/shared/onechat/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/plugin.tsx
@@ -129,6 +129,33 @@ export class OnechatPlugin
 
     const hasAgentBuilder = core.application.capabilities.agentBuilder?.show === true;
 
+    const openFlyoutInternal = (options?: OpenConversationFlyoutOptions) => {
+      const config = options ?? this.conversationFlyoutActiveConfig;
+
+      // If a flyout is already open, update its props instead of creating a new one
+      if (this.activeFlyoutRef && this.updateFlyoutPropsCallback) {
+        this.updateFlyoutPropsCallback(config);
+        return { flyoutRef: this.activeFlyoutRef };
+      }
+
+      // Create new flyout and set up prop updates
+      const { flyoutRef } = openConversationFlyout(config, {
+        coreStart: core,
+        services: internalServices,
+        onPropsUpdate: (callback) => {
+          this.updateFlyoutPropsCallback = callback;
+        },
+        onClose: () => {
+          this.activeFlyoutRef = null;
+          this.updateFlyoutPropsCallback = null;
+        },
+      });
+
+      this.activeFlyoutRef = flyoutRef;
+
+      return { flyoutRef };
+    };
+
     const onechatService: OnechatPluginStart = {
       agents: createPublicAgentsContract({ agentService }),
       attachments: createPublicAttachmentContract({ attachmentsService }),
@@ -146,30 +173,20 @@ export class OnechatPlugin
         this.conversationFlyoutActiveConfig = {};
       },
       openConversationFlyout: (options?: OpenConversationFlyoutOptions) => {
-        const config = options ?? this.conversationFlyoutActiveConfig;
-
-        // If a flyout is already open, update its props instead of creating a new one
-        if (this.activeFlyoutRef && this.updateFlyoutPropsCallback) {
-          this.updateFlyoutPropsCallback(config);
-          return { flyoutRef: this.activeFlyoutRef };
+        return openFlyoutInternal(options);
+      },
+      toggleConversationFlyout: (options?: OpenConversationFlyoutOptions) => {
+        if (this.activeFlyoutRef) {
+          const flyoutRef = this.activeFlyoutRef;
+          // Be defensive: clear local references immediately in case the underlying overlay doesn't
+          // synchronously invoke our onClose callback.
+          this.activeFlyoutRef = null;
+          this.updateFlyoutPropsCallback = null;
+          flyoutRef.close();
+          return;
         }
 
-        // Create new flyout and set up prop updates
-        const { flyoutRef } = openConversationFlyout(config, {
-          coreStart: core,
-          services: internalServices,
-          onPropsUpdate: (callback) => {
-            this.updateFlyoutPropsCallback = callback;
-          },
-          onClose: () => {
-            this.activeFlyoutRef = null;
-            this.updateFlyoutPropsCallback = null;
-          },
-        });
-
-        this.activeFlyoutRef = flyoutRef;
-
-        return { flyoutRef };
+        openFlyoutInternal(options);
       },
     };
 

--- a/x-pack/platform/plugins/shared/onechat/public/types.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/types.ts
@@ -99,6 +99,12 @@ export interface OnechatPluginStart {
    * ```
    */
   openConversationFlyout: (options?: OpenConversationFlyoutOptions) => OpenConversationFlyoutReturn;
+  /**
+   * Toggles the conversation flyout.
+   *
+   * If the flyout is open, it will be closed. Otherwise, it will be opened.
+   */
+  toggleConversationFlyout: (options?: OpenConversationFlyoutOptions) => void;
   setConversationFlyoutActiveConfig: (config: EmbeddableConversationProps) => void;
   clearConversationFlyoutActiveConfig: () => void;
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/agent_builder/hooks/use_agent_builder_attachment.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/agent_builder/hooks/use_agent_builder_attachment.test.tsx
@@ -40,6 +40,7 @@ const createWrapper = (onechatService?: OnechatPluginStart) => {
 const mockOnechatService: OnechatPluginStart = {
   openConversationFlyout:
     mockOpenConversationFlyout as OnechatPluginStart['openConversationFlyout'],
+  toggleConversationFlyout: jest.fn(),
   agents: {} as OnechatPluginStart['agents'],
   tools: {} as OnechatPluginStart['tools'],
   attachments: {} as OnechatPluginStart['attachments'],


### PR DESCRIPTION
## Summary

Adds keyboard shortcut and toggle behavior to `AI Agent` button.

Press `cmd ;` on Mac or `ctrl ;` on Windows to toggle visibility of the flyout (just as before with the O11y/Security Assistants). Functions in each Solution, Stack Management, and regardless of currently focused component. 

https://github.com/user-attachments/assets/f0d2aa37-eb27-4361-b992-19558a1ee95e


### Checklist

Check the PR satisfies following conditions. 




Reviewers should verify this PR satisfies this list as well.

- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


_PR developed with Cursor + GPT 5.2_