### PR TITLE
[8.19] [kbn/scout] disable side/solution tour before tests run (#245071)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Kibana source code with Kibana X-Pack source code
-Copyright 2012-2025 Elasticsearch B.V.
+Copyright 2012-2026 Elasticsearch B.V.
 
 ---
 Adapted from remote-web-worker, which was available under a "MIT" license.

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/context/page_context.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/context/page_context.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { BrowserContext } from 'playwright/test';
+import { coreWorkerFixtures } from '../../worker';
+
+/**
+ * Extends the default Playwright browser context to add initialization scripts
+ * that run before any page is loaded. This is the recommended place to set
+ * global localStorage flags or other browser-level initialization.
+ *
+ * The init script will be executed for all pages created from this context,
+ * ensuring consistent browser state across all tests.
+ */
+export const pageContextFixture = coreWorkerFixtures.extend<{ context: BrowserContext }>({
+  context: async ({ context }, use) => {
+    // set localStorage flags before any page navigation
+    await use(context);
+  },
+});

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/core_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/core_fixtures.ts
@@ -87,6 +87,18 @@ export const coreWorkerFixtures = base.extend<{}, CoreWorkerFixtures>({
       const serversConfigDir = projectUse.serversConfigDir;
       const configInstance = createScoutConfig(serversConfigDir, projectUse.configName, log);
 
+      log.info(
+        `Running tests against ${
+          configInstance.isCloud
+            ? configInstance.serverless
+              ? `MKI ${configInstance.projectType} project`
+              : 'ECH deployment'
+            : `local ${
+                configInstance.serverless ? `serverless ${configInstance.projectType}` : 'stateful'
+              } cluster`
+        }`
+      );
+
       use(configInstance);
     },
     { scope: 'worker' },
@@ -177,6 +189,8 @@ export const coreWorkerFixtures = base.extend<{}, CoreWorkerFixtures>({
 
         customRoleHash = newRoleHash;
       };
+      // Hide the announcements (including the sidenav tour) in the default space
+      await kbnClient.uiSettings.update({ hideAnnouncements: true });
 
       await use({ session, customRoleName, setCustomRole });
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/scout_space/parallel.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/scout_space/parallel.ts
@@ -126,6 +126,14 @@ export const scoutSpaceParallelFixture = coreWorkerFixtures.extend<
         setDefaultTime,
       };
 
+      /**
+       * To hide the sidenav tour we need to enable 'hideAnnouncements' setting
+       * It should hide both space tour and sidenav tour.
+       * Currently it can be set only per space, so we set it right after new space is created.
+       * TODO: update if setting becomes global https://github.com/elastic/kibana/issues/234771
+       */
+      await kbnClient.uiSettings.update({ hideAnnouncements: true }, { space: spaceId });
+
       log.serviceMessage('scoutSpace', `New Kibana space '${spaceId}' created`);
       await use({ savedObjects, uiSettings, id: spaceId });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[kbn/scout] disable side/solution tour before tests run (#245071)](https://github.com/elastic/kibana/pull/245071)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-12-03T15:23:00Z","message":"[kbn/scout] disable side/solution tour before tests run (#245071)\n\n## Summary\n\nOriginal solution with local storage didn't work, so I use Kibana\nuiSettings API to disable tours:\n\n- `hideAnnouncements: true` should be set for each space\n- Scout sets it for the default space when `samlAuth` fixture is loaded\n(assuming first login attempt to be made)\n- Scout sets it for the newly created space (parallel run)\n \nI also added a log message to explicitly mention the environment we run\ntests on:\n\n```\n info [scout-worker] Running tests against MKI oblt project\n info [scout-worker] Reading cloud user credentials from /Users/dmle/github/kibana/.ftr/role_users.json\n```\n\nIt should help us identifying misconfiguration when Playwright runner\ngets a wrong configuration input file.","sha":"0f1ef9d49c86372d425b8ff469c1127561530520","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","test:scout","v9.3.0"],"title":"[kbn/scout] disable side/solution tour before tests run","number":245071,"url":"https://github.com/elastic/kibana/pull/245071","mergeCommit":{"message":"[kbn/scout] disable side/solution tour before tests run (#245071)\n\n## Summary\n\nOriginal solution with local storage didn't work, so I use Kibana\nuiSettings API to disable tours:\n\n- `hideAnnouncements: true` should be set for each space\n- Scout sets it for the default space when `samlAuth` fixture is loaded\n(assuming first login attempt to be made)\n- Scout sets it for the newly created space (parallel run)\n \nI also added a log message to explicitly mention the environment we run\ntests on:\n\n```\n info [scout-worker] Running tests against MKI oblt project\n info [scout-worker] Reading cloud user credentials from /Users/dmle/github/kibana/.ftr/role_users.json\n```\n\nIt should help us identifying misconfiguration when Playwright runner\ngets a wrong configuration input file.","sha":"0f1ef9d49c86372d425b8ff469c1127561530520"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245071","number":245071,"mergeCommit":{"message":"[kbn/scout] disable side/solution tour before tests run (#245071)\n\n## Summary\n\nOriginal solution with local storage didn't work, so I use Kibana\nuiSettings API to disable tours:\n\n- `hideAnnouncements: true` should be set for each space\n- Scout sets it for the default space when `samlAuth` fixture is loaded\n(assuming first login attempt to be made)\n- Scout sets it for the newly created space (parallel run)\n \nI also added a log message to explicitly mention the environment we run\ntests on:\n\n```\n info [scout-worker] Running tests against MKI oblt project\n info [scout-worker] Reading cloud user credentials from /Users/dmle/github/kibana/.ftr/role_users.json\n```\n\nIt should help us identifying misconfiguration when Playwright runner\ngets a wrong configuration input file.","sha":"0f1ef9d49c86372d425b8ff469c1127561530520"}},{"url":"https://github.com/elastic/kibana/pull/247621","number":247621,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/247622","number":247622,"branch":"9.1","state":"OPEN"}]}] BACKPORT-->