### PR TITLE
[MCP connector] add shared cache for tool listing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2747,6 +2747,12 @@ x-pack/solutions/security/test/security_solution_api_integration/test_suites/inv
 /x-pack/platform/plugins/shared/stack_connectors/common/gemini @elastic/security-generative-ai
 /src/platform/packages/shared/kbn-connector-schemas/gemini @elastic/security-generative-ai
 
+# MCP
+/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/mcp @elastic/workchat-eng
+/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp @elastic/workchat-eng
+/x-pack/platform/plugins/shared/stack_connectors/common/mcp @elastic/workchat-eng
+/src/platform/packages/shared/kbn-connector-schemas/mcp @elastic/workchat-eng
+
 # Inference API
 /x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/obs-ai-team
 /x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference @elastic/appex-ai-infra @elastic/security-generative-ai @elastic/obs-ai-team

--- a/x-pack/platform/packages/shared/kbn-mcp-client/mcp/src/client.test.ts
+++ b/x-pack/platform/packages/shared/kbn-mcp-client/mcp/src/client.test.ts
@@ -218,10 +218,10 @@ describe('McpClient', () => {
       });
       const connectStatus = await client.isConnected();
       expect(connectStatus).toEqual(true);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'Attempting to connect to MCP server test-client, 1.0.0'
       );
-      expect(mockLogger.info).toHaveBeenCalledWith('Connected to MCP server test-client, 1.0.0');
+      expect(mockLogger.debug).toHaveBeenCalledWith('Connected to MCP server test-client, 1.0.0');
     });
 
     it('returns undefined capabilities when not available', async () => {
@@ -263,7 +263,7 @@ describe('McpClient', () => {
       // The SDK formats the message as "Streamable HTTP error: Connection failed"
       // Our client just passes through the message without adding a prefix
       await expect(client.connect()).rejects.toThrow('Streamable HTTP error: Connection failed');
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'Attempting to connect to MCP server test-client, 1.0.0'
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -277,7 +277,7 @@ describe('McpClient', () => {
       mockClient.connect.mockRejectedValue(error);
 
       await expect(client.connect()).rejects.toThrow('Unauthorized error: Unauthorized');
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'Attempting to connect to MCP server test-client, 1.0.0'
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -293,7 +293,7 @@ describe('McpClient', () => {
       await expect(client.connect()).rejects.toThrow(
         'Error connecting to MCP server: Generic error'
       );
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'Attempting to connect to MCP server test-client, 1.0.0'
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -337,10 +337,10 @@ describe('McpClient', () => {
 
       expect(mockClient.close).toHaveBeenCalled();
       expect(connectStatus).toEqual(false);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'Attempting to disconnect from MCP server test-client, 1.0.0'
       );
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'Disconnected from MCP client test-client, 1.0.0'
       );
     });
@@ -392,7 +392,7 @@ describe('McpClient', () => {
         description: 'Tool 2',
         inputSchema: {},
       });
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'Listing tools from MCP server test-client, 1.0.0'
       );
     });
@@ -538,7 +538,7 @@ describe('McpClient', () => {
         { type: 'text', text: 'Result 1' },
         { type: 'text', text: 'Result 2' },
       ]);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         'Calling tool test-tool on MCP server test-client, 1.0.0'
       );
     });

--- a/x-pack/platform/packages/shared/kbn-mcp-client/mcp/src/client.ts
+++ b/x-pack/platform/packages/shared/kbn-mcp-client/mcp/src/client.ts
@@ -82,12 +82,12 @@ export class McpClient {
    */
   async connect(): Promise<{ connected: boolean; capabilities?: ServerCapabilities }> {
     if (!this.connected) {
-      this.logger.info(`Attempting to connect to MCP server ${this.name}, ${this.version}`);
+      this.logger.debug(`Attempting to connect to MCP server ${this.name}, ${this.version}`);
       try {
         // connect() performs the initialization handshake with the MCP server as per MCP protocol
         await this.client.connect(this.transport);
         this.connected = true;
-        this.logger.info(`Connected to MCP server ${this.name}, ${this.version}`);
+        this.logger.debug(`Connected to MCP server ${this.name}, ${this.version}`);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         this.logger.error(
@@ -117,10 +117,10 @@ export class McpClient {
    */
   async disconnect(): Promise<void> {
     if (this.connected) {
-      this.logger.info(`Attempting to disconnect from MCP server ${this.name}, ${this.version}`);
+      this.logger.debug(`Attempting to disconnect from MCP server ${this.name}, ${this.version}`);
       await this.client.close();
       this.connected = false;
-      this.logger.info(`Disconnected from MCP client ${this.name}, ${this.version}`);
+      this.logger.debug(`Disconnected from MCP client ${this.name}, ${this.version}`);
     }
   }
 
@@ -132,7 +132,7 @@ export class McpClient {
       throw new Error(`MCP client not connected to ${this.name}, ${this.version}`);
     }
 
-    this.logger.info(`Listing tools from MCP server ${this.name}, ${this.version}`);
+    this.logger.debug(`Listing tools from MCP server ${this.name}, ${this.version}`);
     const getNextPage = async (cursor?: string): Promise<Tool[]> => {
       const response = await this.client.listTools({
         cursor,
@@ -174,7 +174,7 @@ export class McpClient {
       throw new Error(`MCP client not connected to ${this.name}, ${this.version}`);
     }
 
-    this.logger.info(`Calling tool ${params.name} on MCP server ${this.name}, ${this.version}`);
+    this.logger.debug(`Calling tool ${params.name} on MCP server ${this.name}, ${this.version}`);
     const response = await this.client.callTool({
       name: params.name,
       arguments: params.arguments,


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/search-team/issues/12228

Add a cache shared between all `MCP` connector instances to store results of the tool listing operations, to avoid calling the MCP servers every time something needs to know about the tool list or an individual tool's schema (which is happening very frequently in the higher layers of the AB's tool registry).

The solution is not perfect, as the cache isn't shared between different Kibana instances of the same deployment, but this is still a significant quick win compared to the current implementation.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->