### PR TITLE
Cleaner stop of Kibana and ES (they might be undefined)

### DIFF
--- a/src/core/server/integration_tests/ci_checks/saved_objects/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/ci_checks/saved_objects/check_registered_types.test.ts
@@ -38,12 +38,8 @@ describe('checking migration metadata changes on all registered SO types', () =>
   });
 
   afterAll(async () => {
-    if (root) {
-      await root.shutdown();
-    }
-    if (esServer) {
-      await esServer.stop();
-    }
+    await root?.shutdown();
+    await esServer?.stop();
   });
 
   // This test is meant to fail when any change is made in registered types that could potentially impact the SO migration.

--- a/src/core/server/integration_tests/core_app/default_route_provider_config.test.ts
+++ b/src/core/server/integration_tests/core_app/default_route_provider_config.test.ts
@@ -39,8 +39,8 @@ describe('default route provider', () => {
     });
 
     afterAll(async () => {
-      await esServer.stop();
-      await root.shutdown();
+      await esServer?.stop();
+      await root?.shutdown();
     });
 
     it('redirects to the configured default route respecting basePath', async function () {

--- a/src/core/server/integration_tests/elasticsearch/capabilities.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/capabilities.test.ts
@@ -31,9 +31,7 @@ describe('ES capabilities for traditional ES', () => {
   });
 
   afterEach(async () => {
-    if (esServer) {
-      await esServer.stop();
-    }
+    await esServer?.stop();
   });
 
   it('returns the correct capabilities', async () => {

--- a/src/core/server/integration_tests/elasticsearch/client.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/client.test.ts
@@ -35,8 +35,8 @@ describe('elasticsearch clients', () => {
   });
 
   afterAll(async () => {
-    await kibanaServer.stop();
-    await esServer.stop();
+    await kibanaServer?.stop();
+    await esServer?.stop();
   });
 
   it('does not return deprecation warning when x-elastic-product-origin header is set', async () => {

--- a/src/core/server/integration_tests/elasticsearch/error_logging.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/error_logging.test.ts
@@ -52,8 +52,8 @@ describe('Error logging', () => {
 
     afterAll(async () => {
       mockConsoleLog.mockRestore();
-      await kibanaServer.stop();
-      await esServer.stop();
+      await kibanaServer?.stop();
+      await esServer?.stop();
     });
 
     it('logs errors following the expected pattern for the json layout', async () => {

--- a/src/core/server/integration_tests/elasticsearch/errors.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/errors.test.ts
@@ -28,8 +28,8 @@ describe('elasticsearch clients errors', () => {
   });
 
   afterAll(async () => {
-    await kibanaServer.stop();
-    await esServer.stop();
+    await kibanaServer?.stop();
+    await esServer?.stop();
   });
 
   it('has the proper JSON representation', async () => {

--- a/src/core/server/integration_tests/elasticsearch/is_scripting_enabled.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/is_scripting_enabled.test.ts
@@ -19,12 +19,8 @@ describe('isInlineScriptingEnabled', () => {
   let kibanaServer: TestKibanaUtils;
 
   afterEach(async () => {
-    if (kibanaServer) {
-      await kibanaServer.stop();
-    }
-    if (esServer) {
-      await esServer.stop();
-    }
+    await kibanaServer?.stop();
+    await esServer?.stop();
   });
 
   const startServers = async ({ esArgs = [] }: { esArgs?: string[] } = {}) => {

--- a/src/core/server/integration_tests/elasticsearch/max_response_size_logging.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/max_response_size_logging.test.ts
@@ -53,8 +53,8 @@ describe('Elasticsearch max response size', () => {
 
   afterAll(async () => {
     mockConsoleLog.mockRestore();
-    await kibanaServer.stop();
-    await esServer.stop();
+    await kibanaServer?.stop();
+    await esServer?.stop();
   });
 
   it('rejects the response when the response size is larger than the requested limit', async () => {

--- a/src/core/server/integration_tests/elasticsearch/version_compatibility.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/version_compatibility.test.ts
@@ -44,14 +44,9 @@ describe('Version Compatibility', () => {
 
   afterEach(async () => {
     consoleSpy.mockRestore();
-    if (kibanaServer) {
-      await kibanaServer.stop();
-    } else {
-      abortController?.abort();
-    }
-    if (esServer) {
-      await esServer.stop();
-    }
+    await kibanaServer?.stop();
+    abortController?.abort();
+    await esServer?.stop();
     kibanaServer = undefined;
     abortController = undefined;
     esServer = undefined;

--- a/src/core/server/integration_tests/execution_context/tracing.test.ts
+++ b/src/core/server/integration_tests/execution_context/tracing.test.ts
@@ -44,7 +44,7 @@ describe('trace', () => {
   });
 
   afterAll(async () => {
-    await esServer.stop();
+    await esServer?.stop();
   });
 
   beforeEach(async () => {

--- a/src/core/server/integration_tests/saved_objects/migrations/group1/v2_migration.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group1/v2_migration.test.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { setTimeout as timer } from 'timers/promises';
 import { join } from 'path';
 import { omit } from 'lodash';
 import JSON5 from 'json5';
@@ -46,12 +45,7 @@ describe('v2 migration', () => {
     esServer = await startElasticsearch({ dataArchive: BASELINE_TEST_ARCHIVE_LARGE });
   });
 
-  afterAll(async () => {
-    if (esServer) {
-      await esServer.stop();
-      await timer(5_000); // give it a few seconds... cause we always do ¯\_(ツ)_/¯
-    }
-  });
+  afterAll(async () => await esServer?.stop());
 
   describe('to the current stack version', () => {
     let upToDateKit: KibanaMigratorTestKit;

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
@@ -137,9 +137,7 @@ describe('migration actions', () => {
     })();
   });
 
-  afterAll(async () => {
-    await esServer.stop();
-  });
+  afterAll(async () => await esServer?.stop());
 
   describe('fetchIndices', () => {
     afterAll(async () => {

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
@@ -179,7 +179,7 @@ export const runActionTestSuite = ({
     await client.indices.delete({ index: 'existing_index_2' }).catch(() => ({}));
     await client.indices.delete({ index: 'existing_index_with_write_block' }).catch(() => ({}));
 
-    await esServer.stop();
+    await esServer?.stop();
   });
 
   describe('fetchIndices', () => {

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/es_errors.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/es_errors.test.ts
@@ -57,8 +57,8 @@ describe('Elasticsearch Errors', () => {
   });
 
   afterAll(async () => {
-    await esServer.stop();
-    await root.shutdown();
+    await root?.shutdown();
+    await esServer?.stop();
   });
 
   describe('isWriteBlockException', () => {

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/incompatible_cluster_routing_allocation.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/incompatible_cluster_routing_allocation.test.ts
@@ -58,9 +58,7 @@ describe('incompatible_cluster_routing_allocation', () => {
     esServer = await startES();
   });
 
-  afterAll(async () => {
-    await esServer.stop();
-  });
+  afterAll(async () => await esServer?.stop());
 
   it('retries the INIT action with a descriptive message when cluster settings are incompatible', async () => {
     const { client, runMigrations } = await getRelocatingMigratorTestKit({

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/skip_migration.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/skip_migration.test.ts
@@ -66,12 +66,8 @@ describe('starting with `migration.skip: true` when indices are up to date', () 
   });
 
   afterAll(async () => {
-    if (root) {
-      await root.shutdown();
-    }
-    if (esServer) {
-      await esServer.stop();
-    }
+    await root?.shutdown();
+    await esServer?.stop();
   });
 
   it('starts and display the correct service status', async () => {

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/wait_for_migration_completion.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/wait_for_migration_completion.test.ts
@@ -35,12 +35,8 @@ describe('migration with waitForCompletion=true', () => {
   });
 
   afterAll(async () => {
-    if (root) {
-      await root.shutdown();
-    }
-    if (esServer) {
-      await esServer.stop();
-    }
+    await root?.shutdown();
+    await esServer?.stop();
   });
 
   it('waits for another instance to complete the migration', async () => {

--- a/src/core/server/integration_tests/saved_objects/service/internal_client.test.ts
+++ b/src/core/server/integration_tests/saved_objects/service/internal_client.test.ts
@@ -81,12 +81,8 @@ describe('SavedObjects Internal Client Integration', () => {
   });
 
   afterAll(async () => {
-    if (root) {
-      await root.shutdown();
-    }
-    if (esServer) {
-      await esServer.stop();
-    }
+    await root?.shutdown();
+    await esServer?.stop();
   });
 
   describe('Basic Operations', () => {

--- a/src/core/server/integration_tests/saved_objects/service/lib/repository.test.ts
+++ b/src/core/server/integration_tests/saved_objects/service/lib/repository.test.ts
@@ -47,10 +47,8 @@ describe('SavedObjectsRepository', () => {
   });
 
   afterAll(async () => {
-    if (root) {
-      await esServer.stop();
-      await root.shutdown();
-    }
+    await esServer?.stop();
+    await root?.shutdown();
   });
 
   describe('#incrementCounter', () => {

--- a/src/core/server/integration_tests/saved_objects/service/lib/repository_with_proxy.test.ts
+++ b/src/core/server/integration_tests/saved_objects/service/lib/repository_with_proxy.test.ts
@@ -140,11 +140,9 @@ describe('404s from proxies', () => {
   });
 
   afterAll(async () => {
-    if (root) {
-      await root.shutdown();
-      await hapiServer.stop({ timeout: 1000 });
-      await esServer.stop();
-    }
+    await root?.shutdown();
+    await hapiServer?.stop({ timeout: 1000 });
+    await esServer?.stop();
   });
 
   describe('requests when a proxy relays request/responses with the correct product header', () => {

--- a/src/core/server/integration_tests/saved_objects/validation/validator.test.ts
+++ b/src/core/server/integration_tests/saved_objects/validation/validator.test.ts
@@ -160,12 +160,8 @@ describe.skip('validates saved object types when a schema is provided', () => {
   });
 
   afterAll(async () => {
-    if (root) {
-      await root.shutdown();
-    }
-    if (esServer) {
-      await esServer.stop();
-    }
+    await root?.shutdown();
+    await esServer?.stop();
   });
 
   it('does nothing when no schema is provided', async () => {

--- a/src/core/server/integration_tests/ui_settings/create_or_upgrade.test.ts
+++ b/src/core/server/integration_tests/ui_settings/create_or_upgrade.test.ts
@@ -68,8 +68,8 @@ describe('createOrUpgradeSavedConfig()', () => {
   });
 
   afterAll(async () => {
-    await esServer.stop();
-    await kbn.stop();
+    await esServer?.stop();
+    await kbn?.stop();
   });
 
   it('upgrades the previous version on each increment', async function () {

--- a/src/core/server/integration_tests/ui_settings/lib/servers.ts
+++ b/src/core/server/integration_tests/ui_settings/lib/servers.ts
@@ -92,10 +92,6 @@ export function getServices() {
 
 export async function stopServers() {
   services = null!;
-  if (esServer) {
-    await esServer.stop();
-  }
-  if (kbn) {
-    await kbn.stop();
-  }
+  await esServer?.stop();
+  await kbn?.stop();
 }

--- a/src/core/test_helpers/so_migrations.ts
+++ b/src/core/test_helpers/so_migrations.ts
@@ -152,8 +152,8 @@ export const createTestHarness = () => {
       if (stopped)
         throw new Error(`SavedObjectTestHarness already stopped! Cannot call stop again`);
 
-      await root.shutdown();
-      await esServer.stop();
+      await root?.shutdown();
+      await esServer?.stop();
       stopped = true;
     },
 

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
@@ -111,8 +111,8 @@ describe.skip(`daily rollups integration test`, () => {
   });
 
   afterAll(async () => {
-    await esServer.stop();
-    await root.shutdown();
+    await root?.shutdown();
+    await esServer?.stop();
   });
 
   it('deletes documents older that 3 days from the saved objects repository', async () => {

--- a/src/platform/plugins/shared/usage_collection/server/usage_counters/integration_tests/rollups.test.ts
+++ b/src/platform/plugins/shared/usage_collection/server/usage_counters/integration_tests/rollups.test.ts
@@ -142,8 +142,8 @@ describe('usage-counters', () => {
   });
 
   afterAll(async () => {
-    await esServer.stop();
-    await root.shutdown();
+    await root?.shutdown();
+    await esServer?.stop();
   });
 });
 

--- a/src/platform/plugins/shared/usage_collection/server/usage_counters/integration_tests/search.test.ts
+++ b/src/platform/plugins/shared/usage_collection/server/usage_counters/integration_tests/search.test.ts
@@ -230,8 +230,8 @@ describe('usage-counters#search', () => {
   });
 
   afterAll(async () => {
-    await esServer.stop();
-    await root.shutdown();
+    await root?.shutdown();
+    await esServer?.stop();
   });
 });
 


### PR DESCRIPTION
## Summary

This will help making test failures cleaner (see https://github.com/elastic/kibana/issues/188963#issuecomment-3682155854).

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->