### PR TITLE
[Fleet] fix deprecated ilm check

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/data_streams/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/data_streams/handlers.ts
@@ -303,10 +303,6 @@ export const getDeprecatedILMCheckHandler: RequestHandler = async (context, requ
       const componentTemplateResponse = await esClient.cluster.getComponentTemplate(
         {
           name: `${policyType}-*@package`,
-          filter_path: [
-            'component_templates.*.name',
-            'component_templates.*.component_template.template.settings.index.lifecycle.name',
-          ],
         },
         {
           ignore: [404],


### PR DESCRIPTION
## Summary

Relates https://github.com/elastic/kibana/pull/243416

It seems `filter_path` doesn't work as expected, there are no component templates returned.
Without it, the Deprecated ILM policies warning is showing up as expected.

- first modify a `@package` component template to use a deprecated lifecycle e.g. `logs`
- go to Fleet / Data streams and check that the warning callout is visible

<img width="1635" height="1067" alt="image" src="https://github.com/user-attachments/assets/a0f363c1-e393-4430-bd23-583ddbd167f4" />

<img width="1632" height="721" alt="image" src="https://github.com/user-attachments/assets/6b32316e-df11-460c-ba0e-d5126637bfc8" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



