### PR TITLE
[Security Solution][Entity Analytics][PrivMon][Flaky Test] Change to address the flakiness

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_users/cross_source_sync.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_users/cross_source_sync.ts
@@ -18,7 +18,7 @@ export default ({ getService }: FtrProviderContext) => {
   const log = getService('log');
 
   // FLAKY: https://github.com/elastic/kibana/issues/237416
-  describe.skip('@ess @serverless @skipInServerlessMKI Entity Monitoring Privileged Users APIs', () => {
+  describe('@ess @serverless @skipInServerlessMKI Entity Monitoring Privileged Users APIs', () => {
     const kibanaServer = getService('kibanaServer');
     const index1 = 'privmon_index1';
     const indexSyncUtils = PlainIndexSyncUtils(getService, index1);
@@ -82,8 +82,10 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       expect(createEntitySourceResponse.status).toBe(200);
-      // Use scheduleEngineAndWaitForUserCount to ensure sync completes before checking
-      users = await privMonUtils.scheduleEngineAndWaitForUserCount(1);
+      // Schedule the sync manually instead of using scheduleEngineAndWaitForUserCount
+      // because the user count is already 1 (from API/CSV sources), so waiting for count=1
+      // would return immediately before the index sync completes
+      await privMonUtils.scheduleMonitoringEngineNow({ ignoreConflict: true });
 
       // Additional wait to ensure the 'index' source has been merged
       await waitFor(


### PR DESCRIPTION
## Summary

#### Issue
Test `should merge sources when the same user is added through different methods (API, CSV, index)` was probably flaky due to a race condition in how it waited for the index sync to complete.

#### Root Cause
The test used scheduleEngineAndWaitForUserCount(1) to wait for the sync task, but this function only checks if the user count matches the expected value. When adding a third source (index) to an existing user that already has 2 sources (API, CSV), the user count is already 1, so the function returns immediately — often before the sync task has started or completed updating the sources array.
Runtime evidence showed: The sync task takes ~2-3 seconds to complete, but scheduleEngineAndWaitForUserCount(1) was returning in milliseconds when the count was already satisfied.

#### This change:
- Still schedules the sync task properly
-Doesn't wait based on user count (which would return too early)
- Lets the existing waitFor loop (lines 103-124) do its job — continuously polling until the "index" source actually appears in the sources array

#### Why This should probably solve the Flakiness
The test now properly waits for the actual condition it cares about (presence of the "index" source), rather than a proxy condition (user count) that was already satisfied. The waitFor loop:
Polls continuously with 250ms intervals
- Has a 400-second timeout
- Only returns when sources.includes('index') && sources.length === 3

#### Verification: 
Post-fix test run showed the waitFor loop took 4 iterations (~2.8 seconds) before the "index" source appeared, confirming the sync task timing and that the fix properly waits for completion.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.


- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.