### PR TITLE
[9.2] [FSH] Moved package_installer to @kbn/fs usage (#245664)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-fs/validations/file_extension.test.ts
+++ b/x-pack/platform/packages/shared/kbn-fs/validations/file_extension.test.ts
@@ -59,7 +59,6 @@ describe('validateFileExtension', () => {
         '.doc',
         '.pdf',
         '.exe',
-        '.zip',
         '.bat',
         '.cmd',
         '.sh',
@@ -70,7 +69,7 @@ describe('validateFileExtension', () => {
       ];
       unsupportedExtensions.forEach((extension) => {
         expect(() => validateFileExtension(`file${extension}`)).toThrow(
-          `Invalid file type: "file${extension}". Only .txt, .md, .log, .json, .yml, .yaml, .csv, .svg, .png files are allowed.`
+          `Invalid file type: "file${extension}". Only .txt, .md, .log, .json, .yml, .yaml, .csv, .svg, .png, .zip files are allowed.`
         );
       });
     });

--- a/x-pack/platform/packages/shared/kbn-fs/validations/file_extension.ts
+++ b/x-pack/platform/packages/shared/kbn-fs/validations/file_extension.ts
@@ -7,7 +7,18 @@
 
 import path from 'path';
 
-const allowedExtensions = ['.txt', '.md', '.log', '.json', '.yml', '.yaml', '.csv', '.svg', '.png'];
+const allowedExtensions = [
+  '.txt',
+  '.md',
+  '.log',
+  '.json',
+  '.yml',
+  '.yaml',
+  '.csv',
+  '.svg',
+  '.png',
+  '.zip',
+];
 
 export function validateFileExtension(filePath: string) {
   const extension = path.extname(filePath).toLowerCase();

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/moon.yml
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/moon.yml
@@ -23,7 +23,6 @@ dependsOn:
   - '@kbn/config-schema'
   - '@kbn/product-doc-common'
   - '@kbn/core-saved-objects-server'
-  - '@kbn/utils'
   - '@kbn/core-http-browser'
   - '@kbn/logging-mocks'
   - '@kbn/licensing-plugin'
@@ -33,6 +32,8 @@ dependsOn:
   - '@kbn/ml-is-populated-object'
   - '@kbn/i18n'
   - '@kbn/licensing-types'
+  - '@kbn/fs'
+  - '@kbn/react-query'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/moon.yml
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/moon.yml
@@ -33,7 +33,6 @@ dependsOn:
   - '@kbn/i18n'
   - '@kbn/licensing-types'
   - '@kbn/fs'
-  - '@kbn/react-query'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/plugin.ts
@@ -5,9 +5,7 @@
  * 2.0.
  */
 
-import Path from 'path';
 import type { Logger } from '@kbn/logging';
-import { getDataPath } from '@kbn/utils';
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/server';
 import { SavedObjectsClient } from '@kbn/core/server';
 import { productDocInstallStatusSavedObjectTypeName } from '../common/consts';
@@ -85,7 +83,7 @@ export class ProductDocBasePlugin
       esClient: core.elasticsearch.client.asInternalUser,
       productDocClient,
       kibanaVersion: this.context.env.packageInfo.version,
-      artifactsFolder: Path.join(getDataPath(), 'ai-kb-artifacts'),
+      artifactsFolder: 'ai-kb-artifacts',
       artifactRepositoryUrl: this.context.config.get().artifactRepositoryUrl,
       elserInferenceId: this.context.config.get().elserInferenceId,
       logger: this.logger.get('package-installer'),

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.test.ts
@@ -87,6 +87,13 @@ describe('PackageInstaller', () => {
       };
       openZipArchiveMock.mockResolvedValue(zipArchive);
 
+      const artifactName = getArtifactName({
+        productName: 'kibana',
+        productVersion: '8.16',
+      });
+
+      downloadToDiskMock.mockResolvedValue(`${artifactsFolder}/${artifactName}`);
+
       const mappings = {
         properties: {
           semantic: {
@@ -100,11 +107,8 @@ describe('PackageInstaller', () => {
 
       await packageInstaller.installPackage({ productName: 'kibana', productVersion: '8.16' });
 
-      const artifactName = getArtifactName({
-        productName: 'kibana',
-        productVersion: '8.16',
-      });
       const indexName = getProductDocIndexName('kibana');
+
       expect(ensureDefaultElserDeployedMock).toHaveBeenCalledTimes(1);
 
       expect(downloadToDiskMock).toHaveBeenCalledTimes(1);

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.ts
@@ -204,12 +204,12 @@ export class PackageInstaller {
         inferenceId: customInference?.inference_id ?? this.elserInferenceId,
       });
       const artifactUrl = `${this.artifactRepositoryUrl}/${artifactFileName}`;
-      const artifactPath = `${this.artifactsFolder}/${artifactFileName}`;
+      const artifactPathAtVolume = `${this.artifactsFolder}/${artifactFileName}`;
 
-      this.log.debug(`Downloading from [${artifactUrl}] to [${artifactPath}]`);
-      await downloadToDisk(artifactUrl, artifactPath);
+      this.log.debug(`Downloading from [${artifactUrl}] to [${artifactPathAtVolume}]`);
+      const artifactFullPath = await downloadToDisk(artifactUrl, artifactPathAtVolume);
 
-      zipArchive = await openZipArchive(artifactPath);
+      zipArchive = await openZipArchive(artifactFullPath);
       validateArtifactArchive(zipArchive);
 
       const [manifest, mappings] = await Promise.all([

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/download.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/download.test.ts
@@ -6,15 +6,10 @@
  */
 
 import { createReadStream } from 'fs';
-import { mkdir } from 'fs/promises';
 import fetch from 'node-fetch';
 import { downloadToDisk } from './download';
 
-jest.mock('fs', () => ({
-  createReadStream: jest.fn().mockReturnValue({
-    on: jest.fn(),
-    pipe: jest.fn(),
-  }),
+jest.mock('@kbn/fs', () => ({
   createWriteStream: jest.fn(() => ({
     on: jest.fn((event, callback) => {
       if (event === 'finish') {
@@ -23,35 +18,32 @@ jest.mock('fs', () => ({
     }),
     pipe: jest.fn(),
   })),
+  getSafePath: jest.fn().mockReturnValue({
+    fullPath: 'artifacts/package_installer/file.txt',
+    alias: 'disk:artifacts/package_installer/file.txt',
+  }),
 }));
 
-jest.mock('fs/promises', () => ({
-  mkdir: jest.fn(),
+jest.mock('fs', () => ({
+  createReadStream: jest.fn().mockReturnValue({
+    on: jest.fn(),
+    pipe: jest.fn(),
+  }),
+}));
+
+jest.mock('stream/promises', () => ({
+  pipeline: jest.fn(),
 }));
 
 jest.mock('node-fetch', () => jest.fn());
 
 describe('downloadToDisk', () => {
   const mockFileUrl = 'http://example.com/file.txt';
-  const mockFilePath = '/path/to/file.txt';
-  const mockDirPath = '/path/to';
+  const mockFilePathAtVolume = 'artifacts/package_installer/file.txt';
   const mockLocalPath = '/local/path/to/file.txt';
 
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  it('should create the directory if it does not exist', async () => {
-    (fetch as unknown as jest.Mock).mockResolvedValue({
-      body: {
-        pipe: jest.fn(),
-        on: jest.fn(),
-      },
-    });
-
-    await downloadToDisk(mockFileUrl, mockFilePath);
-
-    expect(mkdir).toHaveBeenCalledWith(mockDirPath, { recursive: true });
   });
 
   it('should download a file from a remote URL', async () => {
@@ -64,7 +56,7 @@ describe('downloadToDisk', () => {
       body: mockResponseBody,
     });
 
-    await downloadToDisk(mockFileUrl, mockFilePath);
+    await downloadToDisk(mockFileUrl, mockFilePathAtVolume);
 
     expect(fetch).toHaveBeenCalledWith(mockFileUrl);
   });
@@ -72,7 +64,7 @@ describe('downloadToDisk', () => {
   it('should copy a file from a local file URL', async () => {
     const mockLocalFileUrl = 'file:///local/path/to/file.txt';
 
-    await downloadToDisk(mockLocalFileUrl, mockFilePath);
+    await downloadToDisk(mockLocalFileUrl, mockFilePathAtVolume);
 
     expect(createReadStream).toHaveBeenCalledWith(mockLocalPath);
   });
@@ -81,6 +73,8 @@ describe('downloadToDisk', () => {
     const mockError = new Error('Download failed');
     (fetch as unknown as jest.Mock).mockRejectedValue(mockError);
 
-    await expect(downloadToDisk(mockFileUrl, mockFilePath)).rejects.toThrow('Download failed');
+    await expect(downloadToDisk(mockFileUrl, mockFilePathAtVolume)).rejects.toThrow(
+      'Download failed'
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/download.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/download.ts
@@ -5,17 +5,19 @@
  * 2.0.
  */
 
-import { type ReadStream, createReadStream, createWriteStream } from 'fs';
-import { mkdir } from 'fs/promises';
-import Path from 'path';
+import { type ReadStream, createReadStream } from 'fs';
 import fetch from 'node-fetch';
+import { createWriteStream, getSafePath } from '@kbn/fs';
+import { pipeline } from 'stream/promises';
 import { resolveLocalArtifactsPath } from './local_artifacts';
 
-export const downloadToDisk = async (fileUrl: string, filePath: string) => {
-  const dirPath = Path.dirname(filePath);
-  await mkdir(dirPath, { recursive: true });
-  const writeStream = createWriteStream(filePath);
-  let readStream: ReadStream | NodeJS.ReadableStream;
+export const downloadToDisk = async (
+  fileUrl: string,
+  filePathAtVolume: string
+): Promise<string> => {
+  const { fullPath: artifactFullPath } = getSafePath(filePathAtVolume);
+  const writeStream = createWriteStream(filePathAtVolume);
+  let readStream: ReadStream;
 
   const parsedUrl = new URL(fileUrl);
 
@@ -25,14 +27,10 @@ export const downloadToDisk = async (fileUrl: string, filePath: string) => {
   } else {
     const res = await fetch(fileUrl);
 
-    readStream = res.body;
+    readStream = res.body as ReadStream;
   }
 
-  await new Promise((resolve, reject) => {
-    readStream.pipe(writeStream);
-    // @ts-expect-error upgrade typescript v5.9.3
-    readStream.on('error', reject);
-    // @ts-expect-error upgrade typescript v5.9.3
-    writeStream.on('finish', resolve);
-  });
+  await pipeline(readStream, writeStream);
+
+  return artifactFullPath;
 };

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/tsconfig.json
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/tsconfig.json
@@ -20,7 +20,6 @@
     "@kbn/config-schema",
     "@kbn/product-doc-common",
     "@kbn/core-saved-objects-server",
-    "@kbn/utils",
     "@kbn/core-http-browser",
     "@kbn/logging-mocks",
     "@kbn/licensing-plugin",
@@ -29,6 +28,8 @@
     "@kbn/core-security-server",
     "@kbn/ml-is-populated-object",
     "@kbn/i18n",
-    "@kbn/licensing-types"
+    "@kbn/licensing-types",
+    "@kbn/fs",
+    "@kbn/react-query"
   ]
 }

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/tsconfig.json
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/tsconfig.json
@@ -30,6 +30,5 @@
     "@kbn/i18n",
     "@kbn/licensing-types",
     "@kbn/fs",
-    "@kbn/react-query"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[FSH] Moved package_installer to @kbn/fs usage (#245664)](https://github.com/elastic/kibana/pull/245664)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Shostak","email":"165678770+elena-shostak@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-18T22:51:54Z","message":"[FSH] Moved package_installer to @kbn/fs usage (#245664)\n\n## Summary\n\nMoved package_installer to `@kbn/fs` usage.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"dce7e81c354da638d562b41bd166c90b3bd255a8","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","Feature:Hardening","backport:version","v9.4.0","v9.2.3","v9.1.9","v8.19.9"],"title":"[FSH] Moved package_installer to @kbn/fs usage","number":245664,"url":"https://github.com/elastic/kibana/pull/245664","mergeCommit":{"message":"[FSH] Moved package_installer to @kbn/fs usage (#245664)\n\n## Summary\n\nMoved package_installer to `@kbn/fs` usage.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"dce7e81c354da638d562b41bd166c90b3bd255a8"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.1","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245664","number":245664,"mergeCommit":{"message":"[FSH] Moved package_installer to @kbn/fs usage (#245664)\n\n## Summary\n\nMoved package_installer to `@kbn/fs` usage.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"dce7e81c354da638d562b41bd166c90b3bd255a8"}},{"branch":"9.2","label":"v9.2.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.9","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->