### PR TITLE
[EDR Workflows] [Osquery] Add pagination limit for query results

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/moon.yml
+++ b/x-pack/platform/plugins/shared/osquery/moon.yml
@@ -78,6 +78,7 @@ dependsOn:
   - '@kbn/setup-node-env'
   - '@kbn/core-http-server'
   - '@kbn/react-query'
+  - '@kbn/react-kibana-mount'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/osquery/public/results/results_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/results/results_table.tsx
@@ -15,6 +15,7 @@ import type {
 } from '@elastic/eui';
 import {
   EuiCallOut,
+  EuiCode,
   EuiDataGrid,
   EuiPanel,
   EuiLink,
@@ -24,6 +25,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { toMountPoint } from '@kbn/react-kibana-mount';
 import React, { createContext, useEffect, useState, useCallback, useContext, useMemo } from 'react';
 import type { ECSMapping } from '@kbn/osquery-io-ts-types';
 import { pagePathGetters } from '@kbn/fleet-plugin/public';
@@ -34,11 +36,7 @@ import { Direction } from '../../common/search_strategy';
 import { useKibana } from '../common/lib/kibana';
 import { DEFAULT_MAX_TABLE_QUERY_SIZE } from '../../common/constants';
 import { useActionResults } from '../action_results/use_action_results';
-import {
-  generateEmptyDataMessage,
-  PAGINATION_LIMIT_TITLE,
-  PAGINATION_LIMIT_DESCRIPTION,
-} from './translations';
+import { generateEmptyDataMessage, PAGINATION_LIMIT_TITLE } from './translations';
 import {
   ViewResultsInDiscoverAction,
   ViewResultsInLensAction,
@@ -48,6 +46,11 @@ import { PLUGIN_NAME as OSQUERY_PLUGIN_NAME } from '../../common';
 import { AddToCaseWrapper } from '../cases/add_to_cases';
 
 const DataContext = createContext<ResultEdges>([]);
+
+const PAGINATION_LIMIT_MESSAGE_VALUES = {
+  viewInDiscoverButton: <strong>&quot;View in Discover&quot;</strong>,
+  indexName: <EuiCode>logs-osquery_manager.results</EuiCode>,
+};
 
 const euiDataGridCss = {
   ':not(.euiDataGrid--fullScreen)': {
@@ -105,6 +108,8 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
     appName,
     timelines,
     notifications: { toasts },
+    i18n: i18nStart,
+    theme,
   } = useKibana().services;
   const getFleetAppUrl = useCallback(
     (agentId: any) =>
@@ -117,10 +122,16 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
   const showPaginationLimitToast = useCallback(() => {
     toasts.addWarning({
       title: PAGINATION_LIMIT_TITLE,
-      text: PAGINATION_LIMIT_DESCRIPTION,
-      toastLifeTimeMs: 10000,
+      text: toMountPoint(
+        <FormattedMessage
+          id="xpack.osquery.results.paginationLimitDescription"
+          defaultMessage="Results limited to first 10,000 documents. To see all results, please use the {viewInDiscoverButton} button. Read access to {indexName} index is required."
+          values={PAGINATION_LIMIT_MESSAGE_VALUES}
+        />,
+        { i18n: i18nStart, theme }
+      ),
     });
-  }, [toasts]);
+  }, [i18nStart, theme, toasts]);
 
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 50 });
   const onChangeItemsPerPage = useCallback(

--- a/x-pack/platform/plugins/shared/osquery/public/results/results_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/results/results_table.tsx
@@ -47,27 +47,26 @@ import { AddToCaseWrapper } from '../cases/add_to_cases';
 
 const DataContext = createContext<ResultEdges>([]);
 
-const paginationLimitDescriptionValues = {
-  viewInDiscoverButton: <strong>&quot;View in Discover&quot;</strong>,
-};
-const paginationLimitIndexAccessValues = {
-  indexName: <EuiCode>logs-osquery_manager.results</EuiCode>,
-};
-
 const PaginationLimitToastContent = () => (
   <>
     <p>
       <FormattedMessage
         id="xpack.osquery.results.paginationLimitDescription"
         defaultMessage="Results limited to first 10,000 documents. To see all results, please use the {viewInDiscoverButton} button."
-        values={paginationLimitDescriptionValues}
+        // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
+        values={{
+          viewInDiscoverButton: <strong>&quot;View in Discover&quot;</strong>,
+        }}
       />
     </p>
     <p>
       <FormattedMessage
         id="xpack.osquery.results.paginationLimitIndexAccess"
         defaultMessage="Read access to {indexName} index is required."
-        values={paginationLimitIndexAccessValues}
+        // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
+        values={{
+          indexName: <EuiCode>logs-osquery_manager.results</EuiCode>,
+        }}
       />
     </p>
   </>

--- a/x-pack/platform/plugins/shared/osquery/public/results/results_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/results/results_table.tsx
@@ -40,6 +40,7 @@ import {
   PAGINATION_LIMIT_DESCRIPTION,
 } from './translations';
 import {
+  ViewResultsInDiscoverAction,
   ViewResultsInLensAction,
   ViewResultsActionButtonType,
 } from '../packs/pack_queries_status_table';

--- a/x-pack/platform/plugins/shared/osquery/public/results/results_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/results/results_table.tsx
@@ -47,20 +47,27 @@ import { AddToCaseWrapper } from '../cases/add_to_cases';
 
 const DataContext = createContext<ResultEdges>([]);
 
+const paginationLimitDescriptionValues = {
+  viewInDiscoverButton: <strong>&quot;View in Discover&quot;</strong>,
+};
+const paginationLimitIndexAccessValues = {
+  indexName: <EuiCode>logs-osquery_manager.results</EuiCode>,
+};
+
 const PaginationLimitToastContent = () => (
   <>
     <p>
       <FormattedMessage
         id="xpack.osquery.results.paginationLimitDescription"
         defaultMessage="Results limited to first 10,000 documents. To see all results, please use the {viewInDiscoverButton} button."
-        values={{ viewInDiscoverButton: <strong>&quot;View in Discover&quot;</strong> }}
+        values={paginationLimitDescriptionValues}
       />
     </p>
     <p>
       <FormattedMessage
         id="xpack.osquery.results.paginationLimitIndexAccess"
         defaultMessage="Read access to {indexName} index is required."
-        values={{ indexName: <EuiCode>logs-osquery_manager.results</EuiCode> }}
+        values={paginationLimitIndexAccessValues}
       />
     </p>
   </>

--- a/x-pack/platform/plugins/shared/osquery/public/results/results_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/results/results_table.tsx
@@ -47,10 +47,24 @@ import { AddToCaseWrapper } from '../cases/add_to_cases';
 
 const DataContext = createContext<ResultEdges>([]);
 
-const PAGINATION_LIMIT_MESSAGE_VALUES = {
-  viewInDiscoverButton: <strong>&quot;View in Discover&quot;</strong>,
-  indexName: <EuiCode>logs-osquery_manager.results</EuiCode>,
-};
+const PaginationLimitToastContent = () => (
+  <>
+    <p>
+      <FormattedMessage
+        id="xpack.osquery.results.paginationLimitDescription"
+        defaultMessage="Results limited to first 10,000 documents. To see all results, please use the {viewInDiscoverButton} button."
+        values={{ viewInDiscoverButton: <strong>&quot;View in Discover&quot;</strong> }}
+      />
+    </p>
+    <p>
+      <FormattedMessage
+        id="xpack.osquery.results.paginationLimitIndexAccess"
+        defaultMessage="Read access to {indexName} index is required."
+        values={{ indexName: <EuiCode>logs-osquery_manager.results</EuiCode> }}
+      />
+    </p>
+  </>
+);
 
 const euiDataGridCss = {
   ':not(.euiDataGrid--fullScreen)': {
@@ -122,14 +136,7 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
   const showPaginationLimitToast = useCallback(() => {
     toasts.addWarning({
       title: PAGINATION_LIMIT_TITLE,
-      text: toMountPoint(
-        <FormattedMessage
-          id="xpack.osquery.results.paginationLimitDescription"
-          defaultMessage="Results limited to first 10,000 documents. To see all results, please use the {viewInDiscoverButton} button. Read access to {indexName} index is required."
-          values={PAGINATION_LIMIT_MESSAGE_VALUES}
-        />,
-        { i18n: i18nStart, theme }
-      ),
+      text: toMountPoint(<PaginationLimitToastContent />, { i18n: i18nStart, theme }),
     });
   }, [i18nStart, theme, toasts]);
 

--- a/x-pack/platform/plugins/shared/osquery/public/results/translations.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/results/translations.ts
@@ -25,11 +25,3 @@ export const FAIL_ALL_RESULTS = i18n.translate('xpack.osquery.results.failSearch
 export const PAGINATION_LIMIT_TITLE = i18n.translate('xpack.osquery.results.paginationLimitTitle', {
   defaultMessage: 'Results limit reached',
 });
-
-export const PAGINATION_LIMIT_DESCRIPTION = i18n.translate(
-  'xpack.osquery.results.paginationLimitDescription',
-  {
-    defaultMessage:
-      'Results limited to first 10,000 documents. To see all results, please use the "View in Discover" button.',
-  }
-);

--- a/x-pack/platform/plugins/shared/osquery/public/results/translations.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/results/translations.ts
@@ -21,3 +21,15 @@ export const ERROR_ALL_RESULTS = i18n.translate('xpack.osquery.results.errorSear
 export const FAIL_ALL_RESULTS = i18n.translate('xpack.osquery.results.failSearchDescription', {
   defaultMessage: `Failed to fetch results`,
 });
+
+export const PAGINATION_LIMIT_TITLE = i18n.translate('xpack.osquery.results.paginationLimitTitle', {
+  defaultMessage: 'Results limit reached',
+});
+
+export const PAGINATION_LIMIT_DESCRIPTION = i18n.translate(
+  'xpack.osquery.results.paginationLimitDescription',
+  {
+    defaultMessage:
+      'Results limited to first 10,000 documents. To see all results, please use the "View in Discover" button.',
+  }
+);

--- a/x-pack/platform/plugins/shared/osquery/tsconfig.json
+++ b/x-pack/platform/plugins/shared/osquery/tsconfig.json
@@ -84,6 +84,7 @@
     "@kbn/core-http-server",
     "@kbn/setup-node-env",
     "@kbn/core-http-server",
-    "@kbn/react-query"
+    "@kbn/react-query",
+    "@kbn/react-kibana-mount"
   ]
 }


### PR DESCRIPTION
Adds a 10,000 document pagination limit for osquery query results.
<img width="2551" height="1153" alt="Screenshot 2025-12-17 at 16 13 42" src="https://github.com/user-attachments/assets/77537d6f-0fb2-4a99-911c-202096458f08" />
<img width="313" height="225" alt="Screenshot 2025-12-17 at 16 13 53" src="https://github.com/user-attachments/assets/1b8e296d-7dda-4f2a-91d2-b99dbbea567c" />


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->