### PR TITLE
[Discover][Flaky Test Fix] Close datepicker popover by clicking escape key

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/date_picker.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/date_picker.ts
@@ -56,6 +56,7 @@ export class DatePicker {
     await inputFrom.clear();
     await inputFrom.fill(to);
     await this.page.testSubj.click('parseAbsoluteDateFormat');
+    await this.page.keyboard.press('Escape');
     await this.page.testSubj.click('superDatePickerendDatePopoverButton');
     // and later change start date
     await this.page.testSubj.click('superDatePickerstartDatePopoverButton');

--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/value_suggestions_use_time_range_disabled.spec.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/parallel_tests/value_suggestions_use_time_range_disabled.spec.ts
@@ -8,9 +8,7 @@
 import { expect, tags } from '@kbn/scout';
 import { spaceTest, testData, assertionMessages } from '../fixtures';
 
-// Failing: See https://github.com/elastic/kibana/issues/246229
-// FLAKY: https://github.com/elastic/kibana/issues/246228
-spaceTest.describe.skip(
+spaceTest.describe(
   'Discover app - value suggestions: useTimeRange disabled',
   { tag: tags.DEPLOYMENT_AGNOSTIC },
   () => {


### PR DESCRIPTION
## Summary

This PR adds one step in the `setAbsoluteRange` function, which is closing the datepicker popover via escape key. It makes sure that the popover does not cover the actual datepicker buttons which could potentially cause the test flakiness.

It closes: #246229
it closes: #246228
it closes: #246468

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
