### PR TITLE
[9.3] [Search] EIS promo cleanup and improvements (#247147)

### DIFF
--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_callout.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_callout.test.tsx
@@ -28,7 +28,7 @@ jest.mock('../hooks/use_kibana');
 
 const mockUiSettingsGet = jest.fn();
 const mockNavigateToApp = jest.fn();
-const mockOnDismissTour = jest.fn();
+const mockOnDismissPromo = jest.fn();
 
 const mockUseKibana = (overrides?: Partial<any>) => {
   (useKibana as jest.Mock).mockReturnValue({
@@ -74,7 +74,7 @@ describe('EisCloudConnectPromoCallout', () => {
     mockUseKibana();
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: mockOnDismissTour,
+      onDismissPromo: mockOnDismissPromo,
     });
   });
 
@@ -95,13 +95,13 @@ describe('EisCloudConnectPromoCallout', () => {
     expect(screen.getByText(EIS_CLOUD_CONNECT_PROMO_TOUR_CTA)).toBeInTheDocument();
   });
 
-  it('calls onDismissTour when dismiss button is clicked', () => {
+  it('calls onDismissPromo when dismiss button is clicked', () => {
     renderComponent();
 
     const dismissButton = screen.getByTestId('euiDismissCalloutButton');
     fireEvent.click(dismissButton);
 
-    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
+    expect(mockOnDismissPromo).toHaveBeenCalledTimes(1);
   });
 
   it('calls navigateToApp when CTA button is clicked', () => {
@@ -116,7 +116,7 @@ describe('EisCloudConnectPromoCallout', () => {
   it('does not render when promo is not visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: false,
-      onDismissTour: mockOnDismissTour,
+      onDismissPromo: mockOnDismissPromo,
     });
 
     renderComponent();

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_callout.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_callout.tsx
@@ -40,7 +40,7 @@ export const EisCloudConnectPromoCallout = ({
   const {
     services: { application },
   } = useKibana();
-  const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
+  const { isPromoVisible, onDismissPromo } = useShowEisPromotionalContent({
     promoId: `${promoId}CloudConnectCallout`,
   });
 
@@ -65,7 +65,7 @@ export const EisCloudConnectPromoCallout = ({
           border: `${euiTheme.border.thin}`,
           borderRadius: `${euiTheme.border.radius.medium}`,
         })}
-        onDismiss={onDismissTour}
+        onDismiss={onDismissPromo}
       >
         <EuiFlexGroup direction={direction} alignItems="flexStart">
           <EuiImage src={searchRocketIcon} alt="" size="original" />
@@ -83,7 +83,7 @@ export const EisCloudConnectPromoCallout = ({
               size="s"
               onClick={navigateToApp}
               data-test-subj="eisUpdateCalloutCtaBtn"
-              data-telemetry-id={`${dataId}-cta-btn`}
+              data-telemetry-id={`${dataId}-connectYourCluster-btn`}
               iconSide="right"
               iconType="popout"
             >

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.test.tsx
@@ -44,7 +44,7 @@ const mockUseKibana = (overrides?: Partial<any>) => {
 
 describe('EisCloudConnectPromoTour', () => {
   const promoId = 'cloudConnectPromo';
-  const dataId = `${promoId}-cloud-connect-promo-tour`;
+  const dataId = `${promoId}-cloud-connect-tour`;
   const childTestId = 'tourChild';
 
   const renderComponent = (
@@ -70,7 +70,7 @@ describe('EisCloudConnectPromoTour', () => {
   it('renders children only when promo is not visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: false,
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderComponent();
@@ -82,7 +82,7 @@ describe('EisCloudConnectPromoTour', () => {
   it('renders children and does not render the tour when isReady is false', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true, // would normally show the tour
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderComponent({ isReady: false });
@@ -94,7 +94,7 @@ describe('EisCloudConnectPromoTour', () => {
   it('renders children and does not render the tour when isSelfManaged is false', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderComponent({ isSelfManaged: false });
@@ -106,7 +106,7 @@ describe('EisCloudConnectPromoTour', () => {
   it('renders the tour when promo is visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderComponent();
@@ -119,7 +119,7 @@ describe('EisCloudConnectPromoTour', () => {
   it('renders CTA button and calls navigateToApp when clicked', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderComponent();
@@ -135,7 +135,7 @@ describe('EisCloudConnectPromoTour', () => {
 
   it('removes the tour from DOM after clicking Dismiss, children remain', () => {
     let visible = true;
-    const mockOnDismissTour = jest.fn(() => {
+    const mockOnDismissPromo = jest.fn(() => {
       visible = false;
     });
 
@@ -143,7 +143,7 @@ describe('EisCloudConnectPromoTour', () => {
       get isPromoVisible() {
         return visible;
       },
-      onDismissTour: mockOnDismissTour,
+      onDismissPromo: mockOnDismissPromo,
     }));
 
     const { rerender } = renderComponent();
@@ -151,7 +151,7 @@ describe('EisCloudConnectPromoTour', () => {
     expect(screen.getByTestId(dataId)).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('eisCloudConnectPromoTourCloseBtn'));
-    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
+    expect(mockOnDismissPromo).toHaveBeenCalledTimes(1);
 
     rerender(
       <EisCloudConnectPromoTour

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_ccm_promotional_tour.tsx
@@ -74,11 +74,11 @@ export const EisCloudConnectPromoTour = ({
   } = useKibana();
   // Setting to enable hiding the tour for FTR tests
   const isEISTourEnabled = uiSettings?.get<boolean>(EIS_TOUR_ENABLED_FEATURE_FLAG_ID, true);
-  const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
+  const { isPromoVisible, onDismissPromo } = useShowEisPromotionalContent({
     promoId: `${promoId}CloudConnectTour`,
   });
 
-  const dataId = `${promoId}-cloud-connect-promo-tour`;
+  const dataId = `${promoId}-cloud-connect-tour`;
 
   const hasCloudConnectPermission = Boolean(
     application.capabilities.cloudConnect?.show || application.capabilities.cloudConnect?.configure
@@ -96,7 +96,6 @@ export const EisCloudConnectPromoTour = ({
 
   return (
     <EuiTourStep
-      data-telemetry-id={dataId}
       data-test-subj={dataId}
       title={EIS_CLOUD_CONNECT_PROMO_TOUR_TITLE}
       maxWidth={`${euiTheme.base * 25}px`}
@@ -110,14 +109,19 @@ export const EisCloudConnectPromoTour = ({
       anchorPosition={anchorPosition}
       step={1}
       stepsTotal={1}
-      onFinish={onDismissTour}
+      onFinish={onDismissPromo}
       footerAction={[
-        <EuiButtonEmpty data-test-subj="eisCloudConnectPromoTourCloseBtn" onClick={onDismissTour}>
+        <EuiButtonEmpty
+          data-test-subj="eisCloudConnectPromoTourCloseBtn"
+          data-telemetry-id={`${dataId}-dismiss-btn`}
+          onClick={onDismissPromo}
+        >
           {EIS_TOUR_DISMISS}
         </EuiButtonEmpty>,
         <EuiButton
           onClick={navigateToApp}
           data-test-subj="eisCloudConnectPromoTourCtaBtn"
+          data-telemetry-id={`${dataId}-connectYourCluster-btn`}
           iconSide="right"
           iconType="popout"
         >

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_callout.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_callout.test.tsx
@@ -21,7 +21,7 @@ describe('EisPromotionalCallout', () => {
   const dataId = `${promoId}-eis-promo-callout`;
   const ctaLink = 'https://example.com';
   const direction: EisPromotionalCalloutProps['direction'] = 'row';
-  const mockOnDismissTour = jest.fn();
+  const mockOnDismissPromo = jest.fn();
 
   const renderEisPromotionalCallout = (props?: Partial<EisPromotionalCalloutProps>) => {
     return render(
@@ -41,7 +41,7 @@ describe('EisPromotionalCallout', () => {
     jest.clearAllMocks();
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: mockOnDismissTour,
+      onDismissPromo: mockOnDismissPromo,
     });
   });
 
@@ -62,19 +62,19 @@ describe('EisPromotionalCallout', () => {
     expect(screen.getByTestId('eisPromoCalloutCtaBtn')).toBeInTheDocument();
   });
 
-  it('calls onDismissTour when dismiss button is clicked', () => {
+  it('calls onDismissPromo when dismiss button is clicked', () => {
     renderEisPromotionalCallout();
 
-    const dismissButton = screen.getByTestId('eisPromoCalloutDismissBtn');
+    const dismissButton = screen.getByTestId('euiDismissCalloutButton');
     fireEvent.click(dismissButton);
 
-    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
+    expect(mockOnDismissPromo).toHaveBeenCalledTimes(1);
   });
 
   it('does not render callout when promo is not visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: false,
-      onDismissTour: mockOnDismissTour,
+      onDismissPromo: mockOnDismissPromo,
     });
 
     renderEisPromotionalCallout();

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_callout.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_callout.tsx
@@ -10,10 +10,9 @@
 import React from 'react';
 import {
   EuiButton,
-  EuiButtonIcon,
+  EuiCallOut,
   EuiFlexGroup,
   EuiImage,
-  EuiPanel,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -22,7 +21,6 @@ import searchRocketIcon from '../assets/search-rocket.svg';
 import {
   EIS_CALLOUT_DOCUMENTATION_BTN,
   EIS_PROMO_CALLOUT_DESCRIPTION,
-  EIS_CALLOUT_DISMISS_ARIA,
   EIS_CALLOUT_TITLE,
 } from '../translations';
 import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
@@ -40,8 +38,8 @@ export const EisPromotionalCallout = ({
   isCloudEnabled,
   direction,
 }: EisPromotionalCalloutProps) => {
-  const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
-    promoId: `${promoId}Callout`,
+  const { isPromoVisible, onDismissPromo } = useShowEisPromotionalContent({
+    promoId: `${promoId}EisPromoCallout`,
   });
 
   const dataId = `${promoId}-eis-promo-callout`;
@@ -51,44 +49,36 @@ export const EisPromotionalCallout = ({
   }
 
   return (
-    <EuiPanel
-      grow={false}
-      data-telemetry-id={dataId}
+    <EuiCallOut
       data-test-subj={dataId}
       css={({ euiTheme }) => ({
-        color: euiTheme.colors.primaryText,
-        border: `1px ${euiTheme.colors.borderBaseSubdued} solid`,
-        position: 'relative',
+        backgroundColor: `${euiTheme.colors.backgroundBaseSubdued}`,
+        border: `${euiTheme.border.thin}`,
+        borderRadius: `${euiTheme.border.radius.medium}`,
       })}
-      paddingSize="m"
-      color="subdued"
+      onDismiss={onDismissPromo}
     >
-      <div style={{ position: 'absolute', top: 8, right: 8 }}>
-        <EuiButtonIcon
-          data-test-subj="eisPromoCalloutDismissBtn"
-          iconType="cross"
-          aria-label={EIS_CALLOUT_DISMISS_ARIA}
-          onClick={onDismissTour}
-          size="s"
-        />
-      </div>
-      <EuiFlexGroup direction={direction} alignItems="flexStart">
-        <EuiImage src={searchRocketIcon} alt="" size="original" />
+      <EuiFlexGroup
+        direction={direction}
+        alignItems="flexStart"
+        gutterSize={direction === 'row' ? 'l' : 'm'}
+      >
+        <EuiImage src={searchRocketIcon} alt="" />
         <div>
-          <EuiTitle size="xxs">
-            <h2>{EIS_CALLOUT_TITLE}</h2>
+          <EuiTitle>
+            <h4>{EIS_CALLOUT_TITLE}</h4>
           </EuiTitle>
-          <EuiSpacer size="xs" />
           <EuiText color="subdued" size="s">
             <p>{EIS_PROMO_CALLOUT_DESCRIPTION}</p>
           </EuiText>
-          <EuiSpacer size="s" />
+          <EuiSpacer size="m" />
           <EuiButton
             fullWidth={false}
             color="text"
             size="s"
             href={ctaLink}
             data-test-subj="eisPromoCalloutCtaBtn"
+            data-telemetry-id={`${dataId}-viewEisDocs-link`}
             target="_blank"
             iconSide="right"
             iconType="popout"
@@ -97,6 +87,6 @@ export const EisPromotionalCallout = ({
           </EuiButton>
         </div>
       </EuiFlexGroup>
-    </EuiPanel>
+    </EuiCallOut>
   );
 };

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.test.tsx
@@ -38,7 +38,7 @@ describe('EisPromotionalTour', () => {
   it('renders children only when promo is not visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: false,
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderEisPromotionalTour();
@@ -53,7 +53,7 @@ describe('EisPromotionalTour', () => {
   it('renders the tour when promo is visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderEisPromotionalTour();
@@ -68,11 +68,11 @@ describe('EisPromotionalTour', () => {
     expect(screen.getByText(EIS_PROMO_TOUR_TITLE)).toBeInTheDocument();
   });
 
-  it('calls onDismissTour when clicking the close button', () => {
-    const mockOnDismissTour = jest.fn();
+  it('calls onDismissPromo when clicking the close button', () => {
+    const mockOnDismissPromo = jest.fn();
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: mockOnDismissTour,
+      onDismissPromo: mockOnDismissPromo,
     });
 
     renderEisPromotionalTour();
@@ -80,14 +80,14 @@ describe('EisPromotionalTour', () => {
     const closeBtn = screen.getByTestId('eisPromoTourCloseBtn');
     fireEvent.click(closeBtn);
 
-    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
+    expect(mockOnDismissPromo).toHaveBeenCalledTimes(1);
   });
 
   it('renders CTA button only when ctaLink is provided', () => {
     const ctaLink = 'https://example.com';
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderEisPromotionalTour({ ctaLink });
@@ -101,7 +101,7 @@ describe('EisPromotionalTour', () => {
   it('does not render CTA button when ctaLink is undefined', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderEisPromotionalTour({ ctaLink: undefined });
@@ -115,7 +115,7 @@ describe('EisPromotionalTour', () => {
   it('removes the tour from the DOM when close button is clicked, child remains', () => {
     // Use a variable to simulate state
     let isVisible = true;
-    const mockOnDismissTour = jest.fn(() => {
+    const mockOnDismissPromo = jest.fn(() => {
       isVisible = false;
     });
 
@@ -123,7 +123,7 @@ describe('EisPromotionalTour', () => {
       get isPromoVisible() {
         return isVisible;
       },
-      onDismissTour: mockOnDismissTour,
+      onDismissPromo: mockOnDismissPromo,
     }));
 
     const { rerender } = renderEisPromotionalTour();
@@ -134,7 +134,7 @@ describe('EisPromotionalTour', () => {
 
     // Click the close button
     fireEvent.click(screen.getByTestId('eisPromoTourCloseBtn'));
-    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
+    expect(mockOnDismissPromo).toHaveBeenCalledTimes(1);
 
     // Re-render component to simulate state update
     rerender(

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_promotional_tour.tsx
@@ -40,8 +40,8 @@ export const EisPromotionalTour = ({
   children,
 }: EisPromotionalTourProps) => {
   const { euiTheme } = useEuiTheme();
-  const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
-    promoId: `${promoId}Tour`,
+  const { isPromoVisible, onDismissPromo } = useShowEisPromotionalContent({
+    promoId: `${promoId}EisPromoTour`,
   });
   const dataId = `${promoId}-eis-promo-tour`;
 
@@ -51,7 +51,6 @@ export const EisPromotionalTour = ({
 
   return (
     <EuiTourStep
-      data-telemetry-id={dataId}
       data-test-subj={dataId}
       title={EIS_PROMO_TOUR_TITLE}
       maxWidth={`${euiTheme.base * 25}px`}
@@ -64,9 +63,13 @@ export const EisPromotionalTour = ({
       anchorPosition={anchorPosition}
       step={1}
       stepsTotal={1}
-      onFinish={onDismissTour}
+      onFinish={onDismissPromo}
       footerAction={[
-        <EuiButtonEmpty data-test-subj="eisPromoTourCloseBtn" onClick={onDismissTour}>
+        <EuiButtonEmpty
+          data-test-subj="eisPromoTourCloseBtn"
+          data-telemetry-id={`${dataId}-dismiss-btn`}
+          onClick={onDismissPromo}
+        >
           {EIS_TOUR_DISMISS}
         </EuiButtonEmpty>,
         ...(ctaLink
@@ -74,6 +77,7 @@ export const EisPromotionalTour = ({
               <EuiButton
                 href={ctaLink}
                 data-test-subj="eisPromoTourCtaBtn"
+                data-telemetry-id={`${dataId}-learnMore-btn`}
                 target="_blank"
                 iconSide="right"
                 iconType="popout"

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_token_cost_tour.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_token_cost_tour.test.tsx
@@ -36,7 +36,7 @@ describe('EisTokenCostTour', () => {
   it('renders children only when promo is not visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: false,
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderComponent();
@@ -51,7 +51,7 @@ describe('EisTokenCostTour', () => {
   it('renders children and does not render the tour when isReady is false', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true, // would normally show the tour
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderComponent({ isReady: false });
@@ -66,7 +66,7 @@ describe('EisTokenCostTour', () => {
   it('renders the tour when promo is visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderComponent();
@@ -83,7 +83,7 @@ describe('EisTokenCostTour', () => {
 
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderComponent({ ctaLink });
@@ -98,7 +98,7 @@ describe('EisTokenCostTour', () => {
   it('does not render CTA button when ctaLink is undefined', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: jest.fn(),
+      onDismissPromo: jest.fn(),
     });
 
     renderComponent({ ctaLink: undefined });
@@ -109,7 +109,7 @@ describe('EisTokenCostTour', () => {
 
   it('removes the tour from DOM after clicking close, children remain', () => {
     let visible = true;
-    const mockOnDismissTour = jest.fn(() => {
+    const mockOnDismissPromo = jest.fn(() => {
       visible = false;
     });
 
@@ -117,7 +117,7 @@ describe('EisTokenCostTour', () => {
       get isPromoVisible() {
         return visible;
       },
-      onDismissTour: mockOnDismissTour,
+      onDismissPromo: mockOnDismissPromo,
     }));
 
     const { rerender } = renderComponent();
@@ -125,7 +125,7 @@ describe('EisTokenCostTour', () => {
     expect(screen.getByTestId(dataId)).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('tokenConsumptionCostTourCloseBtn'));
-    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
+    expect(mockOnDismissPromo).toHaveBeenCalledTimes(1);
 
     rerender(
       <EisTokenCostTour promoId={promoId} isCloudEnabled={true}>

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_token_cost_tour.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_token_cost_tour.tsx
@@ -55,8 +55,8 @@ export const EisTokenCostTour = ({
   children,
 }: EisTokenCostTourProps) => {
   const { euiTheme } = useEuiTheme();
-  const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
-    promoId: `${promoId}Tour`,
+  const { isPromoVisible, onDismissPromo } = useShowEisPromotionalContent({
+    promoId: `${promoId}EisCostsTour`,
   });
   const dataId = `${promoId}-eis-costs-tour`;
 
@@ -66,7 +66,6 @@ export const EisTokenCostTour = ({
 
   return (
     <EuiTourStep
-      data-telemetry-id={dataId}
       data-test-subj={dataId}
       title={i18n.EIS_COSTS_TOUR_TITLE}
       maxWidth={`${euiTheme.base * 25}px`}
@@ -79,11 +78,12 @@ export const EisTokenCostTour = ({
       anchorPosition={anchorPosition}
       step={1}
       stepsTotal={1}
-      onFinish={onDismissTour}
+      onFinish={onDismissPromo}
       footerAction={[
         <EuiButtonEmpty
           data-test-subj="tokenConsumptionCostTourCloseBtn"
-          onClick={onDismissTour}
+          data-telemetry-id={`${dataId}-dismiss-btn`}
+          onClick={onDismissPromo}
           aria-label={i18n.EIS_COSTS_TOUR_DISMISS_ARIA}
         >
           {i18n.EIS_TOUR_DISMISS}
@@ -96,6 +96,7 @@ export const EisTokenCostTour = ({
                 size="s"
                 href={ctaLink}
                 data-test-subj="eisCostsTourCtaBtn"
+                data-telemetry-id={`${dataId}-learnMore-btn`}
                 target="_blank"
                 iconSide="right"
                 iconType="popout"

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_update_callout.test.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_update_callout.test.tsx
@@ -28,7 +28,7 @@ describe('EisUpdateCallout', () => {
   const ctaLink = 'https://example.com';
   const direction: EisUpdateCalloutProps['direction'] = 'row';
 
-  const mockOnDismissTour = jest.fn();
+  const mockOnDismissPromo = jest.fn();
   const mockHandleOnClick = jest.fn();
 
   const renderEisUpdateCallout = (props?: Partial<EisUpdateCalloutProps>) => {
@@ -37,7 +37,7 @@ describe('EisUpdateCallout', () => {
         <EisUpdateCallout
           promoId={promoId}
           ctaLink={ctaLink}
-          isCloudEnabled={true}
+          shouldShowEisUpdateCallout={true}
           direction={direction}
           hasUpdatePrivileges={true}
           handleOnClick={mockHandleOnClick}
@@ -51,7 +51,7 @@ describe('EisUpdateCallout', () => {
     jest.clearAllMocks();
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: true,
-      onDismissTour: mockOnDismissTour,
+      onDismissPromo: mockOnDismissPromo,
     });
   });
 
@@ -72,13 +72,13 @@ describe('EisUpdateCallout', () => {
     expect(screen.getByText(EIS_CALLOUT_DOCUMENTATION_BTN)).toBeInTheDocument();
   });
 
-  it('calls onDismissTour when dismiss button is clicked', () => {
+  it('calls onDismissPromo when dismiss button is clicked', () => {
     renderEisUpdateCallout();
 
     const dismissButton = screen.getByTestId('euiDismissCalloutButton');
     fireEvent.click(dismissButton);
 
-    expect(mockOnDismissTour).toHaveBeenCalledTimes(1);
+    expect(mockOnDismissPromo).toHaveBeenCalledTimes(1);
   });
 
   it('calls handleOnClick when CTA button is clicked', () => {
@@ -93,7 +93,7 @@ describe('EisUpdateCallout', () => {
   it('does not render callout when promo is not visible', () => {
     (useShowEisPromotionalContent as jest.Mock).mockReturnValue({
       isPromoVisible: false,
-      onDismissTour: mockOnDismissTour,
+      onDismissPromo: mockOnDismissPromo,
     });
 
     renderEisUpdateCallout();
@@ -102,8 +102,8 @@ describe('EisUpdateCallout', () => {
     expect(panel).not.toBeInTheDocument();
   });
 
-  it('does not render callout when user is not on cloud', () => {
-    renderEisUpdateCallout({ isCloudEnabled: false });
+  it('does not render callout when user does not have the necessary environment/licensing', () => {
+    renderEisUpdateCallout({ shouldShowEisUpdateCallout: false });
 
     const panel = screen.queryByTestId(dataId);
     expect(panel).not.toBeInTheDocument();

--- a/src/platform/packages/shared/kbn-search-api-panels/components/eis_update_callout.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/eis_update_callout.tsx
@@ -22,10 +22,35 @@ import * as i18n from '../translations';
 import { useShowEisPromotionalContent } from '../hooks/use_show_eis_promotional_content';
 import searchRocketIcon from '../assets/search-rocket.svg';
 
+/**
+ * Props for the EisUpdateCallout component.
+ *
+ * @property {string} ctaLink
+ *   URL for the call-to-action link to documentation.
+ *
+ * @property {string} promoId
+ *   Unique identifier for this promo instance. Used for localStorage and telemetry.
+ *
+ * @property {boolean} shouldShowEisUpdateCallout
+ *   Controls whether the callout should be displayed. Should only be set to true when the
+ *   environment is cloud-enabled AND (has an enterprise license OR is serverless-enabled).
+ *
+ * @property {() => void} handleOnClick
+ *   Callback function invoked when the call-to-action button is clicked.
+ *
+ * @property {'row' | 'column'} direction
+ *   Layout direction for the callout content. Determines how the icon and text are arranged.
+ *
+ * @property {boolean | undefined} hasUpdatePrivileges
+ *   Indicates whether the user has update privileges. If false, the callout will not be shown.
+ *
+ * @property {'top' | 'bottom'} [addSpacer]
+ *   Optional spacer placement. Adds spacing above or below the callout when specified.
+ */
 export interface EisUpdateCalloutProps {
   ctaLink: string;
   promoId: string;
-  isCloudEnabled: boolean;
+  shouldShowEisUpdateCallout: boolean;
   handleOnClick: () => void;
   direction: 'row' | 'column';
   hasUpdatePrivileges: boolean | undefined;
@@ -35,19 +60,19 @@ export interface EisUpdateCalloutProps {
 export const EisUpdateCallout = ({
   ctaLink,
   promoId,
-  isCloudEnabled,
+  shouldShowEisUpdateCallout,
   handleOnClick,
   direction,
   hasUpdatePrivileges,
   addSpacer,
 }: EisUpdateCalloutProps) => {
-  const { isPromoVisible, onDismissTour } = useShowEisPromotionalContent({
+  const { isPromoVisible, onDismissPromo } = useShowEisPromotionalContent({
     promoId: `${promoId}UpdateCallout`,
   });
 
   const dataId = `${promoId}-eis-update-callout`;
 
-  if (!isPromoVisible || !isCloudEnabled || hasUpdatePrivileges === false) {
+  if (!isPromoVisible || !shouldShowEisUpdateCallout || hasUpdatePrivileges === false) {
     return null;
   }
 
@@ -55,15 +80,13 @@ export const EisUpdateCallout = ({
     <>
       {addSpacer === 'top' && <EuiSpacer size="l" />}
       <EuiCallOut
-        data-telemetry-id={dataId}
         data-test-subj={dataId}
         css={({ euiTheme }) => ({
-          color: euiTheme.colors.primaryText,
           backgroundColor: `${euiTheme.colors.backgroundBaseSubdued}`,
           border: `${euiTheme.border.thin}`,
           borderRadius: `${euiTheme.border.radius.medium}`,
         })}
-        onDismiss={onDismissTour}
+        onDismiss={onDismissPromo}
       >
         <EuiFlexGroup direction={direction} alignItems="flexStart">
           <EuiImage src={searchRocketIcon} alt="" size="original" />
@@ -82,7 +105,7 @@ export const EisUpdateCallout = ({
                 size="s"
                 onClick={handleOnClick}
                 data-test-subj="eisUpdateCalloutCtaBtn"
-                data-telemetry-id={`${dataId}-cta-btn`}
+                data-telemetry-id={`${dataId}-openUpdateModal-btn`}
               >
                 {i18n.EIS_UPDATE_CALLOUT_CTA}
               </EuiButton>
@@ -91,7 +114,7 @@ export const EisUpdateCallout = ({
                 target="_blank"
                 external
                 color="text"
-                data-telemetry-id={`${dataId}-docs-btn`}
+                data-telemetry-id={`${dataId}-viewEisDocs-btn`}
               >
                 {i18n.EIS_CALLOUT_DOCUMENTATION_BTN}
               </EuiLink>

--- a/src/platform/packages/shared/kbn-search-api-panels/hooks/use_show_eis_promotional_content.test.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/hooks/use_show_eis_promotional_content.test.ts
@@ -27,13 +27,13 @@ describe('useShowEisPromotionalContent', () => {
     expect(result.current.isPromoVisible).toBe(false);
   });
 
-  it('should hide the promo and set localStorage when onDismissTour is called', () => {
+  it('should hide the promo and set localStorage when OnDismissPromo is called', () => {
     const { result } = renderHook(() => useShowEisPromotionalContent({ promoId }));
 
     expect(result.current.isPromoVisible).toBe(true);
 
     act(() => {
-      result.current.onDismissTour();
+      result.current.onDismissPromo();
     });
 
     expect(localStorage.getItem(localStorageKey)).toBe('true');

--- a/src/platform/packages/shared/kbn-search-api-panels/hooks/use_show_eis_promotional_content.ts
+++ b/src/platform/packages/shared/kbn-search-api-panels/hooks/use_show_eis_promotional_content.ts
@@ -16,7 +16,7 @@ interface UseShowEisPromotionalContentProps {
 export const useShowEisPromotionalContent = ({ promoId }: UseShowEisPromotionalContentProps) => {
   const localStorageKey = `${promoId}Closed`;
   const [isPromoVisible, setIsPromoVisible] = useState<boolean>(false);
-  const onDismissTour = useCallback(() => {
+  const onDismissPromo = useCallback(() => {
     localStorage.setItem(localStorageKey, 'true');
     setIsPromoVisible(false);
   }, [localStorageKey]);
@@ -29,5 +29,5 @@ export const useShowEisPromotionalContent = ({ promoId }: UseShowEisPromotionalC
     }
   }, [isPromoVisible, localStorageKey]);
 
-  return { isPromoVisible, onDismissTour };
+  return { isPromoVisible, onDismissPromo };
 };

--- a/x-pack/platform/plugins/shared/index_management/public/application/app_context.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/app_context.tsx
@@ -89,6 +89,7 @@ export interface AppDependencies {
   kibanaVersion: SemVer;
   overlays: OverlayStart;
   canUseSyntheticSource: boolean;
+  canUseEis: boolean;
   privs: {
     monitor: boolean;
     manageEnrich: boolean;

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/lib/utils.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/lib/utils.test.ts
@@ -10,6 +10,11 @@ jest.mock('../constants', () => {
   return { MAIN_DATA_TYPE_DEFINITION: {}, TYPE_DEFINITION };
 });
 
+import type { EuiSelectableOption } from '@elastic/eui';
+import {
+  ELSER_ON_EIS_INFERENCE_ENDPOINT_ID,
+  ELSER_ON_ML_NODE_INFERENCE_ENDPOINT_ID,
+} from '../../../constants/mappings';
 import type { Fields, NormalizedFields, State } from '../types';
 import {
   stripUndefinedValues,
@@ -19,7 +24,9 @@ import {
   getAllFieldTypesFromState,
   getFieldsMatchingFilterFromState,
   getStateWithCopyToFields,
+  prepareFieldsForEisUpdate,
 } from './utils';
+import type { MappingsOptionData } from '../../../sections/home/index_list/details_page/update_elser_mappings/update_elser_mappings_modal';
 
 const fieldsWithnestedFields: NormalizedFields = {
   byId: {
@@ -826,5 +833,128 @@ describe('utils', () => {
         expect(getStateWithCopyToFields(state)).toEqual(expectedState);
       });
     });
+  });
+});
+
+describe('prepareFieldsForEisUpdate', () => {
+  const flattenedFields: NormalizedFields = {
+    byId: {
+      '1': {
+        id: '1',
+        parentId: '2',
+        nestedDepth: 1,
+        isMultiField: false,
+        path: ['animal', 'name'],
+        source: {
+          name: 'name',
+          type: 'semantic_text',
+          inference_id: ELSER_ON_ML_NODE_INFERENCE_ENDPOINT_ID,
+        },
+        childFieldsName: 'fields',
+        canHaveChildFields: false,
+        hasChildFields: false,
+        canHaveMultiFields: true,
+        hasMultiFields: false,
+        isExpanded: false,
+      },
+      '2': {
+        id: '2',
+        nestedDepth: 0,
+        isMultiField: false,
+        path: ['animal'],
+        source: {
+          name: 'animal',
+          type: 'object',
+        },
+        childFieldsName: 'properties',
+        canHaveChildFields: true,
+        hasChildFields: true,
+        canHaveMultiFields: false,
+        hasMultiFields: false,
+        isExpanded: false,
+        childFields: ['1, 4'],
+      },
+      '3': {
+        id: '3',
+        nestedDepth: 0,
+        isMultiField: false,
+        path: ['name'],
+        source: {
+          name: 'name',
+          type: 'semantic_text',
+          inference_id: ELSER_ON_ML_NODE_INFERENCE_ENDPOINT_ID,
+        },
+        childFieldsName: 'fields',
+        canHaveChildFields: false,
+        hasChildFields: false,
+        canHaveMultiFields: true,
+        hasMultiFields: false,
+        isExpanded: false,
+      },
+      '4': {
+        id: '4',
+        parentId: '2',
+        nestedDepth: 1,
+        isMultiField: false,
+        path: ['animal', 'species'],
+        source: {
+          name: 'species',
+          type: 'semantic_text',
+          inference_id: ELSER_ON_ML_NODE_INFERENCE_ENDPOINT_ID,
+        },
+        childFieldsName: 'fields',
+        canHaveChildFields: false,
+        hasChildFields: false,
+        canHaveMultiFields: true,
+        hasMultiFields: false,
+        isExpanded: false,
+      },
+    },
+    aliases: {},
+    rootLevelFields: ['2', '3'],
+    maxNestedDepth: 1,
+  };
+  it('updates inference_id and includes parent fields', () => {
+    const selectedOption: EuiSelectableOption<MappingsOptionData>[] = [
+      {
+        label: 'animal.name',
+        name: 'name',
+        key: '1',
+        checked: 'on',
+      },
+      {
+        label: 'name',
+        name: 'name',
+        key: '3',
+        checked: 'on',
+      },
+    ];
+    const result = prepareFieldsForEisUpdate(selectedOption, flattenedFields);
+    // The selected option is in the result
+    expect(Object.keys(result.byId)).toContain('1');
+    // The selected option has the EIS endpoint set as the inference_id
+    expect(result.byId['1'].source.inference_id).toBe(ELSER_ON_EIS_INFERENCE_ENDPOINT_ID);
+    // The selected option has a parent id set
+    expect(result.byId['1'].parentId).toEqual('2');
+    // The selected option's parent is in the result
+    expect(result.byId['2']).toBeDefined();
+    // The rootLevelField array contains the grandparent of the selected option
+    expect(result.rootLevelFields).toEqual(['2', '3']);
+  });
+
+  it('prunes unselected childFields', () => {
+    const selectedOptionWithChildren: EuiSelectableOption<MappingsOptionData>[] = [
+      {
+        label: 'animal.name',
+        name: 'name',
+        key: '1',
+        checked: 'on',
+      },
+    ];
+    const result = prepareFieldsForEisUpdate(selectedOptionWithChildren, flattenedFields);
+    // The result contains the selected child option
+    expect(result.byId['1']).toBeDefined();
+    // The result does not contain the unselected sibling option
+    expect(result.byId['4']).toBeUndefined();
   });
 });

--- a/x-pack/platform/plugins/shared/index_management/public/application/mount_management_section.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/mount_management_section.ts
@@ -61,6 +61,7 @@ export function getIndexManagementDependencies({
   startDependencies,
   uiMetricService,
   canUseSyntheticSource,
+  canUseEis,
   reindexService,
 }: {
   core: CoreStart;
@@ -74,6 +75,7 @@ export function getIndexManagementDependencies({
   startDependencies: StartDependencies;
   uiMetricService: UiMetricService;
   canUseSyntheticSource: boolean;
+  canUseEis: boolean;
   reindexService: ReindexServicePublicStart;
 }): AppDependencies {
   const { docLinks, application, uiSettings, settings } = core;
@@ -113,6 +115,7 @@ export function getIndexManagementDependencies({
     kibanaVersion,
     overlays: core.overlays,
     canUseSyntheticSource,
+    canUseEis,
     privs: {
       monitor: !!monitor,
       manageEnrich: !!manageEnrich,
@@ -132,6 +135,7 @@ export async function mountManagementSection({
   config,
   cloud,
   canUseSyntheticSource,
+  canUseEis,
   reindexService,
 }: {
   coreSetup: CoreSetup<StartDependencies>;
@@ -143,6 +147,7 @@ export async function mountManagementSection({
   config: AppDependencies['config'];
   cloud?: CloudSetup;
   canUseSyntheticSource: boolean;
+  canUseEis: boolean;
   reindexService: ReindexServicePublicStart;
 }) {
   const { element, setBreadcrumbs, history } = params;
@@ -173,6 +178,7 @@ export async function mountManagementSection({
     uiMetricService,
     usageCollection,
     canUseSyntheticSource,
+    canUseEis,
     reindexService,
   });
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content/mappings_information_panels.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content/mappings_information_panels.tsx
@@ -49,18 +49,23 @@ export const MappingsInformationPanels = ({
   const {
     plugins: { cloud },
     core: { application },
+    canUseEis,
   } = useAppContext();
   const state = useMappingsState();
+
+  const [isUpdatingElserMappings, setIsUpdatingElserMappings] = useState<boolean>(false);
 
   const showAboutMappingsStyles = css`
     ${useEuiBreakpoint(['xl'])} {
       max-width: 480px;
     }
   `;
+
   const hasSemanticText = hasSemanticTextField(state.mappingViewFields);
   const hasElserOnMlNodeSemanticText = hasElserOnMlNodeSemanticTextField(state.mappingViewFields);
+  const shouldShowEisUpdateCallout =
+    (cloud?.isCloudEnabled && (canUseEis || cloud?.isServerlessEnabled)) ?? false;
 
-  const [isUpdatingElserMappings, setIsUpdatingElserMappings] = useState<boolean>(false);
   return (
     <EuiFlexItem grow={false} css={showAboutMappingsStyles}>
       <EuiFlexGroup direction="column" gutterSize="l">
@@ -70,7 +75,7 @@ export const MappingsInformationPanels = ({
               <EisUpdateCallout
                 ctaLink={documentationService.docLinks.enterpriseSearch.elasticInferenceService}
                 promoId="indexDetailsMappings"
-                isCloudEnabled={cloud?.isCloudEnabled ?? false}
+                shouldShowEisUpdateCallout={shouldShowEisUpdateCallout}
                 handleOnClick={() => setIsUpdatingElserMappings(true)}
                 direction="column"
                 hasUpdatePrivileges={hasUpdateMappingsPrivilege}
@@ -89,6 +94,7 @@ export const MappingsInformationPanels = ({
                 refetchMapping={refetchMapping}
                 setIsModalOpen={setIsUpdatingElserMappings}
                 hasUpdatePrivileges={hasUpdateMappingsPrivilege}
+                modalId="indexDetailsMappings"
               />
             )}
           </>
@@ -97,7 +103,9 @@ export const MappingsInformationPanels = ({
           promoId="indexDetailsMappings"
           isSelfManaged={!cloud?.isCloudEnabled}
           direction="column"
-          navigateToApp={() => application.navigateToApp(CLOUD_CONNECT_NAV_ID)}
+          navigateToApp={() =>
+            application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
+          }
         />
         <EuiPanel grow={false} paddingSize="l" hasShadow={false} hasBorder>
           <EuiFlexGroup alignItems="center" gutterSize="s">

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_overview/details_page_overview.tsx
@@ -69,6 +69,7 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
     core,
     plugins: { cloud, share },
     services: { extensionsService },
+    canUseEis,
   } = useAppContext();
   const state = useMappingsState();
   const { data: mappingsData, resendRequest } = useLoadIndexMappings(name || '');
@@ -91,6 +92,9 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
 
   const isLarge = useIsWithinBreakpoints(['xl']);
 
+  const shouldShowEisUpdateCallout =
+    (cloud?.isCloudEnabled && (canUseEis || cloud?.isServerlessEnabled)) ?? false;
+
   const { parsedDefaultValue } = useMemo(
     () => parseMappings(mappingsData ?? undefined),
     [mappingsData]
@@ -110,14 +114,16 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
         promoId="indexDetailsOverview"
         isSelfManaged={!cloud?.isCloudEnabled}
         direction="row"
-        navigateToApp={() => core.application.navigateToApp(CLOUD_CONNECT_NAV_ID)}
+        navigateToApp={() =>
+          core.application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
+        }
         addSpacer="bottom"
       />
       {hasElserOnMlNodeSemanticText && (
         <EisUpdateCallout
           ctaLink={documentationService.docLinks.enterpriseSearch.elasticInferenceService}
           promoId="indexDetailsOverview"
-          isCloudEnabled={cloud?.isCloudEnabled ?? false}
+          shouldShowEisUpdateCallout={shouldShowEisUpdateCallout}
           handleOnClick={() => setIsUpdatingElserMappings(true)}
           direction="row"
           hasUpdatePrivileges={hasUpdateMappingsPrivileges}
@@ -130,6 +136,7 @@ export const DetailsPageOverview: React.FunctionComponent<Props> = ({ indexDetai
           refetchMapping={resendRequest}
           setIsModalOpen={setIsUpdatingElserMappings}
           hasUpdatePrivileges={hasUpdateMappingsPrivileges}
+          modalId="indexDetailsOverview"
         />
       )}
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/update_elser_mappings/update_elser_mappings_modal.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/update_elser_mappings/update_elser_mappings_modal.test.tsx
@@ -73,6 +73,7 @@ const renderEisUpdateCallout = (props?: Partial<UpdateElserMappingsModalProps>) 
         setIsModalOpen={setIsModalOpen}
         refetchMapping={refetchMapping}
         hasUpdatePrivileges={props?.hasUpdatePrivileges ?? true}
+        modalId="testModal"
       />
     </IntlProvider>
   );

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/update_elser_mappings/update_elser_mappings_modal.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/update_elser_mappings/update_elser_mappings_modal.tsx
@@ -44,6 +44,7 @@ export interface UpdateElserMappingsModalProps {
   refetchMapping: () => void;
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   hasUpdatePrivileges: boolean | undefined;
+  modalId: string;
 }
 
 export function UpdateElserMappingsModal({
@@ -51,6 +52,7 @@ export function UpdateElserMappingsModal({
   refetchMapping,
   setIsModalOpen,
   hasUpdatePrivileges,
+  modalId,
 }: UpdateElserMappingsModalProps) {
   const state = useMappingsState();
   const [options, setOptions] = useState<EuiSelectableOption<MappingsOptionData>[]>([]);
@@ -171,6 +173,7 @@ export function UpdateElserMappingsModal({
         </EuiText>
         <EuiSpacer size="s" />
         <EuiLink
+          data-telemetry-id={`${modalId}-updateElserMappingsModal-learnMore-link`}
           href={documentationService.docLinks.enterpriseSearch.elasticInferenceServicePricing}
           target="_blank"
           external
@@ -204,6 +207,7 @@ export function UpdateElserMappingsModal({
         <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
           <EuiButtonEmpty
             data-test-subj="UpdateElserMappingsModalCancelBtn"
+            data-telemetry-id={`${modalId}-updateElserMappingsModal-cancel-btn`}
             onClick={() => setIsModalOpen(false)}
             aria-label={i18n.translate(
               'xpack.idxMgmt.indexDetails.updateElserMappingsModal.cancelButtonAriaLabel',
@@ -224,6 +228,7 @@ export function UpdateElserMappingsModal({
             onClick={handleApply}
             isLoading={isUpdating}
             data-test-subj="UpdateElserMappingsModalApplyBtn"
+            data-telemetry-id={`${modalId}-updateElserMappingsModal-apply-btn`}
             isDisabled={isApplyDisabled}
           >
             {i18n.translate('xpack.idxMgmt.indexDetails.updateElserMappingsModal.applyButton', {

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.test.tsx
@@ -116,6 +116,7 @@ const getIndexManagementCtx = (overrides: Partial<AppDependencies> = {}): AppDep
     kibanaVersion: {} as unknown as AppDependencies['kibanaVersion'],
     overlays: {} as unknown as AppDependencies['overlays'],
     canUseSyntheticSource: false,
+    canUseEis: false,
     privs: { monitor: true, manageEnrich: true, monitorEnrich: true, manageIndexTemplates: true },
   };
 

--- a/x-pack/platform/plugins/shared/index_management/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/plugin.ts
@@ -76,6 +76,7 @@ export class IndexMgmtUIPlugin
     enableFailureStoreRetentionDisabling: boolean;
   };
   private canUseSyntheticSource: boolean = false;
+  private canUseEis: boolean = false;
   private licensingSubscription?: Subscription;
 
   private capabilities$ = new Subject<Capabilities>();
@@ -147,6 +148,7 @@ export class IndexMgmtUIPlugin
               config: this.config,
               cloud,
               canUseSyntheticSource: this.canUseSyntheticSource,
+              canUseEis: this.canUseEis,
               reindexService,
             });
           },
@@ -177,6 +179,7 @@ export class IndexMgmtUIPlugin
           config: this.config,
           cloud,
           canUseSyntheticSource: this.canUseSyntheticSource,
+          canUseEis: this.canUseEis,
           reindexService,
         });
       },
@@ -223,6 +226,7 @@ export class IndexMgmtUIPlugin
       config: this.config,
       history: deps.history,
       canUseSyntheticSource: this.canUseSyntheticSource,
+      canUseEis: this.canUseEis,
       overlays: core.overlays,
       privs: {
         monitor: !!monitor,
@@ -248,6 +252,7 @@ export class IndexMgmtUIPlugin
 
     this.licensingSubscription = licensing?.license$.subscribe((next) => {
       this.canUseSyntheticSource = next.hasAtLeast('enterprise');
+      this.canUseEis = next.hasAtLeast('enterprise');
     });
     return {
       apiService: this.apiService!,

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_data.tsx
@@ -28,6 +28,7 @@ import { docLinks } from '../../../common/doc_links';
 import { UpdateElserMappingsModal } from '../update_elser_mappings/update_elser_mappings_modal';
 import { flattenMappings, hasElserOnMlNodeSemanticTextField } from '../update_elser_mappings/utils';
 import type { NormalizedFields } from '../update_elser_mappings/types';
+import { useLicense } from '../../hooks/use_license';
 
 interface IndexDetailsDataProps {
   indexName: string;
@@ -46,9 +47,13 @@ export const IndexDetailsData = ({
 }: IndexDetailsDataProps) => {
   const { application, cloud } = useKibana().services;
   const { data: mappingData } = useIndexMapping(indexName);
+  const { isAtLeastEnterprise } = useLicense();
   const [isUpdatingElserMappings, setIsUpdatingElserMappings] = useState<boolean>(false);
 
   const documents = indexDocuments?.results?.data ?? [];
+
+  const shouldShowEisUpdateCallout =
+    (cloud?.isCloudEnabled && (isAtLeastEnterprise() || cloud?.isServerlessEnabled)) ?? false;
 
   const fieldsForUpdate = useMemo<NormalizedFields['byId'] | undefined>(() => {
     const properties = mappingData?.mappings?.properties;
@@ -77,13 +82,16 @@ export const IndexDetailsData = ({
         promoId="indexDetailsData"
         isSelfManaged={!cloud?.isCloudEnabled}
         direction="row"
-        navigateToApp={() => application.navigateToApp(CLOUD_CONNECT_NAV_ID)}
+        navigateToApp={() =>
+          application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
+        }
+        addSpacer="top"
       />
       {fieldsForUpdate && (
         <EisUpdateCallout
           ctaLink={docLinks.elasticInferenceService}
           promoId="indexDetailsData"
-          isCloudEnabled={cloud?.isCloudEnabled ?? false}
+          shouldShowEisUpdateCallout={shouldShowEisUpdateCallout}
           handleOnClick={() => setIsUpdatingElserMappings(true)}
           direction="row"
           hasUpdatePrivileges={userPrivileges?.privileges.canManageIndex}

--- a/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/update_elser_mappings_modal.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/update_elser_mappings/update_elser_mappings_modal.tsx
@@ -132,7 +132,6 @@ export function UpdateElserMappingsModal({
       )}
       onClose={() => setIsModalOpen(false)}
       data-test-subj="updateElserMappingsModal"
-      data-telemetry-id="indexDetailsDataTabUpdateElserMappingsModal"
     >
       <EuiModalHeader>
         <EuiModalHeaderTitle size="s">
@@ -151,7 +150,7 @@ export function UpdateElserMappingsModal({
         <EuiSpacer size="s" />
         <EuiLink
           data-test-subj="updateElserMappingsModalLearnMoreLink"
-          data-telemetry-id="indexDetailsDataTabUpdateElserMappingsModalLearnMoreLink"
+          data-telemetry-id="indexDetailsData-updateElserMappingsModal-learnMore-link"
           href={docLinks.elasticInferenceServicePricing}
           target="_blank"
           external
@@ -185,7 +184,7 @@ export function UpdateElserMappingsModal({
         <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
           <EuiButtonEmpty
             data-test-subj="UpdateElserMappingsModalCancelBtn"
-            data-telemetry-id="indexDetailsDataTabUpdateElserMappingsModalCancelBtn"
+            data-telemetry-id="indexDetailsData-updateElserMappingsModal-cancel-btn"
             onClick={() => setIsModalOpen(false)}
             aria-label={i18n.translate(
               'xpack.searchIndices.updateElserMappingsModal.cancelButtonAriaLabel',
@@ -203,7 +202,7 @@ export function UpdateElserMappingsModal({
             onClick={handleApply}
             isLoading={isLoading}
             data-test-subj="UpdateElserMappingsModalApplyBtn"
-            data-telemetry-id="indexDetailsDataTabUpdateElserMappingsModalApplyBtn"
+            data-telemetry-id="indexDetailsData-updateElserMappingsModal-apply-btn"
             isDisabled={isApplyDisabled}
           >
             {i18n.translate('xpack.searchIndices.updateElserMappingsModal.applyButton', {

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/use_license.test.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/use_license.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import { renderHook } from '@testing-library/react';
+import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
+import type { LicenseType } from '@kbn/licensing-types';
+
+import { useLicense } from './use_license';
+import { useKibana } from './use_kibana';
+
+jest.mock('./use_kibana');
+
+const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
+const mockLicensing = licensingMock.createStart();
+
+const createKibanaMockWithLicense = (licenseType: LicenseType) => {
+  const license = licensingMock.createLicense({
+    license: { type: licenseType },
+  });
+
+  return {
+    services: {
+      licensing: {
+        ...mockLicensing,
+        license$: new BehaviorSubject(license),
+      },
+    },
+  };
+};
+
+describe('useLicense', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isAtLeastEnterprise', () => {
+    it('returns true for an enterprise license', () => {
+      mockUseKibana.mockReturnValue(createKibanaMockWithLicense('enterprise') as any);
+
+      const { result } = renderHook(() => useLicense());
+
+      expect(result.current.isAtLeastEnterprise()).toBe(true);
+    });
+
+    it('returns false for a gold license', () => {
+      mockUseKibana.mockReturnValue(createKibanaMockWithLicense('gold') as any);
+
+      const { result } = renderHook(() => useLicense());
+
+      expect(result.current.isAtLeastEnterprise()).toBe(false);
+    });
+  });
+});

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/use_license.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/use_license.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ILicense, LicenseType } from '@kbn/licensing-types';
+import { useCallback } from 'react';
+import useObservable from 'react-use/lib/useObservable';
+import { Observable } from 'rxjs';
+import { useKibana } from './use_kibana';
+
+interface UseLicenseReturnValue {
+  isAtLeast: (level: LicenseType) => boolean;
+  isAtLeastPlatinum: () => boolean;
+  isAtLeastGold: () => boolean;
+  isAtLeastEnterprise: () => boolean;
+  getLicense: () => ILicense | null | undefined;
+}
+
+export const useLicense = (): UseLicenseReturnValue => {
+  const { licensing } = useKibana().services;
+  const license = useObservable<ILicense | null>(licensing?.license$ ?? new Observable(), null);
+
+  const isAtLeast = useCallback(
+    (level: LicenseType): boolean => {
+      return !!license && license.isAvailable && license.isActive && license.hasAtLeast(level);
+    },
+    [license]
+  );
+
+  const isAtLeastPlatinum = useCallback(() => isAtLeast('platinum'), [isAtLeast]);
+  const isAtLeastGold = useCallback(() => isAtLeast('gold'), [isAtLeast]);
+  const isAtLeastEnterprise = useCallback(() => isAtLeast('enterprise'), [isAtLeast]);
+
+  return {
+    isAtLeast,
+    isAtLeastPlatinum,
+    isAtLeastGold,
+    isAtLeastEnterprise,
+    getLicense: () => license,
+  };
+};

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
@@ -238,7 +238,9 @@ export const TabularPage: React.FC<TabularPageProps> = ({ inferenceEndpoints }) 
           promoId="inferenceEndpointManagement"
           isSelfManaged={!cloud?.isCloudEnabled}
           direction="row"
-          navigateToApp={() => application.navigateToApp(CLOUD_CONNECT_NAV_ID)}
+          navigateToApp={() =>
+            application.navigateToApp(CLOUD_CONNECT_NAV_ID, { openInNewTab: true })
+          }
         />
         <EuiFlexItem>
           <EuiFlexGroup gutterSize="s">


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Search] EIS promo cleanup and improvements (#247147)](https://github.com/elastic/kibana/pull/247147)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brittany","email":"seialkali@gmail.com"},"sourceCommit":{"committedDate":"2025-12-23T15:55:17Z","message":"[Search] EIS promo cleanup and improvements (#247147)\n\n## Summary\n\nThis PR tidies up some of the work done around EIS promotions, and adds\nsome enhancements. The following changes were made:\n\n- Renamed the dismiss callback in `useShowEisPromotionalContent` to\n`onDismissPromo` as it's use for both tours and callouts.\n- Added a license check where `EisUpdateCallout` is used as this\nfunctionality is only available on ECH when there is an Enterprise\nlicense. No license is needed on Serverless.\n- Renamed the `isCloudEnabled` prop in `EisUpdateCallout` to\n`shouldShowEisUpdateCallout` to account for ECH environments now needing\nan Enterprise license\n- Added telemetry IDs on all buttons and links within the EIS/CCM tour\nand callouts, and the update ELSER to ELSER on EIS modal\n- Tidied up telemetry ID and local storage key naming so there was more\nconsistency and it was easier to differentiate between each action and\npromo\n- Updated the links to Cloud Connect so it opened in a new tab\n- Swapped `EuiPanel` for `EuiCallOut` in `EisPromotionalCallout`\n- Added spacing above the `EisCloudConnectPromoCallout`\n- Made `prepareFieldsForEisUpdate` more robust and added unit tests\n\n### Testing\n\nThe following should be tested to ensure the addition of the license\ncheck is working as expected, and that there's been no regression\nfollowing the code changes:\n\n**ECH Environments with Enterprise/Trial license and Serverless**\n- [ ] The update ELSER to ELSER on EIS callout should be shown in\nindexes with `.elser-2-elasticsearch` semantic text field mappings on\nthe following pages:\n  - [ ] Index details data tab (Solution view)\n  - [ ] Index details overview tab (Classic view)\n  - [ ] Index details mappings tab (either view)\n- [ ] You should be able to successfully update `.elser-2-elasticsearch`\nsemantic text field mappings to `.elser-2-elasticsearch` via the callout\nand subsequent modal.\n\n**ECH Environments with Basic license**\n- [ ] The update ELSER to ELSER on EIS callout should **NOT** be shown\nin indexes with `.elser-2-elasticsearch` semantic text field mappings on\nthe following pages:\n  - [ ] Index details data tab (Solution view)\n  - [ ] Index details overview tab (Classic view)\n  - [ ] Index details mappings tab (either view)\n- [ ] The EIS promotional callout should be shown instead\n\n### Testing Setup\n#### ECH environment locally\nTo can mock an ECH environment locally you'll need add the following to\nyour `kibana.dev.yml`:\n\n```\nxpack.cloud:\n  id: 'LOCAL_DEV:ZmFrZS5lbHN0Yy5jbyRsb2NhbF9kZXYuZXMkbG9jYWxfZGV2LmtiCg=='\n  base_url: 'https://fake-cloud.elastic.co'\n```\n\n#### Running EIS locally\nYou will also need to have EIS running locally. You can find\ninstructions on how to do this in the [Inference team\nFAQs](https://docs.elastic.dev/search-team/teams/inference/faq#how-can-i-run-eis-locally-in-kibana).\n\n**Note**: In those instructions there's an example command for running\nElasticsearch.\n**Use this command for a trial/enterprise license**: `yarn es snapshot\n--license trial -E xpack.inference.elastic.url=https://localhost:8443 -E\nxpack.inference.elastic.http.ssl.verification_mode=none`\n\n**Use this command for a basic license**: `yarn es snapshot --license\nbasic -E xpack.inference.elastic.url=https://localhost:8443 -E\nxpack.inference.elastic.http.ssl.verification_mode=none`\n\n#### Quickly creating an index with semantic text mappings\nOnce you have Kibana running with EIS, the following command can be run\nin the Kibana console to quickly create an index with\n`.elser-2-elasticsearch` semantic text mappings:\n\n```\nPUT /update_elser_to_eis\n{\n  \"mappings\": {\n    \"properties\": {\n      \"name\": {\n        \"type\": \"semantic_text\",\n        \"inference_id\": \".elser-2-elasticsearch\"\n      },\n      \"address\": {\n        \"type\": \"semantic_text\",\n        \"inference_id\": \".elser-2-elastic\"\n      }\n    }\n  }\n}\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"862722e78d3fe1c9b123d099c64f6707abf936bf","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Search","backport:version","v9.3.0","v9.4.0"],"title":"[Search] EIS promo cleanup and improvements","number":247147,"url":"https://github.com/elastic/kibana/pull/247147","mergeCommit":{"message":"[Search] EIS promo cleanup and improvements (#247147)\n\n## Summary\n\nThis PR tidies up some of the work done around EIS promotions, and adds\nsome enhancements. The following changes were made:\n\n- Renamed the dismiss callback in `useShowEisPromotionalContent` to\n`onDismissPromo` as it's use for both tours and callouts.\n- Added a license check where `EisUpdateCallout` is used as this\nfunctionality is only available on ECH when there is an Enterprise\nlicense. No license is needed on Serverless.\n- Renamed the `isCloudEnabled` prop in `EisUpdateCallout` to\n`shouldShowEisUpdateCallout` to account for ECH environments now needing\nan Enterprise license\n- Added telemetry IDs on all buttons and links within the EIS/CCM tour\nand callouts, and the update ELSER to ELSER on EIS modal\n- Tidied up telemetry ID and local storage key naming so there was more\nconsistency and it was easier to differentiate between each action and\npromo\n- Updated the links to Cloud Connect so it opened in a new tab\n- Swapped `EuiPanel` for `EuiCallOut` in `EisPromotionalCallout`\n- Added spacing above the `EisCloudConnectPromoCallout`\n- Made `prepareFieldsForEisUpdate` more robust and added unit tests\n\n### Testing\n\nThe following should be tested to ensure the addition of the license\ncheck is working as expected, and that there's been no regression\nfollowing the code changes:\n\n**ECH Environments with Enterprise/Trial license and Serverless**\n- [ ] The update ELSER to ELSER on EIS callout should be shown in\nindexes with `.elser-2-elasticsearch` semantic text field mappings on\nthe following pages:\n  - [ ] Index details data tab (Solution view)\n  - [ ] Index details overview tab (Classic view)\n  - [ ] Index details mappings tab (either view)\n- [ ] You should be able to successfully update `.elser-2-elasticsearch`\nsemantic text field mappings to `.elser-2-elasticsearch` via the callout\nand subsequent modal.\n\n**ECH Environments with Basic license**\n- [ ] The update ELSER to ELSER on EIS callout should **NOT** be shown\nin indexes with `.elser-2-elasticsearch` semantic text field mappings on\nthe following pages:\n  - [ ] Index details data tab (Solution view)\n  - [ ] Index details overview tab (Classic view)\n  - [ ] Index details mappings tab (either view)\n- [ ] The EIS promotional callout should be shown instead\n\n### Testing Setup\n#### ECH environment locally\nTo can mock an ECH environment locally you'll need add the following to\nyour `kibana.dev.yml`:\n\n```\nxpack.cloud:\n  id: 'LOCAL_DEV:ZmFrZS5lbHN0Yy5jbyRsb2NhbF9kZXYuZXMkbG9jYWxfZGV2LmtiCg=='\n  base_url: 'https://fake-cloud.elastic.co'\n```\n\n#### Running EIS locally\nYou will also need to have EIS running locally. You can find\ninstructions on how to do this in the [Inference team\nFAQs](https://docs.elastic.dev/search-team/teams/inference/faq#how-can-i-run-eis-locally-in-kibana).\n\n**Note**: In those instructions there's an example command for running\nElasticsearch.\n**Use this command for a trial/enterprise license**: `yarn es snapshot\n--license trial -E xpack.inference.elastic.url=https://localhost:8443 -E\nxpack.inference.elastic.http.ssl.verification_mode=none`\n\n**Use this command for a basic license**: `yarn es snapshot --license\nbasic -E xpack.inference.elastic.url=https://localhost:8443 -E\nxpack.inference.elastic.http.ssl.verification_mode=none`\n\n#### Quickly creating an index with semantic text mappings\nOnce you have Kibana running with EIS, the following command can be run\nin the Kibana console to quickly create an index with\n`.elser-2-elasticsearch` semantic text mappings:\n\n```\nPUT /update_elser_to_eis\n{\n  \"mappings\": {\n    \"properties\": {\n      \"name\": {\n        \"type\": \"semantic_text\",\n        \"inference_id\": \".elser-2-elasticsearch\"\n      },\n      \"address\": {\n        \"type\": \"semantic_text\",\n        \"inference_id\": \".elser-2-elastic\"\n      }\n    }\n  }\n}\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"862722e78d3fe1c9b123d099c64f6707abf936bf"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247147","number":247147,"mergeCommit":{"message":"[Search] EIS promo cleanup and improvements (#247147)\n\n## Summary\n\nThis PR tidies up some of the work done around EIS promotions, and adds\nsome enhancements. The following changes were made:\n\n- Renamed the dismiss callback in `useShowEisPromotionalContent` to\n`onDismissPromo` as it's use for both tours and callouts.\n- Added a license check where `EisUpdateCallout` is used as this\nfunctionality is only available on ECH when there is an Enterprise\nlicense. No license is needed on Serverless.\n- Renamed the `isCloudEnabled` prop in `EisUpdateCallout` to\n`shouldShowEisUpdateCallout` to account for ECH environments now needing\nan Enterprise license\n- Added telemetry IDs on all buttons and links within the EIS/CCM tour\nand callouts, and the update ELSER to ELSER on EIS modal\n- Tidied up telemetry ID and local storage key naming so there was more\nconsistency and it was easier to differentiate between each action and\npromo\n- Updated the links to Cloud Connect so it opened in a new tab\n- Swapped `EuiPanel` for `EuiCallOut` in `EisPromotionalCallout`\n- Added spacing above the `EisCloudConnectPromoCallout`\n- Made `prepareFieldsForEisUpdate` more robust and added unit tests\n\n### Testing\n\nThe following should be tested to ensure the addition of the license\ncheck is working as expected, and that there's been no regression\nfollowing the code changes:\n\n**ECH Environments with Enterprise/Trial license and Serverless**\n- [ ] The update ELSER to ELSER on EIS callout should be shown in\nindexes with `.elser-2-elasticsearch` semantic text field mappings on\nthe following pages:\n  - [ ] Index details data tab (Solution view)\n  - [ ] Index details overview tab (Classic view)\n  - [ ] Index details mappings tab (either view)\n- [ ] You should be able to successfully update `.elser-2-elasticsearch`\nsemantic text field mappings to `.elser-2-elasticsearch` via the callout\nand subsequent modal.\n\n**ECH Environments with Basic license**\n- [ ] The update ELSER to ELSER on EIS callout should **NOT** be shown\nin indexes with `.elser-2-elasticsearch` semantic text field mappings on\nthe following pages:\n  - [ ] Index details data tab (Solution view)\n  - [ ] Index details overview tab (Classic view)\n  - [ ] Index details mappings tab (either view)\n- [ ] The EIS promotional callout should be shown instead\n\n### Testing Setup\n#### ECH environment locally\nTo can mock an ECH environment locally you'll need add the following to\nyour `kibana.dev.yml`:\n\n```\nxpack.cloud:\n  id: 'LOCAL_DEV:ZmFrZS5lbHN0Yy5jbyRsb2NhbF9kZXYuZXMkbG9jYWxfZGV2LmtiCg=='\n  base_url: 'https://fake-cloud.elastic.co'\n```\n\n#### Running EIS locally\nYou will also need to have EIS running locally. You can find\ninstructions on how to do this in the [Inference team\nFAQs](https://docs.elastic.dev/search-team/teams/inference/faq#how-can-i-run-eis-locally-in-kibana).\n\n**Note**: In those instructions there's an example command for running\nElasticsearch.\n**Use this command for a trial/enterprise license**: `yarn es snapshot\n--license trial -E xpack.inference.elastic.url=https://localhost:8443 -E\nxpack.inference.elastic.http.ssl.verification_mode=none`\n\n**Use this command for a basic license**: `yarn es snapshot --license\nbasic -E xpack.inference.elastic.url=https://localhost:8443 -E\nxpack.inference.elastic.http.ssl.verification_mode=none`\n\n#### Quickly creating an index with semantic text mappings\nOnce you have Kibana running with EIS, the following command can be run\nin the Kibana console to quickly create an index with\n`.elser-2-elasticsearch` semantic text mappings:\n\n```\nPUT /update_elser_to_eis\n{\n  \"mappings\": {\n    \"properties\": {\n      \"name\": {\n        \"type\": \"semantic_text\",\n        \"inference_id\": \".elser-2-elasticsearch\"\n      },\n      \"address\": {\n        \"type\": \"semantic_text\",\n        \"inference_id\": \".elser-2-elastic\"\n      }\n    }\n  }\n}\n```\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~\n- [ ]\n~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] ~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~\n- [ ] ~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~\n- [ ] ~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~\n- [ ] ~The PR description includes the appropriate Release Notes\nsection, and the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"862722e78d3fe1c9b123d099c64f6707abf936bf"}}]}] BACKPORT-->