### PR TITLE
[8.19] add fix missing entry in moon.yml

### DIFF
--- a/x-pack/platform/plugins/private/intercepts/moon.yml
+++ b/x-pack/platform/plugins/private/intercepts/moon.yml
@@ -33,6 +33,7 @@ dependsOn:
   - '@kbn/core-notifications-browser'
   - '@kbn/core-http-browser'
   - '@kbn/logging-mocks'
+  - '@kbn/core-notifications-browser-internal'
 tags:
   - plugin
   - prod


### PR DESCRIPTION
While the moon project regeneration PR was getting merged (https://github.com/elastic/kibana/pull/246580), a tsconfig file changed, causing failure on the 8.19 branch. 

This PR fixes that issue.