### PR TITLE
[8.19] Retry 502 bad gateway responses from Elasticsearch (#243342)

### DIFF
--- a/src/core/packages/elasticsearch/server-utils/src/is_retryable_es_client_error.test.ts
+++ b/src/core/packages/elasticsearch/server-utils/src/is_retryable_es_client_error.test.ts
@@ -51,7 +51,7 @@ describe('isRetryableEsClientError', () => {
       expect(isRetryableEsClientError(error)).toEqual(true);
     });
 
-    it.each([503, 504, 408, 410, 429])('ResponseError with %p status code', (statusCode) => {
+    it.each([502, 503, 504, 408, 410, 429])('ResponseError with %p status code', (statusCode) => {
       const error = new esErrors.ResponseError(
         elasticsearchClientMock.createApiResponse({
           statusCode,

--- a/src/core/packages/elasticsearch/server-utils/src/is_retryable_es_client_error.ts
+++ b/src/core/packages/elasticsearch/server-utils/src/is_retryable_es_client_error.ts
@@ -14,6 +14,7 @@ const DEFAULT_RETRY_STATUS_CODES = [
   410, // Gone
   429, // TooManyRequests -> ES circuit breaker
   503, // ServiceUnavailable
+  502, // BadGateway
   504, // GatewayTimeout
 ];
 

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.test.ts
@@ -62,7 +62,7 @@ describe('catchRetryableEsClientErrors', () => {
         type: 'retryable_es_client_error',
       });
     });
-    it.each([503, 401, 403, 408, 410, 429])(
+    it.each([504, 503, 502, 401, 403, 408, 410, 429])(
       'ResponseError with retryable status code (%d)',
       async (status) => {
         const error = new esErrors.ResponseError(

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.test.ts
@@ -86,7 +86,7 @@ describe('catchRetryableEsClientErrors', () => {
 });
 
 describe('catchRetryableSearchPhaseExecutionException', () => {
-  it('retries search phase execution exception ', async () => {
+  it('retries search phase execution exception', async () => {
     const error = new esErrors.ResponseError(
       elasticsearchClientMock.createApiResponse({
         body: { error: { type: 'search_phase_execution_exception' } },
@@ -98,6 +98,34 @@ describe('catchRetryableSearchPhaseExecutionException', () => {
       message: 'search_phase_execution_exception',
       type: 'retryable_es_client_error',
     });
+  });
+  it('retries search phase execution exception for "all shards failed"', async () => {
+    const error = new esErrors.ResponseError(
+      elasticsearchClientMock.createApiResponse({
+        body: {
+          error: {
+            type: 'search_phase_execution_exception',
+            caused_by: {
+              type: 'search_phase_execution_exception',
+              reason: 'all shards failed',
+            },
+          },
+        },
+      })
+    );
+    expect(
+      ((await Promise.reject(error).catch(catchRetryableSearchPhaseExecutionException)) as any).left
+    ).toMatchInlineSnapshot(`
+      Object {
+        "error": [ResponseError: search_phase_execution_exception
+      	Caused by:
+      		search_phase_execution_exception: all shards failed],
+        "message": "search_phase_execution_exception
+      	Caused by:
+      		search_phase_execution_exception: all shards failed",
+        "type": "retryable_es_client_error",
+      }
+    `);
   });
   it('does not retry other errors', async () => {
     const error = new esErrors.ResponseError(

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.test.ts
@@ -99,42 +99,4 @@ describe('catchRetryableSearchPhaseExecutionException', () => {
       type: 'retryable_es_client_error',
     });
   });
-  it('retries search phase execution exception for "all shards failed"', async () => {
-    const error = new esErrors.ResponseError(
-      elasticsearchClientMock.createApiResponse({
-        body: {
-          error: {
-            type: 'search_phase_execution_exception',
-            caused_by: {
-              type: 'search_phase_execution_exception',
-              reason: 'all shards failed',
-            },
-          },
-        },
-      })
-    );
-    expect(
-      ((await Promise.reject(error).catch(catchRetryableSearchPhaseExecutionException)) as any).left
-    ).toMatchInlineSnapshot(`
-      Object {
-        "error": [ResponseError: search_phase_execution_exception
-      	Caused by:
-      		search_phase_execution_exception: all shards failed],
-        "message": "search_phase_execution_exception
-      	Caused by:
-      		search_phase_execution_exception: all shards failed",
-        "type": "retryable_es_client_error",
-      }
-    `);
-  });
-  it('does not retry other errors', async () => {
-    const error = new esErrors.ResponseError(
-      elasticsearchClientMock.createApiResponse({
-        body: { error: { type: 'cluster_block_exception' } },
-      })
-    );
-    await expect(
-      Promise.reject(error).catch(catchRetryableSearchPhaseExecutionException)
-    ).rejects.toBe(error);
-  });
 });

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.ts
@@ -29,11 +29,6 @@ const retryResponseStatuses = [
   504, // GatewayTimeout
 ];
 
-const temporarySearchPhaseExecutionExceptionReasons = [
-  'Search rejected due to missing shards',
-  'all shards failed',
-];
-
 export const catchRetryableEsClientErrors = (
   e: EsErrors.ElasticsearchClientError
 ): Either.Either<RetryableEsClientError, never> => {
@@ -51,12 +46,7 @@ export const catchRetryableEsClientErrors = (
 export const catchRetryableSearchPhaseExecutionException = (
   e: EsErrors.ResponseError
 ): Either.Either<RetryableEsClientError, never> => {
-  if (
-    e?.body?.error?.type === 'search_phase_execution_exception' &&
-    temporarySearchPhaseExecutionExceptionReasons.some((reason) =>
-      e?.body?.error?.caused_by?.reason?.includes(reason)
-    )
-  ) {
+  if (e?.body?.error?.type === 'search_phase_execution_exception') {
     return Either.left({
       type: 'retryable_es_client_error' as const,
       message: e?.message,

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.ts
@@ -29,6 +29,11 @@ const retryResponseStatuses = [
   504, // GatewayTimeout
 ];
 
+const temporarySearchPhaseExecutionExceptionReasons = [
+  'Search rejected due to missing shards',
+  'all shards failed',
+];
+
 export const catchRetryableEsClientErrors = (
   e: EsErrors.ElasticsearchClientError
 ): Either.Either<RetryableEsClientError, never> => {
@@ -46,7 +51,12 @@ export const catchRetryableEsClientErrors = (
 export const catchRetryableSearchPhaseExecutionException = (
   e: EsErrors.ResponseError
 ): Either.Either<RetryableEsClientError, never> => {
-  if (e?.body?.error?.type === 'search_phase_execution_exception') {
+  if (
+    e?.body?.error?.type === 'search_phase_execution_exception' &&
+    temporarySearchPhaseExecutionExceptionReasons.some((reason) =>
+      e?.body?.error?.caused_by?.reason?.includes(reason)
+    )
+  ) {
     return Either.left({
       type: 'retryable_es_client_error' as const,
       message: e?.message,

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/catch_retryable_es_client_errors.ts
@@ -24,6 +24,7 @@ const retryResponseStatuses = [
   408, // RequestTimeout
   410, // Gone
   429, // TooManyRequests -> ES circuit breaker
+  502, // BadGateway
   503, // ServiceUnavailable
   504, // GatewayTimeout
 ];

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/check_for_unknown_docs.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/check_for_unknown_docs.test.ts
@@ -98,10 +98,10 @@ describe('checkForUnknownDocs', () => {
   });
 
   it('should throw because neither handler can retry', async () => {
-    // Create a mock client that rejects all methods with a 502 status code response.
+    // Create a mock client that rejects all methods with a 500 status code response.
     const retryableError = new EsErrors.ResponseError(
       elasticsearchClientMock.createApiResponse({
-        statusCode: 502,
+        statusCode: 500,
         body: { error: { type: 'es_type', reason: 'es_reason' } },
       })
     );

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/pickup_updated_mappings.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/pickup_updated_mappings.test.ts
@@ -19,11 +19,11 @@ describe('pickupUpdatedMappings', () => {
   });
 
   it('calls both handlers when the promise rejection cannot be retried by either', async () => {
-    // Create a mock client that rejects all methods with a 502 status code
+    // Create a mock client that rejects all methods with a 500 status code
     // response
     const retryableError = new EsErrors.ResponseError(
       elasticsearchClientMock.createApiResponse({
-        statusCode: 502,
+        statusCode: 500,
         body: { error: { type: 'es_type', reason: 'es_reason' } },
       })
     );
@@ -38,7 +38,7 @@ describe('pickupUpdatedMappings', () => {
     );
 
     const task = pickupUpdatedMappings(client, 'my_index', 1000);
-    // Should throw because both handlers can't retry 502 responses
+    // Should throw because both handlers can't retry 500 responses
     await expect(task()).rejects.toThrow();
     expect(catchSearchPhaseExceptionSpy).toHaveBeenCalledWith(retryableError);
     expect(catchClientErrorsSpy).toHaveBeenCalledWith(retryableError);

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/read_with_pit.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/read_with_pit.test.ts
@@ -153,11 +153,11 @@ describe('readWithPit', () => {
   });
 
   it('throws if neither handler can retry', async () => {
-    // Create a mock client that rejects all methods with a 502 status code
+    // Create a mock client that rejects all methods with a 500 status code
     // response.
     const retryableError = new EsErrors.ResponseError(
       elasticsearchClientMock.createApiResponse({
-        statusCode: 502,
+        statusCode: 500,
         body: { error: { type: 'es_type', reason: 'es_reason' } },
       })
     );
@@ -178,7 +178,7 @@ describe('readWithPit', () => {
       batchSize: 10_000,
     });
 
-    // Should throw because both handlers can't retry 502 responses
+    // Should throw because both handlers can't retry 500 responses
     await expect(task()).rejects.toThrow();
     expect(catchSearchPhaseExceptionSpy).toHaveBeenCalledWith(retryableError);
     expect(catchClientErrorsSpy).toHaveBeenCalledWith(retryableError);

--- a/src/core/packages/saved-objects/migration-server-internal/src/actions/wait_for_pickup_updated_mappings_task.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/actions/wait_for_pickup_updated_mappings_task.ts
@@ -36,7 +36,8 @@ export const waitForPickupUpdatedMappingsTask = flow(
             JSON.stringify(res.failures.value)
         );
       } else if (Option.isSome(res.error)) {
-        if (res.error.value.type === 'search_phase_execution_exception') {
+        const error = res.error.value;
+        if (error.type === 'search_phase_execution_exception') {
           // This error is normally fixed in the next try, so let's retry
           // the update mappings task instead of throwing
           return TaskEither.left({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Retry 502 bad gateway responses from Elasticsearch (#243342)](https://github.com/elastic/kibana/pull/243342)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Rudolf Meijering","email":"skaapgif@gmail.com"},"sourceCommit":{"committedDate":"2025-11-19T12:14:53Z","message":"Retry 502 bad gateway responses from Elasticsearch (#243342)\n\n## Summary\n\nRetry on 502 Bad gateway responses from Elasticsearch to avoid\nmigrations throwing a FATAL error and restarting Kibana when these\nerrors are likely transient/infrastructe-level problems.\n\nAlso updates the `isRetryableEsClientError` helper exported by Core\nwhich other plugins consume.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"b0a5eac91a485a7f4b5041fe5897293fd9373674","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport missing","backport:all-open","v9.3.0"],"title":"Retry 502 bad gateway responses from Elasticsearch","number":243342,"url":"https://github.com/elastic/kibana/pull/243342","mergeCommit":{"message":"Retry 502 bad gateway responses from Elasticsearch (#243342)\n\n## Summary\n\nRetry on 502 Bad gateway responses from Elasticsearch to avoid\nmigrations throwing a FATAL error and restarting Kibana when these\nerrors are likely transient/infrastructe-level problems.\n\nAlso updates the `isRetryableEsClientError` helper exported by Core\nwhich other plugins consume.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"b0a5eac91a485a7f4b5041fe5897293fd9373674"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/243342","number":243342,"mergeCommit":{"message":"Retry 502 bad gateway responses from Elasticsearch (#243342)\n\n## Summary\n\nRetry on 502 Bad gateway responses from Elasticsearch to avoid\nmigrations throwing a FATAL error and restarting Kibana when these\nerrors are likely transient/infrastructe-level problems.\n\nAlso updates the `isRetryableEsClientError` helper exported by Core\nwhich other plugins consume.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"b0a5eac91a485a7f4b5041fe5897293fd9373674"}}]}] BACKPORT-->