### PR TITLE
[Synthetics] Fix useSyntheticsRules test

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/hooks/use_synthetics_rules.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/hooks/use_synthetics_rules.test.tsx
@@ -57,8 +57,7 @@ const contextsModule = require('../../../contexts');
 const mockUseSyntheticsSettingsContext =
   contextsModule.useSyntheticsSettingsContext as jest.MockedFunction<any>;
 
-// Failing: See https://github.com/elastic/kibana/issues/246633
-describe.skip('useSyntheticsRules', () => {
+describe('useSyntheticsRules', () => {
   const baseMockState = {
     defaultAlerting: {
       data: {
@@ -181,7 +180,12 @@ describe.skip('useSyntheticsRules', () => {
       wrapper: TestWrapper,
     });
 
-    expect(mockDispatch).toHaveBeenCalledWith(enableDefaultAlertingSilentlyAction.get());
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: enableDefaultAlertingSilentlyAction.get().type,
+        meta: { dispatchedAt: expect.any(Number) },
+      })
+    );
   });
 
   it('dispatches getDefaultAlertingAction when canSave is false and popover opens', () => {
@@ -203,7 +207,12 @@ describe.skip('useSyntheticsRules', () => {
       wrapper: TestWrapper,
     });
 
-    expect(mockDispatch).toHaveBeenCalledWith(getDefaultAlertingAction.get());
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: getDefaultAlertingAction.get().type,
+        meta: { dispatchedAt: expect.any(Number) },
+      })
+    );
   });
 
   it('returns NewRuleFlyout as null when isNewRule is false', () => {


### PR DESCRIPTION
### Summary
Fixes a timing-based flaky test failure in `use_synthetics_rules.test.tsx`.

### Problem
The test assertions were comparing full action objects including `meta.dispatchedAt` timestamps. Since the timestamp is generated at call time, there's a small time difference between when the hook dispatches the action and when the test generates a new action for comparison, causing intermittent failures:

### Solution
Use `expect.objectContaining()` with `expect.any(Number)` to validate the action structure without requiring an exact timestamp match.

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->