### PR TITLE
[9.3] [Agent Builder] Fix conversation round height logic from shrinking causing a 'jump' (#247687)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Kibana source code with Kibana X-Pack source code
-Copyright 2012-2025 Elasticsearch B.V.
+Copyright 2012-2026 Elasticsearch B.V.
 
 ---
 Adapted from remote-web-worker, which was available under a "MIT" license.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Agent Builder] Fix conversation round height logic from shrinking causing a 'jump' (#247687)](https://github.com/elastic/kibana/pull/247687)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Chris","email":"50221462+chrisbmar@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-02T09:23:13Z","message":"[Agent Builder] Fix conversation round height logic from shrinking causing a 'jump' (#247687)","sha":"305dd9beee59ec63a29fdc19923f4338a5f797a0","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.3.0","v9.4.0"],"title":"[Agent Builder] Fix conversation round height logic from shrinking causing a 'jump'","number":247687,"url":"https://github.com/elastic/kibana/pull/247687","mergeCommit":{"message":"[Agent Builder] Fix conversation round height logic from shrinking causing a 'jump' (#247687)","sha":"305dd9beee59ec63a29fdc19923f4338a5f797a0"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247687","number":247687,"mergeCommit":{"message":"[Agent Builder] Fix conversation round height logic from shrinking causing a 'jump' (#247687)","sha":"305dd9beee59ec63a29fdc19923f4338a5f797a0"}}]}] BACKPORT-->