### PR TITLE
[Agent Builder] Fast-follow bugfixes for MCP Tool type 

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/bulk_import/mcp_tools_selection_table_header.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/bulk_import/mcp_tools_selection_table_header.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseEuiTheme } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiSkeletonLoading,
+  EuiSkeletonText,
+  EuiText,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import React, { memo, useCallback } from 'react';
+import useToggle from 'react-use/lib/useToggle';
+import { labels } from '../../../utils/i18n';
+
+const tableHeaderContainerStyles = ({ euiTheme }: UseEuiTheme) => css`
+  margin-block-start: -${euiTheme.size.s};
+`;
+
+const tableHeaderStyles = css`
+  min-height: 24px;
+`;
+
+const tableHeaderSkeletonStyles = css`
+  display: inline-block;
+  width: 200px;
+`;
+
+const tableHeaderButtonStyles = ({ euiTheme }: UseEuiTheme) => css`
+  font-weight: ${euiTheme.font.weight.semiBold};
+`;
+
+export interface McpToolsSelectionTableHeaderProps {
+  isLoading: boolean;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+  selectedCount: number;
+  onSelectAll: () => void;
+  onClearSelection: () => void;
+}
+
+export const McpToolsSelectionTableHeader = memo<McpToolsSelectionTableHeaderProps>(
+  ({
+    isLoading,
+    pageIndex,
+    pageSize,
+    totalCount,
+    selectedCount,
+    onSelectAll,
+    onClearSelection,
+  }) => {
+    const [isPopoverOpen, togglePopover] = useToggle(false);
+
+    const closePopover = useCallback(() => {
+      togglePopover(false);
+    }, [togglePopover]);
+
+    const handleSelectAll = useCallback(() => {
+      onSelectAll();
+      togglePopover(false);
+    }, [onSelectAll, togglePopover]);
+
+    const paginationStart = pageIndex * pageSize + 1;
+    const paginationEnd = Math.min((pageIndex + 1) * pageSize, totalCount);
+
+    return (
+      <EuiSkeletonLoading
+        isLoading={isLoading}
+        css={tableHeaderContainerStyles}
+        loadingContent={<EuiSkeletonText css={tableHeaderSkeletonStyles} lines={1} size="xs" />}
+        loadedContent={
+          totalCount > 0 ? (
+            <EuiFlexGroup gutterSize="s" alignItems="center" css={tableHeaderStyles}>
+              <EuiFlexItem grow={false}>
+                <EuiText size="xs">
+                  <FormattedMessage
+                    id="xpack.onechat.tools.bulkImportMcp.sourceSection.tableSummary"
+                    defaultMessage="Showing {start}-{end} of {total}"
+                    values={{
+                      start: <strong>{paginationStart}</strong>,
+                      end: <strong>{paginationEnd}</strong>,
+                      total: totalCount,
+                    }}
+                  />
+                </EuiText>
+              </EuiFlexItem>
+              {selectedCount > 0 && (
+                <EuiFlexGroup gutterSize="none" alignItems="center">
+                  <EuiFlexItem grow={false}>
+                    <EuiPopover
+                      button={
+                        <EuiButtonEmpty
+                          iconType="arrowDown"
+                          iconSide="right"
+                          iconSize="s"
+                          size="xs"
+                          onClick={togglePopover}
+                          data-test-subj="bulkImportMcpToolsSelectionPopoverButton"
+                          css={tableHeaderButtonStyles}
+                        >
+                          {labels.tools.bulkImportMcp.sourceSection.selectedCount(selectedCount)}
+                        </EuiButtonEmpty>
+                      }
+                      isOpen={isPopoverOpen}
+                      closePopover={closePopover}
+                      panelPaddingSize="none"
+                      anchorPosition="downLeft"
+                    >
+                      <EuiContextMenuPanel
+                        size="s"
+                        items={[
+                          <EuiContextMenuItem
+                            key="selectAll"
+                            icon="pagesSelect"
+                            onClick={handleSelectAll}
+                            data-test-subj="bulkImportMcpToolsSelectAllButton"
+                          >
+                            {labels.tools.selectAllToolsButtonLabel}
+                          </EuiContextMenuItem>,
+                        ]}
+                      />
+                    </EuiPopover>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiButtonEmpty
+                      iconType="cross"
+                      iconSize="s"
+                      size="xs"
+                      color="danger"
+                      onClick={onClearSelection}
+                      data-test-subj="bulkImportMcpToolsClearSelectionButton"
+                      css={tableHeaderButtonStyles}
+                    >
+                      {labels.tools.bulkImportMcp.sourceSection.clearSelection}
+                    </EuiButtonEmpty>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              )}
+            </EuiFlexGroup>
+          ) : null
+        }
+      />
+    );
+  }
+);

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/bulk_import/sections/source.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/bulk_import/sections/source.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { EuiComboBoxOptionOption, UseEuiTheme } from '@elastic/eui';
 import { EuiComboBox, EuiFormRow, EuiLink, euiFontSize, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
+import type { ActionConnector } from '@kbn/alerts-ui-shared';
 import { CONNECTOR_ID as MCP_CONNECTOR_TYPE } from '@kbn/connector-schemas/mcp/constants';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useListConnectors, useListMcpTools } from '../../../../hooks/tools/use_mcp_connectors';
