### PR TITLE
DO NOT MERGE. FOR DEMO PURPOSE ONLY. refactor: reorganize and modularize field preview logic

### DIFF
--- a/src/plugins/data_view_field_editor/public/components/preview/field_preview_context.tsx
+++ b/src/plugins/data_view_field_editor/public/components/preview/field_preview_context.tsx
@@ -8,60 +8,45 @@
 
 import React, {
   createContext,
+  useReducer,
   useState,
   useContext,
   useMemo,
   useCallback,
-  useEffect,
   useRef,
   FunctionComponent,
 } from 'react';
-import { renderToString } from 'react-dom/server';
-import useDebounce from 'react-use/lib/useDebounce';
-import { i18n } from '@kbn/i18n';
-import { get } from 'lodash';
 import { castEsToKbnFieldTypeName } from '@kbn/field-types';
 import { BehaviorSubject } from 'rxjs';
-import { RuntimePrimitiveTypes } from '../../shared_imports';
 
-import { parseEsError } from '../../lib/runtime_field_validation';
 import { useFieldEditorContext } from '../field_editor_context';
-import type {
-  PainlessExecuteContext,
-  Context,
-  Params,
-  ClusterData,
-  From,
-  EsDocument,
-  ScriptErrorCodes,
-  FetchDocError,
-  FieldPreview,
-} from './types';
+import {
+  useDocumentsActions,
+  useFieldPreviewContextValue,
+  usePreviewDerivedState,
+  usePreviewExecution,
+  usePreviewSideEffects,
+} from './hooks';
+import { defaultValueFormatter } from './utils/formatters';
+import {
+  documentsReducer,
+  initialDocumentsState,
+  initialPreviewState,
+  previewReducer,
+} from './reducers';
+import type { Context, Params, From, EsDocument, FieldPreview } from './types';
 
 const fieldPreviewContext = createContext<Context | undefined>(undefined);
 
 const defaultParams: Params = {
   name: null,
-  index: null,
   script: null,
-  document: null,
   type: null,
   format: null,
   parentName: null,
 };
 
-export const defaultValueFormatter = (value: unknown) => {
-  const content = typeof value === 'object' ? JSON.stringify(value) : String(value) ?? '-';
-  return renderToString(<>{content}</>);
-};
-
-export const valueTypeToSelectedType = (value: unknown): RuntimePrimitiveTypes => {
-  const valueType = typeof value;
-  if (valueType === 'string') return 'keyword';
-  if (valueType === 'number') return 'double';
-  if (valueType === 'boolean') return 'boolean';
-  return 'keyword';
-};
+export { defaultValueFormatter, valueTypeToSelectedType } from './utils/formatters';
 
 export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
   const previewCount = useRef(0);
@@ -92,32 +77,18 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
 
   const fieldPreview$ = useRef(new BehaviorSubject<FieldPreview[] | undefined>(undefined));
 
-  /** Response from the Painless _execute API */
-  const [previewResponse, setPreviewResponse] = useState<{
-    fields: Context['fields'];
-    error: Context['error'];
-  }>({ fields: [], error: null });
-  const [initialPreviewComplete, setInitialPreviewComplete] = useState(false);
+  const [documentsState, documentsDispatch] = useReducer(documentsReducer, initialDocumentsState);
+  const [previewState, previewDispatch] = useReducer(previewReducer, initialPreviewState);
 
-  /** Possible error while fetching sample documents */
-  const [fetchDocError, setFetchDocError] = useState<FetchDocError | null>(null);
+  const { clusterData, fetchDocError, isFetchingDocumentInFlight } = documentsState;
+  const { previewResponse, isLoadingPreviewInFlight, initialPreviewComplete } = previewState;
+
+  const [isPanelVisible, setIsPanelVisible] = useState(true);
+  const [customDocIdToLoad, setCustomDocIdToLoad] = useState<string | null>(null);
+  const [from, setFrom] = useState<From>('cluster');
+
   /** The parameters required for the Painless _execute API */
   const [params, setParams] = useState<Params>(defaultParams);
-  /** The sample documents fetched from the cluster */
-  const [clusterData, setClusterData] = useState<ClusterData>({
-    documents: [],
-    currentIdx: 0,
-  });
-  /** Flag to show/hide the preview panel */
-  const [isPanelVisible, setIsPanelVisible] = useState(true);
-  /** Flag to indicate if we are loading document from cluster */
-  const [isFetchingDocument, setIsFetchingDocument] = useState(false);
-  /** Flag to indicate if we are calling the _execute API */
-  const [isLoadingPreview, setIsLoadingPreview] = useState(false);
-  /** Flag to indicate if we are loading a single document by providing its ID */
-  const [customDocIdToLoad, setCustomDocIdToLoad] = useState<string | null>(null);
-  /** Define if we provide the document to preview from the cluster or from a custom JSON */
-  const [from, setFrom] = useState<From>('cluster');
   /** Map of fields pinned to the top of the list */
   const [pinnedFields, setPinnedFields] = useState<{ [key: string]: boolean }>({});
   /** Keep track if the script painless syntax is being validated and if it is valid  */
@@ -133,20 +104,23 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
   const currentDocId: string | undefined = currentDocument?._id;
   const totalDocs = documents.length;
   const isCustomDocId = customDocIdToLoad !== null;
-  let isPreviewAvailable = true;
 
