### PR TITLE
[9.2] [Defend Workflows] Fix endpoint list API to mirror exception list API (#246019)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -15180,9 +15180,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItem'
-                type: array
+                $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItem'
           description: Successful response
         '400':
           content:

--- a/x-pack/solutions/security/packages/kbn-securitysolution-endpoint-exceptions-common/api/read_endpoint_list_item/read_endpoint_list_item.gen.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-endpoint-exceptions-common/api/read_endpoint_list_item/read_endpoint_list_item.gen.ts
@@ -38,4 +38,4 @@ export type ReadEndpointListItemRequestQueryInput = z.input<
 >;
 
 export type ReadEndpointListItemResponse = z.infer<typeof ReadEndpointListItemResponse>;
-export const ReadEndpointListItemResponse = z.array(EndpointListItem);
+export const ReadEndpointListItemResponse = EndpointListItem;

--- a/x-pack/solutions/security/packages/kbn-securitysolution-endpoint-exceptions-common/api/read_endpoint_list_item/read_endpoint_list_item.schema.yaml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-endpoint-exceptions-common/api/read_endpoint_list_item/read_endpoint_list_item.schema.yaml
@@ -29,9 +29,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '../model/endpoint_list_common.schema.yaml#/components/schemas/EndpointListItem'
+                $ref: '../model/endpoint_list_common.schema.yaml#/components/schemas/EndpointListItem'
         400:
           description: Invalid input data
           content:

--- a/x-pack/solutions/security/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/ess/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/ess/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -139,9 +139,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/EndpointListItem'
-                type: array
+                $ref: '#/components/schemas/EndpointListItem'
           description: Successful response
         '400':
           content:

--- a/x-pack/solutions/security/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/serverless/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/serverless/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -139,9 +139,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/EndpointListItem'
-                type: array
+                $ref: '#/components/schemas/EndpointListItem'
           description: Successful response
         '400':
           content:

--- a/x-pack/solutions/security/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/exception_lists/exception_list_client.test.ts
@@ -95,6 +95,50 @@ describe('exception_list_client', () => {
           return extensionPointStorageContext.exceptionPreUpdate.callback;
         },
       ],
+
+      [
+        'createEndpointListItem',
+        (): ReturnType<ExceptionListClient['createEndpointListItem']> => {
+          const mockOptions = getCreateExceptionListItemOptionsMock();
+          return exceptionListClient.createEndpointListItem({
+            comments: mockOptions.comments,
+            description: mockOptions.description,
+            entries: mockOptions.entries,
+            itemId: mockOptions.itemId,
+            meta: mockOptions.meta,
+            name: mockOptions.name,
+            osTypes: mockOptions.osTypes,
+            tags: mockOptions.tags,
+            type: mockOptions.type,
+          });
+        },
+        (): ExtensionPointStorageContextMock['exceptionPreCreate']['callback'] => {
+          return extensionPointStorageContext.exceptionPreCreate.callback;
+        },
+      ],
+
+      [
+        'updateEndpointListItem',
+        (): ReturnType<ExceptionListClient['updateEndpointListItem']> => {
+          const mockOptions = getUpdateExceptionListItemOptionsMock();
+          return exceptionListClient.updateEndpointListItem({
+            _version: mockOptions._version,
+            comments: mockOptions.comments,
+            description: mockOptions.description,
+            entries: mockOptions.entries,
+            id: mockOptions.id,
+            itemId: mockOptions.itemId,
+            meta: mockOptions.meta,
+            name: mockOptions.name,
+            osTypes: mockOptions.osTypes,
+            tags: mockOptions.tags,
+            type: mockOptions.type,
+          });
+        },
+        (): ExtensionPointStorageContextMock['exceptionPreUpdate']['callback'] => {
+          return extensionPointStorageContext.exceptionPreUpdate.callback;
+        },
+      ],
     ])(
       'and calling `ExceptionListClient#%s()`',
       (methodName, callExceptionListClientMethod, getExtensionPointCallback) => {
@@ -292,6 +336,48 @@ describe('exception_list_client', () => {
         },
         (): ExtensionPointStorageContextMock['exceptionPreDelete']['callback'] => {
           return extensionPointStorageContext.exceptionPreDelete.callback;
+        },
+      ],
+      [
+        'getEndpointListItem',
+        (): ReturnType<ExceptionListClient['getEndpointListItem']> => {
+          return exceptionListClient.getEndpointListItem({
+            id: '1',
+            itemId: '1',
+          });
+        },
+        (): ExtensionPointStorageContextMock['exceptionPreGetOne']['callback'] => {
+          return extensionPointStorageContext.exceptionPreGetOne.callback;
+        },
+      ],
+      [
+        'deleteEndpointListItem',
+        (): ReturnType<ExceptionListClient['deleteEndpointListItem']> => {
+          return exceptionListClient.deleteEndpointListItem({
+            id: '1',
+            itemId: '1',
+          });
+        },
+        (): ExtensionPointStorageContextMock['exceptionPreDelete']['callback'] => {
+          return extensionPointStorageContext.exceptionPreDelete.callback;
+        },
+      ],
+      [
+        'findEndpointListItem',
+        (): ReturnType<ExceptionListClient['findEndpointListItem']> => {
+          return exceptionListClient.findEndpointListItem({
+            filter: undefined,
+            page: 1,
+            perPage: 1,
+            pit: undefined,
+            search: undefined,
+            searchAfter: undefined,
+            sortField: 'name',
+            sortOrder: 'asc',
+          });
+        },
+        (): ExtensionPointStorageContextMock['exceptionPreSingleListFind']['callback'] => {
+          return extensionPointStorageContext.exceptionPreSingleListFind.callback;
         },
       ],
       [

--- a/x-pack/solutions/security/plugins/lists/server/services/exception_lists/exception_list_client.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/exception_lists/exception_list_client.ts
@@ -290,7 +290,8 @@ export class ExceptionListClient {
   }: CreateEndpointListItemOptions): Promise<ExceptionListItemSchema> => {
     const { savedObjectsClient, user } = this;
     await this.createEndpointList();
-    return createExceptionListItem({
+
+    let itemData: CreateExceptionListItemOptions = {
       comments,
       description,
       entries,
@@ -301,9 +302,27 @@ export class ExceptionListClient {
       name,
       namespaceType: 'agnostic',
       osTypes,
-      savedObjectsClient,
       tags,
       type,
+    };
+
+    if (this.enableServerExtensionPoints) {
+      itemData = await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreCreateItem',
+        itemData,
+        this.getServerExtensionCallbackContext(),
+        (data) => {
+          return validateData(
+            createExceptionListItemSchema,
+            transformCreateExceptionListItemOptionsToCreateExceptionListItemSchema(data)
+          );
+        }
+      );
+    }
+
+    return createExceptionListItem({
+      ...itemData,
+      savedObjectsClient,
       user,
     });
   };
@@ -364,7 +383,8 @@ export class ExceptionListClient {
   }: UpdateEndpointListItemOptions): Promise<ExceptionListItemSchema | null> => {
     const { savedObjectsClient, user } = this;
     await this.createEndpointList();
-    return updateExceptionListItem({
+
+    let updatedItem: UpdateExceptionListItemOptions = {
       _version,
       comments,
       description,
@@ -376,9 +396,27 @@ export class ExceptionListClient {
       name,
       namespaceType: 'agnostic',
       osTypes,
-      savedObjectsClient,
       tags,
       type,
+    };
+
+    if (this.enableServerExtensionPoints) {
+      updatedItem = await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreUpdateItem',
+        updatedItem,
+        this.getServerExtensionCallbackContext(),
+        (data) => {
+          return validateData(
+            updateExceptionListItemSchema,
+            transformUpdateExceptionListItemOptionsToUpdateExceptionListItemSchema(data)
+          );
+        }
+      );
+    }
+
+    return updateExceptionListItem({
+      ...updatedItem,
+      savedObjectsClient,
       user,
     });
   };
@@ -395,6 +433,15 @@ export class ExceptionListClient {
     id,
   }: GetEndpointListItemOptions): Promise<ExceptionListItemSchema | null> => {
     const { savedObjectsClient } = this;
+
+    if (this.enableServerExtensionPoints) {
+      await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreGetOneItem',
+        { id, itemId, namespaceType: 'agnostic' },
+        this.getServerExtensionCallbackContext()
+      );
+    }
+
     return getExceptionListItem({ id, itemId, namespaceType: 'agnostic', savedObjectsClient });
   };
 
@@ -793,6 +840,15 @@ export class ExceptionListClient {
     itemId,
   }: DeleteEndpointListItemOptions): Promise<ExceptionListItemSchema | null> => {
     const { savedObjectsClient } = this;
+
+    if (this.enableServerExtensionPoints) {
+      await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreDeleteItem',
+        { id, itemId, namespaceType: 'agnostic' },
+        this.getServerExtensionCallbackContext()
+      );
+    }
+
     return deleteExceptionListItem({
       id,
       itemId,
@@ -829,36 +885,30 @@ export class ExceptionListClient {
   }: FindExceptionListItemOptions): Promise<FoundExceptionListItemSchema | null> => {
     const { savedObjectsClient } = this;
 
-    if (this.enableServerExtensionPoints) {
-      await this.serverExtensionsClient.pipeRun(
-        'exceptionsListPreSingleListFind',
-        {
-          filter,
-          listId,
-          namespaceType,
-          page,
-          perPage,
-          pit,
-          searchAfter,
-          sortField,
-          sortOrder,
-        },
-        this.getServerExtensionCallbackContext()
-      );
-    }
-
-    return findExceptionListItem({
+    const findOptions = {
       filter,
       listId,
       namespaceType,
       page,
       perPage,
       pit,
-      savedObjectsClient,
-      search,
       searchAfter,
       sortField,
       sortOrder,
+    };
+
+    if (this.enableServerExtensionPoints) {
+      await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreSingleListFind',
+        findOptions,
+        this.getServerExtensionCallbackContext()
+      );
+    }
+
+    return findExceptionListItem({
+      ...findOptions,
+      savedObjectsClient,
+      search,
     });
   };
 
@@ -1026,18 +1076,31 @@ export class ExceptionListClient {
   }: FindEndpointListItemOptions): Promise<FoundExceptionListItemSchema | null> => {
     const { savedObjectsClient } = this;
     await this.createEndpointList();
-    return findExceptionListItem({
+
+    const findOptions = {
       filter,
       listId: ENDPOINT_LIST_ID,
-      namespaceType: 'agnostic',
+      namespaceType: 'agnostic' as const,
       page,
       perPage,
       pit,
-      savedObjectsClient,
-      search,
       searchAfter,
       sortField,
       sortOrder,
+    };
+
+    if (this.enableServerExtensionPoints) {
+      await this.serverExtensionsClient.pipeRun(
+        'exceptionsListPreSingleListFind',
+        findOptions,
+        this.getServerExtensionCallbackContext()
+      );
+    }
+
+    return findExceptionListItem({
+      ...findOptions,
+      savedObjectsClient,
+      search,
     });
   };
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/endpoint_exceptions.ff_enabled.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/endpoint_exceptions.ff_enabled.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { getRegistryUrl as getRegistryUrlFromIngest } from '@kbn/fleet-plugin/server';
+import { isServerlessKibanaFlavor } from '@kbn/security-solution-plugin/common/endpoint/utils/kibana_status';
+import type { FtrProviderContext } from '../../../../ftr_provider_context_edr_workflows';
+import { ROLE } from '../../../../config/services/security_solution_edr_workflows_roles_users';
+
+/** This is a TEMPORARY test wrapper created to perform Endpoint Exceptions related API tests with
+ * the feature flag `endpointExceptionsMovedUnderManagement` enabled.
+ *
+ * Once Endpoint Exceptions are fully moved under management and the feature flag is removed,
+ * this config file should be deleted.
+ */
+export default function endpointAPIIntegrationTests(providerContext: FtrProviderContext) {
+  const { loadTestFile, getService } = providerContext;
+
+  describe('Endpoint Exceptions with feature flag enabled', function () {
+    const ingestManager = getService('ingestManager');
+    const rolesUsersProvider = getService('rolesUsersProvider');
+    const kbnClient = getService('kibanaServer');
+    const log = getService('log');
+    const endpointRegistryHelpers = getService('endpointRegistryHelpers');
+
+    const roles = Object.values(ROLE);
+    before(async () => {
+      try {
+        if (!endpointRegistryHelpers.isRegistryEnabled()) {
+          log.warning('These tests are being run with an external package registry');
+        }
+
+        const registryUrl =
+          endpointRegistryHelpers.getRegistryUrlFromTestEnv() ?? getRegistryUrlFromIngest();
+        log.info(`Package registry URL for tests: ${registryUrl}`);
+        await ingestManager.setup();
+      } catch (err) {
+        log.warning(`Error setting up ingestManager: ${err}`);
+      }
+
+      if (!(await isServerlessKibanaFlavor(kbnClient))) {
+        // create role/user
+        for (const role of roles) {
+          await rolesUsersProvider.createRole({ predefinedRole: role });
+          await rolesUsersProvider.createUser({ name: role, roles: [role] });
+        }
+      }
+    });
+
+    after(async () => {
+      if (!(await isServerlessKibanaFlavor(kbnClient))) {
+        // delete role/user
+        await rolesUsersProvider.deleteUsers(roles);
+        await rolesUsersProvider.deleteRoles(roles);
+      }
+    });
+
+    loadTestFile(require.resolve('./endpoint_exceptions'));
+    loadTestFile(require.resolve('./endpoint_list_api_rbac'));
+  });
+}

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/endpoint_list_api_rbac.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/endpoint_list_api_rbac.ts
@@ -1,0 +1,363 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type TestAgent from 'supertest/lib/agent';
+import expect from '@kbn/expect';
+import { ENDPOINT_LIST_ITEM_URL } from '@kbn/securitysolution-list-constants';
+import { GLOBAL_ARTIFACT_TAG } from '@kbn/security-solution-plugin/common/endpoint/service/artifacts/constants';
+import { ExceptionsListItemGenerator } from '@kbn/security-solution-plugin/common/endpoint/data_generators/exceptions_list_item_generator';
+import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
+import { SECURITY_FEATURE_ID } from '@kbn/security-solution-plugin/common';
+import {
+  buildPerPolicyTag,
+  isPolicySelectionTag,
+} from '@kbn/security-solution-plugin/common/endpoint/service/artifacts/utils';
+import type { ArtifactTestData } from '@kbn/test-suites-xpack-security-endpoint/services/endpoint_artifacts';
+import type { PolicyTestResourceInfo } from '@kbn/test-suites-xpack-security-endpoint/services/endpoint_policy';
+import { ROLE } from '../../../../config/services/security_solution_edr_workflows_roles_users';
+import type { FtrProviderContext } from '../../../../ftr_provider_context_edr_workflows';
+
+export default function ({ getService }: FtrProviderContext) {
+  const rolesUsersProvider = getService('rolesUsersProvider');
+  const endpointPolicyTestResources = getService('endpointPolicyTestResources');
+  const endpointArtifactTestResources = getService('endpointArtifactTestResources');
+  const utils = getService('securitySolutionUtils');
+  const config = getService('config');
+
+  const IS_ENDPOINT_EXCEPTION_MOVE_FF_ENABLED = (
+    config.get('kbnTestServer.serverArgs', []) as string[]
+  )
+    .find((s) => s.startsWith('--xpack.securitySolution.enableExperimental'))
+    ?.includes('endpointExceptionsMovedUnderManagement');
+
+  // @skipInServerlessMKI due to authentication issues - we should migrate from Basic to Bearer token when available
+  // @skipInServerlessMKI - if you are removing this annotation, make sure to add the test suite to the MKI pipeline in .buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
+  describe('@ess @serverless @skipInServerlessMKI Endpoint List API (deprecated): RBAC and Validation', function () {
+    let fleetEndpointPolicy: PolicyTestResourceInfo;
+
+    let t1AnalystSupertest: TestAgent;
+    let endpointPolicyManagerSupertest: TestAgent;
+
+    before(async () => {
+      t1AnalystSupertest = await utils.createSuperTest(ROLE.t1_analyst);
+      endpointPolicyManagerSupertest = await utils.createSuperTest(ROLE.endpoint_policy_manager);
+
+      // Create an endpoint policy in fleet we can work with
+      fleetEndpointPolicy = await endpointPolicyTestResources.createPolicy();
+    });
+
+    after(async () => {
+      if (fleetEndpointPolicy) {
+        await fleetEndpointPolicy.cleanup();
+      }
+    });
+
+    const anEndpointArtifactError = (res: { body: { message: string } }) => {
+      expect(res.body.message).to.match(/EndpointArtifactError/);
+    };
+    const anErrorMessageWith = (
+      value: string | RegExp
+    ): ((res: { body: { message: string } }) => void) => {
+      return (res) => {
+        if (value instanceof RegExp) {
+          expect(res.body.message).to.match(value);
+        } else {
+          expect(res.body.message).to.be(value);
+        }
+      };
+    };
+
+    const exceptionsGenerator = new ExceptionsListItemGenerator();
+    let endpointExceptionData: ArtifactTestData;
+
+    type EndpointListApiCallsInterface<BodyReturnType = unknown> = Array<{
+      method: keyof Pick<TestAgent, 'post' | 'put' | 'get' | 'delete' | 'patch'>;
+      info?: string;
+      path: string;
+      // The body just needs to have the properties we care about in the tests. This should cover most
+      // mocks used for testing that support different interfaces
+      getBody: () => BodyReturnType;
+    }>;
+
+    const endpointListCalls: EndpointListApiCallsInterface<
+      Pick<ExceptionListItemSchema, 'item_id' | 'os_types' | 'tags' | 'entries'> & {
+        id?: string;
+        _version?: string;
+      }
+    > = [
+      {
+        method: 'post',
+        info: 'create single item',
+        path: ENDPOINT_LIST_ITEM_URL,
+        getBody: () =>
+          exceptionsGenerator.generateEndpointExceptionForCreate({
+            tags: endpointExceptionData?.artifact.tags || [
+              buildPerPolicyTag(fleetEndpointPolicy.packagePolicy.id),
+            ],
+          }),
+      },
+      {
+        method: 'put',
+        info: 'update single item',
+        path: ENDPOINT_LIST_ITEM_URL,
+        getBody: () =>
+          exceptionsGenerator.generateEndpointExceptionForUpdate({
+            id: endpointExceptionData.artifact.id,
+            item_id: endpointExceptionData.artifact.item_id,
+            tags: endpointExceptionData.artifact.tags,
+            _version: endpointExceptionData.artifact._version,
+          }),
+      },
+    ];
+
+    const needsWritePrivilege: EndpointListApiCallsInterface = [
+      {
+        method: 'delete',
+        info: 'delete single item',
+        get path() {
+          return `${ENDPOINT_LIST_ITEM_URL}?item_id=${endpointExceptionData.artifact.item_id}`;
+        },
+        getBody: () => undefined,
+      },
+    ];
+
+    const needsReadPrivilege: EndpointListApiCallsInterface = [
+      {
+        method: 'get',
+        info: 'single item',
+        get path() {
+          return `${ENDPOINT_LIST_ITEM_URL}?item_id=${endpointExceptionData.artifact.item_id}`;
+        },
+        getBody: () => undefined,
+      },
+      {
+        method: 'get',
+        info: 'find items',
+        get path() {
+          return `${ENDPOINT_LIST_ITEM_URL}/_find?page=1&per_page=1&sort_field=name&sort_order=asc`;
+        },
+        getBody: () => undefined,
+      },
+    ];
+
+    beforeEach(async () => {
+      endpointExceptionData = await endpointArtifactTestResources.createEndpointException({
+        tags: [buildPerPolicyTag(fleetEndpointPolicy.packagePolicy.id)],
+      });
+    });
+
+    afterEach(async () => {
+      if (endpointExceptionData) {
+        await endpointExceptionData.cleanup();
+      }
+    });
+
+    describe('and has authorization to manage endpoint security', () => {
+      for (const endpointListApiCall of endpointListCalls) {
+        it(`should work on [${endpointListApiCall.method}] with valid entry`, async () => {
+          const body = endpointListApiCall.getBody();
+
+          // Using superuser here as we need custom license for this action
+          await endpointPolicyManagerSupertest[endpointListApiCall.method](endpointListApiCall.path)
+            .set('kbn-xsrf', 'true')
+            .send(body)
+            .expect(200);
+
+          const deleteUrl = `${ENDPOINT_LIST_ITEM_URL}?item_id=${body.item_id}`;
+          await endpointPolicyManagerSupertest.delete(deleteUrl).set('kbn-xsrf', 'true');
+        });
+
+        it(`should work on [${endpointListApiCall.method}] if more than one OS is set`, async () => {
+          const body = endpointListApiCall.getBody();
+          body.os_types = ['linux', 'windows'];
+
+          await endpointPolicyManagerSupertest[endpointListApiCall.method](endpointListApiCall.path)
+            .set('kbn-xsrf', 'true')
+            .send(body)
+            .expect(200);
+
+          const deleteUrl = `${ENDPOINT_LIST_ITEM_URL}?item_id=${body.item_id}`;
+          await endpointPolicyManagerSupertest.delete(deleteUrl).set('kbn-xsrf', 'true');
+        });
+
+        if (IS_ENDPOINT_EXCEPTION_MOVE_FF_ENABLED) {
+          it(`should accept item on [${endpointListApiCall.method}] if no assignment tag is present`, async () => {
+            const requestBody = endpointListApiCall.getBody();
+            requestBody.tags = [];
+
+            await endpointPolicyManagerSupertest[endpointListApiCall.method](
+              endpointListApiCall.path
+            )
+              .set('kbn-xsrf', 'true')
+              .send(requestBody)
+              .expect(200)
+              .expect(({ body }) => expect(body.tags).to.not.contain(GLOBAL_ARTIFACT_TAG));
+
+            const deleteUrl = `${ENDPOINT_LIST_ITEM_URL}?item_id=${requestBody.item_id}`;
+            await endpointPolicyManagerSupertest.delete(deleteUrl).set('kbn-xsrf', 'true');
+          });
+        } else {
+          it(`should add global artifact tag on [${endpointListApiCall.method}] if no assignment tag is present`, async () => {
+            const requestBody = endpointListApiCall.getBody();
+            requestBody.tags = [];
+
+            await endpointPolicyManagerSupertest[endpointListApiCall.method](
+              endpointListApiCall.path
+            )
+              .set('kbn-xsrf', 'true')
+              .send(requestBody)
+              .expect(200)
+              .expect(({ body }) => expect(body.tags).to.contain(GLOBAL_ARTIFACT_TAG));
+
+            const deleteUrl = `${ENDPOINT_LIST_ITEM_URL}?item_id=${requestBody.item_id}`;
+            await endpointPolicyManagerSupertest.delete(deleteUrl).set('kbn-xsrf', 'true');
+          });
+        }
+
+        if (IS_ENDPOINT_EXCEPTION_MOVE_FF_ENABLED) {
+          it(`should error on [${endpointListApiCall.method}] if policy id is invalid`, async () => {
+            const body = endpointListApiCall.getBody();
+            body.tags = [buildPerPolicyTag('123')];
+
+            await endpointPolicyManagerSupertest[endpointListApiCall.method](
+              endpointListApiCall.path
+            )
+              .set('kbn-xsrf', 'true')
+              .send(body)
+              .expect(400)
+              .expect(anEndpointArtifactError)
+              .expect(anErrorMessageWith(/invalid policy ids/));
+          });
+        }
+      }
+      for (const endpointListApiCall of [...needsWritePrivilege, ...needsReadPrivilege]) {
+        it(`should not error on [${endpointListApiCall.method}] - [${endpointListApiCall.info}]`, async () => {
+          await endpointPolicyManagerSupertest[endpointListApiCall.method](endpointListApiCall.path)
+            .set('kbn-xsrf', 'true')
+            .send(endpointListApiCall.getBody() as object)
+            .expect(200);
+        });
+      }
+    });
+
+    describe('@skipInServerless and user has endpoint exception access but no global artifact access', () => {
+      let noGlobalArtifactSupertest: TestAgent;
+
+      before(async () => {
+        const loadedRole = await rolesUsersProvider.loader.create({
+          name: 'no_global_artifact_role_endpoint_list',
+          kibana: [
+            {
+              base: [],
+              feature: {
+                [SECURITY_FEATURE_ID]: ['read', 'endpoint_exceptions_all'],
+              },
+              spaces: ['*'],
+            },
+          ],
+          elasticsearch: { cluster: [], indices: [], run_as: [] },
+        });
+
+        noGlobalArtifactSupertest = await utils.createSuperTest(loadedRole.username);
+      });
+
+      after(async () => {
+        await rolesUsersProvider.loader.delete('no_global_artifact_role_endpoint_list');
+      });
+
+      for (const endpointListApiCall of endpointListCalls) {
+        if (IS_ENDPOINT_EXCEPTION_MOVE_FF_ENABLED) {
+          it(`should error on [${endpointListApiCall.method}] - [${endpointListApiCall.info}] when global artifact is the target`, async () => {
+            const requestBody = endpointListApiCall.getBody();
+            // keep space tag, but replace any per-policy tags with a global tag
+            requestBody.tags = [
+              ...requestBody.tags.filter((tag) => !isPolicySelectionTag(tag)),
+              GLOBAL_ARTIFACT_TAG,
+            ];
+
+            await noGlobalArtifactSupertest[endpointListApiCall.method](endpointListApiCall.path)
+              .set('kbn-xsrf', 'true')
+              .send(requestBody as object)
+              .expect(403)
+              .expect(anEndpointArtifactError)
+              .expect(
+                anErrorMessageWith(
+                  /Endpoint authorization failure. Management of global artifacts requires additional privilege \(global artifact management\)/
+                )
+              );
+          });
+
+          it(`should work on [${endpointListApiCall.method}] - [${endpointListApiCall.info}] when per-policy artifact is the target`, async () => {
+            const requestBody = endpointListApiCall.getBody();
+
+            // remove existing tag
+            requestBody.tags = requestBody.tags.filter((tag) => !isPolicySelectionTag(tag));
+
+            await noGlobalArtifactSupertest[endpointListApiCall.method](endpointListApiCall.path)
+              .set('kbn-xsrf', 'true')
+              .send(requestBody as object)
+              .expect(200);
+          });
+        } else {
+          it(`should error on [${endpointListApiCall.method}] - [${endpointListApiCall.info}]`, async () => {
+            await noGlobalArtifactSupertest[endpointListApiCall.method](endpointListApiCall.path)
+              .set('kbn-xsrf', 'true')
+              .send(endpointListApiCall.getBody() as object)
+              .expect(403)
+              .expect(anEndpointArtifactError)
+              .expect(
+                anErrorMessageWith(
+                  /Endpoint authorization failure. Management of global artifacts requires additional privilege \(global artifact management\)/
+                )
+              );
+          });
+        }
+      }
+    });
+
+    describe('@skipInServerless and user has authorization to read endpoint exceptions', function () {
+      let hunterSupertest: TestAgent;
+
+      before(async () => {
+        hunterSupertest = await utils.createSuperTest(ROLE.hunter);
+      });
+
+      for (const endpointListApiCall of [...endpointListCalls, ...needsWritePrivilege]) {
+        it(`should error on [${endpointListApiCall.method}] - [${endpointListApiCall.info}]`, async () => {
+          await hunterSupertest[endpointListApiCall.method](endpointListApiCall.path)
+            .set('kbn-xsrf', 'true')
+            .send(endpointListApiCall.getBody() as object)
+            .expect(403);
+        });
+      }
+
+      for (const endpointListApiCall of needsReadPrivilege) {
+        it(`should not error on [${endpointListApiCall.method}] - [${endpointListApiCall.info}]`, async () => {
+          await hunterSupertest[endpointListApiCall.method](endpointListApiCall.path)
+            .set('kbn-xsrf', 'true')
+            .send(endpointListApiCall.getBody() as object)
+            .expect(200);
+        });
+      }
+    });
+
+    describe('and user has no authorization to endpoint exceptions', () => {
+      for (const endpointListApiCall of [
+        ...endpointListCalls,
+        ...needsWritePrivilege,
+        ...needsReadPrivilege,
+      ]) {
+        it(`should error on [${endpointListApiCall.method}] - [${endpointListApiCall.info}]`, async () => {
+          await t1AnalystSupertest[endpointListApiCall.method](endpointListApiCall.path)
+            .set('kbn-xsrf', 'true')
+            .send(endpointListApiCall.getBody() as object)
+            .expect(403);
+        });
+      }
+    });
+  });
+}

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/index.ts
@@ -58,5 +58,6 @@ export default function endpointAPIIntegrationTests(providerContext: FtrProvider
     loadTestFile(require.resolve('./host_isolation_exceptions'));
     loadTestFile(require.resolve('./blocklists'));
     loadTestFile(require.resolve('./endpoint_exceptions'));
+    loadTestFile(require.resolve('./endpoint_list_api_rbac'));
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Defend Workflows] Fix endpoint list API to mirror exception list API (#246019)](https://github.com/elastic/kibana/pull/246019)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Szwarc","email":"konrad.szwarc@elastic.co"},"sourceCommit":{"committedDate":"2025-12-19T09:01:52Z","message":"[Defend Workflows] Fix endpoint list API to mirror exception list API (#246019)\n\nThis PR fixes the deprecated `api/endpoint_list` APIs to properly\nenforce RBAC, space awareness, and security tag assignment through the\nextension point system.\n\nChanges:\n- Modified 5 ExceptionListClient methods to invoke extension points:\n`createEndpointListItem`, `updateEndpointListItem`,\n`deleteEndpointListItem`, `getEndpointListItem`, `findEndpointListItem`\n- Added entry validation and disallowed field checks to create route\n- Fixed return type in read route to match API schema\n- Added comprehensive unit tests for all 5 methods\n- Added API integration tests covering all RBAC scenarios\n\nAll changes mirror the existing exception list API behavior.\n\nCloses https://github.com/elastic/security-team/issues/14818\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"70c5025c3c6bab5496df70f207632d1d8aa5fc9e","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","backport:version","v9.1.0","v9.2.0","v9.3.0","v9.4.0"],"title":"[Defend Workflows] Fix endpoint list API to mirror exception list API","number":246019,"url":"https://github.com/elastic/kibana/pull/246019","mergeCommit":{"message":"[Defend Workflows] Fix endpoint list API to mirror exception list API (#246019)\n\nThis PR fixes the deprecated `api/endpoint_list` APIs to properly\nenforce RBAC, space awareness, and security tag assignment through the\nextension point system.\n\nChanges:\n- Modified 5 ExceptionListClient methods to invoke extension points:\n`createEndpointListItem`, `updateEndpointListItem`,\n`deleteEndpointListItem`, `getEndpointListItem`, `findEndpointListItem`\n- Added entry validation and disallowed field checks to create route\n- Fixed return type in read route to match API schema\n- Added comprehensive unit tests for all 5 methods\n- Added API integration tests covering all RBAC scenarios\n\nAll changes mirror the existing exception list API behavior.\n\nCloses https://github.com/elastic/security-team/issues/14818\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"70c5025c3c6bab5496df70f207632d1d8aa5fc9e"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.2","9.3"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246019","number":246019,"mergeCommit":{"message":"[Defend Workflows] Fix endpoint list API to mirror exception list API (#246019)\n\nThis PR fixes the deprecated `api/endpoint_list` APIs to properly\nenforce RBAC, space awareness, and security tag assignment through the\nextension point system.\n\nChanges:\n- Modified 5 ExceptionListClient methods to invoke extension points:\n`createEndpointListItem`, `updateEndpointListItem`,\n`deleteEndpointListItem`, `getEndpointListItem`, `findEndpointListItem`\n- Added entry validation and disallowed field checks to create route\n- Fixed return type in read route to match API schema\n- Added comprehensive unit tests for all 5 methods\n- Added API integration tests covering all RBAC scenarios\n\nAll changes mirror the existing exception list API behavior.\n\nCloses https://github.com/elastic/security-team/issues/14818\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"70c5025c3c6bab5496df70f207632d1d8aa5fc9e"}}]}] BACKPORT-->