### PR TITLE
Adds `query_vector_builder` Support for Autocomplete for Diversify Retriever

### DIFF
--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/retriever.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/retriever.ts
@@ -28,6 +28,12 @@ export const retriever = (specService: SpecDefinitionsService) => {
       size: 10,
       rank_window_size: 100,
       query_vector: [],
+      query_vector_builder: {
+        text_embedding: {
+          model_id: '',
+          model_text: '',
+        },
+      },
       // lambda is only applicable for 'mmr' diversify type
       lambda: 0.5,
     },


### PR DESCRIPTION
## Summary

Updates the [autocomplete for the diversify retriever](https://github.com/elastic/kibana/pull/244411) to include support for the query_vector_builder field (added to Elasticsearch in https://github.com/elastic/elasticsearch/pull/139094).

