### PR TITLE
[Investigations] - Data view manager logging

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/lib/kibana/kibana_react.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/lib/kibana/kibana_react.mock.ts
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import type { RecursivePartial } from '@elastic/eui/src/components/common';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import { navigationPluginMock } from '@kbn/navigation-plugin/public/mocks';
 import { discoverPluginMock } from '@kbn/discover-plugin/public/mocks';
@@ -114,6 +115,7 @@ export const createStartServicesMock = (
   const apm = mockApm();
   const data = dataPluginMock.createStartContract();
   const customDataService = dataPluginMock.createStartContract();
+  const logger = loggingSystemMock.createLogger();
   const security = securityMock.createSetup();
   const urlService = new MockUrlService();
   const locator = urlService.locators.create(new MlLocatorDefinition());
@@ -155,6 +157,7 @@ export const createStartServicesMock = (
     configSettings: getDefaultConfigSettings(),
     apm,
     cases,
+    logger,
     unifiedSearch,
     navigation,
     discover,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.test.ts
@@ -7,6 +7,7 @@
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { DataView } from '@kbn/data-views-plugin/public';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 
 import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, PageScope } from '../constants';
 import { useDataView } from './use_data_view';
@@ -23,6 +24,7 @@ jest.mock('react-redux', () => ({
 
 const mockGet = jest.fn();
 const mockToastsDanger = jest.fn();
+const mockLogger = loggingSystemMock.createLogger();
 
 const mockNotifications = {
   toasts: {
@@ -47,6 +49,7 @@ jest.mock('../../common/lib/kibana', () => {
       services: {
         dataViews: mockDataViews,
         notifications: mockNotifications,
+        logger: mockLogger,
       },
     }),
   };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.ts
@@ -89,13 +89,15 @@ export const useDataView = (
         setLocalStatus('error');
       }
     })();
+    // This is specifically for the logger as it looks to create a new instance on every run of this hook
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     dataViews,
     dataViewId,
     internalStatus,
     notifications,
     newDataViewPickerEnabled,
-    logger,
+    // logger,
     dataViewManagerScope,
   ]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.ts
@@ -15,6 +15,7 @@ import { PageScope } from '../constants';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { sourcererAdapterSelector } from '../redux/selectors';
 import type { SharedDataViewSelectionState } from '../redux/types';
+import { useDataViewManagerLogger } from './use_data_view_logger';
 
 const INITIAL_DV = new DataView({
   fieldFormats: {} as FieldFormatsStartCommon,
@@ -40,6 +41,7 @@ export const useDataView = (
     sourcererAdapterSelector(dataViewManagerScope)
   );
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
+  const logger = useDataViewManagerLogger('useDataView');
   const [localStatus, setLocalStatus] =
     useState<SharedDataViewSelectionState['status']>('pristine');
   const [retrievedDataView, setRetrievedDataView] = useState<DataView>(INITIAL_DV);
@@ -52,10 +54,16 @@ export const useDataView = (
       }
 
       if (!dataViewId || internalStatus !== 'ready') {
+        logger.debug(
+          `Data view not loaded yet. dataViewId: ${dataViewId}, internalStatus: ${internalStatus}`
+        );
         return;
       }
 
       if (loadedForTheFirstTimeRef.current) {
+        logger.debug(
+          `DataView has loaded once already. Updating data view status to loading for scope ${dataViewManagerScope}...`
+        );
         setLocalStatus('loading');
       }
 
@@ -63,13 +71,16 @@ export const useDataView = (
         // TODO: remove conditional .get call when new data view picker is stabilized
         // this is due to the fact that many of our tests mock kibana hook and do not provide proper
         // double for dataViews service
+        logger.debug(`Fetching data view with ID: ${dataViewId}...`);
         const currDv = await dataViews?.get(dataViewId);
         if (!loadedForTheFirstTimeRef.current) {
           loadedForTheFirstTimeRef.current = true;
         }
+        logger.debug(`Data view with ID: ${dataViewId} fetched successfully.`);
         setRetrievedDataView(currDv);
         setLocalStatus('ready');
       } catch (error) {
+        logger.error(`Error fetching data view with ID: ${dataViewId}`, error);
         // TODO: (remove conditional call when feature flag is on (mocks are broken for some tests))
         notifications?.toasts?.addDanger({
           title: 'Error retrieving data view',
@@ -78,7 +89,15 @@ export const useDataView = (
         setLocalStatus('error');
       }
     })();
-  }, [dataViews, dataViewId, internalStatus, notifications, newDataViewPickerEnabled]);
+  }, [
+    dataViews,
+    dataViewId,
+    internalStatus,
+    notifications,
+    newDataViewPickerEnabled,
+    logger,
+    dataViewManagerScope,
+  ]);
 
   return useMemo(() => {
     if (!newDataViewPickerEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_logger.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_logger.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useKibana } from '../../common/lib/kibana';
+
+export const DATA_VIEW_LOGGER_NAME = 'dataViewManager';
+
+export const useDataViewManagerLogger = (...childContextPaths: string[]) => {
+  const services = useKibana().services;
+  childContextPaths.unshift(DATA_VIEW_LOGGER_NAME);
+  return services.logger.get(...childContextPaths);
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_logger.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_logger.ts
@@ -6,7 +6,7 @@
  */
 import { useKibana } from '../../common/lib/kibana';
 
-export const DATA_VIEW_LOGGER_NAME = 'dataViewManager';
+export const DATA_VIEW_LOGGER_NAME = '[SecuritySolution][DataViewManager]';
 
 export const useDataViewManagerLogger = (...childContextPaths: string[]) => {
   const services = useKibana().services;

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_logger.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_logger.ts
@@ -6,7 +6,7 @@
  */
 import { useKibana } from '../../common/lib/kibana';
 
-export const DATA_VIEW_LOGGER_NAME = '[SecuritySolution][DataViewManager]';
+export const DATA_VIEW_LOGGER_NAME = 'dataViewManager';
 
 export const useDataViewManagerLogger = (...childContextPaths: string[]) => {
   const services = useKibana().services;

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
@@ -22,6 +22,7 @@ import { type SelectDataViewAsyncPayload } from '../redux/actions';
 import { PageScope } from '../constants';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { useUserInfo } from '../../detections/components/user_info';
+import { useDataViewManagerLogger } from './use_data_view_logger';
 
 type OriginalListener = Parameters<typeof originalAddListener>[0];
 
@@ -48,6 +49,12 @@ export const useInitDataViewManager = () => {
     false
   );
 
+  const logger = useDataViewManagerLogger('useInitDataViewManager');
+  const createInitListenerLogger = useDataViewManagerLogger('createInitListener');
+  const createDataViewSelectedListenerLogger = useDataViewManagerLogger(
+    'createDataViewSelectedListener'
+  );
+
   const {
     loading: loadingSignalIndex,
     signalIndexName,
@@ -62,8 +69,9 @@ export const useInitDataViewManager = () => {
           isOutdated: !!signalIndexMappingOutdated,
         })
       );
+      logger.debug('signal index set');
     }
-  }, [dispatch, loadingSignalIndex, signalIndexMappingOutdated, signalIndexName]);
+  }, [dispatch, loadingSignalIndex, logger, signalIndexMappingOutdated, signalIndexName]);
 
   useEffect(() => {
     // TODO: (new data view picker) remove this in cleanup phase https://github.com/elastic/security-team/issues/12665
@@ -93,9 +101,12 @@ export const useInitDataViewManager = () => {
         application: services.application,
         spaces: services.spaces,
         storage: services.storage,
+        logger: createInitListenerLogger,
       },
       attacksAlertsAlignmentEnabled
     );
+
+    logger.debug('Registering data view manager listeners');
 
     dispatch(addListener(dataViewsLoadingListener));
 
@@ -112,8 +123,11 @@ export const useInitDataViewManager = () => {
         scope,
         dataViews: services.dataViews,
         storage: services.storage,
+        logger: createDataViewSelectedListenerLogger,
       })
     );
