### PR TITLE
Expose i18n.formatList in browser

### DIFF
--- a/src/platform/packages/shared/kbn-i18n/index.ts
+++ b/src/platform/packages/shared/kbn-i18n/index.ts
@@ -8,15 +8,15 @@
  */
 
 import {
-  getTranslation,
+  formatList,
+  getIsInitialized,
   getLocale,
-  translate,
+  getTranslation,
+  handleIntlError,
   init,
   load,
-  handleIntlError,
-  getIsInitialized,
+  translate,
 } from './src/core';
-import { formatList } from './src/core/i18n';
 
 import {
   registerTranslationFile,

--- a/src/platform/packages/shared/kbn-i18n/src/core/index.ts
+++ b/src/platform/packages/shared/kbn-i18n/src/core/index.ts
@@ -9,6 +9,14 @@
 
 export type { Formats } from './formats';
 export { defaultEnFormats } from './formats';
-export { getLocale, getTranslation, init, load, translate, getIsInitialized } from './i18n';
+export {
+  getLocale,
+  getTranslation,
+  init,
+  load,
+  translate,
+  formatList,
+  getIsInitialized,
+} from './i18n';
 export type { TranslateArguments } from './i18n';
 export { handleIntlError } from './error_handler';


### PR DESCRIPTION
## Summary

Otherwise it can't be consumed from client-side.

The client-side `i18n` object is build as follows:

* `package.json` defines
```
"browser": "./src/browser",
```

* `browser.ts` does
```
import * as i18nCore from './core';
export const i18n = i18nCore;
```

So by exposing `formatList` in `src/platform/packages/shared/kbn-i18n/src/core/index.ts` we're effectively making it available in browser side.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->