### PR TITLE
[SLO] Add environment context to SLO feedback button

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/common/feedback_button.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/common/feedback_button.tsx
@@ -8,6 +8,9 @@
 import React from 'react';
 import { EuiHeaderLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { getSurveyFeedbackURL } from '@kbn/observability-shared-plugin/public';
+import { useKibana } from '../../../../hooks/use_kibana';
+import { usePluginContext } from '../../../../hooks/use_plugin_context';
 
 const SLO_FEEDBACK_LINK = 'https://ela.st/slo-feedback';
 
@@ -20,10 +23,21 @@ const feedbackButtonLabel = i18n.translate('xpack.slo.featureFeedbackButtonLabel
 });
 
 export function FeedbackButton({ disabled }: Props) {
+  const { kibanaVersion, cloud } = useKibana().services;
+  const { isServerless } = usePluginContext();
+
+  const feedbackUrl = getSurveyFeedbackURL({
+    formUrl: SLO_FEEDBACK_LINK,
+    kibanaVersion,
+    isCloudEnv: cloud?.isCloudEnabled,
+    isServerlessEnv: isServerless,
+    sanitizedPath: window.location.pathname,
+  });
+
   return (
     <EuiHeaderLink
       aria-label={feedbackButtonLabel}
-      href={SLO_FEEDBACK_LINK}
+      href={feedbackUrl}
       size="s"
       iconType="popout"
       iconSide="right"


### PR DESCRIPTION
It closes https://github.com/elastic/kibana/issues/236274

Updates the SLO feedback button to include query string parameters that identify the user's environment:

- `version` - Kibana version
- `deployment_type` - Serverless, Elastic Cloud, or Self-Managed
- `path` - Current page path

Uses `getSurveyFeedbackURL` from `@kbn/observability-shared-plugin` for consistency with other observability plugins.