### PR TITLE
[9.1] [ResponseOps][Rules] Fix alert detail flyout  (#247055)

### DIFF
--- a/src/platform/packages/shared/response-ops/alerts-table/components/default_alerts_flyout.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-table/components/default_alerts_flyout.tsx
@@ -50,11 +50,13 @@ export const DefaultAlertsFlyoutBody = <AC extends AdditionalContext>(
                 title: (column.displayAsText as string) ?? column.id,
                 description:
                   value != null ? (
-                    <DefaultCellValue
-                      columnId={column.id}
-                      alert={props.alert}
-                      openLinksInNewTab={props.openLinksInNewTab}
-                    />
+                    <div className="eui-textBreakWord">
+                      <DefaultCellValue
+                        columnId={column.id}
+                        alert={props.alert}
+                        openLinksInNewTab={props.openLinksInNewTab}
+                      />
+                    </div>
                   ) : (
                     '—'
                   ),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ResponseOps][Rules] Fix alert detail flyout  (#247055)](https://github.com/elastic/kibana/pull/247055)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julian Gernun","email":"17549662+jcger@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-19T13:35:42Z","message":"[ResponseOps][Rules] Fix alert detail flyout  (#247055)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/247030\n\n<details>\n  <summary>Screenshot after fix</summary>\n<img width=\"1261\" height=\"1115\" alt=\"Screenshot 2025-12-19 at 12 26 27\"\nsrc=\"https://github.com/user-attachments/assets/59d22e6a-69c1-47ac-b7e6-5e1b7441d791\"\n/>\n\n</details>\n\nThe `reason` field can be a very long text with long unbreakable\nsegments in it (URLs, comma separated values). I added a wrapping class\nthat takes care of that via css, it effectively adds:\n\n```\nword-break: break-word;\noverflow-wrap: break-word;\n```\n\nThese CSS properties have zero visible effect on content that doesn't\nneed to break - short text, numbers, badges, links all render exactly\nthe same. The CSS only kicks in when there's actually a long unbreakable\nstring.\nThe overhead of one extra `<div>` per row is negligible.\n\nExample of broken `reason` field content:\n```\nDocument count is 1 in the last 5m for 2025-12-19T10:32:24.229Z,Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322),Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322),680,16099067,680,78.218.15.245,sample_web_logs,,,POINT (-82.52886139 42.91095778),US,US,US:US,www.elastic.co,www.elastic.co,kibana_sample_data_logs,kibana_sample_data_logs,78.218.15.245,win 7,win 7,18253611008,78.218.15.245 - - [2018-08-03T10:32:24.229Z] \"GET /site-search HTTP/1.1\" 200 680 \"-\" \"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)\",78.218.15.245 - - [2018-08-03T10:32:24.229Z] \"GET /site-search HTTP/1.1\" 200 680 \"-\" \"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)\",http://twitter.com/success/nikolai-budarin,/site-search,/site-search,200,200,success,info,info,success,2025-12-19T10:32:24.229Z,https://www.elastic.co/solutions/site-search,https://www.elastic.co/solutions/site-search,2025-12-19T10:32:24.229Z. Alert when greater than 0.\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2b31b9712ef09b77e3f5d83e38bbd5625744d704","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","backport:version","v9.3.0","v9.4.0","v9.2.4","v9.1.10"],"title":"[ResponseOps][Rules] Fix alert detail flyout ","number":247055,"url":"https://github.com/elastic/kibana/pull/247055","mergeCommit":{"message":"[ResponseOps][Rules] Fix alert detail flyout  (#247055)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/247030\n\n<details>\n  <summary>Screenshot after fix</summary>\n<img width=\"1261\" height=\"1115\" alt=\"Screenshot 2025-12-19 at 12 26 27\"\nsrc=\"https://github.com/user-attachments/assets/59d22e6a-69c1-47ac-b7e6-5e1b7441d791\"\n/>\n\n</details>\n\nThe `reason` field can be a very long text with long unbreakable\nsegments in it (URLs, comma separated values). I added a wrapping class\nthat takes care of that via css, it effectively adds:\n\n```\nword-break: break-word;\noverflow-wrap: break-word;\n```\n\nThese CSS properties have zero visible effect on content that doesn't\nneed to break - short text, numbers, badges, links all render exactly\nthe same. The CSS only kicks in when there's actually a long unbreakable\nstring.\nThe overhead of one extra `<div>` per row is negligible.\n\nExample of broken `reason` field content:\n```\nDocument count is 1 in the last 5m for 2025-12-19T10:32:24.229Z,Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322),Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322),680,16099067,680,78.218.15.245,sample_web_logs,,,POINT (-82.52886139 42.91095778),US,US,US:US,www.elastic.co,www.elastic.co,kibana_sample_data_logs,kibana_sample_data_logs,78.218.15.245,win 7,win 7,18253611008,78.218.15.245 - - [2018-08-03T10:32:24.229Z] \"GET /site-search HTTP/1.1\" 200 680 \"-\" \"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)\",78.218.15.245 - - [2018-08-03T10:32:24.229Z] \"GET /site-search HTTP/1.1\" 200 680 \"-\" \"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)\",http://twitter.com/success/nikolai-budarin,/site-search,/site-search,200,200,success,info,info,success,2025-12-19T10:32:24.229Z,https://www.elastic.co/solutions/site-search,https://www.elastic.co/solutions/site-search,2025-12-19T10:32:24.229Z. Alert when greater than 0.\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2b31b9712ef09b77e3f5d83e38bbd5625744d704"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247092","number":247092,"state":"OPEN"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247055","number":247055,"mergeCommit":{"message":"[ResponseOps][Rules] Fix alert detail flyout  (#247055)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/247030\n\n<details>\n  <summary>Screenshot after fix</summary>\n<img width=\"1261\" height=\"1115\" alt=\"Screenshot 2025-12-19 at 12 26 27\"\nsrc=\"https://github.com/user-attachments/assets/59d22e6a-69c1-47ac-b7e6-5e1b7441d791\"\n/>\n\n</details>\n\nThe `reason` field can be a very long text with long unbreakable\nsegments in it (URLs, comma separated values). I added a wrapping class\nthat takes care of that via css, it effectively adds:\n\n```\nword-break: break-word;\noverflow-wrap: break-word;\n```\n\nThese CSS properties have zero visible effect on content that doesn't\nneed to break - short text, numbers, badges, links all render exactly\nthe same. The CSS only kicks in when there's actually a long unbreakable\nstring.\nThe overhead of one extra `<div>` per row is negligible.\n\nExample of broken `reason` field content:\n```\nDocument count is 1 in the last 5m for 2025-12-19T10:32:24.229Z,Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322),Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322),680,16099067,680,78.218.15.245,sample_web_logs,,,POINT (-82.52886139 42.91095778),US,US,US:US,www.elastic.co,www.elastic.co,kibana_sample_data_logs,kibana_sample_data_logs,78.218.15.245,win 7,win 7,18253611008,78.218.15.245 - - [2018-08-03T10:32:24.229Z] \"GET /site-search HTTP/1.1\" 200 680 \"-\" \"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)\",78.218.15.245 - - [2018-08-03T10:32:24.229Z] \"GET /site-search HTTP/1.1\" 200 680 \"-\" \"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)\",http://twitter.com/success/nikolai-budarin,/site-search,/site-search,200,200,success,info,info,success,2025-12-19T10:32:24.229Z,https://www.elastic.co/solutions/site-search,https://www.elastic.co/solutions/site-search,2025-12-19T10:32:24.229Z. Alert when greater than 0.\n```\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2b31b9712ef09b77e3f5d83e38bbd5625744d704"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247091","number":247091,"state":"OPEN"},{"branch":"9.1","label":"v9.1.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->