### PR TITLE
[FTR] Add browser coverage collection for functional tests

### DIFF
--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -16,6 +16,7 @@ if [[ "$IS_TEST_EXECUTION_STEP" == "true" ]]; then
   buildkite-agent artifact upload 'target/junit/**/*'
   buildkite-agent artifact upload 'target/kibana-coverage/jest/**/*'
   buildkite-agent artifact upload 'target/kibana-coverage/functional/**/*'
+  buildkite-agent artifact upload 'target/kibana-coverage/browser/**/*'
   buildkite-agent artifact upload 'target/kibana-*'
   buildkite-agent artifact upload 'target/kibana-security-solution/**/*.png'
   buildkite-agent artifact upload 'target/kibana-security-solution/**/management/**/*.mp4'

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/README.md
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/README.md
@@ -1,3 +1,107 @@
 # @kbn/ftr-common-functional-ui-services
 
 Common test services for ui actions.
+
+## Browser coverage (Chromium-only)
+
+FTR supports collecting **browser coverage** (via Chrome DevTools Protocol Profiler)
+from Chromium-based browsers (Chrome / Chromium Edge).
+
+This can be useful to answer "what JS executed during *this* test?" in a functional test.
+
+### Modes
+
+#### Auto mode (default)
+
+Enable automatic per-test coverage collection:
+
+```bash
+node scripts/functional_test_runner --config <config> --browser-coverage
+# or explicitly:
+node scripts/functional_test_runner --config <config> --browser-coverage=auto
+```
+
+When enabled, the `browserCoverageCollector` service will **automatically** capture one coverage
+snapshot per test and write it to disk. No test modifications required.
+
+#### Manual mode
+
+For finer-grained control, use manual mode which only captures coverage when explicitly requested:
+
+```bash
+node scripts/functional_test_runner --config <config> --browser-coverage=manual
+```
+
+In manual mode, use the `capture()` method to wrap specific code blocks:
+
+```ts
+it('captures coverage for specific operations', async function () {
+  const coverage = getService('browserCoverageCollector');
+
+  // Setup code (not captured)
+  await pageObjects.common.navigateToApp('dashboard');
+
+  // Capture coverage for a specific operation
+  const { result, outputPath } = await coverage.capture('load-dashboard', async () => {
+    await pageObjects.dashboard.loadSavedDashboard('My Dashboard');
+    return 'done';
+  });
+
+  // More uncaptured code...
+
+  // Capture another operation
+  await coverage.capture('apply-filter', async () => {
+    await filterBar.addFilter('status', 'is', 'active');
+  });
+});
+```
+
+The `capture()` method also works in auto mode to produce additional granular coverage files.
+
+### Output
+
+Coverage files are written to:
+
+```
+target/kibana-coverage/browser/<testFileBase>.<testFileHash>.json
+```
+
+The test file hash is deterministic based on the test file path.
+Each JSON file contains aggregated coverage for the test file:
+
+- `auto`: combined coverage from all tests in the file (when in auto mode)
+- `manual`: one or more labeled captures (from `capture(label, fn)`)
+
+### Low-level API
+
+For raw CDP profiler access (without source map resolution), use the `browser` service methods:
+
+```ts
+it('collects raw coverage', async function () {
+  const browser = getService('browser');
+
+  const { coverage } = await browser.withPreciseCoverage(
+    async () => {
+      expect(await browser.getCurrentUrl(true)).to.contain('/app/dashboards');
+    },
+    { label: 'url contains /app/dashboards' }
+  );
+
+  // `coverage` is the raw CDP response from `Profiler.takePreciseCoverage()`
+  console.log(`Executed ${coverage.result.length} scripts`);
+});
+```
+
+Available methods on the `browser` service:
+
+- `browser.startPreciseCoverage(options?)` - Start the profiler
+- `browser.takePreciseCoverage()` - Take a coverage snapshot
+- `browser.stopPreciseCoverage()` - Stop the profiler
+- `browser.withPreciseCoverage(callback, options?)` - Convenience wrapper
+
+### Notes
+
+- These APIs **throw** when running against non-Chromium browsers (e.g. Firefox).
+- The automatic collector gracefully skips non-Chromium browsers with a warning.
+- Coverage is resolved through source maps to original TypeScript/JavaScript files.
+- `node_modules` and external dependencies are filtered out.

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/all.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/all.ts
@@ -13,6 +13,7 @@ import { FindProvider } from './find';
 import { TestSubjects } from './test_subjects';
 import { BrowserProvider } from './browser';
 import { ToastsService } from './toasts';
