### PR TITLE
[Traces][Discover] Minor cleanup in trace waterfall tests

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/sync_badge/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/sync_badge/index.test.tsx
@@ -5,146 +5,68 @@
  * 2.0.
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { AgentName } from '@kbn/apm-types/es_schemas_ui';
 import { getSyncLabel, SyncBadge } from '.';
+import userEvent from '@testing-library/user-event';
 
 describe('Sync badge', () => {
-  describe('Nodejs', () => {
-    it('shows blocking badge', () => {
-      expect(getSyncLabel('nodejs', true)).toBe('blocking');
+  describe('getSyncLabel', () => {
+    describe.each([
+      // Agents that show "blocking" when sync=true
+      { agentName: 'nodejs', sync: true, expected: 'blocking', description: 'Nodejs' },
+      { agentName: 'nodejs', sync: false, expected: undefined, description: 'Nodejs' },
+      { agentName: 'js-base', sync: true, expected: 'blocking', description: 'JS' },
+      { agentName: 'js-base', sync: false, expected: undefined, description: 'JS' },
+      { agentName: 'rum-js', sync: true, expected: 'blocking', description: 'RUM' },
+      { agentName: 'rum-js', sync: false, expected: undefined, description: 'RUM' },
+      // Agents that show "async" when sync=false
+      { agentName: 'php', sync: true, expected: undefined, description: 'PHP' },
+      { agentName: 'php', sync: false, expected: 'async', description: 'PHP' },
+      { agentName: 'python', sync: true, expected: undefined, description: 'Python' },
+      { agentName: 'python', sync: false, expected: 'async', description: 'Python' },
+      { agentName: 'dotnet', sync: true, expected: undefined, description: '.NET' },
+      { agentName: 'dotnet', sync: false, expected: 'async', description: '.NET' },
+      { agentName: 'iOS/swift', sync: true, expected: undefined, description: 'iOS' },
+      { agentName: 'iOS/swift', sync: false, expected: 'async', description: 'iOS' },
+      { agentName: 'ruby', sync: true, expected: undefined, description: 'Ruby' },
+      { agentName: 'ruby', sync: false, expected: 'async', description: 'Ruby' },
+      { agentName: 'java', sync: true, expected: undefined, description: 'Java' },
+      { agentName: 'java', sync: false, expected: 'async', description: 'Java' },
+      { agentName: 'go', sync: true, expected: undefined, description: 'Go' },
+      { agentName: 'go', sync: false, expected: 'async', description: 'Go' },
+    ])('$description: agentName=$agentName, sync=$sync', ({ agentName, sync, expected }) => {
+      it(`returns ${expected === undefined ? 'undefined' : `"${expected}"`}`, () => {
+        expect(getSyncLabel(agentName as AgentName, sync)).toBe(expected);
+      });
     });
-    it('does not show async badge', () => {
-      expect(getSyncLabel('nodejs', false)).toBeUndefined();
-    });
-  });
-  describe('PHP', () => {
-    it('does not show blocking badge', () => {
-      expect(getSyncLabel('php', true)).toBeUndefined();
-    });
-    it('shows async badge', () => {
-      expect(getSyncLabel('php', false)).toBe('async');
-    });
-  });
-  describe('Python', () => {
-    it('does not show blocking badge', () => {
-      expect(getSyncLabel('python', true)).toBeUndefined();
-    });
-    it('shows async badge', () => {
-      expect(getSyncLabel('python', false)).toBe('async');
-    });
-  });
-  describe('.NET', () => {
-    it('does not show blocking badge', () => {
-      expect(getSyncLabel('dotnet', true)).toBeUndefined();
-    });
-    it('shows async badge', () => {
-      expect(getSyncLabel('dotnet', false)).toBe('async');
-    });
-  });
-  describe('iOS', () => {
-    it('does not show blocking badge', () => {
-      expect(getSyncLabel('iOS/swift', true)).toBeUndefined();
-    });
-    it('shows async badge', () => {
-      expect(getSyncLabel('iOS/swift', false)).toBe('async');
-    });
-  });
-  describe('Ruby', () => {
-    it('does not show blocking badge', () => {
-      expect(getSyncLabel('ruby', true)).toBeUndefined();
-    });
-    it('shows async badge', () => {
-      expect(getSyncLabel('ruby', false)).toBe('async');
-    });
-  });
-  describe('Java', () => {
-    it('does not show blocking badge', () => {
-      expect(getSyncLabel('java', true)).toBeUndefined();
-    });
-    it('shows async badge', () => {
-      expect(getSyncLabel('java', false)).toBe('async');
-    });
-  });
-  describe('JS', () => {
-    it('shows blocking badge', () => {
-      expect(getSyncLabel('js-base', true)).toBe('blocking');
-    });
-    it('does not show async badge', () => {
-      expect(getSyncLabel('js-base', false)).toBeUndefined();
-    });
-  });
-  describe('RUM', () => {
-    it('shows blocking badge', () => {
-      expect(getSyncLabel('rum-js', true)).toBe('blocking');
-    });
-    it('does not show async badge', () => {
-      expect(getSyncLabel('rum-js', false)).toBeUndefined();
-    });
-  });
 
-  describe('Go', () => {
-    it('does not show blocking badge', () => {
-      expect(getSyncLabel('go', true)).toBeUndefined();
-    });
-    it('shows async badge', () => {
-      expect(getSyncLabel('go', false)).toBe('async');
-    });
-  });
-
-  describe('OTEL documents without agentName', () => {
-    it('does not show badge when agentName is undefined', () => {
-      expect(getSyncLabel(undefined, true)).toBeUndefined();
-      expect(getSyncLabel(undefined, false)).toBeUndefined();
+    describe('OTEL documents without agentName', () => {
+      it('does not show badge when agentName is undefined', () => {
+        expect(getSyncLabel(undefined, true)).toBeUndefined();
+        expect(getSyncLabel(undefined, false)).toBeUndefined();
+      });
     });
   });
 });
 
 describe('SyncBadge Component', () => {
   describe('Tooltip functionality', () => {
-    it('renders blocking badge with tooltip for nodejs', async () => {
-      const user = userEvent.setup();
+    it('renders badge with tooltip on hover', async () => {
       render(<SyncBadge sync={true} agentName="nodejs" />);
-
+      const user = userEvent.setup({ delay: null });
       const badge = screen.getByText('blocking');
       expect(badge).toBeInTheDocument();
 
       await user.hover(badge);
-      expect(
-        await screen.findByText(
-          'Indicates whether the span was executed synchronously or asynchronously.'
-        )
-      ).toBeInTheDocument();
-    });
 
-    it('renders async badge with tooltip for python', async () => {
-      const user = userEvent.setup();
-      render(<SyncBadge sync={false} agentName="python" />);
-
-      const badge = screen.getByText('async');
-      expect(badge).toBeInTheDocument();
-
-      await user.hover(badge);
-      expect(
-        await screen.findByText(
-          'Indicates whether the span was executed synchronously or asynchronously.'
-        )
-      ).toBeInTheDocument();
-    });
-
-    it('renders async badge with tooltip for go', async () => {
-      const user = userEvent.setup();
-      render(<SyncBadge sync={false} agentName="go" />);
-
-      const badge = screen.getByText('async');
-      expect(badge).toBeInTheDocument();
-
-      await user.hover(badge);
-      expect(
-        await screen.findByText(
-          'Indicates whether the span was executed synchronously or asynchronously.'
-        )
-      ).toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.getByText(
+            'Indicates whether the span was executed synchronously or asynchronously.'
+          )
+        ).toBeInTheDocument()
+      );
     });
 
     it('does not render badge when sync is undefined', () => {
@@ -154,11 +76,13 @@ describe('SyncBadge Component', () => {
       expect(screen.queryByText('async')).not.toBeInTheDocument();
     });
 
-    it('does not render badge when label conditions are not met', () => {
+    it('does not render badge when nodejs agent has sync=false', () => {
       render(<SyncBadge sync={false} agentName="nodejs" />);
       expect(screen.queryByText('blocking')).not.toBeInTheDocument();
       expect(screen.queryByText('async')).not.toBeInTheDocument();
+    });
 
+    it('does not render badge when python agent has sync=true', () => {
       render(<SyncBadge sync={true} agentName="python" />);
       expect(screen.queryByText('blocking')).not.toBeInTheDocument();
       expect(screen.queryByText('async')).not.toBeInTheDocument();
@@ -166,34 +90,18 @@ describe('SyncBadge Component', () => {
   });
 
   describe('Badge content', () => {
-    it('shows correct blocking badge for js-base agent', () => {
-      render(<SyncBadge sync={true} agentName="js-base" />);
-      expect(screen.getByText('blocking')).toBeInTheDocument();
-    });
-
-    it('shows correct async badge for php agent', () => {
-      render(<SyncBadge sync={false} agentName="php" />);
-      expect(screen.getByText('async')).toBeInTheDocument();
-    });
-
-    it('shows correct async badge for dotnet agent', () => {
-      render(<SyncBadge sync={false} agentName="dotnet" />);
-      expect(screen.getByText('async')).toBeInTheDocument();
-    });
-
-    it('shows correct async badge for ruby agent', () => {
-      render(<SyncBadge sync={false} agentName="ruby" />);
-      expect(screen.getByText('async')).toBeInTheDocument();
-    });
-
-    it('shows correct async badge for java agent', () => {
-      render(<SyncBadge sync={false} agentName="java" />);
-      expect(screen.getByText('async')).toBeInTheDocument();
-    });
-
-    it('shows correct async badge for iOS/swift agent', () => {
-      render(<SyncBadge sync={false} agentName="iOS/swift" />);
-      expect(screen.getByText('async')).toBeInTheDocument();
+    describe.each([
+      { agentName: 'js-base', sync: true, expected: 'blocking' },
+      { agentName: 'php', sync: false, expected: 'async' },
+      { agentName: 'dotnet', sync: false, expected: 'async' },
+      { agentName: 'ruby', sync: false, expected: 'async' },
+      { agentName: 'java', sync: false, expected: 'async' },
+      { agentName: 'iOS/swift', sync: false, expected: 'async' },
+    ])('$agentName with sync=$sync', ({ agentName, sync, expected }) => {
+      it(`shows correct ${expected} badge`, () => {
+        render(<SyncBadge sync={sync} agentName={agentName as AgentName} />);
+        expect(screen.getByText(expected)).toBeInTheDocument();
+      });
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/sync_badge/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/sync_badge/index.test.tsx
@@ -5,10 +5,9 @@
  * 2.0.
  */
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import type { AgentName } from '@kbn/apm-types/es_schemas_ui';
 import { getSyncLabel, SyncBadge } from '.';
-import userEvent from '@testing-library/user-event';
 
 describe('Sync badge', () => {
   describe('getSyncLabel', () => {
@@ -54,11 +53,10 @@ describe('SyncBadge Component', () => {
   describe('Tooltip functionality', () => {
     it('renders badge with tooltip on hover', async () => {
       render(<SyncBadge sync={true} agentName="nodejs" />);
-      const user = userEvent.setup({ delay: null });
       const badge = screen.getByText('blocking');
       expect(badge).toBeInTheDocument();
 
-      await user.hover(badge);
+      fireEvent.mouseOver(badge);
 
       await waitFor(() =>
         expect(

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_item_row.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_item_row.test.tsx
@@ -31,6 +31,20 @@ jest.mock('./bar_details', () => ({
     <div data-test-subj="bar-details" data-item={item.id} data-left={left} />
   ),
 }));
+jest.mock('./toggle_accordion_button', () => ({
+  TOGGLE_BUTTON_WIDTH: 20,
+  ToggleAccordionButton: ({ isOpen, childrenCount, onClick }: any) => (
+    <div
+      data-test-subj="toggle-btn"
+      data-open={isOpen}
+      data-count={childrenCount}
+      onClick={onClick}
+      onKeyDown={onClick}
+      role="button"
+      tabIndex={0}
+    />
+  ),
+}));
 jest.mock('./trace_waterfall_context');
 jest.mock('@elastic/eui', () => {
   const actual = jest.requireActual('@elastic/eui');
@@ -99,7 +113,9 @@ describe('TraceItemRow', () => {
     const { getByTestId } = render(
       <TraceItemRow item={baseItem} childrenCount={2} state="open" onToggle={jest.fn()} />
     );
-    expect(getByTestId('toggleAccordionButton')).toBeInTheDocument();
+    expect(getByTestId('toggle-btn')).toBeInTheDocument();
+    expect(getByTestId('toggle-btn')).toHaveAttribute('data-open', 'true');
+    expect(getByTestId('toggle-btn')).toHaveAttribute('data-count', '2');
   });
 
   it('calls onToggle when ToggleAccordionButton is clicked', () => {
@@ -107,7 +123,7 @@ describe('TraceItemRow', () => {
     const { getByTestId } = render(
       <TraceItemRow item={baseItem} childrenCount={2} state="open" onToggle={onToggle} />
     );
-    fireEvent.click(getByTestId('toggleAccordionButton'));
+    fireEvent.click(getByTestId('toggle-btn'));
     expect(onToggle).toHaveBeenCalledWith('span-1');
   });
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_item_row.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_item_row.test.tsx
@@ -31,19 +31,6 @@ jest.mock('./bar_details', () => ({
     <div data-test-subj="bar-details" data-item={item.id} data-left={left} />
   ),
 }));
-jest.mock('./toggle_accordion_button', () => ({
-  TOGGLE_BUTTON_WIDTH: 10,
-  ToggleAccordionButton: ({ isOpen, childrenCount, onClick }: any) => (
-    <button
-      data-test-subj="toggle-btn"
-      data-open={isOpen}
-      data-count={childrenCount}
-      onClick={onClick}
-    >
-      Toggle
-    </button>
-  ),
-}));
 jest.mock('./trace_waterfall_context');
 jest.mock('@elastic/eui', () => {
   const actual = jest.requireActual('@elastic/eui');
@@ -112,9 +99,7 @@ describe('TraceItemRow', () => {
     const { getByTestId } = render(
       <TraceItemRow item={baseItem} childrenCount={2} state="open" onToggle={jest.fn()} />
     );
-    expect(getByTestId('toggle-btn')).toBeInTheDocument();
-    expect(getByTestId('toggle-btn')).toHaveAttribute('data-open', 'true');
-    expect(getByTestId('toggle-btn')).toHaveAttribute('data-count', '2');
+    expect(getByTestId('toggleAccordionButton')).toBeInTheDocument();
   });
 
   it('calls onToggle when ToggleAccordionButton is clicked', () => {
@@ -122,7 +107,7 @@ describe('TraceItemRow', () => {
     const { getByTestId } = render(
       <TraceItemRow item={baseItem} childrenCount={2} state="open" onToggle={onToggle} />
     );
-    fireEvent.click(getByTestId('toggle-btn'));
+    fireEvent.click(getByTestId('toggleAccordionButton'));
     expect(onToggle).toHaveBeenCalledWith('span-1');
   });
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_item_row.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_item_row.test.tsx
@@ -32,7 +32,7 @@ jest.mock('./bar_details', () => ({
   ),
 }));
 jest.mock('./toggle_accordion_button', () => ({
-  TOGGLE_BUTTON_WIDTH: 20,
+  TOGGLE_BUTTON_WIDTH: 10,
   ToggleAccordionButton: ({ isOpen, childrenCount, onClick }: any) => (
     <div
       data-test-subj="toggle-btn"


### PR DESCRIPTION
## Summary

Small cleanup in a couple of trace waterfall tests:

- [trace_item_row.test.tsx](https://github.com/lucaslopezf/kibana/blob/d174eda6bc17e07c3b37b7f7313a34a8e5e626ed/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_item_row.test.tsx)
  - Fixes a silent warning
- [BadgeSync tests](https://github.com/lucaslopezf/kibana/blob/d174eda6bc17e07c3b37b7f7313a34a8e5e626ed/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/badges/sync_badge/index.test.tsx)
  - Removes redundant tests
  - Slightly improves performance

Before: 

<img width="572" height="220" alt="image" src="https://github.com/user-attachments/assets/81d572c1-4776-4fdc-8dc4-a1e3c6bcf014" />

Now:

<img width="685" height="224" alt="image" src="https://github.com/user-attachments/assets/4efda1f6-3036-4673-98ab-684991329dc8" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



