### PR TITLE
[Fleet] Deduplicate ids in package policy API handlers

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/package_policy/handlers.ts
@@ -10,7 +10,7 @@ import type { TypeOf } from '@kbn/config-schema';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { RequestHandler } from '@kbn/core/server';
 
-import { groupBy, isEmpty, isEqual, keyBy } from 'lodash';
+import { groupBy, isEmpty, isEqual, keyBy, uniq } from 'lodash';
 
 import { HTTPAuthorizationHeader } from '../../../common/http_authorization_header';
 
@@ -73,6 +73,8 @@ import {
 
 export const isNotNull = <T>(value: T | null): value is T => value !== null;
 
+const deduplicateIds = (ids: string[]) => uniq(ids);
+
 export const getPackagePoliciesHandler: FleetRequestHandler<
   undefined,
   TypeOf<typeof GetPackagePoliciesRequestSchema.query>
@@ -112,7 +114,8 @@ export const bulkGetPackagePoliciesHandler: FleetRequestHandler<
   const fleetContext = await context.fleet;
   const soClient = fleetContext.internalSoClient;
   const limitedToPackages = fleetContext.limitedToPackages;
-  const { ids, ignoreMissing } = request.body;
+  const ignoreMissing = request.body.ignoreMissing;
+  const ids = deduplicateIds(request.body.ids);
 
   try {
     const items = await packagePolicyService.getByIDs(soClient, ids, {
@@ -490,11 +493,12 @@ export const deletePackagePolicyHandler: RequestHandler<
   const soClient = coreContext.savedObjects.client;
   const esClient = coreContext.elasticsearch.client.asInternalUser;
   const user = appContextService.getSecurityCore().authc.getCurrentUser(request) || undefined;
+  const packagePolicyIds = deduplicateIds(request.body.packagePolicyIds);
 
   const body: PostDeletePackagePoliciesResponse = await packagePolicyService.delete(
     soClient,
     esClient,
-    request.body.packagePolicyIds,
+    packagePolicyIds,
     { user, force: request.body.force, skipUnassignFromAgentPolicies: request.body.force },
     context,
     request
@@ -549,10 +553,11 @@ export const upgradePackagePolicyHandler: RequestHandler<
   const soClient = coreContext.savedObjects.client;
   const esClient = coreContext.elasticsearch.client.asInternalUser;
   const user = appContextService.getSecurityCore().authc.getCurrentUser(request) || undefined;
+  const packagePolicyIds = deduplicateIds(request.body.packagePolicyIds);
   const body: UpgradePackagePolicyResponse = await packagePolicyService.bulkUpgrade(
     soClient,
     esClient,
-    request.body.packagePolicyIds,
+    packagePolicyIds,
     { user }
   );
 
@@ -577,7 +582,7 @@ export const dryRunUpgradePackagePolicyHandler: RequestHandler<
   const soClient = (await context.core).savedObjects.client;
 
   const body: UpgradePackagePolicyDryRunResponse = [];
-  const { packagePolicyIds } = request.body;
+  const packagePolicyIds = deduplicateIds(request.body.packagePolicyIds);
   await runWithCache(async () => {
     for (const id of packagePolicyIds) {
       const result = await packagePolicyService.getUpgradeDryRunDiff(soClient, id);


### PR DESCRIPTION
## Summary

Relates https://github.com/elastic/kibana/issues/240983

Deduplicate ids in package policy API handlers to save unnecessarily querying duplicate ids.

To verify:
- take a valid package policy id
- try querying twice with the bulk API
- expect only one result

```
POST kbn:/api/fleet/package_policies/_bulk_get
{
    "ids": ["dc0754de-7111-4de3-91d7-2b7d2a080676", "dc0754de-7111-4de3-91d7-2b7d2a080676"]
}

{
  "items": [
    {
      "id": "dc0754de-7111-4de3-91d7-2b7d2a080676",
      "version": "WzE1NTYsMV0=",
      "spaceIds": [
        "default"
      ],
      ...
    }
  ]
}
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->