+import { BrowserCoverageCollectorProvider } from './browser_coverage_collector';
 
 export const services = {
   retryOnStale: RetryOnStaleProvider,
@@ -21,4 +22,5 @@ export const services = {
   testSubjects: TestSubjects,
   browser: BrowserProvider,
   toasts: ToastsService,
+  browserCoverageCollector: BrowserCoverageCollectorProvider,
 };

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/browser_coverage_collector.test.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/browser_coverage_collector.test.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  shouldIncludeScript,
+  getBundlePath,
+  extractSourceMapUrl,
+  generateCoverageHash,
+  generateTestFileCoverageHash,
+} from './browser_coverage_collector';
+
+describe('browser_coverage_collector', () => {
+  describe('shouldIncludeScript', () => {
+    it('returns false for empty URLs', () => {
+      expect(shouldIncludeScript('')).toBe(false);
+    });
+
+    it('returns false for undefined/null-like values', () => {
+      // @ts-expect-error testing invalid input
+      expect(shouldIncludeScript(undefined)).toBe(false);
+      // @ts-expect-error testing invalid input
+      expect(shouldIncludeScript(null)).toBe(false);
+    });
+
+    it('excludes npm shared deps bundles', () => {
+      expect(
+        shouldIncludeScript(
+          'http://localhost:5620/XXX/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.dll.js'
+        )
+      ).toBe(false);
+      expect(
+        shouldIncludeScript(
+          'http://localhost:5620/XXX/bundles/kbn-ui-shared-deps-npm/kbn-ui-shared-deps-npm.chunk.125.js'
+        )
+      ).toBe(false);
+    });
+
+    it('excludes data URLs', () => {
+      expect(shouldIncludeScript('data:text/javascript,console.log("test")')).toBe(false);
+    });
+
+    it('excludes non-bundle URLs', () => {
+      expect(shouldIncludeScript('http://localhost:5620/bootstrap.js')).toBe(false);
+      expect(shouldIncludeScript('http://localhost:5620/s/default/app/home')).toBe(false);
+    });
+
+    it('includes Kibana plugin bundles', () => {
+      expect(
+        shouldIncludeScript(
+          'http://localhost:5620/XXX/bundles/plugin/banners/1.0.0/banners.plugin.js'
+        )
+      ).toBe(true);
+      expect(
+        shouldIncludeScript(
+          'http://localhost:5620/XXX/bundles/plugin/security/1.0.0/security.plugin.js'
+        )
+      ).toBe(true);
+    });
+
+    it('includes core bundles', () => {
+      expect(shouldIncludeScript('http://localhost:5620/XXX/bundles/core/core.entry.js')).toBe(
+        true
+      );
+    });
+
+    it('includes kbn-ui-shared-deps-src bundles', () => {
+      expect(
+        shouldIncludeScript(
+          'http://localhost:5620/XXX/bundles/kbn-ui-shared-deps-src/kbn-ui-shared-deps-src.js'
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('getBundlePath', () => {
+    it('extracts bundle path from full URL', () => {
+      expect(
+        getBundlePath('http://localhost:5620/XXX/bundles/plugin/banners/1.0.0/banners.plugin.js')
+      ).toBe('bundles/plugin/banners/1.0.0/banners.plugin.js');
+    });
+
+    it('extracts core bundle path', () => {
+      expect(getBundlePath('http://localhost:5620/XXX/bundles/core/core.entry.js')).toBe(
+        'bundles/core/core.entry.js'
+      );
+    });
+
+    it('handles URLs with spaces paths', () => {
+      expect(
+        getBundlePath('http://localhost:5620/s/my-space/XXX/bundles/plugin/foo/foo.plugin.js')
+      ).toBe('bundles/plugin/foo/foo.plugin.js');
+    });
+
+    it('returns pathname for non-bundle URLs', () => {
+      expect(getBundlePath('http://localhost:5620/bootstrap.js')).toBe('/bootstrap.js');
+    });
+
+    it('returns original string for invalid URLs', () => {
+      expect(getBundlePath('not-a-url')).toBe('not-a-url');
+    });
+  });
+
+  describe('extractSourceMapUrl', () => {
+    const scriptUrl = 'http://localhost:5620/XXX/bundles/plugin/foo/foo.plugin.js';
+
+    it('extracts relative source map URL and resolves it', () => {
+      const source = 'console.log("test");\n//# sourceMappingURL=foo.plugin.js.map';
+      expect(extractSourceMapUrl(source, scriptUrl)).toBe(
+        'http://localhost:5620/XXX/bundles/plugin/foo/foo.plugin.js.map'
+      );
+    });
+
+    it('returns absolute source map URLs as-is', () => {
+      const source =
+        'console.log("test");\n//# sourceMappingURL=http://cdn.example.com/maps/foo.js.map';
+      expect(extractSourceMapUrl(source, scriptUrl)).toBe('http://cdn.example.com/maps/foo.js.map');
+    });
+
+    it('handles @ symbol in sourceMappingURL comment', () => {
+      const source = 'console.log("test");\n//@ sourceMappingURL=foo.plugin.js.map';
+      expect(extractSourceMapUrl(source, scriptUrl)).toBe(
+        'http://localhost:5620/XXX/bundles/plugin/foo/foo.plugin.js.map'
+      );
+    });
+
+    it('returns null when no source map URL is present', () => {
+      const source = 'console.log("test");';
+      expect(extractSourceMapUrl(source, scriptUrl)).toBeNull();
+    });
+
+    it('handles source map URL at end of file without newline', () => {
+      const source = 'console.log("test");//# sourceMappingURL=foo.plugin.js.map';
+      expect(extractSourceMapUrl(source, scriptUrl)).toBe(
+        'http://localhost:5620/XXX/bundles/plugin/foo/foo.plugin.js.map'
+      );
+    });
+
+    it('handles source map URL with content after it', () => {
+      const source =
+        'console.log("test");\n//# sourceMappingURL=foo.plugin.js.map\n// some other comment';
+      expect(extractSourceMapUrl(source, scriptUrl)).toBe(
+        'http://localhost:5620/XXX/bundles/plugin/foo/foo.plugin.js.map'
+      );
+    });
+
+    it('returns raw reference when script URL is invalid', () => {
+      const source = 'console.log("test");\n//# sourceMappingURL=foo.plugin.js.map';
+      expect(extractSourceMapUrl(source, 'invalid-url')).toBe('foo.plugin.js.map');
+    });
+  });
+
+  describe('generateCoverageHash', () => {
+    it('generates a 16-character hash', () => {
+      const hash = generateCoverageHash('src/test/file.ts', 'my test title');
+      expect(hash).toHaveLength(16);
+      expect(hash).toMatch(/^[a-f0-9]+$/);
+    });
+
+    it('generates deterministic hashes', () => {
+      const hash1 = generateCoverageHash('src/test/file.ts', 'my test title');
+      const hash2 = generateCoverageHash('src/test/file.ts', 'my test title');
+      expect(hash1).toBe(hash2);
+    });
+
+    it('generates different hashes for different test files', () => {
+      const hash1 = generateCoverageHash('src/test/file1.ts', 'my test title');
+      const hash2 = generateCoverageHash('src/test/file2.ts', 'my test title');
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it('generates different hashes for different test titles', () => {
+      const hash1 = generateCoverageHash('src/test/file.ts', 'test title 1');
+      const hash2 = generateCoverageHash('src/test/file.ts', 'test title 2');
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it('generates different hashes when label is provided', () => {
+      const hash1 = generateCoverageHash('src/test/file.ts', 'my test title');
+      const hash2 = generateCoverageHash('src/test/file.ts', 'my test title', 'my-label');
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it('generates deterministic hashes with label', () => {
+      const hash1 = generateCoverageHash('src/test/file.ts', 'my test title', 'my-label');
+      const hash2 = generateCoverageHash('src/test/file.ts', 'my test title', 'my-label');
+      expect(hash1).toBe(hash2);
+    });
+
+    it('generates different hashes for different labels', () => {
+      const hash1 = generateCoverageHash('src/test/file.ts', 'my test title', 'label-1');
+      const hash2 = generateCoverageHash('src/test/file.ts', 'my test title', 'label-2');
+      expect(hash1).not.toBe(hash2);
+    });
+  });
+
+  describe('generateTestFileCoverageHash', () => {
+    it('generates a 16-character hash', () => {
+      const hash = generateTestFileCoverageHash('src/test/file.ts');
+      expect(hash).toHaveLength(16);
+      expect(hash).toMatch(/^[a-f0-9]+$/);
+    });
+
+    it('generates deterministic hashes', () => {
+      const hash1 = generateTestFileCoverageHash('src/test/file.ts');
+      const hash2 = generateTestFileCoverageHash('src/test/file.ts');
+      expect(hash1).toBe(hash2);
+    });
+
+    it('generates different hashes for different test files', () => {
+      const hash1 = generateTestFileCoverageHash('src/test/file1.ts');
+      const hash2 = generateTestFileCoverageHash('src/test/file2.ts');
+      expect(hash1).not.toBe(hash2);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/browser_coverage_collector.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/services/browser_coverage_collector.ts
@@ -1,0 +1,779 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Path from 'path';
+import crypto from 'crypto';
+import { mkdir, writeFile } from 'fs/promises';
+import { REPO_ROOT } from '@kbn/repo-info';
+import type { FtrProviderContext } from './ftr_provider_context';
+import type { Protocol } from 'devtools-protocol';
+import { SourceMapConsumer, type RawSourceMap } from 'source-map';
+
+const BROWSER_COVERAGE_ENV_VAR = 'TEST_BROWSER_COVERAGE';
+const OUTPUT_DIR = 'target/kibana-coverage/browser';
+
+type CoverageMode = 'auto' | 'manual';
+
+/**
+ * Generate a deterministic hash for coverage output filename.
+ * @internal exported for testing
+ */
+export function generateCoverageHash(testFile: string, testTitle: string, label?: string): string {
+  const input = label ? `${testFile}::${testTitle}::${label}` : `${testFile}::${testTitle}`;
+  return crypto.createHash('sha256').update(input).digest('hex').substring(0, 16);
+}
+
+/**
+ * Generate a deterministic hash for a test file.
+ * Intended for stable per-test-file output filenames.
+ * @internal exported for testing
+ */
+export function generateTestFileCoverageHash(testFile: string): string {
+  return crypto.createHash('sha256').update(testFile).digest('hex').substring(0, 16);
+}
+
+interface SourceFileCoverage {
+  path: string;
+  functions: Array<{
+    name: string;
+    line: number;
+    column: number;
+    count: number;
+  }>;
+}
+
+type FunctionCoverage = { name: string; line: number; column: number; count: number };
+type DedupedSourceFilesMap = Map<string, Map<string, FunctionCoverage>>;
+
+/**
+ * Determines if a script URL should be included in coverage.
+ * Excludes npm bundles, empty URLs, and non-Kibana sources.
+ * @internal exported for testing
+ */
+export function shouldIncludeScript(url: string): boolean {
+  if (!url) return false;
+
+  // Exclude npm shared deps (node_modules)
+  if (url.includes('kbn-ui-shared-deps-npm')) return false;
+
+  // Exclude inline scripts and data URLs
+  if (url.startsWith('data:')) return false;
+
+  // Only include Kibana bundle URLs
+  if (!url.includes('/bundles/')) return false;
+
+  return true;
+}
+
+/**
+ * Extracts the bundle path from a full URL.
+ * e.g., "http://localhost:5620/XXXX/bundles/plugin/foo/foo.plugin.js"
+ *       -> "bundles/plugin/foo/foo.plugin.js"
+ * @internal exported for testing
+ */
+export function getBundlePath(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const match = parsed.pathname.match(/\/bundles\/(.+)$/);
+    return match ? `bundles/${match[1]}` : parsed.pathname;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Extract source map URL from script source.
+ * @internal exported for testing
+ */
+export function extractSourceMapUrl(source: string, scriptUrl: string): string | null {
+  const match = source.match(/\/\/[#@]\s*sourceMappingURL=(.+?)(\s|$)/);
+  if (!match) return null;
+
+  const sourceMapRef = match[1];
+
+  // Handle absolute URLs
+  if (sourceMapRef.startsWith('http')) {
+    return sourceMapRef;
+  }
+
+  // Resolve relative URLs against script URL
+  try {
+    const scriptUrlObj = new URL(scriptUrl);
+    return new URL(sourceMapRef, scriptUrlObj).toString();
+  } catch {
+    return sourceMapRef;
+  }
+}
+
+/**
+ * Determines if a source path is Kibana-owned code (not node_modules, not external).
+ */
+function isKibanaSourcePath(sourcePath: string): boolean {
+  if (!sourcePath) return false;
+
+  // Exclude node_modules
+  if (sourcePath.includes('node_modules')) return false;
+
+  // Exclude webpack internal paths
+  if (sourcePath.startsWith('webpack/')) return false;
+
+  // Must be a relative path within the repo or start with known prefixes
+  if (
+    sourcePath.startsWith('src/') ||
+    sourcePath.startsWith('x-pack/') ||
+    sourcePath.startsWith('packages/') ||
+    sourcePath.includes('/src/') ||
+    sourcePath.includes('/x-pack/') ||
+    sourcePath.includes('/packages/')
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Normalize source path to be relative to repo root.
+ */
+function normalizeSourcePath(sourcePath: string): string {
+  // Remove webpack:// prefix if present
+  let normalized = sourcePath.replace(/^webpack:\/\/[^/]*\//, '');
+
+  // Remove leading ./ or ../
+  normalized = normalized.replace(/^(\.\.?\/)+/, '');
+
+  // Extract path starting from src/, x-pack/, or packages/
+  const match = normalized.match(/((?:src|x-pack|packages)\/.*)/);
+  if (match) {
+    return match[1];
+  }
+
+  return normalized;
+}
+
+/**
+ * Thin service that automatically captures browser coverage per test
+ * when enabled via `--browser-coverage` CLI flag.
+ *
+ * Coverage is resolved through source maps to original TypeScript/JavaScript
+ * source files, filtering out node_modules and external dependencies.
+ *
+ * Modes:
+ * - `auto` (default): Automatically captures coverage per test via lifecycle hooks
+ * - `manual`: Only captures coverage when `capture()` is explicitly called
+ */
+export async function BrowserCoverageCollectorProvider(ctx: FtrProviderContext) {
+  const envValue = process.env[BROWSER_COVERAGE_ENV_VAR];
+
+  // Parse mode: '1' or 'auto' = auto mode, 'manual' = manual mode, anything else = disabled
+  let mode: CoverageMode | null = null;
+  if (envValue === '1' || envValue === 'auto') {
+    mode = 'auto';
+  } else if (envValue === 'manual') {
+    mode = 'manual';
+  }
+
+  if (!mode) {
+    return {
+      enabled: false as const,
+      mode: null,
+      capture: async () => {
+        throw new Error(
+          'Browser coverage is not enabled. Use --browser-coverage or --browser-coverage=manual'
+        );
+      },
+    };
+  }
+
+  const log = ctx.getService('log');
+  const lifecycle = ctx.getService('lifecycle');
+  const browser = ctx.getService('browser');
+
+  const outputRoot = Path.resolve(REPO_ROOT, OUTPUT_DIR);
+
+  log.info(`Browser coverage collector enabled (mode: ${mode}). Output: ${outputRoot}`);
+  await mkdir(outputRoot, { recursive: true });
+
+  let coverageActive = false;
+  let warnedNonChromium = false;
+  let currentTestFile: string | null = null;
+
+  // Cache for script sources and source maps
+  const scriptSourceCache = new Map<string, string>();
+  const sourceMapCache = new Map<string, SourceMapConsumer | null>();
+
+  function getOutputPathForTestFile(relTestFile: string) {
+    const safeBase = Path.basename(relTestFile).replace(/[^a-zA-Z0-9._-]/g, '_');
+    const hash = generateTestFileCoverageHash(relTestFile);
+    return Path.join(outputRoot, `${safeBase}.${hash}.json`);
+  }
+
+  function mergeSourceFileCoverageIntoDedupedMap(
+    target: DedupedSourceFilesMap,
+    source: Map<string, SourceFileCoverage>
+  ) {
+    for (const [path, fileCoverage] of source) {
+      if (!target.has(path)) {
+        target.set(path, new Map());
+      }
+      const funcs = target.get(path)!;
+      for (const fn of fileCoverage.functions) {
+        const key = `${fn.name}:${fn.line}:${fn.column}`;
+        if (funcs.has(key)) {
+          funcs.get(key)!.count += fn.count;
+        } else {
+          funcs.set(key, { name: fn.name, line: fn.line, column: fn.column, count: fn.count });
+        }
+      }
+    }
+  }
+
+  /**
+   * Clear caches and destroy SourceMapConsumer instances to free WASM memory.
+   */
+  function clearCaches() {
+    // Destroy all SourceMapConsumer instances to free WASM memory
+    for (const consumer of sourceMapCache.values()) {
+      if (consumer) {
+        consumer.destroy();
+      }
+    }
+    sourceMapCache.clear();
+    scriptSourceCache.clear();
+    log.debug('Cleared browser coverage caches');
+  }
+
+  /**
+   * Fetch script source content from the browser via CDP.
+   */
+  async function fetchScriptSource(scriptId: string): Promise<string | null> {
+    try {
+      const result = await browser.sendCdpCommandAndGetResult<{ scriptSource: string }>(
+        'Debugger.getScriptSource',
+        { scriptId }
+      );
+      return result?.scriptSource ?? null;
+    } catch (err) {
+      log.debug(`Failed to fetch script source for ${scriptId}: ${err}`);
+      return null;
+    }
+  }
+
+  /**
+   * Fetch and parse a source map.
+   */
+  async function fetchSourceMap(sourceMapUrl: string): Promise<SourceMapConsumer | null> {
+    if (sourceMapCache.has(sourceMapUrl)) {
+      return sourceMapCache.get(sourceMapUrl) ?? null;
+    }
+
+    try {
+      const response = await fetch(sourceMapUrl);
+      if (!response.ok) {
+        log.debug(`Failed to fetch source map from ${sourceMapUrl}: ${response.status}`);
+        sourceMapCache.set(sourceMapUrl, null);
+        return null;
+      }
+
+      const rawSourceMap = (await response.json()) as RawSourceMap;
+      const consumer = await new SourceMapConsumer(rawSourceMap);
+      sourceMapCache.set(sourceMapUrl, consumer);
+      return consumer;
+    } catch (err) {
+      log.debug(`Failed to parse source map from ${sourceMapUrl}: ${err}`);
+      sourceMapCache.set(sourceMapUrl, null);
+      return null;
+    }
+  }
+
+  /**
+   * Convert byte offset to line/column in source text.
+   */
+  function offsetToLineColumn(
+    source: string,
+    offset: number
+  ): { line: number; column: number } | null {
+    if (offset < 0 || offset > source.length) return null;
+
+    let line = 1;
+    let column = 0;
+    for (let i = 0; i < offset && i < source.length; i++) {
+      if (source[i] === '\n') {
+        line++;
+        column = 0;
+      } else {
+        column++;
+      }
+    }
+    return { line, column };
+  }
+
+  /**
+   * Process coverage for a single script, resolving to original source files.
+   * Deduplicates functions by name+line+column and aggregates counts.
+   */
+  async function processScriptCoverage(
+    script: Protocol.Profiler.ScriptCoverage,
+    bundleSource: string,
+    sourceMapUrl: string | null
+  ): Promise<Map<string, SourceFileCoverage>> {
+    // Use nested maps for deduplication: path -> functionKey -> function data
+    const sourceFilesMap = new Map<
+      string,
+      Map<string, { name: string; line: number; column: number; count: number }>
+    >();
+
+    if (!sourceMapUrl) {
+      return convertToSourceFileCoverage(sourceFilesMap);
+    }
+
+    const consumer = await fetchSourceMap(sourceMapUrl);
+    if (!consumer) {
+      return convertToSourceFileCoverage(sourceFilesMap);
+    }
+
+    for (const func of script.functions) {
+      for (const range of func.ranges) {
+        if (range.count === 0) continue; // Skip uncovered ranges
+
+        // Convert start offset to line/column
+        const pos = offsetToLineColumn(bundleSource, range.startOffset);
+        if (!pos) continue;
+
+        // Map to original source
+        const original = consumer.originalPositionFor({
+          line: pos.line,
+          column: pos.column,
+        });
+
+        if (!original.source) continue;
+
+        const normalizedPath = normalizeSourcePath(original.source);
+
+        // Filter to only Kibana-owned source files
+        if (!isKibanaSourcePath(normalizedPath)) continue;
+
+        const name = func.functionName || original.name || '(anonymous)';
+        const line = original.line ?? 0;
+        const column = original.column ?? 0;
+
+        // Create unique key for deduplication
+        const funcKey = `${name}:${line}:${column}`;
+
+        // Initialize file map if needed
+        if (!sourceFilesMap.has(normalizedPath)) {
+          sourceFilesMap.set(normalizedPath, new Map());
+        }
+
+        const fileFuncs = sourceFilesMap.get(normalizedPath)!;
+
+        // Aggregate counts for duplicate entries
+        if (fileFuncs.has(funcKey)) {
+          fileFuncs.get(funcKey)!.count += range.count;
+        } else {
+          fileFuncs.set(funcKey, { name, line, column, count: range.count });
+        }
+      }
+    }
+
+    return convertToSourceFileCoverage(sourceFilesMap);
+  }
+
+  /**
+   * Convert the deduplicated map structure to SourceFileCoverage array format.
+   */
+  function convertToSourceFileCoverage(
+    sourceFilesMap: DedupedSourceFilesMap
+  ): Map<string, SourceFileCoverage> {
+    const result = new Map<string, SourceFileCoverage>();
+
+    for (const [path, funcsMap] of sourceFilesMap) {
+      result.set(path, {
+        path,
+        functions: Array.from(funcsMap.values()).sort((a, b) => {
+          // Sort by line, then column, then name
+          if (a.line !== b.line) return a.line - b.line;
+          if (a.column !== b.column) return a.column - b.column;
+          return a.name.localeCompare(b.name);
+        }),
+      });
+    }
+
+    return result;
+  }
+
+  const aggregatesByTestFile = new Map<
+    string,
+    {
+      auto: { tests: Set<string>; bundlesProcessed: number; sourceFiles: DedupedSourceFilesMap };
+      manual: Map<
+        string,
+        { tests: Set<string>; bundlesProcessed: number; sourceFiles: DedupedSourceFilesMap }
+      >;
+    }
+  >();
+  const initializedTestFiles = new Set<string>();
+
+  function getOrCreateAggregate(relTestFile: string) {
+    if (!aggregatesByTestFile.has(relTestFile)) {
+      aggregatesByTestFile.set(relTestFile, {
+        auto: { tests: new Set(), bundlesProcessed: 0, sourceFiles: new Map() },
+        manual: new Map(),
+      });
+    }
+    return aggregatesByTestFile.get(relTestFile)!;
+  }
+
+  async function writeAggregatedCoverageForTestFile(relTestFile: string) {
+    const agg = aggregatesByTestFile.get(relTestFile);
+    if (!agg) return;
+
+    const autoSourceFilesArray = Array.from(convertToSourceFileCoverage(agg.auto.sourceFiles).values())
+      .sort((a, b) => a.path.localeCompare(b.path));
+
+    const manualCaptures = Array.from(agg.manual.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([label, captureAgg]) => {
+        const sourceFilesArray = Array.from(
+          convertToSourceFileCoverage(captureAgg.sourceFiles).values()
+        ).sort((a, b) => a.path.localeCompare(b.path));
+
+        return {
+          label,
+          tests: Array.from(captureAgg.tests).sort(),
+          bundlesProcessed: captureAgg.bundlesProcessed,
+          sourceFilesCount: sourceFilesArray.length,
+          sourceFiles: sourceFilesArray,
+        };
+      });
+
+    const payload = {
+      meta: {
+        testFile: relTestFile,
+        fileHash: generateTestFileCoverageHash(relTestFile),
+        timestamp: new Date().toISOString(),
+      },
+      auto: {
+        tests: Array.from(agg.auto.tests).sort(),
+        bundlesProcessed: agg.auto.bundlesProcessed,
+        sourceFilesCount: autoSourceFilesArray.length,
+        sourceFiles: autoSourceFilesArray,
+      },
+      manual: {
+        captures: manualCaptures,
+      },
+    };
+
+    const outputPath = getOutputPathForTestFile(relTestFile);
+    await writeFile(outputPath, JSON.stringify(payload, null, 2), 'utf8');
+    log.info(
+      `Browser coverage updated: ${outputPath} (auto source files: ${autoSourceFilesArray.length}, manual captures: ${manualCaptures.length})`
+    );
+  }
+
+  // Track current test for manual capture context
+  let currentTest: { file: string; title: string } | null = null;
+
+  // Only register lifecycle hooks in auto mode
+  if (mode === 'auto') {
+    lifecycle.beforeEachTest.add(async (test) => {
+      if (!browser.isChromium()) {
+        if (!warnedNonChromium) {
+          log.warning(
+            'Browser coverage collection is only supported on Chromium browsers. Skipping.'
+          );
+          warnedNonChromium = true;
+        }
+        return;
+      }
+
+      // Clear caches when switching to a new test file to limit memory growth
+      const testFile = test.file ?? test.parent?.file ?? null;
+      if (testFile !== currentTestFile) {
+        if (currentTestFile !== null) {
+          clearCaches();
+        }
+        currentTestFile = testFile;
+      }
+
+      const relTestFile = testFile
+        ? Path.isAbsolute(testFile)
+          ? Path.relative(REPO_ROOT, testFile)
+          : testFile
+        : 'unknown_test_file';
+
+      // Ensure a stable per-testFile artifact exists even if coverage ends up empty/skipped.
+      if (!initializedTestFiles.has(relTestFile)) {
+        initializedTestFiles.add(relTestFile);
+        getOrCreateAggregate(relTestFile);
+        await writeAggregatedCoverageForTestFile(relTestFile);
+      }
+
+      // Track current test for potential manual captures
+      currentTest = {
+        file: testFile ?? 'unknown_test_file',
+        title: test.fullTitle(),
+      };
+
+      try {
+        await browser.sendCdpCommand('Debugger.enable');
+        await browser.startPreciseCoverage();
+        coverageActive = true;
+        log.debug(`Browser coverage started for: ${test.fullTitle()}`);
+      } catch (err) {
+        log.warning(`Failed to start browser coverage: ${err}`);
+      }
+    });
+  }
+
+  // In manual mode, still track current test via beforeEachTest but don't start coverage
+  if (mode === 'manual') {
+    lifecycle.beforeEachTest.add(async (test) => {
+      const testFile = test.file ?? test.parent?.file ?? null;
+
+      // Clear caches when switching to a new test file
+      if (testFile !== currentTestFile) {
+        if (currentTestFile !== null) {
+          clearCaches();
+        }
+        currentTestFile = testFile;
+      }
+
+      const relTestFile = testFile
+        ? Path.isAbsolute(testFile)
+          ? Path.relative(REPO_ROOT, testFile)
+          : testFile
+        : 'unknown_test_file';
+
+      // Ensure a stable per-testFile artifact exists even if only manual captures happen later.
+      if (!initializedTestFiles.has(relTestFile)) {
+        initializedTestFiles.add(relTestFile);
+        getOrCreateAggregate(relTestFile);
+        await writeAggregatedCoverageForTestFile(relTestFile);
+      }
+
+      currentTest = {
+        file: testFile ?? 'unknown_test_file',
+        title: test.fullTitle(),
+      };
+    });
+  }
+
+  // Only register afterEachTest in auto mode
+  if (mode === 'auto') {
+    lifecycle.afterEachTest.add(async (test) => {
+      if (!coverageActive) {
+        return;
+      }
+      coverageActive = false;
+
+    try {
+      const coverage = await browser.takePreciseCoverage();
+      await browser.stopPreciseCoverage();
+
+      if (!coverage?.result) {
+        log.debug('No coverage data returned');
+        await browser.sendCdpCommand('Debugger.disable');
+        return;
+      }
+
+      // Filter to only Kibana source scripts
+      const relevantScripts = coverage.result.filter((script) => shouldIncludeScript(script.url));
+
+      if (relevantScripts.length === 0) {
+        log.debug('No relevant scripts in coverage');
+        await browser.sendCdpCommand('Debugger.disable');
+        return;
+      }
+
+      log.debug(
+        `Processing coverage for ${relevantScripts.length} scripts (filtered from ${coverage.result.length})`
+      );
+
+      // Fetch all script sources in parallel
+      const scriptsNeedingSource = relevantScripts.filter(
+        (script) => !scriptSourceCache.has(script.scriptId)
+      );
+
+      if (scriptsNeedingSource.length > 0) {
+        log.debug(`Fetching sources for ${scriptsNeedingSource.length} scripts in parallel`);
+        const sourceResults = await Promise.all(
+          scriptsNeedingSource.map(async (script) => ({
+            scriptId: script.scriptId,
+            source: await fetchScriptSource(script.scriptId),
+          }))
+        );
+
+        for (const { scriptId, source } of sourceResults) {
+          if (source) {
+            scriptSourceCache.set(scriptId, source);
+          }
+        }
+      }
+
+      await browser.sendCdpCommand('Debugger.disable');
+
+      // Process each script and resolve to original source files
+      const allSourceFiles = new Map<string, SourceFileCoverage>();
+
+      for (const script of relevantScripts) {
+        const bundleSource = scriptSourceCache.get(script.scriptId) ?? '';
+        const sourceMapUrl = bundleSource ? extractSourceMapUrl(bundleSource, script.url) : null;
+
+        const scriptSourceFiles = await processScriptCoverage(script, bundleSource, sourceMapUrl);
+
+        // Merge while deduplicating across scripts
+        for (const [path, fileCoverage] of scriptSourceFiles) {
+          if (allSourceFiles.has(path)) {
+            allSourceFiles.get(path)!.functions.push(...fileCoverage.functions);
+          } else {
+            allSourceFiles.set(path, fileCoverage);
+          }
+        }
+      }
+
+      const testFile = test.file ?? test.parent?.file ?? 'unknown_test_file';
+      const relTestFile = Path.isAbsolute(testFile)
+        ? Path.relative(REPO_ROOT, testFile)
+        : testFile;
+
+      const agg = getOrCreateAggregate(relTestFile);
+      agg.auto.tests.add(test.fullTitle());
+      agg.auto.bundlesProcessed += relevantScripts.length;
+      mergeSourceFileCoverageIntoDedupedMap(agg.auto.sourceFiles, allSourceFiles);
+      await writeAggregatedCoverageForTestFile(relTestFile);
+    } catch (err) {
+      log.warning(`Failed to capture browser coverage: ${err}`);
+      try {
+        await browser.sendCdpCommand('Debugger.disable');
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+    });
+  } // end if (mode === 'auto')
+
+  lifecycle.cleanup.add(async () => {
+    for (const relTestFile of aggregatesByTestFile.keys()) {
+      await writeAggregatedCoverageForTestFile(relTestFile);
+    }
+  });
+
+  /**
+   * Manually capture coverage for a specific code block.
+   * Works in both auto and manual modes.
+   */
+  async function capture<T>(
+    label: string,
+    fn: () => Promise<T>
+  ): Promise<{ result: T; outputPath: string }> {
+    if (!browser.isChromium()) {
+      throw new Error('Browser coverage is only supported on Chromium browsers');
+    }
+
+    if (!currentTest) {
+      throw new Error('capture() must be called within a test context');
+    }
+
+    const relTestFile = Path.isAbsolute(currentTest.file)
+      ? Path.relative(REPO_ROOT, currentTest.file)
+      : currentTest.file;
+
+    log.debug(`Starting manual coverage capture: ${label}`);
+
+    // Start coverage for this capture
+    await browser.sendCdpCommand('Debugger.enable');
+    await browser.startPreciseCoverage();
+
+    let result!: T;
+    let thrown: unknown;
+
+    try {
+      result = await fn();
+    } catch (e) {
+      thrown = e;
+    }
+
+    // Capture and process coverage
+    const coverage = await browser.takePreciseCoverage();
+    await browser.stopPreciseCoverage();
+
+    if (!coverage?.result) {
+      await browser.sendCdpCommand('Debugger.disable');
+      if (thrown) throw thrown;
+      throw new Error('No coverage data returned');
+    }
+
+    const relevantScripts = coverage.result.filter((script) => shouldIncludeScript(script.url));
+
+    // Fetch script sources in parallel
+    const scriptsNeedingSource = relevantScripts.filter(
+      (script) => !scriptSourceCache.has(script.scriptId)
+    );
+
+    if (scriptsNeedingSource.length > 0) {
+      const sourceResults = await Promise.all(
+        scriptsNeedingSource.map(async (script) => ({
+          scriptId: script.scriptId,
+          source: await fetchScriptSource(script.scriptId),
+        }))
+      );
+
+      for (const { scriptId, source } of sourceResults) {
+        if (source) {
+          scriptSourceCache.set(scriptId, source);
+        }
+      }
+    }
+
+    await browser.sendCdpCommand('Debugger.disable');
+
+    // Process coverage
+    const allSourceFiles = new Map<string, SourceFileCoverage>();
+
+    for (const script of relevantScripts) {
+      const bundleSource = scriptSourceCache.get(script.scriptId) ?? '';
+      const sourceMapUrl = bundleSource ? extractSourceMapUrl(bundleSource, script.url) : null;
+
+      const scriptSourceFiles = await processScriptCoverage(script, bundleSource, sourceMapUrl);
+
+      for (const [path, fileCoverage] of scriptSourceFiles) {
+        if (allSourceFiles.has(path)) {
+          allSourceFiles.get(path)!.functions.push(...fileCoverage.functions);
+        } else {
+          allSourceFiles.set(path, fileCoverage);
+        }
+      }
+    }
+
+    const agg = getOrCreateAggregate(relTestFile);
+    if (!agg.manual.has(label)) {
+      agg.manual.set(label, { tests: new Set(), bundlesProcessed: 0, sourceFiles: new Map() });
+    }
+
+    const labelAgg = agg.manual.get(label)!;
+    labelAgg.tests.add(currentTest.title);
+    labelAgg.bundlesProcessed += relevantScripts.length;
+    mergeSourceFileCoverageIntoDedupedMap(labelAgg.sourceFiles, allSourceFiles);
+
+    await writeAggregatedCoverageForTestFile(relTestFile);
+    const outputPath = getOutputPathForTestFile(relTestFile);
+    log.info(`Manual coverage captured: ${label} -> ${outputPath}`);
+
+    if (thrown) throw thrown;
+    return { result, outputPath };
+  }
+
+  return {
+    enabled: true as const,
+    mode,
+    outputRoot,
+    capture,
+  };
+}

--- a/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/tsconfig.json
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-ui-services/tsconfig.json
@@ -12,6 +12,7 @@
     "@kbn/repo-info",
     "@kbn/test-subj-selector",
     "@kbn/ftr-common-functional-services",
+    "@kbn/ftr-screenshot-filename",
     "@kbn/std",
     "@kbn/expect",
     "@kbn/core-chrome-layout-constants",

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/cli/ftr.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/cli/ftr.ts
@@ -73,6 +73,14 @@ export function runFtrCli() {
         process.env.TEST_BROWSER_HEADLESS = '1';
       }
 
+      // FlagsReader.string() converts "" to undefined, but `--browser-coverage` is valid without a value.
+      // Use arrayOfStrings() so we can distinguish "not passed" (undefined) from "passed without value" ([]).
+      const browserCoverageValues = flagsReader.arrayOfStrings('browser-coverage');
+      if (browserCoverageValues !== undefined) {
+        // 'auto' is default when flag is present without value, 'manual' for explicit manual mode
+        process.env.TEST_BROWSER_COVERAGE = browserCoverageValues.at(-1) || 'auto';
+      }
+
       let teardownRun = false;
       const teardown = async (err?: Error) => {
         if (teardownRun) return;
@@ -134,6 +142,7 @@ export function runFtrCli() {
           'exclude-tag',
           'kibana-install-dir',
           'es-version',
+          'browser-coverage',
         ],
         boolean: [
           'bail',
@@ -170,6 +179,9 @@ export function runFtrCli() {
           --kibana-install-dir  directory where the Kibana install being tested resides
           --throttle         enable network throttling in Chrome browser
           --headless         run browser in headless mode
+          --browser-coverage[=mode]  enable browser coverage collection
+                               modes: auto (default) - capture per test
+                                      manual - only capture via service.capture()
           --dry-run          report tests without executing them
           --pauseOnError     pause test runner on error
         `,

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/lifecycle.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/lifecycle.ts
@@ -28,6 +28,8 @@ export class Lifecycle {
   public readonly beforeTestSuite = new LifecyclePhase<[Suite]>(this.sub);
   /** lifecycle phase that runs handlers before each test */
   public readonly beforeEachTest = new LifecyclePhase<[Test]>(this.sub);
+  /** lifecycle phase that runs handlers after each test */
+  public readonly afterEachTest = new LifecyclePhase<[Test]>(this.sub);
   /** lifecycle phase that runs handlers after each suite */
   public readonly afterTestSuite = new LifecyclePhase<[Suite]>(this.sub);
   /** lifecycle phase that runs handlers after a test fails */

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/setup_mocha.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/mocha/setup_mocha.ts
@@ -71,6 +71,11 @@ export async function setupMocha({
     await lifecycle.beforeEachTest.trigger(this.currentTest!);
   });
 
+  // global afterEach hook in root suite triggers after all others
+  mocha.suite.afterEach('global after each', async function (this: Suite) {
+    await lifecycle.afterEachTest.trigger(this.currentTest!);
+  });
+
   loadTests({
     mocha,
     log,

--- a/src/platform/packages/shared/kbn-test/src/functional_tests/run_tests/flags.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_tests/run_tests/flags.test.ts
@@ -62,6 +62,12 @@ describe('parse runTest flags', () => {
     `);
   });
 
+  it('treats bare --browser-coverage as auto', () => {
+    const withBrowserCoverage = getFlags(['--config=foo', '--browser-coverage'], FLAG_OPTIONS);
+    const opts = parseFlags(new FlagsReader(withBrowserCoverage));
+    expect(opts.browserCoverage).toBe('auto');
+  });
+
   it('allows combinations of config and journey', () => {
     expect(() => test({ config: undefined })).toThrowErrorMatchingInlineSnapshot(
       `"At least one --config or --journey flag is required"`

--- a/src/platform/packages/shared/kbn-test/src/functional_tests/run_tests/flags.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_tests/run_tests/flags.ts
@@ -19,7 +19,14 @@ import { EsVersion } from '../../functional_test_runner';
 export type RunTestsOptions = ReturnType<typeof parseFlags>;
 
 export const FLAG_OPTIONS: FlagOptions = {
-  boolean: ['bail', 'logToFile', 'dry-run', 'updateBaselines', 'updateSnapshots', 'updateAll'],
+  boolean: [
+    'bail',
+    'logToFile',
+    'dry-run',
+    'updateBaselines',
+    'updateSnapshots',
+    'updateAll',
+  ],
   string: [
     'config',
     'journey',
@@ -32,6 +39,7 @@ export const FLAG_OPTIONS: FlagOptions = {
     'include',
     'exclude',
     'writeLogsToPath',
+    'browser-coverage',
   ],
   alias: {
     updateAll: 'u',
@@ -54,6 +62,9 @@ export const FLAG_OPTIONS: FlagOptions = {
     --updateBaselines    Replace baseline screenshots with whatever is generated from the test
     --updateSnapshots    Replace inline and file snapshots with whatever is generated from the test
     --updateAll, -u      Replace both baseline screenshots and snapshots
+    --browser-coverage[=mode]  Enable browser coverage collection
+                         modes: auto (default) - capture per test
+                                manual - only capture via service.capture()
   `,
   examples: `
 Run the latest verified, kibana-compatible ES Serverless image:
@@ -102,5 +113,12 @@ export function parseFlags(flags: FlagsReader) {
       include: flags.arrayOfPaths('include') ?? [],
       exclude: flags.arrayOfPaths('exclude') ?? [],
     },
+    // FlagsReader.string() converts "" to undefined, but `--browser-coverage` is valid without a value.
+    // Use arrayOfStrings() so we can distinguish "not passed" (undefined) from "passed without value" ([]).
+    browserCoverage: (() => {
+      const values = flags.arrayOfStrings('browser-coverage');
+      if (values === undefined) return undefined;
+      return values.at(-1) || 'auto';
+    })(),
   };
 }

--- a/src/platform/packages/shared/kbn-test/src/functional_tests/run_tests/run_tests.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_tests/run_tests/run_tests.ts
@@ -27,6 +27,11 @@ import type { RunTestsOptions } from './flags';
  * Run servers and tests for each config
  */
 export async function runTests(log: ToolingLog, options: RunTestsOptions) {
+  if (options.browserCoverage !== undefined) {
+    // 'auto' is default when flag is present without value, 'manual' for explicit manual mode
+    process.env.TEST_BROWSER_COVERAGE = options.browserCoverage || 'auto';
+  }
+
   if (!process.env.CI) {
     log.warning('❗️❗️❗️');
     log.warning('❗️❗️❗️');


### PR DESCRIPTION
Adds the ability to automatically collect browser coverage during FTR
test runs. When enabled via the `--browser-coverage` flag, coverage is
captured per test and written to disk for upload as CI artifacts.

Changes:
- Add `--browser-coverage` CLI flag to FTR
- Add `afterEachTest` lifecycle hook to capture coverage after each test
- Add `browserCoverageCollector` service for automatic per-test coverage
- Add CDP coverage methods to browser service (startPreciseCoverage,
  takePreciseCoverage, stopPreciseCoverage, withPreciseCoverage)
- Coverage files written to target/kibana-coverage/browser/