### PR TITLE
[fix] Add a global hook to satisfy new lint rule

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/test/scout/ui/parallel_tests/global.setup.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { globalSetupHook } from '@kbn/scout-search';
+
+globalSetupHook('Ingest data to Elasticsearch', { tag: ['@ess'] }, async ({}) => {
+  return;
+});


### PR DESCRIPTION
## Summary
A new lint rule was added in https://github.com/elastic/kibana/pull/247219 - and a test that breaches it was added in https://github.com/elastic/kibana/pull/246777

This PR tries to satisfy the lint rule, but doesn't actually do anything in the setup hook - @steliosmavro | @efegurkan  please check if it's right this way.