### PR TITLE
[Search] Add ELSER update callout to index details data tab

### DIFF
--- a/x-pack/solutions/search/plugins/search_indices/common/doc_links.ts
+++ b/x-pack/solutions/search/plugins/search_indices/common/doc_links.ts
@@ -12,6 +12,8 @@ class SearchIndicesDocLinks {
   public searchAPIReference: string = '';
   public setupSemanticSearch: string = '';
   public analyzeLogs: string = '';
+  public elasticInferenceService: string = '';
+  public elasticInferenceServicePricing: string = '';
 
   constructor() {}
 
@@ -20,6 +22,8 @@ class SearchIndicesDocLinks {
     this.setupSemanticSearch = newDocLinks.enterpriseSearch.semanticSearch;
     this.analyzeLogs = newDocLinks.serverlessSearch.integrations;
     this.searchAPIReference = newDocLinks.query.queryDsl;
+    this.elasticInferenceService = newDocLinks.elasticsearch.elasticInferenceService;
+    this.elasticInferenceServicePricing = newDocLinks.elasticsearch.elasticInferenceServicePricing;
   }
 }
 export const docLinks = new SearchIndicesDocLinks();

--- a/x-pack/solutions/search/plugins/search_indices/common/types.ts
+++ b/x-pack/solutions/search/plugins/search_indices/common/types.ts
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
+import type { MappingFieldType } from '@elastic/elasticsearch/lib/api/types';
+
 export interface Field {
   name: string;
-  type: FieldType;
+  type: MappingFieldType;
   properties?: { [key: string]: Omit<Field, 'name'> };
   fields?: Fields;
   inference_id?: string | undefined;
@@ -16,8 +18,6 @@ export interface Field {
 export interface Fields {
   [key: string]: Omit<Field, 'name'>;
 }
-
-export type FieldType = 'object' | 'semantic_text';
 
 export interface IndicesStatusResponse {
   indexNames: string[];

--- a/x-pack/solutions/search/plugins/search_indices/common/types.ts
+++ b/x-pack/solutions/search/plugins/search_indices/common/types.ts
@@ -5,6 +5,20 @@
  * 2.0.
  */
 
+export interface Field {
+  name: string;
+  type: FieldType;
+  properties?: { [key: string]: Omit<Field, 'name'> };
+  fields?: Fields;
+  inference_id?: string | undefined;
+}
+
+export interface Fields {
+  [key: string]: Omit<Field, 'name'>;
+}
+
+export type FieldType = 'object' | 'semantic_text';
+
 export interface IndicesStatusResponse {
   indexNames: string[];
 }
@@ -27,4 +41,9 @@ export interface CreateIndexRequest {
 
 export interface CreateIndexResponse {
   index: string;
+}
+
+export interface UpdateIndexMappingsRequest {
+  indexName: string;
+  fields: Fields;
 }

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 
 import {
   EuiFlexGroup,
@@ -15,7 +15,7 @@ import {
   EuiSpacer,
   EuiHorizontalRule,
 } from '@elastic/eui';
-import { EisCloudConnectPromoCallout } from '@kbn/search-api-panels';
+import { EisCloudConnectPromoCallout, EisUpdateCallout } from '@kbn/search-api-panels';
 import { CLOUD_CONNECT_NAV_ID } from '@kbn/deeplinks-management/constants';
 
 import type { UserStartPrivilegesResponse } from '../../../common';
@@ -24,6 +24,10 @@ import { useIndexMapping } from '../../hooks/api/use_index_mappings';
 import type { IndexDocuments as IndexDocumentsType } from '../../hooks/api/use_document_search';
 import { IndexDocuments } from '../index_documents/index_documents';
 import { IndexSearchExample } from './details_search_example';
+import { docLinks } from '../../../common/doc_links';
+import { UpdateElserMappingsModal } from '../update_elser_mappings/update_elser_mappings_modal';
+import { flattenMappings, hasElserOnMlNodeSemanticTextField } from '../update_elser_mappings/utils';
+import type { NormalizedFields } from '../update_elser_mappings/types';
 
 interface IndexDetailsDataProps {
   indexName: string;
@@ -42,7 +46,21 @@ export const IndexDetailsData = ({
 }: IndexDetailsDataProps) => {
   const { application, cloud } = useKibana().services;
   const { data: mappingData } = useIndexMapping(indexName);
+  const [isUpdatingElserMappings, setIsUpdatingElserMappings] = useState<boolean>(false);
+
   const documents = indexDocuments?.results?.data ?? [];
+
+  const fieldsForUpdate = useMemo<NormalizedFields['byId'] | undefined>(() => {
+    const properties = mappingData?.mappings?.properties;
+    if (properties && Object.keys(properties).length > 0) {
+      const flattenedMappings = flattenMappings(properties);
+      if (hasElserOnMlNodeSemanticTextField(flattenedMappings)) {
+        return flattenedMappings;
+      }
+    }
+    // Return undefined when there are no ELSER fields on ML node to update
+    return undefined;
+  }, [mappingData]);
 
   if (isInitialLoading) {
     return (
@@ -60,8 +78,26 @@ export const IndexDetailsData = ({
         isSelfManaged={!cloud?.isCloudEnabled}
         direction="row"
         navigateToApp={() => application.navigateToApp(CLOUD_CONNECT_NAV_ID)}
-        addSpacer="top"
       />
+      {fieldsForUpdate && (
+        <EisUpdateCallout
+          ctaLink={docLinks.elasticInferenceService}
+          promoId="indexDetailsData"
+          isCloudEnabled={cloud?.isCloudEnabled ?? false}
+          handleOnClick={() => setIsUpdatingElserMappings(true)}
+          direction="row"
+          hasUpdatePrivileges={userPrivileges?.privileges.canManageIndex}
+          addSpacer="top"
+        />
+      )}
+      {isUpdatingElserMappings && fieldsForUpdate && (
+        <UpdateElserMappingsModal
+          indexName={indexName}
+          setIsModalOpen={setIsUpdatingElserMappings}
+          hasUpdatePrivileges={userPrivileges?.privileges.canManageIndex}
+          mappings={fieldsForUpdate}
+        />
+      )}
       <EuiPanel hasBorder={false} hasShadow={false} paddingSize="none">
         <EuiSpacer />
         <EuiFlexGroup direction="column" gutterSize="s">

--- a/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/fixtures.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/fixtures.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MappingProperty } from '@elastic/elasticsearch/lib/api/types';
+import type { EuiSelectableOption } from '@elastic/eui';
+import {
+  ELSER_ON_EIS_INFERENCE_ENDPOINT_ID,
+  ELSER_ON_ML_NODE_INFERENCE_ENDPOINT_ID,
+} from '../../constants';
+import type { MappingsOptionData, NormalizedFields } from './types';
+
+export const flattenedFields: NormalizedFields['byId'] = {
+  '1': {
+    id: '1',
+    path: ['address'],
+    source: {
+      name: 'address',
+      type: 'semantic_text',
+      inference_id: ELSER_ON_EIS_INFERENCE_ENDPOINT_ID,
+    },
+    hasChildFields: false,
+  },
+  '2': {
+    id: '2',
+    path: ['animal'],
+    source: {
+      name: 'animal',
+      type: 'object',
+    },
+    hasChildFields: true,
+    childFieldsName: 'properties',
+    childFields: ['3', '4', '6'],
+  },
+  '3': {
+    id: '3',
+    parentId: '2',
+    path: ['animal', 'name'],
+    source: {
+      name: 'name',
+      type: 'semantic_text',
+      inference_id: ELSER_ON_ML_NODE_INFERENCE_ENDPOINT_ID,
+    },
+    hasChildFields: false,
+  },
+  '4': {
+    id: '4',
+    parentId: '2',
+    path: ['animal', 'owner'],
+    source: {
+      name: 'owner',
+      type: 'object',
+    },
+    hasChildFields: true,
+    childFieldsName: 'properties',
+    childFields: ['5'],
+  },
+  '5': {
+    id: '5',
+    parentId: '4',
+    path: ['animal', 'owner', 'name'],
+    source: {
+      name: 'name',
+      type: 'semantic_text',
+      inference_id: ELSER_ON_ML_NODE_INFERENCE_ENDPOINT_ID,
+    },
+    hasChildFields: false,
+  },
+  '6': {
+    id: '6',
+    parentId: '2',
+    path: ['animal', 'species'],
+    source: {
+      name: 'species',
+      type: 'semantic_text',
+      inference_id: ELSER_ON_ML_NODE_INFERENCE_ENDPOINT_ID,
+    },
+    hasChildFields: false,
+  },
+  '7': {
+    id: '7',
+    path: ['name'],
+    source: {
+      name: 'name',
+      type: 'semantic_text',
+      inference_id: ELSER_ON_ML_NODE_INFERENCE_ENDPOINT_ID,
+    },
+    hasChildFields: false,
+  },
+};
+
+export const flattenedTextFields: NormalizedFields['byId'] = {
+  '1': {
+    id: '1',
+    path: ['first_name'],
+    source: {
+      name: 'first_name',
+      type: 'text',
+    },
+    hasChildFields: false,
+  },
+  '2': {
+    id: '2',
+    path: ['last_name'],
+    source: {
+      name: 'last_name',
+      type: 'text',
+    },
+    hasChildFields: false,
+  },
+};
+
+export const mappings: Record<string, MappingProperty> = {
+  address: {
+    type: 'semantic_text',
+    inference_id: '.elser-2-elastic',
+  },
+  animal: {
+    properties: {
+      name: {
+        type: 'semantic_text',
+        inference_id: '.elser-2-elasticsearch',
+      },
+      owner: {
+        properties: {
+          name: {
+            type: 'semantic_text',
+            inference_id: '.elser-2-elasticsearch',
+          },
+        },
+      },
+      species: {
+        type: 'semantic_text',
+        inference_id: '.elser-2-elasticsearch',
+      },
+    },
+  },
+  name: {
+    type: 'semantic_text',
+    inference_id: '.elser-2-elasticsearch',
+  },
+};
+
+export const textFieldMappings: Record<string, MappingProperty> = {
+  first_name: {
+    type: 'text',
+  },
+  last_name: {
+    type: 'text',
+  },
+};
+
+export const selectedOption: EuiSelectableOption<MappingsOptionData>[] = [
+  {
+    label: 'animal.owner.name',
+    name: 'name',
+    key: '5',
+    checked: 'on',
+  },
+];
+
+export const selectedOptionWithChildren: EuiSelectableOption<MappingsOptionData>[] = [
+  {
+    label: 'animal.name',
+    name: 'name',
+    key: '3',
+    checked: 'on',
+  },
+];
+
+export const normalizedFields: NormalizedFields = {
+  byId: {
+    '5': {
+      id: '5',
+      parentId: '4',
+      path: ['animal', 'owner', 'name'],
+      source: {
+        name: 'name',
+        type: 'semantic_text',
+        inference_id: '.elser-2-elastic',
+      },
+      hasChildFields: false,
+    },
+    '4': {
+      id: '4',
+      parentId: '2',
+      path: ['animal', 'owner'],
+      source: {
+        name: 'owner',
+        type: 'object',
+      },
+      hasChildFields: true,
+      childFieldsName: 'properties',
+      childFields: ['5'],
+    },
+    '2': {
+      id: '2',
+      path: ['animal'],
+      source: {
+        name: 'animal',
+        type: 'object',
+      },
+      hasChildFields: true,
+      childFieldsName: 'properties',
+      childFields: ['4'],
+    },
+  },
+  aliases: {},
+  rootLevelFields: ['2'],
+};
+
+export const deNormalizedField = {
+  animal: {
+    type: 'object',
+    properties: {
+      owner: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'semantic_text',
+            inference_id: '.elser-2-elastic',
+          },
+        },
+      },
+    },
+  },
+};

--- a/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/types.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { Field, FieldType } from '../../../common/types';
+import type { Field } from '../../../common/types';
 
 export interface MappingsOptionData {
   name: string;
@@ -35,7 +35,7 @@ export interface NormalizedField extends FieldMeta {
 export type ChildFieldName = 'properties' | 'fields';
 
 export interface MappingNode {
-  type?: FieldType;
+  type?: 'semantic_text' | 'object';
   inference_id?: string;
   properties?: Record<string, MappingNode>;
 }

--- a/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/types.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/types.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Field, FieldType } from '../../../common/types';
+
+export interface MappingsOptionData {
+  name: string;
+}
+
+export interface FieldMeta {
+  childFieldsName?: ChildFieldName;
+  hasChildFields: boolean;
+  childFields?: string[];
+}
+
+export interface NormalizedFields {
+  byId: {
+    [id: string]: NormalizedField;
+  };
+  rootLevelFields: string[];
+  aliases: { [key: string]: string[] };
+}
+
+export interface NormalizedField extends FieldMeta {
+  id: string;
+  parentId?: string;
+  path: string[];
+  source: Omit<Field, 'properties' | 'fields'>;
+}
+
+export type ChildFieldName = 'properties' | 'fields';
+
+export interface MappingNode {
+  type?: FieldType;
+  inference_id?: string;
+  properties?: Record<string, MappingNode>;
+}

--- a/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/update_elser_mappings_modal.test.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/update_elser_mappings_modal.test.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as utils from './utils';
+import {
+  UpdateElserMappingsModal,
+  type UpdateElserMappingsModalProps,
+} from './update_elser_mappings_modal';
+import { useUpdateMappings } from '../../hooks/api/use_update_mappings';
+import { useKibana } from '../../hooks/use_kibana';
+import type { NormalizedFields } from './types';
+
+jest.mock('./utils', () => ({
+  deNormalize: jest.fn(),
+  prepareFieldsForEisUpdate: jest.fn(),
+  isElserOnMlNodeSemanticField: jest.fn(),
+}));
+
+jest.mock('../../hooks/api/use_update_mappings');
+
+jest.mock('../../hooks/use_kibana');
+
+jest.mock('../../../common/doc_links', () => ({
+  docLinks: {
+    elasticInferenceServicePricing: 'http://example.com/docs',
+  },
+}));
+
+const deNormalizeMock = jest.mocked(utils.deNormalize);
+const prepareFieldsForEisUpdateMock = jest.mocked(utils.prepareFieldsForEisUpdate);
+const isElserOnMlNodeSemanticFieldMock = jest.mocked(utils.isElserOnMlNodeSemanticField);
+const mockUseKibana = useKibana as jest.Mock;
+const mockUseUpdateMappings = useUpdateMappings as jest.Mock;
+
+const setIsModalOpen = jest.fn();
+const mockToasts = { addSuccess: jest.fn(), addError: jest.fn() };
+const updateIndexMappings = jest.fn();
+
+const renderUpdateElserMappingsModal = (props?: Partial<UpdateElserMappingsModalProps>) => {
+  const mockMappings: NormalizedFields['byId'] = {
+    first: {
+      id: 'first',
+      path: ['name'],
+      source: { name: 'name', type: 'semantic_text', inference_id: '.elser-2-elasticsearch' },
+      hasChildFields: false,
+    },
+    second: {
+      id: 'second',
+      path: ['text'],
+      source: { name: 'text', type: 'semantic_text', inference_id: '.elser-2-elasticsearch' },
+      hasChildFields: false,
+    },
+  };
+
+  return render(
+    <IntlProvider>
+      <UpdateElserMappingsModal
+        indexName="test-index"
+        setIsModalOpen={setIsModalOpen}
+        hasUpdatePrivileges={props?.hasUpdatePrivileges ?? true}
+        mappings={props?.mappings ?? mockMappings}
+      />
+    </IntlProvider>
+  );
+};
+
+describe('UpdateElserMappingsModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseKibana.mockReturnValue({
+      services: {
+        notifications: { toasts: mockToasts },
+      },
+    });
+
+    mockUseUpdateMappings.mockReturnValue({
+      updateIndexMappings,
+      isLoading: false,
+    });
+
+    isElserOnMlNodeSemanticFieldMock.mockImplementation((field) => {
+      return field.source.inference_id === '.elser-2-elasticsearch';
+    });
+
+    prepareFieldsForEisUpdateMock.mockReturnValue({
+      byId: {
+        first: {
+          id: 'first',
+          path: ['name'],
+          source: { name: 'name', type: 'semantic_text', inference_id: '.elser-2-elasticsearch' },
+          hasChildFields: false,
+        },
+      },
+      aliases: {},
+      rootLevelFields: ['first'],
+    });
+
+    deNormalizeMock.mockReturnValue({
+      name: {
+        type: 'semantic_text',
+        inference_id: '.elser-2-elastic',
+      },
+    });
+  });
+
+  it('should render modal and load options', () => {
+    renderUpdateElserMappingsModal();
+
+    expect(screen.getByTestId('updateElserMappingsModal')).toBeInTheDocument();
+    expect(screen.getByTestId('updateElserMappingsSelect')).toBeInTheDocument();
+
+    expect(screen.getByRole('option', { name: 'name' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'text' })).toBeInTheDocument();
+
+    const badges = screen.getAllByText('.elser-2-elasticsearch');
+    expect(badges).toHaveLength(2);
+  });
+
+  it('should disable Apply button if no options are checked', () => {
+    renderUpdateElserMappingsModal();
+    const applyBtn = screen.getByTestId('UpdateElserMappingsModalApplyBtn');
+    expect(applyBtn).toBeDisabled();
+  });
+
+  it('should enable Apply button when at least one option is checked', async () => {
+    renderUpdateElserMappingsModal();
+    const selectable = screen.getByTestId('updateElserMappingsSelect');
+    const firstOption = within(selectable).getByRole('option', { name: 'name' });
+    await userEvent.click(firstOption);
+
+    const applyBtn = screen.getByTestId('UpdateElserMappingsModalApplyBtn');
+    expect(applyBtn).toBeEnabled();
+  });
+
+  it('should disable Apply if hasUpdatePrivileges is false', () => {
+    renderUpdateElserMappingsModal({ hasUpdatePrivileges: false });
+    const applyBtn = screen.getByTestId('UpdateElserMappingsModalApplyBtn');
+    expect(applyBtn).toBeDisabled();
+  });
+
+  it('should call API and close modal on successful Apply', async () => {
+    renderUpdateElserMappingsModal();
+
+    const selectable = screen.getByTestId('updateElserMappingsSelect');
+    const firstOption = within(selectable).getByRole('option', { name: 'name' });
+    await userEvent.click(firstOption);
+
+    updateIndexMappings.mockImplementation((input, callbacks) => {
+      callbacks?.onSuccess?.();
+    });
+
+    const applyBtn = screen.getByTestId('UpdateElserMappingsModalApplyBtn');
+    await userEvent.click(applyBtn);
+
+    expect(updateIndexMappings).toHaveBeenCalledTimes(1);
+    expect(updateIndexMappings).toHaveBeenCalledWith(
+      {
+        indexName: 'test-index',
+        fields: {
+          name: {
+            type: 'semantic_text',
+            inference_id: '.elser-2-elastic',
+          },
+        },
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      })
+    );
+    expect(mockToasts.addSuccess).toHaveBeenCalledTimes(1);
+    expect(setIsModalOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('should display error message if API fails', async () => {
+    renderUpdateElserMappingsModal();
+
+    const selectable = screen.getByTestId('updateElserMappingsSelect');
+    const firstOption = within(selectable).getByRole('option', { name: 'name' });
+    await userEvent.click(firstOption);
+
+    const mockError = {
+      message: 'API request failed',
+      body: {
+        message: 'Error updating mappings',
+        statusCode: 500,
+      },
+    };
+
+    updateIndexMappings.mockImplementation((input, callbacks) => {
+      callbacks?.onError?.(mockError);
+    });
+
+    const applyBtn = screen.getByTestId('UpdateElserMappingsModalApplyBtn');
+    await userEvent.click(applyBtn);
+
+    expect(updateIndexMappings).toHaveBeenCalledTimes(1);
+    expect(mockToasts.addError).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close modal when Cancel button is clicked', async () => {
+    renderUpdateElserMappingsModal();
+    const cancelBtn = screen.getByTestId('UpdateElserMappingsModalCancelBtn');
+    await userEvent.click(cancelBtn);
+    expect(setIsModalOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('should show loading state when isLoading is true', () => {
+    mockUseUpdateMappings.mockReturnValue({
+      updateIndexMappings,
+      isLoading: true,
+    } as any);
+
+    renderUpdateElserMappingsModal();
+    const applyBtn = screen.getByTestId('UpdateElserMappingsModalApplyBtn');
+    // EuiButton with isLoading prop adds a loading spinner
+    expect(applyBtn.querySelector('.euiLoadingSpinner')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/update_elser_mappings_modal.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/update_elser_mappings_modal.tsx
@@ -1,0 +1,217 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiSpacer,
+  EuiButtonEmpty,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiSelectable,
+  EuiText,
+  EuiLink,
+  EuiBadge,
+  EuiToken,
+  type EuiSelectableOption,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { isElserOnMlNodeSemanticField, prepareFieldsForEisUpdate, deNormalize } from './utils';
+import type { MappingsOptionData, NormalizedFields } from './types';
+import { useKibana } from '../../hooks/use_kibana';
+import { useUpdateMappings } from '../../hooks/api/use_update_mappings';
+import { docLinks } from '../../../common/doc_links';
+
+export interface UpdateElserMappingsModalProps {
+  indexName: string;
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  hasUpdatePrivileges: boolean | undefined;
+  mappings: NormalizedFields['byId'];
+}
+
+export function UpdateElserMappingsModal({
+  indexName,
+  setIsModalOpen,
+  hasUpdatePrivileges,
+  mappings,
+}: UpdateElserMappingsModalProps) {
+  const { notifications } = useKibana().services;
+  const { updateIndexMappings, isLoading } = useUpdateMappings();
+
+  const [options, setOptions] = useState<EuiSelectableOption<MappingsOptionData>[]>([]);
+  const isApplyDisabled = hasUpdatePrivileges === false || options.every((o) => o.checked !== 'on');
+
+  const buildElserOptions = useCallback(
+    (flattenedMappings: NormalizedFields['byId']): EuiSelectableOption<MappingsOptionData>[] => {
+      const elserMappings = Object.values(flattenedMappings).filter(isElserOnMlNodeSemanticField);
+
+      return elserMappings.map((field) => ({
+        label: field.path.join('.'),
+        name: field.source.name,
+        key: field.id,
+        prepend: <EuiToken iconType="tokenSemanticText" />,
+        append: <EuiBadge color="hollow">{field.source.inference_id as string}</EuiBadge>,
+      }));
+    },
+    []
+  );
+
+  const renderMappingOption = useCallback((option: EuiSelectableOption<MappingsOptionData>) => {
+    return (
+      <>
+        <EuiText size="s">{option.name}</EuiText>
+        <EuiText size="xs" color="subdued" className="eui-displayBlock">
+          <small>{option.label || ''}</small>
+        </EuiText>
+      </>
+    );
+  }, []);
+
+  const handleApply = useCallback(async () => {
+    const selectedOptions = options.filter((option) => option.checked === 'on');
+    const selectedFields = prepareFieldsForEisUpdate(selectedOptions, mappings);
+    const denormalizedFields = deNormalize(selectedFields);
+
+    updateIndexMappings(
+      {
+        indexName,
+        fields: denormalizedFields,
+      },
+      {
+        onSuccess: () => {
+          notifications.toasts.addSuccess({
+            title: i18n.translate(
+              'xpack.searchIndices.updateElserMappingsModal.successfullyUpdatedIndexMappingsTitle',
+              { defaultMessage: 'Mappings updated' }
+            ),
+            text: i18n.translate(
+              'xpack.searchIndices.updateElserMappingsModal.successfullyUpdatedIndexMappingsText',
+              { defaultMessage: 'Your index mappings have been updated.' }
+            ),
+          });
+          setIsModalOpen(false);
+        },
+        onError: (error) => {
+          const fallbackErrorMessage = i18n.translate(
+            'xpack.searchIndices.updateElserMappingsModal.error.defaultMessage',
+            {
+              defaultMessage: 'Mappings could not be updated. Please try again.',
+            }
+          );
+          const errorMessage = error?.body?.message ?? error?.message ?? fallbackErrorMessage;
+          notifications.toasts.addError(new Error(errorMessage), {
+            title: i18n.translate('xpack.searchIndices.updateElserMappingsModal.error.title', {
+              defaultMessage: 'Error updating mappings',
+            }),
+          });
+        },
+      }
+    );
+  }, [indexName, options, notifications.toasts, setIsModalOpen, updateIndexMappings, mappings]);
+
+  useEffect(() => {
+    const elserOptions = buildElserOptions(mappings);
+    setOptions(elserOptions);
+  }, [mappings, buildElserOptions]);
+
+  return (
+    <EuiModal
+      style={{ width: 600 }}
+      aria-labelledby={i18n.translate(
+        'xpack.searchIndices.updateElserMappingsModal.ariaLabelledBy',
+        {
+          defaultMessage: 'Update mappings to ELSER on EIS modal',
+        }
+      )}
+      onClose={() => setIsModalOpen(false)}
+      data-test-subj="updateElserMappingsModal"
+      data-telemetry-id="indexDetailsDataTabUpdateElserMappingsModal"
+    >
+      <EuiModalHeader>
+        <EuiModalHeaderTitle size="s">
+          {i18n.translate('xpack.searchIndices.updateElserMappingsModal.title', {
+            defaultMessage: 'Update mappings to ELSER on EIS',
+          })}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiText>
+          {i18n.translate('xpack.searchIndices.updateElserMappingsModal.costsTransparency', {
+            defaultMessage:
+              'Performing inference and other ML tasks using the Elastic Inference Service (EIS) will incur token-based costs.',
+          })}
+        </EuiText>
+        <EuiSpacer size="s" />
+        <EuiLink
+          data-test-subj="updateElserMappingsModalLearnMoreLink"
+          data-telemetry-id="indexDetailsDataTabUpdateElserMappingsModalLearnMoreLink"
+          href={docLinks.elasticInferenceServicePricing}
+          target="_blank"
+          external
+        >
+          {i18n.translate('xpack.searchIndices.updateElserMappingsModal.learnMoreLink', {
+            defaultMessage: 'Learn more',
+          })}
+        </EuiLink>
+        <EuiSpacer size="l" />
+        <EuiSelectable<MappingsOptionData>
+          data-test-subj="updateElserMappingsSelect"
+          aria-label={i18n.translate('xpack.searchIndices.updateElserMappingsModal.select', {
+            defaultMessage: 'Select ELSER mappings',
+          })}
+          options={options}
+          listProps={{ bordered: true, isVirtualized: true, rowHeight: 50 }}
+          onChange={(newOptions) => setOptions(newOptions)}
+          renderOption={renderMappingOption}
+        >
+          {(list) => list}
+        </EuiSelectable>
+        <EuiSpacer size="l" />
+        <EuiText size="s" color="subdued">
+          {i18n.translate('xpack.searchIndices.updateElserMappingsModal.updateConditions', {
+            defaultMessage:
+              'Only fields using .elser-2-elasticsearch can be updated to use .elser-2-elastic on the Elastic Inference Service.',
+          })}
+        </EuiText>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
+          <EuiButtonEmpty
+            data-test-subj="UpdateElserMappingsModalCancelBtn"
+            data-telemetry-id="indexDetailsDataTabUpdateElserMappingsModalCancelBtn"
+            onClick={() => setIsModalOpen(false)}
+            aria-label={i18n.translate(
+              'xpack.searchIndices.updateElserMappingsModal.cancelButtonAriaLabel',
+              {
+                defaultMessage: 'Cancel and close modal',
+              }
+            )}
+          >
+            {i18n.translate('xpack.searchIndices.updateElserMappingsModal.cancelButtonLabel', {
+              defaultMessage: 'Cancel',
+            })}
+          </EuiButtonEmpty>
+          <EuiButton
+            fill
+            onClick={handleApply}
+            isLoading={isLoading}
+            data-test-subj="UpdateElserMappingsModalApplyBtn"
+            data-telemetry-id="indexDetailsDataTabUpdateElserMappingsModalApplyBtn"
+            isDisabled={isApplyDisabled}
+          >
+            {i18n.translate('xpack.searchIndices.updateElserMappingsModal.applyButton', {
+              defaultMessage: 'Apply',
+            })}
+          </EuiButton>
+        </EuiFlexGroup>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+}

--- a/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/utils.test.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/utils.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import {
+  isElserOnMlNodeSemanticField,
+  hasElserOnMlNodeSemanticTextField,
+  flattenMappings,
+  prepareFieldsForEisUpdate,
+  deNormalize,
+} from './utils';
+
+import {
+  deNormalizedField,
+  flattenedFields,
+  flattenedTextFields,
+  mappings,
+  normalizedFields,
+  selectedOption,
+  selectedOptionWithChildren,
+  textFieldMappings,
+} from './fixtures';
+import { ELSER_ON_EIS_INFERENCE_ENDPOINT_ID } from '../../constants';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(),
+}));
+
+let mockUuid = 0;
+
+describe('hasElserOnMlNodeSemanticTextField', () => {
+  it('returns true if at least one field matches', () => {
+    expect(hasElserOnMlNodeSemanticTextField(flattenedFields)).toBe(true);
+  });
+
+  it('returns false if no fields match', () => {
+    expect(hasElserOnMlNodeSemanticTextField(flattenedTextFields)).toBe(false);
+  });
+
+  it('returns false for empty input', () => {
+    expect(hasElserOnMlNodeSemanticTextField({})).toBe(false);
+  });
+});
+
+describe('isElserOnMlNodeSemanticField', () => {
+  it('returns true when inference_id matches ELSER ML node endpoint', () => {
+    expect(isElserOnMlNodeSemanticField(flattenedFields['3'])).toBe(true);
+  });
+
+  it('returns false when inference_id does not match', () => {
+    expect(isElserOnMlNodeSemanticField(flattenedFields['1'])).toBe(false);
+  });
+
+  it('returns false when inference_id is missing', () => {
+    expect(isElserOnMlNodeSemanticField(flattenedTextFields['1'])).toBe(false);
+  });
+});
+
+describe('flattenMappings', () => {
+  beforeAll(() => {
+    (uuidv4 as jest.Mock).mockImplementation(() => (++mockUuid).toString());
+  });
+
+  afterEach(() => {
+    mockUuid = 0;
+  });
+
+  it('flattens a simple object with a semantic_text child', () => {
+    const result = flattenMappings(mappings);
+
+    expect(result).toEqual(flattenedFields);
+  });
+
+  it('ignores fields without type semantic_text or properties', () => {
+    const result = flattenMappings(textFieldMappings);
+
+    expect(result).toEqual({});
+  });
+});
+
+describe('prepareFieldsForEisUpdate', () => {
+  it('updates inference_id and includes parent fields', () => {
+    const result = prepareFieldsForEisUpdate(selectedOption, flattenedFields);
+    // The selected option is in the result
+    expect(Object.keys(result.byId)).toContain('5');
+    // The selected option has the EIS endpoint set as the inference_id
+    expect(result.byId['5'].source.inference_id).toBe(ELSER_ON_EIS_INFERENCE_ENDPOINT_ID);
+    // The selected option has a parent id set
+    expect(result.byId['5'].parentId).toEqual('4');
+    // The selected option's parent is in the result
+    expect(result.byId['4']).toBeDefined();
+    // The rootLevelField array contains the grandparent of the selected option
+    expect(result.rootLevelFields).toEqual(['2']);
+  });
+
+  it('prunes unselected childFields', () => {
+    const result = prepareFieldsForEisUpdate(selectedOptionWithChildren, flattenedFields);
+    // The result contains the selected child option
+    expect(result.byId['3']).toBeDefined();
+    // The result does not contain the unselected sibling option
+    expect(result.byId['4']).toBeUndefined();
+  });
+});
+
+describe('deNormalize', () => {
+  it('reconstructs nested fields from normalized structure', () => {
+    const result = deNormalize(normalizedFields);
+
+    expect(result).toEqual(deNormalizedField);
+  });
+});

--- a/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/utils.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/utils.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import type { EuiSelectableOption } from '@elastic/eui';
+import type { MappingProperty } from '@elastic/elasticsearch/lib/api/types';
+import {
+  ELSER_ON_EIS_INFERENCE_ENDPOINT_ID,
+  ELSER_ON_ML_NODE_INFERENCE_ENDPOINT_ID,
+} from '../../constants';
+import type { Field, Fields } from '../../../common/types';
+import type { MappingNode, MappingsOptionData, NormalizedField, NormalizedFields } from './types';
+
+export const isElserOnMlNodeSemanticField = (field: NormalizedField) =>
+  field.source.inference_id === ELSER_ON_ML_NODE_INFERENCE_ENDPOINT_ID;
+
+export function hasElserOnMlNodeSemanticTextField(fields: NormalizedFields['byId']): boolean {
+  return Object.values(fields).some(isElserOnMlNodeSemanticField);
+}
+
+export function flattenMappings(input: Record<string, MappingProperty>): NormalizedFields['byId'] {
+  const result: NormalizedFields['byId'] = {};
+
+  const processMappingNode = (
+    node: MappingNode,
+    name: string,
+    path: string[],
+    parentId?: string
+  ): string => {
+    const id = uuidv4();
+    const hasChildren = Boolean(node.properties);
+
+    const entry: NormalizedField = {
+      id,
+      parentId,
+      path,
+      source: {
+        name,
+        type: node.type ?? 'object',
+        ...(node.inference_id && { inference_id: node.inference_id }),
+      },
+      hasChildFields: hasChildren,
+    };
+
+    if (hasChildren) {
+      entry.childFieldsName = 'properties';
+      entry.childFields = [];
+    }
+
+    result[id] = entry;
+
+    if (node.properties) {
+      for (const [childName, childNode] of Object.entries(node.properties)) {
+        const childId = processMappingNode(childNode, childName, [...path, childName], id);
+        entry.childFields?.push(childId);
+      }
+    }
+
+    return id;
+  };
+
+  for (const [name, node] of Object.entries(input)) {
+    if (isMappingNode(node)) {
+      processMappingNode(node, name, [name]);
+    }
+  }
+
+  return result;
+}
+
+function isMappingNode(node: MappingProperty): node is MappingNode {
+  return node.type === 'semantic_text' || (typeof node === 'object' && 'properties' in node);
+}
+
+export const prepareFieldsForEisUpdate = (
+  selectedMappings: EuiSelectableOption<MappingsOptionData>[],
+  flattenedMappings: NormalizedFields['byId']
+) => {
+  const selectedIds = selectedMappings.flatMap((item) => item.key ?? []);
+
+  const resultById: NormalizedFields['byId'] = {};
+  const resultRootLevel: string[] = [];
+
+  function getSelectedFieldData(id: string) {
+    // Prevent duplicate processing - if already in resultById, skip
+    if (resultById[id]) {
+      return;
+    }
+
+    const field = flattenedMappings[id];
+    if (!field) return;
+
+    const clonedField = { ...field };
+
+    // Only update inference_id if it exists in source
+    if (clonedField.source?.inference_id !== undefined) {
+      clonedField.source = {
+        ...clonedField.source,
+        inference_id: ELSER_ON_EIS_INFERENCE_ENDPOINT_ID,
+      };
+    }
+    resultById[id] = clonedField;
+
+    // Include parent if it exists and hasn't been processed yet
+    if (field.parentId) {
+      if (!resultById[field.parentId]) {
+        getSelectedFieldData(field.parentId);
+      }
+    } else {
+      resultRootLevel.push(id);
+    }
+  }
+
+  selectedIds.forEach((id) => getSelectedFieldData(id));
+
+  // Prune childFields arrays so they only include selected field IDs
+  Object.values(resultById).forEach((field) => {
+    if (field.childFields) {
+      field.childFields = field.childFields.filter((id) => !!resultById[id]);
+      if (field.childFields.length === 0) {
+        delete field.childFields;
+      }
+    }
+  });
+
+  return {
+    byId: resultById,
+    aliases: {},
+    rootLevelFields: resultRootLevel,
+  };
+};
+
+export const deNormalize = ({ rootLevelFields, byId }: NormalizedFields): Fields => {
+  const deNormalizePaths = (ids: string[], to: Fields = {}): Fields => {
+    ids.forEach((id) => {
+      const { source, childFields, childFieldsName } = byId[id];
+      const { name, ...normalizedField } = source;
+      const field: Omit<Field, 'name'> = normalizedField;
+
+      to[name] = field;
+
+      if (childFields && childFieldsName) {
+        field[childFieldsName] = {};
+        return deNormalizePaths(childFields, field[childFieldsName]);
+      }
+    });
+    return to;
+  };
+
+  return deNormalizePaths(rootLevelFields);
+};

--- a/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/utils.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/utils.ts
@@ -79,7 +79,7 @@ function isMappingNode(node: MappingProperty): node is MappingNode {
 export const prepareFieldsForEisUpdate = (
   selectedMappings: EuiSelectableOption<MappingsOptionData>[],
   flattenedMappings: NormalizedFields['byId']
-) => {
+): NormalizedFields => {
   const selectedIds = selectedMappings.flatMap((item) => item.key ?? []);
 
   const resultById: NormalizedFields['byId'] = {};

--- a/x-pack/solutions/search/plugins/search_indices/public/constants.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/constants.ts
@@ -21,6 +21,7 @@ export enum QueryKeys {
 export enum MutationKeys {
   SearchIndicesCreateIndex = 'searchIndicesCreateIndex',
   SearchIndicesDeleteDocument = 'searchIndicesDeleteDocument',
+  SearchIndicesUpdateMappings = 'searchIndicesUpdateMappings',
 }
 
 export const API_KEY_PLACEHOLDER = 'YOUR_API_KEY';
@@ -35,3 +36,7 @@ export const BREADCRUMB_TEXT = i18n.translate('xpack.searchIndices.indexManageme
 export const PARENT_BREADCRUMB = {
   text: BREADCRUMB_TEXT,
 };
+
+export const ELSER_ON_ML_NODE_INFERENCE_ENDPOINT_ID = '.elser-2-elasticsearch';
+
+export const ELSER_ON_EIS_INFERENCE_ENDPOINT_ID = '.elser-2-elastic';

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_update_mappings.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_update_mappings.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AcknowledgedResponseBase } from '@elastic/elasticsearch/lib/api/types';
+import { useMutation, useQueryClient } from '@kbn/react-query';
+import type { IHttpFetchError, ResponseErrorBody } from '@kbn/core/public';
+import { MutationKeys, QueryKeys } from '../../constants';
+import { useKibana } from '../use_kibana';
+import type { UpdateIndexMappingsRequest } from '../../../common/types';
+
+export type ServerError = IHttpFetchError<ResponseErrorBody>;
+
+export const useUpdateMappings = () => {
+  const { http } = useKibana().services;
+  const queryClient = useQueryClient();
+
+  const { mutate: updateIndexMappings, ...rest } = useMutation<
+    AcknowledgedResponseBase,
+    ServerError,
+    UpdateIndexMappingsRequest
+  >({
+    mutationKey: [MutationKeys.SearchIndicesUpdateMappings],
+    mutationFn: async (input: UpdateIndexMappingsRequest) =>
+      http.put<AcknowledgedResponseBase>(
+        `/api/index_management/mapping/${encodeURIComponent(input.indexName)}`,
+        {
+          body: JSON.stringify(input.fields),
+        }
+      ),
+    onSettled: (data, error, variables) => {
+      queryClient.invalidateQueries([QueryKeys.FetchMapping, variables.indexName]);
+    },
+  });
+
+  return { updateIndexMappings, ...rest };
+};


### PR DESCRIPTION
## Summary

This PR adds the update ELSER to ELSER on EIS callout to the data tab of the index details page in an Elasticsearch solution space. 

**Notes**
I added a utils and types file for `UpdateElserMappingsModal` next to the component file because these will only be used by this component, and will likely eventually get removed at some point.

I also need to add an Enterprise license check to everywhere that uses `EisUpdateCallout`, but I will do this in a separate PR.

### Acceptance criteria
The Data tab callout should:
- [ ] appear on the overview tab of the index details page (Elasticsearch solution view)
- [ ] only be shown for in cloud environments (ECH & Serverless)
- [ ] only show if the user has semantic text field mappings with the `.elser-2-elasticsearch` inference endpoint
- [ ] allow the user the select the fields they want to update, and on applying the update, only the selected fields should be updated
- [ ] disappear when there are no more semantic text field mappings with the `.elser-2-elasticsearch` inference endpoint
- [ ] close and not reappear on page reload when the dismiss icon is clicked - a local storage key will be set to prevent the callout from showing

### Testing

#### ECH environment locally
To can mock an ECH environment locally you'll need add the following to your `kibana.dev.yml`:

```
xpack.cloud:
  id: 'LOCAL_DEV:ZmFrZS5lbHN0Yy5jbyRsb2NhbF9kZXYuZXMkbG9jYWxfZGV2LmtiCg=='
  base_url: 'https://fake-cloud.elastic.co'
```

#### Running EIS locally
You will also need to have EIS running locally. You can find instructions on how to do this in the [Inference team FAQs](https://docs.elastic.dev/search-team/teams/inference/faq#how-can-i-run-eis-locally-in-kibana).

**Note**: In those instructions there's an example command for running Elasticsearch. Use this command for a trial/enterprise license: `yarn es snapshot --license trial -E xpack.inference.elastic.url=https://localhost:8443 -E xpack.inference.elastic.http.ssl.verification_mode=none`

#### Quickly creating an index with semantic text mappings
Once you have Kibana running with EIS, the following command can be run in the Kibana console to quickly create an index with `.elser-2-elasticsearch` semantic text mappings:

```
PUT /update_elser_to_eis
{
  "mappings": {
    "properties": {
      "name": {
        "type": "semantic_text",
        "inference_id": ".elser-2-elasticsearch"
      },
      "address": {
        "type": "semantic_text",
        "inference_id": ".elser-2-elastic"
      },
      "animal": {
        "type": "object",
        "properties": {
          "name": {
            "type": "semantic_text",
            "inference_id": ".elser-2-elasticsearch"
          },
          "species": {
            "type": "semantic_text",
            "inference_id": ".elser-2-elasticsearch"
          },
          "owner": {
            "type": "object",
            "properties": {
              "name": {
                "type": "semantic_text",
                "inference_id": ".elser-2-elasticsearch"
              }
            }
          }
        }
      }
    }
  }
}
```
Once you have your environment set up and your index created, make sure you are viewing Kibana in an `Elasticsearch` space. Navigate to the Index Management page. It will load on the Data tab, which is where you can test the acceptance criteria.

### Screenshot
<img width="1508" height="827" alt="Screenshot 2025-12-16 at 23 32 46" src="https://github.com/user-attachments/assets/a45b2370-2097-4616-a640-555b71d71ffc" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines]~(https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->