-  // If no documents could be fetched from the cluster (and we are not trying to load
-  // a custom doc ID) then we disable preview as the script field validation expect the result
-  // of the preview to before resolving. If there are no documents we can't have a preview
-  // (the _execute API expects one) and thus the validation should not expect a value.
-  if (!isFetchingDocument && !isCustomDocId && documents.length === 0) {
-    isPreviewAvailable = false;
-  }
-
-  const { name, document, script, format, type, parentName } = params;
+  const { name, script, format, type, parentName } = params;
 
   const updateParams: Context['params']['update'] = useCallback((updated) => {
     setParams((prev) => ({ ...prev, ...updated }));
+  }, []);
+
+  const setPanelVisible = useCallback((isVisible: boolean) => {
+    setIsPanelVisible(isVisible);
+  }, []);
+
+  const setDocIdToLoad = useCallback((docId: string) => {
+    setCustomDocIdToLoad(docId);
+  }, []);
+
+  const setFromValue = useCallback((nextFrom: From) => {
+    setFrom(nextFrom);
   }, []);
 
   const allParamsDefined = useMemo(() => {
@@ -162,24 +136,7 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
       lastExecutePainlessRequestParams.current.script !== script?.source ||
       lastExecutePainlessRequestParams.current.documentId !== currentDocId
     );
-  }, [type, script, currentDocId]);
-
-  const setPreviewError = useCallback((error: Context['error']) => {
-    setPreviewResponse((prev) => ({
-      ...prev,
-      error,
-    }));
-  }, []);
-
-  const clearPreviewError = useCallback((errorCode: ScriptErrorCodes) => {
-    setPreviewResponse((prev) => {
-      const error = prev.error === null || prev.error?.code === errorCode ? null : prev.error;
-      return {
-        ...prev,
-        error,
-      };
-    });
-  }, []);
+  }, [type, script?.source, currentDocId]);
 
   const valueFormatter = useCallback(
     (value: unknown) => {
@@ -203,552 +160,119 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
     [format, type, fieldFormats]
   );
 
+  const { fetchSampleDocuments: fetchSampleDocumentsBase, loadDocument } = useDocumentsActions({
+    dataView,
+    search,
+    documentsDispatch,
+    previewDispatch,
+    lastExecutePainlessRequestParams,
+  });
+
   const fetchSampleDocuments = useCallback(
-    async (limit: number = 50) => {
-      if (typeof limit !== 'number') {
-        // We guard ourself from passing an <input /> event accidentally
-        throw new Error('The "limit" option must be a number');
-      }
-
-      lastExecutePainlessRequestParams.current.documentId = undefined;
-      setIsFetchingDocument(true);
-      setPreviewResponse({ fields: [], error: null });
-
-      const [response, searchError] = await search
-        .search({
-          params: {
-            index: dataView.getIndexPattern(),
-            body: {
-              size: limit,
-            },
-          },
-        })
-        .toPromise()
-        .then((res) => [res, null])
-        .catch((err) => [null, err]);
-
-      setIsFetchingDocument(false);
+    async (limit?: number) => {
       setCustomDocIdToLoad(null);
-
-      const error: FetchDocError | null = Boolean(searchError)
-        ? {
-            code: 'ERR_FETCHING_DOC',
-            error: {
-              message: searchError.toString(),
-              reason: i18n.translate(
-                'indexPatternFieldEditor.fieldPreview.error.errorLoadingSampleDocumentsDescription',
-                {
-                  defaultMessage: 'Error loading sample documents.',
-                }
-              ),
-            },
-          }
-        : null;
-
-      setFetchDocError(error);
-
-      if (error === null) {
-        setClusterData({
-          documents: response ? response.rawResponse.hits.hits : [],
-          currentIdx: 0,
-        });
-      }
+      await fetchSampleDocumentsBase(limit);
     },
-    [dataView, search]
+    [fetchSampleDocumentsBase]
   );
 
-  const loadDocument = useCallback(
-    async (id: string) => {
-      if (!Boolean(id.trim())) {
-        return;
-      }
-
-      lastExecutePainlessRequestParams.current.documentId = undefined;
-      setIsFetchingDocument(true);
-
-      const [response, searchError] = await search
-        .search({
-          params: {
-            index: dataView.getIndexPattern(),
-            body: {
-              size: 1,
-              query: {
-                ids: {
-                  values: [id],
-                },
-              },
-            },
-          },
-        })
-        .toPromise()
-        .then((res) => [res, null])
-        .catch((err) => [null, err]);
-
-      setIsFetchingDocument(false);
-
-      const isDocumentFound = response?.rawResponse.hits.total > 0;
-      const loadedDocuments: EsDocument[] = isDocumentFound ? response.rawResponse.hits.hits : [];
-      const error: FetchDocError | null = Boolean(searchError)
-        ? {
-            code: 'ERR_FETCHING_DOC',
-            error: {
-              message: searchError.toString(),
-              reason: i18n.translate(
-                'indexPatternFieldEditor.fieldPreview.error.errorLoadingDocumentDescription',
-                {
-                  defaultMessage: 'Error loading document.',
-                }
-              ),
-            },
-          }
-        : isDocumentFound === false
-        ? {
-            code: 'DOC_NOT_FOUND',
-            error: {
-              message: i18n.translate(
-                'indexPatternFieldEditor.fieldPreview.error.documentNotFoundDescription',
-                {
-                  defaultMessage: 'Document ID not found',
-                }
-              ),
-            },
-          }
-        : null;
-
-      setFetchDocError(error);
-
-      if (error === null) {
-        setClusterData({
-          documents: loadedDocuments,
-          currentIdx: 0,
-        });
-      } else {
-        // Make sure we disable the "Updating..." indicator as we have an error
-        // and we won't fetch the preview
-        setIsLoadingPreview(false);
-      }
-    },
-    [dataView, search]
-  );
-
-  const updateSingleFieldPreview = useCallback(
-    (fieldName: string, values: unknown[]) => {
-      const [value] = values;
-      const formattedValue = valueFormatter(value);
-
-      setPreviewResponse({
-        fields: [{ key: fieldName, value, formattedValue }],
-        error: null,
-      });
-    },
-    [valueFormatter]
-  );
-
-  const updateCompositeFieldPreview = useCallback(
-    (compositeValues: Record<string, unknown[]>) => {
-      const updatedFieldsInScript: string[] = [];
-      // if we're displaying a composite subfield, filter results
-      const filterSubfield = parentName ? (field: FieldPreview) => field.key === name : () => true;
-
-      const fields = Object.entries(compositeValues)
-        .map<FieldPreview>(([key, values]) => {
-          // The Painless _execute API returns the composite field values under a map.
-          // Each of the key is prefixed with "composite_field." (e.g. "composite_field.field1: ['value']")
-          const { 1: fieldName } = key.split('composite_field.');
-          updatedFieldsInScript.push(fieldName);
-
-          const [value] = values;
-          const formattedValue = valueFormatter(value);
-
-          return {
-            key: parentName
-              ? `${parentName ?? ''}.${fieldName}`
-              : `${fieldName$.getValue() ?? ''}.${fieldName}`,
-            value,
-            formattedValue,
-            type: valueTypeToSelectedType(value),
-          };
-        })
-        .filter(filterSubfield)
-        // ...and sort alphabetically
-        .sort((a, b) => a.key.localeCompare(b.key));
-
-      fieldPreview$.current.next(fields);
-      setPreviewResponse({
-        fields,
-        error: null,
-      });
-    },
-    [valueFormatter, parentName, name, fieldPreview$, fieldName$]
-  );
-
-  const updatePreview = useCallback(async () => {
-    // don't prevent rendering if we're working with a composite subfield (has parentName)
-    if (!parentName && scriptEditorValidation.isValidating) {
-      return;
-    }
-
-    if (
-      !parentName &&
-      (!allParamsDefined || !hasSomeParamsChanged || scriptEditorValidation.isValid === false)
-    ) {
-      setIsLoadingPreview(false);
-      return;
-    }
-
-    lastExecutePainlessRequestParams.current = {
-      type,
-      script: script?.source,
-      documentId: currentDocId,
-    };
-
-    const currentApiCall = ++previewCount.current;
-
-    const previewScript = (parentName && dataView.getRuntimeField(parentName)?.script) || script!;
-
-    const response = await getFieldPreview({
-      index: currentDocIndex,
-      document: document!,
-      context: (parentName ? 'composite_field' : `${type!}_field`) as PainlessExecuteContext,
-      script: previewScript,
-    });
-
-    if (currentApiCall !== previewCount.current) {
-      // Discard this response as there is another one inflight
-      // or we have called reset() and no longer need the response.
-      return;
-    }
-
-    const { error: serverError } = response;
-
-    if (serverError) {
-      // Server error (not an ES error)
-      const title = i18n.translate('indexPatternFieldEditor.fieldPreview.errorTitle', {
-        defaultMessage: 'Failed to load field preview',
-      });
-      notifications.toasts.addError(serverError, { title });
-
-      setIsLoadingPreview(false);
-      return;
-    }
-
-    if (response.data) {
-      const { values, error } = response.data;
-
-      if (error) {
-        setPreviewResponse({
-          fields: [
-            {
-              key: name ?? '',
-              value: '',
-              formattedValue: defaultValueFormatter(''),
-            },
-          ],
-          error: { code: 'PAINLESS_SCRIPT_ERROR', error: parseEsError(error) },
-        });
-      } else {
-        if (!Array.isArray(values)) {
-          updateCompositeFieldPreview(values);
-        } else {
-          updateSingleFieldPreview(name!, values);
-        }
-      }
-    }
-
-    setInitialPreviewComplete(true);
-    setIsLoadingPreview(false);
-  }, [
+  const { updatePreview } = usePreviewExecution({
     name,
     type,
     script,
     parentName,
     dataView,
-    document,
-    currentDocId,
     getFieldPreview,
-    notifications.toasts,
-    allParamsDefined,
-    scriptEditorValidation,
-    hasSomeParamsChanged,
-    updateSingleFieldPreview,
-    updateCompositeFieldPreview,
+    toasts: notifications.toasts,
     currentDocIndex,
-  ]);
+    currentDocId,
+    currentDocument,
+    allParamsDefined,
+    hasSomeParamsChanged,
+    scriptEditorValidation,
+    fieldName$,
+    fieldPreview$: fieldPreview$.current,
+    valueFormatter,
+    previewDispatch,
+    previewCount,
+    lastExecutePainlessRequestParams,
+  });
 
   const goToNextDoc = useCallback(() => {
-    if (currentIdx >= totalDocs - 1) {
-      setClusterData((prev) => ({ ...prev, currentIdx: 0 }));
-    } else {
-      setClusterData((prev) => ({ ...prev, currentIdx: prev.currentIdx + 1 }));
-    }
-  }, [currentIdx, totalDocs]);
+    documentsDispatch({ type: 'NAV_NEXT' });
+  }, [documentsDispatch]);
 
   const goToPrevDoc = useCallback(() => {
-    if (currentIdx === 0) {
-      setClusterData((prev) => ({ ...prev, currentIdx: totalDocs - 1 }));
-    } else {
-      setClusterData((prev) => ({ ...prev, currentIdx: prev.currentIdx - 1 }));
-    }
-  }, [currentIdx, totalDocs]);
+    documentsDispatch({ type: 'NAV_PREV' });
+  }, [documentsDispatch]);
 
   const reset = useCallback(() => {
     // By resetting the previewCount we will discard previous inflight
     // API call response coming in after calling reset() was called
     previewCount.current = 0;
 
-    setClusterData({
-      documents: [],
-      currentIdx: 0,
-    });
-    setPreviewResponse({ fields: [], error: null });
+    documentsDispatch({ type: 'RESET_DOCUMENTS' });
+    previewDispatch({ type: 'RESET_PREVIEW_RESPONSE' });
+    setCustomDocIdToLoad(null);
     setFrom('cluster');
-    setIsLoadingPreview(false);
-    setIsFetchingDocument(false);
-  }, []);
+    setIsPanelVisible(true);
+  }, [documentsDispatch, previewDispatch]);
 
