### PR TITLE
Make gap auto fill scheduler feature available in 9.3

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/plugin.ts
@@ -429,15 +429,13 @@ export class AlertingPlugin {
       });
     }
 
-    if (this?.config?.gapAutoFillScheduler?.enabled ?? false) {
-      registerGapAutoFillSchedulerTask({
-        taskManager: plugins.taskManager,
-        logger: this.logger,
-        getRulesClientWithRequest: (request) => this?.getRulesClientWithRequest?.(request),
-        eventLogger: this.eventLogger!,
-        schedulerConfig: this.config.gapAutoFillScheduler,
-      });
-    }
+    registerGapAutoFillSchedulerTask({
+      taskManager: plugins.taskManager,
+      logger: this.logger,
+      getRulesClientWithRequest: (request) => this?.getRulesClientWithRequest?.(request),
+      eventLogger: this.eventLogger!,
+      schedulerConfig: this.config.gapAutoFillScheduler,
+    });
 
     // Routes
     const router = core.http.createRouter<AlertingRequestHandlerContext>();

--- a/x-pack/platform/plugins/shared/alerting/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/index.ts
@@ -168,13 +168,11 @@ export function defineRoutes(opts: RouteOptions) {
   getRuleIdsWithGapsRoute(router, licenseState);
   getGapsSummaryByRuleIdsRoute(router, licenseState);
 
-  if (alertingConfig?.gapAutoFillScheduler?.enabled) {
-    createAutoFillSchedulerRoute(router, licenseState);
-    getAutoFillSchedulerRoute(router, licenseState);
-    updateAutoFillSchedulerRoute(router, licenseState);
-    deleteAutoFillSchedulerRoute(router, licenseState);
-    findAutoFillSchedulerLogsRoute(router, licenseState);
-  }
+  createAutoFillSchedulerRoute(router, licenseState);
+  getAutoFillSchedulerRoute(router, licenseState);
+  updateAutoFillSchedulerRoute(router, licenseState);
+  deleteAutoFillSchedulerRoute(router, licenseState);
+  findAutoFillSchedulerLogsRoute(router, licenseState);
 
   // Rules Settings APIs
   if (alertingConfig.rulesSettings.enabled) {

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -197,6 +197,7 @@ export default function ({ getService }: FtrProviderContext) {
         'fleet:update_agent_tags:retry',
         'fleet:upgrade-agentless-deployments-task',
         'fleet:upgrade_action:retry',
+        'gap-auto-fill-scheduler-task',
         'logs-data-telemetry',
         'maintenance-window:generate-events',
         'osquery:telemetry-configs',

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -202,7 +202,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables the Gap Auto Fill Scheduler feature.
    */
-  gapAutoFillSchedulerEnabled: false,
+  gapAutoFillSchedulerEnabled: true,
   /**
    * Enables DNS events toggle for Linux in Endpoint policy configuration.
    * When disabled, DNS field is not added to Linux policies and not shown in UI.


### PR DESCRIPTION
## Make gap auto fill scheduler feature available in 9.3

We want to only make this feature available in 9.3 branch to be able tests BC.

We will remove it from main close to 9.3 release, when docs are ready that it can be released in serverless.