### PR TITLE
[ES|QL] Update LIKE wildcard symbols from SQL to ES|QL style

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/complete_items.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/complete_items.ts
@@ -238,21 +238,21 @@ export const listCompleteItem: ISuggestionItem = withAutoSuggest({
 
 export const likePatternItems: ISuggestionItem[] = [
   {
-    label: '%',
-    text: '"${0:%}"',
+    label: '*',
+    text: '"${0:*}"',
     asSnippet: true,
     kind: 'Value',
-    detail: i18n.translate('kbn-esql-language.esql.autocomplete.likePercentDoc', {
+    detail: i18n.translate('kbn-esql-language.esql.autocomplete.likeAsteriskDoc', {
       defaultMessage: 'Matches any sequence of zero or more characters',
     }),
     sortText: '1',
   },
   {
-    label: '_',
-    text: '"${0:_}"',
+    label: '?',
+    text: '"${0:?}"',
     asSnippet: true,
     kind: 'Value',
-    detail: i18n.translate('kbn-esql-language.esql.autocomplete.likeUnderscoreDoc', {
+    detail: i18n.translate('kbn-esql-language.esql.autocomplete.likeQuestionMarkDoc', {
       defaultMessage: 'Matches any single character',
     }),
     sortText: '1',


### PR DESCRIPTION
## Summary

 Update LIKE wildcard symbols from SQL to ES|QL style



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->