-  const ctx = useMemo<Context>(
-    () => ({
-      fields: previewResponse.fields,
-      error: previewResponse.error,
-      fieldPreview$: fieldPreview$.current,
-      isPreviewAvailable,
-      isLoadingPreview,
-      initialPreviewComplete,
-      params: {
-        value: params,
-        update: updateParams,
-      },
-      currentDocument: {
-        value: currentDocument,
-        id: isCustomDocId ? customDocIdToLoad! : currentDocId,
-        isLoading: isFetchingDocument,
-        isCustomId: isCustomDocId,
-      },
-      documents: {
-        loadSingle: setCustomDocIdToLoad,
-        loadFromCluster: fetchSampleDocuments,
-        fetchDocError,
-      },
-      navigation: {
-        isFirstDoc: currentIdx === 0,
-        isLastDoc: currentIdx >= totalDocs - 1,
-        next: goToNextDoc,
-        prev: goToPrevDoc,
-      },
-      panel: {
-        isVisible: isPanelVisible,
-        setIsVisible: setIsPanelVisible,
-      },
-      from: {
-        value: from,
-        set: setFrom,
-      },
-      reset,
-      pinnedFields: {
-        value: pinnedFields,
-        set: setPinnedFields,
-      },
-      validation: {
-        setScriptEditorValidation,
-      },
-    }),
-    [
+  const { fields, error, isPreviewAvailable, isLoadingPreview, isFetchingDocument } =
+    usePreviewDerivedState({
       previewResponse,
-      fieldPreview$,
-      fetchDocError,
+      scriptEditorValidation,
       params,
-      isPreviewAvailable,
-      isLoadingPreview,
-      updateParams,
-      currentDocument,
-      currentDocId,
+      currentDocumentSource: currentDocument?._source,
+      valueFormatter,
+      allParamsDefined,
+      hasSomeParamsChanged,
+      isLoadingPreviewInFlight,
+      isFetchingDocumentInFlight,
       isCustomDocId,
-      fetchSampleDocuments,
-      isFetchingDocument,
       customDocIdToLoad,
-      currentIdx,
       totalDocs,
-      goToNextDoc,
-      goToPrevDoc,
-      isPanelVisible,
-      from,
-      reset,
-      pinnedFields,
-      initialPreviewComplete,
-    ]
-  );
-
-  /**
-   * In order to immediately display the "Updating..." state indicator and not have to wait
-   * the 500ms of the debounce, we set the isLoadingPreview state in this effect whenever
-   * one of the _execute API param changes
-   */
-  useEffect(() => {
-    if (allParamsDefined && hasSomeParamsChanged) {
-      setIsLoadingPreview(true);
-    }
-  }, [allParamsDefined, hasSomeParamsChanged, script?.source, type, currentDocId]);
-
-  /**
-   * In order to immediately display the "Updating..." state indicator and not have to wait
-   * the 500ms of the debounce, we set the isFetchingDocument state in this effect whenever
-   * "customDocIdToLoad" changes
-   */
-  useEffect(() => {
-    if (customDocIdToLoad !== null && Boolean(customDocIdToLoad.trim())) {
-      setIsFetchingDocument(true);
-    }
-  }, [customDocIdToLoad]);
-
-  /**
-   * Whenever we show the preview panel we will update the documents from the cluster
-   */
-  useEffect(() => {
-    if (isPanelVisible) {
-      fetchSampleDocuments();
-    }
-  }, [isPanelVisible, fetchSampleDocuments, fieldTypeToProcess]);
-
-  /**
-   * Each time the current document changes we update the parameters
-   * that will be sent in the _execute HTTP request.
-   */
-  useEffect(() => {
-    updateParams({
-      document: currentDocument?._source,
-      index: currentDocument?._index,
     });
-  }, [currentDocument, updateParams]);
 
-  /**
-   * Whenever the name or the format changes we immediately update the preview
-   */
-  useEffect(() => {
-    setPreviewResponse((prev) => {
-      const { fields } = prev;
+  const ctx = useFieldPreviewContextValue({
+    fieldPreview$: fieldPreview$.current,
+    fields,
+    error,
+    isPreviewAvailable,
+    isLoadingPreview,
+    initialPreviewComplete,
+    params,
+    updateParams,
+    currentDocument,
+    currentDocId,
+    customDocIdToLoad,
+    isCustomDocId,
+    isFetchingDocument,
+    fetchSampleDocuments,
+    loadSingleDocumentId: setDocIdToLoad,
+    fetchDocError,
+    currentIdx,
+    totalDocs,
+    goToNextDoc,
+    goToPrevDoc,
+    isPanelVisible,
+    setPanelVisible,
+    from,
+    setFromValue,
+    reset,
+    pinnedFields,
+    setPinnedFields,
+    setScriptEditorValidation,
+  });
 
-      let updatedFields: Context['fields'] = fields.map((field) => {
-        let key = name ?? '';
-
-        if (type === 'composite') {
-          // restore initial key segement (the parent name), which was not returned
-          const { 1: fieldName } = field.key.split('.');
-          key = `${name ?? ''}.${fieldName}`;
-        }
-
-        return {
-          ...field,
-          key,
-        };
-      });
-
-      // If the user has entered a name but not yet any script we will display
-      // the field in the preview with just the name
-      if (updatedFields.length === 0 && name !== null) {
-        updatedFields = [
-          { key: name, value: undefined, formattedValue: undefined, type: undefined },
-        ];
-      }
-
-      return {
-        ...prev,
-        fields: updatedFields,
-      };
-    });
-  }, [name, type, parentName]);
-
-  /**
-   * Whenever the format changes we immediately update the preview
-   */
-  useEffect(() => {
-    setPreviewResponse((prev) => {
-      const { fields } = prev;
-
-      return {
-        ...prev,
-        fields: fields.map((field) => {
-          const nextValue =
-            script === null && Boolean(document)
-              ? get(document, name ?? '') // When there is no script we try to read the value from _source
-              : field?.value;
-
-          const formattedValue = valueFormatter(nextValue);
-
-          return {
-            ...field,
-            value: nextValue,
-            formattedValue,
-          };
-        }),
-      };
-    });
-  }, [name, script, document, valueFormatter]);
-
-  useEffect(() => {
-    if (script?.source === undefined) {
-      // Whenever the source is not defined ("Set value" is toggled off or the
-      // script is empty) we clear the error and update the params cache.
-      lastExecutePainlessRequestParams.current.script = undefined;
-      setPreviewError(null);
-    }
-  }, [script?.source, setPreviewError]);
-
-  // Handle the validation state coming from the Painless DiagnosticAdapter
-  // (see @kbn-monaco/src/painless/diagnostics_adapter.ts)
-  useEffect(() => {
-    if (scriptEditorValidation.isValidating) {
-      return;
-    }
-
-    if (scriptEditorValidation.isValid === false) {
-      // Make sure to remove the "Updating..." spinner
-      setIsLoadingPreview(false);
-
-      // Set preview response error so it is displayed in the flyout footer
-      const error =
-        script?.source === undefined
-          ? null
-          : {
-              code: 'PAINLESS_SYNTAX_ERROR' as const,
-              error: {
-                reason:
-                  scriptEditorValidation.message ??
-                  i18n.translate('indexPatternFieldEditor.fieldPreview.error.painlessSyntax', {
-                    defaultMessage: 'Invalid Painless syntax',
-                  }),
-              },
-            };
-      setPreviewError(error);
-
-      // Make sure to update the lastExecutePainlessRequestParams cache so when the user updates
-      // the script and fixes the syntax the "updatePreview()" will run
-      lastExecutePainlessRequestParams.current.script = script?.source;
-    } else {
-      // Clear possible previous syntax error
-      clearPreviewError('PAINLESS_SYNTAX_ERROR');
-    }
-  }, [scriptEditorValidation, script?.source, setPreviewError, clearPreviewError]);
-
-  /**
-   * Whenever updatePreview() changes (meaning whenever a param changes)
-   * we call it to update the preview response with the field(s) value or possible error.
-   */
-  useDebounce(updatePreview, 500, [updatePreview]);
-
-  /**
-   * Whenever the doc ID to load changes we load the document (after a 500ms debounce)
-   */
-  useDebounce(
-    () => {
-      if (customDocIdToLoad === null) {
-        return;
-      }
-
-      loadDocument(customDocIdToLoad);
-    },
-    500,
-    [customDocIdToLoad]
-  );
+  usePreviewSideEffects({
+    isPanelVisible,
+    refetchKey: fieldTypeToProcess,
+    fetchSampleDocuments,
+    updatePreview,
+    customDocIdToLoad,
+    loadDocument,
+  });
 
   return <fieldPreviewContext.Provider value={ctx}>{children}</fieldPreviewContext.Provider>;
 };

--- a/src/plugins/data_view_field_editor/public/components/preview/hooks/index.ts
+++ b/src/plugins/data_view_field_editor/public/components/preview/hooks/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 and the Server
+ * Side Public License, v 1.
+ */
+
+export { useFieldPreviewContextValue } from './use_field_preview_context_value';
+export { useDocumentsActions } from './use_documents_actions';
+export { usePreviewDerivedState } from './use_preview_derived_state';
+export { usePreviewExecution } from './use_preview_execution';
+export { DEFAULT_PREVIEW_DEBOUNCE_MS, usePreviewSideEffects } from './use_preview_side_effects';
+

--- a/src/plugins/data_view_field_editor/public/components/preview/hooks/use_documents_actions.ts
+++ b/src/plugins/data_view_field_editor/public/components/preview/hooks/use_documents_actions.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useCallback } from 'react';
+import { i18n } from '@kbn/i18n';
+
+import type { DataPublicPluginStart, DataView } from '../../../shared_imports';
+import type { FetchDocError, EsDocument } from '../types';
+import type { DocumentsAction } from '../reducers';
+import type { PreviewAction } from '../reducers';
+
+type SearchObservable = ReturnType<DataPublicPluginStart['search']['search']>;
+type SearchResponse = Awaited<ReturnType<SearchObservable['toPromise']>>;
+
+interface Args {
+  dataView: DataView;
+  search: DataPublicPluginStart['search'];
+  documentsDispatch: React.Dispatch<DocumentsAction>;
+  previewDispatch: React.Dispatch<PreviewAction>;
+  lastExecutePainlessRequestParams: React.MutableRefObject<{
+    type: unknown;
+    script: string | undefined;
+    documentId: string | undefined;
+  }>;
+}
+
+export const useDocumentsActions = ({
+  dataView,
+  search,
+  documentsDispatch,
+  previewDispatch,
+  lastExecutePainlessRequestParams,
+}: Args) => {
+  const fetchSampleDocuments = useCallback(
+    async (limit: number = 50) => {
+      if (typeof limit !== 'number') {
+        // We guard ourself from passing an <input /> event accidentally
+        throw new Error('The "limit" option must be a number');
+      }
+
+      lastExecutePainlessRequestParams.current.documentId = undefined;
+      documentsDispatch({ type: 'FETCH_SAMPLE_START' });
+      previewDispatch({ type: 'RESET_PREVIEW_RESPONSE' });
+
+      let response: SearchResponse | null = null;
+      let searchError: unknown = null;
+      try {
+        response = await search
+          .search({
+            params: {
+              index: dataView.getIndexPattern(),
+              body: {
+                size: limit,
+              },
+            },
+          })
+          .toPromise();
+      } catch (err) {
+        searchError = err;
+      }
+
+      const error: FetchDocError | null = Boolean(searchError)
+        ? {
+            code: 'ERR_FETCHING_DOC',
+            error: {
+              message: String(searchError),
+              reason: i18n.translate(
+                'indexPatternFieldEditor.fieldPreview.error.errorLoadingSampleDocumentsDescription',
+                {
+                  defaultMessage: 'Error loading sample documents.',
+                }
+              ),
+            },
+          }
+        : null;
+
+      documentsDispatch({
+        type: 'FETCH_SAMPLE_FINISH',
+        error,
+        documents: response ? response.rawResponse.hits.hits : [],
+      });
+    },
+    [dataView, search, documentsDispatch, previewDispatch, lastExecutePainlessRequestParams]
+  );
+
+  const loadDocument = useCallback(
+    async (id: string) => {
+      if (!Boolean(id.trim())) {
+        return;
+      }
+
+      lastExecutePainlessRequestParams.current.documentId = undefined;
+      documentsDispatch({ type: 'LOAD_DOC_START' });
+
+      let response: SearchResponse | null = null;
+      let searchError: unknown = null;
+      try {
+        response = await search
+          .search({
+            params: {
+              index: dataView.getIndexPattern(),
+              body: {
+                size: 1,
+                query: {
+                  ids: {
+                    values: [id],
+                  },
+                },
+              },
+            },
+          })
+          .toPromise();
+      } catch (err) {
+        searchError = err;
+      }
+
+      const totalHits = response ? Number(response.rawResponse.hits.total) : 0;
+      const isDocumentFound = totalHits > 0;
+      const loadedDocuments: EsDocument[] =
+        isDocumentFound && response ? response.rawResponse.hits.hits : [];
+      const error: FetchDocError | null = Boolean(searchError)
+        ? {
+            code: 'ERR_FETCHING_DOC',
+            error: {
+              message: String(searchError),
+              reason: i18n.translate(
+                'indexPatternFieldEditor.fieldPreview.error.errorLoadingDocumentDescription',
+                {
+                  defaultMessage: 'Error loading document.',
+                }
+              ),
+            },
+          }
+        : isDocumentFound === false
+        ? {
+            code: 'DOC_NOT_FOUND',
+            error: {
+              message: i18n.translate(
+                'indexPatternFieldEditor.fieldPreview.error.documentNotFoundDescription',
+                {
+                  defaultMessage: 'Document ID not found',
+                }
+              ),
+            },
+          }
+        : null;
+
+      documentsDispatch({ type: 'LOAD_DOC_FINISH', error, documents: loadedDocuments });
+
+      if (error !== null) {
+        // Make sure we disable the "Updating..." indicator as we have an error
+        // and we won't fetch the preview
+        previewDispatch({ type: 'SET_LOADING_IN_FLIGHT', isLoadingPreviewInFlight: false });
+      }
+    },
+    [dataView, search, documentsDispatch, previewDispatch, lastExecutePainlessRequestParams]
+  );
+
+  return { fetchSampleDocuments, loadDocument };
+};

