### PR TITLE
[mcp] Persist Jest JSON to temp file, stabilize parsing

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Kibana source code with Kibana X-Pack source code
-Copyright 2012-2025 Elasticsearch B.V.
+Copyright 2012-2026 Elasticsearch B.V.
 
 ---
 Adapted from remote-web-worker, which was available under a "MIT" license.

--- a/src/platform/packages/shared/kbn-mcp-dev-server/src/tools/run_unit_tests.test.ts
+++ b/src/platform/packages/shared/kbn-mcp-dev-server/src/tools/run_unit_tests.test.ts
@@ -162,12 +162,14 @@ describe('runUnitTestsTool', () => {
         throw new Error(`File not found: ${filePath}`);
       });
 
-      // Mock execa.command for Jest execution
+      // Mock execa.command for Jest execution.
+      // The code uses execa's `all` property (combined stdout+stderr).
       if (jestError) {
         mockedExeca.command.mockRejectedValue(jestError);
       } else {
         mockedExeca.command.mockResolvedValue({
-          stdout: `Some prefix text\n${JSON.stringify(jestOutput)}`,
+          all: `Some prefix text\n${JSON.stringify(jestOutput)}`,
+          exitCode: 0,
         } as any);
       }
 
@@ -375,6 +377,7 @@ describe('runUnitTestsTool', () => {
         const jestError = {
           stdout: `Error prefix\n${JSON.stringify(mockJestOutput)}`,
           stderr: 'Some error',
+          all: `Error prefix\n${JSON.stringify(mockJestOutput)}\nSome error`,
         };
 
         setupMocks({ jestError });
@@ -390,9 +393,10 @@ describe('runUnitTestsTool', () => {
 
       it('handles Jest output without JSON', async () => {
         setupMocks({});
-        // Override the execa mock after setupMocks to return output without JSON
+        // Override the execa mock after setupMocks to return output without JSON.
         mockedExeca.command.mockResolvedValue({
-          stdout: 'No JSON here',
+          all: 'No JSON here',
+          exitCode: 0,
         } as any);
 
         const result = await runUnitTestsTool.handler({


### PR DESCRIPTION

## Summary

The `jest` MCP tool was having a lot of trouble with `@kbn/docs-utils`, claiming the tool returned the following error:

```
the tool failed to start with a JSON parse error (“Expected property name or '}' in JSON at position 2”).
```

The issue was that `jest` was outputting more than JSON to `stdout`-- logs, warnings, and other items.  As a result, the pure JSON parse of the response was failing.

This PR fixes those issues by outputting just the JSON to a flat file in the `target` directory for the MCP tool to read.  This allows us to separate the log spew from the response, all without "hunting" through `stdout` for the response JSON.

### Details

- Invoke `node scripts/jest` with `--outputFile` to write the JSON report into `[package]/target/mcp-jest-*`, falling back to OS `temp` when the package path is unavailable and clean up the `temp` directory after each run.

- Simplify parsing: read the report file first; if it is missing or unreadable, minimally parse combined `stdout`/`stderr`, and treat missing JSON on successful exits as an empty result instead of erroring.

- Keep coverage parsing and changed-file handling intact while removing brittle multi-strategy “JSON hunting.”

- This fixes cases like `kbn-docs-utils,` where noisy `stdout`/`stderr` or absent report files caused JSON parsing to fail, leading the MCP tool to report errors even though Jest had completed.