### PR TITLE
[8.19] [APM] Skip flaky test (Service map) (#209510)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_map/service_map.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_map/service_map.cy.ts
@@ -29,7 +29,8 @@ const detailedServiceMap = url.format({
   },
 });
 
-describe('service map', () => {
+// Flaky: https://github.com/elastic/kibana/issues/207005
+describe.skip('service map', () => {
   before(() => {
     synthtrace.index(
       opbeans({
@@ -52,7 +53,7 @@ describe('service map', () => {
       cy.intercept('GET', '/internal/apm/service-map?*').as('serviceMap');
     });
 
-    it.skip('shows nodes in service map', () => {
+    it('shows nodes in service map', () => {
       cy.visitKibana(serviceMapHref);
       cy.wait('@serviceMap');
 
@@ -68,7 +69,7 @@ describe('service map', () => {
       );
     });
 
-    it.skip('shows nodes in detailed service map', () => {
+    it('shows nodes in detailed service map', () => {
       cy.visitKibana(detailedServiceMap);
       cy.wait('@serviceMap');
       cy.contains('h1', 'opbeans-java');


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/207005

# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM] Skip flaky test (Service map) (#209510)](https://github.com/elastic/kibana/pull/209510)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-02-05T09:23:44Z","message":"[APM] Skip flaky test (Service map) (#209510)\n\nCloses #207005 \r\n\r\n## Summary\r\n\r\nThis PR skips flaky tests - 2 of the flaky tests were already skipped so\r\nI skipped the test on the top level (as all the tests will be skipped\r\nanyway it makes more sense to have the whole test skipped)\r\nI tried to fix it and managed to reproduce the flaky behavior only once\r\nout of many runs (the input was not filled but the next check failed -\r\nwhich was not an expected behavior as it should fail on the previous\r\nstep or retry it) - It's super hard to reproduce it. I followed the\r\nsteps locally and it worked as expected so it's not an actual issue:\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/d0d33622-c186-4b31-bcf7-b2c27df330ac\r\n\r\n\r\n\r\nAs we plan to refactor the test anyway we should not spend more time on\r\nit so I skipped it for now.","sha":"2e84285a32ed32f1d8532a915cf1d11ca17ede58","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["skipped-test","release_note:skip","v9.0.0","Team:obs-ux-infra_services - DEPRECATED","v9.1.0"],"title":"[APM] Skip flaky test (Service map)","number":209510,"url":"https://github.com/elastic/kibana/pull/209510","mergeCommit":{"message":"[APM] Skip flaky test (Service map) (#209510)\n\nCloses #207005 \r\n\r\n## Summary\r\n\r\nThis PR skips flaky tests - 2 of the flaky tests were already skipped so\r\nI skipped the test on the top level (as all the tests will be skipped\r\nanyway it makes more sense to have the whole test skipped)\r\nI tried to fix it and managed to reproduce the flaky behavior only once\r\nout of many runs (the input was not filled but the next check failed -\r\nwhich was not an expected behavior as it should fail on the previous\r\nstep or retry it) - It's super hard to reproduce it. I followed the\r\nsteps locally and it worked as expected so it's not an actual issue:\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/d0d33622-c186-4b31-bcf7-b2c27df330ac\r\n\r\n\r\n\r\nAs we plan to refactor the test anyway we should not spend more time on\r\nit so I skipped it for now.","sha":"2e84285a32ed32f1d8532a915cf1d11ca17ede58"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209713","number":209713,"state":"MERGED","mergeCommit":{"sha":"37168173f183b5878151b702ad90e720e777bfda","message":"[9.0] [APM] Skip flaky test (Service map) (#209510) (#209713)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[APM] Skip flaky test (Service map)\n(#209510)](https://github.com/elastic/kibana/pull/209510)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: jennypavlova <dzheni.pavlova@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209510","number":209510,"mergeCommit":{"message":"[APM] Skip flaky test (Service map) (#209510)\n\nCloses #207005 \r\n\r\n## Summary\r\n\r\nThis PR skips flaky tests - 2 of the flaky tests were already skipped so\r\nI skipped the test on the top level (as all the tests will be skipped\r\nanyway it makes more sense to have the whole test skipped)\r\nI tried to fix it and managed to reproduce the flaky behavior only once\r\nout of many runs (the input was not filled but the next check failed -\r\nwhich was not an expected behavior as it should fail on the previous\r\nstep or retry it) - It's super hard to reproduce it. I followed the\r\nsteps locally and it worked as expected so it's not an actual issue:\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/d0d33622-c186-4b31-bcf7-b2c27df330ac\r\n\r\n\r\n\r\nAs we plan to refactor the test anyway we should not spend more time on\r\nit so I skipped it for now.","sha":"2e84285a32ed32f1d8532a915cf1d11ca17ede58"}}]}] BACKPORT-->