--- a/src/plugins/data_view_field_editor/public/components/preview/hooks/use_field_preview_context_value.ts
+++ b/src/plugins/data_view_field_editor/public/components/preview/hooks/use_field_preview_context_value.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useMemo } from 'react';
+import type { BehaviorSubject } from 'rxjs';
+
+import type { Context, EsDocument, FieldPreview, FetchDocError, From, Params } from '../types';
+
+interface Args {
+  fieldPreview$: BehaviorSubject<FieldPreview[] | undefined>;
+
+  fields: Context['fields'];
+  error: Context['error'];
+  isPreviewAvailable: boolean;
+  isLoadingPreview: boolean;
+  initialPreviewComplete: boolean;
+
+  params: Params;
+  updateParams: Context['params']['update'];
+
+  currentDocument?: EsDocument;
+  currentDocId?: string;
+  customDocIdToLoad: string | null;
+  isCustomDocId: boolean;
+  isFetchingDocument: boolean;
+
+  fetchSampleDocuments: () => Promise<void>;
+  loadSingleDocumentId: (id: string) => void;
+  fetchDocError: FetchDocError | null;
+
+  currentIdx: number;
+  totalDocs: number;
+  goToNextDoc: () => void;
+  goToPrevDoc: () => void;
+
+  isPanelVisible: boolean;
+  setPanelVisible: (isVisible: boolean) => void;
+
+  from: From;
+  setFromValue: (value: From) => void;
+
+  reset: () => void;
+  pinnedFields: { [key: string]: boolean };
+  setPinnedFields: React.Dispatch<React.SetStateAction<{ [key: string]: boolean }>>;
+
+  setScriptEditorValidation: React.Dispatch<
+    React.SetStateAction<{ isValid: boolean; isValidating: boolean; message: string | null }>
+  >;
+}
+
+export const useFieldPreviewContextValue = ({
+  fieldPreview$,
+  fields,
+  error,
+  isPreviewAvailable,
+  isLoadingPreview,
+  initialPreviewComplete,
+  params,
+  updateParams,
+  currentDocument,
+  currentDocId,
+  customDocIdToLoad,
+  isCustomDocId,
+  isFetchingDocument,
+  fetchSampleDocuments,
+  loadSingleDocumentId,
+  fetchDocError,
+  currentIdx,
+  totalDocs,
+  goToNextDoc,
+  goToPrevDoc,
+  isPanelVisible,
+  setPanelVisible,
+  from,
+  setFromValue,
+  reset,
+  pinnedFields,
+  setPinnedFields,
+  setScriptEditorValidation,
+}: Args): Context => {
+  return useMemo<Context>(
+    () => ({
+      fields,
+      error,
+      fieldPreview$,
+      isPreviewAvailable,
+      isLoadingPreview,
+      initialPreviewComplete,
+      params: {
+        value: params,
+        update: updateParams,
+      },
+      currentDocument: {
+        value: currentDocument,
+        id: isCustomDocId ? customDocIdToLoad! : currentDocId,
+        isLoading: isFetchingDocument,
+        isCustomId: isCustomDocId,
+      },
+      documents: {
+        loadSingle: loadSingleDocumentId,
+        loadFromCluster: fetchSampleDocuments,
+        fetchDocError,
+      },
+      navigation: {
+        isFirstDoc: currentIdx === 0,
+        isLastDoc: currentIdx >= totalDocs - 1,
+        next: goToNextDoc,
+        prev: goToPrevDoc,
+      },
+      panel: {
+        isVisible: isPanelVisible,
+        setIsVisible: setPanelVisible,
+      },
+      from: {
+        value: from,
+        set: setFromValue,
+      },
+      reset,
+      pinnedFields: {
+        value: pinnedFields,
+        set: setPinnedFields,
+      },
+      validation: {
+        setScriptEditorValidation,
+      },
+    }),
+    [
+      fields,
+      error,
+      fieldPreview$,
+      isPreviewAvailable,
+      isLoadingPreview,
+      initialPreviewComplete,
+      params,
+      updateParams,
+      currentDocument,
+      currentDocId,
+      customDocIdToLoad,
+      isCustomDocId,
+      isFetchingDocument,
+      loadSingleDocumentId,
+      fetchSampleDocuments,
+      fetchDocError,
+      currentIdx,
+      totalDocs,
+      goToNextDoc,
+      goToPrevDoc,
+      isPanelVisible,
+      setPanelVisible,
+      from,
+      setFromValue,
+      reset,
+      pinnedFields,
+      setPinnedFields,
+      setScriptEditorValidation,
+    ]
+  );
+};

