### PR TITLE
[ILM] Fix misleading description for read-only action

### DIFF
--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/shared_fields/readonly_field.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/shared_fields/readonly_field.tsx
@@ -25,7 +25,7 @@ export const ReadonlyField: React.FunctionComponent<Props> = ({ phase }) => {
         <EuiTextColor color="subdued">
           <FormattedMessage
             id="xpack.indexLifecycleMgmt.editPolicy.readonlyDescription"
-            defaultMessage="Enable to make the index read only, disable to allow writes changes."
+            defaultMessage="Enable to make the index read only. Disable to allow writing to the index."
           />{' '}
           <LearnMoreLink docPath={docLinks.links.elasticsearch.ilmReadOnly} />
         </EuiTextColor>

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/shared_fields/readonly_field.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/application/sections/edit_policy/components/phases/shared_fields/readonly_field.tsx
@@ -25,7 +25,7 @@ export const ReadonlyField: React.FunctionComponent<Props> = ({ phase }) => {
         <EuiTextColor color="subdued">
           <FormattedMessage
             id="xpack.indexLifecycleMgmt.editPolicy.readonlyDescription"
-            defaultMessage="Enable to make the index and index metadata read only, disable to allow writes and metadata changes."
+            defaultMessage="Enable to make the index read only, disable to allow writes changes."
           />{' '}
           <LearnMoreLink docPath={docLinks.links.elasticsearch.ilmReadOnly} />
         </EuiTextColor>


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/207192

## Summary

The description incorrectly stated that enabling the read-only option would make both the index and the index metadata read-only. However, the ILM read-only action only sets `index.blocks.write=true`, which doesn't affect changes metadata.



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->