### PR TITLE
[Lens] [ES|QL] Show and disable "Convert to ES|QL" button when the visualization has more than one layer

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -305,19 +305,25 @@ export function LensEditConfigurationFlyout({
   }, [textBasedMode]);
 
   const { isConvertToEsqlButtonDisabled, convertToEsqlButtonTooltip } = useMemo(() => {
-    const disabled = (tooltip: string = 'The visualization cannot be converted') => ({
+    const disabled = (
+      tooltip: string = i18n.translate('xpack.lens.config.cannotConvertToEsqlTooltip', {
+        defaultMessage: 'This visualization cannot be converted to ES|QL',
+      })
+    ) => ({
       isConvertToEsqlButtonDisabled: true,
       convertToEsqlButtonTooltip: tooltip,
     });
 
     const enabled = () => ({
       isConvertToEsqlButtonDisabled: false,
-      convertToEsqlButtonTooltip: 'Switch to query mode',
+      convertToEsqlButtonTooltip: i18n.translate('xpack.lens.config.convertToEsqlTooltip', {
+        defaultMessage: 'Convert visualization to ES|QL',
+      }),
     });
 
     // Guard: prerequisites
     if (!showConvertToEsqlButton || !activeVisualization || !visualization.state) {
-      return disabled('');
+      return disabled();
     }
 
     const { state } = visualization;
@@ -333,12 +339,20 @@ export function LensEditConfigurationFlyout({
       state.trendlineMetricAccessor &&
       state.trendlineTimeAccessor
     ) {
-      return disabled('Metric visualization with a trend line are not supported in query mode');
+      return disabled(
+        i18n.translate('xpack.lens.config.cannotConvertToEsqlMetricWithTrendlineTooltip', {
+          defaultMessage: 'Metric visualization with a trend line are not supported in query mode',
+        })
+      );
     }
 
     // Guard: layer count
     if (layerIds.length > 1) {
-      return disabled('Multi-layer visualizations cannot be converted to query mode');
+      return disabled(
+        i18n.translate('xpack.lens.config.cannotConvertToEsqlMultilayerTooltip', {
+          defaultMessage: 'Multi-layer visualizations cannot be converted to query mode',
+        })
+      );
     }
 
     // Guard: datasource state exists and has layers
@@ -350,19 +364,19 @@ export function LensEditConfigurationFlyout({
       !('layers' in datasourceState) ||
       !datasourceState.layers
     ) {
-      return disabled('The visualization cannot be converted');
+      return disabled();
     }
 
     // Guard: layer access
     const layerId = layerIds[0];
     const layers = datasourceState.layers as Record<string, FormBasedLayer>;
     if (!layerId || !layers[layerId]) {
-      return disabled('');
+      return disabled();
     }
 
     const singleLayer = layers[layerId];
     if (!singleLayer?.columnOrder || !singleLayer?.columns) {
-      return disabled('');
+      return disabled();
     }
 
     // Main logic: compute esqlLayer
@@ -387,7 +401,11 @@ export function LensEditConfigurationFlyout({
 
     return esqlLayer
       ? enabled()
-      : disabled('The visualization has unsupported settings for query mode');
+      : disabled(
+          i18n.translate('xpack.lens.config.cannotConvertToEsqlUnsupportedSettingsTooltip', {
+            defaultMessage: 'The visualization has unsupported settings for query mode',
+          })
+        );
   }, [
     coreStart.uiSettings,
     datasourceId,


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana-team/issues/2179

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