--- a/src/plugins/data_view_field_editor/public/components/preview/hooks/use_preview_derived_state.ts
+++ b/src/plugins/data_view_field_editor/public/components/preview/hooks/use_preview_derived_state.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
+import { get } from 'lodash';
+
+import type { Context, FieldPreview, Params } from '../types';
+
+interface ScriptEditorValidationState {
+  isValidating: boolean;
+  isValid: boolean;
+  message: string | null;
+}
+
+interface Args {
+  previewResponse: { fields: Context['fields']; error: Context['error'] };
+  scriptEditorValidation: ScriptEditorValidationState;
+  params: Params;
+  currentDocumentSource?: Record<string, unknown>;
+  valueFormatter: (value: unknown) => string;
+
+  allParamsDefined: boolean;
+  hasSomeParamsChanged: boolean;
+  isLoadingPreviewInFlight: boolean;
+
+  isFetchingDocumentInFlight: boolean;
+  isCustomDocId: boolean;
+  customDocIdToLoad: string | null;
+  totalDocs: number;
+}
+
+export const usePreviewDerivedState = ({
+  previewResponse,
+  scriptEditorValidation,
+  params,
+  currentDocumentSource,
+  valueFormatter,
+  allParamsDefined,
+  hasSomeParamsChanged,
+  isLoadingPreviewInFlight,
+  isFetchingDocumentInFlight,
+  isCustomDocId,
+  customDocIdToLoad,
+  totalDocs,
+}: Args) => {
+  const { name, type, script, parentName } = params;
+
+  const isCustomDocIdPending = useMemo(
+    () => customDocIdToLoad !== null && Boolean(customDocIdToLoad.trim()),
+    [customDocIdToLoad]
+  );
+
+  // If no documents could be fetched from the cluster (and we are not trying to load
+  // a custom doc ID) then we disable preview as the script field validation expect the result
+  // of the preview to before resolving. If there are no documents we can't have a preview
+  // (the _execute API expects one) and thus the validation should not expect a value.
+  const isPreviewAvailable = useMemo(() => {
+    if (!isFetchingDocumentInFlight && !isCustomDocId && totalDocs === 0) {
+      return false;
+    }
+    return true;
+  }, [isFetchingDocumentInFlight, isCustomDocId, totalDocs]);
+
+  const syntaxError: Context['error'] = useMemo(() => {
+    if (scriptEditorValidation.isValidating) {
+      return null;
+    }
+
+    if (scriptEditorValidation.isValid === false && script?.source !== undefined) {
+      return {
+        code: 'PAINLESS_SYNTAX_ERROR',
+        error: {
+          reason:
+            scriptEditorValidation.message ??
+            i18n.translate('indexPatternFieldEditor.fieldPreview.error.painlessSyntax', {
+              defaultMessage: 'Invalid Painless syntax',
+            }),
+        },
+      };
+    }
+
+    return null;
+  }, [scriptEditorValidation, script?.source]);
+
+  const error: Context['error'] = useMemo(() => {
+    if (script?.source === undefined) {
+      return null;
+    }
+
+    return syntaxError ?? previewResponse.error;
+  }, [previewResponse.error, syntaxError, script?.source]);
+
+  const fields: Context['fields'] = useMemo(() => {
+    const executeFields = previewResponse.fields;
+
+    // If the user has entered a name but not yet any script we will display
+    // the field in the preview with just the name
+    if (executeFields.length === 0 && name !== null) {
+      return [{ key: name, value: undefined, formattedValue: undefined, type: undefined }];
+    }
+
+    return executeFields.map((field) => {
+      // Keep the key in sync with the current name when editing a composite field
+      let key = name ?? '';
+      if (type === 'composite') {
+        // restore initial key segement (the parent name), which was not returned
+        const { 1: fieldName } = field.key.split('.');
+        key = `${name ?? ''}.${fieldName}`;
+      }
+
+      const nextValue =
+        script === null && Boolean(currentDocumentSource)
+          ? get(currentDocumentSource, name ?? '') // When there is no script we try to read the value from _source
+          : field?.value;
+
+      const formattedValue = valueFormatter(nextValue);
+
+      const nextField: FieldPreview = {
+        ...field,
+        key,
+        value: nextValue,
+        formattedValue,
+      };
+
+      return nextField;
+    });
+  }, [previewResponse.fields, name, type, script, currentDocumentSource, valueFormatter]);
+
+  const isLoadingPreviewPending =
+    Boolean(parentName) === false &&
+    allParamsDefined &&
+    hasSomeParamsChanged &&
+    scriptEditorValidation.isValidating === false &&
+    scriptEditorValidation.isValid;
+
+  const isLoadingPreview = isLoadingPreviewInFlight || isLoadingPreviewPending;
+  const isFetchingDocument = isFetchingDocumentInFlight || isCustomDocIdPending;
+
+  return {
+    fields,
+    error,
+    isPreviewAvailable,
+    isLoadingPreview,
+    isFetchingDocument,
+    isCustomDocIdPending,
+  };
+};

