### PR TITLE
[9.1] Add max character validation to the email connector params and config (#246453)

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
+++ b/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
@@ -5579,7 +5579,18 @@ Object {
             "error": [Function],
             "presence": "optional",
           },
+          "metas": Array [
+            Object {
+              "x-oas-max-length": 512,
+            },
+          ],
           "rules": Array [
+            Object {
+              "args": Object {
+                "method": [Function],
+              },
+              "name": "custom",
+            },
             Object {
               "args": Object {
                 "method": [Function],
@@ -5588,6 +5599,14 @@ Object {
             },
           ],
           "type": "string",
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "limit": 100,
+          },
+          "name": "max",
         },
       ],
       "type": "array",
@@ -5604,7 +5623,18 @@ Object {
             "error": [Function],
             "presence": "optional",
           },
+          "metas": Array [
+            Object {
+              "x-oas-max-length": 512,
+            },
+          ],
           "rules": Array [
+            Object {
+              "args": Object {
+                "method": [Function],
+              },
+              "name": "custom",
+            },
             Object {
               "args": Object {
                 "method": [Function],
@@ -5613,6 +5643,14 @@ Object {
             },
           ],
           "type": "string",
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "limit": 100,
+          },
+          "name": "max",
         },
       ],
       "type": "array",
@@ -5739,7 +5777,18 @@ Object {
             "error": [Function],
             "presence": "optional",
           },
+          "metas": Array [
+            Object {
+              "x-oas-max-length": 512,
+            },
+          ],
           "rules": Array [
+            Object {
+              "args": Object {
+                "method": [Function],
+              },
+              "name": "custom",
+            },
             Object {
               "args": Object {
                 "method": [Function],
@@ -5748,6 +5797,14 @@ Object {
             },
           ],
           "type": "string",
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "limit": 100,
+          },
+          "name": "max",
         },
       ],
       "type": "array",

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/email/index.test.ts
@@ -620,6 +620,73 @@ describe('params validation', () => {
       )
     ).not.toThrowError();
   });
+
+  test('throws for too long "to" address ', async () => {
+    const configUtils = actionsConfigMock.create();
+    configUtils.validateEmailAddresses.mockImplementation(validateEmailAddressesImpl);
+
+    const longEmailAddress = 'a'.repeat(513 - '@example.com'.length) + '@example.com';
+
+    expect(() => {
+      validateParams(
+        connectorType,
+        {
+          to: [longEmailAddress],
+          cc: ['cc@example.com'],
+          bcc: ['bcc@example.com'],
+          subject: 'this is a test',
+          message: 'this is the message',
+        },
+        { configurationUtilities: configUtils }
+      );
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"error validating action params: [to.0]: value has length [513] but it must have a maximum length of [512]."`
+    );
+  });
+  test('throws for too long "cc" address ', async () => {
+    const configUtils = actionsConfigMock.create();
+    configUtils.validateEmailAddresses.mockImplementation(validateEmailAddressesImpl);
+
+    const longEmailAddress = 'a'.repeat(513 - '@example.com'.length) + '@example.com';
+
+    expect(() => {
+      validateParams(
+        connectorType,
+        {
+          to: ['to@example.com'],
+          cc: [longEmailAddress],
+          bcc: ['bcc@example.com'],
+          subject: 'this is a test',
+          message: 'this is the message',
+        },
+        { configurationUtilities: configUtils }
+      );
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"error validating action params: [cc.0]: value has length [513] but it must have a maximum length of [512]."`
+    );
+  });
+  test('throws for too long "bcc" address ', async () => {
+    const configUtils = actionsConfigMock.create();
+    configUtils.validateEmailAddresses.mockImplementation(validateEmailAddressesImpl);
+
+    const longEmailAddress = 'a'.repeat(513 - '@example.com'.length) + '@example.com';
+
+    expect(() => {
+      validateParams(
+        connectorType,
+        {
+          to: ['to@example.com'],
+          cc: ['cc@example.com'],
+          bcc: [longEmailAddress],
+          subject: 'this is a test',
+          message: 'this is the message',
+        },
+        { configurationUtilities: configUtils }
+      );
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"error validating action params: [bcc.0]: value has length [513] but it must have a maximum length of [512]."`
+    );
+  });
 });
 
 describe('execute()', () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Add max character validation to the email connector params and config (#246453)](https://github.com/elastic/kibana/pull/246453)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ersin Erdal","email":"92688503+ersin-erdal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-30T11:18:55Z","message":"Add max character validation to the email connector params and config (#246453)\n\nThis PR adds length validation to the email params to prevent crushing\nerrors.\n\n---------\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>","sha":"06218847e4528caf724a541d9443c02339001982","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","backport:all-open","v9.3.0","v9.4.0"],"title":"Add max character validation to the email connector params and config","number":246453,"url":"https://github.com/elastic/kibana/pull/246453","mergeCommit":{"message":"Add max character validation to the email connector params and config (#246453)\n\nThis PR adds length validation to the email params to prevent crushing\nerrors.\n\n---------\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>","sha":"06218847e4528caf724a541d9443c02339001982"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247600","number":247600,"state":"MERGED","mergeCommit":{"sha":"c5d5d8697c5d6d5ddd214c2deab73d7f7404659e","message":"[9.3] Add max character validation to the email connector params and config (#246453) (#247600)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [Add max character validation to the email connector params and config\n(#246453)](https://github.com/elastic/kibana/pull/246453)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ersin Erdal <92688503+ersin-erdal@users.noreply.github.com>\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246453","number":246453,"mergeCommit":{"message":"Add max character validation to the email connector params and config (#246453)\n\nThis PR adds length validation to the email params to prevent crushing\nerrors.\n\n---------\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>","sha":"06218847e4528caf724a541d9443c02339001982"}}]}] BACKPORT-->