### PR TITLE
test(search_notebooks): remove skipped unit test

### DIFF
--- a/x-pack/solutions/search/plugins/search_notebooks/server/lib/notebook_catalog.test.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/server/lib/notebook_catalog.test.ts
@@ -68,18 +68,6 @@ describe('Notebook Catalog', () => {
       it('returns default notebooks when theres an empty catalog config', async () => {
         await expect(getNotebookCatalog(staticOptions)).resolves.toMatchObject(DEFAULT_NOTEBOOKS);
       });
-      it.skip('returns requested list of notebooks when it exists', async () => {
-        // Re-enable this with actual list when we implement them
-        await expect(
-          getNotebookCatalog({ ...staticOptions, notebookList: 'ml' })
-        ).resolves.toMatchObject({
-          notebooks: [
-            NOTEBOOKS_MAP['03_elser'],
-            NOTEBOOKS_MAP['02_hybrid_search'],
-            NOTEBOOKS_MAP['04_multilingual'],
-          ],
-        });
-      });
       it('returns default list if requested list doesnt exist', async () => {
         await expect(
           getNotebookCatalog({ ...staticOptions, notebookList: 'foo' })


### PR DESCRIPTION
## Summary

Removing skipped test for functionality that was never added. This test was skipped until we added lists to the notebook catalog, but that work was never picked up. This skip was more of a todo, but it's making our skipped test report noisy since it's not an actual issue.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->