### PR TITLE
[Streams] Fix Processing, field name autocomplete not working on new fields

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/interactive_mode_machine/interactive_mode_machine.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/interactive_mode_machine/interactive_mode_machine.ts
@@ -220,7 +220,6 @@ export const interactiveModeMachine = setup({
     sendStepsToSimulator: enqueueActions(({ context }) => {
       // Check parent for any errors (schema or validation) - don't simulate if there are errors
       if (hasErrorsInParentSnapshot(context.parentRef.getSnapshot())) {
-        context.parentRef.send({ type: 'simulation.reset' });
         return;
       }
 


### PR DESCRIPTION
Closes #246680 

## Summary

Fixes the loss of the previously created fields on the simulation by removing the reset and keeping the last stable simulation

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->