### PR TITLE
[APM] Migrate Infra home page tests to Scout - Part I

### DIFF
--- a/src/platform/packages/shared/kbn-scout/index.ts
+++ b/src/platform/packages/shared/kbn-scout/index.ts
@@ -83,4 +83,4 @@ export type {
 } from './src/playwright/fixtures/scope/worker/core_fixtures';
 
 // Re-exported Playwright types
-export type { Locator, CDPSession, Request } from 'playwright/test';
+export type { Locator, CDPSession } from 'playwright/test';

--- a/src/platform/packages/shared/kbn-scout/index.ts
+++ b/src/platform/packages/shared/kbn-scout/index.ts
@@ -83,4 +83,4 @@ export type {
 } from './src/playwright/fixtures/scope/worker/core_fixtures';
 
 // Re-exported Playwright types
-export type { Locator, CDPSession } from 'playwright/test';
+export type { Locator, CDPSession, Request } from 'playwright/test';

--- a/src/platform/packages/shared/kbn-scout/index.ts
+++ b/src/platform/packages/shared/kbn-scout/index.ts
@@ -84,3 +84,6 @@ export type {
 
 // Re-exported Playwright types
 export type { Locator, CDPSession } from 'playwright/test';
+
+// Utility for overriding synthtrace clients
+export { getSynthtraceClient } from './src/common/services/synthtrace';

--- a/src/platform/packages/shared/kbn-scout/src/common/services/synthtrace.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/synthtrace.ts
@@ -73,6 +73,13 @@ export async function getSynthtraceClient<
     skipInstallation: overrides.skipInstallation ?? false,
   });
 
+  if (overrides.skipInstallation) {
+    log.serviceMessage(
+      synthClient,
+      'Skipped fleet package installation because "overrides.skipInstallation" is true'
+    );
+  }
+
   log.serviceLoaded(synthClient);
 
   instantiatedClients[synthClient] = clients[synthClient];

