### PR TITLE
[9.2] [Search Playground] Fix the issue related to token count (#246589)

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/public/utils/api.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/api.test.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { parseDataStream } from './api';
+import { MessageRole } from '../types';
+
+interface MockChunk {
+  type: string;
+  data?: unknown[];
+  delta?: string;
+  id?: string;
+  errorText?: string;
+}
+
+// Helper to create a mock reader that yields chunks in sequence
+function createMockReader(chunks: MockChunk[]): ReadableStreamDefaultReader<Uint8Array> {
+  let index = 0;
+  const encoder = new TextEncoder();
+
+  return {
+    read: jest.fn().mockImplementation(async () => {
+      if (index >= chunks.length) {
+        return { done: true, value: undefined };
+      }
+      const chunk = chunks[index];
+      index += 1;
+      const sseData = `data: ${JSON.stringify(chunk)}\n\n`;
+      return { done: false, value: encoder.encode(sseData) };
+    }),
+    releaseLock: jest.fn(),
+    cancel: jest.fn(),
+    closed: Promise.resolve(undefined),
+  } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+}
+
+describe('parseDataStream', () => {
+  const mockDate = new Date('2024-01-01T00:00:00.000Z');
+  const mockId = 'test-id';
+
+  describe('annotations handling', () => {
+    it('should preserve annotations received before text-start chunk', async () => {
+      // This test verifies the fix for the NaN token count bug.
+      // In AI SDK v5, annotations are sent BEFORE text-start, so they must persist.
+      const chunks: MockChunk[] = [
+        // Annotations come first (AI SDK v5 behavior)
+        {
+          type: 'data-message_annotations',
+          data: [
+            { type: 'context_token_count', count: 100 },
+            { type: 'prompt_token_count', count: 200 },
+          ],
+        },
+        // Then text-start arrives
+        { type: 'text-start' },
+        // Then text content streams in
+        { type: 'text-delta', delta: 'Hello' },
+        { type: 'text-delta', delta: ' world' },
+      ];
+
+      const reader = createMockReader(chunks);
+      const updateMock = jest.fn();
+      const handleFailureMock = jest.fn();
+
+      const result = await parseDataStream({
+        reader,
+        update: updateMock,
+        handleFailure: handleFailureMock,
+        generateId: () => mockId,
+        getCurrentDate: () => mockDate,
+      });
+
+      // Verify the final message has annotations attached
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].annotations).toBeDefined();
+      expect(result.messages[0].annotations).toEqual([
+        { type: 'context_token_count', count: 100 },
+        { type: 'prompt_token_count', count: 200 },
+      ]);
+      expect(result.messages[0].content).toBe('Hello world');
+      expect(result.messages[0].role).toBe(MessageRole.assistant);
+    });
+
+    it('should accumulate multiple annotation chunks', async () => {
+      const chunks: MockChunk[] = [
+        {
+          type: 'data-message_annotations',
+          data: [{ type: 'context_token_count', count: 100 }],
+        },
+        {
+          type: 'data-message_annotations',
+          data: [{ type: 'prompt_token_count', count: 200 }],
+        },
+        { type: 'text-start' },
+        { type: 'text-delta', delta: 'Response' },
+      ];
+
+      const reader = createMockReader(chunks);
+      const updateMock = jest.fn();
+      const handleFailureMock = jest.fn();
+
+      const result = await parseDataStream({
+        reader,
+        update: updateMock,
+        handleFailure: handleFailureMock,
+        generateId: () => mockId,
+        getCurrentDate: () => mockDate,
+      });
+
+      expect(result.messages[0].annotations).toHaveLength(2);
+      expect(result.messages[0].annotations).toContainEqual({
+        type: 'context_token_count',
+        count: 100,
+      });
+      expect(result.messages[0].annotations).toContainEqual({
+        type: 'prompt_token_count',
+        count: 200,
+      });
+    });
+
+    it('should handle annotations with retrieved docs and citations', async () => {
+      const mockDoc = {
+        metadata: { _id: 'doc1', _index: 'test-index', _score: 1 },
+        pageContent: 'Test content',
+      };
+
+      const chunks: MockChunk[] = [
+        {
+          type: 'data-message_annotations',
+          data: [{ type: 'retrieved_docs', documents: [mockDoc] }],
+        },
+        {
+          type: 'data-message_annotations',
+          data: [{ type: 'context_token_count', count: 50 }],
+        },
+        { type: 'text-start' },
+        { type: 'text-delta', delta: 'Based on the documents...' },
+        {
+          type: 'data-message_annotations',
+          data: [{ type: 'citations', documents: [mockDoc] }],
+        },
+      ];
+
+      const reader = createMockReader(chunks);
+      const updateMock = jest.fn();
+      const handleFailureMock = jest.fn();
+
+      const result = await parseDataStream({
+        reader,
+        update: updateMock,
+        handleFailure: handleFailureMock,
+        generateId: () => mockId,
+        getCurrentDate: () => mockDate,
+      });
+
+      expect(result.messages[0].annotations).toHaveLength(3);
+      expect(result.messages[0].annotations).toContainEqual({
+        type: 'retrieved_docs',
+        documents: [mockDoc],
+      });
+      expect(result.messages[0].annotations).toContainEqual({
+        type: 'context_token_count',
+        count: 50,
+      });
+      expect(result.messages[0].annotations).toContainEqual({
+        type: 'citations',
+        documents: [mockDoc],
+      });
+    });
+  });
+
+  describe('text streaming', () => {
+    it('should correctly assemble text from multiple delta chunks', async () => {
+      const chunks: MockChunk[] = [
+        { type: 'text-start' },
+        { type: 'text-delta', delta: 'The ' },
+        { type: 'text-delta', delta: 'quick ' },
+        { type: 'text-delta', delta: 'brown ' },
+        { type: 'text-delta', delta: 'fox' },
+      ];
+
+      const reader = createMockReader(chunks);
+      const updateMock = jest.fn();
+      const handleFailureMock = jest.fn();
+
+      const result = await parseDataStream({
+        reader,
+        update: updateMock,
+        handleFailure: handleFailureMock,
+        generateId: () => mockId,
+        getCurrentDate: () => mockDate,
+      });
+
+      expect(result.messages[0].content).toBe('The quick brown fox');
+    });
+
+    it('should call update callback for each chunk', async () => {
+      const chunks: MockChunk[] = [
+        { type: 'text-start' },
+        { type: 'text-delta', delta: 'A' },
+        { type: 'text-delta', delta: 'B' },
+        { type: 'text-delta', delta: 'C' },
+      ];
+
+      const reader = createMockReader(chunks);
+      const updateMock = jest.fn();
+      const handleFailureMock = jest.fn();
+
+      await parseDataStream({
+        reader,
+        update: updateMock,
+        handleFailure: handleFailureMock,
+        generateId: () => mockId,
+        getCurrentDate: () => mockDate,
+      });
+
+      // Update should be called for each text-delta chunk
+      expect(updateMock).toHaveBeenCalledTimes(3);
+      // Last call should have the complete message
+      const lastCall = updateMock.mock.calls[2][0];
+      expect(lastCall[0].content).toBe('ABC');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should call handleFailure on error chunk', async () => {
+      const chunks: MockChunk[] = [
+        { type: 'text-start' },
+        { type: 'text-delta', delta: 'Starting...' },
+        { type: 'error', errorText: 'Something went wrong' },
+      ];
+
+      const reader = createMockReader(chunks);
+      const updateMock = jest.fn();
+      const handleFailureMock = jest.fn();
+
+      await parseDataStream({
+        reader,
+        update: updateMock,
+        handleFailure: handleFailureMock,
+        generateId: () => mockId,
+        getCurrentDate: () => mockDate,
+      });
+
+      expect(handleFailureMock).toHaveBeenCalledWith('Something went wrong');
+    });
+  });
+});

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/api.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/api.ts
@@ -119,7 +119,6 @@ export async function parseDataStream({
       responseMessageId =
         'id' in chunk && chunk.id ? allocateResponseId(chunk.id) : allocateResponseId();
       prefixMap.text = undefined;
-      messageAnnotations = undefined;
       continue;
     } else if (type === 'text-delta' && 'delta' in chunk && typeof chunk.delta === 'string') {
       if (prefixMap.text) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Search Playground] Fix the issue related to token count (#246589)](https://github.com/elastic/kibana/pull/246589)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Saikat Sarkar","email":"132922331+saikatsarkar056@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-17T00:27:12Z","message":"[Search Playground] Fix the issue related to token count (#246589)\n\n## Summary\n\nFixes token count display showing \"NaN / 200,000 tokens sent\" in the\nSearch Playground after the AI SDK v5 upgrade.\n\nThe issue was on the client-side in `parseDataStream` (`api.ts`), where\n`messageAnnotations` was being reset to `undefined` when a `text-start`\nchunk was received. In AI SDK v5, annotations (including token counts)\nare sent *before* the `text-start` chunk, so this reset was clearing the\nalready-collected token data. This PR removes that reset to preserve\nannotations across the stream, ensuring token counts are correctly\nattached to the final message and displayed in the UI.\n\n\n### Before\n<img width=\"865\" height=\"502\" alt=\"Screenshot 2025-12-16 at 10 39 42 AM\"\nsrc=\"https://github.com/user-attachments/assets/331d3c7c-1b3e-455e-b8d7-561e2832054c\"\n/>\n\n\n### After\n<img width=\"1008\" height=\"519\" alt=\"Screenshot 2025-12-16 at 9 56 13 AM\"\nsrc=\"https://github.com/user-attachments/assets/ec507093-e382-4320-b610-cc3d53a74c3b\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n## Release note\nFixes token count display showing \"NaN\" in Search Playground by\npreserving message annotations across the AI SDK v5 stream.","sha":"6eae531e0d82503feff37f1abebeb7d5b0e0907f","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Search","backport:version","v9.3.0","v9.4.0"],"title":"[Search Playground] Fix the issue related to token count","number":246589,"url":"https://github.com/elastic/kibana/pull/246589","mergeCommit":{"message":"[Search Playground] Fix the issue related to token count (#246589)\n\n## Summary\n\nFixes token count display showing \"NaN / 200,000 tokens sent\" in the\nSearch Playground after the AI SDK v5 upgrade.\n\nThe issue was on the client-side in `parseDataStream` (`api.ts`), where\n`messageAnnotations` was being reset to `undefined` when a `text-start`\nchunk was received. In AI SDK v5, annotations (including token counts)\nare sent *before* the `text-start` chunk, so this reset was clearing the\nalready-collected token data. This PR removes that reset to preserve\nannotations across the stream, ensuring token counts are correctly\nattached to the final message and displayed in the UI.\n\n\n### Before\n<img width=\"865\" height=\"502\" alt=\"Screenshot 2025-12-16 at 10 39 42 AM\"\nsrc=\"https://github.com/user-attachments/assets/331d3c7c-1b3e-455e-b8d7-561e2832054c\"\n/>\n\n\n### After\n<img width=\"1008\" height=\"519\" alt=\"Screenshot 2025-12-16 at 9 56 13 AM\"\nsrc=\"https://github.com/user-attachments/assets/ec507093-e382-4320-b610-cc3d53a74c3b\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n## Release note\nFixes token count display showing \"NaN\" in Search Playground by\npreserving message annotations across the AI SDK v5 stream.","sha":"6eae531e0d82503feff37f1abebeb7d5b0e0907f"}},"sourceBranch":"main","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246589","number":246589,"mergeCommit":{"message":"[Search Playground] Fix the issue related to token count (#246589)\n\n## Summary\n\nFixes token count display showing \"NaN / 200,000 tokens sent\" in the\nSearch Playground after the AI SDK v5 upgrade.\n\nThe issue was on the client-side in `parseDataStream` (`api.ts`), where\n`messageAnnotations` was being reset to `undefined` when a `text-start`\nchunk was received. In AI SDK v5, annotations (including token counts)\nare sent *before* the `text-start` chunk, so this reset was clearing the\nalready-collected token data. This PR removes that reset to preserve\nannotations across the stream, ensuring token counts are correctly\nattached to the final message and displayed in the UI.\n\n\n### Before\n<img width=\"865\" height=\"502\" alt=\"Screenshot 2025-12-16 at 10 39 42 AM\"\nsrc=\"https://github.com/user-attachments/assets/331d3c7c-1b3e-455e-b8d7-561e2832054c\"\n/>\n\n\n### After\n<img width=\"1008\" height=\"519\" alt=\"Screenshot 2025-12-16 at 9 56 13 AM\"\nsrc=\"https://github.com/user-attachments/assets/ec507093-e382-4320-b610-cc3d53a74c3b\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n\n## Release note\nFixes token count display showing \"NaN\" in Search Playground by\npreserving message annotations across the AI SDK v5 stream.","sha":"6eae531e0d82503feff37f1abebeb7d5b0e0907f"}},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"url":"https://github.com/elastic/kibana/pull/246764","number":246764,"branch":"8.19","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/246765","number":246765,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->