### PR TITLE
[Spaces API Tests] Add missing `testConfigCategory` to two FTR configs

### DIFF
--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/config.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/config.ts
@@ -23,6 +23,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   );
 
   return {
+    testConfigCategory: xPackAPITestsConfig.get('testConfigCategory'),
     testFiles: [
       resolve(__dirname, './apis/spaces/access_control_objects.ts'),
       resolve(__dirname, './apis/spaces/import_export.ts'),

--- a/x-pack/platform/test/spaces_api_integration/access_control_objects/feature_disabled.config.ts
+++ b/x-pack/platform/test/spaces_api_integration/access_control_objects/feature_disabled.config.ts
@@ -23,6 +23,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   );
 
   return {
+    testConfigCategory: xPackAPITestsConfig.get('testConfigCategory'),
     testFiles: [resolve(__dirname, './apis/spaces/feature_disabled.ts')],
     services: {
       ...kibanaAPITestsConfig.get('services'),


### PR DESCRIPTION
This PR adds two missing `testConfigCategory` properties to two FTR missing config. This will ensure the data our Scout Reporter collects (which is then used by AppEx QA dashboards, AI weekly report, etc.) is accurate and complete.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->