### PR TITLE
Truncate text for value list column in value list modal

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/value_list/components/list_item_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/value_list/components/list_item_table.tsx
@@ -40,6 +40,7 @@ export const ListItemTable = ({
       render: (value, item) =>
         canWriteIndex ? <InlineEditListItemValue listItem={item} key={value} /> : value,
       sortable: list.type !== 'text' && list.type !== 'ip_range',
+      truncateText: true,
     },
     {
       field: LIST_ITEM_FIELDS.updatedAt,


### PR DESCRIPTION
Close: https://github.com/elastic/kibana/issues/243046
Before:
<img width="1371" height="768" alt="Screenshot 2025-12-17 at 10 18 36" src="https://github.com/user-attachments/assets/40237fe2-d6e0-491f-bf91-ac9a195870a6" />

After:
<img width="1402" height="809" alt="Screenshot 2025-12-17 at 10 20 25" src="https://github.com/user-attachments/assets/1e22c7cc-bc7b-4631-910b-9a315bd2e0ad" />



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->