### PR TITLE
[9.3] [ES|QL] Update LIKE wildcard symbols from SQL to ES|QL style (#247782)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/complete_items.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/complete_items.ts
@@ -238,21 +238,21 @@ export const listCompleteItem: ISuggestionItem = withAutoSuggest({
 
 export const likePatternItems: ISuggestionItem[] = [
   {
-    label: '%',
-    text: '"${0:%}"',
+    label: '*',
+    text: '"${0:*}"',
     asSnippet: true,
     kind: 'Value',
-    detail: i18n.translate('kbn-esql-ast.esql.autocomplete.likePercentDoc', {
+    detail: i18n.translate('kbn-esql-language.esql.autocomplete.likeAsteriskDoc', {
       defaultMessage: 'Matches any sequence of zero or more characters',
     }),
     sortText: '1',
   },
   {
-    label: '_',
-    text: '"${0:_}"',
+    label: '?',
+    text: '"${0:?}"',
     asSnippet: true,
     kind: 'Value',
-    detail: i18n.translate('kbn-esql-ast.esql.autocomplete.likeUnderscoreDoc', {
+    detail: i18n.translate('kbn-esql-language.esql.autocomplete.likeQuestionMarkDoc', {
       defaultMessage: 'Matches any single character',
     }),
     sortText: '1',

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/complete_items.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/complete_items.ts
@@ -242,7 +242,7 @@ export const likePatternItems: ISuggestionItem[] = [
     text: '"${0:*}"',
     asSnippet: true,
     kind: 'Value',
-    detail: i18n.translate('kbn-esql-language.esql.autocomplete.likeAsteriskDoc', {
+    detail: i18n.translate('kbn-esql-ast.esql.autocomplete.likeAsteriskDoc', {
       defaultMessage: 'Matches any sequence of zero or more characters',
     }),
     sortText: '1',
@@ -252,7 +252,7 @@ export const likePatternItems: ISuggestionItem[] = [
     text: '"${0:?}"',
     asSnippet: true,
     kind: 'Value',
-    detail: i18n.translate('kbn-esql-language.esql.autocomplete.likeQuestionMarkDoc', {
+    detail: i18n.translate('kbn-esql-ast.esql.autocomplete.likeQuestionMarkDoc', {
       defaultMessage: 'Matches any single character',
     }),
     sortText: '1',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[ES|QL] Update LIKE wildcard symbols from SQL to ES|QL style (#247782)](https://github.com/elastic/kibana/pull/247782)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Valerio","email":"79913332+bartoval@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-05T09:42:24Z","message":"[ES|QL] Update LIKE wildcard symbols from SQL to ES|QL style (#247782)\n\n## Summary\n\n Update LIKE wildcard symbols from SQL to ES|QL style","sha":"d3bed353a24d69605d7821d77b1e1ca31ec04e2a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:ES|QL","Team:ESQL","backport:version","v9.3.0","9.3 candidate","v9.4.0"],"title":"[ES|QL] Update LIKE wildcard symbols from SQL to ES|QL style","number":247782,"url":"https://github.com/elastic/kibana/pull/247782","mergeCommit":{"message":"[ES|QL] Update LIKE wildcard symbols from SQL to ES|QL style (#247782)\n\n## Summary\n\n Update LIKE wildcard symbols from SQL to ES|QL style","sha":"d3bed353a24d69605d7821d77b1e1ca31ec04e2a"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247782","number":247782,"mergeCommit":{"message":"[ES|QL] Update LIKE wildcard symbols from SQL to ES|QL style (#247782)\n\n## Summary\n\n Update LIKE wildcard symbols from SQL to ES|QL style","sha":"d3bed353a24d69605d7821d77b1e1ca31ec04e2a"}}]}] BACKPORT-->