### PR TITLE
[Embeddable console]Fix animation from minimized to enlarged jumping over bottom bar

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/embeddable/embeddable_console.styles.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/embeddable/embeddable_console.styles.ts
@@ -10,7 +10,7 @@
 import { css } from '@emotion/react';
 import { useEuiTheme, useEuiBreakpoint } from '@elastic/eui';
 
-import { layoutVar } from '@kbn/core-chrome-layout-constants';
+import { layoutVar, layoutLevels } from '@kbn/core-chrome-layout-constants';
 import { useEmbeddableConsoleContentStyles, useEmbeddableConsoleStyleVariables } from './styles';
 
 export const useStyles = () => {
@@ -83,7 +83,7 @@ export const useStyles = () => {
 
     embeddableConsoleFixed: css`
       position: fixed;
-      z-index: calc(${euiTheme.levels.header} - 2);
+      z-index: ${layoutLevels.footer - 1};
     `,
 
     embeddableConsoleControls: css`


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/239722

## Summary
 The embedded console overlaped with the bottom bar when expanding from minimized to enlarged. The console styles now use the layout level (Z-index levels for layout components) from the footer as a reference por the z-index of the console.

### How to test
The debug footer was removed when the developer toolbar was added, but using the devbar as a reference also works. In your `kibana.dev.yml` add:

```
# For the developer toolbar
developer_toolbar.enabled: true
inspect_component.enabled: true

# For grid if you wanna it as a reference. The debug footer is no longer present.
feature_flags.overrides:
  core.chrome.layoutType: 'grid'
  core.chrome.layoutDebug: true
```

#### Demo

**Before**

https://github.com/user-attachments/assets/a64df845-3148-41a2-b250-19697eec4006


**After**

https://github.com/user-attachments/assets/ded7e555-4f5e-4a17-9f0d-434da2820ad8