+
+    logger.debug('Registering data view selected listeners for all scopes');
 
     listeners.forEach((dataViewSelectedListener) => {
       dispatch(addListener(dataViewSelectedListener));
@@ -122,27 +136,33 @@ export const useInitDataViewManager = () => {
     // NOTE: this kicks off the data loading in the Data View Picker
 
     return () => {
+      logger.debug('Cleaning up listeners');
       dispatch(removeListener(dataViewsLoadingListener));
       listeners.forEach((dataViewSelectedListener) => {
+        logger.debug(`Removed listener for scope ${dataViewSelectedListener.actionCreator.name}`);
         dispatch(removeListener(dataViewSelectedListener));
       });
     };
   }, [
     attacksAlertsAlignmentEnabled,
     dispatch,
+    logger,
     newDataViewPickerEnabled,
     services.application,
     services.dataViews,
     services.http,
+    createInitListenerLogger,
     services.spaces,
     services.storage,
     services.uiSettings,
+    createDataViewSelectedListenerLogger,
   ]);
 
   return useCallback(
     (initialSelection: SelectDataViewAsyncPayload[]) => {
+      logger.debug('Initializing Data View Manager with initial selection');
       dispatch(sharedDataViewManagerSlice.actions.init(initialSelection));
     },
-    [dispatch]
+    [dispatch, logger]
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
@@ -69,7 +69,7 @@ export const useInitDataViewManager = () => {
           isOutdated: !!signalIndexMappingOutdated,
         })
       );
