### PR TITLE
[ResponseOps] Error validating isEsqlMode field for CSV scheduled reports

### DIFF
--- a/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/validator.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/validator.test.ts
@@ -22,6 +22,18 @@ describe('validateJobParams', () => {
     expect(() => validateJobParams(validParams)).not.toThrow();
   });
 
+  it('accepts valid csv job params', () => {
+    const validParams = {
+      browserTimezone: 'America/Los_Angeles',
+      isEsqlMode: true,
+      objectType: 'search',
+      title: 'Discover session',
+      version: '9.4.0',
+    } as unknown as BaseParams;
+
+    expect(() => validateJobParams(validParams)).not.toThrow();
+  });
+
   it('sanitizes title', () => {
     const validParams = {
       title: 'Monthly Report<script>alert("xss")</script>',

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/validator.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/validator.ts
@@ -99,8 +99,6 @@ const locatorParamsSchema = z.array(locatorObjectSchema).max(1).or(locatorObject
 const relativeUrlSchema = z.string().max(4096);
 const relativeUrlsSchema = z.array(relativeUrlSchema).max(100);
 
-const isEsqlModeSchema = z.boolean();
-
 const jobParamsSchema = z
   .object({
     browserTimezone: timezoneSchema.optional(),
@@ -115,7 +113,7 @@ const jobParamsSchema = z
     columns: z.array(z.string()).optional(), // this is for CSV v1 compatibility
     relativeUrls: relativeUrlsSchema.optional(), // used in tests could be legacy
     relativeUrl: relativeUrlSchema.optional(), // used in tests could be legacy
-    isEsqlMode: isEsqlModeSchema.optional(),
+    isEsqlMode: z.boolean().optional(), // for CSV reports
   })
   .strict();
 

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/validator.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/validator.ts
@@ -99,6 +99,8 @@ const locatorParamsSchema = z.array(locatorObjectSchema).max(1).or(locatorObject
 const relativeUrlSchema = z.string().max(4096);
 const relativeUrlsSchema = z.array(relativeUrlSchema).max(100);
 
+const isEsqlModeSchema = z.boolean();
+
 const jobParamsSchema = z
   .object({
     browserTimezone: timezoneSchema.optional(),
@@ -113,6 +115,7 @@ const jobParamsSchema = z
     columns: z.array(z.string()).optional(), // this is for CSV v1 compatibility
     relativeUrls: relativeUrlsSchema.optional(), // used in tests could be legacy
     relativeUrl: relativeUrlSchema.optional(), // used in tests could be legacy
+    isEsqlMode: isEsqlModeSchema.optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

This PR adds validation for `isEsqlMode` that can be a job params for CSV scheduled reports.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### To verify

1. Go to discover and search in ES|QL mode
2. Try to create a CSV scheduled report
3. Verify that the scheduled report is created successfully and there is no error
4. Verify that you can generate scheduled reports for the other report types CSV (non ES|QL), PDF, PDF for-print, and PNG





<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->