### PR TITLE
[ES|QL] expand arrow in query history is cut off

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx
@@ -469,6 +469,9 @@ export function QueryColumn({
           iconType={isRowExpanded ? 'arrowDown' : 'arrowRight'}
           size="xs"
           color="text"
+          css={css`
+            flex-shrink: 0;
+          `}
         />
       )}
       <span


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/246185

## Summary

In the query history of the esql editor some longer queries have their expand arrow cut off so we add `flex-shrink: 0` to stop it from losing any space.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->