### PR TITLE
[Dashboard] Improve chart content alignment with dashboard panel title

### DIFF
--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_header.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_header.tsx
@@ -68,7 +68,7 @@ export const PresentationPanelHeader = <
         height: ${euiTheme.size.l};
         overflow: hidden;
         line-height: ${euiTheme.size.l};
-        padding: 0px ${euiTheme.size.s};
+        padding: ${euiTheme.size.s} ${euiTheme.size.s} 0px ${euiTheme.size.s};
 
         display: flex;
         flex-wrap: nowrap;

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -33,7 +33,7 @@ import {
   Placement,
   Direction,
   Tooltip,
-  LEGACY_LIGHT_THEME,
+  LIGHT_THEME,
 } from '@elastic/charts';
 import { partition } from 'lodash';
 import type { IconType } from '@elastic/eui';
@@ -865,17 +865,33 @@ export function XYChart({
                     labelOptions: { maxLines: legend.shouldTruncate ? legend?.maxLines ?? 1 : 0 },
                   },
                   // if not title or labels are shown for axes, add some padding if required by reference line markers
-                  chartMargins: {
-                    // Temporary margin defaults
-                    ...LEGACY_LIGHT_THEME.chartMargins,
-                    ...computeChartMargins(
+                  chartMargins: (() => {
+                    const computed = computeChartMargins(
                       linesPaddings,
                       { ...tickLabelsVisibilitySettings, x: xAxisConfig?.showLabels },
                       { ...axisTitlesVisibilitySettings, x: xAxisConfig?.showTitle },
                       yAxesMap,
                       shouldRotate
-                    ),
-                  },
+                    );
+                    const marginValues = {
+                      ...LIGHT_THEME.chartMargins,
+                      ...computed,
+                    };
+
+                    // Left margin adjustment for dashboard panel title alignment
+                    const shouldAdjustLeft =
+                      // Vertical: no left Y-axis title, but has tick labels
+                      (!shouldRotate &&
+                        !axisTitlesVisibilitySettings.yLeft &&
+                        tickLabelsVisibilitySettings.yLeft) ||
+                      // Horizontal: no X-axis title, but has tick labels
+                      (shouldRotate && !xAxisConfig?.showTitle && xAxisConfig?.showLabels);
+
+                    return {
+                      ...marginValues,
+                      left: shouldAdjustLeft ? marginValues.left - 8 : marginValues.left,
+                    };
+                  })(),
                   markSizeRatio: args.markSizeRatio,
                 },
                 ...(Array.isArray(settingsThemeOverrides)

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/heatmap/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/heatmap/visualization.tsx
@@ -566,4 +566,10 @@ export const getHeatmapVisualization = ({
       ],
     };
   },
+
+  getDisplayOptions() {
+    return {
+      noPadding: true,
+    };
+  },
 });

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -334,4 +334,10 @@ export const getLegacyMetricVisualization = ({
       ],
     };
   },
+
+  getDisplayOptions() {
+    return {
+      noPadding: true,
+    };
+  },
 });

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/tagcloud/tagcloud_visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/tagcloud/tagcloud_visualization.tsx
@@ -332,4 +332,10 @@ export const getTagcloudVisualization = ({
   getTelemetryEventsOnSave(state, prevState) {
     return getColorMappingTelemetryEvents(state?.colorMapping, prevState?.colorMapping);
   },
+
+  getDisplayOptions() {
+    return {
+      noPadding: true,
+    };
+  },
 });


### PR DESCRIPTION
Closes https://github.com/elastic/elastic-charts/issues/2723

## Summary

This PR improves the alignment between Dashboard panel titles and chart content. Rather than implementing the exact values specified in the issue, the changes strike a balance that works across all chart types without reducing the chart's content area.

## Before & After Comparison

> **Note**: "After" images include a temporary dim blue border around the canvas to make alignment inspection easier.

| Before | After |
|--------|-------|
| <img width="1074" alt="before-01" src="https://github.com/user-attachments/assets/654b0aa9-0ebf-4d61-b733-18d93641426c" /> | <img width="1074" alt="after-01" src="https://github.com/user-attachments/assets/a7e7008f-a03a-4031-96bd-da15ede8b954" /> |
| <img width="1074" alt="before-02" src="https://github.com/user-attachments/assets/9c654c2e-fecf-4eec-b8e6-e6ed096ea275" /> | <img width="1074" alt="after-02" src="https://github.com/user-attachments/assets/29414268-5f0a-4f94-bd69-14b79a8cfa87" /> |
| <img width="1074" alt="before-03" src="https://github.com/user-attachments/assets/f486a1c1-060a-4fa3-85d6-43f0d043c340" /> | <img width="1074" alt="after-03" src="https://github.com/user-attachments/assets/b2860145-38dc-47c3-a84d-a346f3f65f6b" /> |
| <img width="1074" alt="before-04" src="https://github.com/user-attachments/assets/21bb9e42-47a6-495a-9d13-2c29de802f40" /> | <img width="1074" alt="after-04" src="https://github.com/user-attachments/assets/81e44f63-b868-45c1-9d5f-c3e5a5058276" /> |
| <img width="1074" alt="before-05" src="https://github.com/user-attachments/assets/a8c8cea6-f200-4631-a949-7ffafd2424fa" /> | <img width="1074" alt="after-05" src="https://github.com/user-attachments/assets/f1562d0d-1672-4770-b33d-c468466fe84f" /> |
| <img width="1074" alt="before-06" src="https://github.com/user-attachments/assets/2be51520-3b38-4ebe-85a2-e62bf2b73a91" /> | <img width="1074" alt="after-06" src="https://github.com/user-attachments/assets/ab9a66e1-6f5d-4cd6-a84e-7a2ab36f6e74" /> |
| <img width="1074" alt="before-07" src="https://github.com/user-attachments/assets/29cf44e0-41bc-458b-ad2d-dd89ea0faf3a" /> | <img width="1074" alt="after-07" src="https://github.com/user-attachments/assets/4b4e0982-ed3f-4183-9882-6a251fce4abc" /> |

