### PR TITLE
[9.2] [Security Solution][Analyzer] ensure we render analyzer only when the dataView is ready (#245712)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.test.tsx
@@ -12,7 +12,12 @@ import { TableId } from '@kbn/securitysolution-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { DocumentDetailsContext } from '../../shared/context';
 import { TestProviders } from '../../../../common/mock';
-import { AnalyzeGraph, ANALYZER_PREVIEW_BANNER } from './analyze_graph';
+import {
+  AnalyzeGraph,
+  ANALYZER_PREVIEW_BANNER,
+  DATA_VIEW_ERROR_TEST_ID,
+  DATA_VIEW_LOADING_TEST_ID,
+} from './analyze_graph';
 import { ANALYZER_GRAPH_TEST_ID } from './test_ids';
 import { useWhichFlyout } from '../../shared/hooks/use_which_flyout';
 import { mockFlyoutApi } from '../../shared/mocks/mock_flyout_context';
@@ -20,6 +25,9 @@ import { DocumentDetailsAnalyzerPanelKey } from '../../shared/constants/panel_ke
 import { useIsInvestigateInResolverActionEnabled } from '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver';
 import { useEnableExperimental } from '../../../../common/hooks/use_experimental_features';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -50,65 +58,114 @@ jest.mock('react-redux', () => {
 const NO_ANALYZER_MESSAGE =
   'You can only visualize events triggered by hosts configured with the Elastic Defend integration or any sysmon data from winlogbeat. Refer to Visual event analyzer(external, opens in a new tab or window) for more information.';
 
+const dataView: DataView = createStubDataView({
+  spec: { title: '.alerts-security.alerts-default' },
+});
+
+const renderAnalyzer = (
+  contextValue = {
+    eventId: 'eventId',
+    scopeId: TableId.test,
+  } as unknown as DocumentDetailsContext
+) =>
+  render(
+    <TestProviders>
+      <DocumentDetailsContext.Provider value={contextValue}>
+        <AnalyzeGraph />
+      </DocumentDetailsContext.Provider>
+    </TestProviders>
+  );
+
 describe('<AnalyzeGraph />', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
+
     mockUseWhichFlyout.mockReturnValue(FLYOUT_KEY);
     jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
     (useEnableExperimental as jest.Mock).mockReturnValue({
       newDataViewPickerEnabled: true,
     });
     (useSelectedPatterns as jest.Mock).mockReturnValue(['index']);
+    (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'ready',
+      dataView: {
+        ...dataView,
+        hasMatchedIndices: jest.fn().mockReturnValue(true),
+      },
+    });
   });
 
   it('renders analyzer graph correctly', () => {
-    (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-    const contextValue = {
-      eventId: 'eventId',
-      scopeId: TableId.test,
-    } as unknown as DocumentDetailsContext;
+    const wrapper = renderAnalyzer();
 
-    const wrapper = render(
-      <TestProviders>
-        <DocumentDetailsContext.Provider value={contextValue}>
-          <AnalyzeGraph />
-        </DocumentDetailsContext.Provider>
-      </TestProviders>
-    );
     expect(wrapper.getByTestId(ANALYZER_GRAPH_TEST_ID)).toBeInTheDocument();
   });
 
-  it('renders no data message when analyzer is not enabled', () => {
+  it('should render no data message when analyzer is not enabled', () => {
     (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(false);
+
     const contextValue = {
       eventId: 'eventId',
       scopeId: TableId.test,
       dataAsNestedObject: {},
     } as unknown as DocumentDetailsContext;
 
-    const { container } = render(
-      <TestProviders>
-        <DocumentDetailsContext.Provider value={contextValue}>
-          <AnalyzeGraph />
-        </DocumentDetailsContext.Provider>
-      </TestProviders>
-    );
+    const { container } = renderAnalyzer(contextValue);
+
     expect(container).toHaveTextContent(NO_ANALYZER_MESSAGE);
   });
 
-  it('clicking view button should open details panel in preview', () => {
-    (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
-    const contextValue = {
-      eventId: 'eventId',
-      scopeId: TableId.test,
-    } as unknown as DocumentDetailsContext;
+  it('should show loading spinner while data view is loading', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'loading',
+    });
 
-    const wrapper = render(
-      <TestProviders>
-        <DocumentDetailsContext.Provider value={contextValue}>
-          <AnalyzeGraph />
-        </DocumentDetailsContext.Provider>
-      </TestProviders>
+    const { getByTestId } = renderAnalyzer();
+
+    expect(getByTestId(DATA_VIEW_LOADING_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('should show loading spinner while data view is pristine', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'pristine',
+    });
+
+    const { getByTestId } = renderAnalyzer();
+
+    expect(getByTestId(DATA_VIEW_LOADING_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('should show error message if data view is error', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'error',
+    });
+
+    const { getByTestId } = renderAnalyzer();
+
+    expect(getByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
+      'Unable to retrieve the data view for analyzer'
     );
+  });
+
+  it('should show error message if data view is ready but no matched indices', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'ready',
+      dataView: {
+        ...dataView,
+        hasMatchedIndices: jest.fn().mockReturnValue(false),
+      },
+    });
+
+    const { getByTestId } = renderAnalyzer();
+
+    expect(getByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
+      'Unable to retrieve the data view for analyzer'
+    );
+  });
+
+  it('should open details panel in preview when clicking on view button', () => {
+    const wrapper = renderAnalyzer();
 
     expect(wrapper.getByTestId('resolver:graph-controls:show-panel-button')).toBeInTheDocument();
     wrapper.getByTestId('resolver:graph-controls:show-panel-button').click();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
@@ -17,8 +17,6 @@ import {
   EuiPanel,
 } from '@elastic/eui';
 import { SourcererScopeName } from '../../../../sourcerer/store/model';
-import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
-import { PageScope } from '../../../../data_view_manager/constants';
 import { useWhichFlyout } from '../../shared/hooks/use_which_flyout';
 import { useDocumentDetailsContext } from '../../shared/context';
 import { ANALYZER_GRAPH_TEST_ID } from './test_ids';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
@@ -9,8 +9,16 @@ import type { FC } from 'react';
 import React, { useMemo, useCallback } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { i18n } from '@kbn/i18n';
-import { EuiPanel } from '@elastic/eui';
+import {
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPanel,
+} from '@elastic/eui';
 import { SourcererScopeName } from '../../../../sourcerer/store/model';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import { PageScope } from '../../../../data_view_manager/constants';
 import { useWhichFlyout } from '../../shared/hooks/use_which_flyout';
 import { useDocumentDetailsContext } from '../../shared/context';
 import { ANALYZER_GRAPH_TEST_ID } from './test_ids';
@@ -25,7 +33,12 @@ import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { useEnableExperimental } from '../../../../common/hooks/use_experimental_features';
 
 export const ANALYZE_GRAPH_ID = 'analyze_graph';
+export const DATA_VIEW_LOADING_TEST_ID = 'analyzer-data-view-loading';
+export const DATA_VIEW_ERROR_TEST_ID = 'analyzer-data-view-error';
 
+const DATAVIEW_ERROR = i18n.translate('xpack.securitySolution.analyzer.dataViewError', {
+  defaultMessage: 'Unable to retrieve the data view for analyzer',
+});
 export const ANALYZER_PREVIEW_BANNER = {
   title: i18n.translate(
     'xpack.securitySolution.flyout.left.visualizations.analyzer.panelPreviewTitle',
@@ -69,7 +82,36 @@ export const AnalyzeGraph: FC = () => {
     });
   }, [openPreviewPanel, key, scopeId]);
 
-  return isEnabled ? (
+  if (!isEnabled) {
+    return (
+      <EuiPanel hasShadow={false}>
+        <AnalyzerPreviewNoDataMessage />
+      </EuiPanel>
+    );
+  }
+
+  if (status === 'loading' || status === 'pristine') {
+    return (
+      <EuiFlexGroup gutterSize="m" justifyContent="center" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiLoadingSpinner data-test-subj={DATA_VIEW_LOADING_TEST_ID} size="xxl" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+
+  if (status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices())) {
+    return (
+      <EuiEmptyPrompt
+        color="danger"
+        data-test-subj={DATA_VIEW_ERROR_TEST_ID}
+        iconType="error"
+        title={<h2>{DATAVIEW_ERROR}</h2>}
+      />
+    );
+  }
+
+  return (
     <div data-test-subj={ANALYZER_GRAPH_TEST_ID}>
       <Resolver
         databaseDocumentID={eventId}
@@ -81,10 +123,6 @@ export const AnalyzeGraph: FC = () => {
         showPanelOnClick={onClick}
       />
     </div>
-  ) : (
-    <EuiPanel hasShadow={false}>
-      <AnalyzerPreviewNoDataMessage />
-    </EuiPanel>
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FC } from 'react';
-import React, { useMemo, useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { i18n } from '@kbn/i18n';
 import {
@@ -16,6 +16,7 @@ import {
   EuiLoadingSpinner,
   EuiPanel,
 } from '@elastic/eui';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useWhichFlyout } from '../../shared/hooks/use_which_flyout';
 import { useDocumentDetailsContext } from '../../shared/context';
@@ -67,6 +68,8 @@ export const AnalyzeGraph: FC = () => {
   const selectedPatterns = newDataViewPickerEnabled
     ? experimentalAnalyzerPatterns
     : oldAnalyzerPatterns;
+
+  const { dataView, status } = useDataView(SourcererScopeName.analyzer);
 
   const { openPreviewPanel } = useExpandableFlyoutApi();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.test.tsx
@@ -13,10 +13,13 @@ import { mockContextValue } from '../../shared/mocks/mock_context';
 import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_formatted_for_field_browser';
 import { DocumentDetailsContext } from '../../shared/context';
 import { AnalyzerPreview } from './analyzer_preview';
-import { ANALYZER_PREVIEW_TEST_ID } from './test_ids';
+import { ANALYZER_PREVIEW_LOADING_TEST_ID, ANALYZER_PREVIEW_TEST_ID } from './test_ids';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import * as mock from '../mocks/mock_analyzer_data';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 
 jest.mock('../../shared/hooks/use_alert_prevalence_from_process_tree', () => ({
   useAlertPrevalenceFromProcessTree: jest.fn(),
@@ -42,22 +45,31 @@ const renderAnalyzerPreview = (contextValue: DocumentDetailsContext) =>
     </TestProviders>
   );
 
-const NO_DATA_MESSAGE = 'An error is preventing this alert from being analyzed.';
+const dataView: DataView = createStubDataView({
+  spec: { title: '.alerts-security.alerts-default' },
+});
 
 describe('<AnalyzerPreview />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockUseAlertPrevalenceFromProcessTree.mockReturnValue(mockTreeValues);
     (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
     (useSelectedPatterns as jest.Mock).mockReturnValue(['index']);
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'ready',
+      dataView: {
+        ...dataView,
+        hasMatchedIndices: jest.fn().mockReturnValue(true),
+      },
+    });
   });
 
   it('shows analyzer preview correctly when documentId and index are present', () => {
-    mockUseAlertPrevalenceFromProcessTree.mockReturnValue(mockTreeValues);
     const contextValue = {
       ...mockContextValue,
       dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
     };
-
     const wrapper = renderAnalyzerPreview(contextValue);
 
     expect(mockUseAlertPrevalenceFromProcessTree).toHaveBeenCalledWith({
@@ -69,11 +81,11 @@ describe('<AnalyzerPreview />', () => {
   });
 
   it('should use selected index patterns for non-alerts', () => {
-    mockUseAlertPrevalenceFromProcessTree.mockReturnValue(mockTreeValues);
-    const wrapper = renderAnalyzerPreview({
+    const contextValue = {
       ...mockContextValue,
       dataFormattedForFieldBrowser: [],
-    });
+    };
+    const wrapper = renderAnalyzerPreview(contextValue);
 
     expect(mockUseAlertPrevalenceFromProcessTree).toHaveBeenCalledWith({
       isActiveTimeline: false,
@@ -84,14 +96,12 @@ describe('<AnalyzerPreview />', () => {
   });
 
   it('should use ancestor id as document id when in preview', () => {
-    mockUseAlertPrevalenceFromProcessTree.mockReturnValue(mockTreeValues);
     const contextValue = {
       ...mockContextValue,
       getFieldsData: () => 'ancestors-id',
       dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
       isRulePreview: true,
     };
-
     const wrapper = renderAnalyzerPreview(contextValue);
 
     expect(mockUseAlertPrevalenceFromProcessTree).toHaveBeenCalledWith({
@@ -102,14 +112,90 @@ describe('<AnalyzerPreview />', () => {
     expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
   });
 
-  it('shows error message when there is an error', () => {
+  it('should show loading skeleton when the data view is loading', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'loading',
+    });
+
+    const contextValue = {
+      ...mockContextValue,
+      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
+    };
+    const { getByTestId } = renderAnalyzerPreview(contextValue);
+
+    expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('should show loading skeleton when the data view is pristine', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'pristine',
+    });
+
+    const contextValue = {
+      ...mockContextValue,
+      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
+    };
+    const { getByTestId } = renderAnalyzerPreview(contextValue);
+
+    expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('should show loading skeleton when the process tree is being fetched', () => {
+    mockUseAlertPrevalenceFromProcessTree.mockReturnValue({
+      loading: true,
+    });
+
+    const contextValue = {
+      ...mockContextValue,
+      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
+    };
+    const { getByTestId } = renderAnalyzerPreview(contextValue);
+
+    expect(getByTestId(ANALYZER_PREVIEW_LOADING_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('should show error message if the data view is error', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'error',
+    });
+
+    const contextValue = {
+      ...mockContextValue,
+      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
+    };
+    const { getByText } = renderAnalyzerPreview(contextValue);
+
+    expect(getByText('Unable to retrieve the data view for analyzer.')).toBeInTheDocument();
+  });
+
+  it('should show error message if the data view is ready but no matched indices', () => {
+    (useDataView as jest.Mock).mockReturnValue({
+      status: 'ready',
+      dataView: {
+        ...dataView,
+        hasMatchedIndices: jest.fn().mockReturnValue(false),
+      },
+    });
+
+    const contextValue = {
+      ...mockContextValue,
+      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
+    };
+    const { getByText } = renderAnalyzerPreview(contextValue);
+
+    expect(getByText('Unable to retrieve the data view for analyzer.')).toBeInTheDocument();
+  });
+
+  it('should show error message when there is an error fetching the process tree data', () => {
     mockUseAlertPrevalenceFromProcessTree.mockReturnValue({
       loading: false,
       error: true,
       alertIds: undefined,
       statsNodes: undefined,
     });
+
     const { getByText } = renderAnalyzerPreview(mockContextValue);
-    expect(getByText(NO_DATA_MESSAGE)).toBeInTheDocument();
+
+    expect(getByText('An error is preventing this alert from being analyzed.')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.test.tsx
@@ -27,6 +27,7 @@ jest.mock('../../shared/hooks/use_alert_prevalence_from_process_tree', () => ({
 const mockUseAlertPrevalenceFromProcessTree = useAlertPrevalenceFromProcessTree as jest.Mock;
 
 jest.mock('../../../../data_view_manager/hooks/use_selected_patterns');
+jest.mock('../../../../data_view_manager/hooks/use_data_view');
 jest.mock('../../../../common/hooks/use_experimental_features');
 
 const mockTreeValues = {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.tsx
@@ -9,6 +9,7 @@ import { find } from 'lodash/fp';
 import { EuiSkeletonText, EuiTreeView } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { ANALYZER_PREVIEW_LOADING_TEST_ID, ANALYZER_PREVIEW_TEST_ID } from './test_ids';
 import { getTreeNodes } from '../utils/analyzer_helpers';
@@ -21,6 +22,20 @@ import { getField } from '../../shared/utils';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { DataViewManagerScopeName } from '../../../../data_view_manager/constants';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
+
+const DATAVIEW_ERROR = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.visualizations.analyzerPreview.dataViewErrorDescription"
+    defaultMessage="Unable to retrieve the data view for analyzer."
+  />
+);
+
+const ANALYZER_ERROR = (
+  <FormattedMessage
+    id="xpack.securitySolution.flyout.right.visualizations.analyzerPreview.errorDescription"
+    defaultMessage="An error is preventing this alert from being analyzed."
+  />
+);
 
 const CHILD_COUNT_LIMIT = 3;
 const ANCESTOR_LEVEL = 3;
@@ -57,10 +72,20 @@ export const AnalyzerPreview: React.FC = () => {
     ? experimentalAnalyzerPatterns
     : oldAnalyzerPatterns;
 
-  const index = find({ category: 'kibana', field: RULE_INDICES }, data);
-  const indices = index?.values ?? selectedPatterns; // adding sourcerer indices for non-alert documents
+  const { dataView, status } = useDataView(PageScope.analyzer);
 
-  const { statsNodes, loading, error } = useAlertPrevalenceFromProcessTree({
+  const index = find({ category: 'kibana', field: RULE_INDICES }, data);
+  const indices = index?.values ?? selectedPatterns;
+
+  const needToFallbackToDataViewIndices = Boolean(index?.values);
+  const dataViewLoading =
+    needToFallbackToDataViewIndices && (status === 'loading' || status === 'pristine');
+
+  const {
+    statsNodes,
+    loading: dataLoading,
+    error,
+  } = useAlertPrevalenceFromProcessTree({
     isActiveTimeline: isActiveTimeline(scopeId),
     documentId,
     indices,
@@ -79,17 +104,29 @@ export const AnalyzerPreview: React.FC = () => {
 
   const showAnalyzerTree = items && items.length > 0 && !error;
 
-  return loading ? (
-    <EuiSkeletonText
-      data-test-subj={ANALYZER_PREVIEW_LOADING_TEST_ID}
-      contentAriaLabel={i18n.translate(
-        'xpack.securitySolution.flyout.right.visualizations.analyzerPreview.loadingAriaLabel',
-        {
-          defaultMessage: 'analyzer preview',
-        }
-      )}
-    />
-  ) : showAnalyzerTree ? (
+  if (dataViewLoading || dataLoading) {
+    return (
+      <EuiSkeletonText
+        data-test-subj={ANALYZER_PREVIEW_LOADING_TEST_ID}
+        contentAriaLabel={i18n.translate(
+          'xpack.securitySolution.flyout.right.visualizations.analyzerPreview.loadingAriaLabel',
+          {
+            defaultMessage: 'analyzer preview',
+          }
+        )}
+      />
+    );
+  }
+
+  if (status === 'error' || (status === 'ready' && !dataView.hasMatchedIndices())) {
+    return DATAVIEW_ERROR;
+  }
+
+  if (!showAnalyzerTree) {
+    return ANALYZER_ERROR;
+  }
+
+  return (
     <EuiTreeView
       items={items}
       display="compressed"
@@ -101,11 +138,6 @@ export const AnalyzerPreview: React.FC = () => {
       )}
       showExpansionArrows
       data-test-subj={ANALYZER_PREVIEW_TEST_ID}
-    />
-  ) : (
-    <FormattedMessage
-      id="xpack.securitySolution.flyout.right.visualizations.analyzerPreview.errorDescription"
-      defaultMessage="An error is preventing this alert from being analyzed."
     />
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview.tsx
@@ -72,7 +72,7 @@ export const AnalyzerPreview: React.FC = () => {
     ? experimentalAnalyzerPatterns
     : oldAnalyzerPatterns;
 
-  const { dataView, status } = useDataView(PageScope.analyzer);
+  const { dataView, status } = useDataView(DataViewManagerScopeName.analyzer);
 
   const index = find({ category: 'kibana', field: RULE_INDICES }, data);
   const indices = index?.values ?? selectedPatterns;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/analyzer_preview_container.test.tsx
@@ -24,6 +24,9 @@ import {
 } from '../../../shared/components/test_ids';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useInvestigateInTimeline } from '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
+import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 
 jest.mock(
   '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver'
@@ -33,6 +36,7 @@ jest.mock(
   '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
 );
 jest.mock('../../../../common/hooks/use_experimental_features');
+jest.mock('../../../../data_view_manager/hooks/use_data_view');
 
 const mockNavigateToAnalyzer = jest.fn();
 jest.mock('../../shared/hooks/use_navigate_to_analyzer', () => {
@@ -50,6 +54,10 @@ jest.mock('react-redux', () => {
     ...original,
     useDispatch: () => jest.fn(),
   };
+});
+
+const dataView: DataView = createStubDataView({
+  spec: { title: '.alerts-security.alerts-default' },
 });
 
 const NO_ANALYZER_MESSAGE =
@@ -81,6 +89,13 @@ describe('AnalyzerPreviewContainer', () => {
       });
       (useInvestigateInTimeline as jest.Mock).mockReturnValue({
         investigateInTimelineAlertClick: jest.fn(),
+      });
+      (useDataView as jest.Mock).mockReturnValue({
+        status: 'ready',
+        dataView: {
+          ...dataView,
+          hasMatchedIndices: jest.fn().mockReturnValue(true),
+        },
       });
 
       const { getByTestId } = renderAnalyzerPreview();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Security Solution][Analyzer] ensure we render analyzer only when the dataView is ready (#245712)](https://github.com/elastic/kibana/pull/245712)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-12-23T14:41:34Z","message":"[Security Solution][Analyzer] ensure we render analyzer only when the dataView is ready (#245712)\n\n## Summary\n\nThis PR adds a bit of code to prevent the analyzer and analyzer preview\ncomponents to render while the data view is still loading. This will\nprevent unnecessary call being made without correct list of indices,\nwhich is something we've noticed recently (especially the first `entity`\ncall).\n\n### Context\n\nWe've recently seen in some SDHs that there are some weird behavior\nhappening with analyzer. After doing some investigation, we realized\nthat some `entity` calls are being fired without an empty list of\nindices, which should never happen. Those calls fail with a 500, which\nis expected.\n\n### PR changes\n\nThis PR ensures that no calls will be made while the data view is still\nloading. The code impacts 2 places:\n- the analyzer component, rendered in the alert details flyout left\npanel Visualize tab\n- the analyzer preview component, rendered in the alert details flyout\nright panel Overview tab\n\nThe code added will show either a loading spinner (for analyzer) or\nloading skeleton (for analyzer preview) while loading.\nIt will also show an error message if the data view fails to load\ncorrectly, or has no indices.\n\n#### Analyzer\n\n| Loading state  | Error state |\n| ------------- | ------------- |\n| <img width=\"1519\" height=\"1047\" alt=\"Screenshot 2025-12-11 at 3 57\n01 PM\"\nsrc=\"https://github.com/user-attachments/assets/033c06bf-287c-4cc3-9cea-0ee593b1236e\"\n/> | <img width=\"1520\" height=\"1048\" alt=\"Screenshot 2025-12-11 at 3 59\n02 PM\"\nsrc=\"https://github.com/user-attachments/assets/8391ce34-ab5e-4722-b029-12d7bb5ee21f\"\n/> |\n\n#### Analyzer preview\n\n| Loading state  | Error state |\n| ------------- | ------------- |\n| <img width=\"589\" height=\"952\" alt=\"Screenshot 2025-12-11 at 4 10\n46 PM\"\nsrc=\"https://github.com/user-attachments/assets/70464270-2eef-469d-9adb-e99fe30aebc6\"\n/> | <img width=\"587\" height=\"956\" alt=\"Screenshot 2025-12-11 at 4 11\n32 PM\"\nsrc=\"https://github.com/user-attachments/assets/1bce2f02-82d3-4404-8c96-f4e3f5c0f77d\"\n/> |\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"5b0aa1c3aa6ca6fcaac3c7c21c6fcc5a88b6601a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","backport:version","v9.3.0","v9.4.0","v9.2.3"],"title":"[Security Solution][Analyzer] ensure we render analyzer only when the dataView is ready","number":245712,"url":"https://github.com/elastic/kibana/pull/245712","mergeCommit":{"message":"[Security Solution][Analyzer] ensure we render analyzer only when the dataView is ready (#245712)\n\n## Summary\n\nThis PR adds a bit of code to prevent the analyzer and analyzer preview\ncomponents to render while the data view is still loading. This will\nprevent unnecessary call being made without correct list of indices,\nwhich is something we've noticed recently (especially the first `entity`\ncall).\n\n### Context\n\nWe've recently seen in some SDHs that there are some weird behavior\nhappening with analyzer. After doing some investigation, we realized\nthat some `entity` calls are being fired without an empty list of\nindices, which should never happen. Those calls fail with a 500, which\nis expected.\n\n### PR changes\n\nThis PR ensures that no calls will be made while the data view is still\nloading. The code impacts 2 places:\n- the analyzer component, rendered in the alert details flyout left\npanel Visualize tab\n- the analyzer preview component, rendered in the alert details flyout\nright panel Overview tab\n\nThe code added will show either a loading spinner (for analyzer) or\nloading skeleton (for analyzer preview) while loading.\nIt will also show an error message if the data view fails to load\ncorrectly, or has no indices.\n\n#### Analyzer\n\n| Loading state  | Error state |\n| ------------- | ------------- |\n| <img width=\"1519\" height=\"1047\" alt=\"Screenshot 2025-12-11 at 3 57\n01 PM\"\nsrc=\"https://github.com/user-attachments/assets/033c06bf-287c-4cc3-9cea-0ee593b1236e\"\n/> | <img width=\"1520\" height=\"1048\" alt=\"Screenshot 2025-12-11 at 3 59\n02 PM\"\nsrc=\"https://github.com/user-attachments/assets/8391ce34-ab5e-4722-b029-12d7bb5ee21f\"\n/> |\n\n#### Analyzer preview\n\n| Loading state  | Error state |\n| ------------- | ------------- |\n| <img width=\"589\" height=\"952\" alt=\"Screenshot 2025-12-11 at 4 10\n46 PM\"\nsrc=\"https://github.com/user-attachments/assets/70464270-2eef-469d-9adb-e99fe30aebc6\"\n/> | <img width=\"587\" height=\"956\" alt=\"Screenshot 2025-12-11 at 4 11\n32 PM\"\nsrc=\"https://github.com/user-attachments/assets/1bce2f02-82d3-4404-8c96-f4e3f5c0f77d\"\n/> |\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"5b0aa1c3aa6ca6fcaac3c7c21c6fcc5a88b6601a"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247385","number":247385,"state":"OPEN"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245712","number":245712,"mergeCommit":{"message":"[Security Solution][Analyzer] ensure we render analyzer only when the dataView is ready (#245712)\n\n## Summary\n\nThis PR adds a bit of code to prevent the analyzer and analyzer preview\ncomponents to render while the data view is still loading. This will\nprevent unnecessary call being made without correct list of indices,\nwhich is something we've noticed recently (especially the first `entity`\ncall).\n\n### Context\n\nWe've recently seen in some SDHs that there are some weird behavior\nhappening with analyzer. After doing some investigation, we realized\nthat some `entity` calls are being fired without an empty list of\nindices, which should never happen. Those calls fail with a 500, which\nis expected.\n\n### PR changes\n\nThis PR ensures that no calls will be made while the data view is still\nloading. The code impacts 2 places:\n- the analyzer component, rendered in the alert details flyout left\npanel Visualize tab\n- the analyzer preview component, rendered in the alert details flyout\nright panel Overview tab\n\nThe code added will show either a loading spinner (for analyzer) or\nloading skeleton (for analyzer preview) while loading.\nIt will also show an error message if the data view fails to load\ncorrectly, or has no indices.\n\n#### Analyzer\n\n| Loading state  | Error state |\n| ------------- | ------------- |\n| <img width=\"1519\" height=\"1047\" alt=\"Screenshot 2025-12-11 at 3 57\n01 PM\"\nsrc=\"https://github.com/user-attachments/assets/033c06bf-287c-4cc3-9cea-0ee593b1236e\"\n/> | <img width=\"1520\" height=\"1048\" alt=\"Screenshot 2025-12-11 at 3 59\n02 PM\"\nsrc=\"https://github.com/user-attachments/assets/8391ce34-ab5e-4722-b029-12d7bb5ee21f\"\n/> |\n\n#### Analyzer preview\n\n| Loading state  | Error state |\n| ------------- | ------------- |\n| <img width=\"589\" height=\"952\" alt=\"Screenshot 2025-12-11 at 4 10\n46 PM\"\nsrc=\"https://github.com/user-attachments/assets/70464270-2eef-469d-9adb-e99fe30aebc6\"\n/> | <img width=\"587\" height=\"956\" alt=\"Screenshot 2025-12-11 at 4 11\n32 PM\"\nsrc=\"https://github.com/user-attachments/assets/1bce2f02-82d3-4404-8c96-f4e3f5c0f77d\"\n/> |\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"5b0aa1c3aa6ca6fcaac3c7c21c6fcc5a88b6601a"}},{"branch":"9.2","label":"v9.2.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->