### PR TITLE
[scout] use stateful mode to run api-int tests

### DIFF
--- a/.buildkite/scripts/steps/test/scout_test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout_test_run_builder.sh
@@ -17,7 +17,7 @@ buildkite-agent artifact upload "scout_playwright_configs.json"
 
 echo '--- Running Scout API Integration Tests'
 node scripts/scout.js run-tests \
---serverless=security \
+--stateful \
 --config src/platform/packages/shared/kbn-scout/test/scout/api/playwright.config.ts \
 --kibana-install-dir "$KIBANA_BUILD_LOCATION"
 


### PR DESCRIPTION
## Summary

Scout internal integration tests (to check our api helpers) are run against serverless distro, which is totally ok for `main` branch but might be an issue for the older branches.

Changing step to use `stateful` mode as both Kibana and ES builds are available there.





<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->