### PR TITLE
[Agent Builder] Fix redirect after MCP tool deletion

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/mcp/mcp_readonly_fields.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/components/mcp/mcp_readonly_fields.tsx
@@ -9,6 +9,7 @@ import { EuiComboBox, EuiFormRow } from '@elastic/eui';
 import { ToolType } from '@kbn/onechat-common';
 import React, { useEffect } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
+import { appPaths } from '../../../../../utils/app_paths';
 import { labels } from '../../../../../utils/i18n';
 import { McpToolHealthStatus } from '../../types/mcp';
 import { useToolHealth } from '../../../../../hooks/tools/use_tools_health';
@@ -26,7 +27,7 @@ export const McpReadOnlyFields = ({
   setMcpHealthStatus,
 }: McpConfigurationFieldsProps) => {
   const { createTool, deleteTool } = useToolsActions();
-  const { navigateToManageConnectors } = useNavigation();
+  const { navigateToManageConnectors, navigateToOnechatUrl } = useNavigation();
 
   const { control, setError, clearErrors } = useFormContext<McpToolFormData>();
   const [connectorId, mcpToolName, toolId] = useWatch({
@@ -118,7 +119,9 @@ export const McpReadOnlyFields = ({
       {mcpHealthStatus && (
         <McpHealthBanner
           status={mcpHealthStatus}
-          onDeleteTool={() => deleteTool(toolId)}
+          onDeleteTool={() =>
+            deleteTool(toolId, { onConfirm: () => navigateToOnechatUrl(appPaths.tools.list) })
+          }
           onCreateNewTool={() => createTool(ToolType.mcp)}
           onViewConnectors={navigateToManageConnectors}
           onViewMcpServer={openEditMcpServerFlyout}


### PR DESCRIPTION
## Summary

Small fix to correctly redirect users back to the tools page after they've deleted their tool.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

