### PR TITLE
[ES|QL] Show next actions after simple field assignment in RERANK ON Clause

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/rerank/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/rerank/autocomplete.test.ts
@@ -253,6 +253,18 @@ describe('RERANK Autocomplete', () => {
 
       await expectRerankSuggestions(query, NEXT_ACTIONS_EXPRESSIONS);
     });
+
+    test('suggests next actions after simple field assignment', async () => {
+      const query =
+        buildRerankQuery({
+          query: '"search query"',
+          onClause: 'col0 = keywordField',
+        }) + ' ';
+
+      await expectRerankSuggestions(query, {
+        contains: NEXT_ACTIONS,
+      });
+    });
   });
 
   describe('Terminal operators', () => {

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/rerank/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/rerank/autocomplete.ts
@@ -235,9 +235,9 @@ async function handleOnExpression({
     },
   });
 
-  const { expressionType, isComplete, insideFunction } = computed;
+  const { isComplete, insideFunction } = computed;
 
-  if (expressionRoot && expressionType === 'boolean' && isComplete && !insideFunction) {
+  if (expressionRoot && isComplete && !insideFunction) {
     suggestions.push(...buildNextActions());
   }
 


### PR DESCRIPTION
_## Summary

There is an incorrect interpretation of the RERANK grammar, namely `rerankField qualifiedName (ASSIGN BooleanExpression)`. This does not mean it should return a Boolean, but simply the name describing the rule. 

so even simple fields are valid