### PR TITLE
[Discover][Traces] Prevent nested button in full traces in discover

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_item_row.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/trace_item_row.tsx
@@ -163,6 +163,7 @@ export function TraceItemRow({ item, childrenCount, state, onToggle }: Props) {
     <>
       <EuiAccordion
         id={item.id}
+        buttonElement="div"
         buttonContent={content}
         paddingSize="none"
         forceState={state}


### PR DESCRIPTION
Closes #247514

## Summary

Fixes the React DOM nesting warning `validateDOMNesting(...): <button> cannot appear as a descendant of <button>` that appears in the Trace Waterfall component.

## Problem

`EuiAccordion` renders a `<button>` element by default. Inside the `buttonContent`, interactive `EuiBadge` components (for related errors and span links) also render as `<button>` elements, causing invalid HTML nesting.

## Solution

Added `buttonElement="div"` to `EuiAccordion`, as we can see in the [EUI Documentation](https://eui.elastic.co/docs/components/containers/accordion/#interactive-content-in-the-trigger)

This follows an established pattern already used in other Kibana components (e.g., `infra/section.tsx`, `search_indices/quick_stat.tsx`).

## How to test

1. Go to Discover
2. Look for a span with traces
3. Open the document
4. Open Dev tools → console
5. Click on "Fulltrace expand"
6. Verify no `validateDOMNesting` warnings appear

## Demo


https://github.com/user-attachments/assets/c27537cf-5722-4b25-88b7-7910e023a00c



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



