### PR TITLE
[Obs AI] Clean up attachment labels

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/attachment_types/index.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/attachment_types/index.test.ts
@@ -53,7 +53,7 @@ describe('registerAttachmentUiDefinitions', () => {
 
     const config = alertCall![1];
     expect(config.getIcon()).toBe('warning');
-    expect(config.getLabel({ id: 'test', type: 'test', data: {} })).toBe('Observability Alert');
+    expect(config.getLabel({ id: 'test', type: 'test', data: {} })).toBe('Observability alert');
   });
 
   it('registers error attachment type with correct config', () => {
@@ -66,7 +66,7 @@ describe('registerAttachmentUiDefinitions', () => {
 
     const config = errorCall![1];
     expect(config.getIcon()).toBe('bug');
-    expect(config.getLabel({ id: 'test', type: 'test', data: {} })).toBe('APM Error');
+    expect(config.getLabel({ id: 'test', type: 'test', data: {} })).toBe('APM error');
   });
 
   it('registers log attachment type with correct config', () => {
@@ -79,7 +79,7 @@ describe('registerAttachmentUiDefinitions', () => {
 
     const config = logCall![1];
     expect(config.getIcon()).toBe('logPatternAnalysis');
-    expect(config.getLabel({ id: 'test', type: 'test', data: {} })).toBe('Log Entry');
+    expect(config.getLabel({ id: 'test', type: 'test', data: {} })).toBe('Log entry');
   });
 
   it('returns attachmentLabel when provided in attachment data', () => {
@@ -111,7 +111,7 @@ describe('registerAttachmentUiDefinitions', () => {
       type: 'test',
       data: {},
     };
-    expect(config.getLabel(attachment)).toBe('Observability Alert');
+    expect(config.getLabel(attachment)).toBe('Observability alert');
   });
 
   it('returns default label when attachment data is undefined', () => {
@@ -127,6 +127,6 @@ describe('registerAttachmentUiDefinitions', () => {
       type: 'test',
       data: undefined,
     };
-    expect(config.getLabel(attachment)).toBe('Observability Alert');
+    expect(config.getLabel(attachment)).toBe('Observability alert');
   });
 });

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/attachment_types/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/attachment_types/index.ts
@@ -37,21 +37,21 @@ const ATTACHMENT_TYPE_CONFIGS: AttachmentTypeConfig[] = [
   {
     type: OBSERVABILITY_ALERT_ATTACHMENT_TYPE_ID,
     label: i18n.translate('xpack.observabilityAgentBuilder.attachments.alert.label', {
-      defaultMessage: 'Observability Alert',
+      defaultMessage: 'Observability alert',
     }),
     icon: 'warning',
   },
   {
     type: OBSERVABILITY_ERROR_ATTACHMENT_TYPE_ID,
     label: i18n.translate('xpack.observabilityAgentBuilder.attachments.error.label', {
-      defaultMessage: 'APM Error',
+      defaultMessage: 'APM error',
     }),
     icon: 'bug',
   },
   {
     type: OBSERVABILITY_LOG_ATTACHMENT_TYPE_ID,
     label: i18n.translate('xpack.observabilityAgentBuilder.attachments.log.label', {
-      defaultMessage: 'Log Entry',
+      defaultMessage: 'Log entry',
     }),
     icon: 'logPatternAnalysis',
   },


### PR DESCRIPTION
## Summary

Some attachment labels use title case and some labels use sentence case. This looks a little odd when they appear together in the conversation UI.

This PR fixes all of them to be sentence case.

### Before
<img width="1697" height="1226" alt="image" src="https://github.com/user-attachments/assets/a11b0883-bcd0-49ab-bb11-af90dbcd3149" />

<img width="1703" height="1271" alt="image" src="https://github.com/user-attachments/assets/f96f9fd9-8f97-4b0c-bfb7-62cb6b224ea0" />

#### After

<img width="2045" height="1108" alt="Screenshot 2025-12-19 at 9 58 30 AM" src="https://github.com/user-attachments/assets/9cc4c02f-e729-4259-940c-e983e9dca5e1" />

<img width="2049" height="1157" alt="image" src="https://github.com/user-attachments/assets/184d6e86-688d-4173-a047-772b1c6b8ac0" />

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->