### PR TITLE
[Runtime Fields] Replace enzyme with RTL

### DIFF
--- a/x-pack/platform/plugins/private/runtime_fields/moon.yml
+++ b/x-pack/platform/plugins/private/runtime_fields/moon.yml
@@ -21,13 +21,13 @@ dependsOn:
   - '@kbn/core'
   - '@kbn/es-ui-shared-plugin'
   - '@kbn/kibana-react-plugin'
-  - '@kbn/test-jest-helpers'
   - '@kbn/i18n'
   - '@kbn/i18n-react'
   - '@kbn/monaco'
   - '@kbn/code-editor'
   - '@kbn/code-editor-mock'
   - '@kbn/react-kibana-mount'
+  - '@kbn/core-doc-links-browser-mocks'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/private/runtime_fields/public/__jest__/setup_environment.tsx
+++ b/x-pack/platform/plugins/private/runtime_fields/public/__jest__/setup_environment.tsx
@@ -11,15 +11,35 @@ import '@kbn/code-editor-mock/jest_helper';
 jest.mock('@elastic/eui', () => {
   const original = jest.requireActual('@elastic/eui');
 
+  const isRecord = (v: unknown): v is Record<string, unknown> =>
+    typeof v === 'object' && v !== null;
+
+  const isArrayLikeWithZero = (v: unknown): v is { 0: unknown } => isRecord(v) && '0' in v;
+
   return {
     ...original,
-    EuiComboBox: (props: any) => (
+    EuiComboBox: (props: {
+      onChange: (options: Array<{ label: string; value?: string }>) => void;
+      selectedOptions: Array<{ value?: string }>;
+      'data-test-subj'?: string;
+    }) => (
       <input
         data-test-subj={props['data-test-subj'] || 'mockComboBox'}
         data-currentvalue={props.selectedOptions}
         value={props.selectedOptions[0]?.value}
-        onChange={async (syntheticEvent: any) => {
-          props.onChange([syntheticEvent['0']]);
+        onChange={(evt: unknown) => {
+          if (isArrayLikeWithZero(evt)) {
+            const first = evt[0];
+            if (isRecord(first) && typeof first.label === 'string') {
+              props.onChange([first as { label: string; value?: string }]);
+            }
+            return;
+          }
+
+          if (isRecord(evt) && isRecord(evt.target) && typeof evt.target.value === 'string') {
+            const value = evt.target.value;
+            props.onChange([{ label: value, value }]);
+          }
         }}
       />
     ),

--- a/x-pack/platform/plugins/private/runtime_fields/public/components/runtime_field_editor_flyout_content/runtime_field_editor_flyout_content.test.tsx
+++ b/x-pack/platform/plugins/private/runtime_fields/public/components/runtime_field_editor_flyout_content/runtime_field_editor_flyout_content.test.tsx
@@ -5,49 +5,33 @@
  * 2.0.
  */
 
-import { act } from 'react-dom/test-utils';
-import type { DocLinksStart } from '@kbn/core/public';
+import React from 'react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { docLinksServiceMock } from '@kbn/core-doc-links-browser-mocks';
 
 import '../../__jest__/setup_environment';
-import type { TestBed } from '../../test_utils';
-import { registerTestBed } from '../../test_utils';
 import type { RuntimeField } from '../../types';
 import type { Props } from './runtime_field_editor_flyout_content';
 import { RuntimeFieldEditorFlyoutContent } from './runtime_field_editor_flyout_content';
 
-const setup = (props?: Props) =>
-  registerTestBed(RuntimeFieldEditorFlyoutContent, {
-    memoryRouter: {
-      wrapComponent: false,
-    },
-  })(props) as TestBed;
-
-const docLinks: DocLinksStart = {
-  ELASTIC_WEBSITE_URL: 'htts://jestTest.elastic.co',
-  DOC_LINK_VERSION: 'jest',
-  links: {
-    runtimeFields: { mapping: 'https://jestTest.elastic.co/to-be-defined.html' },
-    scriptedFields: {} as any,
-  } as any,
-};
+const docLinks = docLinksServiceMock.createStartContract();
 
 const noop = () => {};
 const defaultProps = { onSave: noop, onCancel: noop, docLinks };
 
 describe('Runtime field editor flyout', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
-  });
+  const renderComponent = (props: Partial<Props> = {}) =>
+    render(
+      <I18nProvider>
+        <RuntimeFieldEditorFlyoutContent {...defaultProps} {...props} />
+      </I18nProvider>
+    );
 
   test('should have a flyout title', () => {
-    const { exists, find } = setup(defaultProps);
+    renderComponent();
 
-    expect(exists('flyoutTitle')).toBe(true);
-    expect(find('flyoutTitle').text()).toBe('Create new field');
+    expect(screen.getByTestId('flyoutTitle')).toHaveTextContent('Create new field');
   });
 
   test('should allow a runtime field to be provided', () => {
@@ -57,12 +41,12 @@ describe('Runtime field editor flyout', () => {
       script: { source: 'test=123' },
     };
 
-    const { find } = setup({ ...defaultProps, defaultValue: field });
+    renderComponent({ defaultValue: field });
 
-    expect(find('flyoutTitle').text()).toBe(`Edit ${field.name} field`);
-    expect(find('nameField.input').props().value).toBe(field.name);
-    expect(find('typeField').props().value).toBe(field.type);
-    expect(find('scriptField').props().value).toBe(field.script.source);
+    expect(screen.getByTestId('flyoutTitle')).toHaveTextContent(`Edit ${field.name} field`);
+    expect(screen.getByLabelText('Name field')).toHaveValue(field.name);
+    expect(screen.getByTestId('typeField')).toHaveValue(field.type);
+    expect(screen.getByTestId('scriptField')).toHaveValue(field.script.source);
   });
 
   test('should accept an onSave prop', async () => {
@@ -73,23 +57,19 @@ describe('Runtime field editor flyout', () => {
     };
     const onSave: jest.Mock<Props['onSave']> = jest.fn();
 
-    const { find } = setup({ ...defaultProps, onSave, defaultValue: field });
+    renderComponent({ onSave, defaultValue: field });
 
-    await act(async () => {
-      find('saveFieldButton').simulate('click');
-      jest.advanceTimersByTime(0); // advance timers to allow the form to validate
-    });
+    fireEvent.click(screen.getByTestId('saveFieldButton'));
 
-    expect(onSave).toHaveBeenCalled();
-    const fieldReturned: RuntimeField = onSave.mock.calls[onSave.mock.calls.length - 1][0];
-    expect(fieldReturned).toEqual(field);
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[onSave.mock.calls.length - 1][0]).toEqual(field);
   });
 
   test('should accept an onCancel prop', () => {
     const onCancel = jest.fn();
-    const { find } = setup({ ...defaultProps, onCancel });
+    renderComponent({ onCancel });
 
-    find('closeFlyoutButton').simulate('click');
+    fireEvent.click(screen.getByTestId('closeFlyoutButton'));
 
     expect(onCancel).toHaveBeenCalled();
   });
@@ -98,62 +78,45 @@ describe('Runtime field editor flyout', () => {
     test('should validate the fields and prevent saving invalid form', async () => {
       const onSave: jest.Mock<Props['onSave']> = jest.fn();
 
-      const { find, exists, form, component } = setup({ ...defaultProps, onSave });
+      renderComponent({ onSave });
 
-      expect(find('saveFieldButton').props().disabled).toBe(false);
+      expect(screen.getByTestId('saveFieldButton')).not.toBeDisabled();
 
-      await act(async () => {
-        find('saveFieldButton').simulate('click');
-        jest.advanceTimersByTime(0); // advance timers to allow the form to validate
-      });
-      component.update();
+      fireEvent.click(screen.getByTestId('saveFieldButton'));
 
-      expect(onSave).toHaveBeenCalledTimes(0);
-      expect(find('saveFieldButton').props().disabled).toBe(true);
-      expect(form.getErrorsMessages()).toEqual(['Give a name to the field.']);
-      expect(exists('formError')).toBe(true);
-      expect(find('formError').text()).toBe('Fix errors in form before continuing.');
+      await waitFor(() => expect(onSave).not.toHaveBeenCalled());
+      await waitFor(() => expect(screen.getByTestId('saveFieldButton')).toBeDisabled());
+
+      await screen.findByText('Give a name to the field.');
+      await screen.findByTestId('formError');
+      expect(screen.getByTestId('formError')).toHaveTextContent(
+        'Fix errors in form before continuing.'
+      );
     });
 
     test('should forward values from the form', async () => {
       const onSave: jest.Mock<Props['onSave']> = jest.fn();
 
-      const { find, form } = setup({ ...defaultProps, onSave });
+      renderComponent({ onSave });
 
-      act(() => {
-        form.setInputValue('nameField.input', 'someName');
-        form.setInputValue('scriptField', 'script=123');
-      });
+      fireEvent.change(screen.getByLabelText('Name field'), { target: { value: 'someName' } });
+      fireEvent.change(screen.getByTestId('scriptField'), { target: { value: 'script=123' } });
 
-      await act(async () => {
-        find('saveFieldButton').simulate('click');
-        jest.advanceTimersByTime(0);
-      });
+      fireEvent.click(screen.getByTestId('saveFieldButton'));
 
-      expect(onSave).toHaveBeenCalled();
-      let fieldReturned: RuntimeField = onSave.mock.calls[onSave.mock.calls.length - 1][0];
-      expect(fieldReturned).toEqual({
+      await waitFor(() => expect(onSave).toHaveBeenCalled());
+      expect(onSave.mock.calls[onSave.mock.calls.length - 1][0]).toEqual({
         name: 'someName',
         type: 'keyword', // default to keyword
         script: { source: 'script=123' },
       });
 
       // Change the type and make sure it is forwarded
-      act(() => {
-        find('typeField').simulate('change', [
-          {
-            label: 'Other type',
-            value: 'other_type',
-          },
-        ]);
-        jest.advanceTimersByTime(0);
-      });
-      await act(async () => {
-        find('saveFieldButton').simulate('click');
-        jest.advanceTimersByTime(0);
-      });
-      fieldReturned = onSave.mock.calls[onSave.mock.calls.length - 1][0];
-      expect(fieldReturned).toEqual({
+      fireEvent.change(screen.getByTestId('typeField'), { target: { value: 'other_type' } });
+      fireEvent.click(screen.getByTestId('saveFieldButton'));
+
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(2));
+      expect(onSave.mock.calls[onSave.mock.calls.length - 1][0]).toEqual({
         name: 'someName',
         type: 'other_type',
         script: { source: 'script=123' },

--- a/x-pack/platform/plugins/private/runtime_fields/public/test_utils.ts
+++ b/x-pack/platform/plugins/private/runtime_fields/public/test_utils.ts
@@ -1,9 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
-export type { TestBed } from '@kbn/test-jest-helpers';
-export { registerTestBed } from '@kbn/test-jest-helpers';

--- a/x-pack/platform/plugins/private/runtime_fields/tsconfig.json
+++ b/x-pack/platform/plugins/private/runtime_fields/tsconfig.json
@@ -1,25 +1,20 @@
 {
   "extends": "@kbn/tsconfig-base/tsconfig.json",
   "compilerOptions": {
-    "outDir": "target/types",
+    "outDir": "target/types"
   },
-  "include": [
-    "public/**/*",
-    "../../../../../typings/**/*",
-  ],
+  "include": ["public/**/*", "../../../../../typings/**/*"],
   "kbn_references": [
     "@kbn/core",
     "@kbn/es-ui-shared-plugin",
     "@kbn/kibana-react-plugin",
-    "@kbn/test-jest-helpers",
     "@kbn/i18n",
     "@kbn/i18n-react",
     "@kbn/monaco",
     "@kbn/code-editor",
     "@kbn/code-editor-mock",
     "@kbn/react-kibana-mount",
+    "@kbn/core-doc-links-browser-mocks"
   ],
-  "exclude": [
-    "target/**/*",
-  ]
+  "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/241532

## Summary
- Migrate Runtime Fields UI tests from testbed/Enzyme to React Testing Library.
- Remove legacy fake-timer patterns and make async waits explicit.
- Add lightweight mocks for CodeEditor/ComboBox to keep unit tests deterministic.

## Test titles table of change
To make it easier to verify individual tests here is a table of test titles before and after change
for each changed file in the PR. 
- https://gist.github.com/kapral18/709502e63dafb2b798e6762ac303f775

## Test plan
- [x] node scripts/jest x-pack/platform/plugins/private/runtime_fields --config x-pack/platform/plugins/private/runtime_fields/jest.config.js
- [x] node scripts/type_check --project x-pack/platform/plugins/private/runtime_fields/tsconfig.json
- [x] node scripts/eslint x-pack/platform/plugins/private/runtime_fields/public