### PR TITLE
[Streams] Fixes browser console errors

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/preview_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/preview_table.tsx
@@ -26,7 +26,7 @@ import { i18n } from '@kbn/i18n';
 import type { SampleDocument } from '@kbn/streams-schema';
 import ColumnHeaderTruncateContainer from '@kbn/unified-data-table/src/components/column_header_truncate_container';
 import { FieldIcon } from '@kbn/react-field';
-import React, { useMemo, useState, useCallback, createContext, useContext } from 'react';
+import React, { useMemo, useState, useCallback, createContext, useContext, useEffect } from 'react';
 import type {
   IgnoredField,
   DocumentWithIgnoredFields,
@@ -77,6 +77,35 @@ function RowSelectionButton({ rowIndex }: { rowIndex: number }) {
       color={selectedRowIndex === rowIndex ? 'primary' : 'text'}
     />
   );
+}
+
+function RowSelectionCell({
+  rowIndex,
+  setCellProps,
+  highlightColor,
+}: {
+  rowIndex: number;
+  setCellProps: (props: { style: React.CSSProperties }) => void;
+  highlightColor: string;
+}) {
+  const { selectedRowIndex } = useRowSelection();
+  const isSelected = selectedRowIndex === rowIndex;
+
+  useEffect(() => {
+    if (isSelected) {
+      setCellProps({
+        style: {
+          backgroundColor: highlightColor,
+        },
+      });
+    } else {
+      setCellProps({
+        style: {},
+      });
+    }
+  }, [isSelected, setCellProps, highlightColor]);
+
+  return <RowSelectionButton rowIndex={rowIndex} />;
 }
 
 export const MemoPreviewTable = React.memo(PreviewTable);
@@ -280,23 +309,13 @@ export function PreviewTable({
         id: 'selection',
         width: 36,
         headerCellRender: () => null,
-        rowCellRender: ({ rowIndex, setCellProps }) => {
-          // eslint-disable-next-line react-hooks/rules-of-hooks
-          const { selectedRowIndex } = useRowSelection();
-
-          if (selectedRowIndex === rowIndex) {
-            setCellProps({
-              style: {
-                backgroundColor: theme.colors.highlight,
-              },
-            });
-          } else {
-            setCellProps({
-              style: {},
-            });
-          }
-          return <RowSelectionButton rowIndex={rowIndex} />;
-        },
+        rowCellRender: ({ rowIndex, setCellProps }) => (
+          <RowSelectionCell
+            rowIndex={rowIndex}
+            setCellProps={setCellProps}
+            highlightColor={theme.colors.highlight}
+          />
+        ),
       },
     ],
     [theme.colors.highlight]

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/preview_table_cell.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/shared/preview_table_cell.tsx
@@ -14,7 +14,7 @@ import type {
 } from '@kbn/streams-schema/src/shared/record_types';
 import { LazySummaryColumn } from '@kbn/discover-contextual-components';
 import { DataGridDensity, ROWS_HEIGHT_OPTIONS } from '@kbn/unified-data-table';
-import React, { useContext, memo } from 'react';
+import React, { useContext, memo, useEffect } from 'react';
 import type { CoreStart } from '@kbn/core/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
@@ -162,18 +162,21 @@ export function PreviewTableCell({
 }: PreviewTableCellProps) {
   const { euiTheme: theme } = useEuiTheme();
   const { selectedRowIndex } = useContext(RowSelectionContext);
+  const isSelected = selectedRowIndex === rowIndex;
 
-  if (selectedRowIndex === rowIndex) {
-    setCellProps({
-      style: {
-        backgroundColor: theme.colors.highlight,
-      },
-    });
-  } else {
-    setCellProps({
-      style: {},
-    });
-  }
+  useEffect(() => {
+    if (isSelected) {
+      setCellProps({
+        style: {
+          backgroundColor: theme.colors.highlight,
+        },
+      });
+    } else {
+      setCellProps({
+        style: {},
+      });
+    }
+  }, [isSelected, setCellProps, theme.colors.highlight]);
 
   const doc = documents[rowIndex];
   const document = isDocumentWithIgnoredFields(doc) ? doc.values : doc;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/child_stream_list.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/child_stream_list.tsx
@@ -105,7 +105,7 @@ export function ChildStreamList({ availableStreams }: { availableStreams: string
 
   const renderCreateButton = () => {
     return (
-      <EuiFlexItem grow={false} alignItems="flex-start">
+      <EuiFlexItem grow={false}>
         <EuiFlexGroup
           justifyContent="center"
           alignItems="center"


### PR DESCRIPTION
## Summary

This fixes two React errors in the console in dev mode:

**Reason: Incorrectly added `alignItems` prop on `EuiFlexItem` https://github.com/elastic/kibana/pull/247267/changes/c85dc53ff100c586710ebe743c4a28a50b29c1d1**
<img width="2326" height="1427" alt="Screenshot 2025-12-22 at 15 05 56" src="https://github.com/user-attachments/assets/174c8e5f-9e90-4bba-92a3-0014827fbb98" />

**Reason: Cannot update during an existing state transition (such as within `render`): moved cell rendering into its own component https://github.com/elastic/kibana/pull/247267/changes/db5ebe831c80ccf378eb2ff118c59bef862ff444**
<img width="2326" height="1427" alt="Screenshot 2025-12-22 at 15 07 03" src="https://github.com/user-attachments/assets/cae31cb7-bde3-4977-adee-ce0231de042b" />

