### PR TITLE
[ftr/scout] Remove serverless.indices.validate_dot_prefixes

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/default/serverless/serverless.base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/default/serverless/serverless.base.config.ts
@@ -87,7 +87,6 @@ export const defaultConfig: ScoutServerConfig = {
       'xpack.security.authc.realms.jwt.jwt1.order=-98',
       `xpack.security.authc.realms.jwt.jwt1.pkc_jwkset_path=${getDockerFileMountPath(JWKS_PATH)}`,
       `xpack.security.authc.realms.jwt.jwt1.token_type=access_token`,
-      'serverless.indices.validate_dot_prefixes=true',
       // controller cluster-settings
       `cluster.service.slow_task_logging_threshold=15s`,
       `cluster.service.slow_task_thread_dump_timeout=5s`,

--- a/x-pack/platform/test/serverless/shared/config.base.ts
+++ b/x-pack/platform/test/serverless/shared/config.base.ts
@@ -90,7 +90,6 @@ export default async () => {
         'xpack.security.authc.realms.jwt.jwt1.order=-98',
         `xpack.security.authc.realms.jwt.jwt1.pkc_jwkset_path=${getDockerFileMountPath(jwksPath)}`,
         `xpack.security.authc.realms.jwt.jwt1.token_type=access_token`,
-        'serverless.indices.validate_dot_prefixes=true',
         // controller cluster-settings
         `cluster.service.slow_task_logging_threshold=15s`,
         `cluster.service.slow_task_thread_dump_timeout=5s`,


### PR DESCRIPTION
This is now the default value.  Removing to avoid conflicts with the config being renamed.

Fixes https://buildkite.com/elastic/kibana-elasticsearch-serverless-verify-and-promote/builds/4912

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->