### PR TITLE
[Infra] Optimize test to use synthtrace in serverless to avoid timeout

### DIFF
--- a/x-pack/solutions/observability/test/serverless/functional/services/index.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/services/index.ts
@@ -7,6 +7,7 @@
 
 import { services as svlPlatformServices } from '@kbn/test-suites-xpack-platform/serverless/functional/services';
 import { services as platformServices } from '@kbn/test-suites-xpack-platform/functional/services';
+import { services as platformApiServices } from '@kbn/test-suites-xpack-platform/api_integration/services';
 import { SvlObltNavigationServiceProvider } from './svl_oblt_navigation';
 
 export const services = {
@@ -14,6 +15,7 @@ export const services = {
   ml: platformServices.ml,
   // Observability Solution serverless FTR services
   svlObltNavigation: SvlObltNavigationServiceProvider,
+  synthtrace: platformApiServices.synthtrace,
 };
 
 export type {

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/infra/constants.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/infra/constants.ts
@@ -27,3 +27,12 @@ export const DATES = {
 };
 
 export const DATE_PICKER_FORMAT = 'MMM D, YYYY @ HH:mm:ss.SSS';
+
+// synthtrace date constants
+export const DATE_WITH_HOSTS_DATA_FROM = '2023-03-28T18:20:00.000Z';
+export const DATE_WITH_HOSTS_DATA_TO = '2023-03-28T18:21:00.000Z';
+export const DATE_WITH_HOSTS_DATA = '03/28/2023 6:20:59 PM';
+
+export const DATE_WITH_POD_DATA_FROM = '2023-09-19T07:20:00.000Z';
+export const DATE_WITH_POD_DATA_TO = '2023-09-19T07:21:00.000Z';
+export const DATE_WITH_POD_DATA = '09/19/2023 7:20:59 AM';

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/infra/helpers.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/infra/helpers.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { timerange, infra } from '@kbn/synthtrace-client';
+
+export function generateHostData({
+  from,
+  to,
+  hosts,
+}: {
+  from: string;
+  to: string;
+  hosts: Array<{ hostName: string; cpuValue?: number }>;
+}) {
+  const range = timerange(from, to);
+
+  return range
+    .interval('30s')
+    .rate(1)
+    .generator((timestamp) =>
+      hosts.flatMap(({ hostName, cpuValue }) => [
+        infra.host(hostName).cpu({ 'system.cpu.total.norm.pct': cpuValue }).timestamp(timestamp),
+        infra.host(hostName).memory().timestamp(timestamp),
+        infra.host(hostName).network().timestamp(timestamp),
+        infra.host(hostName).load().timestamp(timestamp),
+        infra.host(hostName).filesystem().timestamp(timestamp),
+        infra.host(hostName).diskio().timestamp(timestamp),
+        infra.host(hostName).core().timestamp(timestamp),
+      ])
+    );
+}
+
+export function generatePodsData({
+  from,
+  to,
+  count = 1,
+}: {
+  from: string;
+  to: string;
+  count: number;
+}) {
+  const range = timerange(from, to);
+
+  const pods = Array(count)
+    .fill(0)
+    .map((_, idx) => infra.pod(`pod-${idx}`, `node-name-${idx}`));
+
+  return range
+    .interval('30s')
+    .rate(1)
+    .generator((timestamp) =>
+      pods.flatMap((pod, idx) => [
+        pod.metrics().timestamp(timestamp),
+        pod.container(`container-${idx}`).metrics().timestamp(timestamp),
+      ])
+    );
+}


### PR DESCRIPTION
Closes #245692 

## Summary

This PR optimizes the failed test to use synthtrace in serverless to avoid timeout ( I assume the archives take longer, and that can cause flakiness, as it is not easy to reproduce). We are planning to migrate to Scout anyway, so the changes in this PR should stabilize the test in the meantime. 

## Teting 

Run the server
```
node scripts/functional_tests_server.js --config x-pack/solutions/observability/test/serverless/functional/configs/config.feature_flags.ts
```
Run the tests: 
```
node x-pack/scripts/functional_test_runner.js --config x-pack/solutions/observability/test/serverless/functional/configs/config.feature_flags.ts --grep "Infra pages"
```

>[!WARNING]
> If you are on Mac and the server is crashing, make sure to allocate enough memory to Docker: > 8 GB
> You can do that in the Docker app > Settings (up right) > Resources

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed