### PR TITLE
[Agent Builder] Add explicit error message for invalid license level

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/wrap_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/wrap_handler.ts
@@ -44,7 +44,7 @@ export const getHandlerWrapper =
           return res.forbidden({
             body: {
               message:
-                'Invalid license level. Agent Builder APIs require an enterprise license or superior.',
+                'Invalid license level. Agent Builder APIs require an Enterprise license or higher.',
             },
           });
         }

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/wrap_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/wrap_handler.ts
@@ -41,7 +41,12 @@ export const getHandlerWrapper =
       if (!ignoreLicense) {
         const { license } = await ctx.licensing;
         if (!isValidLicense(license)) {
-          return res.forbidden();
+          return res.forbidden({
+            body: {
+              message:
+                'Invalid license level. Agent Builder APIs require an enterprise license or superior.',
+            },
+          });
         }
       }
 


### PR DESCRIPTION
## Summary

Add an explicit error message for 403's returned by the HTTP APIs when the license level is not sufficient 

