### PR TITLE
[ES|QL] Fix STATS grouping column tracking for backticked names

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/columns_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/columns_after.test.ts
@@ -96,4 +96,26 @@ describe('STATS', () => {
       { name: 'buckets', type: 'date', userDefined: true, location: { min: 30, max: 36 } },
     ]);
   });
+
+  it('keeps grouping column names unescaped when quoted', () => {
+    const previousCommandFields: ESQLColumnData[] = [
+      { name: 'field2', type: 'double', userDefined: false },
+      { name: 'ss', type: 'keyword', userDefined: true, location: { min: 0, max: 0 } },
+    ];
+
+    const queryString = `FROM a | STATS AVG(field2) BY \`ss\``;
+
+    const {
+      root: {
+        commands: [, command],
+      },
+    } = Parser.parseQuery(queryString);
+
+    const result = columnsAfter(command, previousCommandFields, queryString);
+
+    expect(result).toEqual<ESQLColumnData[]>([
+      { name: 'AVG(field2)', type: 'double', userDefined: true, location: { min: 15, max: 25 } },
+      { name: 'ss', type: 'keyword', userDefined: true, location: { min: 30, max: 33 } },
+    ]);
+  });
 });

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/columns_after.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/stats/columns_after.ts
@@ -54,6 +54,18 @@ const getUserDefinedColumns = (
       continue;
     }
 
+    if (isColumn(expression)) {
+      const name = expression.parts.join('.');
+      const newColumn: ESQLUserDefinedColumn = {
+        name,
+        type: typeOf(expression),
+        location: expression.location,
+        userDefined: true,
+      };
+      columns.push(newColumn);
+      continue;
+    }
+
     if (!isOptionNode(expression) && !Array.isArray(expression)) {
       const newColumn: ESQLUserDefinedColumn = {
         name: query.substring(expression.location.min, expression.location.max + 1),


### PR DESCRIPTION
## Summary
```javascript
FROM kibana_sample_data_logs
  | SORT @timestamp
  | EVAL now = NOW()
  | EVAL
      `ss` =
        CASE(@timestamp < now - 1 hour AND @timestamp > now - 2 hour, "Last hour",
          "Other")
  | STATS count = COUNT(*)
        BY `ss`
  | EVAL
      count_last_hour = CASE(`ss` == "Last hour", count),
      count_rest = CASE(`ss` == "Other", count)
  | EVAL
      total_visits =
        TO_DOUBLE(
          COALESCE(count_last_hour, 0::LONG) + COALESCE(count_rest, 0::LONG))
  | STATS count_last_hour = SUM(count_last_hour), total_visits = SUM(total_visits)
```

this query generate a validation error : unknow column in:

```javascript
count_last_hour = CASE(`ss
````

In STATS ` columns_after.ts,` -> the last fallback block in `BY `failed to strip backticks because it relied on raw query text rather than a normalized identifier.


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->