--- a/src/plugins/data_view_field_editor/public/components/preview/hooks/use_preview_execution.ts
+++ b/src/plugins/data_view_field_editor/public/components/preview/hooks/use_preview_execution.ts
@@ -1,0 +1,287 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useCallback } from 'react';
+import { i18n } from '@kbn/i18n';
+import type { BehaviorSubject } from 'rxjs';
+
+import { parseEsError } from '../../../lib/runtime_field_validation';
+import type { DataView } from '../../../shared_imports';
+import type { ApiService } from '../../../lib/api';
+import type { EsDocument, FieldPreview, Params, PainlessExecuteContext } from '../types';
+import { defaultValueFormatter, valueTypeToSelectedType } from '../utils/formatters';
+import type { PreviewAction } from '../reducers';
+
+const getExecuteContext = (args: {
+  parentName: Params['parentName'];
+  type: Params['type'];
+}): PainlessExecuteContext | 'composite_field' => {
+  if (args.parentName) {
+    return 'composite_field';
+  }
+
+  return `${args.type!}_field` as PainlessExecuteContext;
+};
+
+const shouldDeferPreviewWhileValidating = (args: {
+  parentName: Params['parentName'];
+  scriptEditorValidation: ScriptEditorValidationState;
+}): boolean => {
+  // don't prevent rendering if we're working with a composite subfield (has parentName)
+  return !args.parentName && args.scriptEditorValidation.isValidating;
+};
+
+const shouldSkipPreviewRequest = (args: {
+  parentName: Params['parentName'];
+  allParamsDefined: boolean;
+  hasSomeParamsChanged: boolean;
+  scriptEditorValidation: ScriptEditorValidationState;
+}): boolean => {
+  // Only gate requests for non-composite subfields. Composite subfields depend on the parent script.
+  if (args.parentName) {
+    return false;
+  }
+
+  return (
+    !args.allParamsDefined ||
+    !args.hasSomeParamsChanged ||
+    args.scriptEditorValidation.isValid === false
+  );
+};
+
+interface ToastsLike {
+  addError: (error: Error, options: { title: string }) => unknown;
+}
+
+interface ScriptEditorValidationState {
+  isValidating: boolean;
+  isValid: boolean;
+  message: string | null;
+}
+
+interface Args {
+  name: string | null;
+  type: Params['type'];
+  script: Params['script'];
+  parentName: Params['parentName'];
+
+  dataView: DataView;
+  getFieldPreview: ApiService['getFieldPreview'];
+  toasts: ToastsLike;
+
+  currentDocIndex?: string;
+  currentDocId?: string;
+  currentDocument?: EsDocument;
+
+  allParamsDefined: boolean;
+  hasSomeParamsChanged: boolean;
+  scriptEditorValidation: ScriptEditorValidationState;
+
+  fieldName$: BehaviorSubject<string>;
+  fieldPreview$: BehaviorSubject<FieldPreview[] | undefined>;
+
+  valueFormatter: (value: unknown) => string;
+  previewDispatch: React.Dispatch<PreviewAction>;
+  previewCount: React.MutableRefObject<number>;
+  lastExecutePainlessRequestParams: React.MutableRefObject<{
+    type: Params['type'];
+    script: string | undefined;
+    documentId: string | undefined;
+  }>;
+}
+
+export const usePreviewExecution = ({
+  name,
+  type,
+  script,
+  parentName,
+  dataView,
+  getFieldPreview,
+  toasts,
+  currentDocIndex,
+  currentDocId,
+  currentDocument,
+  allParamsDefined,
+  hasSomeParamsChanged,
+  scriptEditorValidation,
+  fieldName$,
+  fieldPreview$,
+  valueFormatter,
+  previewDispatch,
+  previewCount,
+  lastExecutePainlessRequestParams,
+}: Args) => {
+  const setLoadingInFlight = useCallback(
+    (next: boolean) => {
+      previewDispatch({ type: 'SET_LOADING_IN_FLIGHT', isLoadingPreviewInFlight: next });
+    },
+    [previewDispatch]
+  );
+
+  const updateSingleFieldPreview = useCallback(
+    (fieldName: string, values: unknown[]) => {
+      const [value] = values;
+      const formattedValue = valueFormatter(value);
+
+      previewDispatch({
+        type: 'SET_PREVIEW_RESPONSE',
+        previewResponse: {
+          fields: [{ key: fieldName, value, formattedValue }],
+          error: null,
+        },
+      });
+    },
+    [valueFormatter, previewDispatch]
+  );
+
+  const updateCompositeFieldPreview = useCallback(
+    (compositeValues: Record<string, unknown[]>) => {
+      const basePrefix = parentName ? `${parentName}.` : `${fieldName$.getValue() ?? ''}.`;
+      const expectedSubfieldKey = parentName ? name : null;
+
+      const fields = Object.entries(compositeValues)
+        .map<FieldPreview>(([key, values]) => {
+          // The Painless _execute API returns the composite field values under a map.
+          // Each of the key is prefixed with "composite_field." (e.g. "composite_field.field1: ['value']")
+          const { 1: fieldName } = key.split('composite_field.');
+
+          const [value] = values;
+          const formattedValue = valueFormatter(value);
+
+          return {
+            key: `${basePrefix}${fieldName}`,
+            value,
+            formattedValue,
+            type: valueTypeToSelectedType(value),
+          };
+        })
+        .filter((field) => (expectedSubfieldKey ? field.key === expectedSubfieldKey : true))
+        // ...and sort alphabetically
+        .sort((a, b) => a.key.localeCompare(b.key));
+
+      fieldPreview$.next(fields);
+      previewDispatch({
+        type: 'SET_PREVIEW_RESPONSE',
+        previewResponse: { fields, error: null },
+      });
+    },
+    [valueFormatter, parentName, name, fieldPreview$, fieldName$, previewDispatch]
+  );
+
+  const updatePreview = useCallback(async () => {
+    if (shouldDeferPreviewWhileValidating({ parentName, scriptEditorValidation })) {
+      return;
+    }
+
+    if (
+      shouldSkipPreviewRequest({
+        parentName,
+        allParamsDefined,
+        hasSomeParamsChanged,
+        scriptEditorValidation,
+      })
+    ) {
+      setLoadingInFlight(false);
+      return;
+    }
+
+    if (!currentDocIndex || !currentDocId || !currentDocument?._source || !script) {
+      setLoadingInFlight(false);
+      return;
+    }
+
+    lastExecutePainlessRequestParams.current = {
+      type,
+      script: script.source,
+      documentId: currentDocId,
+    };
+
+    const currentApiCall = ++previewCount.current;
+
+    const previewScript = (parentName && dataView.getRuntimeField(parentName)?.script) || script;
+
+    setLoadingInFlight(true);
+
+    const response = await getFieldPreview({
+      index: currentDocIndex,
+      document: currentDocument._source,
+      context: getExecuteContext({ parentName, type }) as PainlessExecuteContext,
+      script: previewScript,
+    });
+
+    if (currentApiCall !== previewCount.current) {
+      // Discard this response as there is another one inflight
+      // or we have called reset() and no longer need the response.
+      return;
+    }
+
+    const { error: serverError } = response;
+
+    if (serverError) {
+      // Server error (not an ES error)
+      const title = i18n.translate('indexPatternFieldEditor.fieldPreview.errorTitle', {
+        defaultMessage: 'Failed to load field preview',
+      });
+      toasts.addError(serverError, { title });
+
+      setLoadingInFlight(false);
+      return;
+    }
+
+    if (response.data) {
+      const { values, error } = response.data;
+
+      if (error) {
+        previewDispatch({
+          type: 'SET_PREVIEW_RESPONSE',
+          previewResponse: {
+            fields: [
+              {
+                key: name ?? '',
+                value: '',
+                formattedValue: defaultValueFormatter(''),
+              },
+            ],
+            error: { code: 'PAINLESS_SCRIPT_ERROR', error: parseEsError(error) },
+          },
+        });
+      } else {
+        if (!Array.isArray(values)) {
+          updateCompositeFieldPreview(values);
+        } else {
+          updateSingleFieldPreview(name!, values);
+        }
+      }
+    }
+
+    previewDispatch({ type: 'SET_INITIAL_PREVIEW_COMPLETE', initialPreviewComplete: true });
+    setLoadingInFlight(false);
+  }, [
+    parentName,
+    scriptEditorValidation,
+    allParamsDefined,
+    hasSomeParamsChanged,
+    currentDocIndex,
+    currentDocId,
+    currentDocument?._source,
+    script,
+    lastExecutePainlessRequestParams,
+    type,
+    previewCount,
+    dataView,
+    setLoadingInFlight,
+    getFieldPreview,
+    previewDispatch,
+    toasts,
+    name,
+    updateCompositeFieldPreview,
+    updateSingleFieldPreview,
+  ]);
+
+  return { updatePreview };
+};

