### PR TITLE
[ObsPresentation][A11y][ServiceMap] Add dark mode check to getAgentIcon on Service Map

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/cytoscape.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/cytoscape.tsx
@@ -49,9 +49,9 @@ function useCytoscape(options: cytoscape.CytoscapeOptions) {
 }
 
 function CytoscapeComponent({ children, elements, height, serviceName, style }: CytoscapeProps) {
-  const { euiTheme } = useEuiTheme();
+  const { euiTheme, colorMode } = useEuiTheme();
   const [ref, cy] = useCytoscape({
-    ...getCytoscapeOptions(euiTheme),
+    ...getCytoscapeOptions(euiTheme, colorMode),
     elements,
   });
   useCytoscapeEventHandlers({ cy, serviceName, euiTheme });

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/cytoscape_options.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/cytoscape_options.ts
@@ -7,7 +7,7 @@
 
 import type cytoscape from 'cytoscape';
 import type { CSSProperties } from 'react';
-import type { EuiThemeComputed } from '@elastic/eui';
+import type { EuiThemeColorModeStandard, EuiThemeComputed } from '@elastic/eui';
 import type { ServiceAnomalyStats } from '../../../../common/anomaly_detection';
 import { SERVICE_NAME, SPAN_DESTINATION_SERVICE_RESOURCE } from '../../../../common/es_fields/apm';
 import {
@@ -97,8 +97,12 @@ function isService(el: cytoscape.NodeSingular) {
   return el.data(SERVICE_NAME) !== undefined;
 }
 
-const getStyle = (euiTheme: EuiThemeComputed): cytoscape.StylesheetJson => {
+const getStyle = (
+  euiTheme: EuiThemeComputed,
+  colorMode: EuiThemeColorModeStandard
+): cytoscape.StylesheetJson => {
   const lineColor = euiTheme.colors.mediumShade;
+  const isDarkMode = colorMode === 'DARK';
   return [
     {
       selector: 'core',
@@ -111,7 +115,7 @@ const getStyle = (euiTheme: EuiThemeComputed): cytoscape.StylesheetJson => {
         'background-color': euiTheme.colors.backgroundBasePlain,
         // The DefinitelyTyped definitions don't specify that a function can be
         // used here.
-        'background-image': (el: cytoscape.NodeSingular) => iconForNode(el),
+        'background-image': (el: cytoscape.NodeSingular) => iconForNode(el, isDarkMode),
         'background-height': (el: cytoscape.NodeSingular) => (isService(el) ? '60%' : '40%'),
         'background-width': (el: cytoscape.NodeSingular) => (isService(el) ? '60%' : '40%'),
         'border-color': getBorderColorFn(euiTheme),
@@ -237,9 +241,12 @@ ${euiTheme.colors.lightShade}`,
   marginTop: 0,
 });
 
-export const getCytoscapeOptions = (euiTheme: EuiThemeComputed): cytoscape.CytoscapeOptions => ({
+export const getCytoscapeOptions = (
+  euiTheme: EuiThemeComputed,
+  colorMode: EuiThemeColorModeStandard
+): cytoscape.CytoscapeOptions => ({
   boxSelectionEnabled: false,
   maxZoom: 3,
   minZoom: 0.2,
-  style: getStyle(euiTheme),
+  style: getStyle(euiTheme, colorMode),
 });

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/icons.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/icons.ts
@@ -10,10 +10,10 @@ import type cytoscape from 'cytoscape';
 import { getSpanIcon } from '@kbn/apm-ui-shared';
 import { AGENT_NAME, SPAN_SUBTYPE, SPAN_TYPE } from '../../../../common/es_fields/apm';
 
-export function iconForNode(node: cytoscape.NodeSingular) {
+export function iconForNode(node: cytoscape.NodeSingular, isDarkMode: boolean = false) {
   const agentName = node.data(AGENT_NAME);
   const subtype = node.data(SPAN_SUBTYPE);
   const type = node.data(SPAN_TYPE);
 
-  return agentName ? getAgentIcon(agentName, false) : getSpanIcon(type, subtype);
+  return agentName ? getAgentIcon(agentName, isDarkMode) : getSpanIcon(type, subtype);
 }


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/240982

## Summary

Icons in service map were low contrast in dark mode

### What has been done

Pass `isDarkMode` parameter to `getAgentIcon`

BEFORE

<img width="1707" height="719" alt="Screenshot 2025-12-17 at 12 36 25" src="https://github.com/user-attachments/assets/7a2dbc18-941c-4e38-9bab-329a8cd070f0" />

AFTER

<img width="1390" height="811" alt="Screenshot 2025-12-17 at 15 14 13" src="https://github.com/user-attachments/assets/c739aa83-c414-42bb-8355-c92a918d54f7" />





<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->