### PR TITLE
[Cloud Security] Clean up cloud connector secrets and prevent cloud connector secret deletion for package policy delete

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector/handlers.ts
@@ -171,7 +171,9 @@ export const deleteCloudConnectorHandler: FleetRequestHandler<
   TypeOf<typeof DeleteCloudConnectorRequestSchema.query>
 > = async (context, request, response) => {
   const fleetContext = await context.fleet;
+  const coreContext = await context.core;
   const { internalSoClient } = fleetContext;
+  const esClient = coreContext.elasticsearch.client.asInternalUser;
   const cloudConnectorId = request.params.cloudConnectorId;
   const force = request.query.force || false;
   const logger = appContextService
@@ -180,7 +182,12 @@ export const deleteCloudConnectorHandler: FleetRequestHandler<
 
   try {
     logger.info(`Deleting cloud connector ${cloudConnectorId} (force: ${force})`);
-    const result = await cloudConnectorService.delete(internalSoClient, cloudConnectorId, force);
+    const result = await cloudConnectorService.delete(
+      internalSoClient,
+      esClient,
+      cloudConnectorId,
+      force
+    );
     logger.info(`Successfully deleted cloud connector ${cloudConnectorId}`);
     const body: DeleteCloudConnectorResponse = {
       id: result.id,

--- a/x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector/index.test.ts
@@ -1043,6 +1043,7 @@ describe('Cloud Connector API', () => {
 
       expect(mockCloudConnectorService.delete).toHaveBeenCalledWith(
         expect.any(Object), // internalSoClient
+        expect.any(Object), // esClient
         'connector-123',
         false // default force value
       );
@@ -1072,6 +1073,7 @@ describe('Cloud Connector API', () => {
 
       expect(mockCloudConnectorService.delete).toHaveBeenCalledWith(
         expect.any(Object), // internalSoClient
+        expect.any(Object), // esClient
         'connector-123',
         true
       );
@@ -1101,6 +1103,7 @@ describe('Cloud Connector API', () => {
 
       expect(mockCloudConnectorService.delete).toHaveBeenCalledWith(
         expect.any(Object), // internalSoClient
+        expect.any(Object), // esClient
         'connector-123',
         'true' // Handler will pass the string value
       );
@@ -1125,6 +1128,7 @@ describe('Cloud Connector API', () => {
 
       expect(mockCloudConnectorService.delete).toHaveBeenCalledWith(
         expect.any(Object), // internalSoClient
+        expect.any(Object), // esClient
         'connector-123',
         false
       );
@@ -1171,6 +1175,7 @@ describe('Cloud Connector API', () => {
 
       expect(mockCloudConnectorService.delete).toHaveBeenCalledWith(
         expect.any(Object), // internalSoClient
+        expect.any(Object), // esClient
         undefined,
         false
       );
@@ -1194,6 +1199,7 @@ describe('Cloud Connector API', () => {
 
       expect(mockCloudConnectorService.delete).toHaveBeenCalledWith(
         expect.any(Object), // internalSoClient
+        expect.any(Object), // esClient
         'connector-123',
         false // should default to false
       );
@@ -1219,6 +1225,7 @@ describe('Cloud Connector API', () => {
 
       expect(mockCloudConnectorService.delete).toHaveBeenCalledWith(
         expect.any(Object), // internalSoClient
+        expect.any(Object), // esClient
         'connector-123',
         false
       );

--- a/x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/cloud_connector/index.test.ts
@@ -73,6 +73,13 @@ describe('Cloud Connector API', () => {
           find: jest.fn(),
         },
       }),
+      core: Promise.resolve({
+        elasticsearch: {
+          client: {
+            asInternalUser: {},
+          },
+        },
+      }),
     } as any;
     response = httpServerMock.createResponseFactory();
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.test.ts
@@ -733,7 +733,7 @@ describe('AgentlessPoliciesService', () => {
       expect(createSpy).toHaveBeenCalledTimes(1);
 
       // Verify rollback: cloud connector should be deleted
-      expect(deleteSpy).toHaveBeenCalledWith(soClient, 'aws-cloud-connector-123', true);
+      expect(deleteSpy).toHaveBeenCalledWith(soClient, esClient, 'aws-cloud-connector-123', true);
 
       // Verify rollback: agent policy should be deleted
       expect(jest.mocked(agentPolicyService.delete)).toHaveBeenCalledWith(

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless/agentless_policies.ts
@@ -239,7 +239,7 @@ export class AgentlessPoliciesServiceImpl implements AgentlessPoliciesService {
             `Rolling back: deleting created cloud connector ${createdCloudConnectorId}`
           );
           await cloudConnectorService
-            .delete(this.soClient, createdCloudConnectorId, true)
+            .delete(this.soClient, this.esClient, createdCloudConnectorId, true)
             .catch((e: Error) => {
               this.logger.error(
                 `Failed to delete cloud connector ${createdCloudConnectorId}: ${e.message}`,

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -85,6 +85,7 @@ import { agentPolicyService } from './agent_policy';
 import { isSpaceAwarenessEnabled } from './spaces/helpers';
 import { licenseService } from './license';
 import { cloudConnectorService } from './cloud_connector';
+import * as secretsModule from './secrets';
 
 jest.mock('./spaces/helpers', () => {
   return {
@@ -280,7 +281,10 @@ jest.mock('./secrets', () => ({
     isSecretRef: true,
   })),
   extractAndWriteSecrets: jest.fn(),
+  deleteSecretsIfNotReferenced: jest.fn(),
 }));
+
+const mockedSecretsModule = secretsModule as jest.Mocked<typeof secretsModule>;
 
 type CombinedExternalCallback = PutPackagePolicyUpdateCallback | PostPackagePolicyCreateCallback;
 
@@ -4548,6 +4552,196 @@ describe('Package policy service', () => {
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
       const res = await packagePolicyService.delete(soClient, esClient, ['test-package-policy']);
       expect(res).toEqual([]);
+    });
+
+    it('should delete secrets for regular package policies', async () => {
+      const soClient = createSavedObjectClientMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      // Clear mock calls from previous tests
+      mockedSecretsModule.deleteSecretsIfNotReferenced.mockClear();
+
+      const packagePolicyWithSecrets = {
+        ...createPackagePolicyMock(),
+        id: 'policy-with-secrets',
+        secret_references: [{ id: 'secret-1' }, { id: 'secret-2' }],
+      };
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            id: 'policy-with-secrets',
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            references: [],
+            version: 'test',
+            attributes: packagePolicyWithSecrets,
+          },
+        ],
+      });
+
+      soClient.get.mockResolvedValueOnce({
+        id: 'policy-with-secrets',
+        type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+        attributes: packagePolicyWithSecrets,
+        references: [],
+      });
+
+      mockAgentPolicyGet();
+
+      (getPackageInfo as jest.Mock).mockResolvedValue({
+        name: 'test',
+        version: '1.0.0',
+      } as PackageInfo);
+
+      soClient.bulkDelete.mockResolvedValue({
+        statuses: [
+          {
+            id: 'policy-with-secrets',
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            success: true,
+          },
+        ],
+      });
+
+      await packagePolicyService.delete(soClient, esClient, ['policy-with-secrets']);
+
+      // Verify that deleteSecretsIfNotReferenced was called with the correct secret IDs
+      expect(mockedSecretsModule.deleteSecretsIfNotReferenced).toHaveBeenCalledWith({
+        esClient,
+        soClient,
+        ids: ['secret-1', 'secret-2'],
+      });
+    });
+
+    it('should NOT delete secrets for package policies with cloud_connector_id', async () => {
+      const soClient = createSavedObjectClientMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      // Clear mock calls from previous tests
+      mockedSecretsModule.deleteSecretsIfNotReferenced.mockClear();
+
+      const packagePolicyWithCloudConnector = {
+        ...createPackagePolicyMock(),
+        id: 'policy-with-cloud-connector',
+        cloud_connector_id: 'test-cloud-connector-123',
+        secret_references: [{ id: 'cloud-connector-secret-1' }, { id: 'cloud-connector-secret-2' }],
+      };
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            id: 'policy-with-cloud-connector',
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            references: [],
+            version: 'test',
+            attributes: packagePolicyWithCloudConnector,
+          },
+        ],
+      });
+
+      soClient.get.mockResolvedValueOnce({
+        id: 'policy-with-cloud-connector',
+        type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+        attributes: packagePolicyWithCloudConnector,
+        references: [],
+      });
+
+      mockAgentPolicyGet();
+
+      (getPackageInfo as jest.Mock).mockResolvedValue({
+        name: 'test',
+        version: '1.0.0',
+      } as PackageInfo);
+
+      soClient.bulkDelete.mockResolvedValue({
+        statuses: [
+          {
+            id: 'policy-with-cloud-connector',
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            success: true,
+          },
+        ],
+      });
+
+      await packagePolicyService.delete(soClient, esClient, ['policy-with-cloud-connector']);
+
+      // Verify that deleteSecretsIfNotReferenced was NOT called for cloud connector secrets
+      expect(mockedSecretsModule.deleteSecretsIfNotReferenced).not.toHaveBeenCalled();
+    });
+
+    it('should handle mixed package policies - some with cloud connector, some without', async () => {
+      const soClient = createSavedObjectClientMock();
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      // Clear mock calls from previous tests
+      mockedSecretsModule.deleteSecretsIfNotReferenced.mockClear();
+
+      const regularPackagePolicy = {
+        ...createPackagePolicyMock(),
+        id: 'regular-policy',
+        secret_references: [{ id: 'regular-secret-1' }],
+      };
+
+      const cloudConnectorPackagePolicy = {
+        ...createPackagePolicyMock(),
+        id: 'cloud-connector-policy',
+        cloud_connector_id: 'test-cloud-connector-123',
+        secret_references: [{ id: 'cloud-connector-secret-1' }],
+      };
+
+      soClient.bulkGet.mockResolvedValue({
+        saved_objects: [
+          {
+            id: 'regular-policy',
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            references: [],
+            version: 'test',
+            attributes: regularPackagePolicy,
+          },
+          {
+            id: 'cloud-connector-policy',
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            references: [],
+            version: 'test',
+            attributes: cloudConnectorPackagePolicy,
+          },
+        ],
+      });
+
+      mockAgentPolicyGet();
+
+      (getPackageInfo as jest.Mock).mockResolvedValue({
+        name: 'test',
+        version: '1.0.0',
+      } as PackageInfo);
+
+      soClient.bulkDelete.mockResolvedValue({
+        statuses: [
+          {
+            id: 'regular-policy',
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            success: true,
+          },
+          {
+            id: 'cloud-connector-policy',
+            type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+            success: true,
+          },
+        ],
+      });
+
+      await packagePolicyService.delete(soClient, esClient, [
+        'regular-policy',
+        'cloud-connector-policy',
+      ]);
+
+      // Should have been called once for the regular policy secrets only
+      expect(mockedSecretsModule.deleteSecretsIfNotReferenced).toHaveBeenCalledTimes(1);
+      expect(mockedSecretsModule.deleteSecretsIfNotReferenced).toHaveBeenCalledWith({
+        esClient,
+        soClient,
+        ids: ['regular-secret-1'],
+      });
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -2201,8 +2201,18 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
             policy_id: packagePolicy.policy_id,
             policy_ids: packagePolicy.policy_ids,
           });
+          // Only delete secrets that belong to the package policy itself,
+          // not to cloud connectors (which manage their own secret lifecycle)
           if (packagePolicy?.secret_references?.length) {
-            secretsToDelete.push(...packagePolicy.secret_references.map((s) => s.id));
+            if (!packagePolicy.cloud_connector_id) {
+              // Regular package policy secrets - safe to delete
+              secretsToDelete.push(...packagePolicy.secret_references.map((s) => s.id));
+            } else {
+              // Cloud connector secrets - managed by cloud connector lifecycle
+              logger.debug(
+                `Skipping secret deletion for package policy ${packagePolicy.id} - secrets are managed by cloud connector ${packagePolicy.cloud_connector_id}`
+              );
+            }
           }
         } else if (!success && error) {
           result.push({

--- a/x-pack/platform/test/fleet_api_integration/apis/cloud_connector/cloud_connector.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/cloud_connector/cloud_connector.ts
@@ -1560,9 +1560,9 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       it('should delete AWS cloud connector secrets when connector is deleted', async () => {
-        // External ID must be exactly 20 chars to match EXTERNAL_ID_REGEX validation
+        // External ID must be exactly 20 chars to match EXTERNAL_ID_REGEX validation /^[a-zA-Z0-9_-]{20}$/
         const timestamp = Date.now().toString();
-        const externalIdSecretId = `test${timestamp.slice(-16)}`; // 'test' (4) + 16 digits = 20 chars
+        const externalIdSecretId = `awstest${timestamp.slice(-13)}`; // 'awstest' (7) + 13 digits = 20 chars
         const secretValue = 'test-external-id-value-123';
 
         // Create the secret in .fleet-secrets index

--- a/x-pack/platform/test/fleet_api_integration/apis/cloud_connector/cloud_connector.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/cloud_connector/cloud_connector.ts
@@ -15,6 +15,7 @@ export default function (providerContext: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const fleetAndAgents = getService('fleetAndAgents');
+  const es = getService('es');
 
   describe('fleet_cloud_connectors', () => {
     skipIfNoDockerRegistry(providerContext);
@@ -1511,6 +1512,192 @@ export default function (providerContext: FtrProviderContext) {
         // Verify packagePolicyCount is preserved (still 0 since no package policies reference this connector)
         expect(updatedConnector.item.packagePolicyCount).to.equal(0);
         expect(updatedConnector.item.name).to.equal('updated-azure-name-preserve-count');
+      });
+    });
+
+    describe('DELETE /api/fleet/cloud_connectors/{id} - Secret cleanup', () => {
+      const SECRETS_INDEX_NAME = '.fleet-secrets';
+
+      const createSecret = async (id: string, value: string) => {
+        await es.index({
+          index: SECRETS_INDEX_NAME,
+          id,
+          body: {
+            value,
+          },
+          refresh: 'wait_for',
+        });
+      };
+
+      const secretExists = async (id: string): Promise<boolean> => {
+        try {
+          await es.get({
+            index: SECRETS_INDEX_NAME,
+            id,
+          });
+          return true;
+        } catch (err) {
+          if (err.meta?.statusCode === 404) {
+            return false;
+          }
+          throw err;
+        }
+      };
+
+      afterEach(async () => {
+        // Clean up any remaining secrets
+        try {
+          await es.deleteByQuery({
+            index: SECRETS_INDEX_NAME,
+            refresh: true,
+            query: {
+              match_all: {},
+            },
+          });
+        } catch (err) {
+          // Index might not exist, that's fine
+        }
+      });
+
+      it('should delete AWS cloud connector secrets when connector is deleted', async () => {
+        const externalIdSecretId = `aws-secret-cleanup-test-${Date.now()}`;
+        const secretValue = 'test-external-id-value-123';
+
+        // Create the secret in .fleet-secrets index
+        await createSecret(externalIdSecretId, secretValue);
+
+        // Verify secret exists
+        expect(await secretExists(externalIdSecretId)).to.be(true);
+
+        // Create AWS cloud connector with the secret reference
+        const { body: createResponse } = await supertest
+          .post(`/api/fleet/cloud_connectors`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `aws-secret-cleanup-test-${Date.now()}`,
+            cloudProvider: 'aws',
+            vars: {
+              role_arn: { value: 'arn:aws:iam::123456789012:role/test-cleanup', type: 'text' },
+              external_id: {
+                type: 'password',
+                value: {
+                  id: externalIdSecretId,
+                  isSecretRef: true,
+                },
+              },
+            },
+          })
+          .expect(200);
+
+        const connectorId = createResponse.item.id;
+
+        // Delete the cloud connector
+        await supertest
+          .delete(`/api/fleet/cloud_connectors/${connectorId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .expect(200);
+
+        // Verify the secret was deleted
+        expect(await secretExists(externalIdSecretId)).to.be(false);
+      });
+
+      it('should delete Azure cloud connector secrets when connector is deleted', async () => {
+        const tenantIdSecretId = `azure-tenant-cleanup-test-${Date.now()}`;
+        const clientIdSecretId = `azure-client-cleanup-test-${Date.now()}`;
+        const tenantSecretValue = 'test-tenant-id-value-456';
+        const clientSecretValue = 'test-client-id-value-789';
+
+        // Create the secrets in .fleet-secrets index
+        await createSecret(tenantIdSecretId, tenantSecretValue);
+        await createSecret(clientIdSecretId, clientSecretValue);
+
+        // Verify secrets exist
+        expect(await secretExists(tenantIdSecretId)).to.be(true);
+        expect(await secretExists(clientIdSecretId)).to.be(true);
+
+        // Create Azure cloud connector with the secret references
+        const { body: createResponse } = await supertest
+          .post(`/api/fleet/cloud_connectors`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `azure-secret-cleanup-test-${Date.now()}`,
+            cloudProvider: 'azure',
+            vars: {
+              tenant_id: {
+                type: 'password',
+                value: {
+                  id: tenantIdSecretId,
+                  isSecretRef: true,
+                },
+              },
+              client_id: {
+                type: 'password',
+                value: {
+                  id: clientIdSecretId,
+                  isSecretRef: true,
+                },
+              },
+              azure_credentials_cloud_connector_id: {
+                value: 'test-azure-cleanup-id',
+                type: 'text',
+              },
+            },
+          })
+          .expect(200);
+
+        const connectorId = createResponse.item.id;
+
+        // Delete the cloud connector
+        await supertest
+          .delete(`/api/fleet/cloud_connectors/${connectorId}`)
+          .set('kbn-xsrf', 'xxxx')
+          .expect(200);
+
+        // Verify both secrets were deleted
+        expect(await secretExists(tenantIdSecretId)).to.be(false);
+        expect(await secretExists(clientIdSecretId)).to.be(false);
+      });
+
+      it('should delete secrets even when force deleting a connector', async () => {
+        const externalIdSecretId = `aws-force-delete-secret-${Date.now()}`;
+        const secretValue = 'test-force-delete-value';
+
+        // Create the secret in .fleet-secrets index
+        await createSecret(externalIdSecretId, secretValue);
+
+        // Verify secret exists
+        expect(await secretExists(externalIdSecretId)).to.be(true);
+
+        // Create AWS cloud connector with the secret reference
+        const { body: createResponse } = await supertest
+          .post(`/api/fleet/cloud_connectors`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: `aws-force-delete-test-${Date.now()}`,
+            cloudProvider: 'aws',
+            vars: {
+              role_arn: { value: 'arn:aws:iam::123456789012:role/test-force', type: 'text' },
+              external_id: {
+                type: 'password',
+                value: {
+                  id: externalIdSecretId,
+                  isSecretRef: true,
+                },
+              },
+            },
+          })
+          .expect(200);
+
+        const connectorId = createResponse.item.id;
+
+        // Force delete the cloud connector
+        await supertest
+          .delete(`/api/fleet/cloud_connectors/${connectorId}?force=true`)
+          .set('kbn-xsrf', 'xxxx')
+          .expect(200);
+
+        // Verify the secret was deleted even with force=true
+        expect(await secretExists(externalIdSecretId)).to.be(false);
       });
     });
   });

--- a/x-pack/platform/test/fleet_api_integration/apis/cloud_connector/cloud_connector.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/cloud_connector/cloud_connector.ts
@@ -1560,7 +1560,9 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       it('should delete AWS cloud connector secrets when connector is deleted', async () => {
-        const externalIdSecretId = `aws-secret-cleanup-test-${Date.now()}`;
+        // External ID must be exactly 20 chars to match EXTERNAL_ID_REGEX validation
+        const timestamp = Date.now().toString();
+        const externalIdSecretId = `test${timestamp.slice(-16)}`; // 'test' (4) + 16 digits = 20 chars
         const secretValue = 'test-external-id-value-123';
 
         // Create the secret in .fleet-secrets index

--- a/x-pack/platform/test/fleet_api_integration/apis/cloud_connector/cloud_connector.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/cloud_connector/cloud_connector.ts
@@ -1572,7 +1572,13 @@ export default function (providerContext: FtrProviderContext) {
         expect(await secretExists(externalIdSecretId)).to.be(true);
 
         // Create AWS cloud connector with the secret reference
-        const { body: createResponse } = await supertest
+        // Log the external ID for debugging - should be exactly 20 chars
+        // eslint-disable-next-line no-console
+        console.log(
+          `[DEBUG] externalIdSecretId: "${externalIdSecretId}" (length: ${externalIdSecretId.length})`
+        );
+
+        const createResult = await supertest
           .post(`/api/fleet/cloud_connectors`)
           .set('kbn-xsrf', 'xxxx')
           .send({
@@ -1588,8 +1594,19 @@ export default function (providerContext: FtrProviderContext) {
                 },
               },
             },
-          })
-          .expect(200);
+          });
+
+        // Log the response for debugging if it's not 200
+        if (createResult.status !== 200) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `[DEBUG] Create cloud connector failed with status ${createResult.status}:`,
+            JSON.stringify(createResult.body, null, 2)
+          );
+        }
+        expect(createResult.status).to.be(200);
+
+        const createResponse = createResult.body;
 
         const connectorId = createResponse.item.id;
 


### PR DESCRIPTION
## Summary

This commit implemented automatic secret cleanup when deleting cloud connectors and prevent cloud connector secrets deletion when the package policy is deleted

This ensures that when you delete a cloud connector, the associated secrets stored in the .fleet-secrets index are automatically cleaned up, preventing orphaned secrets in Elasticsearch.


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks
None



