### PR TITLE
[Agent Builder] Update README to indicate MCP tool support.

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/README.md
+++ b/x-pack/platform/plugins/shared/onechat/README.md
@@ -86,7 +86,7 @@ and how to call it.
 Tools can come from multiple sources:
 - built-in from Kibana
 - created by users
-- from MCP servers (not implemented yet)
+- from MCP servers
 
 ### Type of tools
 
@@ -94,6 +94,29 @@ Tools can come from multiple sources:
 - esql: ES|QL tools, which are defined by a templated ES|QL query and its corresponding parameters.
 - index_search: An agentic search tool that can be scoped to an index pattern.
 - workflow: A tool that executes a workflow.
+- mcp: A tool provided by an external MCP (Model Context Protocol) server.
+
+### Enabling MCP tools
+
+MCP tools allow you to connect to external MCP servers and use their tools within Agent Builder. To enable MCP tools, add the following to your `kibana.dev.yml`:
+
+```yml
+uiSettings.overrides:
+  agentBuilder:externalMcp: true
+```
+
+Or via API:
+
+```
+POST kbn://internal/kibana/settings
+{
+   "changes": {
+      "agentBuilder:externalMcp": true
+   }
+}
+```
+
+Once enabled, you can create MCP tools by configuring an MCP connector and selecting tools from the connected MCP server.
 
 ### Registering a tool
 


### PR DESCRIPTION
## Summary

Updating the Agent Builder README with instructions on how to enable MCP tools and indicate their support.

Note: After #246759 is merged to enable the MCP KSC by default, users will only need to set the single UI setting for MCP tool support.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
