### PR TITLE
[Streams] No longer use spread as it spread `stepId` onto the component

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wrapper.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wrapper.tsx
@@ -177,7 +177,19 @@ export function Wrapper({
           const stepProps = tourStepId ? getStepPropsByStepId(tourStepId) : undefined;
 
           const wrappedLabel = stepProps ? (
-            <EuiTourStep {...stepProps}>
+            <EuiTourStep
+              step={stepProps.step}
+              stepsTotal={stepProps.stepsTotal}
+              title={stepProps.title}
+              subtitle={stepProps.subtitle}
+              content={stepProps.content}
+              anchorPosition={stepProps.anchorPosition}
+              offset={stepProps.offset}
+              maxWidth={stepProps.maxWidth}
+              isStepOpen={stepProps.isStepOpen}
+              footerAction={stepProps.footerAction}
+              onFinish={stepProps.onFinish}
+            >
               <span>{label}</span>
             </EuiTourStep>
           ) : (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
@@ -307,7 +307,19 @@ export function StreamsTreeTable({
       )}
       <EuiFlexItem>
         {streamsListStepProps ? (
-          <EuiTourStep {...streamsListStepProps}>
+          <EuiTourStep
+            step={streamsListStepProps.step}
+            stepsTotal={streamsListStepProps.stepsTotal}
+            title={streamsListStepProps.title}
+            subtitle={streamsListStepProps.subtitle}
+            content={streamsListStepProps.content}
+            anchorPosition={streamsListStepProps.anchorPosition}
+            offset={streamsListStepProps.offset}
+            maxWidth={streamsListStepProps.maxWidth}
+            isStepOpen={streamsListStepProps.isStepOpen}
+            footerAction={streamsListStepProps.footerAction}
+            onFinish={streamsListStepProps.onFinish}
+          >
             <span>{NAME_COLUMN_HEADER}</span>
           </EuiTourStep>
         ) : (


### PR DESCRIPTION
## Summary

This fixes a React error being output to the browser console in dev mode.

<img width="494" height="308" alt="Screenshot 2025-12-17 at 13 29 03" src="https://github.com/user-attachments/assets/9aa58c4b-8bb9-4566-abe8-56e8b459a9b6" />

React flags camel cased props that are output to DOM elements. In this case, due to spreading of all props,  `stepId` was output to the DOM.  