--- a/src/plugins/data_view_field_editor/public/components/preview/hooks/use_preview_side_effects.ts
+++ b/src/plugins/data_view_field_editor/public/components/preview/hooks/use_preview_side_effects.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useCallback, useEffect } from 'react';
+import useDebounce from 'react-use/lib/useDebounce';
+
+export const DEFAULT_PREVIEW_DEBOUNCE_MS = 500;
+
+export interface PreviewSideEffectsArgs {
+  isPanelVisible: boolean;
+  refetchKey?: unknown;
+  fetchSampleDocuments: () => void | Promise<void>;
+
+  updatePreview: () => void | Promise<void>;
+
+  customDocIdToLoad: string | null;
+  loadDocument: (id: string) => void | Promise<void>;
+
+  debounceMs?: number;
+}
+
+export const usePreviewSideEffects = ({
+  isPanelVisible,
+  refetchKey,
+  fetchSampleDocuments,
+  updatePreview,
+  customDocIdToLoad,
+  loadDocument,
+  debounceMs = DEFAULT_PREVIEW_DEBOUNCE_MS,
+}: PreviewSideEffectsArgs) => {
+  // Fetch sample documents when the panel is visible (and when the refetch key changes).
+  useEffect(() => {
+    if (isPanelVisible) {
+      fetchSampleDocuments();
+    }
+  }, [isPanelVisible, fetchSampleDocuments, refetchKey]);
+
+  // Debounced preview update.
+  const runUpdatePreview = useCallback(() => {
+    void updatePreview();
+  }, [updatePreview]);
+  useDebounce(runUpdatePreview, debounceMs, [runUpdatePreview]);
+
+  // Debounced document loading by ID.
+  const runLoadDocument = useCallback(() => {
+    const docId = customDocIdToLoad?.trim();
+    if (!docId) {
+      return;
+    }
+    void loadDocument(docId);
+  }, [customDocIdToLoad, loadDocument]);
+  useDebounce(runLoadDocument, debounceMs, [runLoadDocument]);
+};

