### PR TITLE
[Obs AI] Skip recall test suite

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/complete/functions/recall.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant/complete/functions/recall.spec.ts
@@ -25,7 +25,8 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantApi');
   const es = getService('es');
 
-  describe('tool: recall', function () {
+  // Skipping temporarily: https://github.com/elastic/kibana/issues/246720
+  describe.skip('tool: recall', function () {
     // fails/flaky on MKI, see https://github.com/elastic/kibana/issues/232588
     this.tags(['failsOnMKI']);
 


### PR DESCRIPTION
## Summary

This PR skips the recall test suite temporarily until the RC is found.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

