### PR TITLE
[9.1] [ResponseOps][Rules] Tags combobox container doesn't take badge sizes into account and wraps to a new line (#247009)

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_details/rule_details.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_details/rule_details.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useCallback, useMemo } from 'react';
+import { css } from '@emotion/react';
 import {
   EuiFormRow,
   EuiFieldText,
@@ -97,10 +98,14 @@ export const RuleDetails = () => {
     [dispatch, formData.artifacts]
   );
 
+  const flexItemCss = css`
+    min-width: 0;
+  `;
+
   return (
     <>
       <EuiFlexGroup>
-        <EuiFlexItem>
+        <EuiFlexItem grow={1} css={flexItemCss}>
           <EuiFormRow
             data-test-subj="ruleDetails"
             fullWidth
@@ -118,7 +123,7 @@ export const RuleDetails = () => {
             />
           </EuiFormRow>
         </EuiFlexItem>
-        <EuiFlexItem>
+        <EuiFlexItem grow={1} css={flexItemCss}>
           <EuiFormRow
             fullWidth
             label={RULE_TAG_INPUT_TITLE}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ResponseOps][Rules] Tags combobox container doesn't take badge sizes into account and wraps to a new line (#247009)](https://github.com/elastic/kibana/pull/247009)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2025-12-19T12:50:24Z","message":"[ResponseOps][Rules] Tags combobox container doesn't take badge sizes into account and wraps to a new line (#247009)\n\nCloses https://github.com/elastic/kibana/issues/108853\n\n## Summary\n\nThe originally reported issue described the `Tags` combobox wrapping to\na new line when when badges had long titles, instead of staying aligned\nnext to the `Rule Name `input.\nThis issue is no longer reproducible, but long tag values still cause\nthe Tags input to expand and shrink the Rule Name field.\nThis PR fixes the flexbox sizing issue by allowing items to shrink\n(min-width: 0), keeping both inputs aligned and equal width.","sha":"18782fbb51cffabc6242da1782cfc38c1a04080b","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","backport:version","v9.3.0","v9.4.0","v9.2.4","v9.1.10"],"title":"[ResponseOps][Rules] Tags combobox container doesn't take badge sizes into account and wraps to a new line","number":247009,"url":"https://github.com/elastic/kibana/pull/247009","mergeCommit":{"message":"[ResponseOps][Rules] Tags combobox container doesn't take badge sizes into account and wraps to a new line (#247009)\n\nCloses https://github.com/elastic/kibana/issues/108853\n\n## Summary\n\nThe originally reported issue described the `Tags` combobox wrapping to\na new line when when badges had long titles, instead of staying aligned\nnext to the `Rule Name `input.\nThis issue is no longer reproducible, but long tag values still cause\nthe Tags input to expand and shrink the Rule Name field.\nThis PR fixes the flexbox sizing issue by allowing items to shrink\n(min-width: 0), keeping both inputs aligned and equal width.","sha":"18782fbb51cffabc6242da1782cfc38c1a04080b"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247077","number":247077,"state":"OPEN"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247009","number":247009,"mergeCommit":{"message":"[ResponseOps][Rules] Tags combobox container doesn't take badge sizes into account and wraps to a new line (#247009)\n\nCloses https://github.com/elastic/kibana/issues/108853\n\n## Summary\n\nThe originally reported issue described the `Tags` combobox wrapping to\na new line when when badges had long titles, instead of staying aligned\nnext to the `Rule Name `input.\nThis issue is no longer reproducible, but long tag values still cause\nthe Tags input to expand and shrink the Rule Name field.\nThis PR fixes the flexbox sizing issue by allowing items to shrink\n(min-width: 0), keeping both inputs aligned and equal width.","sha":"18782fbb51cffabc6242da1782cfc38c1a04080b"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247076","number":247076,"state":"OPEN"},{"branch":"9.1","label":"v9.1.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->