### PR TITLE
[Alerts page] [Add to Case] Use Scout instead of FTR for Alerts page

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/constants.ts
@@ -9,6 +9,27 @@ export const BIGGER_TIMEOUT = 20000 as const;
 export const SHORTER_TIMEOUT = 5000 as const;
 
 /**
+ * Constants for data-test-subj values used in alerts page tests
+ */
+export const ALERTS_PAGE_TEST_SUBJECTS = {
+  // Alerts Table
+  ALERTS_TABLE_LOADING: 'internalAlertsPageLoading',
+  ALERTS_TABLE_LOADED: 'alertsTableIsLoaded',
+  ALERTS_TABLE_EMPTY_STATE: 'alertsTableEmptyState',
+  ALERTS_TABLE_ROW_ACTION_MORE: 'alertsTableRowActionMore',
+  ALERTS_TABLE_ACTIONS_MENU: 'alertsTableActionsMenu',
+
+  // Case Actions
+  ADD_TO_NEW_CASE_ACTION: 'add-to-new-case-action',
+  ADD_TO_EXISTING_CASE_ACTION: 'add-to-existing-case-action',
+  CREATE_CASE_FLYOUT: 'create-case-flyout',
+  CREATE_CASE_MODAL: 'create-case-modal',
+  CREATE_CASE_CANCEL: 'create-case-cancel',
+  ALL_CASES_MODAL: 'all-cases-modal',
+  ALL_CASES_MODAL_CANCEL: 'all-cases-modal-cancel-button',
+} as const;
+
+/**
  * Constants for data-test-subj values used in rules settings flyout tests
  */
 export const RULES_SETTINGS_TEST_SUBJECTS = {
@@ -74,3 +95,7 @@ export const CUSTOM_THRESHOLD_RULE_TEST_SUBJECTS = {
   RULE_SAVE_BUTTON: 'rulePageFooterSaveButton',
   CONFIRM_MODAL_BUTTON: 'confirmModalConfirmButton',
 } as const;
+
+export const GENERATED_METRICS = {
+  metricName: 'system.diskio.write.bytes',
+};

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/generators.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/generators.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 import type { ApiServicesFixture, KbnClient } from '@kbn/scout-oblt';
-import type { ApmFields, LogDocument } from '@kbn/synthtrace-client';
+import type { ApmFields, InfraDocument, LogDocument } from '@kbn/synthtrace-client';
 import type { SynthtraceEsClient } from '@kbn/synthtrace/src/lib/shared/base_client';
-import { apm, log, timerange } from '@kbn/synthtrace-client';
+import { apm, infra, log, timerange } from '@kbn/synthtrace-client';
 import { AxiosError } from 'axios';
 
 export const TEST_START_DATE = '2024-01-01T00:00:00.000Z';
@@ -77,6 +77,55 @@ export async function generateApmData({
         .duration(100)
         .success()
     );
+
+  await client.index(generator);
+}
+
+/**
+ * Generate synthetic metrics data for testing
+ */
+export async function generateMetricsData({
+  from,
+  to,
+  client,
+  metricName = 'system.diskio.write.bytes',
+  hostName = 'test-host',
+}: {
+  from: number;
+  to: number;
+  client: Pick<SynthtraceEsClient<InfraDocument>, 'index'>;
+  metricName?: string;
+  hostName?: string;
+  cpuValue?: number;
+  memoryUsedPct?: number;
+}): Promise<void> {
+  const range = timerange(from, to);
+
+  const THRESHOLD = 48 * 1024 * 1024; // 48MB
+  const distributionPattern = [
+    THRESHOLD - 1_000_000, // < 48M (47M approx)
+    THRESHOLD - 500_000, // < 48M (47.5M approx)
+    THRESHOLD + 1_000_000, // > 48M (49M approx)
+  ];
+
+  let index = 0;
+
+  const generator = range
+    .interval('30s')
+    .rate(1)
+    .generator((timestamp) => {
+      const writeBytes = distributionPattern[index % distributionPattern.length];
+      index++;
+
+      return [
+        infra
+          .host(hostName)
+          .diskio({
+            [metricName]: writeBytes,
+          })
+          .timestamp(timestamp),
+      ];
+    });
 
   await client.index(generator);
 }

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/index.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/index.ts
@@ -30,4 +30,4 @@ export const test = baseTest.extend<TriggersActionsTestFixtures, ScoutWorkerFixt
   },
 });
 
