### PR TITLE
[9.1] [Dashboard] Fix compound filters showing unsaved changes on dashboard load (#247309)

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.ts
@@ -113,7 +113,7 @@ export function initializeUnifiedSearchManager(
   // setAndSyncUnifiedSearchFilters method not needed since filters synced with 2-way data binding
   function setUnifiedSearchFilters(unifiedSearchFilters: Filter[]) {
     if (!fastIsEqual(unifiedSearchFilters, unifiedSearchFilters$.value)) {
-      unifiedSearchFilters$.next(unifiedSearchFilters);
+      unifiedSearchFilters$.next(cleanFiltersForSerialize(unifiedSearchFilters));
     }
   }
 
@@ -205,7 +205,7 @@ export function initializeUnifiedSearchManager(
           query: query$.value ?? dataService.query.queryString.getDefaultQuery(),
         }),
         set: ({ filters: newFilters, query: newQuery }) => {
-          setUnifiedSearchFilters(cleanFiltersForSerialize(newFilters));
+          setUnifiedSearchFilters(newFilters);
           setQuery(newQuery);
         },
         state$: combineLatest([query$, unifiedSearchFilters$]).pipe(

--- a/src/platform/plugins/shared/dashboard/public/utils/clean_filters_for_serialize.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/utils/clean_filters_for_serialize.test.ts
@@ -18,13 +18,61 @@ describe('cleanFiltersForSerialize', () => {
   test('should remove "meta.value" property from each filter', () => {
     const filters: Filter[] = [
       { query: { a: 'a' }, meta: { value: 'value1' } },
-      { query: { b: 'b' }, meta: { value: 'value2' } },
+      { query: { b: 'b' }, meta: { value: undefined } },
     ];
 
     const cleanedFilters = cleanFiltersForSerialize(filters);
 
     expect(cleanedFilters[0]).toEqual({ query: { a: 'a' }, meta: {} });
     expect(cleanedFilters[1]).toEqual({ query: { b: 'b' }, meta: {} });
+  });
+
+  test('should remove undefined "meta.key" property from each filter', () => {
+    const filters: Filter[] = [
+      { query: { a: 'a' }, meta: { key: undefined } },
+      { query: { b: 'b' }, meta: { key: undefined } },
+    ];
+
+    const cleanedFilters = cleanFiltersForSerialize(filters);
+
+    expect(cleanedFilters[0]).toEqual({ query: { a: 'a' }, meta: {} });
+    expect(cleanedFilters[1]).toEqual({ query: { b: 'b' }, meta: {} });
+  });
+
+  test('should remove undefined "meta.alias" property from each filter', () => {
+    const filters: Filter[] = [
+      { query: { a: 'a' }, meta: { alias: undefined } },
+      { query: { b: 'b' }, meta: { alias: undefined } },
+    ];
+
+    const cleanedFilters = cleanFiltersForSerialize(filters);
+
+    expect(cleanedFilters[0]).toEqual({ query: { a: 'a' }, meta: {} });
+    expect(cleanedFilters[1]).toEqual({ query: { b: 'b' }, meta: {} });
+  });
+
+  test('should remove undefined "meta.key", "meta.alias", and "meta.value" properties from nested compound filters', () => {
+    const filters: Filter[] = [
+      {
+        meta: {
+          params: [
+            { query: { a: 'a' }, meta: { value: undefined, key: undefined, alias: undefined } },
+            { query: { b: 'b' }, meta: { value: undefined, key: undefined, alias: undefined } },
+          ],
+        },
+      },
+    ];
+
+    const cleanedFilters = cleanFiltersForSerialize(filters);
+
+    expect(cleanedFilters[0]).toEqual({
+      meta: {
+        params: [
+          { query: { a: 'a' }, meta: {} },
+          { query: { b: 'b' }, meta: {} },
+        ],
+      },
+    });
   });
 
   test('should not fail if meta is missing from filters', () => {

--- a/src/platform/plugins/shared/dashboard/public/utils/clean_filters_for_serialize.ts
+++ b/src/platform/plugins/shared/dashboard/public/utils/clean_filters_for_serialize.ts
@@ -7,12 +7,38 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Filter } from '@kbn/es-query';
+import type { Filter, FilterMeta } from '@kbn/es-query';
+import { isCombinedFilter } from '@kbn/es-query';
+
+const removeUndefinedProperty = (obj: Record<string, any>, key: string): void => {
+  if (obj[key] === undefined) {
+    delete obj[key];
+  }
+};
 
 export function cleanFiltersForSerialize(filters?: Filter[]): Filter[] {
   if (!filters) return [];
   return filters.map((filter) => {
-    if (filter.meta?.value) delete filter.meta.value;
-    return filter;
+    if (!filter.meta) {
+      return filter;
+    }
+
+    const cleanedFilter = { ...filter };
+    if (typeof cleanedFilter.meta.value !== 'undefined') {
+      // Create a new filter object with meta excluding 'value'
+      delete cleanedFilter.meta.value;
+    }
+
+    removeUndefinedProperty(cleanedFilter.meta, 'key');
+    removeUndefinedProperty(cleanedFilter.meta, 'alias');
+
+    if (isCombinedFilter(filter) && filter.meta?.params) {
+      // Recursively clean filters in combined filters
+      cleanedFilter.meta.params = cleanFiltersForSerialize(
+        cleanedFilter.meta.params as Filter[]
+      ) as FilterMeta['params'];
+    }
+
+    return cleanedFilter;
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Dashboard] Fix compound filters showing unsaved changes on dashboard load (#247309)](https://github.com/elastic/kibana/pull/247309)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Catherine Liu","email":"catherine.liu@elastic.co"},"sourceCommit":{"committedDate":"2026-01-04T12:19:42Z","message":"[Dashboard] Fix compound filters showing unsaved changes on dashboard load (#247309)","sha":"0c83763ed84cf55dd54e7e1556d98dc6e04015a3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Dashboard","release_note:fix","Team:Presentation","loe:medium","impact:high","backport:all-open","v9.3.0","v9.4.0","v9.2.4","v9.1.10","v8.19.10"],"title":"[Dashboard] Fix compound filters showing unsaved changes on dashboard load","number":247309,"url":"https://github.com/elastic/kibana/pull/247309","mergeCommit":{"message":"[Dashboard] Fix compound filters showing unsaved changes on dashboard load (#247309)","sha":"0c83763ed84cf55dd54e7e1556d98dc6e04015a3"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247764","number":247764,"state":"MERGED","mergeCommit":{"sha":"bdc9650f3649e05b768f68227d3494d1bdd57f75","message":"[9.3] [Dashboard] Fix compound filters showing unsaved changes on dashboard load (#247309) (#247764)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Dashboard] Fix compound filters showing unsaved changes on dashboard\nload (#247309)](https://github.com/elastic/kibana/pull/247309)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Catherine Liu <catherine.liu@elastic.co>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247309","number":247309,"mergeCommit":{"message":"[Dashboard] Fix compound filters showing unsaved changes on dashboard load (#247309)","sha":"0c83763ed84cf55dd54e7e1556d98dc6e04015a3"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247763","number":247763,"state":"MERGED","mergeCommit":{"sha":"40e588a2ac0046a2256393d821b067ff35719db6","message":"[9.2] [Dashboard] Fix compound filters showing unsaved changes on dashboard load (#247309) (#247763)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Dashboard] Fix compound filters showing unsaved changes on dashboard\nload (#247309)](https://github.com/elastic/kibana/pull/247309)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Catherine Liu <catherine.liu@elastic.co>"}},{"branch":"9.1","label":"v9.1.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->