### PR TITLE
[.buildkite] Version global installs

### DIFF
--- a/.buildkite/package-lock.json
+++ b/.buildkite/package-lock.json
@@ -30,7 +30,8 @@
         "nock": "^12.0.2",
         "ts-jest": "^29.4.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.1.6"
+        "typescript": "^5.1.6",
+        "yarn": "^1.22.22"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5865,6 +5866,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/yarn": {
+      "version": "1.22.22",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.22.tgz",
+      "integrity": "sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "yarn": "bin/yarn.js",
+        "yarnpkg": "bin/yarn.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -9907,6 +9923,12 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true
+    },
+    "yarn": {
+      "version": "1.22.22",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.22.tgz",
+      "integrity": "sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==",
       "dev": true
     },
     "yn": {

--- a/.buildkite/package.json
+++ b/.buildkite/package.json
@@ -30,7 +30,8 @@
     "nock": "^12.0.2",
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "yarn": "^1.22.22"
   },
   "imports": {
     "#pipeline-utils": "./pipeline-utils/index.ts",

--- a/.buildkite/scripts/common/setup_buildkite_deps.sh
+++ b/.buildkite/scripts/common/setup_buildkite_deps.sh
@@ -8,15 +8,12 @@ if [[ "$(type -t retry)" != "function" ]]; then
   source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
 fi
 
-# `rm -rf <ts-node node_modules dir>; npm install -g ts-node` will cause ts-node bin files to be messed up
-# but literally just calling `npm install -g ts-node` a second time fixes it
-# this is only on newer versions of npm
-npm_install_global ts-node
-if ! ts-node --version; then
-  npm_install_global ts-node
-  ts-node --version;
-fi
-
 cd '.buildkite'
 retry 5 15 npm ci --no-audit
+GLOBAL_NODE_MODULES="$(npm root)/.bin"
 cd -
+
+export PATH="$GLOBAL_NODE_MODULES:$PATH"
+
+echo "yarn: $(yarn --version)"
+echo "ts-node: $(ts-node --version)"

--- a/.buildkite/scripts/common/setup_buildkite_deps.sh
+++ b/.buildkite/scripts/common/setup_buildkite_deps.sh
@@ -10,10 +10,14 @@ fi
 
 cd '.buildkite'
 retry 5 15 npm ci --no-audit
-GLOBAL_NODE_MODULES="$(npm root)/.bin"
+BIN_DIR="$(npm root)/.bin"
 cd -
 
-export PATH="$GLOBAL_NODE_MODULES:$PATH"
+mkdir -p "$HOME/.kibana-buildkite/bin"
+ln -sf "$BIN_DIR/yarn" "$HOME/.kibana-buildkite/bin/yarn"
+ln -sf "$BIN_DIR/ts-node" "$HOME/.kibana-buildkite/bin/ts-node"
+
+export PATH="$HOME/.kibana-buildkite/bin:$PATH"
 
 echo "yarn: $(yarn --version)"
 echo "ts-node: $(ts-node --version)"

--- a/.buildkite/scripts/common/setup_node.sh
+++ b/.buildkite/scripts/common/setup_node.sh
@@ -69,16 +69,3 @@ else
 fi
 
 export PATH="$NODE_BIN_DIR:$PATH"
-
-echo "--- Setup Yarn"
-
-YARN_VERSION=$(node -e "console.log(String(require('./package.json').engines.yarn || '').replace(/^[^\d]+/,''))")
-export YARN_VERSION
-
-if [[ ! $(which yarn) || $(yarn --version) != "$YARN_VERSION" ]]; then
-  npm_install_global yarn "^$YARN_VERSION"
-fi
-
-YARN_GLOBAL_BIN=$(yarn global bin)
-export YARN_GLOBAL_BIN
-export PATH="$PATH:$YARN_GLOBAL_BIN"

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -132,33 +132,6 @@ set_git_merge_base() {
   export GITHUB_PR_MERGE_BASE
 }
 
-# If npm install is terminated early, e.g. because the build was cancelled in buildkite,
-# a package directory is left behind in a bad state that can cause all subsequent installs to fail
-# So this function contains some cleanup/retry logic to try to recover from this kind of situation
-npm_install_global() {
-  package="$1"
-  version="${2:-latest}"
-  toInstall="$package@$version"
-
-  npmRoot=$(npm root -g)
-  packageRoot="${npmRoot:?}/$package"
-
-  # The success flag file exists just to try to make sure we know that the full install was done
-  # For example, if a job terminates in the middle of npm install, a directory could be left behind that we don't know the state of
-  successFlag="${packageRoot:?}/.install-success"
-
-  if [[ -d "$packageRoot" && ! -f "$successFlag" ]]; then
-    echo "Removing existing package directory $packageRoot before install, seems previous installation was not successful"
-    rm -rf "$packageRoot"
-  fi
-
-  if [[ ! $(npm install -g "$toInstall" && touch "$successFlag") ]]; then
-    rm -rf "$packageRoot"
-    echo "Trying again to install $toInstall..."
-    npm install -g "$toInstall" && touch "$successFlag"
-  fi
-}
-
 # Download an artifact using the buildkite-agent, takes the same arguments as https://buildkite.com/docs/agent/v3/cli-artifact#downloading-artifacts-usage
 # times-out after 60 seconds and retries up to 3 times
 download_artifact() {


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/128025. Adds ts-node and yarn to our path from .buildkite, removes global install helpers.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->