-export { RULES_SETTINGS_TEST_SUBJECTS } from './constants';
+export { RULES_SETTINGS_TEST_SUBJECTS, ALERTS_PAGE_TEST_SUBJECTS } from './constants';

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/alerts_page.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/alerts_page.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { ScoutPage } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt';
+import { ALERTS_PAGE_TEST_SUBJECTS, BIGGER_TIMEOUT, SHORTER_TIMEOUT } from '../constants';
+
+export class AlertsPage {
+  constructor(private readonly page: ScoutPage) {}
+
+  async goto(rangeFrom?: string, rangeTo?: string) {
+    const params =
+      rangeFrom && rangeTo ? `?_a=(rangeFrom:'${rangeFrom}',rangeTo:'${rangeTo}')` : '';
+    await this.page.gotoApp(`observability/alerts${params}`);
+  }
+
+  async waitForTableToLoad() {
+    // Wait for loading to disappear
+    await this.page.testSubj
+      .locator(ALERTS_PAGE_TEST_SUBJECTS.ALERTS_TABLE_LOADING)
+      .waitFor({ state: 'hidden', timeout: BIGGER_TIMEOUT })
+      .catch(() => {
+        // Ignore if it doesn't exist or disappears quickly
+      });
+
+    // Wait for either table with data or empty state using race condition
+    await Promise.race([
+      this.page.testSubj.waitForSelector(ALERTS_PAGE_TEST_SUBJECTS.ALERTS_TABLE_LOADED, {
+        state: 'visible',
+        timeout: BIGGER_TIMEOUT,
+      }),
+      this.page.testSubj.waitForSelector(ALERTS_PAGE_TEST_SUBJECTS.ALERTS_TABLE_EMPTY_STATE, {
+        state: 'visible',
+        timeout: BIGGER_TIMEOUT,
+      }),
+    ]);
+  }
+
+  async waitForAlertRows(expectedCount: number = 1) {
+    const locator = this.page.testSubj.locator(
+      ALERTS_PAGE_TEST_SUBJECTS.ALERTS_TABLE_ROW_ACTION_MORE
+    );
+    await expect(locator).toHaveCount(expectedCount, { timeout: BIGGER_TIMEOUT });
+  }
+
+  async openActionsMenuForRow(rowIndex: number) {
+    const actionsButtons = await this.page.testSubj
+      .locator(ALERTS_PAGE_TEST_SUBJECTS.ALERTS_TABLE_ROW_ACTION_MORE)
+      .all();
+
+    if (rowIndex >= actionsButtons.length) {
+      throw new Error(
+        `Row index ${rowIndex} out of bounds. Only ${actionsButtons.length} rows found.`
+      );
+    }
+
+    await actionsButtons[rowIndex].click();
+    await expect(
+      this.page.testSubj.locator(ALERTS_PAGE_TEST_SUBJECTS.ALERTS_TABLE_ACTIONS_MENU)
+    ).toBeVisible();
+  }
+
+  async isAddToNewCaseActionVisible() {
+    return this.page.testSubj.locator(ALERTS_PAGE_TEST_SUBJECTS.ADD_TO_NEW_CASE_ACTION).isVisible();
+  }
+
+  async isAddToExistingCaseActionVisible() {
+    return this.page.testSubj
+      .locator(ALERTS_PAGE_TEST_SUBJECTS.ADD_TO_EXISTING_CASE_ACTION)
+      .isVisible();
+  }
+
+  async isCreateCaseFlyoutVisible() {
+    // Check for either flyout or modal version (different deployments use different components)
+    const flyout = this.page.testSubj.locator(ALERTS_PAGE_TEST_SUBJECTS.CREATE_CASE_FLYOUT);
+    const modal = this.page.testSubj.locator(ALERTS_PAGE_TEST_SUBJECTS.CREATE_CASE_MODAL);
+
+    const isFlyoutVisible = await flyout.isVisible().catch(() => false);
+    const isModalVisible = await modal.isVisible().catch(() => false);
+
+    return isFlyoutVisible || isModalVisible;
+  }
+
+  async isAddToExistingCaseModalVisible() {
+    const modal = this.page.testSubj.locator(ALERTS_PAGE_TEST_SUBJECTS.ALL_CASES_MODAL);
+    try {
+      await modal.waitFor({ state: 'visible', timeout: SHORTER_TIMEOUT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async clickAddToNewCase() {
+    await this.page.testSubj.locator(ALERTS_PAGE_TEST_SUBJECTS.ADD_TO_NEW_CASE_ACTION).click();
+  }
+
+  async clickAddToExistingCase() {
+    await this.page.testSubj.locator(ALERTS_PAGE_TEST_SUBJECTS.ADD_TO_EXISTING_CASE_ACTION).click();
+  }
+
+  async closeFlyout() {
+    // Try to close either flyout or modal
+    const flyoutCloseButton = this.page.testSubj.locator('euiFlyoutCloseButton');
+    const createCaseModal = this.page.testSubj.locator(ALERTS_PAGE_TEST_SUBJECTS.CREATE_CASE_MODAL);
+    const createCaseCancelButton = this.page.testSubj.locator(
+      ALERTS_PAGE_TEST_SUBJECTS.CREATE_CASE_CANCEL
+    );
+
+    const isFlyout = await flyoutCloseButton.isVisible().catch(() => false);
+    const isModal = await createCaseModal.isVisible().catch(() => false);
+
+    if (isFlyout) {
+      await flyoutCloseButton.click();
+      await expect(flyoutCloseButton).toBeHidden();
+    } else if (isModal) {
+      // Cancel button works for both modal and flyout
+      await createCaseCancelButton.click();
+      await expect(createCaseModal).toBeHidden();
+    }
+  }
+}

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/index.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/page_objects/index.ts
@@ -8,9 +8,11 @@
 import type { ObltPageObjects, ScoutPage } from '@kbn/scout-oblt';
 import { createLazyPageObject } from '@kbn/scout-oblt';
 import { RulesPage } from './rules_page';
+import { AlertsPage } from './alerts_page';
 
 export interface TriggersActionsPageObjects extends ObltPageObjects {
   rulesPage: RulesPage;
+  alertsPage: AlertsPage;
 }
 
 export function extendPageObjects(
@@ -20,5 +22,6 @@ export function extendPageObjects(
   return {
     ...pageObjects,
     rulesPage: createLazyPageObject(RulesPage, page),
+    alertsPage: createLazyPageObject(AlertsPage, page),
   };
 }

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/alerts/add_to_case.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/alerts/add_to_case.spec.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRole } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt';
+import { test } from '../../fixtures';
+import { GENERATED_METRICS } from '../../fixtures/constants';
+
+// Use current time for alert querying
+const now = Date.now();
+const DATE_WITH_DATA = {
+  rangeFrom: new Date(now - 5 * 60 * 1000).toISOString(), // 5 minutes ago
+  rangeTo: new Date(now + 5 * 60 * 1000).toISOString(), // 5 minutes in the future
+};
+
+/**
+ * Defines a custom role for observability with specified case privileges
+ */
+const defineObservabilityRoleWithCasePrivileges = (casePrivileges: string[]): KibanaRole => {
+  return {
+    elasticsearch: {
+      cluster: ['all'],
+      indices: [
+        { names: ['filebeat-*', 'logs-*', 'metrics-*'], privileges: ['all'] },
+        { names: ['.alerts-observability*'], privileges: ['read', 'view_index_metadata'] },
+      ],
+    },
+    kibana: [
+      {
+        spaces: ['*'],
+        base: [],
+        feature: {
+          observabilityCasesV3: casePrivileges,
+          logs: ['all'],
+        },
+      },
+    ],
+  };
+};
+
+test.describe('Observability alerts - Add to case', { tag: ['@ess', '@svlOblt'] }, () => {
+  let ruleId: string;
+
+  const alertName = `Write bytes test rule ${Date.now()}`;
+
+  test.beforeAll(async ({ apiServices }) => {
+    const createdRule = (await apiServices.alerting.rules.create({
+      tags: [],
+      params: {
+        criteria: [
+          {
+            comparator: '>',
+            metrics: [
+              {
+                name: 'A',
+                field: GENERATED_METRICS.metricName,
+                aggType: 'max',
+              },
+            ],
+            threshold: [100],
+            timeSize: 1,
+            timeUnit: 'd',
+          },
+        ],
+        alertOnNoData: false,
+        alertOnGroupDisappear: false,
+        searchConfiguration: {
+          query: {
+            query: '',
+            language: 'kuery',
+          },
+          index: 'metrics-*',
+        },
+      },
+      schedule: {
+        interval: '1m',
+      },
+      consumer: 'alerts',
+      name: alertName,
+      ruleTypeId: 'observability.rules.custom_threshold',
+      actions: [],
+    })) as { data: { id: string } };
+    ruleId = createdRule.data.id;
+  });
+
+  test.afterEach(async ({ apiServices, log }) => {
+    // Clean up any cases created during tests
+    log.info('Cleaning up test cases...');
+    try {
+      await apiServices.cases.cleanup.deleteAllCases();
+    } catch (error) {
+      log.error(`Failed to cleanup cases: ${error}`);
+    }
+  });
+
+  test.afterAll(async ({ apiServices, log }) => {
+    // Clean up the created rule
+    if (ruleId) {
+      log.info(`Cleaning up rule ${ruleId}...`);
+      try {
+        await apiServices.alerting.rules.delete(ruleId);
+      } catch (error) {
+        log.error(`Failed to delete rule: ${error}`);
+      }
+    }
+  });
+
+  test('renders case options when user has all privileges', async ({
+    browserAuth,
+    pageObjects,
+  }) => {
+    const roleWithAllPrivileges = defineObservabilityRoleWithCasePrivileges(['all']);
+    await browserAuth.loginWithCustomRole(roleWithAllPrivileges);
+    await pageObjects.alertsPage.goto(DATE_WITH_DATA.rangeFrom, DATE_WITH_DATA.rangeTo);
+    await pageObjects.alertsPage.waitForTableToLoad();
+    await pageObjects.alertsPage.waitForAlertRows(1);
+
+    await pageObjects.alertsPage.openActionsMenuForRow(0);
+
+    expect(await pageObjects.alertsPage.isAddToExistingCaseActionVisible()).toBe(true);
+    expect(await pageObjects.alertsPage.isAddToNewCaseActionVisible()).toBe(true);
+  });
+
+  test('opens flyout when "Add to new case" is clicked', async ({ browserAuth, pageObjects }) => {
+    await expect(async () => {
+      const roleWithAllPrivileges = defineObservabilityRoleWithCasePrivileges(['all']);
+      await browserAuth.loginWithCustomRole(roleWithAllPrivileges);
+      await pageObjects.alertsPage.goto(DATE_WITH_DATA.rangeFrom, DATE_WITH_DATA.rangeTo);
+      await pageObjects.alertsPage.waitForTableToLoad();
+      await pageObjects.alertsPage.waitForAlertRows(1);
+
+      await pageObjects.alertsPage.openActionsMenuForRow(0);
+      await pageObjects.alertsPage.clickAddToNewCase();
+
+      expect(await pageObjects.alertsPage.isCreateCaseFlyoutVisible()).toBe(true);
+
+      // Clean up by closing the flyout
+      await pageObjects.alertsPage.closeFlyout();
+    }).toPass({ timeout: 60_000, intervals: [2_000] });
+  });
+
+  test('opens modal when "Add to existing case" is clicked', async ({
+    browserAuth,
+    pageObjects,
+  }) => {
+    const roleWithAllPrivileges = defineObservabilityRoleWithCasePrivileges(['all']);
+    await browserAuth.loginWithCustomRole(roleWithAllPrivileges);
+    await pageObjects.alertsPage.goto(DATE_WITH_DATA.rangeFrom, DATE_WITH_DATA.rangeTo);
+    await pageObjects.alertsPage.waitForTableToLoad();
+    await pageObjects.alertsPage.waitForAlertRows(1);
+
+    await pageObjects.alertsPage.openActionsMenuForRow(0);
+    await pageObjects.alertsPage.clickAddToExistingCase();
+
+    expect(await pageObjects.alertsPage.isAddToExistingCaseModalVisible()).toBe(true);
+  });
+
+  test('does not render case options when user has read permissions', async ({
+    browserAuth,
+    pageObjects,
+  }) => {
+    const roleWithReadPrivileges = defineObservabilityRoleWithCasePrivileges(['read']);
+    await browserAuth.loginWithCustomRole(roleWithReadPrivileges);
+    await pageObjects.alertsPage.goto(DATE_WITH_DATA.rangeFrom, DATE_WITH_DATA.rangeTo);
+    await pageObjects.alertsPage.waitForTableToLoad();
+    await pageObjects.alertsPage.waitForAlertRows(1);
+
+    await pageObjects.alertsPage.openActionsMenuForRow(0);
+
+    expect(await pageObjects.alertsPage.isAddToExistingCaseActionVisible()).toBe(false);
+    expect(await pageObjects.alertsPage.isAddToNewCaseActionVisible()).toBe(false);
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/global.setup.ts
@@ -6,14 +6,35 @@
  */
 
 import { globalSetupHook } from '@kbn/scout-oblt';
-import { createDataView, generateLogsData, generateRulesData } from '../fixtures/generators';
+import {
+  createDataView,
+  generateLogsData,
+  generateRulesData,
+  generateMetricsData,
+} from '../fixtures/generators';
+import { GENERATED_METRICS } from '../fixtures/constants';
 
 globalSetupHook(
   'Ingest data to Elasticsearch',
   { tag: ['@ess', '@svlOblt'] },
-  async ({ apiServices, log, logsSynthtraceEsClient, kbnClient, esClient }) => {
+  async ({
+    apiServices,
+    log,
+    logsSynthtraceEsClient,
+    kbnClient,
+    esClient,
+    infraSynthtraceEsClient,
+  }) => {
     log.info('Generating Observability data...');
     await generateRulesData(apiServices);
+
+    log.info('Generating metrics data for alert tests...');
+    await generateMetricsData({
+      client: infraSynthtraceEsClient,
+      from: Date.now() - 5 * 60 * 1000, // 5 minutes ago
+      to: Date.now(),
+      metricName: GENERATED_METRICS.metricName,
+    });
 
     log.info('Generating sample data into .alerts-observability.test index...');
     await esClient.index({


### PR DESCRIPTION
## Summary

Closes #247601

### How to run the tests

Run server (first terminal):

`node scripts/scout.js start-server --stateful`

Run tests (second terminal):

`npx playwright test --project local --ui --config x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel.playwright.config.ts`