--- a/src/platform/packages/shared/kbn-scout/src/common/services/synthtrace.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/synthtrace.ts
@@ -42,7 +42,8 @@ export async function getSynthtraceClient<
   TClient extends SynthtraceClientTypes = SynthtraceClientTypes
 >(
   synthClient: TClient,
-  { esClient, kbnUrl, log, config }: SynthtraceClientOptions
+  { esClient, kbnUrl, log, config }: SynthtraceClientOptions,
+  overrides: { skipInstallation?: boolean } = {}
 ): Promise<GetClientsReturn<TClient>> {
   if (instantiatedClients[synthClient]) {
     return instantiatedClients[synthClient] as unknown as GetClientsReturn<TClient>;
@@ -69,7 +70,7 @@ export async function getSynthtraceClient<
 
   await clientManager.initFleetPackageForClient({
     clients,
-    skipInstallation: false,
+    skipInstallation: overrides.skipInstallation ?? false,
   });
 
   log.serviceLoaded(synthClient);

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
@@ -83,4 +83,4 @@ export type {
 export type { RoleApiCredentials } from '@kbn/scout';
 
 // Re-exported Playwright types
-export type { Locator, CDPSession } from '@kbn/scout';
+export type { Locator, CDPSession, Request } from '@kbn/scout';

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
@@ -84,3 +84,6 @@ export type { RoleApiCredentials } from '@kbn/scout';
 
 // Re-exported Playwright types
 export type { Locator, CDPSession } from '@kbn/scout';
+
+// Re-exported utility for overriding synthtrace clients
+export { getSynthtraceClient } from '@kbn/scout';

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
@@ -83,4 +83,4 @@ export type {
 export type { RoleApiCredentials } from '@kbn/scout';
 
 // Re-exported Playwright types
-export type { Locator, CDPSession, Request } from '@kbn/scout';
+export type { Locator, CDPSession } from '@kbn/scout';

--- a/x-pack/solutions/observability/plugins/infra/public/components/loading/index.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/loading/index.tsx
@@ -13,13 +13,14 @@ interface InfraLoadingProps {
   text: string | JSX.Element;
   height: number | string;
   width: number | string;
+  'data-test-subj'?: string;
 }
 
 export class InfraLoadingPanel extends React.PureComponent<InfraLoadingProps, {}> {
   public render() {
-    const { height, text, width } = this.props;
+    const { height, text, width, 'data-test-subj': dataTestSubj } = this.props;
     return (
-      <InfraLoadingStaticPanel style={{ height, width }}>
+      <InfraLoadingStaticPanel style={{ height, width }} data-test-subj={dataTestSubj}>
         <InfraLoadingStaticContentPanel>
           <EuiPanel>
             <EuiLoadingChart size="m" />

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/nodes_overview.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/nodes_overview.tsx
@@ -128,6 +128,7 @@ export const NodesOverview = ({
         text={i18n.translate('xpack.infra.waffle.loadingDataText', {
           defaultMessage: 'Loading data',
         })}
+        data-test-subj="infraNodesOverviewLoadingPanel"
       />
     );
   } else if (noData) {
@@ -174,7 +175,7 @@ export const NodesOverview = ({
 
   if (view === 'table') {
     return (
-      <TableContainer>
+      <TableContainer data-test-subj="infraNodesOverviewTable">
         <TableView
           nodeType={nodeType}
           nodes={nodes}

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/snapshot_container.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/snapshot_container.tsx
@@ -15,7 +15,7 @@ import { useWaffleTimeContext } from '../hooks/use_waffle_time';
 import { FilterBar } from './filter_bar';
 import { LayoutView } from './layout_view';
 
-export const SnapshotContainer = React.memo(() => {
+export const SnapshotContainer = React.memo(function SnapshotContainer() {
   const { sourceId } = useSourceContext();
   const { metric, groupBy, nodeType, accountId, region, preferredSchema } =
     useWaffleOptionsContext();

--- a/x-pack/solutions/observability/plugins/infra/test/scout/README.md
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/README.md
@@ -1,3 +1,15 @@
+# Test distribution
+
+We have 2 separate playwright configs, one for parallel tests under `/parallel_tests` and another one for sequential tests under `/tests`.
+We're striving to implement as many parallel tests as possible, in order to improve test execution times.
+
+So, by default, we should write all our tests under /parallel_tests having in mind that they will run alongside other suites and making use of the global setup hook for data loading,
+instead of loading data separately in each test suite.
+
+However, some tests might have special traits that make them unsuitable for parallel execution, like particular data needs in ES indexes that could impact other test setups if ran concurrently.
+For these instances we have the sequential tests folder where each test will run in isolation and where no global setup hook exists, so each suite can set the stage as required. Just remember to
+cleanup any stage you've setup after your suite is done so the next test can start on a clean slate. This should nonetheless be a special case, last resort, measure when writing tests. Try to think of a way to write your tests in a parallel-safe way before resorting to including them in the sequential run.
+
 # How to run tests
 
 First start the servers:
@@ -18,6 +30,16 @@ npx playwright test --config x-pack/solutions/observability/plugins/infra/test/s
 
 // Serverless
 npx playwright test --project local --config x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel.playwright.config.ts --grep @svlOblt
+```
+
+Alternatively, you can run sequential tests by passing in the proper playwright config:
+
+```bash
+// ESS
+npx playwright test --config x-pack/solutions/observability/plugins/infra/test/scout/ui/playwright.config.ts --project=local --grep @ess
+
+// Serverless
+npx playwright test --project local --config x-pack/solutions/observability/plugins/infra/test/scout/ui/playwright.config.ts --grep @svlOblt
 ```
 
 Test results are available in `x-pack/solutions/observability/plugins/infra/test/scout/ui/output`

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -7,7 +7,7 @@
 
 export const DATE_WITH_HOSTS_DATA_FROM = '2023-03-28T18:20:00.000Z';
 export const DATE_WITH_HOSTS_DATA_TO = '2023-03-28T18:21:00.000Z';
-export const DATE_WITH_HOSTS_DATA = '03/28/2023 8:20:59 PM';
+export const DATE_WITH_HOSTS_DATA = '03/28/2023 6:20:59 PM';
 
 export const HOST1_NAME = 'host-1';
 export const HOST2_NAME = 'host-2';
@@ -48,7 +48,7 @@ export const HOSTS = [
 
 export const DATE_WITH_HOSTS_WITHOUT_DATA_FROM = '2023-03-29T18:20:00.000Z';
 export const DATE_WITH_HOSTS_WITHOUT_DATA_TO = '2023-03-29T18:21:00.000Z';
-export const DATE_WITH_HOSTS_WITHOUT_DATA = '03/29/2023 8:20:59 PM';
+export const DATE_WITH_HOSTS_WITHOUT_DATA = '03/29/2023 6:20:59 PM';
 
 export const HOST7_NAME = 'host-7';
 
@@ -60,7 +60,7 @@ export const HOSTS_WITHOUT_DATA = [
 
 export const DATE_WITH_K8S_HOSTS_DATA_FROM = '2023-03-30T18:20:00.000Z';
 export const DATE_WITH_K8S_HOSTS_DATA_TO = '2023-03-30T18:21:00.000Z';
-export const DATE_WITH_K8S_HOSTS_DATA = '03/30/2023 8:20:59 PM';
+export const DATE_WITH_K8S_HOSTS_DATA = '03/30/2023 6:20:59 PM';
 
 export const K8S_POD_NAME = 'demo-stack-kubernetes-pod-1';
 export const K8S_HOST_NAME = 'demo-stack-kubernetes-01';
@@ -76,7 +76,7 @@ export const K8S_HOSTS = [
 
 export const DATE_WITH_DOCKER_DATA_FROM = '2023-03-31T18:20:00.000Z';
 export const DATE_WITH_DOCKER_DATA_TO = '2023-03-31T18:21:00.000Z';
-export const DATE_WITH_DOCKER_DATA = '03/31/2023 8:20:59 PM';
+export const DATE_WITH_DOCKER_DATA = '03/31/2023 6:20:59 PM';
 export const CONTAINER_COUNT = 1;
 export const CONTAINER_NAMES = Array.from(
   { length: CONTAINER_COUNT },
@@ -85,8 +85,8 @@ export const CONTAINER_NAMES = Array.from(
 
 export const DATE_WITH_POD_DATA_FROM = '2023-04-01T18:20:00.000Z';
 export const DATE_WITH_POD_DATA_TO = '2023-04-01T18:21:00.000Z';
-export const DATE_WITH_POD_DATA = '04/01/2023 8:20:59 PM';
+export const DATE_WITH_POD_DATA = '04/01/2023 6:20:59 PM';
 export const POD_COUNT = 1;
 export const POD_NAMES = Array.from({ length: POD_COUNT }, (_, i) => `pod-${i}`);
 
-export const DATE_WITHOUT_DATA = '04/01/2024 8:20:59 PM';
+export const DATE_WITHOUT_DATA = '04/01/2024 6:20:59 PM';

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -94,7 +94,7 @@ export const DATE_WITH_DOCKER_DATA = moment()
 export const CONTAINER_COUNT = 1;
 export const CONTAINER_NAMES = Array.from(
   { length: CONTAINER_COUNT },
-  (_, i) => `container-container-id-${i}`
+  (_, i) => `container-container-${i}`
 );
 
 export const DATE_WITH_POD_DATA_FROM = moment().subtract(94, 'minutes').toISOString();

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment';
+
+export const DATE_WITH_HOSTS_DATA_FROM = moment().subtract(11, 'minutes').toISOString();
+export const DATE_WITH_HOSTS_DATA_TO = moment().subtract(1, 'minute').toISOString();
+export const DATE_WITH_HOSTS_DATA = moment()
+  .subtract(1, 'minute')
+  .subtract(1, 'second')
+  .format('MM/DD/YYYY h:mm:ss A');
+
+export const HOST1_NAME = 'host-1';
+export const HOST2_NAME = 'host-2';
+export const HOST3_NAME = 'host-3';
+export const HOST4_NAME = 'host-4';
+export const HOST5_NAME = 'host-5';
+export const HOST6_NAME = 'host-6';
+
+export const HOST_NAME_WITH_SERVICES = HOST1_NAME;
+export const SERVICE_PER_HOST_COUNT = 3;
+
+export const HOSTS = [
+  {
+    hostName: HOST1_NAME,
+    cpuValue: 0.5,
+  },
+  {
+    hostName: HOST2_NAME,
+    cpuValue: 0.7,
+  },
+  {
+    hostName: HOST3_NAME,
+    cpuValue: 0.9,
+  },
+  {
+    hostName: HOST4_NAME,
+    cpuValue: 0.3,
+  },
+  {
+    hostName: HOST5_NAME,
+    cpuValue: 0.1,
+  },
+  {
+    hostName: HOST6_NAME,
+    cpuValue: 0.4,
+  },
+];
+
+export const DATE_WITH_HOSTS_WITHOUT_DATA_FROM = moment().subtract(22, 'minutes').toISOString();
+export const DATE_WITH_HOSTS_WITHOUT_DATA_TO = moment().subtract(12, 'minutes').toISOString();
+export const DATE_WITH_HOSTS_WITHOUT_DATA = moment()
+  .subtract(12, 'minutes')
+  .subtract(1, 'second')
+  .format('MM/DD/YYYY h:mm:ss A');
+
+export const HOST7_NAME = 'host-7';
+
+export const HOSTS_WITHOUT_DATA = [
+  {
+    hostName: HOST7_NAME,
+  },
+];
+
+export const DATE_WITH_K8S_HOSTS_DATA_FROM = moment().subtract(33, 'minutes').toISOString();
+export const DATE_WITH_K8S_HOSTS_DATA_TO = moment().subtract(23, 'minutes').toISOString();
+export const DATE_WITH_K8S_HOSTS_DATA = moment()
+  .subtract(23, 'minutes')
+  .subtract(1, 'second')
+  .format('MM/DD/YYYY h:mm:ss A');
+
+export const K8S_POD_NAME = 'pod-1';
+export const K8S_HOST_NAME = 'demo-stack-kubernetes-01';
+
+// cpuValue is sent to the generator to simulate different 'system.cpu.total.norm.pct' metric
+// that is the default metric in inventory and hosts view and host details page
+export const K8S_HOSTS = [
+  {
+    hostName: K8S_HOST_NAME,
+    cpuValue: 0.5,
+  },
+];
+
+export const DATE_WITH_POD_DATA_FROM = moment().subtract(44, 'minutes').toISOString();
+export const DATE_WITH_POD_DATA_TO = moment().subtract(34, 'minutes').toISOString();
+export const DATE_WITH_POD_DATA = moment()
+  .subtract(34, 'minutes')
+  .subtract(1, 'second')
+  .format('MM/DD/YYYY h:mm:ss A');
+export const POD_COUNT = 1;

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -48,9 +48,9 @@ export const HOSTS = [
   },
 ];
 
-export const DATE_WITH_HOSTS_WITHOUT_DATA_FROM = '2023-03-28T18:20:00.000Z';
-export const DATE_WITH_HOSTS_WITHOUT_DATA_TO = '2023-03-28T18:21:00.000Z';
-export const DATE_WITH_HOSTS_WITHOUT_DATA = '03/28/2023 8:20:59 PM';
+export const DATE_WITH_HOSTS_WITHOUT_DATA_FROM = '2023-03-29T18:20:00.000Z';
+export const DATE_WITH_HOSTS_WITHOUT_DATA_TO = '2023-03-29T18:21:00.000Z';
+export const DATE_WITH_HOSTS_WITHOUT_DATA = '03/29/2023 8:20:59 PM';
 
 export const HOST7_NAME = 'host-7';
 
@@ -60,9 +60,9 @@ export const HOSTS_WITHOUT_DATA = [
   },
 ];
 
-export const DATE_WITH_K8S_HOSTS_DATA_FROM = '2023-03-28T18:20:00.000Z';
-export const DATE_WITH_K8S_HOSTS_DATA_TO = '2023-03-28T18:21:00.000Z';
-export const DATE_WITH_K8S_HOSTS_DATA = '03/28/2023 8:20:59 PM';
+export const DATE_WITH_K8S_HOSTS_DATA_FROM = '2023-03-30T18:20:00.000Z';
+export const DATE_WITH_K8S_HOSTS_DATA_TO = '2023-03-30T18:21:00.000Z';
+export const DATE_WITH_K8S_HOSTS_DATA = '03/30/2023 8:20:59 PM';
 
 export const K8S_POD_NAME = 'demo-stack-kubernetes-pod-1';
 export const K8S_HOST_NAME = 'demo-stack-kubernetes-01';
@@ -76,18 +76,18 @@ export const K8S_HOSTS = [
   },
 ];
 
-export const DATE_WITH_DOCKER_DATA_FROM = '2023-03-28T18:20:00.000Z';
-export const DATE_WITH_DOCKER_DATA_TO = '2023-03-28T18:21:00.000Z';
-export const DATE_WITH_DOCKER_DATA = '03/28/2023 8:20:59 PM';
+export const DATE_WITH_DOCKER_DATA_FROM = '2023-03-31T18:20:00.000Z';
+export const DATE_WITH_DOCKER_DATA_TO = '2023-03-31T18:21:00.000Z';
+export const DATE_WITH_DOCKER_DATA = '03/31/2023 8:20:59 PM';
 export const CONTAINER_COUNT = 1;
 export const CONTAINER_NAMES = Array.from(
   { length: CONTAINER_COUNT },
   (_, i) => `container-container-${i}`
 );
 
-export const DATE_WITH_POD_DATA_FROM = '2023-03-28T18:20:00.000Z';
-export const DATE_WITH_POD_DATA_TO = '2023-03-28T18:21:00.000Z';
-export const DATE_WITH_POD_DATA = '03/28/2023 8:20:59 PM';
+export const DATE_WITH_POD_DATA_FROM = '2023-04-01T18:20:00.000Z';
+export const DATE_WITH_POD_DATA_TO = '2023-04-01T18:21:00.000Z';
+export const DATE_WITH_POD_DATA = '04/01/2023 8:20:59 PM';
 export const POD_COUNT = 1;
 export const POD_NAMES = Array.from({ length: POD_COUNT }, (_, i) => `pod-${i}`);
 

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import moment from 'moment';
-
 export const DATE_WITH_HOSTS_DATA_FROM = '2023-03-28T18:20:00.000Z';
 export const DATE_WITH_HOSTS_DATA_TO = '2023-03-28T18:21:00.000Z';
 export const DATE_WITH_HOSTS_DATA = '03/28/2023 8:20:59 PM';
@@ -91,4 +89,4 @@ export const DATE_WITH_POD_DATA = '04/01/2023 8:20:59 PM';
 export const POD_COUNT = 1;
 export const POD_NAMES = Array.from({ length: POD_COUNT }, (_, i) => `pod-${i}`);
 
-export const DATE_WITHOUT_DATA = moment().add(20, 'minutes').format('MM/DD/YYYY h:mm:ss A');
+export const DATE_WITHOUT_DATA = '04/01/2024 8:20:59 PM';

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -73,7 +73,7 @@ export const DATE_WITH_K8S_HOSTS_DATA = moment()
   .subtract(1, 'second')
   .format('MM/DD/YYYY h:mm:ss A');
 
-export const K8S_POD_NAME = 'pod-1';
+export const K8S_POD_NAME = 'demo-stack-kubernetes-pod-1';
 export const K8S_HOST_NAME = 'demo-stack-kubernetes-01';
 
 // cpuValue is sent to the generator to simulate different 'system.cpu.total.norm.pct' metric
@@ -85,10 +85,25 @@ export const K8S_HOSTS = [
   },
 ];
 
-export const DATE_WITH_POD_DATA_FROM = moment().subtract(44, 'minutes').toISOString();
-export const DATE_WITH_POD_DATA_TO = moment().subtract(34, 'minutes').toISOString();
-export const DATE_WITH_POD_DATA = moment()
+export const DATE_WITH_DOCKER_DATA_FROM = moment().subtract(44, 'minutes').toISOString();
+export const DATE_WITH_DOCKER_DATA_TO = moment().subtract(34, 'minutes').toISOString();
+export const DATE_WITH_DOCKER_DATA = moment()
   .subtract(34, 'minutes')
   .subtract(1, 'second')
   .format('MM/DD/YYYY h:mm:ss A');
+export const CONTAINER_COUNT = 1;
+export const CONTAINER_NAMES = Array.from(
+  { length: CONTAINER_COUNT },
+  (_, i) => `container-container-id-${i}`
+);
+
+export const DATE_WITH_POD_DATA_FROM = moment().subtract(94, 'minutes').toISOString();
+export const DATE_WITH_POD_DATA_TO = moment().subtract(84, 'minutes').toISOString();
+export const DATE_WITH_POD_DATA = moment()
+  .subtract(84, 'minutes')
+  .subtract(1, 'second')
+  .format('MM/DD/YYYY h:mm:ss A');
 export const POD_COUNT = 1;
+export const POD_NAMES = Array.from({ length: POD_COUNT }, (_, i) => `pod-${i}`);
+
+export const DATE_WITHOUT_DATA = moment().add(20, 'minutes').format('MM/DD/YYYY h:mm:ss A');

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -7,12 +7,9 @@
 
 import moment from 'moment';
 
-export const DATE_WITH_HOSTS_DATA_FROM = moment().subtract(11, 'minutes').toISOString();
-export const DATE_WITH_HOSTS_DATA_TO = moment().subtract(1, 'minute').toISOString();
-export const DATE_WITH_HOSTS_DATA = moment()
-  .subtract(1, 'minute')
-  .subtract(1, 'second')
-  .format('MM/DD/YYYY h:mm:ss A');
+export const DATE_WITH_HOSTS_DATA_FROM = '2023-03-28T18:20:00.000Z';
+export const DATE_WITH_HOSTS_DATA_TO = '2023-03-28T18:21:00.000Z';
+export const DATE_WITH_HOSTS_DATA = '03/28/2023 8:20:59 PM';
 
 export const HOST1_NAME = 'host-1';
 export const HOST2_NAME = 'host-2';
@@ -51,12 +48,9 @@ export const HOSTS = [
   },
 ];
 
-export const DATE_WITH_HOSTS_WITHOUT_DATA_FROM = moment().subtract(22, 'minutes').toISOString();
-export const DATE_WITH_HOSTS_WITHOUT_DATA_TO = moment().subtract(12, 'minutes').toISOString();
-export const DATE_WITH_HOSTS_WITHOUT_DATA = moment()
-  .subtract(12, 'minutes')
-  .subtract(1, 'second')
-  .format('MM/DD/YYYY h:mm:ss A');
+export const DATE_WITH_HOSTS_WITHOUT_DATA_FROM = '2023-03-28T18:20:00.000Z';
+export const DATE_WITH_HOSTS_WITHOUT_DATA_TO = '2023-03-28T18:21:00.000Z';
+export const DATE_WITH_HOSTS_WITHOUT_DATA = '03/28/2023 8:20:59 PM';
 
 export const HOST7_NAME = 'host-7';
 
@@ -66,12 +60,9 @@ export const HOSTS_WITHOUT_DATA = [
   },
 ];
 
-export const DATE_WITH_K8S_HOSTS_DATA_FROM = moment().subtract(33, 'minutes').toISOString();
-export const DATE_WITH_K8S_HOSTS_DATA_TO = moment().subtract(23, 'minutes').toISOString();
-export const DATE_WITH_K8S_HOSTS_DATA = moment()
-  .subtract(23, 'minutes')
-  .subtract(1, 'second')
-  .format('MM/DD/YYYY h:mm:ss A');
+export const DATE_WITH_K8S_HOSTS_DATA_FROM = '2023-03-28T18:20:00.000Z';
+export const DATE_WITH_K8S_HOSTS_DATA_TO = '2023-03-28T18:21:00.000Z';
+export const DATE_WITH_K8S_HOSTS_DATA = '03/28/2023 8:20:59 PM';
 
 export const K8S_POD_NAME = 'demo-stack-kubernetes-pod-1';
 export const K8S_HOST_NAME = 'demo-stack-kubernetes-01';
@@ -85,24 +76,18 @@ export const K8S_HOSTS = [
   },
 ];
 
-export const DATE_WITH_DOCKER_DATA_FROM = moment().subtract(44, 'minutes').toISOString();
-export const DATE_WITH_DOCKER_DATA_TO = moment().subtract(34, 'minutes').toISOString();
-export const DATE_WITH_DOCKER_DATA = moment()
-  .subtract(34, 'minutes')
-  .subtract(1, 'second')
-  .format('MM/DD/YYYY h:mm:ss A');
+export const DATE_WITH_DOCKER_DATA_FROM = '2023-03-28T18:20:00.000Z';
+export const DATE_WITH_DOCKER_DATA_TO = '2023-03-28T18:21:00.000Z';
+export const DATE_WITH_DOCKER_DATA = '03/28/2023 8:20:59 PM';
 export const CONTAINER_COUNT = 1;
 export const CONTAINER_NAMES = Array.from(
   { length: CONTAINER_COUNT },
   (_, i) => `container-container-${i}`
 );
 
-export const DATE_WITH_POD_DATA_FROM = moment().subtract(94, 'minutes').toISOString();
-export const DATE_WITH_POD_DATA_TO = moment().subtract(84, 'minutes').toISOString();
-export const DATE_WITH_POD_DATA = moment()
-  .subtract(84, 'minutes')
-  .subtract(1, 'second')
-  .format('MM/DD/YYYY h:mm:ss A');
+export const DATE_WITH_POD_DATA_FROM = '2023-03-28T18:20:00.000Z';
+export const DATE_WITH_POD_DATA_TO = '2023-03-28T18:21:00.000Z';
+export const DATE_WITH_POD_DATA = '03/28/2023 8:20:59 PM';
 export const POD_COUNT = 1;
 export const POD_NAMES = Array.from({ length: POD_COUNT }, (_, i) => `pod-${i}`);
 

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/index.ts
@@ -59,6 +59,9 @@ export const globalSetupHook = baseGlobalSetupHook.extend({
         log,
         config,
       },
+      // Metrics system indexes are TSDS and thus, time bound.
+      // In order to have fixed dates in the tests, we need to skip the system package installation so that the TSDS configuration doesn't get applied.
+      // Otherwise, time-bound indexes will reject documents outside their time range, which depends on the time the test is being ran, making them less deterministic.
       { skipInstallation: true }
     );
 

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -137,7 +137,7 @@ export class InventoryPage {
     }));
   }
 
-  public async goToHosts() {
+  public async showHosts() {
     await expect(this.inventorySwitcherButton).toBeVisible();
     await this.inventorySwitcherButton.click();
     await expect(this.inventorySwitcherHostsButton).toBeVisible();
@@ -146,7 +146,7 @@ export class InventoryPage {
     await this.waitForNodesToLoad(requestPromise);
   }
 
-  public async goToPods() {
+  public async showPods() {
     await expect(this.inventorySwitcherButton).toBeVisible();
     await this.inventorySwitcherButton.click();
     await expect(this.inventorySwitcherPodsButton).toBeVisible();
@@ -155,7 +155,7 @@ export class InventoryPage {
     await this.waitForNodesToLoad(requestPromise);
   }
 
-  public async goToContainers() {
+  public async showContainers() {
     await expect(this.inventorySwitcherButton).toBeVisible();
     await this.inventorySwitcherButton.click();
     await expect(this.inventorySwitcherContainersButton).toBeVisible();

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -38,6 +38,9 @@ export class InventoryPage {
 
   public readonly noDataPrompt: Locator;
 
+  public readonly noDataPage: Locator;
+  public readonly noDataPageActionButton: Locator;
+
   constructor(private readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {
     this.feedbackLink = this.page.getByTestId('infraInventoryFeedbackLink');
     this.k8sFeedbackLink = this.page.getByTestId('infra-kubernetes-feedback-link');
@@ -62,6 +65,9 @@ export class InventoryPage {
     this.nodesOverviewTable = this.page.getByTestId('infraNodesOverviewTable');
 
     this.noDataPrompt = this.page.getByTestId('noMetricsDataPrompt');
+
+    this.noDataPage = this.page.getByTestId('kbnNoDataPage');
+    this.noDataPageActionButton = this.noDataPage.getByTestId('noDataDefaultActionButton');
   }
 
   private async startWaitingForSnapshotRequest() {
@@ -162,5 +168,10 @@ export class InventoryPage {
     const requestPromise = this.startWaitingForSnapshotRequest();
     await this.inventorySwitcherContainersButton.click();
     await this.waitForNodesToLoad(requestPromise);
+  }
+
+  public async clickNoDataPageAddDataButton() {
+    await expect(this.noDataPageActionButton).toBeVisible();
+    await this.noDataPageActionButton.click();
   }
 }

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -5,14 +5,162 @@
  * 2.0.
  */
 
-import type { KibanaUrl, ScoutPage } from '@kbn/scout-oblt';
+import {
+  expect,
+  type KibanaUrl,
+  type Locator,
+  type ScoutPage,
+  type Request,
+} from '@kbn/scout-oblt';
 
 export class InventoryPage {
-  constructor(private readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {}
+  public readonly feedbackLink: Locator;
+  public readonly k8sFeedbackLink: Locator;
 
-  async goToPage() {
-    await this.page.goto(`${this.kbnUrl.app('metrics')}/inventory`);
+  public readonly datePickerInput: Locator;
+
+  public readonly inventorySwitcherButton: Locator;
+  public readonly inventorySwitcherHostsButton: Locator;
+  public readonly inventorySwitcherPodsButton: Locator;
+  public readonly inventorySwitcherContainersButton: Locator;
+
+  public readonly k8sTourText: Locator;
+  public readonly k8sTourDismissButton: Locator;
+
+  public readonly mapViewButton: Locator;
+  public readonly waffleMap: Locator;
+  public readonly toggleTimelineButton: Locator;
+  public readonly timelineContainerClosed: Locator;
+  public readonly timelineContainerOpen: Locator;
+
+  public readonly tableViewButton: Locator;
+  public readonly nodesOverviewTable: Locator;
+
+  public readonly noDataPrompt: Locator;
+
+  constructor(private readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {
+    this.feedbackLink = this.page.getByTestId('infraInventoryFeedbackLink');
+    this.k8sFeedbackLink = this.page.getByTestId('infra-kubernetes-feedback-link');
+
+    this.datePickerInput = this.page.getByTestId('waffleDatePicker').getByRole('textbox');
+
+    this.inventorySwitcherButton = this.page.getByTestId('openInventorySwitcher');
+    this.inventorySwitcherHostsButton = this.page.getByTestId('goToHost');
+    this.inventorySwitcherPodsButton = this.page.getByTestId('goToPods');
+    this.inventorySwitcherContainersButton = this.page.getByTestId('goToContainer');
+
+    this.k8sTourText = this.page.getByTestId('infra-kubernetesTour-text');
+    this.k8sTourDismissButton = this.page.getByTestId('infra-kubernetesTour-dismiss');
+
+    this.mapViewButton = this.page.getByRole('button', { name: 'Map view' });
+    this.waffleMap = this.page.getByTestId('waffleMap');
+    this.toggleTimelineButton = this.page.getByTestId('toggleTimelineButton');
+    this.timelineContainerClosed = this.page.getByTestId('timelineContainerClosed');
+    this.timelineContainerOpen = this.page.getByTestId('timelineContainerOpen');
+
+    this.tableViewButton = this.page.getByRole('button', { name: 'Table view' });
+    this.nodesOverviewTable = this.page.getByTestId('infraNodesOverviewTable');
+
+    this.noDataPrompt = this.page.getByTestId('noMetricsDataPrompt');
+  }
+
+  private async startWaitingForSnapshotRequest() {
+    // Once the page has loaded once, visual loading indicator doesn't always appear on subsequent loads.
+    // So we need to wait for the network request too to ensure new data has been retrieved.
+    return this.page.waitForRequest((request) => request.url().includes('/api/metrics/snapshot'));
+  }
+
+  private async waitForNodesToLoad(snapshotPromise?: Promise<Request>) {
+    const panelPromise = this.page
+      .getByTestId('infraNodesOverviewLoadingPanel')
+      .waitFor({ state: 'hidden' });
+
+    if (snapshotPromise) {
+      await Promise.all([panelPromise, snapshotPromise]);
+    } else {
+      await panelPromise;
+    }
+  }
+
+  private async waitForPageToLoad() {
     await this.page.getByTestId('infraMetricsPage').waitFor();
-    await this.page.getByTestId('infraNodesOverviewLoadingPanel').waitFor({ state: 'hidden' });
+    await this.waitForNodesToLoad();
+  }
+
+  public async goToPage() {
+    await this.page.goto(`${this.kbnUrl.app('metrics')}/inventory`);
+    await this.waitForPageToLoad();
+  }
+
+  public async reload() {
+    await this.page.reload();
+    await this.waitForPageToLoad();
+  }
+
+  public async toggleTimeline() {
+    await expect(this.toggleTimelineButton).toBeVisible();
+    await this.toggleTimelineButton.click();
+  }
+
+  public async switchToTableView() {
+    await expect(this.tableViewButton).toBeVisible();
+    await this.tableViewButton.click();
+  }
+
+  public async switchToMapView() {
+    await expect(this.mapViewButton).toBeVisible();
+    await this.mapViewButton.click();
+  }
+
+  public async dismissK8sTour() {
+    await expect(this.k8sTourDismissButton).toBeVisible();
+    await this.k8sTourDismissButton.click();
+  }
+
+  public async goToTime(time: string) {
+    await expect(this.datePickerInput).toBeVisible();
+    await this.datePickerInput.focus();
+    await this.datePickerInput.clear();
+    const requestPromise = this.startWaitingForSnapshotRequest();
+    await this.datePickerInput.fill(time);
+    await this.datePickerInput.press('Enter');
+    await this.waitForNodesToLoad(requestPromise);
+  }
+
+  public async getWaffleNodes() {
+    const containers = await this.waffleMap.getByTestId('nodeContainer').all();
+
+    return containers.map((container) => ({
+      container,
+      name: container.getByTestId('nodeName'),
+      value: container.getByTestId('nodeValue'),
+    }));
+  }
+
+  public async goToHosts() {
+    await expect(this.inventorySwitcherButton).toBeVisible();
+    await this.inventorySwitcherButton.click();
+    await expect(this.inventorySwitcherHostsButton).toBeVisible();
+    const requestPromise = this.startWaitingForSnapshotRequest();
+    await this.inventorySwitcherHostsButton.click();
+    await this.waitForNodesToLoad(requestPromise);
+  }
+
+  public async goToPods() {
+    await expect(this.inventorySwitcherButton).toBeVisible();
+    await this.inventorySwitcherButton.click();
+    await expect(this.inventorySwitcherPodsButton).toBeVisible();
+    const requestPromise = this.startWaitingForSnapshotRequest();
+    await this.inventorySwitcherPodsButton.click();
+    await this.waitForNodesToLoad(requestPromise);
+  }
+
+  public async goToContainers() {
+    await expect(this.inventorySwitcherButton).toBeVisible();
+    await this.inventorySwitcherButton.click();
+    await expect(this.inventorySwitcherContainersButton).toBeVisible();
+    const requestPromise = this.startWaitingForSnapshotRequest();
+    await this.inventorySwitcherContainersButton.click();
+    await this.waitForNodesToLoad(requestPromise);
   }
 }

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -5,13 +5,7 @@
  * 2.0.
  */
 
-import {
-  expect,
-  type KibanaUrl,
-  type Locator,
-  type ScoutPage,
-  type Request,
-} from '@kbn/scout-oblt';
+import { type KibanaUrl, type Locator, type ScoutPage } from '@kbn/scout-oblt';
 
 export class InventoryPage {
   public readonly feedbackLink: Locator;
@@ -70,22 +64,15 @@ export class InventoryPage {
     this.noDataPageActionButton = this.noDataPage.getByTestId('noDataDefaultActionButton');
   }
 
-  private async startWaitingForSnapshotRequest() {
-    // Once the page has loaded once, visual loading indicator doesn't always appear on subsequent loads.
-    // So we need to wait for the network request too to ensure new data has been retrieved.
-    return this.page.waitForRequest((request) => request.url().includes('/api/metrics/snapshot'));
-  }
-
-  private async waitForNodesToLoad(snapshotPromise?: Promise<Request>) {
-    const panelPromise = this.page
-      .getByTestId('infraNodesOverviewLoadingPanel')
-      .waitFor({ state: 'hidden' });
-
-    if (snapshotPromise) {
-      await Promise.all([panelPromise, snapshotPromise]);
-    } else {
-      await panelPromise;
+  private async waitForNodesToLoad(opts: { waitForSnapshotRequest?: boolean } = {}) {
+    if (opts.waitForSnapshotRequest) {
+      // Wait for successful API completion
+      await this.page.waitForResponse(
+        (resp) => resp.url().includes('/api/metrics/snapshot') && resp.status() === 200
+      );
     }
+
+    await this.page.getByTestId('infraNodesOverviewLoadingPanel').waitFor({ state: 'hidden' });
   }
 
   private async waitForPageToLoad() {
@@ -104,33 +91,27 @@ export class InventoryPage {
   }
 
   public async toggleTimeline() {
-    await expect(this.toggleTimelineButton).toBeVisible();
     await this.toggleTimelineButton.click();
   }
 
   public async switchToTableView() {
-    await expect(this.tableViewButton).toBeVisible();
     await this.tableViewButton.click();
   }
 
   public async switchToMapView() {
-    await expect(this.mapViewButton).toBeVisible();
     await this.mapViewButton.click();
   }
 
   public async dismissK8sTour() {
-    await expect(this.k8sTourDismissButton).toBeVisible();
     await this.k8sTourDismissButton.click();
   }
 
   public async goToTime(time: string) {
-    await expect(this.datePickerInput).toBeVisible();
     await this.datePickerInput.focus();
     await this.datePickerInput.clear();
-    const requestPromise = this.startWaitingForSnapshotRequest();
     await this.datePickerInput.fill(time);
     await this.datePickerInput.press('Enter');
-    await this.waitForNodesToLoad(requestPromise);
+    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
   }
 
   public async getWaffleNode(nodeName: string) {
@@ -144,34 +125,24 @@ export class InventoryPage {
   }
 
   public async showHosts() {
-    await expect(this.inventorySwitcherButton).toBeVisible();
     await this.inventorySwitcherButton.click();
-    await expect(this.inventorySwitcherHostsButton).toBeVisible();
-    const requestPromise = this.startWaitingForSnapshotRequest();
     await this.inventorySwitcherHostsButton.click();
-    await this.waitForNodesToLoad(requestPromise);
+    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
   }
 
   public async showPods() {
-    await expect(this.inventorySwitcherButton).toBeVisible();
     await this.inventorySwitcherButton.click();
-    await expect(this.inventorySwitcherPodsButton).toBeVisible();
-    const requestPromise = this.startWaitingForSnapshotRequest();
     await this.inventorySwitcherPodsButton.click();
-    await this.waitForNodesToLoad(requestPromise);
+    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
   }
 
   public async showContainers() {
-    await expect(this.inventorySwitcherButton).toBeVisible();
     await this.inventorySwitcherButton.click();
-    await expect(this.inventorySwitcherContainersButton).toBeVisible();
-    const requestPromise = this.startWaitingForSnapshotRequest();
     await this.inventorySwitcherContainersButton.click();
-    await this.waitForNodesToLoad(requestPromise);
+    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
   }
 
   public async clickNoDataPageAddDataButton() {
-    await expect(this.noDataPageActionButton).toBeVisible();
     await this.noDataPageActionButton.click();
   }
 }

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -10,8 +10,9 @@ import type { KibanaUrl, ScoutPage } from '@kbn/scout-oblt';
 export class InventoryPage {
   constructor(private readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {}
 
-  async goto() {
+  async goToPage() {
     await this.page.goto(`${this.kbnUrl.app('metrics')}/inventory`);
-    await this.page.testSubj.waitForSelector('infraMetricsPage');
+    await this.page.getByTestId('infraMetricsPage').waitFor();
+    await this.page.getByTestId('infraNodesOverviewLoadingPanel').waitFor({ state: 'hidden' });
   }
 }

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -133,14 +133,14 @@ export class InventoryPage {
     await this.waitForNodesToLoad(requestPromise);
   }
 
-  public async getWaffleNodes() {
-    const containers = await this.waffleMap.getByTestId('nodeContainer').all();
+  public async getWaffleNode(nodeName: string) {
+    const container = this.waffleMap.getByTestId('nodeContainer').filter({ hasText: nodeName });
 
-    return containers.map((container) => ({
+    return {
       container,
       name: container.getByTestId('nodeName'),
       value: container.getByTestId('nodeValue'),
-    }));
+    };
   }
 
   public async showHosts() {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/add_services_to_existing_hosts.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/add_services_to_existing_hosts.ts
@@ -7,7 +7,6 @@
 
 import { apm, timerange } from '@kbn/synthtrace-client';
 
-const SERVICE_PREFIX = 'service';
 // generates traces, metrics for services
 export function generateAddServicesToExistingHost({
   from,
@@ -26,7 +25,7 @@ export function generateAddServicesToExistingHost({
     .map((_, serviceIdx) =>
       apm
         .service({
-          name: `${SERVICE_PREFIX}-${serviceIdx}`,
+          name: `service-${serviceIdx}`,
           environment: 'production',
           agentName: 'nodejs',
         })

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/add_services_to_existing_hosts.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/add_services_to_existing_hosts.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apm, timerange } from '@kbn/synthtrace-client';
+
+const SERVICE_PREFIX = 'service';
+// generates traces, metrics for services
+export function generateAddServicesToExistingHost({
+  from,
+  to,
+  hostName,
+  servicesPerHost = 1,
+}: {
+  from: string;
+  to: string;
+  hostName: string;
+  servicesPerHost?: number;
+}) {
+  const range = timerange(from, to);
+  const services = Array(servicesPerHost)
+    .fill(null)
+    .map((_, serviceIdx) =>
+      apm
+        .service({
+          name: `${SERVICE_PREFIX}-${serviceIdx}`,
+          environment: 'production',
+          agentName: 'nodejs',
+        })
+        .instance(hostName)
+    );
+
+  return range
+    .interval('1m')
+    .rate(1)
+    .generator((timestamp) =>
+      services.map((service) =>
+        service
+          .transaction({ transactionName: 'GET /foo' })
+          .timestamp(timestamp)
+          .duration(500)
+          .success()
+      )
+    );
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/docker_containers_data.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/docker_containers_data.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { infra, timerange } from '@kbn/synthtrace-client';
+
+export function generateDockerContainersData({
+  from,
+  to,
+  count = 1,
+}: {
+  from: string;
+  to: string;
+  count?: number;
+}) {
+  const range = timerange(from, to);
+
+  const containers = Array(count)
+    .fill(0)
+    .map((_, idx) => infra.dockerContainer(`container-id-${idx}`));
+
+  return range
+    .interval('30s')
+    .rate(1)
+    .generator((timestamp) =>
+      containers.flatMap((container) => container.metrics().timestamp(timestamp))
+    );
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/docker_containers_data.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/docker_containers_data.ts
@@ -20,7 +20,7 @@ export function generateDockerContainersData({
 
   const containers = Array(count)
     .fill(0)
-    .map((_, idx) => infra.dockerContainer(`container-id-${idx}`));
+    .map((_, idx) => infra.dockerContainer(`container-${idx}`));
 
   return range
     .interval('30s')

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/host_data.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/host_data.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { infra, timerange } from '@kbn/synthtrace-client';
+
+export function generateHostData({
+  from,
+  to,
+  hosts,
+}: {
+  from: string;
+  to: string;
+  hosts: Array<{ hostName: string; cpuValue?: number }>;
+}) {
+  const range = timerange(from, to);
+
+  return range
+    .interval('30s')
+    .rate(1)
+    .generator((timestamp) =>
+      hosts.flatMap(({ hostName, cpuValue }) => [
+        infra.host(hostName).cpu({ 'system.cpu.total.norm.pct': cpuValue }).timestamp(timestamp),
+        infra.host(hostName).memory().timestamp(timestamp),
+        infra.host(hostName).network().timestamp(timestamp),
+        infra.host(hostName).load().timestamp(timestamp),
+        infra.host(hostName).filesystem().timestamp(timestamp),
+        infra.host(hostName).diskio().timestamp(timestamp),
+        infra.host(hostName).core().timestamp(timestamp),
+      ])
+    );
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/hosts_with_k8s_node_data.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/hosts_with_k8s_node_data.ts
@@ -6,24 +6,16 @@
  */
 
 import { infra, timerange } from '@kbn/synthtrace-client';
+import { K8S_HOST_NAME, K8S_HOSTS, K8S_POD_NAME } from '../constants';
 
 export function generateHostsWithK8sNodeData({ from, to }: { from: string; to: string }) {
   const range = timerange(from, to);
-
-  // cpuValue is sent to the generator to simulate different 'system.cpu.total.norm.pct' metric
-  // that is the default metric in inventory and hosts view and host details page
-  const hosts = [
-    {
-      hostName: 'demo-stack-kubernetes-01',
-      cpuValue: 0.5,
-    },
-  ];
 
   return range
     .interval('30s')
     .rate(1)
     .generator((timestamp) =>
-      hosts.flatMap(({ hostName, cpuValue }) => [
+      K8S_HOSTS.flatMap(({ hostName, cpuValue }) => [
         infra.host(hostName).cpu({ 'system.cpu.total.norm.pct': cpuValue }).timestamp(timestamp),
         infra.host(hostName).memory().timestamp(timestamp),
         infra.host(hostName).network().timestamp(timestamp),
@@ -31,8 +23,8 @@ export function generateHostsWithK8sNodeData({ from, to }: { from: string; to: s
         infra.host(hostName).filesystem().timestamp(timestamp),
         infra.host(hostName).diskio().timestamp(timestamp),
         infra.host(hostName).core().timestamp(timestamp),
-        infra.host(hostName).node('demo-stack-kubernetes-01').metrics().timestamp(timestamp),
-        infra.host(hostName).pod('pod-1').metrics().timestamp(timestamp),
+        infra.host(hostName).node(K8S_HOST_NAME).metrics().timestamp(timestamp),
+        infra.host(hostName).pod(K8S_POD_NAME).metrics().timestamp(timestamp),
       ])
     );
 }

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/hosts_with_k8s_node_data.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/hosts_with_k8s_node_data.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { infra, timerange } from '@kbn/synthtrace-client';
+
+export function generateHostsWithK8sNodeData({ from, to }: { from: string; to: string }) {
+  const range = timerange(from, to);
+
+  // cpuValue is sent to the generator to simulate different 'system.cpu.total.norm.pct' metric
+  // that is the default metric in inventory and hosts view and host details page
+  const hosts = [
+    {
+      hostName: 'demo-stack-kubernetes-01',
+      cpuValue: 0.5,
+    },
+  ];
+
+  return range
+    .interval('30s')
+    .rate(1)
+    .generator((timestamp) =>
+      hosts.flatMap(({ hostName, cpuValue }) => [
+        infra.host(hostName).cpu({ 'system.cpu.total.norm.pct': cpuValue }).timestamp(timestamp),
+        infra.host(hostName).memory().timestamp(timestamp),
+        infra.host(hostName).network().timestamp(timestamp),
+        infra.host(hostName).load().timestamp(timestamp),
+        infra.host(hostName).filesystem().timestamp(timestamp),
+        infra.host(hostName).diskio().timestamp(timestamp),
+        infra.host(hostName).core().timestamp(timestamp),
+        infra.host(hostName).node('demo-stack-kubernetes-01').metrics().timestamp(timestamp),
+        infra.host(hostName).pod('pod-1').metrics().timestamp(timestamp),
+      ])
+    );
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/logs_data_for_hosts.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/logs_data_for_hosts.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { generateShortId, log, timerange } from '@kbn/synthtrace-client';
+
+export function generateLogsDataForHosts({
+  from,
+  to,
+  hosts,
+}: {
+  from: string;
+  to: string;
+  hosts: Array<{ hostName: string }>;
+}) {
+  const range = timerange(from, to);
+
+  // Logs Data logic
+  const MESSAGE_LOG_LEVELS = [
+    { message: 'A simple log', level: 'info' },
+    { message: 'Yet another debug log', level: 'debug' },
+    { message: 'Error with certificate: "ca_trusted_fingerprint"', level: 'error' },
+  ];
+  const CLOUD_PROVIDERS = ['gcp', 'aws', 'azure'];
+  const CLOUD_REGION = ['eu-central-1', 'us-east-1', 'area-51'];
+
+  const CLUSTER = [
+    { clusterId: generateShortId(), clusterName: 'synth-cluster-1' },
+    { clusterId: generateShortId(), clusterName: 'synth-cluster-2' },
+    { clusterId: generateShortId(), clusterName: 'synth-cluster-3' },
+  ];
+
+  return range
+    .interval('30s')
+    .rate(1)
+    .generator((timestamp) =>
+      hosts.flatMap(({ hostName }) => {
+        const index = Math.floor(Math.random() * MESSAGE_LOG_LEVELS.length);
+        return log
+          .create()
+          .message(MESSAGE_LOG_LEVELS[index].message)
+          .logLevel(MESSAGE_LOG_LEVELS[index].level)
+          .hostName(hostName)
+          .defaults({
+            'trace.id': generateShortId(),
+            'agent.name': 'synth-agent',
+            'orchestrator.cluster.name': CLUSTER[index].clusterName,
+            'orchestrator.cluster.id': CLUSTER[index].clusterId,
+            'orchestrator.resource.id': generateShortId(),
+            'cloud.provider': CLOUD_PROVIDERS[index],
+            'cloud.region': CLOUD_REGION[index],
+            'cloud.availability_zone': `${CLOUD_REGION[index]}a`,
+            'cloud.project.id': generateShortId(),
+            'cloud.instance.id': generateShortId(),
+            'log.file.path': `/logs/${generateShortId()}/error.txt`,
+          })
+          .timestamp(timestamp);
+      })
+    );
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/pods_data.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/pods_data.ts
@@ -28,7 +28,7 @@ export function generatePodsData({
     .generator((timestamp) =>
       pods.flatMap((pod, idx) => [
         pod.metrics().timestamp(timestamp),
-        pod.container(`container-${idx}`).metrics().timestamp(timestamp),
+        pod.container(`k8s-container-${idx}`).metrics().timestamp(timestamp),
       ])
     );
 }

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/pods_data.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/synthtrace/pods_data.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { infra, timerange } from '@kbn/synthtrace-client';
+
+export function generatePodsData({
+  from,
+  to,
+  count = 1,
+}: {
+  from: string;
+  to: string;
+  count: number;
+}) {
+  const range = timerange(from, to);
+
+  const pods = Array(count)
+    .fill(0)
+    .map((_, idx) => infra.pod(`pod-${idx}`, `node-name-${idx}`));
+
+  return range
+    .interval('30s')
+    .rate(1)
+    .generator((timestamp) =>
+      pods.flatMap((pod, idx) => [
+        pod.metrics().timestamp(timestamp),
+        pod.container(`container-${idx}`).metrics().timestamp(timestamp),
+      ])
+    );
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/global.setup.ts
@@ -8,6 +8,9 @@
 import { globalSetupHook } from '@kbn/scout-oblt';
 import { generateHostData } from '../fixtures/synthtrace/host_data';
 import {
+  CONTAINER_COUNT,
+  DATE_WITH_DOCKER_DATA_FROM,
+  DATE_WITH_DOCKER_DATA_TO,
   DATE_WITH_HOSTS_DATA_FROM,
   DATE_WITH_HOSTS_DATA_TO,
   DATE_WITH_HOSTS_WITHOUT_DATA_FROM,
@@ -26,6 +29,7 @@ import { generateHostsWithK8sNodeData } from '../fixtures/synthtrace/hosts_with_
 import { generatePodsData } from '../fixtures/synthtrace/pods_data';
 import { generateLogsDataForHosts } from '../fixtures/synthtrace/logs_data_for_hosts';
 import { generateAddServicesToExistingHost } from '../fixtures/synthtrace/add_services_to_existing_hosts';
+import { generateDockerContainersData } from '../fixtures/synthtrace/docker_containers_data';
 
 globalSetupHook(
   'Ingest data to Elasticsearch',
@@ -57,6 +61,13 @@ globalSetupHook(
           from: DATE_WITH_POD_DATA_FROM,
           to: DATE_WITH_POD_DATA_TO,
           count: POD_COUNT,
+        })
+      ),
+      infraSynthtraceEsClient.index(
+        generateDockerContainersData({
+          from: DATE_WITH_DOCKER_DATA_FROM,
+          to: DATE_WITH_DOCKER_DATA_TO,
+          count: CONTAINER_COUNT,
         })
       ),
       logsSynthtraceEsClient.index(

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/global.setup.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { globalSetupHook } from '@kbn/scout-oblt';
 import { generateHostData } from '../fixtures/synthtrace/host_data';
 import {
   CONTAINER_COUNT,
@@ -30,6 +29,7 @@ import { generatePodsData } from '../fixtures/synthtrace/pods_data';
 import { generateLogsDataForHosts } from '../fixtures/synthtrace/logs_data_for_hosts';
 import { generateAddServicesToExistingHost } from '../fixtures/synthtrace/add_services_to_existing_hosts';
 import { generateDockerContainersData } from '../fixtures/synthtrace/docker_containers_data';
+import { globalSetupHook } from '../fixtures';
 
 globalSetupHook(
   'Ingest data to Elasticsearch',

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/global.setup.ts
@@ -6,7 +6,74 @@
  */
 
 import { globalSetupHook } from '@kbn/scout-oblt';
+import { generateHostData } from '../fixtures/synthtrace/host_data';
+import {
+  DATE_WITH_HOSTS_DATA_FROM,
+  DATE_WITH_HOSTS_DATA_TO,
+  DATE_WITH_HOSTS_WITHOUT_DATA_FROM,
+  DATE_WITH_HOSTS_WITHOUT_DATA_TO,
+  DATE_WITH_K8S_HOSTS_DATA_FROM,
+  DATE_WITH_K8S_HOSTS_DATA_TO,
+  DATE_WITH_POD_DATA_FROM,
+  DATE_WITH_POD_DATA_TO,
+  HOST_NAME_WITH_SERVICES,
+  HOSTS,
+  HOSTS_WITHOUT_DATA,
+  POD_COUNT,
+  SERVICE_PER_HOST_COUNT,
+} from '../fixtures/constants';
+import { generateHostsWithK8sNodeData } from '../fixtures/synthtrace/hosts_with_k8s_node_data';
+import { generatePodsData } from '../fixtures/synthtrace/pods_data';
+import { generateLogsDataForHosts } from '../fixtures/synthtrace/logs_data_for_hosts';
+import { generateAddServicesToExistingHost } from '../fixtures/synthtrace/add_services_to_existing_hosts';
 
-globalSetupHook('Ingest data to Elasticsearch', { tag: ['@ess', '@svlOblt'] }, async ({}) => {
-  return;
-});
+globalSetupHook(
+  'Ingest data to Elasticsearch',
+  { tag: ['@ess', '@svlOblt'] },
+  async ({ infraSynthtraceEsClient, logsSynthtraceEsClient, apmSynthtraceEsClient }) => {
+    await Promise.all([
+      infraSynthtraceEsClient.index(
+        generateHostData({
+          from: DATE_WITH_HOSTS_DATA_FROM,
+          to: DATE_WITH_HOSTS_DATA_TO,
+          hosts: HOSTS,
+        })
+      ),
+      infraSynthtraceEsClient.index(
+        generateHostData({
+          from: DATE_WITH_HOSTS_WITHOUT_DATA_FROM,
+          to: DATE_WITH_HOSTS_WITHOUT_DATA_TO,
+          hosts: HOSTS_WITHOUT_DATA,
+        })
+      ),
+      infraSynthtraceEsClient.index(
+        generateHostsWithK8sNodeData({
+          from: DATE_WITH_K8S_HOSTS_DATA_FROM,
+          to: DATE_WITH_K8S_HOSTS_DATA_TO,
+        })
+      ),
+      infraSynthtraceEsClient.index(
+        generatePodsData({
+          from: DATE_WITH_POD_DATA_FROM,
+          to: DATE_WITH_POD_DATA_TO,
+          count: POD_COUNT,
+        })
+      ),
+      logsSynthtraceEsClient.index(
+        generateLogsDataForHosts({
+          from: DATE_WITH_HOSTS_DATA_FROM,
+          to: DATE_WITH_HOSTS_DATA_TO,
+          hosts: HOSTS,
+        })
+      ),
+      apmSynthtraceEsClient.index(
+        generateAddServicesToExistingHost({
+          from: DATE_WITH_HOSTS_DATA_FROM,
+          to: DATE_WITH_HOSTS_DATA_TO,
+          hostName: HOST_NAME_WITH_SERVICES,
+          servicesPerHost: SERVICE_PER_HOST_COUNT,
+        })
+      ),
+    ]);
+  }
+);

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/global.setup.ts
@@ -34,57 +34,68 @@ import { generateDockerContainersData } from '../fixtures/synthtrace/docker_cont
 globalSetupHook(
   'Ingest data to Elasticsearch',
   { tag: ['@ess', '@svlOblt'] },
-  async ({ infraSynthtraceEsClient, logsSynthtraceEsClient, apmSynthtraceEsClient }) => {
-    await Promise.all([
-      infraSynthtraceEsClient.index(
-        generateHostData({
-          from: DATE_WITH_HOSTS_DATA_FROM,
-          to: DATE_WITH_HOSTS_DATA_TO,
-          hosts: HOSTS,
-        })
-      ),
-      infraSynthtraceEsClient.index(
-        generateHostData({
-          from: DATE_WITH_HOSTS_WITHOUT_DATA_FROM,
-          to: DATE_WITH_HOSTS_WITHOUT_DATA_TO,
-          hosts: HOSTS_WITHOUT_DATA,
-        })
-      ),
-      infraSynthtraceEsClient.index(
-        generateHostsWithK8sNodeData({
-          from: DATE_WITH_K8S_HOSTS_DATA_FROM,
-          to: DATE_WITH_K8S_HOSTS_DATA_TO,
-        })
-      ),
-      infraSynthtraceEsClient.index(
-        generatePodsData({
-          from: DATE_WITH_POD_DATA_FROM,
-          to: DATE_WITH_POD_DATA_TO,
-          count: POD_COUNT,
-        })
-      ),
-      infraSynthtraceEsClient.index(
-        generateDockerContainersData({
-          from: DATE_WITH_DOCKER_DATA_FROM,
-          to: DATE_WITH_DOCKER_DATA_TO,
-          count: CONTAINER_COUNT,
-        })
-      ),
-      logsSynthtraceEsClient.index(
-        generateLogsDataForHosts({
-          from: DATE_WITH_HOSTS_DATA_FROM,
-          to: DATE_WITH_HOSTS_DATA_TO,
-          hosts: HOSTS,
-        })
-      ),
-      apmSynthtraceEsClient.index(
-        generateAddServicesToExistingHost({
-          from: DATE_WITH_HOSTS_DATA_FROM,
-          to: DATE_WITH_HOSTS_DATA_TO,
-          hostName: HOST_NAME_WITH_SERVICES,
-          servicesPerHost: SERVICE_PER_HOST_COUNT,
-        })
-      ),
-    ]);
+  async ({ infraSynthtraceEsClient, logsSynthtraceEsClient, apmSynthtraceEsClient, log }) => {
+    await infraSynthtraceEsClient.index(
+      generateHostData({
+        from: DATE_WITH_HOSTS_DATA_FROM,
+        to: DATE_WITH_HOSTS_DATA_TO,
+        hosts: HOSTS,
+      })
+    );
+    log.info('Host data indexed');
+
+    await logsSynthtraceEsClient.index(
+      generateLogsDataForHosts({
+        from: DATE_WITH_HOSTS_DATA_FROM,
+        to: DATE_WITH_HOSTS_DATA_TO,
+        hosts: HOSTS,
+      })
+    );
+    log.info('Logs data for hosts indexed');
+
+    await apmSynthtraceEsClient.index(
+      generateAddServicesToExistingHost({
+        from: DATE_WITH_HOSTS_DATA_FROM,
+        to: DATE_WITH_HOSTS_DATA_TO,
+        hostName: HOST_NAME_WITH_SERVICES,
+        servicesPerHost: SERVICE_PER_HOST_COUNT,
+      })
+    );
+    log.info('Service data for hosts indexed');
+
+    await infraSynthtraceEsClient.index(
+      generateHostData({
+        from: DATE_WITH_HOSTS_WITHOUT_DATA_FROM,
+        to: DATE_WITH_HOSTS_WITHOUT_DATA_TO,
+        hosts: HOSTS_WITHOUT_DATA,
+      })
+    );
+    log.info('Hosts without data indexed');
+
+    await infraSynthtraceEsClient.index(
+      generateHostsWithK8sNodeData({
+        from: DATE_WITH_K8S_HOSTS_DATA_FROM,
+        to: DATE_WITH_K8S_HOSTS_DATA_TO,
+      })
+    );
+    log.info('Hosts with K8s node data indexed');
+
+    await infraSynthtraceEsClient.index(
+      generatePodsData({
+        from: DATE_WITH_POD_DATA_FROM,
+        to: DATE_WITH_POD_DATA_TO,
+        count: POD_COUNT,
+      })
+    );
+    log.info('Pods data indexed');
+
+    await infraSynthtraceEsClient.index(
+      generateDockerContainersData({
+        from: DATE_WITH_DOCKER_DATA_FROM,
+        to: DATE_WITH_DOCKER_DATA_TO,
+        count: CONTAINER_COUNT,
+      })
+    );
+    log.info('Docker containers data indexed');
   }
 );

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
@@ -108,22 +108,22 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
   test('Inventory switcher changes node types', async ({ pageObjects: { inventoryPage } }) => {
     await test.step('show hosts by default', async () => {
       await expect(inventoryPage.inventorySwitcherButton).toContainText('Hosts');
-      const nodeValues = await inventoryPage.getWaffleNodes();
-      expect(nodeValues.length).toBeGreaterThan(0);
-      const nodeName = await nodeValues[0].name.textContent();
-      expect(nodeName).toBeDefined();
-      expect(HOSTS.map((h) => h.hostName)).toContain(nodeName!.trim());
+
+      const hostName = HOSTS[Math.floor(Math.random() * HOSTS.length)].hostName;
+      const waffleNode = await inventoryPage.getWaffleNode(hostName);
+      await expect(waffleNode.container).toBeVisible();
+      await expect(waffleNode.name).toHaveText(hostName);
     });
 
     await test.step('switch to k8s pods', async () => {
       await inventoryPage.goToTime(DATE_WITH_POD_DATA);
       await inventoryPage.showPods();
       await expect(inventoryPage.inventorySwitcherButton).toContainText('Kubernetes Pods');
-      const nodeValues = await inventoryPage.getWaffleNodes();
-      expect(nodeValues.length).toBeGreaterThan(0);
-      const nodeName = await nodeValues[0].name.textContent();
-      expect(nodeName).toBeDefined();
-      expect(POD_NAMES).toContain(nodeName!.trim());
+
+      const podName = POD_NAMES[Math.floor(Math.random() * POD_NAMES.length)];
+      const waffleNode = await inventoryPage.getWaffleNode(podName);
+      await expect(waffleNode.container).toBeVisible();
+      await expect(waffleNode.name).toHaveText(podName);
 
       await expect(inventoryPage.k8sFeedbackLink).toBeVisible();
     });
@@ -132,11 +132,11 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
       await inventoryPage.goToTime(DATE_WITH_DOCKER_DATA);
       await inventoryPage.showContainers();
       await expect(inventoryPage.inventorySwitcherButton).toContainText('Docker Containers');
-      const nodeValues = await inventoryPage.getWaffleNodes();
-      expect(nodeValues.length).toBeGreaterThan(0);
-      const nodeName = await nodeValues[0].name.textContent();
-      expect(nodeName).toBeDefined();
-      expect(CONTAINER_NAMES).toContain(nodeName!.trim());
+
+      const containerName = CONTAINER_NAMES[Math.floor(Math.random() * CONTAINER_NAMES.length)];
+      const waffleNode = await inventoryPage.getWaffleNode(containerName);
+      await expect(waffleNode.container).toBeVisible();
+      await expect(waffleNode.name).toHaveText(containerName);
     });
   });
 

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
@@ -139,4 +139,9 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
       expect(CONTAINER_NAMES).toContain(nodeName!.trim());
     });
   });
+
+  test('Has no detectable a11y violations on load', async ({ page }) => {
+    const { violations } = await page.checkA11y({ include: ['main'] });
+    expect(violations).toHaveLength(0);
+  });
 });

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
@@ -6,16 +6,18 @@
  */
 
 import { expect } from '@kbn/scout-oblt';
-import { KUBERNETES_TOUR_STORAGE_KEY } from '../../../../../public/pages/metrics/inventory_view/components/kubernetes_tour';
 import { test } from '../../fixtures';
 import {
   CONTAINER_NAMES,
   DATE_WITH_DOCKER_DATA,
+  DATE_WITH_HOSTS_DATA,
   DATE_WITH_POD_DATA,
   DATE_WITHOUT_DATA,
   HOSTS,
   POD_NAMES,
 } from '../../fixtures/constants';
+
+const KUBERNETES_TOUR_STORAGE_KEY = 'isKubernetesTourSeen';
 
 test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
   test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
@@ -24,6 +26,7 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
     // Dismiss k8s tour if it's present to avoid interference with other test assertions
     // The k8s tour specific test will take care of adding it back during its own execution
     await inventoryPage.dismissK8sTour();
+    await inventoryPage.goToTime(DATE_WITH_HOSTS_DATA);
   });
 
   test('Render expected content', async ({ page, pageObjects: { inventoryPage } }) => {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
@@ -9,10 +9,61 @@ import { expect } from '@kbn/scout-oblt';
 import { test } from '../../fixtures';
 
 test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
-  test('Page should load', async ({ pageObjects: { inventoryPage }, browserAuth, page }) => {
+  test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
     await browserAuth.loginAsViewer();
-    await inventoryPage.goto();
+    await inventoryPage.goToPage();
+  });
 
-    await expect(page.getByTestId('breadcrumb last')).toHaveText('Infrastructure inventory');
+  test('Render expected content', async ({ page }) => {
+    await test.step('set the correct browser page title', async () => {
+      const title = await page.title();
+      expect(title).toBe('Infrastructure inventory - Infrastructure - Observability - Elastic');
+    });
+
+    await test.step('display inventory survey link', async () => {
+      await expect(page.getByTestId('infraInventoryFeedbackLink')).toBeVisible();
+    });
+
+    await test.step('display waffle map', async () => {
+      await expect(page.getByTestId('waffleMap')).toBeVisible();
+    });
+
+    await test.step('open and display timeline', async () => {
+      const toggleTimelineButton = page.getByTestId('toggleTimelineButton');
+      await expect(toggleTimelineButton).toBeVisible();
+      await toggleTimelineButton.click();
+      await expect(page.getByTestId('timelineContainerOpen')).toBeVisible();
+    });
+
+    await test.step('switch to table view and display inventory table', async () => {
+      const tableViewButton = page.getByRole('button', { name: 'Table view' });
+      await expect(tableViewButton).toBeVisible();
+      await tableViewButton.click();
+      await expect(page.getByTestId('infraNodesOverviewTable')).toBeVisible();
+    });
+  });
+
+  test('Render and dismiss k8s tour', async ({ page }) => {
+    await test.step('display k8s tour with proper message', async () => {
+      const tourText = page.getByTestId('infra-kubernetesTour-text');
+      await expect(tourText).toBeVisible();
+      await expect(tourText).toHaveText(
+        'Click here to see your infrastructure in different ways, including Kubernetes pods.'
+      );
+    });
+
+    await test.step('dismiss k8s tour', async () => {
+      const dismissButton = page.getByTestId('infra-kubernetesTour-dismiss');
+      await expect(dismissButton).toBeVisible();
+      await dismissButton.click();
+      await expect(page.getByTestId('infra-kubernetesTour-text')).toBeHidden();
+    });
+
+    await test.step('reload page and verify tour remains dismissed', async () => {
+      await page.reload();
+      await page.getByTestId('infraMetricsPage').waitFor();
+      await page.getByTestId('infraNodesOverviewLoadingPanel').waitFor({ state: 'hidden' });
+      await expect(page.getByTestId('infra-kubernetesTour-text')).toBeHidden();
+    });
   });
 });

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
@@ -114,7 +114,7 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
 
     await test.step('switch to k8s pods', async () => {
       await inventoryPage.goToTime(DATE_WITH_POD_DATA);
-      await inventoryPage.goToPods();
+      await inventoryPage.showPods();
       await expect(inventoryPage.inventorySwitcherButton).toContainText('Kubernetes Pods');
       const nodeValues = await inventoryPage.getWaffleNodes();
       expect(nodeValues.length).toBeGreaterThan(0);
@@ -127,7 +127,7 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
 
     await test.step('switch to containers', async () => {
       await inventoryPage.goToTime(DATE_WITH_DOCKER_DATA);
-      await inventoryPage.goToContainers();
+      await inventoryPage.showContainers();
       await expect(inventoryPage.inventorySwitcherButton).toContainText('Docker Containers');
       const nodeValues = await inventoryPage.getWaffleNodes();
       expect(nodeValues.length).toBeGreaterThan(0);

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
@@ -19,6 +19,10 @@ import {
 
 const KUBERNETES_TOUR_STORAGE_KEY = 'isKubernetesTourSeen';
 
+test.use({
+  timezoneId: 'GMT',
+});
+
 test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
   test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
     await browserAuth.loginAsViewer();

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/playwright.config.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/playwright.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPlaywrightConfig } from '@kbn/scout-oblt';
+
+export default createPlaywrightConfig({
+  testDir: './tests',
+});

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/inventory/inventory.spec.ts
@@ -25,8 +25,7 @@ test.describe('Infrastructure Inventory - Sequential', { tag: ['@ess', '@svlOblt
 
     await test.step('redirect to onboarding page when clicking on the add data button', async () => {
       await inventoryPage.clickNoDataPageAddDataButton();
-      const url = new URL(page.url());
-      expect(url.pathname).toContain('/app/observabilityOnboarding');
+      await expect(page.getByTestId('obltOnboardingHomeTitle')).toBeVisible();
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/inventory/inventory.spec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-oblt';
+import { test } from '../../fixtures';
+
+test.describe('Infrastructure Inventory - Sequential', { tag: ['@ess', '@svlOblt'] }, () => {
+  test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
+    await browserAuth.loginAsViewer();
+    await inventoryPage.goToPage();
+  });
+
+  test('Renders no data page and redirects to onboarding page when no data is present', async ({
+    page,
+    pageObjects: { inventoryPage },
+  }) => {
+    await test.step('display empty state', async () => {
+      await expect(inventoryPage.noDataPage).toBeVisible();
+      await expect(inventoryPage.noDataPageActionButton).toBeVisible();
+    });
+
+    await test.step('redirect to onboarding page when clicking on the add data button', async () => {
+      await inventoryPage.clickNoDataPageAddDataButton();
+      const url = new URL(page.url());
+      expect(url.pathname).toContain('/app/observabilityOnboarding');
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/inventory/inventory.spec.ts
@@ -8,7 +8,7 @@
 import { expect } from '@kbn/scout-oblt';
 import { test } from '../../fixtures';
 
-test.describe('Infrastructure Inventory - Sequential', { tag: ['@ess', '@svlOblt'] }, () => {
+test.describe('Infrastructure Inventory - Onboarding', { tag: ['@ess', '@svlOblt'] }, () => {
   test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
     await browserAuth.loginAsViewer();
     await inventoryPage.goToPage();

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/tsconfig.json
@@ -4,6 +4,9 @@
     "outDir": "target/types"
   },
   "include": ["**/*"],
-  "kbn_references": ["@kbn/scout-oblt"],
+  "kbn_references": [
+    "@kbn/scout-oblt",
+    "@kbn/synthtrace-client",
+  ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/solutions/observability/test/functional/apps/infra/home_page.ts
+++ b/x-pack/solutions/observability/test/functional/apps/infra/home_page.ts
@@ -71,7 +71,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       return !!currentUrl.match(path);
     });
 
-  describe('Home page', function () {
+  describe.skip('Home page', function () {
     this.tags('includeFirefox');
     let synthEsClient: InfraSynthtraceEsClient;
 

--- a/x-pack/solutions/observability/test/functional/apps/infra/home_page.ts
+++ b/x-pack/solutions/observability/test/functional/apps/infra/home_page.ts
@@ -141,6 +141,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
       after(async () => browser.removeLocalStorageItem(KUBERNETES_TOUR_STORAGE_KEY));
 
+      // Done
       it('renders the correct page title', async () => {
         await pageObjects.header.waitUntilLoadingHasFinished();
 
@@ -150,6 +151,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         );
       });
 
+      // Done
       it('renders the inventory survey link', async () => {
         await pageObjects.header.waitUntilLoadingHasFinished();
         await pageObjects.infraHome.waitForLoading();
@@ -157,6 +159,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await pageObjects.infraHome.ensureInventoryFeedbackLinkIsVisible();
       });
 
+      // Done
       it('renders the kubernetes tour component and allows user to dismiss it without seeing it again', async () => {
         await pageObjects.header.waitUntilLoadingHasFinished();
         const kubernetesTourText =
@@ -177,11 +180,13 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         });
       });
 
+      // Done
       it('renders an empty data prompt for dates with no data', async () => {
         await pageObjects.infraHome.goToTime(DATE_WITHOUT_DATA);
         await pageObjects.infraHome.getNoMetricsDataPrompt();
       });
 
+      // Done
       it('renders the waffle map and tooltips for dates with data', async () => {
         await pageObjects.infraHome.goToTime(DATE_WITH_HOSTS_DATA);
         await pageObjects.infraHome.getWaffleMap();
@@ -428,6 +433,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         });
       });
 
+      // Done
       it('toggle the timeline', async () => {
         await pageObjects.infraHome.goToTime(DATE_WITH_HOSTS_DATA);
         await pageObjects.infraHome.getWaffleMap();
@@ -435,6 +441,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await pageObjects.infraHome.closeTimeline();
       });
 
+      // Done
       it('toggles the inventory switcher', async () => {
         await pageObjects.infraHome.toggleInventorySwitcher();
       });

--- a/x-pack/solutions/observability/test/functional/apps/infra/home_page.ts
+++ b/x-pack/solutions/observability/test/functional/apps/infra/home_page.ts
@@ -85,7 +85,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
     after(() => synthEsClient.clean());
 
-    describe('without metrics present', () => {
+    // Done
+    describe.skip('without metrics present', () => {
       it('renders an empty data prompt and redirects to the onboarding page', async () => {
         await pageObjects.common.navigateToApp('infraOps');
         await pageObjects.infraHome.noDataPromptExists();


### PR DESCRIPTION
## Summary
Part of #246428
Closes #233920

This PR is part I of the test migration effort to port infra home page tests from FTR to Scout. The original FTR file contains lots of tests that I believe could be split into multiple separate suites following the recommended approach of keeping 1 describe block per test file. The migration will consist of these steps:

- [X] Infra home page (this PR). Includes most of the standalone `it` tests inside the outter most describe block in the original FTR suite. It tests the main home page contents, without opening any flyout pr navigating away.
- [ ] Asset details flyout. Will cover the asset details flyout that opens up after clicking a node in the waffle map. Will in turn be split into 2 separate files to cover the 2 distinct FTR describe blocks, one for hosts and another for containers. This will also cover the "Redirect to Node Details page" block as the redirection occurs within the flyout.
- [ ] Alert flyouts. Will cover the equivalent describe block around alerts from the infra home page
- [ ] Saved views. Will cover the block around saved views functionality
- [ ] React component test for waffle map. Will cover the outstanding `it` tests focused around waffle map functionality. As already specified in the FTR file, this are better suited as unit tests

Given this is the first step of the migration, this PR also takes care of adapting the FTR data ingestion into Scout fixtures. This way, we can leverage the scout global setup patter to load data once, speeding up test execution.

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed






<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->