### PR TITLE
[CPS] Design update

### DIFF
--- a/src/platform/packages/shared/kbn-cps-utils/components/cps_icon.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/cps_icon.tsx
@@ -7,42 +7,33 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useEuiTheme } from '@elastic/eui';
 import React from 'react';
-
-export const CPSIcon = () => {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none">
-      <path
-        fill="currentColor"
-        fillRule="evenodd"
-        d="M8.5 9h4a1 1 0 0 1 1 1v2.065A1.999 1.999 0 1 1 11 14c0-.932.638-1.712 1.5-1.935V10h-4v2.065A1.999 1.999 0 1 1 6 14c0-.932.638-1.712 1.5-1.935V10h-4v2.065A1.999 1.999 0 1 1 1 14c0-.932.638-1.712 1.5-1.935V10a1 1 0 0 1 1-1h4V7h1v2ZM3 13a1 1 0 1 0 0 2 1 1 0 0 0 0-2Zm5 0a1 1 0 1 0 0 2 1 1 0 0 0 0-2Zm5 0a1 1 0 1 0 0 2 1 1 0 0 0 0-2ZM7 0a3 3 0 0 1 3 3c0 .648-.208 1.246-.557 1.736l1.91 1.91-.707.708-1.91-1.91A3 3 0 1 1 7 0Zm0 1a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"
-        clipRule="evenodd"
-      />
-    </svg>
-  );
-};
+import { useEuiTheme } from '@elastic/eui';
 
 export const CPSIconDisabled = () => {
-  const { euiTheme } = useEuiTheme();
+  const {
+    euiTheme: {
+      colors: { textDisabled },
+    },
+  } = useEuiTheme();
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none">
       <path
-        fill={euiTheme.colors.textDisabled}
+        fill={textDisabled}
         d="M4.856 13.264c.091.228.144.475.144.736a2 2 0 0 1-2 2c-.26 0-.508-.053-.736-.144l.866-.866a.998.998 0 0 0 .86-.86l.866-.866Z"
       />
       <path
-        fill={euiTheme.colors.textDisabled}
+        fill={textDisabled}
         fillRule="evenodd"
         d="M12.5 9a1 1 0 0 1 1 1v2.065A1.999 1.999 0 1 1 11 14c0-.932.638-1.712 1.5-1.935V10h-4v2.065A1.999 1.999 0 1 1 6 14c0-.932.638-1.712 1.5-1.935v-1.444L9.121 9H12.5ZM8 13a1 1 0 1 0 0 2 1 1 0 0 0 0-2Zm5 0a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z"
         clipRule="evenodd"
       />
       <path
-        fill={euiTheme.colors.textDisabled}
+        fill={textDisabled}
         d="M15.354 1.354 1.447 15.259l-.093.095-.708-.707 14-14 .707.707ZM3.879 10H3.5v.379l-1 1V10a1 1 0 0 1 1-1h1.379l-1 1Z"
       />
       <path
-        fill={euiTheme.colors.textDisabled}
+        fill={textDisabled}
         fillRule="evenodd"
         d="M7 0a3 3 0 0 1 3 3c0 .383-.075.748-.207 1.085L8.085 5.793A2.969 2.969 0 0 1 7 6a3 3 0 0 1 0-6Zm0 1a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"
         clipRule="evenodd"

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker.tsx
@@ -13,11 +13,10 @@ import type { UseEuiTheme } from '@elastic/eui';
 import {
   EuiPopover,
   EuiToolTip,
-  EuiHeaderSectionItemButton,
-  EuiIcon,
   EuiTourStep,
   EuiButton,
   EuiButtonIcon,
+  EuiButtonEmpty,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { ProjectRouting } from '@kbn/es-query';
@@ -27,7 +26,7 @@ import { ProjectPickerContent } from './project_picker_content';
 import { useFetchProjects } from './use_fetch_projects';
 import { useProjectPickerTour } from './use_project_picker_tour';
 import { strings } from './strings';
-import { CPSIcon, CPSIconDisabled } from './cps_icon';
+import { CPSIconDisabled } from './cps_icon';
 
 export interface ProjectPickerProps {
   projectRouting?: ProjectRouting;
@@ -53,26 +52,27 @@ export const ProjectPicker = ({
     return null;
   }
 
+  const totalProjects = linkedProjects.length + 1;
+  const activeProjectsCount = projectRouting === PROJECT_ROUTING.ALL ? totalProjects : 1;
+
   const button = (
     <EuiToolTip
       delay="long"
-      content={strings.getProjectPickerButtonLabel(
-        projectRouting === PROJECT_ROUTING.ORIGIN ? 1 : linkedProjects.length + 1,
-        linkedProjects.length + 1
-      )}
+      content={strings.getProjectPickerButtonLabel(activeProjectsCount, totalProjects)}
       disableScreenReaderOutput
     >
-      <EuiHeaderSectionItemButton
+      <EuiButtonEmpty
         aria-label={strings.getProjectPickerButtonAriaLabel()}
         data-test-subj="project-picker-button"
-        onClick={() => setShowPopover(!showPopover)}
         size="s"
-        notification={projectRouting !== PROJECT_ROUTING.ALL ? 1 : undefined}
-        notificationColor="success"
-        css={styles.button}
+        iconType="crossProjectSearch"
+        onClick={() => setShowPopover(!showPopover)}
+        color="text"
       >
-        <EuiIcon type={CPSIcon} />
-      </EuiHeaderSectionItemButton>
+        {activeProjectsCount === totalProjects
+          ? strings.allButtonLabel()
+          : `${activeProjectsCount}/${totalProjects}`}
+      </EuiButtonEmpty>
     </EuiToolTip>
   );
 
@@ -149,14 +149,5 @@ const projectPickerStyles = {
   disabledButton: ({ euiTheme }: UseEuiTheme) =>
     css({
       margin: euiTheme.size.s,
-    }),
-  button: ({ euiTheme }: UseEuiTheme) =>
-    css({
-      svg: {
-        verticalAlign: 'middle',
-      },
-      '.euiNotificationBadge': {
-        insetInlineEnd: `-${euiTheme.size.s}`,
-      },
     }),
 };

--- a/src/platform/packages/shared/kbn-cps-utils/components/strings.ts
+++ b/src/platform/packages/shared/kbn-cps-utils/components/strings.ts
@@ -10,6 +10,10 @@
 import { i18n } from '@kbn/i18n';
 
 export const strings = {
+  allButtonLabel: () =>
+    i18n.translate('cpsUtils.projectPicker.allButtonLabel', {
+      defaultMessage: 'All',
+    }),
   getProjectPickerButtonAriaLabel: () =>
     i18n.translate('cpsUtils.projectPicker.projectPickerButtonLabel', {
       defaultMessage: 'Cross-project search project picker',

--- a/src/platform/plugins/private/presentation_panel/public/panel_actions/customize_panel_action/cps_usage_overrides_badge.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_actions/customize_panel_action/cps_usage_overrides_badge.tsx
@@ -129,7 +129,7 @@ export class CpsUsageOverridesBadge
   }
 
   public getIconType() {
-    return 'beaker';
+    return 'crossProjectSearch';
   }
 
   public async isCompatible({ embeddable }: EmbeddableApiContext) {

--- a/src/platform/plugins/shared/cps/server/routes/get_projects_tags.ts
+++ b/src/platform/plugins/shared/cps/server/routes/get_projects_tags.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { schema } from '@kbn/config-schema';
 import type { IRouter, PluginInitializerContext } from '@kbn/core/server';
 import type { ProjectTagsResponse } from '@kbn/cps-utils';
 
@@ -17,7 +18,11 @@ export const registerGetProjectTagsRoute = (
   router.get(
     {
       path: '/internal/cps/projects_tags',
-      validate: false,
+      validate: {
+        query: schema.object({
+          project_routing: schema.maybe(schema.string()),
+        }),
+      },
       security: {
         authz: {
           enabled: false,
@@ -28,10 +33,13 @@ export const registerGetProjectTagsRoute = (
     async (requestHandlerContext, request, response) => {
       try {
         const core = await requestHandlerContext.core;
+        const { project_routing } = request.query;
+
         const result: ProjectTagsResponse =
           await core.elasticsearch.client.asCurrentUser.transport.request({
             method: 'GET',
             path: `/_project/tags`,
+            querystring: project_routing ? { project_routing } : undefined,
           });
 
         return response.ok({


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/245195

Uses eui crossProjectSearch Icon instead of a custom one.

Exposes `project_routing` query param in endpoint `/internal/cps/projects_tags` - not used yet though, but we'll need it soon.

A small design change to show a project picker without a notification - like badge:

<img width="427" height="189" alt="Screenshot 2025-12-20 at 13 40 21" src="https://github.com/user-attachments/assets/35f4a42b-eff9-476d-a573-afc24803f7ae" />
<img width="519" height="198" alt="Screenshot 2025-12-20 at 13 40 16" src="https://github.com/user-attachments/assets/84255b8d-eefe-4f63-929b-a1fbb2522b4e" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



