### PR TITLE
[Ingest pipelines] Fix flaky tree test

### DIFF
--- a/x-pack/platform/test/functional/apps/ingest_pipelines/ingest_pipelines.ts
+++ b/x-pack/platform/test/functional/apps/ingest_pipelines/ingest_pipelines.ts
@@ -211,6 +211,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           const baseUrl = await browser.getCurrentUrl();
           await browser.navigateTo(baseUrl + '?pipeline=' + TREE_PIPELINE_NAME);
 
+          // Wait for the details flyout to load with the expected pipeline
+          await pageObjects.ingestPipelines.waitForDetailsFlyoutTitle(TREE_PIPELINE_NAME);
+
           const treeExists = await pageObjects.ingestPipelines.pipelineTreeExists();
           expect(treeExists).to.be(true);
 
@@ -219,8 +222,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
           await pageObjects.ingestPipelines.clickTreeNode(TEST_PIPELINE_NAME);
 
-          // Allow for new pipeline data to load
-          await pageObjects.common.sleep(1000);
+          // Wait for the details panel to update with the new pipeline
+          await pageObjects.ingestPipelines.waitForDetailsFlyoutTitle(TEST_PIPELINE_NAME);
 
           // The details panel should have changed
           detailsPanelTitle = await pageObjects.ingestPipelines.getDetailsFlyoutTitle();

--- a/x-pack/platform/test/functional/page_objects/ingest_pipelines_page.ts
+++ b/x-pack/platform/test/functional/page_objects/ingest_pipelines_page.ts
@@ -117,6 +117,13 @@ export function IngestPipelinesPageProvider({ getService, getPageObjects }: FtrP
       return await testSubjects.getVisibleText('detailsPanelTitle');
     },
 
+    async waitForDetailsFlyoutTitle(expectedTitle: string) {
+      await retry.waitFor(`details flyout title to be "${expectedTitle}"`, async () => {
+        const title = await testSubjects.getVisibleText('detailsPanelTitle');
+        return title === expectedTitle;
+      });
+    },
+
     async pipelineTreeExists() {
       return await testSubjects.exists('pipelineTreePanel');
     },


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/235299

## Summary

This test was flaky. Added await `testSubjects.waitForDetailsFlyoutTitle` helper that waits for the expected pipeline tree to be loaded before assertions. 

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10218

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->