### PR TITLE
[ResponseOps][Rules] Tags combobox container doesn't take badge sizes into account and wraps to a new line

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_details/rule_details.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_details/rule_details.tsx
@@ -9,6 +9,8 @@
 
 import React, { useCallback, useMemo } from 'react';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
+import { css } from '@emotion/react';
+
 import {
   EuiFormRow,
   EuiFieldText,
@@ -97,10 +99,14 @@ export const RuleDetails = () => {
     [dispatch, formData.artifacts]
   );
 
+  const flexItemCss = css`
+    min-width: 0;
+  `;
+
   return (
     <>
       <EuiFlexGroup>
-        <EuiFlexItem>
+        <EuiFlexItem grow={1} css={flexItemCss}>
           <EuiFormRow
             data-test-subj="ruleDetails"
             fullWidth
@@ -118,7 +124,7 @@ export const RuleDetails = () => {
             />
           </EuiFormRow>
         </EuiFlexItem>
-        <EuiFlexItem>
+        <EuiFlexItem grow={1} css={flexItemCss}>
           <EuiFormRow
             fullWidth
             label={RULE_TAG_INPUT_TITLE}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/108853

## Summary

The originally reported issue described the `Tags` combobox wrapping to a new line when when badges had long titles, instead of staying aligned next to the `Rule Name `input. 
This issue is no longer reproducible, but long tag values still cause the Tags input to expand and shrink the Rule Name field. 
This PR fixes the flexbox sizing issue by allowing items to shrink (min-width: 0), keeping both inputs aligned and equal width.


<!--ONMERGE {"backportTargets":["9.1","9.2","9.3"]} ONMERGE-->