### PR TITLE
[Synthetics] Use unicode escaping to prevent Agent from interpreting JS template literals as policy variables

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.test.ts
@@ -244,14 +244,15 @@ describe('replaceStringWithParams', () => {
     expect(result).toEqual({});
   });
 
-  it(`should replace $ {} with adding $ in start for template literal`, () => {
+  it(`should escape template literals using unicode for private location compatibility`, () => {
     const value = inlineSourceFormatter(
       {
         [ConfigKey.SOURCE_INLINE]: 'const a = ${b}; const c = ${d}',
       },
       ConfigKey.SOURCE_INLINE
     );
-    expect(value).toEqual('const a = $${b}; const c = $${d}');
+    // Uses unicode escape \u0024 for $ to prevent Elastic Agent from interpreting as policy variables
+    expect(value).toEqual('const a = \\u0024{b}; const c = \\u0024{d}');
   });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
@@ -125,7 +125,10 @@ export const formatMWs = (mws?: MaintenanceWindow[], strRes = true) => {
 };
 
 function escapeTemplateLiterals(script: string): string {
-  return script.replace(/\$\{/g, '$$${');
+  // Escape ${...} to prevent Elastic Agent from interpreting as policy variables.
+  // Using unicode escape \u0024 for $ - agent won't recognize as variable,
+  // but JavaScript will interpret \u0024 as $ when the script runs.
+  return script.replace(/\$\{/g, '\\u0024{');
 }
 
 export const inlineSourceFormatter: FormatterFn = (fields, key) => {


### PR DESCRIPTION
## Summary
Related to https://github.com/elastic/kibana/pull/228696
Use Unicode escaping to prevent the Agent from interpreting JS template literals as policy variables

<img width="1724" height="539" alt="Image" src="https://github.com/user-attachments/assets/e5601d2c-90f1-4206-a3dc-1c4c42f0d0e4" />


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->