### PR TITLE
[9.3] Fix change password broken test (#247565)

### DIFF
--- a/x-pack/platform/test/functional/page_objects/account_settings_page.ts
+++ b/x-pack/platform/test/functional/page_objects/account_settings_page.ts
@@ -12,6 +12,7 @@ export class AccountSettingsPageObject extends FtrService {
   private readonly find = this.ctx.getService('find');
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly userMenu = this.ctx.getService('userMenu');
+  private readonly log = this.ctx.getService('log');
 
   async verifyAccountSettings(expectedUserName: string) {
     await this.userMenu.clickProvileLink();
@@ -28,15 +29,22 @@ export class AccountSettingsPageObject extends FtrService {
 
     const currentPasswordInput = await this.find.byName('current_password');
     await currentPasswordInput.clearValue();
-    await currentPasswordInput.type(currentPassword);
+    await currentPasswordInput.type(currentPassword, { charByChar: true });
 
     const passwordInput = await this.find.byName('password');
     await passwordInput.clearValue();
-    await passwordInput.type(newPassword);
+    await passwordInput.type(newPassword, { charByChar: true });
 
     const confirmPasswordInput = await this.find.byName('confirm_password');
     await confirmPasswordInput.clearValue();
-    await confirmPasswordInput.type(newPassword);
+    await confirmPasswordInput.type(newPassword, { charByChar: true });
+
+    // Debug logging for password fields before submitting
+    this.log.debug('Password fields before submit:', {
+      currentPassword,
+      newPassword,
+      confirmPassword: newPassword,
+    });
 
     await this.testSubjects.clickWhenNotDisabled('changePasswordFormSubmitButton');
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix change password broken test (#247565)](https://github.com/elastic/kibana/pull/247565)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ryan","email":"ryan.godfrey@elastic.co"},"sourceCommit":{"committedDate":"2025-12-30T20:07:06Z","message":"Fix change password broken test (#247565)\n\nCloses: https://github.com/elastic/kibana/issues/241763\n\n# Summary\n- changed the password input to be entered character by character to\nhopefully allow the input validations to run more consistently\n- added temporary debug logging to confirm form values before attempting\nto click submit","sha":"46e596f0480bc0585467c86b5209f0f7bea7a8bb","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:version","v9.3.0","v9.4.0","v9.2.4","v9.1.10"],"title":"Fix change password broken test","number":247565,"url":"https://github.com/elastic/kibana/pull/247565","mergeCommit":{"message":"Fix change password broken test (#247565)\n\nCloses: https://github.com/elastic/kibana/issues/241763\n\n# Summary\n- changed the password input to be entered character by character to\nhopefully allow the input validations to run more consistently\n- added temporary debug logging to confirm form values before attempting\nto click submit","sha":"46e596f0480bc0585467c86b5209f0f7bea7a8bb"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247565","number":247565,"mergeCommit":{"message":"Fix change password broken test (#247565)\n\nCloses: https://github.com/elastic/kibana/issues/241763\n\n# Summary\n- changed the password input to be entered character by character to\nhopefully allow the input validations to run more consistently\n- added temporary debug logging to confirm form values before attempting\nto click submit","sha":"46e596f0480bc0585467c86b5209f0f7bea7a8bb"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247655","number":247655,"state":"MERGED","mergeCommit":{"sha":"0615a1eeb0615c48c77a7a87c55c68df3a8ae832","message":"[9.2] Fix change password broken test (#247565) (#247655)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [Fix change password broken test\n(#247565)](https://github.com/elastic/kibana/pull/247565)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ryan <ryan.godfrey@elastic.co>"}},{"branch":"9.1","label":"v9.1.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247654","number":247654,"state":"MERGED","mergeCommit":{"sha":"bdfa55d1d88bb7cb4b42364fe0cf56149aa83a27","message":"[9.1] Fix change password broken test (#247565) (#247654)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [Fix change password broken test\n(#247565)](https://github.com/elastic/kibana/pull/247565)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ryan <ryan.godfrey@elastic.co>"}}]}] BACKPORT-->