### PR TITLE
chore(NA): run older dind version

### DIFF
--- a/.buildkite/scripts/steps/es_snapshots/build.sh
+++ b/.buildkite/scripts/steps/es_snapshots/build.sh
@@ -52,7 +52,7 @@ docker rm -f dind || true # If there's an old daemon running that somehow didn't
 CERTS_DIR="$HOME/dind-certs"
 rm -rf "$CERTS_DIR"
 
-export DIND_IMAGE=docker:23.0-dind
+export DIND_IMAGE=docker:28.5-dind
 docker run -d --rm --privileged --name dind --userns host -p 2377:2376 -e DOCKER_TLS_CERTDIR=/certs -v "$CERTS_DIR":/certs "$DIND_IMAGE"
 
 trap "docker rm -f dind" EXIT

--- a/.buildkite/scripts/steps/es_snapshots/build.sh
+++ b/.buildkite/scripts/steps/es_snapshots/build.sh
@@ -51,7 +51,9 @@ echo "--- Setting up Docker-in-Docker for Elasticsearch"
 docker rm -f dind || true # If there's an old daemon running that somehow didn't get cleaned up, lets remove it first
 CERTS_DIR="$HOME/dind-certs"
 rm -rf "$CERTS_DIR"
-docker run -d --rm --privileged --name dind --userns host -p 2377:2376 -e DOCKER_TLS_CERTDIR=/certs -v "$CERTS_DIR":/certs docker:dind
+
+export DIND_IMAGE=docker:23.0-dind
+docker run -d --rm --privileged --name dind --userns host -p 2377:2376 -e DOCKER_TLS_CERTDIR=/certs -v "$CERTS_DIR":/certs "$DIND_IMAGE"
 
 trap "docker rm -f dind" EXIT
 


### PR DESCRIPTION
The current snapshot build for ES 7.17 is broken due to the differences in the docker api version. Those changes should fix the problem until we are ready to decommission this pipeline.

Verified at https://buildkite.com/elastic/kibana-elasticsearch-snapshot-build/builds/7444