### PR TITLE
[inference] add thinking token count for Gemini

### DIFF
--- a/src/platform/packages/private/kbn-gen-ai-functional-testing/src/manage_connector_config.ts
+++ b/src/platform/packages/private/kbn-gen-ai-functional-testing/src/manage_connector_config.ts
@@ -14,7 +14,7 @@ import { REPO_ROOT } from '@kbn/repo-info';
 
 const LOCAL_FILE = Path.join(
   REPO_ROOT,
-  'packages/kbn-gen-ai-functional-testing/connector_config.json'
+  'src/platform/packages/private/kbn-gen-ai-functional-testing/connector_config.json'
 );
 
 export const retrieveFromVault = async () => {

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/events.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/events.ts
@@ -120,7 +120,11 @@ export interface ChatCompletionTokenCount {
    */
   completion: number;
   /**
-   * Total token count
+   * Thinking token count, if available
+   */
+  thinking?: number;
+  /**
+   * Total token count (prompt + completion + thinking)
    */
   total: number;
   /**

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/gemini/process_vertex_stream.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/gemini/process_vertex_stream.ts
@@ -30,6 +30,7 @@ export function processVertexStream(model?: string) {
               tokens: {
                 prompt: value.usageMetadata.promptTokenCount,
                 completion: value.usageMetadata.candidatesTokenCount,
+                thinking: value.usageMetadata.thoughtsTokenCount,
                 cached: value.usageMetadata.cachedContentTokenCount,
                 total: value.usageMetadata.totalTokenCount,
               },

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/gemini/types.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/gemini/types.ts
@@ -11,6 +11,7 @@ export interface GenerateContentResponseUsageMetadata {
   promptTokenCount: number;
   candidatesTokenCount: number;
   totalTokenCount: number;
+  thoughtsTokenCount?: number;
 }
 
 /**

--- a/x-pack/platform/test/functional_gen_ai/inference/tests/chat_complete.ts
+++ b/x-pack/platform/test/functional_gen_ai/inference/tests/chat_complete.ts
@@ -310,8 +310,9 @@ export const chatCompleteSuite = (
         expect(tokenEvent.type).to.eql('chatCompletionTokenCount');
         expect(tokenEvent.tokens.prompt).to.be.greaterThan(0);
         expect(tokenEvent.tokens.completion).to.be.greaterThan(0);
-        expect(tokenEvent.tokens.total).to.be(
-          tokenEvent.tokens.prompt + tokenEvent.tokens.completion
+        // can include thinking token depending on the model
+        expect(tokenEvent.tokens.total).to.greaterThan(
+          tokenEvent.tokens.prompt + tokenEvent.tokens.completion - 1
         );
         // Model field is optional and may be present if provided by the connector
         if (tokenEvent.model !== undefined) {

--- a/x-pack/platform/test/functional_gen_ai/inference/tests/chat_complete.ts
+++ b/x-pack/platform/test/functional_gen_ai/inference/tests/chat_complete.ts
@@ -311,9 +311,12 @@ export const chatCompleteSuite = (
         expect(tokenEvent.tokens.prompt).to.be.greaterThan(0);
         expect(tokenEvent.tokens.completion).to.be.greaterThan(0);
         // can include thinking token depending on the model
-        expect(tokenEvent.tokens.total).to.greaterThan(
-          tokenEvent.tokens.prompt + tokenEvent.tokens.completion - 1
-        );
+        const totalIsPromptAndCompletion =
+          tokenEvent.tokens.total === tokenEvent.tokens.prompt + tokenEvent.tokens.completion;
+        const totalIsPromptCompletionAndThinking =
+          tokenEvent.tokens.total ===
+          tokenEvent.tokens.prompt + tokenEvent.tokens.completion + tokenEvent.tokens.thinking;
+        expect(totalIsPromptAndCompletion || totalIsPromptCompletionAndThinking).to.be(true);
         // Model field is optional and may be present if provided by the connector
         if (tokenEvent.model !== undefined) {
           expect(tokenEvent.model).to.be.a('string');


### PR DESCRIPTION
## Summary

While trying to add new models (Gemini 2.5-pro/flash and Gemini 3 pro) to the list of models we run our inference and AB smoke tests against, I discovered that recent Gemini models are counting thinking tokens in their "total token" metric.

This PR does two things:
1. adapt an assert we do on total token count to take those thinking token into account
2. update our token count structure to have a dedicated property for thinking token when present