### PR TITLE
[ResponseOps][Alerting] Add the alerting v2 feature privileges

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const APP_ID = 'alerting_v2';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/security/privileges.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/security/privileges.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+import type { AppCategory } from '@kbn/core/types';
+import { APP_ID } from '../constants';
+
+const ALERTS_FEATURE_ID = 'alerting_v2_alerts';
+const RULES_FEATURE_ID = 'alerting_v2_rules';
+const CATEGORY_ID = 'alerting';
+
+const getPrivileges = () => ({
+  all: {
+    app: [APP_ID],
+    savedObject: {
+      all: [],
+      read: [],
+    },
+    ui: [],
+    api: [],
+  },
+  read: {
+    app: [APP_ID],
+    savedObject: {
+      all: [],
+      read: [],
+    },
+    ui: [],
+    api: [],
+  },
+});
+
+const category: AppCategory = {
+  id: CATEGORY_ID,
+  label: 'Alerting',
+  order: 1000,
+  euiIconType: 'watchesApp',
+};
+
+const alertsFeature = {
+  id: ALERTS_FEATURE_ID,
+  name: 'Alerts',
+  category,
+  app: [APP_ID],
+  privileges: getPrivileges(),
+};
+
+const rulesFeature = {
+  id: RULES_FEATURE_ID,
+  name: 'Rules',
+  category,
+  app: [APP_ID],
+  privileges: getPrivileges(),
+};
+
+export const registerFeaturePrivileges = (features: FeaturesPluginSetup) => {
+  features.registerKibanaFeature(alertsFeature);
+  features.registerKibanaFeature(rulesFeature);
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/plugin.ts
@@ -19,6 +19,7 @@ import type {
   AlertingServerSetupDependencies,
   AlertingServerStartDependencies,
 } from './types';
+import { registerFeaturePrivileges } from './lib/security/privileges';
 
 export class AlertingPlugin
   implements
@@ -37,7 +38,7 @@ export class AlertingPlugin
   }
 
   public setup(core: CoreSetup, plugins: AlertingServerSetupDependencies) {
-    return;
+    registerFeaturePrivileges(plugins.features);
   }
 
   public start(core: CoreStart, plugins: AlertingServerStartDependencies) {


### PR DESCRIPTION
## Summary

> [!NOTE]
> This PR is getting merged into a feature branch.

This PR adds the alerting feature privilege for the alerting v2 engine

<img width="753" height="140" alt="Screenshot 2025-12-24 at 1 49 48 PM" src="https://github.com/user-attachments/assets/a5c4edeb-17b4-4d5f-a441-a85cb8bfc2e2" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)