### PR TITLE
[9.1] unconditionally register intercept saved objects (#246512)

### DIFF
--- a/x-pack/platform/plugins/private/intercepts/server/plugin.test.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/plugin.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { coreMock } from '@kbn/core/server/mocks';
+import { createUsageCollectionSetupMock } from '@kbn/usage-collection-plugin/server/mocks';
+import { InterceptsServerPlugin } from './plugin';
+import {
+  interceptTriggerRecordSavedObject,
+  interceptInteractionUserRecordSavedObject,
+} from './saved_objects';
+
+describe('InterceptsServerPlugin', () => {
+  let interceptsPlugin: InterceptsServerPlugin;
+  let coreSetupMock: ReturnType<typeof coreMock.createSetup>;
+  const usageCollectionSetupMock = createUsageCollectionSetupMock();
+  const initContext = coreMock.createPluginInitializerContext();
+
+  beforeEach(() => {
+    interceptsPlugin = new InterceptsServerPlugin(initContext);
+  });
+
+  describe('setup', () => {
+    it('should register the backing saved object types for the intercept plugin', () => {
+      coreSetupMock = coreMock.createSetup();
+
+      interceptsPlugin.setup(coreSetupMock, { usageCollection: usageCollectionSetupMock });
+
+      expect(coreSetupMock.savedObjects.registerType).toHaveBeenCalledWith(
+        interceptTriggerRecordSavedObject
+      );
+
+      expect(coreSetupMock.savedObjects.registerType).toHaveBeenCalledWith(
+        interceptInteractionUserRecordSavedObject
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/private/intercepts/server/plugin.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/plugin.ts
@@ -15,6 +15,10 @@ import {
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import { InterceptsTriggerOrchestrator } from './orchestrator';
 import type { ServerConfigSchema } from '../common/config';
+import {
+  interceptTriggerRecordSavedObject,
+  interceptInteractionUserRecordSavedObject,
+} from './saved_objects';
 
 interface InterceptsServerSetupDeps {
   usageCollection?: UsageCollectionSetup;
@@ -37,6 +41,11 @@ export class InterceptsServerPlugin
   }
 
   public setup(core: CoreSetup, { usageCollection }: InterceptsServerSetupDeps) {
+    // Always register saved objects unconditionally to ensure mappings are created
+    // during setup, regardless of plugin configuration or node roles
+    core.savedObjects.registerType(interceptTriggerRecordSavedObject);
+    core.savedObjects.registerType(interceptInteractionUserRecordSavedObject);
+
     this.interceptsOrchestrator?.setup(core, {
       logger: this.logger,
       kibanaVersion: this.initContext.env.packageInfo.version,

--- a/x-pack/platform/plugins/private/intercepts/server/services/intercept_trigger.test.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/services/intercept_trigger.test.ts
@@ -18,24 +18,6 @@ const usageCollectionSetupMock = createUsageCollectionSetupMock();
 describe('InterceptTriggerService', () => {
   const usageCounter = usageCollectionSetupMock.createUsageCounter('interceptsTriggerTest');
 
-  describe('#setup', () => {
-    it('invoking setup registers the backing saved object', () => {
-      const interceptTrigger = new InterceptTriggerService();
-
-      const coreSetupMock = coreMock.createSetup();
-
-      interceptTrigger.setup(coreSetupMock, {
-        logger: loggerMock.create(),
-        kibanaVersion: '9.1.0',
-        usageCollector: usageCounter,
-      });
-
-      expect(coreSetupMock.savedObjects.registerType).toHaveBeenCalledWith(
-        interceptTriggerRecordSavedObject
-      );
-    });
-  });
-
   describe('#start', () => {
     it('should return a specific of properties', () => {
       const interceptTrigger = new InterceptTriggerService();

--- a/x-pack/platform/plugins/private/intercepts/server/services/intercept_trigger.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/services/intercept_trigger.ts
@@ -39,8 +39,6 @@ export class InterceptTriggerService {
     this.kibanaVersion = kibanaVersion;
     this.counter = getCounters(usageCollector);
 
-    core.savedObjects.registerType(this.savedObjectRef);
-
     return {
       fetchRegisteredTask: this.fetchRegisteredTask.bind(this),
     };

--- a/x-pack/platform/plugins/private/intercepts/server/services/intercept_user_interaction.ts
+++ b/x-pack/platform/plugins/private/intercepts/server/services/intercept_user_interaction.ts
@@ -26,8 +26,6 @@ export class InterceptUserInteractionService {
   private savedObjectRef = interceptInteractionUserRecordSavedObject;
 
   setup(core: CoreSetup, logger: Logger) {
-    core.savedObjects.registerType(this.savedObjectRef);
-
     const router = core.http.createRouter<RequestHandlerContext>();
 
     router.get(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [unconditionally register intercept saved objects (#246512)](https://github.com/elastic/kibana/pull/246512)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-18T13:04:50Z","message":"unconditionally register intercept saved objects (#246512)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/246120\n\nWhat resulted in test failures? \n\nhttps://github.com/elastic/kibana/pull/242358 introduced changes that\nsetup intercepts conditionally\n([see](https://github.com/elastic/kibana/pull/242358/files#diff-e5efcd489d0ec57f80904c6e96f87183e43757661455bbd0561cc8cfe4dd3d88R34)),\nand we had test that were directly trying to create a record for these\nsaved object types that were expected to have been registered hence the\nerror we saw, we typically wouldn't get this issue for real users,\nbecause in UI nodes the saved object would have been registered.\n\nThis PR makes it so that the backing saved object are always registered\nregardless of the node type, however for nodes other than the UI node we\nstill keep it such that the intercept doesn't get instantiated.\n\n\n## How to verify that this change resolves the failing test on MKI\nlocally\n\nThe following steps assumes you have qaf configured, with a user having\nthe `viewer` role in the qa environment\n\n- create a project with qaf like so;\n\t```\n\nKIBANA_DOCKER_IMAGE=docker.elastic.co/kibana-ci/kibana-serverless:pr-246512-2f19a7d78cc8\n\\\n\tqaf elastic-cloud projects create \\\n\t  --project-type elasticsearch \\\n\t  --project-name custom-kibana-pr-246512 \\\n\t  --environment qa \\\n\t  --region aws-eu-west-1 \\\n\t  --es-docker-image current-dev\n\t```\n\n- When this completes, run the command below to ascertain that no\nintercept tests fail;\n\t```\n\tKIBANA_REPO_ROOT=. qaf kibana ftr run-config \\\n\t  --ec-project-name custom-kibana-pr-246512 \\\n\nx-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/search.serverless.config.ts\n\t```\n\n","sha":"aa76f347385cf686580ca83beb4b56968e0caf3c","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:SharedUX","backport:all-open","ci:build-serverless-image","v9.4.0"],"title":"unconditionally register intercept saved objects","number":246512,"url":"https://github.com/elastic/kibana/pull/246512","mergeCommit":{"message":"unconditionally register intercept saved objects (#246512)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/246120\n\nWhat resulted in test failures? \n\nhttps://github.com/elastic/kibana/pull/242358 introduced changes that\nsetup intercepts conditionally\n([see](https://github.com/elastic/kibana/pull/242358/files#diff-e5efcd489d0ec57f80904c6e96f87183e43757661455bbd0561cc8cfe4dd3d88R34)),\nand we had test that were directly trying to create a record for these\nsaved object types that were expected to have been registered hence the\nerror we saw, we typically wouldn't get this issue for real users,\nbecause in UI nodes the saved object would have been registered.\n\nThis PR makes it so that the backing saved object are always registered\nregardless of the node type, however for nodes other than the UI node we\nstill keep it such that the intercept doesn't get instantiated.\n\n\n## How to verify that this change resolves the failing test on MKI\nlocally\n\nThe following steps assumes you have qaf configured, with a user having\nthe `viewer` role in the qa environment\n\n- create a project with qaf like so;\n\t```\n\nKIBANA_DOCKER_IMAGE=docker.elastic.co/kibana-ci/kibana-serverless:pr-246512-2f19a7d78cc8\n\\\n\tqaf elastic-cloud projects create \\\n\t  --project-type elasticsearch \\\n\t  --project-name custom-kibana-pr-246512 \\\n\t  --environment qa \\\n\t  --region aws-eu-west-1 \\\n\t  --es-docker-image current-dev\n\t```\n\n- When this completes, run the command below to ascertain that no\nintercept tests fail;\n\t```\n\tKIBANA_REPO_ROOT=. qaf kibana ftr run-config \\\n\t  --ec-project-name custom-kibana-pr-246512 \\\n\nx-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/search.serverless.config.ts\n\t```\n\n","sha":"aa76f347385cf686580ca83beb4b56968e0caf3c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246512","number":246512,"mergeCommit":{"message":"unconditionally register intercept saved objects (#246512)\n\n## Summary\n\nResolves https://github.com/elastic/kibana/issues/246120\n\nWhat resulted in test failures? \n\nhttps://github.com/elastic/kibana/pull/242358 introduced changes that\nsetup intercepts conditionally\n([see](https://github.com/elastic/kibana/pull/242358/files#diff-e5efcd489d0ec57f80904c6e96f87183e43757661455bbd0561cc8cfe4dd3d88R34)),\nand we had test that were directly trying to create a record for these\nsaved object types that were expected to have been registered hence the\nerror we saw, we typically wouldn't get this issue for real users,\nbecause in UI nodes the saved object would have been registered.\n\nThis PR makes it so that the backing saved object are always registered\nregardless of the node type, however for nodes other than the UI node we\nstill keep it such that the intercept doesn't get instantiated.\n\n\n## How to verify that this change resolves the failing test on MKI\nlocally\n\nThe following steps assumes you have qaf configured, with a user having\nthe `viewer` role in the qa environment\n\n- create a project with qaf like so;\n\t```\n\nKIBANA_DOCKER_IMAGE=docker.elastic.co/kibana-ci/kibana-serverless:pr-246512-2f19a7d78cc8\n\\\n\tqaf elastic-cloud projects create \\\n\t  --project-type elasticsearch \\\n\t  --project-name custom-kibana-pr-246512 \\\n\t  --environment qa \\\n\t  --region aws-eu-west-1 \\\n\t  --es-docker-image current-dev\n\t```\n\n- When this completes, run the command below to ascertain that no\nintercept tests fail;\n\t```\n\tKIBANA_REPO_ROOT=. qaf kibana ftr run-config \\\n\t  --ec-project-name custom-kibana-pr-246512 \\\n\nx-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/search.serverless.config.ts\n\t```\n\n","sha":"aa76f347385cf686580ca83beb4b56968e0caf3c"}},{"url":"https://github.com/elastic/kibana/pull/246880","number":246880,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->