### PR TITLE
[Agent Builder] fix conversation truncation bug

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/add_round_complete_event.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/services/agents/modes/utils/add_round_complete_event.ts
@@ -97,7 +97,7 @@ export const addRoundCompleteEvent = ({
             type: ChatEventType.roundComplete,
             data: {
               round,
-              resumed: pendingRound !== null,
+              resumed: pendingRound !== undefined,
             },
           };
 

--- a/x-pack/platform/test/onechat_api_integration/apis/converse/multi_rounds.ts
+++ b/x-pack/platform/test/onechat_api_integration/apis/converse/multi_rounds.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { OneChatApiFtrProviderContext } from '../../../onechat/services/api';
+import { createLlmProxy, type LlmProxy } from '../../utils/llm_proxy';
+import { setupAgentDirectAnswer } from '../../utils/proxy_scenario';
+import {
+  createLlmProxyActionConnector,
+  deleteActionConnector,
+} from '../../utils/llm_proxy/llm_proxy_action_connector';
+import { createOneChatApiClient } from '../../utils/one_chat_client';
+
+export default function ({ getService }: OneChatApiFtrProviderContext) {
+  const supertest = getService('supertest');
+
+  const log = getService('log');
+  const oneChatApiClient = createOneChatApiClient(supertest);
+
+  describe('FOO POST /api/agent_builder/converse: multi rounds', function () {
+    let llmProxy: LlmProxy;
+    let connectorId: string;
+
+    before(async () => {
+      llmProxy = await createLlmProxy(log);
+      connectorId = await createLlmProxyActionConnector(getService, { port: llmProxy.getPort() });
+    });
+
+    after(async () => {
+      llmProxy.close();
+      await deleteActionConnector(getService, { actionId: connectorId });
+    });
+
+    const MOCKED_LLM_RESPONSE_1 = 'Response 1';
+    const MOCKED_LLM_RESPONSE_2 = 'Response 2';
+    const MOCKED_LLM_TITLE = 'Mocked Conversation Title';
+
+    it('handles a simple multi-round conversation', async () => {
+      await setupAgentDirectAnswer({
+        proxy: llmProxy,
+        title: MOCKED_LLM_TITLE,
+        response: MOCKED_LLM_RESPONSE_1,
+      });
+
+      const firstResponse = await oneChatApiClient.converse({
+        input: 'Hello OneChat',
+        connector_id: connectorId,
+      });
+
+      await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+      const conversationId = firstResponse.conversation_id;
+
+      await setupAgentDirectAnswer({
+        proxy: llmProxy,
+        continueConversation: true,
+        response: MOCKED_LLM_RESPONSE_2,
+      });
+
+      const secondResponse = await oneChatApiClient.converse({
+        input: 'Follow up',
+        conversation_id: conversationId,
+        connector_id: connectorId,
+      });
+
+      await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+      expect(secondResponse.response.message).to.eql(MOCKED_LLM_RESPONSE_2);
+
+      const conversation = await oneChatApiClient.getConversation(conversationId);
+
+      expect(conversation.rounds.length).to.eql(2);
+      expect(conversation.rounds[0].response.message).to.eql(MOCKED_LLM_RESPONSE_1);
+      expect(conversation.rounds[1].response.message).to.eql(MOCKED_LLM_RESPONSE_2);
+    });
+  });
+}

--- a/x-pack/platform/test/onechat_api_integration/apis/index.ts
+++ b/x-pack/platform/test/onechat_api_integration/apis/index.ts
@@ -25,6 +25,7 @@ export default function ({ loadTestFile, getService }: FtrProviderContext) {
     });
 
     loadTestFile(require.resolve('./converse/simple_conversation.ts'));
+    loadTestFile(require.resolve('./converse/multi_rounds.ts'));
     loadTestFile(require.resolve('./converse/tool_calling.ts'));
     loadTestFile(require.resolve('./converse/attachments.ts'));
     loadTestFile(require.resolve('./converse/error_handling.ts'));


### PR DESCRIPTION
## Summary

Fix a bug introduced by https://github.com/elastic/kibana/pull/245795 which was causing all conversations to be truncated to the last round when we update them at the end of the stream/round