### PR TITLE
[Security solution] Threat hunting agent, add esql tools

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/agents/threat_hunting_agent.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/agents/threat_hunting_agent.ts
@@ -25,6 +25,8 @@ const PLATFORM_TOOL_IDS = [
   platformCoreTools.getDocumentById,
   platformCoreTools.cases,
   platformCoreTools.productDocumentation,
+  platformCoreTools.generateEsql,
+  platformCoreTools.executeEsql,
 ];
 
 const SECURITY_TOOL_IDS = [


### PR DESCRIPTION
## Summary

Adds platform ESQL tools to the threat hunting agent:

- `platformCoreTools.generateEsql`
- `platformCoreTools.executeEsql`

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->