### PR TITLE
[ES|QL] WIP: Wrong validation for DATE_FORMAT

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/expressions.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/expressions.ts
@@ -201,6 +201,13 @@ export function getMatchingSignatures(
       return false;
     }
 
+    // Reject signature if there are required params after the last provided arg.
+    // E.g. DATE_FORMAT(format?, date) with 1 arg fails because 'date' (required) is at index 1.
+    const lastRequiredIndex = sig.params.findLastIndex((p) => !p.optional);
+    if (!sig.minParams && lastRequiredIndex >= givenTypes.length) {
+      return false;
+    }
+
     return givenTypes.every((givenType, index) => {
       let param;
       const totalArgs = givenTypes.length;


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/issues/246543

` DATE_FORMAT("", true, 5) doesn't show an error.`  
this bug is fixed here https://github.com/elastic/kibana/pull/246715 from kibana core

The issue occurred because we use the `formatList `function, which is not exported by i18n. This resulted in an exception in `wrongNumberArgsVariadics`.

Here we add a small improvement to ensure that when the first parameter is a text or keyword, the second parameter is required.
