### PR TITLE
[.buildkite] Disable install scripts

### DIFF
--- a/.buildkite/.npmrc
+++ b/.buildkite/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+ignore-scripts=true


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/128025.  This only covers CI scripts in the buildkite directory.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->