### PR TITLE
[9.2] [Security Solution] Persist analyzer dataview in local storage (#245002)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
@@ -86,6 +86,7 @@ export const useInitDataViewManager = () => {
       uiSettings: services.uiSettings,
       application: services.application,
       spaces: services.spaces,
+      storage: services.storage,
     });
 
     dispatch(addListener(dataViewsLoadingListener));
@@ -101,6 +102,7 @@ export const useInitDataViewManager = () => {
       createDataViewSelectedListener({
         scope,
         dataViews: services.dataViews,
+        storage: services.storage,
       })
     );
 
@@ -123,6 +125,7 @@ export const useInitDataViewManager = () => {
     services.dataViews,
     services.http,
     services.spaces,
+    services.storage,
     services.uiSettings,
   ]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
@@ -178,12 +178,12 @@ describe('createDataViewSelectedListener', () => {
     it('should store data view ID in storage when scope is analyzer', async () => {
       const analyzerListener = createDataViewSelectedListener({
         dataViews: mockDataViewsService,
-        scope: PageScope.analyzer,
+        scope: DataViewManagerScopeName.analyzer,
         storage: mockStorage,
       });
 
       await analyzerListener.effect(
-        selectDataViewAsync({ id: 'adhoc_test-*', scope: PageScope.analyzer }),
+        selectDataViewAsync({ id: 'adhoc_test-*', scope: DataViewManagerScopeName.analyzer }),
         mockListenerApi
       );
 
@@ -195,7 +195,7 @@ describe('createDataViewSelectedListener', () => {
 
     it('should not store data view ID in storage when scope is not analyzer', async () => {
       await listener.effect(
-        selectDataViewAsync({ id: 'adhoc_test-*', scope: PageScope.default }),
+        selectDataViewAsync({ id: 'adhoc_test-*', scope: DataViewManagerScopeName.default }),
         mockListenerApi
       );
 
@@ -205,12 +205,12 @@ describe('createDataViewSelectedListener', () => {
     it('should store resolved data view ID from cached view when scope is analyzer', async () => {
       const analyzerListener = createDataViewSelectedListener({
         dataViews: mockDataViewsService,
-        scope: PageScope.analyzer,
+        scope: DataViewManagerScopeName.analyzer,
         storage: mockStorage,
       });
 
       await analyzerListener.effect(
-        selectDataViewAsync({ id: 'persisted_test-*', scope: PageScope.analyzer }),
+        selectDataViewAsync({ id: 'persisted_test-*', scope: DataViewManagerScopeName.analyzer }),
         mockListenerApi
       );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
@@ -12,6 +12,7 @@ import type { AnyAction, Dispatch, ListenerEffectAPI } from '@reduxjs/toolkit';
 import type { RootState } from '../reducer';
 import { DataViewManagerScopeName, DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID } from '../../constants';
 import { DEFAULT_ALERT_DATA_VIEW_ID } from '../../../../common/constants';
+import type { Storage } from '@kbn/kibana-utils-plugin/public';
 
 const mockDataViewsService = {
   getDataViewLazy: jest.fn(),
@@ -79,6 +80,12 @@ const mockedState: RootState = {
 
 const mockDispatch = jest.fn();
 const mockGetState = jest.fn(() => mockedState);
+const mockStorage = {
+  set: jest.fn(),
+  get: jest.fn(),
+  remove: jest.fn(),
+  clear: jest.fn(),
+} as unknown as Storage;
 
 const mockListenerApi = {
   dispatch: mockDispatch,
@@ -95,6 +102,7 @@ describe('createDataViewSelectedListener', () => {
     listener = createDataViewSelectedListener({
       dataViews: mockDataViewsService,
       scope: DataViewManagerScopeName.default,
+      storage: mockStorage,
     });
   });
 
@@ -164,5 +172,52 @@ describe('createDataViewSelectedListener', () => {
         payload: 'adhoc_test-*',
       })
     );
+  });
+
+  describe('analyzer scope storage', () => {
+    it('should store data view ID in storage when scope is analyzer', async () => {
+      const analyzerListener = createDataViewSelectedListener({
+        dataViews: mockDataViewsService,
+        scope: PageScope.analyzer,
+        storage: mockStorage,
+      });
+
+      await analyzerListener.effect(
+        selectDataViewAsync({ id: 'adhoc_test-*', scope: PageScope.analyzer }),
+        mockListenerApi
+      );
+
+      expect(mockStorage.set).toHaveBeenCalledWith(
+        'securitySolution.dataViewManager.selectedDataView.analyzer',
+        'adhoc_test-*'
+      );
+    });
+
+    it('should not store data view ID in storage when scope is not analyzer', async () => {
+      await listener.effect(
+        selectDataViewAsync({ id: 'adhoc_test-*', scope: PageScope.default }),
+        mockListenerApi
+      );
+
+      expect(mockStorage.set).not.toHaveBeenCalled();
+    });
+
+    it('should store resolved data view ID from cached view when scope is analyzer', async () => {
+      const analyzerListener = createDataViewSelectedListener({
+        dataViews: mockDataViewsService,
+        scope: PageScope.analyzer,
+        storage: mockStorage,
+      });
+
+      await analyzerListener.effect(
+        selectDataViewAsync({ id: 'persisted_test-*', scope: PageScope.analyzer }),
+        mockListenerApi
+      );
+
+      expect(mockStorage.set).toHaveBeenCalledWith(
+        'securitySolution.dataViewManager.selectedDataView.analyzer',
+        'persisted_test-*'
+      );
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
@@ -7,6 +7,7 @@
 
 import type { DataView, DataViewLazy, DataViewsServicePublic } from '@kbn/data-views-plugin/public';
 import type { AnyAction, Dispatch, ListenerEffectAPI } from '@reduxjs/toolkit';
+import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import { isEmpty } from 'lodash';
 import type { RootState } from '../reducer';
 import { scopes } from '../reducer';
@@ -27,12 +28,13 @@ import type { DataViewManagerScopeName } from '../../constants';
  * If a data view is successfully resolved, it dispatches an action to set it as selected for the current scope.
  * If an error occurs during fetching or creation, it dispatches an error action for the current scope.
  *
- * @param dependencies - The dependencies required for the listener, including the scope and DataViews service.
+ * @param dependencies - The dependencies required for the listener, including the scope, DataViews service, and storage.
  * @returns An object with the action creator and effect for Redux middleware.
  */
 export const createDataViewSelectedListener = (dependencies: {
   scope: DataViewManagerScopeName;
   dataViews: DataViewsServicePublic;
+  storage: Storage;
 }) => {
   return {
     actionCreator: selectDataViewAsync,
@@ -130,6 +132,12 @@ export const createDataViewSelectedListener = (dependencies: {
         }
 
         listenerApi.dispatch(currentScopeActions.setSelectedDataView(resolvedIdToUse));
+        if (action.payload.scope === PageScope.analyzer) {
+          dependencies.storage.set(
+            `securitySolution.dataViewManager.selectedDataView.${action.payload.scope}`,
+            resolvedIdToUse
+          );
+        }
       } else if (dataViewByIdError || adhocDataViewCreationError) {
         const err = dataViewByIdError || adhocDataViewCreationError;
         listenerApi.dispatch(

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
@@ -13,7 +13,7 @@ import type { RootState } from '../reducer';
 import { scopes } from '../reducer';
 import { selectDataViewAsync } from '../actions';
 import { sharedDataViewManagerSlice } from '../slices';
-import type { DataViewManagerScopeName } from '../../constants';
+import { DataViewManagerScopeName } from '../../constants';
 
 /**
  * Creates a Redux listener for handling data view selection logic in the data view manager.
@@ -132,7 +132,7 @@ export const createDataViewSelectedListener = (dependencies: {
         }
 
         listenerApi.dispatch(currentScopeActions.setSelectedDataView(resolvedIdToUse));
-        if (action.payload.scope === PageScope.analyzer) {
+        if (action.payload.scope === DataViewManagerScopeName.analyzer) {
           dependencies.storage.set(
             `securitySolution.dataViewManager.selectedDataView.${action.payload.scope}`,
             resolvedIdToUse

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -68,21 +68,19 @@ describe('createInitListener', () => {
       kibanaDataViews: [],
     } as unknown as Awaited<ReturnType<typeof createDefaultDataView>>);
 
-    listener = createInitListener(
-      {
-        dataViews: mockDataViewsService,
-        http,
-        application,
-        uiSettings,
-        spaces,
-        storage: {
-          get: jest.fn(),
-          set: jest.fn(),
-          remove: jest.fn(),
-          clear: jest.fn(),
-        } as unknown as Storage,
-      }
-    );
+    listener = createInitListener({
+      dataViews: mockDataViewsService,
+      http,
+      application,
+      uiSettings,
+      spaces,
+      storage: {
+        get: jest.fn(),
+        set: jest.fn(),
+        remove: jest.fn(),
+        clear: jest.fn(),
+      } as unknown as Storage,
+    });
   });
 
   it('should load the data views and dispatch further actions', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -17,6 +17,7 @@ import { selectDataViewAsync } from '../actions';
 import type { CoreStart } from '@kbn/core/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { createDefaultDataView } from '../../utils/create_default_data_view';
+import type { Storage } from '@kbn/kibana-utils-plugin/public';
 
 jest.mock('../../utils/create_default_data_view', () => ({
   createDefaultDataView: jest.fn(),
@@ -67,13 +68,21 @@ describe('createInitListener', () => {
       kibanaDataViews: [],
     } as unknown as Awaited<ReturnType<typeof createDefaultDataView>>);
 
-    listener = createInitListener({
-      dataViews: mockDataViewsService,
-      http,
-      application,
-      uiSettings,
-      spaces,
-    });
+    listener = createInitListener(
+      {
+        dataViews: mockDataViewsService,
+        http,
+        application,
+        uiSettings,
+        spaces,
+        storage: {
+          get: jest.fn(),
+          set: jest.fn(),
+          remove: jest.fn(),
+          clear: jest.fn(),
+        } as unknown as Storage,
+      }
+    );
   });
 
   it('should load the data views and dispatch further actions', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Security Solution] Persist analyzer dataview in local storage (#245002)](https://github.com/elastic/kibana/pull/245002)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kevin Qualters","email":"56408403+kqualters-elastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-16T13:01:50Z","message":"[Security Solution] Persist analyzer dataview in local storage (#245002)\n\n## Summary\n\nThis PR will persist analyzer (only for now, but easily extendible to\nother scopes) selected data view to local storage when it's set, by the\nuser or some other dispatch of that action. If the data view this is set\nto is deleted, and the value is set in local storage, the first data\nview in the data view selection list is used. With a bit more logic we\ncould probably fall back to security solution default, but I think the\nfirst is fine. If the key doesn't exist at all, the default is used in\nthis case.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\nhttps://github.com/elastic/kibana/issues/210926","sha":"40e1f9f3a24e5d955c8385d914d19e343b7166c2","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","backport missing","Team:Threat Hunting:Investigations","backport:version","v9.3.0","v9.2.4"],"title":"[Security Solution] Persist analyzer dataview in local storage","number":245002,"url":"https://github.com/elastic/kibana/pull/245002","mergeCommit":{"message":"[Security Solution] Persist analyzer dataview in local storage (#245002)\n\n## Summary\n\nThis PR will persist analyzer (only for now, but easily extendible to\nother scopes) selected data view to local storage when it's set, by the\nuser or some other dispatch of that action. If the data view this is set\nto is deleted, and the value is set in local storage, the first data\nview in the data view selection list is used. With a bit more logic we\ncould probably fall back to security solution default, but I think the\nfirst is fine. If the key doesn't exist at all, the default is used in\nthis case.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\nhttps://github.com/elastic/kibana/issues/210926","sha":"40e1f9f3a24e5d955c8385d914d19e343b7166c2"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245002","number":245002,"mergeCommit":{"message":"[Security Solution] Persist analyzer dataview in local storage (#245002)\n\n## Summary\n\nThis PR will persist analyzer (only for now, but easily extendible to\nother scopes) selected data view to local storage when it's set, by the\nuser or some other dispatch of that action. If the data view this is set\nto is deleted, and the value is set in local storage, the first data\nview in the data view selection list is used. With a bit more logic we\ncould probably fall back to security solution default, but I think the\nfirst is fine. If the key doesn't exist at all, the default is used in\nthis case.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\nhttps://github.com/elastic/kibana/issues/210926","sha":"40e1f9f3a24e5d955c8385d914d19e343b7166c2"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->