### PR TITLE
[9.0] [Infra] Skip flaky test (#221783)

### DIFF
--- a/x-pack/test/functional/apps/infra/node_details.ts
+++ b/x-pack/test/functional/apps/infra/node_details.ts
@@ -579,7 +579,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         });
       });
 
-      describe('Osquery Tab', () => {
+      // FLAKY: https://github.com/elastic/kibana/issues/216514
+      // We should revisit this test and decide if it is usefull and worth to keep
+      describe.skip('Osquery Tab', () => {
         before(async () => {
           await browser.scrollTop();
           await pageObjects.assetDetails.clickOsqueryTab();


### PR DESCRIPTION
Closes #216514 

# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Infra] Skip flaky test (#221783)](https://github.com/elastic/kibana/pull/221783)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-05-28T15:04:44Z","message":"[Infra] Skip flaky test (#221783)\n\nCloses #216514 \n## Summary\n\nThis PR skips the flaky Osquery tab test: I added some context in the\n[issue\ncomment](https://github.com/elastic/kibana/issues/216514#issuecomment-2916281697).\nI don't find this test super useful the way it is, so we should revisit\nit in the future (I added a comment as a reminder). I am also fine to\nremove it.","sha":"27eb6af09335a67d78e304825e03ca5c363b210b","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:obs-ux-infra_services - DEPRECATED","v9.1.0"],"title":"[Infra] Skip flaky test","number":221783,"url":"https://github.com/elastic/kibana/pull/221783","mergeCommit":{"message":"[Infra] Skip flaky test (#221783)\n\nCloses #216514 \n## Summary\n\nThis PR skips the flaky Osquery tab test: I added some context in the\n[issue\ncomment](https://github.com/elastic/kibana/issues/216514#issuecomment-2916281697).\nI don't find this test super useful the way it is, so we should revisit\nit in the future (I added a comment as a reminder). I am also fine to\nremove it.","sha":"27eb6af09335a67d78e304825e03ca5c363b210b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221783","number":221783,"mergeCommit":{"message":"[Infra] Skip flaky test (#221783)\n\nCloses #216514 \n## Summary\n\nThis PR skips the flaky Osquery tab test: I added some context in the\n[issue\ncomment](https://github.com/elastic/kibana/issues/216514#issuecomment-2916281697).\nI don't find this test super useful the way it is, so we should revisit\nit in the future (I added a comment as a reminder). I am also fine to\nremove it.","sha":"27eb6af09335a67d78e304825e03ca5c363b210b"}}]}] BACKPORT-->