### PR TITLE
[ES|QL] Fixes not recognized GROK patterns

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/grok/columns_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/grok/columns_after.test.ts
@@ -78,6 +78,28 @@ describe('GROK', () => {
           type: 'keyword',
         },
       ]);
+
+      const pattern7 = '^(?<url.domain>http?s://[^/]+/)';
+      const columns7 = extractSemanticsFromGrok(pattern7);
+      expect(columns7).toStrictEqual([
+        {
+          name: 'url.domain',
+          type: 'keyword',
+        },
+      ]);
+
+      const pattern8 = '%{IP:client.ip} %{WORD:request.method}';
+      const columns8 = extractSemanticsFromGrok(pattern8);
+      expect(columns8).toStrictEqual([
+        {
+          name: 'client.ip',
+          type: 'keyword',
+        },
+        {
+          name: 'request.method',
+          type: 'keyword',
+        },
+      ]);
     });
 
     describe('GROK column type extraction', () => {

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/grok/columns_after.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/grok/columns_after.ts
@@ -29,7 +29,7 @@ export function extractSemanticsFromGrok(pattern: string): GrokColumn[] {
   const columns: GrokColumn[] = [];
 
   // Regex for Grok's %{SYNTAX:SEMANTIC:TYPE} pattern
-  const grokSyntaxRegex = /%{\w+:(?<column>[\w@]+)(?::(?<type>\w+))?}/g;
+  const grokSyntaxRegex = /%{\w+:(?<column>[\w@.]+)(?::(?<type>\w+))?}/g;
   let grokMatch;
   while ((grokMatch = grokSyntaxRegex.exec(pattern)) !== null) {
     if (grokMatch?.groups?.column) {
@@ -44,7 +44,7 @@ export function extractSemanticsFromGrok(pattern: string): GrokColumn[] {
 
   // Regex for Oniguruma-style named capture groups (?<name>...) or (?'name'...)
   // Oniguruma supports both `?<name>` and `?'name'` for named capture groups.
-  const onigurumaNamedCaptureRegex = /(?<column>\(\?<(\w+)>|\(\?'(\w+)'\)[^)]*\))/g;
+  const onigurumaNamedCaptureRegex = /(?<column>\(\?<([\w.]+)>|\(\?'([\w.]+)'\)[^)]*\))/g;
   let onigurumaMatch;
   while ((onigurumaMatch = onigurumaNamedCaptureRegex.exec(pattern)) !== null) {
     // If it's a (?<name>...) style


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/246803

## Summary

Some patterns in the GROK command were not properly recognized and were producing unknown columns in the query.

before
<img width="743" height="815" alt="image" src="https://github.com/user-attachments/assets/417c16c3-cd61-40e4-bf43-aa3695e52e3d" />

after
<img width="766" height="795" alt="image" src="https://github.com/user-attachments/assets/8323fcd2-d6a7-41f8-90cf-7eb7176639d1" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->