--- a/src/plugins/data_view_field_editor/public/components/preview/reducers/documents_reducer.ts
+++ b/src/plugins/data_view_field_editor/public/components/preview/reducers/documents_reducer.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { ClusterData, EsDocument, FetchDocError } from '../types';
+
+export interface DocumentsState {
+  clusterData: ClusterData;
+  fetchDocError: FetchDocError | null;
+  isFetchingDocumentInFlight: boolean;
+}
+
+export type DocumentsAction =
+  | { type: 'FETCH_SAMPLE_START' }
+  | { type: 'FETCH_SAMPLE_FINISH'; error: FetchDocError | null; documents?: EsDocument[] }
+  | { type: 'LOAD_DOC_START' }
+  | { type: 'LOAD_DOC_FINISH'; error: FetchDocError | null; documents?: EsDocument[] }
+  | { type: 'NAV_NEXT' }
+  | { type: 'NAV_PREV' }
+  | { type: 'RESET_DOCUMENTS' };
+
+export const initialDocumentsState: DocumentsState = {
+  clusterData: { documents: [], currentIdx: 0 },
+  fetchDocError: null,
+  isFetchingDocumentInFlight: false,
+};
+
+export const documentsReducer = (
+  state: DocumentsState,
+  action: DocumentsAction
+): DocumentsState => {
+  switch (action.type) {
+    case 'FETCH_SAMPLE_START':
+      return { ...state, isFetchingDocumentInFlight: true };
+    case 'FETCH_SAMPLE_FINISH': {
+      const next: DocumentsState = {
+        ...state,
+        isFetchingDocumentInFlight: false,
+        fetchDocError: action.error,
+      };
+      if (action.error === null && action.documents) {
+        next.clusterData = { documents: action.documents, currentIdx: 0 };
+      }
+      return next;
+    }
+    case 'LOAD_DOC_START':
+      return { ...state, isFetchingDocumentInFlight: true };
+    case 'LOAD_DOC_FINISH': {
+      const next: DocumentsState = {
+        ...state,
+        isFetchingDocumentInFlight: false,
+        fetchDocError: action.error,
+      };
+      if (action.error === null && action.documents) {
+        next.clusterData = { documents: action.documents, currentIdx: 0 };
+      }
+      return next;
+    }
+    case 'NAV_NEXT': {
+      const totalDocs = state.clusterData.documents.length;
+      if (totalDocs === 0) {
+        return state;
+      }
+      const currentIdx =
+        state.clusterData.currentIdx >= totalDocs - 1 ? 0 : state.clusterData.currentIdx + 1;
+      return { ...state, clusterData: { ...state.clusterData, currentIdx } };
+    }
+    case 'NAV_PREV': {
+      const totalDocs = state.clusterData.documents.length;
+      if (totalDocs === 0) {
+        return state;
+      }
+      const currentIdx =
+        state.clusterData.currentIdx === 0 ? totalDocs - 1 : state.clusterData.currentIdx - 1;
+      return { ...state, clusterData: { ...state.clusterData, currentIdx } };
+    }
+    case 'RESET_DOCUMENTS':
+      return {
+        ...state,
+        clusterData: { documents: [], currentIdx: 0 },
+        isFetchingDocumentInFlight: false,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/plugins/data_view_field_editor/public/components/preview/reducers/index.ts
+++ b/src/plugins/data_view_field_editor/public/components/preview/reducers/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export type { DocumentsAction, DocumentsState } from './documents_reducer';
+export { documentsReducer, initialDocumentsState } from './documents_reducer';
+
+export type { PreviewAction, PreviewState } from './preview_reducer';
+export { previewReducer, initialPreviewState } from './preview_reducer';

--- a/src/plugins/data_view_field_editor/public/components/preview/reducers/preview_reducer.ts
+++ b/src/plugins/data_view_field_editor/public/components/preview/reducers/preview_reducer.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Context } from '../types';
+
+export interface PreviewState {
+  previewResponse: { fields: Context['fields']; error: Context['error'] };
+  isLoadingPreviewInFlight: boolean;
+  initialPreviewComplete: boolean;
+}
+
+export type PreviewAction =
+  | { type: 'SET_LOADING_IN_FLIGHT'; isLoadingPreviewInFlight: boolean }
+  | { type: 'SET_PREVIEW_RESPONSE'; previewResponse: PreviewState['previewResponse'] }
+  | { type: 'SET_INITIAL_PREVIEW_COMPLETE'; initialPreviewComplete: boolean }
+  | { type: 'RESET_PREVIEW_RESPONSE' };
+
+export const initialPreviewState: PreviewState = {
+  previewResponse: { fields: [], error: null },
+  isLoadingPreviewInFlight: false,
+  initialPreviewComplete: false,
+};
+
+export const previewReducer = (state: PreviewState, action: PreviewAction): PreviewState => {
+  switch (action.type) {
+    case 'SET_LOADING_IN_FLIGHT':
+      return { ...state, isLoadingPreviewInFlight: action.isLoadingPreviewInFlight };
+    case 'SET_PREVIEW_RESPONSE':
+      return { ...state, previewResponse: action.previewResponse };
+    case 'SET_INITIAL_PREVIEW_COMPLETE':
+      return { ...state, initialPreviewComplete: action.initialPreviewComplete };
+    case 'RESET_PREVIEW_RESPONSE':
+      return {
+        ...state,
+        previewResponse: { fields: [], error: null },
+        isLoadingPreviewInFlight: false,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/plugins/data_view_field_editor/public/components/preview/types.ts
+++ b/src/plugins/data_view_field_editor/public/components/preview/types.ts
@@ -30,7 +30,7 @@ export interface EsDocument {
 export type ScriptErrorCodes = 'PAINLESS_SCRIPT_ERROR' | 'PAINLESS_SYNTAX_ERROR';
 export type FetchDocErrorCodes = 'DOC_NOT_FOUND' | 'ERR_FETCHING_DOC';
 
-interface PreviewError {
+export interface PreviewError {
   code: ScriptErrorCodes;
   error:
     | RuntimeFieldPainlessError
@@ -57,11 +57,9 @@ export interface ClusterData {
 // The parameters required to preview the field
 export interface Params {
   name: string | null;
-  index: string | null;
   type: RuntimeType | null;
   script: Required<RuntimeField>['script'] | null;
   format: SerializedFieldFormat | null;
-  document: { [key: string]: unknown } | null;
   // used for composite subfields
   parentName: string | null;
 }

--- a/src/plugins/data_view_field_editor/public/components/preview/utils/formatters.tsx
+++ b/src/plugins/data_view_field_editor/public/components/preview/utils/formatters.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import type { RuntimePrimitiveTypes } from '../../../shared_imports';
+
+export const defaultValueFormatter = (value: unknown) => {
+  const content = typeof value === 'object' ? JSON.stringify(value) : String(value) ?? '-';
+  return renderToString(<>{content}</>);
+};
+
+export const valueTypeToSelectedType = (value: unknown): RuntimePrimitiveTypes => {
+  const valueType = typeof value;
+  if (valueType === 'string') return 'keyword';
+  if (valueType === 'number') return 'double';
+  if (valueType === 'boolean') return 'boolean';
+  return 'keyword';
+};
+


### PR DESCRIPTION
- Create new hooks for handling documents actions, derived state, preview execution, and side effects
- Refactor `field_preview_context.tsx` to use new hooks and reducers
- Introduce reducers for managing documents and preview states
- Update types and utils related to field preview
- Remove redundant code and improve readability



