### PR TITLE
Allow EIS script to fallback to HTTP

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-cli/README.md
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/README.md
@@ -45,12 +45,12 @@ You can connect your local Elasticsearch to the Elastic Inference Service (EIS) 
 
 ### Prerequisites
 
-1. **Vault Access**: Make sure you have configured Vault to point at Elastic's [Infra Vault](https://docs.elastic.dev/vault/infra-vault/home) server and that you're logged in via `vault login -method=okta`. The script will fetch the EIS API key from `secret/kibana-issues/dev/inference/kibana-eis-ccm`.
+1. **Vault Access**: Make sure you have configured Vault to point at Elastic's [Infra Vault](https://docs.elastic.dev/vault#infra-vault) server and that you're logged in via `vault login --method oidc`. The script will fetch the EIS API key from `secret/kibana-issues/dev/inference/kibana-eis-ccm`.
 
 2. **Elasticsearch**: Start Elasticsearch with the CCM URL flag:
 
    ```bash
-   yarn es snapshot -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
+   yarn es snapshot --license trial -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
    ```
 
 3. **Credentials**: The script will automatically detect Elasticsearch credentials from:

--- a/x-pack/platform/packages/shared/kbn-inference-cli/README.md
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/README.md
@@ -35,8 +35,8 @@ log.info(response.output);
 
 Running a recipe:
 
-```
-$ yarn run ts-node x-pack/solutions/observability/packages/kbn-genai-cli/recipes/hello_world.ts
+```bash
+yarn run ts-node x-pack/solutions/observability/packages/kbn-genai-cli/recipes/hello_world.ts
 ```
 
 ## EIS
@@ -48,6 +48,7 @@ You can connect your local Elasticsearch to the Elastic Inference Service (EIS) 
 1. **Vault Access**: Make sure you have configured Vault to point at Elastic's [Infra Vault](https://docs.elastic.dev/vault/infra-vault/home) server and that you're logged in via `vault login -method=okta`. The script will fetch the EIS API key from `secret/kibana-issues/dev/inference/kibana-eis-ccm`.
 
 2. **Elasticsearch**: Start Elasticsearch with the CCM URL flag:
+
    ```bash
    yarn es snapshot -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
    ```
@@ -60,9 +61,10 @@ You can connect your local Elasticsearch to the Elastic Inference Service (EIS) 
 
 ```bash
 # Start Elasticsearch with CCM enabled
-yarn es snapshot -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
+yarn es snapshot --license trial -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
 
-# In a separate terminal, configure CCM
+# In a separate terminal, configure CCM 
+# Use --no-ssl for HTTP connections
 node scripts/eis.js
 ```
 

--- a/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
@@ -135,7 +135,9 @@ async function setCcmApiKey(
 
   const maxRetries = 3;
   const retryDelayMs = 2000;
-  const esUrl = `${es.baseUrl}/_inference/_ccm`;
+  const ccmEndpoint = '_inference/_ccm';
+  let esUrl = `${es.baseUrl}/${ccmEndpoint}`;
+  let ssl = es.ssl;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
@@ -156,7 +158,7 @@ async function setCcmApiKey(
           rejectUnauthorized: false,
         },
         body,
-        es.ssl
+        ssl
       );
 
       if (statusCode >= 200 && statusCode < 300) {
@@ -166,11 +168,28 @@ async function setCcmApiKey(
 
       throw new Error(`HTTP ${statusCode}`);
     } catch (error) {
+      const handshakeFailurePatterns = [
+        'EPROTO',
+        'ERR_SSL_WRONG_VERSION_NUMBER',
+        'packet length too long',
+      ];
+      const handshakeFailure = handshakeFailurePatterns.some((p) => error.message.includes(p));
+
+      if (handshakeFailure && ssl) {
+        log.info('HTTPS handshake failed due to protocol mismatch — falling back to HTTP');
+        ssl = false;
+        esUrl = `http://localhost:9200/${ccmEndpoint}`;
+        // Retry immediately with HTTP (don't count this as a failed attempt)
+        continue;
+      }
+
       if (attempt < maxRetries) {
         log.debug(`Attempt ${attempt} failed, retrying in ${retryDelayMs}ms...`);
         await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
       } else {
-        throw new Error('Failed to set CCM API key after 3 attempts', { cause: error });
+        throw new Error(`Failed to set CCM API key after ${maxRetries} attempts`, {
+          cause: error,
+        });
       }
     }
   }

--- a/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
@@ -120,7 +120,7 @@ async function getEisApiKey(log: ToolingLog): Promise<string> {
     return apiKey.trim();
   } catch (error) {
     throw new Error(
-      'Failed to read EIS API key from vault. Please ensure you are logged in to vault (vault login -method=okta) and connected to VPN if needed. See https://docs.elastic.dev/vault',
+      'Failed to read EIS API key from vault. Please ensure you are logged in to vault (vault login --method oidc) and connected to VPN if needed. See https://docs.elastic.dev/vault',
       { cause: error }
     );
   }


### PR DESCRIPTION
## Summary

- Allow the EIS script to fallback to HTTP when a protocol mismatch is detected
- Update README to include mention of `--no-ssl` flag
- Change vault login method to `oidc` and fix broken docs link


