### PR TITLE
[ES|QL] Esql indentation shortcut on the editor

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.test.ts
@@ -151,10 +151,11 @@ describe('Custom Editor Commands', () => {
     it('should call toggleVisor function when command is executed', () => {
       const mockOnQuerySubmit = jest.fn();
       const mockToggleVisor = jest.fn();
+      const mockOnPrettifyQuery = jest.fn();
 
-      addEditorKeyBindings(mockEditor, mockOnQuerySubmit, mockToggleVisor);
+      addEditorKeyBindings(mockEditor, mockOnQuerySubmit, mockToggleVisor, mockOnPrettifyQuery);
 
-      expect(mockEditor.addCommand).toHaveBeenCalledTimes(2);
+      expect(mockEditor.addCommand).toHaveBeenCalledTimes(3);
 
       const cmdKCall = (mockEditor.addCommand as jest.Mock).mock.calls.find(
         // eslint-disable-next-line no-bitwise
@@ -172,8 +173,9 @@ describe('Custom Editor Commands', () => {
     it('should call onQuerySubmit when CMD+Enter is pressed', () => {
       const mockOnQuerySubmit = jest.fn();
       const mockToggleVisor = jest.fn();
+      const mockOnPrettifyQuery = jest.fn();
 
-      addEditorKeyBindings(mockEditor, mockOnQuerySubmit, mockToggleVisor);
+      addEditorKeyBindings(mockEditor, mockOnQuerySubmit, mockToggleVisor, mockOnPrettifyQuery);
 
       const cmdEnterCall = (mockEditor.addCommand as jest.Mock).mock.calls.find(
         // eslint-disable-next-line no-bitwise
@@ -186,6 +188,26 @@ describe('Custom Editor Commands', () => {
       cmdEnterHandler();
 
       expect(mockOnQuerySubmit).toHaveBeenCalledWith('manual');
+    });
+
+    it('should call onPrettifyQuery when CMD+I is pressed', () => {
+      const mockOnQuerySubmit = jest.fn();
+      const mockToggleVisor = jest.fn();
+      const mockOnPrettifyQuery = jest.fn();
+
+      addEditorKeyBindings(mockEditor, mockOnQuerySubmit, mockToggleVisor, mockOnPrettifyQuery);
+
+      const cmdICall = (mockEditor.addCommand as jest.Mock).mock.calls.find(
+        // eslint-disable-next-line no-bitwise
+        ([keyMod]) => keyMod === (monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyI)
+      );
+      expect(cmdICall).toBeDefined();
+
+      const cmdIHandler = cmdICall[1];
+
+      cmdIHandler();
+
+      expect(mockOnPrettifyQuery).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.ts
@@ -11,6 +11,7 @@ import { monaco } from '@kbn/monaco';
 import { ESQLVariableType, type ESQLControlVariable, QuerySource } from '@kbn/esql-types';
 import { ControlTriggerSource } from '@kbn/esql-types';
 import type { CoreStart } from '@kbn/core/public';
+import { prettifyQuery } from '@kbn/esql-utils';
 import type { ESQLEditorDeps, ControlsContext } from './types';
 import type { ESQLEditorTelemetryService } from './telemetry/telemetry_service';
 
@@ -160,8 +161,9 @@ export const registerCustomCommands = (deps: MonacoCommandDependencies): monaco.
 
 export const addEditorKeyBindings = (
   editor: monaco.editor.IStandaloneCodeEditor,
-  onQuerySubmit: (source: any) => void,
-  toggleVisor: () => void
+  onQuerySubmit: (source: QuerySource) => void,
+  toggleVisor: () => void,
+  onQueryUpdate: (qs: string) => void
 ) => {
   // Add editor key bindings
   editor.addCommand(
@@ -174,6 +176,18 @@ export const addEditorKeyBindings = (
     // eslint-disable-next-line no-bitwise
     monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK,
     () => toggleVisor()
+  );
+
+  editor.addCommand(
+    // eslint-disable-next-line no-bitwise
+    monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyI,
+    () => {
+      const code = editor.getValue();
+      const prettyCode = prettifyQuery(code);
+      if (code !== prettyCode) {
+        onQueryUpdate(prettyCode);
+      }
+    }
   );
 };
 

--- a/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/custom_editor_commands.ts
@@ -11,7 +11,6 @@ import { monaco } from '@kbn/monaco';
 import { ESQLVariableType, type ESQLControlVariable, QuerySource } from '@kbn/esql-types';
 import { ControlTriggerSource } from '@kbn/esql-types';
 import type { CoreStart } from '@kbn/core/public';
-import { prettifyQuery } from '@kbn/esql-utils';
 import type { ESQLEditorDeps, ControlsContext } from './types';
 import type { ESQLEditorTelemetryService } from './telemetry/telemetry_service';
 
@@ -163,7 +162,7 @@ export const addEditorKeyBindings = (
   editor: monaco.editor.IStandaloneCodeEditor,
   onQuerySubmit: (source: QuerySource) => void,
   toggleVisor: () => void,
-  onQueryUpdate: (qs: string) => void
+  onPrettifyQuery: () => void
 ) => {
   // Add editor key bindings
   editor.addCommand(
@@ -182,11 +181,7 @@ export const addEditorKeyBindings = (
     // eslint-disable-next-line no-bitwise
     monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyI,
     () => {
-      const code = editor.getValue();
-      const prettyCode = prettifyQuery(code);
-      if (code !== prettyCode) {
-        onQueryUpdate(prettyCode);
-      }
+      onPrettifyQuery();
     }
   );
 };

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
@@ -50,7 +50,7 @@ interface EditorFooterProps {
   detectedTimestamp?: string;
   onErrorClick: (error: MonacoMessage) => void;
   onUpdateAndSubmitQuery: (newQuery: string, querySource: QuerySource) => void;
-  updateQuery: (qs: string) => void;
+  onPrettifyQuery: () => void;
   isHistoryOpen: boolean;
   setIsHistoryOpen: (status: boolean) => void;
   isLanguageComponentOpen: boolean;
@@ -77,7 +77,7 @@ export const EditorFooter = memo(function EditorFooter({
   detectedTimestamp,
   onErrorClick,
   onUpdateAndSubmitQuery,
-  updateQuery,
+  onPrettifyQuery,
   hideRunQueryText,
   editorIsInline,
   isSpaceReduced,
@@ -139,7 +139,7 @@ export const EditorFooter = memo(function EditorFooter({
                 gap: 12px;
               `}
             >
-              <QueryWrapComponent code={code} updateQuery={updateQuery} />
+              <QueryWrapComponent onPrettifyQuery={onPrettifyQuery} />
               <EuiFlexItem grow={false}>
                 <EuiText size="xs" color="subdued" data-test-subj="ESQLEditor-footer-lines">
                   <p>

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/keyboard_shortcuts.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/keyboard_shortcuts.tsx
@@ -58,6 +58,16 @@ const listItems = [
       defaultMessage: 'Open quick search',
     }),
   },
+  {
+    title: (
+      <>
+        <kbd>{COMMAND_KEY}</kbd> <kbd>I</kbd>
+      </>
+    ),
+    description: i18n.translate('esqlEditor.query.prettifyKeyboardShortcutsLabel', {
+      defaultMessage: 'Prettify query',
+    }),
+  },
 ];
 
 export function KeyboardShortcuts() {

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/query_wrap_component.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/query_wrap_component.tsx
@@ -10,15 +10,8 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFlexItem, EuiToolTip, EuiButtonIcon } from '@elastic/eui';
-import { prettifyQuery } from '@kbn/esql-utils';
 
-export function QueryWrapComponent({
-  code,
-  updateQuery,
-}: {
-  code: string;
-  updateQuery: (qs: string) => void;
-}) {
+export function QueryWrapComponent({ onPrettifyQuery }: { onPrettifyQuery: () => void }) {
   return (
     <EuiFlexItem grow={false}>
       <EuiToolTip
@@ -36,12 +29,7 @@ export function QueryWrapComponent({
           aria-label={i18n.translate('esqlEditor.query.formatQueryLabel', {
             defaultMessage: 'Prettify query',
           })}
-          onClick={() => {
-            const updatedCode = prettifyQuery(code);
-            if (code !== updatedCode) {
-              updateQuery(updatedCode);
-            }
-          }}
+          onClick={onPrettifyQuery}
         />
       </EuiToolTip>
     </EuiFlexItem>

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -33,6 +33,7 @@ import {
   getInferenceEndpoints,
   getEditorExtensions,
   fixESQLQueryWithVariables,
+  prettifyQuery,
 } from '@kbn/esql-utils';
 import type { CodeEditorProps } from '@kbn/code-editor';
 import { CodeEditor } from '@kbn/code-editor';
@@ -257,6 +258,16 @@ const ESQLEditorInternal = function ESQLEditor({
     },
     [onQuerySubmit, onQueryUpdate, telemetryService]
   );
+
+  const onPrettifyQuery = useCallback(() => {
+    const qs = editorRef.current?.getValue();
+    if (qs) {
+      const prettyCode = prettifyQuery(qs);
+      if (qs !== prettyCode) {
+        onQueryUpdate(prettyCode);
+      }
+    }
+  }, [onQueryUpdate]);
 
   const onCommentLine = useCallback(() => {
     const currentSelection = editorRef?.current?.getSelection();
@@ -1103,7 +1114,7 @@ const ESQLEditorInternal = function ESQLEditor({
                     });
 
                     // Add editor key bindings
-                    addEditorKeyBindings(editor, onQuerySubmit, toggleVisor, onQueryUpdate);
+                    addEditorKeyBindings(editor, onQuerySubmit, toggleVisor, onPrettifyQuery);
 
                     // Store disposables for cleanup
                     const currentEditor = editorRef.current;
@@ -1214,7 +1225,7 @@ const ESQLEditorInternal = function ESQLEditor({
         code={code}
         onErrorClick={onErrorClick}
         onUpdateAndSubmitQuery={onUpdateAndSubmitQuery}
-        updateQuery={onQueryUpdate}
+        onPrettifyQuery={onPrettifyQuery}
         detectedTimestamp={detectedTimestamp}
         hideRunQueryText={hideRunQueryText}
         editorIsInline={editorIsInline}

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -1103,7 +1103,7 @@ const ESQLEditorInternal = function ESQLEditor({
                     });
 
                     // Add editor key bindings
-                    addEditorKeyBindings(editor, onQuerySubmit, toggleVisor);
+                    addEditorKeyBindings(editor, onQuerySubmit, toggleVisor, onQueryUpdate);
 
                     // Store disposables for cleanup
                     const currentEditor = editorRef.current;


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/188772

## Summary

We are enhancing the editor with a new keyboard shortcut to prettify the query.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


