### PR TITLE
[9.3] Adds `query_vector_builder` Support for Autocomplete for Diversify Retriever (#246752)

### DIFF
--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/retriever.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/retriever.ts
@@ -28,6 +28,12 @@ export const retriever = (specService: SpecDefinitionsService) => {
       size: 10,
       rank_window_size: 100,
       query_vector: [],
+      query_vector_builder: {
+        text_embedding: {
+          model_id: '',
+          model_text: '',
+        },
+      },
       // lambda is only applicable for 'mmr' diversify type
       lambda: 0.5,
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Adds &#x60;query_vector_builder&#x60; Support for Autocomplete for Diversify Retriever (#246752)](https://github.com/elastic/kibana/pull/246752)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mark J. Hoy","email":"mark.hoy@elastic.co"},"sourceCommit":{"committedDate":"2025-12-18T10:20:15Z","message":"Adds `query_vector_builder` Support for Autocomplete for Diversify Retriever (#246752)\n\n## Summary\n\nUpdates the [autocomplete for the diversify\nretriever](https://github.com/elastic/kibana/pull/244411) to include\nsupport for the query_vector_builder field (added to Elasticsearch in\nhttps://github.com/elastic/elasticsearch/pull/139094).","sha":"b5f4e9523741757acdc0b95cfe7829419a4d101c","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["non-issue","release_note:skip","backport:skip","Team:Search","v9.3.0","v9.4.0"],"title":"Adds `query_vector_builder` Support for Autocomplete for Diversify Retriever","number":246752,"url":"https://github.com/elastic/kibana/pull/246752","mergeCommit":{"message":"Adds `query_vector_builder` Support for Autocomplete for Diversify Retriever (#246752)\n\n## Summary\n\nUpdates the [autocomplete for the diversify\nretriever](https://github.com/elastic/kibana/pull/244411) to include\nsupport for the query_vector_builder field (added to Elasticsearch in\nhttps://github.com/elastic/elasticsearch/pull/139094).","sha":"b5f4e9523741757acdc0b95cfe7829419a4d101c"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246752","number":246752,"mergeCommit":{"message":"Adds `query_vector_builder` Support for Autocomplete for Diversify Retriever (#246752)\n\n## Summary\n\nUpdates the [autocomplete for the diversify\nretriever](https://github.com/elastic/kibana/pull/244411) to include\nsupport for the query_vector_builder field (added to Elasticsearch in\nhttps://github.com/elastic/elasticsearch/pull/139094).","sha":"b5f4e9523741757acdc0b95cfe7829419a4d101c"}}]}] BACKPORT-->