### PR TITLE
[9.1] [Security Solution][Endpoint] Add server configuration setting for disabling the auto install of endpoint rule on policy create (#246418)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/config.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/config.mock.ts
@@ -31,6 +31,7 @@ export const createMockConfig = (): ConfigType => {
     alertMergeStrategy: 'missingFields',
     alertIgnoreFields: [],
     maxUploadResponseActionFileBytes: 26214400,
+    disableEndpointRuleAutoInstall: false,
     settings: getDefaultConfigSettings(),
     experimentalFeatures: parseExperimentalConfigValue(enableExperimental).features,
     enabled: true,

--- a/x-pack/solutions/security/plugins/security_solution/server/config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/config.ts
@@ -155,6 +155,14 @@ export const configSchema = schema.object({
     max: 104857600, // 100MB,
   }),
   /**
+   * Disables the auto-install/enable of the Elastic Defend SIEM rule.
+   * Whenever a Policy is created via Fleet's API, we check if the corresponding Elastic Defend SIEM
+   * rule is installed/enabled in the active space, and if not, we auto-install it. Set this configuration
+   * setting to `false` to disable that behavior
+   */
+  disableEndpointRuleAutoInstall: schema.boolean({ defaultValue: false }),
+
+  /**
    * Defines the settings for a specific offering of the Security Solution app.
    * They override the default values.
    * @example

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -59,6 +59,7 @@ import type {
 } from './services/fleet/endpoint_fleet_services_factory';
 import { EndpointFleetServicesFactory } from './services/fleet/endpoint_fleet_services_factory';
 import { registerListsPluginEndpointExtensionPoints } from '../lists_integration';
+import { EndpointError } from '../../common/endpoint/errors';
 import type { EndpointAuthz } from '../../common/endpoint/types/authz';
 import { calculateEndpointAuthz } from '../../common/endpoint/service/authz';
 import type { FeatureUsageService } from './services/feature_usage/service';

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -446,4 +446,18 @@ export class EndpointAppContextService {
       this.createLogger('ReferenceDataClient')
     );
   }
+
+  public getServerConfigValue<TKey extends keyof ConfigType = keyof ConfigType>(
+    key: TKey
+  ): ConfigType[TKey] {
+    if (!this.startDependencies?.config) {
+      throw new EndpointAppContentServicesNotStartedError();
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(this.startDependencies.config, key)) {
+      throw new EndpointError(`Missing config value for key: ${key}`);
+    }
+
+    return this.startDependencies.config[key];
+  }
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/mocks/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/mocks/mocks.ts
@@ -159,6 +159,7 @@ export const createMockEndpointAppContextService = (
     })),
     getSpaceId: jest.fn().mockReturnValue('default'),
     getReferenceDataClient: jest.fn().mockReturnValue(referenceDataMocks.createClient()),
+    getServerConfigValue: jest.fn(),
   } as unknown as jest.Mocked<EndpointAppContextService>;
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
@@ -1207,7 +1207,9 @@ describe('Fleet integrations', () => {
       );
       const policyConfig = generator.generatePolicyPackagePolicy();
 
+      // @ts-expect-error TS2790: The operand of a delete operator must be optional
       delete policyConfig.inputs[0]!.config!.policy;
+      // @ts-expect-error TS2790: The operand of a delete operator must be optional
       delete policyConfig.inputs[0]!.config!.artifact_manifest;
 
       await expect(() =>

--- a/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
@@ -31,7 +31,7 @@ import {
   getPackagePolicyPostCreateCallback,
   getPackagePolicyUpdateCallback,
 } from './fleet_integration';
-import type { KibanaRequest, Logger } from '@kbn/core/server';
+import type { KibanaRequest, Logger, RequestHandlerContext } from '@kbn/core/server';
 import {
   ALL_PRODUCT_FEATURE_KEYS,
   ProductFeatureSecurityKey,
@@ -88,6 +88,26 @@ import { FleetPackagePolicyGenerator } from '../../common/endpoint/data_generato
 import { RESPONSE_ACTIONS_SUPPORTED_INTEGRATION_TYPES } from '../../common/endpoint/service/response_actions/constants';
 import { pick } from 'lodash';
 import { ENDPOINT_ACTIONS_INDEX } from '../../common/endpoint/constants';
+import type { IRequestContextFactory } from '../request_context_factory';
+import { installEndpointSecurityPrebuiltRule as _installEndpointSecurityPrebuiltRule } from '../lib/detection_engine/prebuilt_rules/logic/integrations/install_endpoint_security_prebuilt_rule';
+
+const installEndpointSecurityPrebuiltRuleMock = _installEndpointSecurityPrebuiltRule as jest.Mock;
+
+jest.mock(
+  '../lib/detection_engine/prebuilt_rules/logic/integrations/install_endpoint_security_prebuilt_rule',
+  () => {
+    const actualModule = jest.requireActual(
+      '../lib/detection_engine/prebuilt_rules/logic/integrations/install_endpoint_security_prebuilt_rule'
+    );
+
+    return {
+      ...actualModule,
+      installEndpointSecurityPrebuiltRule: jest.fn(
+        actualModule.installEndpointSecurityPrebuiltRule
+      ),
+    };
+  }
+);
 
 jest.mock('uuid', () => ({
   v4: (): string => 'NEW_UUID',
@@ -152,47 +172,17 @@ describe('Fleet integrations', () => {
     jest.clearAllMocks();
   });
 
-  describe('package policy init callback (atifacts manifest initialisation tests)', () => {
-    const soClient = savedObjectsClientMock.create();
-    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
-
-    const createNewEndpointPolicyInput = (
-      manifest: ManifestSchema,
-      license = 'platinum',
-      cloud = cloudService.isCloudEnabled,
-      licenseUuid = 'updated-uid',
-      clusterUuid = '',
-      clusterName = '',
-      isServerlessEnabled = cloudService.isServerlessEnabled,
-      isTelemetryEnabled = true
-    ) => ({
-      type: 'endpoint',
-      enabled: true,
-      streams: [],
-      config: {
-        integration_config: {},
-        policy: {
-          value: disableProtections(
-            policyFactory({
-              license,
-              cloud,
-              licenseUuid,
-              clusterUuid,
-              clusterName,
-              serverless: isServerlessEnabled,
-              isGlobalTelemetryEnabled: isTelemetryEnabled,
-            })
-          ),
-        },
-        artifact_manifest: { value: manifest },
-      },
-    });
+  describe('package policy create callback', () => {
+    let soClient: ReturnType<typeof savedObjectsClientMock.create>;
+    let esClient: ReturnType<typeof elasticsearchServiceMock.createClusterClient>['asInternalUser'];
+    let securitySolutionRequestContextFactory: jest.Mocked<IRequestContextFactory>;
+    let endpointServicesMock: ReturnType<typeof createMockEndpointAppContextService>;
 
     const invokeCallback = async (manifestManager: ManifestManager): Promise<NewPackagePolicy> => {
       const callback = getPackagePolicyCreateCallback(
         logger,
         manifestManager,
-        requestContextFactoryMock.create(),
+        securitySolutionRequestContextFactory,
         endpointAppContextStartContract.alerting,
         licenseService,
         cloudService,
@@ -209,183 +199,245 @@ describe('Fleet integrations', () => {
       );
     };
 
-    const TEST_POLICY_ID_1 = 'c6d16e42-c32d-4dce-8a88-113cfe276ad1';
-    const TEST_POLICY_ID_2 = '93c46720-c217-11ea-9906-b5b8a21b268e';
-    const ARTIFACT_NAME_EXCEPTIONS_MACOS = 'endpoint-exceptionlist-macos-v1';
-    const ARTIFACT_NAME_TRUSTED_APPS_MACOS = 'endpoint-trustlist-macos-v1';
-    const ARTIFACT_NAME_TRUSTED_APPS_WINDOWS = 'endpoint-trustlist-windows-v1';
-    let ARTIFACT_EXCEPTIONS_MACOS: InternalArtifactCompleteSchema;
-    let ARTIFACT_EXCEPTIONS_WINDOWS: InternalArtifactCompleteSchema;
-    let ARTIFACT_TRUSTED_APPS_MACOS: InternalArtifactCompleteSchema;
-    let ARTIFACT_TRUSTED_APPS_WINDOWS: InternalArtifactCompleteSchema;
-
-    beforeAll(async () => {
-      const artifacts = await getMockArtifacts();
-      ARTIFACT_EXCEPTIONS_MACOS = artifacts[0];
-      ARTIFACT_EXCEPTIONS_WINDOWS = artifacts[1];
-      ARTIFACT_TRUSTED_APPS_MACOS = artifacts[3];
-      ARTIFACT_TRUSTED_APPS_WINDOWS = artifacts[4];
+    beforeEach(async () => {
+      soClient = savedObjectsClientMock.create();
+      esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      endpointServicesMock = createMockEndpointAppContextService();
+      securitySolutionRequestContextFactory = requestContextFactoryMock.create();
+      const reqContextMock = await securitySolutionRequestContextFactory.create(
+        ctx as unknown as RequestHandlerContext,
+        req
+      );
+      (reqContextMock.getEndpointService as jest.Mock).mockReturnValue(endpointServicesMock);
+      securitySolutionRequestContextFactory.create.mockReturnValue(Promise.resolve(reqContextMock));
     });
 
-    beforeEach(() => {
-      licenseEmitter.next(Platinum); // set license level to platinum
+    describe('SIEM rule install', () => {
+      it('should call utility to install SIEM prebuilt rule', async () => {
+        await invokeCallback(buildManifestManagerMock());
+
+        expect(installEndpointSecurityPrebuiltRuleMock).toHaveBeenCalled();
+      });
+
+      it('should not call utility to install SIEM prebuilt rule when server config setting is enabled', async () => {
+        (endpointServicesMock.getServerConfigValue as jest.Mock).mockReturnValue(true);
+        await invokeCallback(buildManifestManagerMock());
+
+        expect(installEndpointSecurityPrebuiltRuleMock).not.toHaveBeenCalled();
+      });
     });
 
-    test('default manifest is taken when there is none and there are errors building new one', async () => {
-      const manifestManager = buildManifestManagerMock();
-      manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
-      manifestManager.buildNewManifest = jest.fn().mockRejectedValue(new Error());
+    describe('Artifacts manifest initialisation', () => {
+      const createNewEndpointPolicyInput = (
+        manifest: ManifestSchema,
+        license = 'platinum',
+        cloud = cloudService.isCloudEnabled,
+        licenseUuid = 'updated-uid',
+        clusterUuid = '',
+        clusterName = '',
+        isServerlessEnabled = cloudService.isServerlessEnabled,
+        isTelemetryEnabled = true
+      ) => ({
+        type: 'endpoint',
+        enabled: true,
+        streams: [],
+        config: {
+          integration_config: {},
+          policy: {
+            value: disableProtections(
+              policyFactory({
+                license,
+                cloud,
+                licenseUuid,
+                clusterUuid,
+                clusterName,
+                serverless: isServerlessEnabled,
+                isGlobalTelemetryEnabled: isTelemetryEnabled,
+              })
+            ),
+          },
+          artifact_manifest: { value: manifest },
+        },
+      });
 
-      expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
-        createNewEndpointPolicyInput({
-          artifacts: {},
-          manifest_version: '1.0.0',
-          schema_version: 'v1',
-        })
-      );
+      const TEST_POLICY_ID_1 = 'c6d16e42-c32d-4dce-8a88-113cfe276ad1';
+      const TEST_POLICY_ID_2 = '93c46720-c217-11ea-9906-b5b8a21b268e';
+      const ARTIFACT_NAME_EXCEPTIONS_MACOS = 'endpoint-exceptionlist-macos-v1';
+      const ARTIFACT_NAME_TRUSTED_APPS_MACOS = 'endpoint-trustlist-macos-v1';
+      const ARTIFACT_NAME_TRUSTED_APPS_WINDOWS = 'endpoint-trustlist-windows-v1';
+      let ARTIFACT_EXCEPTIONS_MACOS: InternalArtifactCompleteSchema;
+      let ARTIFACT_EXCEPTIONS_WINDOWS: InternalArtifactCompleteSchema;
+      let ARTIFACT_TRUSTED_APPS_MACOS: InternalArtifactCompleteSchema;
+      let ARTIFACT_TRUSTED_APPS_WINDOWS: InternalArtifactCompleteSchema;
 
-      expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
-      expect(manifestManager.pushArtifacts).not.toHaveBeenCalled();
-      expect(manifestManager.commit).not.toHaveBeenCalled();
-    });
+      beforeAll(async () => {
+        const artifacts = await getMockArtifacts();
+        ARTIFACT_EXCEPTIONS_MACOS = artifacts[0];
+        ARTIFACT_EXCEPTIONS_WINDOWS = artifacts[1];
+        ARTIFACT_TRUSTED_APPS_MACOS = artifacts[3];
+        ARTIFACT_TRUSTED_APPS_WINDOWS = artifacts[4];
+      });
 
-    test('default manifest is taken when there is none and there are errors pushing artifacts', async () => {
-      const newManifest = ManifestManager.createDefaultManifest();
-      newManifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
+      beforeEach(() => {
+        licenseEmitter.next(Platinum); // set license level to platinum
+      });
 
-      const manifestManager = buildManifestManagerMock();
-      manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
-      manifestManager.buildNewManifest = jest.fn().mockResolvedValue(newManifest);
-      manifestManager.pushArtifacts = jest.fn().mockResolvedValue([new Error()]);
-
-      expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
-        createNewEndpointPolicyInput({
-          artifacts: {},
-          manifest_version: '1.0.0',
-          schema_version: 'v1',
-        })
-      );
-
-      expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
-      expect(manifestManager.pushArtifacts).toHaveBeenCalledWith(
-        [ARTIFACT_EXCEPTIONS_MACOS],
-        newManifest
-      );
-      expect(manifestManager.commit).not.toHaveBeenCalled();
-    });
-
-    test('default manifest is taken when there is none and there are errors commiting manifest', async () => {
-      const newManifest = ManifestManager.createDefaultManifest();
-      newManifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
-
-      const manifestManager = buildManifestManagerMock();
-      manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
-      manifestManager.buildNewManifest = jest.fn().mockResolvedValue(newManifest);
-      manifestManager.pushArtifacts = jest.fn().mockResolvedValue([]);
-      manifestManager.commit = jest.fn().mockRejectedValue(new Error());
-
-      expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
-        createNewEndpointPolicyInput({
-          artifacts: {},
-          manifest_version: '1.0.0',
-          schema_version: 'v1',
-        })
-      );
-
-      expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
-      expect(manifestManager.pushArtifacts).toHaveBeenCalledWith(
-        [ARTIFACT_EXCEPTIONS_MACOS],
-        newManifest
-      );
-      expect(manifestManager.commit).toHaveBeenCalledWith(newManifest);
-    });
-
-    test('manifest is created successfuly when there is none', async () => {
-      const newManifest = ManifestManager.createDefaultManifest();
-      newManifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
-      newManifest.addEntry(ARTIFACT_TRUSTED_APPS_MACOS);
-
-      const manifestManager = buildManifestManagerMock();
-      manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
-      manifestManager.buildNewManifest = jest.fn().mockResolvedValue(newManifest);
-      manifestManager.pushArtifacts = jest.fn().mockResolvedValue([]);
-      manifestManager.commit = jest.fn().mockResolvedValue(null);
-
-      expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
-        createNewEndpointPolicyInput({
-          artifacts: toArtifactRecords({
-            [ARTIFACT_NAME_EXCEPTIONS_MACOS]: ARTIFACT_EXCEPTIONS_MACOS,
-            [ARTIFACT_NAME_TRUSTED_APPS_MACOS]: ARTIFACT_TRUSTED_APPS_MACOS,
-          }),
-          manifest_version: '1.0.0',
-          schema_version: 'v1',
-        })
-      );
-
-      expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
-      expect(manifestManager.pushArtifacts).toHaveBeenCalledWith(
-        [ARTIFACT_EXCEPTIONS_MACOS, ARTIFACT_TRUSTED_APPS_MACOS],
-        newManifest
-      );
-      expect(manifestManager.commit).toHaveBeenCalledWith(newManifest);
-    });
-
-    test('policy is updated with only default entries from manifest', async () => {
-      const manifest = new Manifest({ soVersion: '1.0.1', semanticVersion: '1.0.1' });
-      manifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
-      manifest.addEntry(ARTIFACT_EXCEPTIONS_WINDOWS, TEST_POLICY_ID_1);
-      manifest.addEntry(ARTIFACT_TRUSTED_APPS_MACOS, TEST_POLICY_ID_2);
-      manifest.addEntry(ARTIFACT_TRUSTED_APPS_WINDOWS);
-
-      const manifestManager = buildManifestManagerMock();
-      manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(manifest);
-
-      expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
-        createNewEndpointPolicyInput({
-          artifacts: toArtifactRecords({
-            [ARTIFACT_NAME_EXCEPTIONS_MACOS]: ARTIFACT_EXCEPTIONS_MACOS,
-            [ARTIFACT_NAME_TRUSTED_APPS_WINDOWS]: ARTIFACT_TRUSTED_APPS_WINDOWS,
-          }),
-          manifest_version: '1.0.1',
-          schema_version: 'v1',
-        })
-      );
-
-      expect(manifestManager.buildNewManifest).not.toHaveBeenCalled();
-      expect(manifestManager.pushArtifacts).not.toHaveBeenCalled();
-      expect(manifestManager.commit).not.toHaveBeenCalled();
-    });
-
-    it('should correctly set meta.billable', async () => {
-      const isBillablePolicySpy = jest.spyOn(PolicyConfigHelpers, 'isBillablePolicy');
-      isBillablePolicySpy.mockReturnValue(false);
-      const manifestManager = buildManifestManagerMock();
-
-      let packagePolicy = await invokeCallback(manifestManager);
-      expect(isBillablePolicySpy).toHaveBeenCalled();
-      expect(packagePolicy.inputs[0].config!.policy.value.meta.billable).toBe(false);
-
-      isBillablePolicySpy.mockReset();
-      isBillablePolicySpy.mockReturnValue(true);
-      packagePolicy = await invokeCallback(manifestManager);
-      expect(isBillablePolicySpy).toHaveBeenCalled();
-      expect(packagePolicy.inputs[0].config!.policy.value.meta.billable).toBe(true);
-
-      isBillablePolicySpy.mockRestore();
-    });
-
-    it.each([false, true])(
-      'should correctly set `global_telemetry_enabled` to %s',
-      async (targetValue) => {
+      test('default manifest is taken when there is none and there are errors building new one', async () => {
         const manifestManager = buildManifestManagerMock();
-        telemetryConfigProviderMock.getIsOptedIn.mockReturnValue(targetValue);
+        manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
+        manifestManager.buildNewManifest = jest.fn().mockRejectedValue(new Error());
 
-        const packagePolicy = await invokeCallback(manifestManager);
+        expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
+          createNewEndpointPolicyInput({
+            artifacts: {},
+            manifest_version: '1.0.0',
+            schema_version: 'v1',
+          })
+        );
 
-        const policyConfig: PolicyConfig = packagePolicy.inputs[0].config!.policy.value;
-        expect(policyConfig.global_telemetry_enabled).toBe(targetValue);
-      }
-    );
+        expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
+        expect(manifestManager.pushArtifacts).not.toHaveBeenCalled();
+        expect(manifestManager.commit).not.toHaveBeenCalled();
+      });
+
+      test('default manifest is taken when there is none and there are errors pushing artifacts', async () => {
+        const newManifest = ManifestManager.createDefaultManifest();
+        newManifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
+
+        const manifestManager = buildManifestManagerMock();
+        manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
+        manifestManager.buildNewManifest = jest.fn().mockResolvedValue(newManifest);
+        manifestManager.pushArtifacts = jest.fn().mockResolvedValue([new Error()]);
+
+        expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
+          createNewEndpointPolicyInput({
+            artifacts: {},
+            manifest_version: '1.0.0',
+            schema_version: 'v1',
+          })
+        );
+
+        expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
+        expect(manifestManager.pushArtifacts).toHaveBeenCalledWith(
+          [ARTIFACT_EXCEPTIONS_MACOS],
+          newManifest
+        );
+        expect(manifestManager.commit).not.toHaveBeenCalled();
+      });
+
+      test('default manifest is taken when there is none and there are errors commiting manifest', async () => {
+        const newManifest = ManifestManager.createDefaultManifest();
+        newManifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
+
+        const manifestManager = buildManifestManagerMock();
+        manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
+        manifestManager.buildNewManifest = jest.fn().mockResolvedValue(newManifest);
+        manifestManager.pushArtifacts = jest.fn().mockResolvedValue([]);
+        manifestManager.commit = jest.fn().mockRejectedValue(new Error());
+
+        expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
+          createNewEndpointPolicyInput({
+            artifacts: {},
+            manifest_version: '1.0.0',
+            schema_version: 'v1',
+          })
+        );
+
+        expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
+        expect(manifestManager.pushArtifacts).toHaveBeenCalledWith(
+          [ARTIFACT_EXCEPTIONS_MACOS],
+          newManifest
+        );
+        expect(manifestManager.commit).toHaveBeenCalledWith(newManifest);
+      });
+
+      test('manifest is created successfuly when there is none', async () => {
+        const newManifest = ManifestManager.createDefaultManifest();
+        newManifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
+        newManifest.addEntry(ARTIFACT_TRUSTED_APPS_MACOS);
+
+        const manifestManager = buildManifestManagerMock();
+        manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(null);
+        manifestManager.buildNewManifest = jest.fn().mockResolvedValue(newManifest);
+        manifestManager.pushArtifacts = jest.fn().mockResolvedValue([]);
+        manifestManager.commit = jest.fn().mockResolvedValue(null);
+
+        expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
+          createNewEndpointPolicyInput({
+            artifacts: toArtifactRecords({
+              [ARTIFACT_NAME_EXCEPTIONS_MACOS]: ARTIFACT_EXCEPTIONS_MACOS,
+              [ARTIFACT_NAME_TRUSTED_APPS_MACOS]: ARTIFACT_TRUSTED_APPS_MACOS,
+            }),
+            manifest_version: '1.0.0',
+            schema_version: 'v1',
+          })
+        );
+
+        expect(manifestManager.buildNewManifest).toHaveBeenCalledWith();
+        expect(manifestManager.pushArtifacts).toHaveBeenCalledWith(
+          [ARTIFACT_EXCEPTIONS_MACOS, ARTIFACT_TRUSTED_APPS_MACOS],
+          newManifest
+        );
+        expect(manifestManager.commit).toHaveBeenCalledWith(newManifest);
+      });
+
+      test('policy is updated with only default entries from manifest', async () => {
+        const manifest = new Manifest({ soVersion: '1.0.1', semanticVersion: '1.0.1' });
+        manifest.addEntry(ARTIFACT_EXCEPTIONS_MACOS);
+        manifest.addEntry(ARTIFACT_EXCEPTIONS_WINDOWS, TEST_POLICY_ID_1);
+        manifest.addEntry(ARTIFACT_TRUSTED_APPS_MACOS, TEST_POLICY_ID_2);
+        manifest.addEntry(ARTIFACT_TRUSTED_APPS_WINDOWS);
+
+        const manifestManager = buildManifestManagerMock();
+        manifestManager.getLastComputedManifest = jest.fn().mockResolvedValue(manifest);
+
+        expect((await invokeCallback(manifestManager)).inputs[0]).toStrictEqual(
+          createNewEndpointPolicyInput({
+            artifacts: toArtifactRecords({
+              [ARTIFACT_NAME_EXCEPTIONS_MACOS]: ARTIFACT_EXCEPTIONS_MACOS,
+              [ARTIFACT_NAME_TRUSTED_APPS_WINDOWS]: ARTIFACT_TRUSTED_APPS_WINDOWS,
+            }),
+            manifest_version: '1.0.1',
+            schema_version: 'v1',
+          })
+        );
+
+        expect(manifestManager.buildNewManifest).not.toHaveBeenCalled();
+        expect(manifestManager.pushArtifacts).not.toHaveBeenCalled();
+        expect(manifestManager.commit).not.toHaveBeenCalled();
+      });
+
+      it('should correctly set meta.billable', async () => {
+        const isBillablePolicySpy = jest.spyOn(PolicyConfigHelpers, 'isBillablePolicy');
+        isBillablePolicySpy.mockReturnValue(false);
+        const manifestManager = buildManifestManagerMock();
+
+        let packagePolicy = await invokeCallback(manifestManager);
+        expect(isBillablePolicySpy).toHaveBeenCalled();
+        expect(packagePolicy.inputs[0].config!.policy.value.meta.billable).toBe(false);
+
+        isBillablePolicySpy.mockReset();
+        isBillablePolicySpy.mockReturnValue(true);
+        packagePolicy = await invokeCallback(manifestManager);
+        expect(isBillablePolicySpy).toHaveBeenCalled();
+        expect(packagePolicy.inputs[0].config!.policy.value.meta.billable).toBe(true);
+
+        isBillablePolicySpy.mockRestore();
+      });
+
+      it.each([false, true])(
+        'should correctly set `global_telemetry_enabled` to %s',
+        async (targetValue) => {
+          const manifestManager = buildManifestManagerMock();
+          telemetryConfigProviderMock.getIsOptedIn.mockReturnValue(targetValue);
+
+          const packagePolicy = await invokeCallback(manifestManager);
+
+          const policyConfig: PolicyConfig = packagePolicy.inputs[0].config!.policy.value;
+          expect(policyConfig.global_telemetry_enabled).toBe(targetValue);
+        }
+      );
+    });
   });
 
   describe('package policy post create callback', () => {
@@ -1155,9 +1207,7 @@ describe('Fleet integrations', () => {
       );
       const policyConfig = generator.generatePolicyPackagePolicy();
 
-      // @ts-expect-error TS2790: The operand of a delete operator must be optional
       delete policyConfig.inputs[0]!.config!.policy;
-      // @ts-expect-error TS2790: The operand of a delete operator must be optional
       delete policyConfig.inputs[0]!.config!.artifact_manifest;
 
       await expect(() =>

--- a/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.ts
@@ -169,23 +169,39 @@ export const getPackagePolicyCreateCallback = (
       validateIntegrationConfig(endpointIntegrationConfig, logger);
     }
 
-    // In this callback we are handling an HTTP request to the fleet plugin. Since we use
-    // code from the security_solution plugin to handle it (installPrepackagedRules),
-    // we need to build the context that is native to security_solution and pass it there.
-    const securitySolutionContext = await securitySolutionRequestContextFactory.create(
-      context,
-      request
-    );
+    const conditionallyInstallEndpointSecurityPrebuiltRule = async () => {
+      // In this callback we are handling an HTTP request to the fleet plugin. Since we use
+      // code from the security_solution plugin to handle it (installPrepackagedRules),
+      // we need to build the context that is native to security_solution and pass it there.
+      const securitySolutionContext = await securitySolutionRequestContextFactory.create(
+        context,
+        request
+      );
+
+      if (
+        !securitySolutionContext
+          .getEndpointService()
+          .getServerConfigValue('disableEndpointRuleAutoInstall')
+      ) {
+        logger.debug(`Checking if Endpoint Security prebuilt rule is installed/enabled...`);
+
+        return installEndpointSecurityPrebuiltRule({
+          logger,
+          context: securitySolutionContext,
+          request,
+          alerts,
+          soClient,
+        });
+      } else {
+        logger.debug(
+          `Server setting 'disableEndpointRuleAutoInstall' is 'true' - skipping the install of Endpoint Security prebuilt rule`
+        );
+      }
+    };
 
     // perform these operations in parallel in order to help in not delaying the API response too much
     const [, manifestValue] = await Promise.all([
-      installEndpointSecurityPrebuiltRule({
-        logger,
-        context: securitySolutionContext,
-        request,
-        alerts,
-        soClient,
-      }),
+      conditionallyInstallEndpointSecurityPrebuiltRule(),
 
       // create the Artifact Manifest for this policy
       createPolicyArtifactManifest(logger, manifestManager),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Security Solution][Endpoint] Add server configuration setting for disabling the auto install of endpoint rule on policy create (#246418)](https://github.com/elastic/kibana/pull/246418)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-17T19:13:58Z","message":"[Security Solution][Endpoint] Add server configuration setting for disabling the auto install of endpoint rule on policy create (#246418)\n\n## Summary\n\n- Add a new server configuration setting:\n`disableEndpointRuleAutoInstall`\n- When set to `true`, the Elastic Defend SIEM rule will NOT be\nauto-installed/enabled when the first Elastic Defend Integration policy\nis created\n- Default value is `false` - thus backwards compatible: we will continue\nto auto-install/enable the Elastic Defend SIEM rule when an Elastic\nDefend integration policy is created","sha":"1c974a43f6977d1513202df02aabd7ef8002de71","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Defend Workflows","backport:version","v9.3.0","v9.1.9","v9.2.4"],"title":"[Security Solution][Endpoint] Add server configuration setting for disabling the auto install of endpoint rule on policy create","number":246418,"url":"https://github.com/elastic/kibana/pull/246418","mergeCommit":{"message":"[Security Solution][Endpoint] Add server configuration setting for disabling the auto install of endpoint rule on policy create (#246418)\n\n## Summary\n\n- Add a new server configuration setting:\n`disableEndpointRuleAutoInstall`\n- When set to `true`, the Elastic Defend SIEM rule will NOT be\nauto-installed/enabled when the first Elastic Defend Integration policy\nis created\n- Default value is `false` - thus backwards compatible: we will continue\nto auto-install/enable the Elastic Defend SIEM rule when an Elastic\nDefend integration policy is created","sha":"1c974a43f6977d1513202df02aabd7ef8002de71"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246418","number":246418,"mergeCommit":{"message":"[Security Solution][Endpoint] Add server configuration setting for disabling the auto install of endpoint rule on policy create (#246418)\n\n## Summary\n\n- Add a new server configuration setting:\n`disableEndpointRuleAutoInstall`\n- When set to `true`, the Elastic Defend SIEM rule will NOT be\nauto-installed/enabled when the first Elastic Defend Integration policy\nis created\n- Default value is `false` - thus backwards compatible: we will continue\nto auto-install/enable the Elastic Defend SIEM rule when an Elastic\nDefend integration policy is created","sha":"1c974a43f6977d1513202df02aabd7ef8002de71"}},{"branch":"9.1","label":"v9.1.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->