### PR TITLE
[8.19] Add refusal field to assistant conversations (#243423)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -59209,6 +59209,9 @@ components:
         reader:
           $ref: '#/components/schemas/Security_AI_Assistant_API_Reader'
           description: Message content.
+        refusal:
+          description: Refusal reason returned by the model when content is filtered.
+          type: string
         role:
           $ref: '#/components/schemas/Security_AI_Assistant_API_MessageRole'
           description: Message role.

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -43758,6 +43758,9 @@ components:
         reader:
           $ref: '#/components/schemas/Security_AI_Assistant_API_Reader'
           description: Message content.
+        refusal:
+          description: Refusal reason returned by the model when content is filtered.
+          type: string
         role:
           $ref: '#/components/schemas/Security_AI_Assistant_API_MessageRole'
           description: Message role.

--- a/src/platform/packages/shared/kbn-saved-search-component/moon.yml
+++ b/src/platform/packages/shared/kbn-saved-search-component/moon.yml
@@ -27,6 +27,7 @@ dependsOn:
   - '@kbn/i18n'
   - '@kbn/presentation-publishing'
   - '@kbn/saved-search-plugin'
+  - '@kbn/unified-data-table'
 tags:
   - shared-browser
   - package

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/api.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/api.ts
@@ -197,6 +197,10 @@ export interface ChatCompleteResponse<
    */
   content: string;
   /**
+   * Optional refusal reason returned by the model when content is filtered.
+   */
+  refusal?: string;
+  /**
    * The eventual tool calls performed by the LLM.
    */
   toolCalls: ToolCallsOf<TOptions>['toolCalls'];

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/events.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/events.ts
@@ -36,6 +36,10 @@ export type ChatCompletionMessageEvent<TToolOptions extends ToolOptions = ToolOp
        */
       toolCalls: ToolCallsOf<TToolOptions>['toolCalls'];
       /**
+       * Optional refusal reason returned by the model when content is filtered.
+       */
+      refusal?: string;
+      /**
        * Optional deanonymized input messages metadata
        */
       deanonymized_input?: Array<{ message: Message; deanonymizations: Deanonymization[] }>;
@@ -83,6 +87,10 @@ export type ChatCompletionChunkEvent = InferenceTaskEventBase<
      * The content chunk
      */
     content: string;
+    /**
+     * Optional refusal reason chunk.
+     */
+    refusal?: string;
     /**
      * The tool call chunks
      */

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/messages.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/messages.ts
@@ -59,6 +59,10 @@ export type AssistantMessage = MessageBase<MessageRole.Assistant> & {
    * Note that LLM with parallel tool invocation can potentially call multiple tools at the same time.
    */
   toolCalls?: ToolCall[];
+  /**
+   * Optional refusal reason returned by the model when content is filtered.
+   */
+  refusal?: string | null;
 };
 
 /**

--- a/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/from_inference/chunks.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/from_inference/chunks.ts
@@ -23,10 +23,12 @@ export const completionChunkToLangchain = (chunk: ChatCompletionChunkEvent): AIM
     };
   });
 
+  const additionalKwargs = chunk.refusal ? { refusal: chunk.refusal } : {};
+
   return new AIMessageChunk({
     content: chunk.content,
     tool_call_chunks: toolCallChunks,
-    additional_kwargs: {},
+    additional_kwargs: additionalKwargs,
     response_metadata: {},
   });
 };

--- a/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/from_inference/messages.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/from_inference/messages.ts
@@ -9,8 +9,10 @@ import type { ChatCompleteResponse } from '@kbn/inference-common';
 import { AIMessage } from '@langchain/core/messages';
 
 export const responseToLangchainMessage = (response: ChatCompleteResponse): AIMessage => {
+  const additionalKwargs = response.refusal ? { refusal: response.refusal } : undefined;
   return new AIMessage({
     content: response.content,
+    ...(additionalKwargs ? { additional_kwargs: additionalKwargs } : {}),
     tool_calls: response.toolCalls.map((toolCall) => {
       return {
         id: toolCall.toolCallId,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -2739,6 +2739,9 @@ components:
         reader:
           $ref: '#/components/schemas/Reader'
           description: Message content.
+        refusal:
+          description: Refusal reason returned by the model when content is filtered.
+          type: string
         role:
           $ref: '#/components/schemas/MessageRole'
           description: Message role.

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -2739,6 +2739,9 @@ components:
         reader:
           $ref: '#/components/schemas/Reader'
           description: Message content.
+        refusal:
+          description: Refusal reason returned by the model when content is filtered.
+          type: string
         role:
           $ref: '#/components/schemas/MessageRole'
           description: Message role.

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/conversations/common_attributes.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/conversations/common_attributes.gen.ts
@@ -249,6 +249,10 @@ export const Message = z.object({
    */
   content: z.string(),
   /**
+   * Refusal reason returned by the model when content is filtered.
+   */
+  refusal: z.string().optional(),
+  /**
    * Message content.
    */
   reader: Reader.optional(),

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/conversations/common_attributes.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/conversations/common_attributes.schema.yaml
@@ -257,6 +257,9 @@ components:
           type: string
           description: Message content.
           example: 'Hello, how can I assist you today?'
+        refusal:
+          type: string
+          description: Refusal reason returned by the model when content is filtered.
         reader:
           $ref: '#/components/schemas/Reader'
           description: Message content.

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/from_openai.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/openai/from_openai.ts
@@ -18,6 +18,7 @@ export function chunkFromOpenAI(chunk: OpenAI.ChatCompletionChunk): ChatCompleti
   return {
     type: ChatCompletionEventType.ChatCompletionChunk,
     content: delta.content ?? '',
+    refusal: delta.refusal ?? undefined,
     tool_calls:
       delta.tool_calls?.map((toolCall) => {
         return {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/chunks_into_message.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/chunks_into_message.ts
@@ -45,7 +45,7 @@ export function chunksIntoMessage<TToolOptions extends ToolOptions>({
 
           logger.debug(() => `Received completed message: ${JSON.stringify(concatenatedChunk)}`);
 
-          const { content, tool_calls: toolCalls } = concatenatedChunk;
+          const { content, refusal, tool_calls: toolCalls } = concatenatedChunk;
           const activeSpan = trace.getActiveSpan();
           if (activeSpan) {
             setChoice(activeSpan, { content, toolCalls });
@@ -56,6 +56,7 @@ export function chunksIntoMessage<TToolOptions extends ToolOptions>({
           return {
             type: ChatCompletionEventType.ChatCompletionMessage,
             content,
+            ...(refusal ? { refusal } : {}),
             toolCalls: validatedToolCalls,
           };
         })

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/merge_chunks.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/merge_chunks.ts
@@ -9,6 +9,7 @@ import { ChatCompletionChunkEvent, UnvalidatedToolCall } from '@kbn/inference-co
 
 interface UnvalidatedMessage {
   content: string;
+  refusal?: string;
   tool_calls: UnvalidatedToolCall[];
 }
 
@@ -19,6 +20,9 @@ export const mergeChunks = (chunks: ChatCompletionChunkEvent[]): UnvalidatedMess
   const message = chunks.reduce<UnvalidatedMessage>(
     (prev, chunk) => {
       prev.content += chunk.content ?? '';
+      if (chunk.refusal) {
+        prev.refusal = chunk.refusal;
+      }
 
       chunk.tool_calls?.forEach((toolCall) => {
         let prevToolCall = prev.tool_calls[toolCall.index];

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/stream_to_response.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/stream_to_response.ts
@@ -33,6 +33,7 @@ export const streamToResponse = <TToolOptions extends ToolOptions = ToolOptions>
 
         return {
           content: messageEvent.content,
+          refusal: messageEvent.refusal,
           toolCalls: messageEvent.toolCalls,
           tokens: tokenEvent?.tokens,
           deanonymized_input: messageEvent.deanonymized_input,

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference/helpers.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference/helpers.ts
@@ -47,6 +47,9 @@ export function chunksIntoMessage(obs$: Observable<UnifiedChatCompleteResponse>)
           (prev, chunk) => {
             if (chunk.choices.length > 0 && !chunk.usage) {
               prev.choices[0].message.content += chunk.choices[0].message.content ?? '';
+              if (chunk.choices[0].message.refusal) {
+                prev.choices[0].message.refusal = chunk.choices[0].message.refusal;
+              }
 
               chunk.choices[0].message.tool_calls?.forEach((toolCall) => {
                 if (toolCall.index !== undefined) {
@@ -89,6 +92,7 @@ export function chunksIntoMessage(obs$: Observable<UnifiedChatCompleteResponse>)
               {
                 message: {
                   content: '',
+                  refusal: null,
                   role: 'assistant',
                 },
               },

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/append_conversation_messages.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/append_conversation_messages.test.ts
@@ -323,6 +323,29 @@ describe('appendConversationMessages', () => {
       })
     );
   });
+
+  it('preserves refusal reason when present on messages', async () => {
+    const messageWithRefusal = createMockMessage({
+      refusal: 'Detected harmful input content: INSULTS',
+    });
+    setupSuccessfulTest();
+
+    await callAppendConversationMessages([messageWithRefusal]);
+
+    expect(dataWriter.bulk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentsToUpdate: expect.arrayContaining([
+          expect.objectContaining({
+            messages: expect.arrayContaining([
+              expect.objectContaining({
+                refusal: 'Detected harmful input content: INSULTS',
+              }),
+            ]),
+          }),
+        ]),
+      })
+    );
+  });
 });
 
 describe('transformToUpdateScheme', () => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/append_conversation_messages.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/append_conversation_messages.ts
@@ -104,6 +104,7 @@ export const transformToUpdateScheme = (
     messages: messages?.map((message) => ({
       '@timestamp': message.timestamp,
       content: message.content,
+      ...(message.refusal ? { refusal: message.refusal } : {}),
       is_error: message.isError,
       reader: message.reader,
       role: message.role,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/create_conversation.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/create_conversation.ts
@@ -94,6 +94,7 @@ export const transformToCreateScheme = (
     messages: messages?.map((message) => ({
       '@timestamp': message.timestamp,
       content: message.content,
+      ...(message.refusal ? { refusal: message.refusal } : {}),
       is_error: message.isError,
       reader: message.reader,
       role: message.role,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/field_maps_configuration.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/field_maps_configuration.ts
@@ -72,6 +72,11 @@ export const conversationsFieldMap: FieldMap = {
     array: false,
     required: false,
   },
+  'messages.refusal': {
+    type: 'text',
+    array: false,
+    required: false,
+  },
   'messages.reader': {
     type: 'object',
     array: false,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transforms.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transforms.ts
@@ -50,6 +50,7 @@ export const transformESToConversation = (
           messageContent: message.content,
           replacements,
         }),
+        ...(message.refusal ? { refusal: message.refusal } : {}),
         ...(message.is_error ? { isError: message.is_error } : {}),
         ...(message.reader ? { reader: message.reader } : {}),
         ...(message.user ? { user: message.user } : {}),

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/types.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/types.ts
@@ -33,6 +33,7 @@ export interface EsConversationSchema {
   messages?: Array<{
     '@timestamp': string;
     content: string;
+    refusal?: string;
     reader?: Reader;
     role: MessageRole;
     is_error?: boolean;
@@ -70,6 +71,7 @@ export interface CreateMessageSchema {
   messages?: Array<{
     '@timestamp': string;
     content: string;
+    refusal?: string;
     reader?: Reader;
     role: MessageRole;
     is_error?: boolean;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/update_conversation.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/update_conversation.ts
@@ -28,6 +28,7 @@ export interface UpdateConversationSchema {
   messages?: Array<{
     '@timestamp': string;
     content: string;
+    refusal?: string;
     reader?: Reader;
     role: MessageRole;
     is_error?: boolean;
@@ -133,6 +134,7 @@ export const transformToUpdateScheme = (
           messages: messages.map((message) => ({
             '@timestamp': message.timestamp,
             content: message.content,
+            ...(message.refusal ? { refusal: message.refusal } : {}),
             is_error: message.isError,
             reader: message.reader,
             role: message.role,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/executors/types.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/executors/types.ts
@@ -35,7 +35,8 @@ import { AIAssistantDataClient } from '../../../ai_assistant_data_clients';
 export type OnLlmResponse = (
   content: string,
   traceData?: Message['traceData'],
-  isError?: boolean
+  isError?: boolean,
+  refusal?: string
 ) => Promise<void>;
 
 export interface AssistantDataClients {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/helpers.test.ts
@@ -112,7 +112,8 @@ describe('streamGraph', () => {
           expect(mockOnLlmResponse).toHaveBeenCalledWith(
             'final message',
             { transactionId: 'transactionId', traceId: 'traceId' },
-            false
+            false,
+            undefined
           );
         });
       });
@@ -172,7 +173,8 @@ describe('streamGraph', () => {
           expect(mockOnLlmResponse).toHaveBeenCalledWith(
             'final message',
             { transactionId: 'transactionId', traceId: 'traceId' },
-            false
+            false,
+            undefined
           );
         });
       });
@@ -204,7 +206,8 @@ describe('streamGraph', () => {
           expect(mockOnLlmResponse).toHaveBeenCalledWith(
             'content',
             { transactionId: 'transactionId', traceId: 'traceId' },
-            false
+            false,
+            undefined
           );
         });
       });
@@ -290,7 +293,8 @@ describe('streamGraph', () => {
         expect(mockOnLlmResponse).toHaveBeenCalledWith(
           'Look at these rare IP addresses.',
           { transactionId: 'transactionId', traceId: 'traceId' },
-          false
+          false,
+          undefined
         );
       });
     };

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.ts
@@ -212,7 +212,8 @@ export const chatCompleteRoute = (
           const onLlmResponse = async (
             content: string,
             traceData: Message['traceData'] = {},
-            isError = false
+            isError = false,
+            refusal
           ): Promise<void> => {
             if (conversationId && conversationsDataClient) {
               const { prunedContent, prunedContentReferencesStore } = pruneContentReferences(
@@ -224,6 +225,7 @@ export const chatCompleteRoute = (
                 conversationId,
                 conversationsDataClient,
                 messageContent: prunedContent,
+                messageRefusal: refusal,
                 replacements: latestReplacements,
                 isError,
                 traceData,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.ts
@@ -213,7 +213,7 @@ export const chatCompleteRoute = (
             content: string,
             traceData: Message['traceData'] = {},
             isError = false,
-            refusal
+            refusal?: string
           ): Promise<void> => {
             if (conversationId && conversationsDataClient) {
               const { prunedContent, prunedContentReferencesStore } = pruneContentReferences(

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/helpers.ts
@@ -105,11 +105,13 @@ export const getPluginNameFromRequest = ({
 export const getMessageFromRawResponse = ({
   rawContent,
   metadata,
+  refusal,
   isError,
   traceData,
 }: {
   rawContent?: string;
   metadata?: MessageMetadata;
+  refusal?: string;
   traceData?: TraceData;
   isError?: boolean;
 }): Message => {
@@ -118,6 +120,7 @@ export const getMessageFromRawResponse = ({
     return {
       role: 'assistant',
       content: rawContent,
+      ...(refusal ? { refusal } : {}),
       timestamp: dateTimeString,
       metadata,
       isError,
@@ -175,6 +178,7 @@ export const getSystemPromptFromUserConversation = async ({
 export interface AppendAssistantMessageToConversationParams {
   conversationsDataClient: AIAssistantConversationsDataClient;
   messageContent: string;
+  messageRefusal?: string;
   replacements: Replacements;
   conversationId: string;
   contentReferences: ContentReferences;
@@ -184,6 +188,7 @@ export interface AppendAssistantMessageToConversationParams {
 export const appendAssistantMessageToConversation = async ({
   conversationsDataClient,
   messageContent,
+  messageRefusal,
   replacements,
   conversationId,
   contentReferences,
@@ -207,6 +212,7 @@ export const appendAssistantMessageToConversation = async ({
           messageContent,
           replacements,
         }),
+        refusal: messageRefusal,
         metadata: !isEmpty(metadata) ? metadata : undefined,
         traceData,
         isError,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/helpers.ts
@@ -254,7 +254,8 @@ export interface LangChainExecuteParams {
   onLlmResponse?: (
     content: string,
     traceData?: Message['traceData'],
-    isError?: boolean
+    isError?: boolean,
+    refusal?: string
   ) => Promise<void>;
   response: KibanaResponseFactory;
   responseLanguage?: string;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
@@ -144,7 +144,7 @@ export const postActionsConnectorExecuteRoute = (
             content: string,
             traceData: Message['traceData'] = {},
             isError = false,
-            refusal
+            refusal?: string
           ): Promise<void> => {
             if (conversationsDataClient && conversationId) {
               const { prunedContent, prunedContentReferencesStore } = pruneContentReferences(

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
@@ -143,7 +143,8 @@ export const postActionsConnectorExecuteRoute = (
           onLlmResponse = async (
             content: string,
             traceData: Message['traceData'] = {},
-            isError = false
+            isError = false,
+            refusal
           ): Promise<void> => {
             if (conversationsDataClient && conversationId) {
               const { prunedContent, prunedContentReferencesStore } = pruneContentReferences(
@@ -155,6 +156,7 @@ export const postActionsConnectorExecuteRoute = (
                 conversationId,
                 conversationsDataClient,
                 messageContent: prunedContent,
+                messageRefusal: refusal,
                 replacements: latestReplacements,
                 isError,
                 traceData,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add refusal field to assistant conversations (#243423)](https://github.com/elastic/kibana/pull/243423)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jason Botzas-Coluni","email":"44372106+jaybcee@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-19T15:39:35Z","message":"Add refusal field to assistant conversations (#243423)","sha":"fe9c9fd75355732baf10cda2b70fe4bb9f36652b","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:all-open","ci:cloud-deploy","ci:cloud-redeploy","ci:project-deploy-security","v9.4.0"],"title":"Add refusal field to assistant conversations","number":243423,"url":"https://github.com/elastic/kibana/pull/243423","mergeCommit":{"message":"Add refusal field to assistant conversations (#243423)","sha":"fe9c9fd75355732baf10cda2b70fe4bb9f36652b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243423","number":243423,"mergeCommit":{"message":"Add refusal field to assistant conversations (#243423)","sha":"fe9c9fd75355732baf10cda2b70fe4bb9f36652b"}},{"url":"https://github.com/elastic/kibana/pull/247135","number":247135,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->