@@ -28,11 +29,20 @@ export const SourceSection = () => {
   const { control, formState, setValue } = useFormContext<BulkImportMcpToolsFormData>();
   const { errors } = formState;
 
+  const handleConnectorCreated = useCallback(
+    (connector: ActionConnector) => {
+      setValue('connectorId', connector.id, { shouldValidate: true });
+      // Clear tool selection when connector changes
+      setValue('tools', []);
+    },
+    [setValue]
+  );
+
   const {
     openFlyout: openCreateMcpServerFlyout,
     isOpen: isCreateMcpServerFlyoutOpen,
     flyout: createMcpServerFlyout,
-  } = useAddMcpServerFlyout();
+  } = useAddMcpServerFlyout({ onConnectorCreated: handleConnectorCreated });
 
   const { connectors, isLoading: isLoadingConnectors } = useListConnectors({
     type: MCP_CONNECTOR_TYPE,

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/bulk_import/use_mcp_tools_search.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/bulk_import/use_mcp_tools_search.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiSearchBarOnChangeArgs, Search } from '@elastic/eui';
+import { EuiSearchBar } from '@elastic/eui';
+import type { Tool as McpTool } from '@kbn/mcp-client';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { labels } from '../../../utils/i18n';
+
+export interface McpToolsSearch {
+  searchConfig: Search;
+  searchQuery: string;
+  results: McpTool[];
+}
+
+export interface UseMcpToolsSearchOptions {
+  tools: readonly McpTool[];
+  isDisabled?: boolean;
+}
+
+export const useMcpToolsSearch = ({
+  tools,
+  isDisabled = false,
+}: UseMcpToolsSearchOptions): McpToolsSearch => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [results, setResults] = useState<McpTool[]>([...tools]);
+
+  useEffect(() => {
+    setResults([...tools]);
+  }, [tools]);
+
+  const handleChange = useCallback(
+    ({ query, queryText, error: searchError }: EuiSearchBarOnChangeArgs) => {
+      if (searchError) {
+        return;
+      }
+
+      const newItems = query
+        ? EuiSearchBar.Query.execute(query, tools as McpTool[], {
+            defaultFields: ['name', 'description'],
+          })
+        : [...tools];
+
+      setSearchQuery(queryText);
+      setResults(newItems);
+    },
+    [tools]
+  );
+
+  const searchConfig: Search = useMemo(
+    () => ({
+      onChange: handleChange,
+      box: {
+        incremental: true,
+        placeholder: labels.tools.bulkImportMcp.sourceSection.searchPlaceholder,
+        disabled: isDisabled || tools.length === 0,
+        'data-test-subj': 'bulkImportMcpToolsSearchInput',
+      },
+    }),
+    [handleChange, isDisabled, tools.length]
+  );
+
+  return {
+    searchConfig,
+    searchQuery,
+    results,
+  };
+};

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/mcp/mcp_editable_fields.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/mcp/mcp_editable_fields.tsx
@@ -18,6 +18,7 @@ import {
   useUpdateEffect,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import type { ActionConnector } from '@kbn/alerts-ui-shared';
 import { CONNECTOR_ID as MCP_CONNECTOR_TYPE } from '@kbn/connector-schemas/mcp/constants';
 import type { Tool } from '@kbn/mcp-client';
 import React, { useCallback, useEffect, useMemo } from 'react';
@@ -51,17 +52,24 @@ export const McpEditableFields = ({
   const { navigateToOnechatUrl } = useNavigation();
 
   const {
-    openFlyout: openCreateMcpServerFlyout,
-    isOpen: isCreateMcpServerFlyoutOpen,
-    flyout: createMcpServerFlyout,
-  } = useAddMcpServerFlyout();
-
-  const {
     control,
     formState: { errors },
     clearErrors,
     setValue,
   } = useFormContext<McpToolFormData>();
+
+  const handleConnectorCreated = useCallback(
+    (connector: ActionConnector) => {
+      setValue('connectorId', connector.id, { shouldValidate: true });
+    },
+    [setValue]
+  );
+
+  const {
+    openFlyout: openCreateMcpServerFlyout,
+    isOpen: isCreateMcpServerFlyoutOpen,
+    flyout: createMcpServerFlyout,
+  } = useAddMcpServerFlyout({ onConnectorCreated: handleConnectorCreated });
 
   const handleBulkImportClick = useCallback(() => {
     navigateToOnechatUrl(appPaths.tools.bulkImportMcp);

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/mcp/mcp_readonly_fields.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/mcp/mcp_readonly_fields.tsx
@@ -34,7 +34,7 @@ export const McpReadOnlyFields = ({
     name: ['connectorId', 'mcpToolName', 'toolId'],
   });
 
-  const { toolHealth } = useToolHealth({ toolId });
+  const { toolHealth, isLoading: isLoadingToolHealth } = useToolHealth({ toolId });
 
   const {
     connector,
@@ -57,7 +57,7 @@ export const McpReadOnlyFields = ({
   } = useListMcpTools({ connectorId });
 
   useEffect(() => {
-    if (isLoadingConnector || isLoadingMcpTools) {
+    if (isLoadingConnector || isLoadingMcpTools || isLoadingToolHealth) {
       return;
     }
 
@@ -107,6 +107,7 @@ export const McpReadOnlyFields = ({
     isLoadingMcpToolsError,
     isLoadingConnector,
     isLoadingMcpTools,
+    isLoadingToolHealth,
     setMcpHealthStatus,
     setError,
     clearErrors,

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/mcp/mcp_readonly_fields.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/mcp/mcp_readonly_fields.tsx
@@ -39,7 +39,7 @@ export const McpReadOnlyFields = ({
   const {
     connector,
     isLoading: isLoadingConnector,
-    isError: isLoadingConnectorError,
+    failureReason: loadingConnectorError,
   } = useGetConnector({
     connectorId,
   });
@@ -53,7 +53,7 @@ export const McpReadOnlyFields = ({
   const {
     mcpTools,
     isLoading: isLoadingMcpTools,
-    isError: isLoadingMcpToolsError,
+    failureReason: loadingMcpToolsError,
   } = useListMcpTools({ connectorId });
 
   useEffect(() => {
@@ -62,7 +62,7 @@ export const McpReadOnlyFields = ({
     }
 
     // MCP connector deleted
-    if (isLoadingConnectorError) {
+    if (loadingConnectorError) {
       setMcpHealthStatus(McpToolHealthStatus.ConnectorNotFound);
       setError('connectorId', {
         message: labels.tools.mcpHealthStatus.connectorNotFound.title,
@@ -71,7 +71,7 @@ export const McpReadOnlyFields = ({
     }
 
     // MCP tools not found
-    if (isLoadingMcpToolsError) {
+    if (loadingMcpToolsError) {
       setMcpHealthStatus(McpToolHealthStatus.ListToolsFailed);
       setError('connectorId', {
         message: labels.tools.mcpHealthStatus.listToolsFailed.title,
@@ -103,8 +103,8 @@ export const McpReadOnlyFields = ({
     mcpToolName,
     mcpTools,
     toolHealth,
-    isLoadingConnectorError,
-    isLoadingMcpToolsError,
+    loadingConnectorError,
+    loadingMcpToolsError,
     isLoadingConnector,
     isLoadingMcpTools,
     isLoadingToolHealth,

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/hooks/use_add_mcp_server_flyout.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/hooks/use_add_mcp_server_flyout.ts
@@ -13,7 +13,13 @@ import { useKibana } from '../../../../hooks/use_kibana';
 import { useFlyoutState } from '../../../../hooks/use_flyout_state';
 import { queryKeys } from '../../../../query_keys';
 
-export const useAddMcpServerFlyout = () => {
+export interface UseAddMcpServerFlyoutOptions {
+  onConnectorCreated?: (connector: ActionConnector) => void;
+}
+
+export const useAddMcpServerFlyout = ({
+  onConnectorCreated,
+}: UseAddMcpServerFlyoutOptions = {}) => {
   const {
     services: {
       plugins: { triggersActionsUi },
@@ -25,12 +31,13 @@ export const useAddMcpServerFlyout = () => {
 
   // Refresh the list of MCP connectors when a new MCP connector is created
   const handleConnectorCreated = useCallback(
-    (_: ActionConnector) => {
+    (connector: ActionConnector) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.tools.connectors.list(MCP_CONNECTOR_TYPE),
       });
+      onConnectorCreated?.(connector);
     },
-    [queryClient]
+    [queryClient, onConnectorCreated]
   );
 
   const flyout = useMemo(

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_mcp_connectors.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_mcp_connectors.ts
@@ -19,44 +19,38 @@ export interface UseListConnectorsOptions {
 }
 export const useListConnectors = ({ type }: UseListConnectorsOptions) => {
   const { toolsService } = useOnechatServices();
-  const { data, isLoading, error, isError } = useQuery({
+  const { data, ...queryFields } = useQuery({
     queryKey: queryKeys.tools.connectors.list(type),
     queryFn: () => toolsService.listConnectors({ type }),
   });
   return {
     connectors: data?.connectors ?? EMPTY_CONNECTORS,
-    isLoading,
-    error,
-    isError,
+    ...queryFields,
   };
 };
 
 export const useGetConnector = ({ connectorId }: { connectorId: string }) => {
   const { toolsService } = useOnechatServices();
-  const { data, isLoading, error, isError } = useQuery({
+  const { data, ...queryFields } = useQuery({
     queryKey: queryKeys.tools.connectors.get(connectorId),
     queryFn: () => toolsService.getConnector({ connectorId }),
     enabled: !!connectorId,
   });
   return {
     connector: data?.connector,
-    isLoading,
-    error,
-    isError,
+    ...queryFields,
   };
 };
 
 export const useListMcpTools = ({ connectorId }: { connectorId: string }) => {
   const { toolsService } = useOnechatServices();
-  const { data, isLoading, error, isError } = useQuery({
+  const { data, ...queryFields } = useQuery({
     queryKey: queryKeys.tools.connectors.listMcpTools(connectorId),
     queryFn: () => toolsService.listMcpTools({ connectorId }),
     enabled: !!connectorId,
   });
   return {
     mcpTools: data?.mcpTools ?? EMPTY_TOOLS,
-    isLoading,
-    error,
-    isError,
+    ...queryFields,
   };
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tools_health.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tools_health.ts
@@ -43,6 +43,7 @@ export const useToolHealth = ({ toolId }: UseToolHealthOptions) => {
     queryKey: queryKeys.tools.health.byId(toolId),
     queryFn: () => toolsService.getToolHealth({ toolId }),
     enabled: !!toolId,
+    retry: false,
   });
 
   return {
@@ -61,6 +62,7 @@ export const useMcpToolsHealth = ({ enabled = true }: { enabled?: boolean } = {}
     queryKey: queryKeys.tools.health.mcp(),
     queryFn: () => toolsService.listMcpToolsHealth(),
     enabled,
+    retry: false,
   });
 
   return {

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tools_health.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_tools_health.ts
@@ -17,17 +17,15 @@ const EMPTY_HEALTH_STATES: readonly ToolHealthState[] = [];
 export const useToolsHealth = () => {
   const { toolsService } = useOnechatServices();
 
-  const { data, isLoading, error, isError, refetch } = useQuery({
+  const { data, ...queryFields } = useQuery({
     queryKey: queryKeys.tools.health.list(),
     queryFn: () => toolsService.listToolsHealth(),
+    retry: false,
   });
 
   return {
     healthStates: data?.results ?? EMPTY_HEALTH_STATES,
-    isLoading,
-    error,
-    isError,
-    refetch,
+    ...queryFields,
   };
 };
 
@@ -39,7 +37,7 @@ export interface UseToolHealthOptions {
 export const useToolHealth = ({ toolId }: UseToolHealthOptions) => {
   const { toolsService } = useOnechatServices();
 
-  const { data, isLoading, error, isError, refetch } = useQuery({
+  const { data, ...queryFields } = useQuery({
     queryKey: queryKeys.tools.health.byId(toolId),
     queryFn: () => toolsService.getToolHealth({ toolId }),
     enabled: !!toolId,
@@ -48,17 +46,14 @@ export const useToolHealth = ({ toolId }: UseToolHealthOptions) => {
 
   return {
     toolHealth: data?.health,
-    isLoading,
-    error,
-    isError,
-    refetch,
+    ...queryFields,
   };
 };
 
 export const useMcpToolsHealth = ({ enabled = true }: { enabled?: boolean } = {}) => {
   const { toolsService } = useOnechatServices();
 
-  const { data, isLoading, error, isError, refetch } = useQuery({
+  const { data, ...queryFields } = useQuery({
     queryKey: queryKeys.tools.health.mcp(),
     queryFn: () => toolsService.listMcpToolsHealth(),
     enabled,
@@ -67,9 +62,6 @@ export const useMcpToolsHealth = ({ enabled = true }: { enabled?: boolean } = {}
 
   return {
     mcpHealthStates: data?.results ?? EMPTY_MCP_HEALTH_STATES,
-    isLoading,
-    error,
-    isError,
-    refetch,
+    ...queryFields,
   };
 };


### PR DESCRIPTION
## Summary

A couple of relatively small bugfixes for MCP tool type support in Agent Builder bundled together:
- __MCP tool search not working on the bulk import page__: I forgot that if you have a custom change handler for `search`, you need to handle the filtering as well
- __Select all MCP tools__: Would inadvertently get reset when clicking on the "x selected" button due to some reconciliation logic built into `EuiInMemoryTable`
- __Namespace validation__: Focused on the complicated one first but forgot to add the simple ones — added similar validation rules to tool IDs
- __UX improvement: Automatically select newly created connector__
- __Health status improvements__: Disabled retries for health checks (faster feedback) and some minor refactor and improvements to how they're rendered


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

