### PR TITLE
[Security Solution][Entity Analytics][PrivMon][Flaky Test] Align privilege monitoring tests to wildcarded ML anomalies index

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privilege_monitoring_privileges_check.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privilege_monitoring_privileges_check.ts
@@ -25,7 +25,7 @@ export default ({ getService }: FtrProviderContext) => {
 
   // Failing: See https://github.com/elastic/kibana/issues/243722
   // Failing: See https://github.com/elastic/kibana/issues/243721
-  describe.skip('@ess @serverless @skipInServerlessMKI Entity Privilege Monitoring APIs', () => {
+  describe('@ess @serverless @skipInServerlessMKI Entity Privilege Monitoring APIs', () => {
     describe('privileges checks', () => {
       before(async () => {
         await enablePrivmonSetting(kibanaServer);
@@ -75,7 +75,7 @@ export default ({ getService }: FtrProviderContext) => {
               '.entity_analytics.monitoring.users-default': {
                 read: false,
               },
-              '.ml-anomalies-shared': {
+              '.ml-anomalies-shared*': {
                 read: false,
               },
               'risk-score.risk-score-*': {
@@ -99,7 +99,7 @@ export default ({ getService }: FtrProviderContext) => {
               '.entity_analytics.monitoring.users-default': {
                 read: true,
               },
-              '.ml-anomalies-shared': {
+              '.ml-anomalies-shared*': {
                 read: false,
               },
               'risk-score.risk-score-*': {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privilege_monitoring_privileges_check.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privilege_monitoring_privileges_check.ts
@@ -23,8 +23,6 @@ export default ({ getService }: FtrProviderContext) => {
   const authHelper = privMonRolesUtils.createUnifiedAuthHelper(getService);
   const kibanaServer = getService('kibanaServer');
 
-  // Failing: See https://github.com/elastic/kibana/issues/243722
-  // Failing: See https://github.com/elastic/kibana/issues/243721
   describe('@ess @serverless @skipInServerlessMKI Entity Privilege Monitoring APIs', () => {
     describe('privileges checks', () => {
       before(async () => {


### PR DESCRIPTION
## Summary

Updated privilege monitoring integration tests to match the actual privilege payload returned by the API: 

The ML anomalies index is reported with a wildcard suffix `.ml-anomalies-shared*` instead of `.ml-anomalies-shared`

No service logic changed; only test expectations were aligned to the real index key used by the privilege check endpoint, covering both serverless and ECH paths.

API response : 

`http://localhost:5601/api/entity_analytics/monitoring/privileges/privileges`

```json

{"privileges":{"elasticsearch":{"index":{".alerts-security.alerts-default":{"read":true},".entity_analytics.monitoring.users-default":{"read":true},".ml-anomalies-shared*":{"read":true},"risk-score.risk-score-*":{"read":true}}},"kibana":{}},"has_all_required":true,"has_read_permissions":false,"has_write_permissions":false}%  
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.


- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.