### PR TITLE
[Fleet] Fix unhandled scenario in rollback with all spaces policies

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -86,8 +86,14 @@ import { agentPolicyService } from './agent_policy';
 import { isSpaceAwarenessEnabled } from './spaces/helpers';
 import { licenseService } from './license';
 import { cloudConnectorService } from './cloud_connector';
+import { initial } from 'lodash';
 
-jest.mock('./spaces/helpers');
+jest.mock('./spaces/helpers', () => {
+  return {
+    ...jest.requireActual('./spaces/helpers'),
+    isSpaceAwarenessEnabled: jest.fn(),
+  };
+});
 
 jest.mock('./license');
 
@@ -8111,6 +8117,7 @@ describe('Package policy service', () => {
               updated_at: '2025-12-22T21:28:05.380Z',
               updated_by: 'elastic',
             },
+            initialNamespaces: ['default'],
             references: [],
             score: 0,
           },
@@ -8136,6 +8143,7 @@ describe('Package policy service', () => {
               updated_at: '2025-12-22T21:28:05.380Z',
               updated_by: 'elastic',
             },
+            initialNamespaces: ['myspace'],
             references: [],
             score: 0,
           },
@@ -8226,6 +8234,7 @@ describe('Package policy service', () => {
                 updated_by: 'elastic',
               },
               references: [],
+              initialNamespaces: ['default'],
               score: 0,
             },
           ],
@@ -8261,6 +8270,7 @@ describe('Package policy service', () => {
               },
               references: [],
               score: 0,
+              initialNamespaces: ['myspace'],
             },
           ],
           { namespace: 'myspace' }

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -86,7 +86,6 @@ import { agentPolicyService } from './agent_policy';
 import { isSpaceAwarenessEnabled } from './spaces/helpers';
 import { licenseService } from './license';
 import { cloudConnectorService } from './cloud_connector';
-import { initial } from 'lodash';
 
 jest.mock('./spaces/helpers', () => {
   return {

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/helpers.ts
@@ -75,6 +75,12 @@ export function getSpaceForPackagePolicy(packagePolicy: Pick<PackagePolicy, 'spa
   return getValidSpaceId(packagePolicy.spaceIds);
 }
 
+export function getSpaceForPackagePolicySO(
+  packagePolicySO: Pick<SavedObject<AgentPolicySOAttributes>, 'namespaces'>
+): string {
+  return getValidSpaceId(packagePolicySO.namespaces);
+}
+
 export function getValidSpaceId(spacedIds?: string[]) {
   const space = spacedIds?.[0];
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/package_policy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../../../common/constants';
+import { ALL_SPACES_ID, PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../../../common/constants';
 
 import { appContextService } from '../app_context';
 
@@ -29,7 +29,7 @@ export async function updatePackagePolicySpaces({
       },
     ],
     newSpaceIds,
-    [],
+    newSpaceIds.length === 1 && newSpaceIds[0] === ALL_SPACES_ID ? [currentSpaceId] : [],
     { refresh: 'wait_for', namespace: currentSpaceId }
   );
 

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/api_helper.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/api_helper.ts
@@ -218,6 +218,7 @@ export class SpaceTestApiClient {
   ): Promise<GetOnePackagePolicyResponse> {
     const res = await this.supertest
       .get(`${this.getBaseUrl(spaceId)}/api/fleet/package_policies/${packagePolicyId}`)
+      .auth(this.auth.username, this.auth.password)
       .send();
 
     expectStatusCode200(res);

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/package_policies.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/package_policies.ts
@@ -102,6 +102,9 @@ export default function (providerContext: FtrProviderContext) {
 
         expect(packagePolicyRes.item).to.have.property('id');
         packagePolicyId = packagePolicyRes.item.id;
+
+        const updatedPolicy = await apiClient.getPackagePolicy(packagePolicyId);
+        expect(updatedPolicy.item.spaceIds).to.eql('*');
       });
 
       it('should allow to add a package policy to an all agent policy in the test space', async () => {


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/245199

That PR fix when handling package policies rollback, that was not fix in previous [PR](https://github.com/elastic/kibana/pull/245271), due to another bug that was creating policies with two namespace for all space ids `[currentSpace, '*']` instead of `['*']`

## Tests 

Follow the test instructions there https://github.com/elastic/kibana/issues/245199#issuecomment-3669405404 and verify you can rollback 



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->