-      logger.debug('signal index set');
+      logger.debug(`signal index set: ${signalIndexName}`);
     }
   }, [dispatch, loadingSignalIndex, logger, signalIndexMappingOutdated, signalIndexName]);
 
@@ -160,7 +160,9 @@ export const useInitDataViewManager = () => {
 
   return useCallback(
     (initialSelection: SelectDataViewAsyncPayload[]) => {
-      logger.debug('Initializing Data View Manager with initial selection');
+      logger.debug(
+        `Initializing Data View Manager with initial selection: ${JSON.stringify(initialSelection)}`
+      );
       dispatch(sharedDataViewManagerSlice.actions.init(initialSelection));
     },
     [dispatch, logger]

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
@@ -8,10 +8,10 @@
 import { createDataViewSelectedListener } from './data_view_selected';
 import { selectDataViewAsync } from '../actions';
 import type { DataViewsServicePublic, FieldSpec } from '@kbn/data-views-plugin/public';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import type { AnyAction, Dispatch, ListenerEffectAPI } from '@reduxjs/toolkit';
 import type { RootState } from '../reducer';
 import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, PageScope } from '../../constants';
-import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { DEFAULT_ALERT_DATA_VIEW_ID } from '../../../../common/constants';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 
@@ -186,6 +186,7 @@ describe('createDataViewSelectedListener', () => {
       const analyzerListener = createDataViewSelectedListener({
         dataViews: mockDataViewsService,
         scope: PageScope.analyzer,
+        logger: mockLogger,
         storage: mockStorage,
       });
 
@@ -213,6 +214,7 @@ describe('createDataViewSelectedListener', () => {
       const analyzerListener = createDataViewSelectedListener({
         dataViews: mockDataViewsService,
         scope: PageScope.analyzer,
+        logger: mockLogger,
         storage: mockStorage,
       });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
@@ -11,6 +11,7 @@ import type { DataViewsServicePublic, FieldSpec } from '@kbn/data-views-plugin/p
 import type { AnyAction, Dispatch, ListenerEffectAPI } from '@reduxjs/toolkit';
 import type { RootState } from '../reducer';
 import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, PageScope } from '../../constants';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { DEFAULT_ALERT_DATA_VIEW_ID } from '../../../../common/constants';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 
@@ -81,6 +82,7 @@ const mockedState: RootState = {
     },
   },
 };
+const mockLogger = loggingSystemMock.createLogger();
 
 const mockDispatch = jest.fn();
 const mockGetState = jest.fn(() => mockedState);
@@ -105,6 +107,7 @@ describe('createDataViewSelectedListener', () => {
     jest.clearAllMocks();
     listener = createDataViewSelectedListener({
       dataViews: mockDataViewsService,
+      logger: mockLogger,
       scope: PageScope.default,
       storage: mockStorage,
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
@@ -1,10 +1,11 @@
-/* eslint-disable complexity */
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
+/* eslint-disable complexity */
 
 import type { DataView, DataViewLazy, DataViewsServicePublic } from '@kbn/data-views-plugin/public';
 import type { AnyAction, Dispatch, ListenerEffectAPI } from '@reduxjs/toolkit';

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
@@ -98,7 +98,7 @@ export const createDataViewSelectedListener = (dependencies: {
 
       logger.debug(
         `Cached data view lookup for id: ${action.payload.id} returned: ${
-          cachedDataViewSpec ?? 'null'
+          cachedDataViewSpec?.title ?? 'null'
         }`
       );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -9,6 +10,7 @@ import type { DataView, DataViewLazy, DataViewsServicePublic } from '@kbn/data-v
 import type { AnyAction, Dispatch, ListenerEffectAPI } from '@reduxjs/toolkit';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import { isEmpty } from 'lodash';
+import type { Logger } from '@kbn/logging';
 import type { RootState } from '../reducer';
 import { scopes } from '../reducer';
 import { selectDataViewAsync } from '../actions';
@@ -35,6 +37,7 @@ export const createDataViewSelectedListener = (dependencies: {
   scope: PageScope;
   dataViews: DataViewsServicePublic;
   storage: Storage;
+  logger: Logger;
 }) => {
   return {
     actionCreator: selectDataViewAsync,
@@ -42,12 +45,20 @@ export const createDataViewSelectedListener = (dependencies: {
       action: ReturnType<typeof selectDataViewAsync>,
       listenerApi: ListenerEffectAPI<RootState, Dispatch<AnyAction>>
     ) => {
+      const logger = dependencies.logger;
+      logger.debug(
+        `Data view selection requested for scope: ${
+          dependencies.scope
+        } with payload: ${JSON.stringify(action.payload)}`
+      );
       if (dependencies.scope !== action.payload.scope) {
         return;
       }
 
       // Cancel effects running for the current scope to prevent race conditions
       listenerApi.cancelActiveListeners();
+
+      logger.debug(`cancelActiveListeners called for scope: ${dependencies.scope}`);
 
       let dataViewByIdError: unknown;
       let adhocDataViewCreationError: unknown;
@@ -85,17 +96,25 @@ export const createDataViewSelectedListener = (dependencies: {
        */
       const cachedDataViewSpec = findCachedDataView(action.payload.id);
 
+      logger.debug(
+        `Cached data view lookup for id: ${action.payload.id} returned: ${
+          cachedDataViewSpec ?? 'null'
+        }`
+      );
+
       if (!cachedDataViewSpec) {
         try {
           if (action.payload.id) {
             dataViewById = await dependencies.dataViews.getDataViewLazy(action.payload.id);
           }
         } catch (error: unknown) {
+          logger.error(`Error fetching data view by id ${action.payload.id}: ${error}`);
           dataViewByIdError = error;
         }
       }
 
       if (!dataViewById) {
+        logger.debug(`Data view by id lookup failed for id: ${action.payload.id}`);
         try {
           const title = action.payload.fallbackPatterns?.join(',') ?? '';
           if (!title.length) {
@@ -106,10 +125,12 @@ export const createDataViewSelectedListener = (dependencies: {
             id: `adhoc_${title}`,
             title,
           });
+          logger.debug(`Ad-hoc data view created with title: ${title}`);
           if (adHocDataView) {
             listenerApi.dispatch(sharedDataViewManagerSlice.actions.addDataView(adHocDataView));
           }
         } catch (error: unknown) {
+          logger.error(`Error creating ad-hoc data view: ${error}`);
           adhocDataViewCreationError = error;
         }
       }
@@ -123,14 +144,20 @@ export const createDataViewSelectedListener = (dependencies: {
         // seem to depend on this, not sure if we want it.
         state.dataViewManager.shared.defaultDataViewId;
 
+      logger.debug(
+        `Data view resolved id to use for scope ${dependencies.scope}: ${resolvedIdToUse ?? 'null'}`
+      );
+
       const currentScopeActions = scopes[action.payload.scope].actions;
       if (resolvedIdToUse) {
         // NOTE: this skips data view selection if an override selection
         // has been dispatched
         if (listenerApi.signal.aborted) {
+          logger.debug(`Data view selection aborted for scope: ${dependencies.scope}`);
           return;
         }
 
+        logger.debug(`Setting selected data view for scope: ${dependencies.scope}`);
         listenerApi.dispatch(currentScopeActions.setSelectedDataView(resolvedIdToUse));
         if (action.payload.scope === PageScope.analyzer) {
           dependencies.storage.set(
@@ -139,6 +166,11 @@ export const createDataViewSelectedListener = (dependencies: {
           );
         }
       } else if (dataViewByIdError || adhocDataViewCreationError) {
+        logger.error(
+          `Data view selection error for scope ${dependencies.scope}: ${
+            dataViewByIdError || adhocDataViewCreationError
+          }`
+        );
         const err = dataViewByIdError || adhocDataViewCreationError;
         listenerApi.dispatch(
           currentScopeActions.dataViewSelectionError(

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AnyAction, Dispatch, ListenerEffectAPI } from '@reduxjs/toolkit';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { mockDataViewManagerState } from '../mock';
 import { createInitListener } from './init_listener';
 import type { DataViewsServicePublic } from '@kbn/data-views-plugin/public';
@@ -60,6 +61,7 @@ const mockListenerApi = {
   getState: mockGetState,
 } as unknown as ListenerEffectAPI<RootState, Dispatch<AnyAction>>;
 
+const mockLogger = loggingSystemMock.createLogger();
 describe('createInitListener', () => {
   let listener: ReturnType<typeof createInitListener>;
 
@@ -76,6 +78,7 @@ describe('createInitListener', () => {
     listener = createInitListener(
       {
         dataViews: mockDataViewsService,
+        logger: mockLogger,
         http,
         application,
         uiSettings,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
@@ -66,7 +66,7 @@ export const createInitListener = (
           attacksAlertsAlignmentEnabled,
         });
 
-        logger.info(`Default data views created: 
+        logger.debug(`Default data views created: 
           - Default Data View: ${defaultDataView.title} (ID: ${defaultDataView.id}) 
           - Alert Data View: ${alertDataView.title} (ID: ${alertDataView.id}) 
           ${
@@ -84,7 +84,7 @@ export const createInitListener = (
           alertDataView.title
         );
 
-        logger.info(`Explore Data View created: 
+        logger.debug(`Explore Data View created: 
           - Explore Data View: ${exploreDataView.title} (ID: ${exploreDataView.id})`);
 
         // Store the created data views in the Redux state
@@ -93,15 +93,25 @@ export const createInitListener = (
         // NOTE: This is later used in the data view manager drop-down selector
         const dataViews = await dependencies.dataViews.getAllDataViewLazy();
 
-        logger.info(`Fetched ${dataViews.length} data views from the Data Views service.`);
+        logger.debug(
+          `Fetched ${
+            dataViews.length
+          } data views from the Data Views service. Data View Names: ${dataViews
+            .map((dv) => dv.getName())
+            .join(', ')}`
+        );
 
         const dataViewSpecs = await Promise.all(dataViews.map((dataView) => dataView.toSpec()));
 
-        logger.info(`Converted data views to specs.`);
+        logger.debug(`Converted ${dataViewSpecs.length} data views to specs`);
 
         listenerApi.dispatch(sharedDataViewManagerSlice.actions.setDataViews(dataViewSpecs));
 
-        logger.info(`Set data views in the Redux state.`);
+        logger.debug(
+          `Set ${dataViewSpecs.length} data views in the Redux state with names: ${dataViewSpecs
+            .map((dv) => dv.title)
+            .join(', ')}`
+        );
 
         // NOTE: save default dataview id for the given space in the store.
         // this is used to identify the default selection in pickers across Kibana Space
@@ -112,7 +122,7 @@ export const createInitListener = (
           })
         );
 
-        logger.info(`Set default and alert data view IDs in the Redux state.`);
+        logger.debug(`Set default and alert data view IDs in the Redux state.`);
 
         // Preload the default data view for all the scopes
         // Immediate calls that would dispatch this call from other places will cancel this action,
@@ -129,7 +139,7 @@ export const createInitListener = (
           // NOTE: only init default data view for slices that are not initialized yet
           .filter((scope) => !listenerApi.getState().dataViewManager[scope].dataViewId)
           .forEach((scope) => {
-            logger.info(`Preloading data view for scope: ${scope}`);
+            logger.debug(`Preloading data view for scope: ${scope}`);
             if (scope === PageScope.explore) {
               return listenerApi.dispatch(
                 selectDataViewAsync({
@@ -174,7 +184,7 @@ export const createInitListener = (
 
         // NOTE: if there is a list of data views to preload other than default one (eg. coming in from the url storage)
         action.payload.forEach((defaultSelection) => {
-          logger.info(`Preloading additional data view for scope: ${defaultSelection.scope}`);
+          logger.debug(`Preloading additional data view for scope: ${defaultSelection.scope}`);
           listenerApi.dispatch(selectDataViewAsync(defaultSelection));
         });
       } catch (error: unknown) {

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -19,6 +19,7 @@ import type {
 } from '@kbn/core/public';
 import { AppStatus, DEFAULT_APP_CATEGORIES } from '@kbn/core/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
+import type { Logger } from '@kbn/logging';
 import { uiMetricService } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
 import type { SecuritySolutionCellRendererFeature } from '@kbn/discover-shared-plugin/public/services/discover_features';
 import { ProductFeatureSecurityKey } from '@kbn/security-solution-features/keys';
@@ -74,6 +75,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
   private experimentalFeatures: ExperimentalFeatures;
   private contract: PluginContract;
   private services: PluginServices;
+  private logger: Logger;
   private isServerless: boolean;
 
   private appUpdater$ = new Subject<AppUpdater>();
@@ -91,12 +93,14 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     ).features;
     this.contract = new PluginContract(this.experimentalFeatures);
     this.isServerless = initializerContext.env.packageInfo.buildFlavor === 'serverless';
+    this.logger = initializerContext.logger.get(); // Initializes logger with name plugins.securitySolution
 
     this.services = new PluginServices(
       this.config,
       this.experimentalFeatures,
       this.contract,
-      initializerContext.env.packageInfo
+      initializerContext.env.packageInfo,
+      this.logger
     );
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin_services.ts
@@ -9,6 +9,7 @@ import type { AppMountParameters, CoreSetup, CoreStart, PackageInfo } from '@kbn
 import { NowProvider, QueryService } from '@kbn/data-plugin/public';
 import type { DataPublicPluginStart, QueryStart } from '@kbn/data-plugin/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
+import type { Logger } from '@kbn/logging';
 import { initTelemetry, TelemetryService } from './common/lib/telemetry';
 import { KibanaServices } from './common/lib/kibana/services';
 import type { ExperimentalFeatures } from '../common/experimental_features';
@@ -55,7 +56,8 @@ export class PluginServices {
     private readonly config: SecuritySolutionUiConfigType,
     private readonly experimentalFeatures: ExperimentalFeatures,
     private readonly contract: PluginContract,
-    private readonly packageInfo: PackageInfo
+    private readonly packageInfo: PackageInfo,
+    private logger: Logger
   ) {
     this.configSettings = parseConfigSettings(this.config.offeringSettings ?? {}).settings;
     this.prebuiltRulesPackageVersion = this.config.prebuiltRulesPackageVersion;
@@ -147,6 +149,7 @@ export class PluginServices {
       apm,
       config: this.config,
       inference: startPlugins.inference,
+      logger: this.logger,
       configSettings: this.configSettings,
       savedObjectsTagging: savedObjectsTaggingOss.getTaggingApi(),
       storage: this.storage,

--- a/x-pack/solutions/security/plugins/security_solution/public/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/types.ts
@@ -67,6 +67,7 @@ import type { ElasticAssistantSharedStatePublicPluginStart } from '@kbn/elastic-
 import type { InferencePublicStart } from '@kbn/inference-plugin/public';
 import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
+import type { Logger } from '@kbn/logging';
 import type { ResolverPluginSetup } from './resolver/types';
 import type { Inspect } from '../common/search_strategy';
 import type { Detections } from './detections';
@@ -209,6 +210,7 @@ export type StartServices = CoreStart &
     timelineDataService: DataPublicPluginStart;
     siemMigrations: SiemMigrationsService;
     productDocBase: ProductDocBasePluginStart;
+    logger: Logger;
   };
 
 export type StartRenderServices = Pick<


### PR DESCRIPTION
## Summary

This PR introduces logging to the data view manager system for better debugging. To enable add the following to your `kibana.dev.yaml`

```
logging.browser:
  loggers:
       - name: plugins.securitySolution.dataViewManager
         level: debug
```



<!--ONMERGE {"backportTargets":["8.18","8.19","9.0","9.1","9.2","9.3"]} ONMERGE-->