### PR TITLE
Use simplified retriever, and log requests and error responses

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/relevance_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/relevance_search.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Logger } from '@kbn/logging';
 import type { ScopedModel } from '@kbn/agent-builder-server';
 import type { PerformMatchSearchResponse } from './steps';
 import { performMatchSearch } from './steps';
@@ -19,12 +20,14 @@ export const relevanceSearch = async ({
   size = 10,
   model,
   esClient,
+  logger,
 }: {
   term: string;
   target: string;
   size?: number;
   model: ScopedModel;
   esClient: ElasticsearchClient;
+  logger: Logger;
 }): Promise<RelevanceSearchResponse> => {
   const { fields } = await resolveResource({ resourceName: target, esClient });
 
@@ -42,5 +45,6 @@ export const relevanceSearch = async ({
     fields: selectedFields,
     size,
     esClient,
+    logger,
   });
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/graph.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/graph.ts
@@ -54,7 +54,7 @@ export const createSearchToolGraph = ({
   logger: Logger;
   events: ToolEventEmitter;
 }) => {
-  const relevanceTool = createRelevanceSearchTool({ model, esClient, events });
+  const relevanceTool = createRelevanceSearchTool({ model, esClient, events, logger });
 
   const selectAndValidateIndex = async (state: StateType) => {
     events?.reportProgress(progressMessages.selectingTarget());

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/inner_tools.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/inner_tools.ts
@@ -42,10 +42,12 @@ export const createRelevanceSearchTool = ({
   model,
   esClient,
   events,
+  logger,
 }: {
   model: ScopedModel;
   esClient: ElasticsearchClient;
   events?: ToolEventEmitter;
+  logger: Logger;
 }) => {
   return toTool(
     async ({ term, index, size }) => {
@@ -60,6 +62,7 @@ export const createRelevanceSearchTool = ({
             size,
             model,
             esClient,
+            logger,
           });
           const results = rawResults.map(convertMatchResult);
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { Logger } from '@kbn/logging';
 import type { MappingField } from '../utils/mappings';
 
 export interface MatchResult {
@@ -24,56 +25,48 @@ export const performMatchSearch = async ({
   index,
   size,
   esClient,
+  logger,
 }: {
   term: string;
   fields: MappingField[];
   index: string;
   size: number;
   esClient: ElasticsearchClient;
+  logger: Logger;
 }): Promise<PerformMatchSearchResponse> => {
   const textFields = fields.filter((field) => field.type === 'text');
   const semanticTextFields = fields.filter((field) => field.type === 'semantic_text');
+  const allSearchableFields = [...textFields, ...semanticTextFields];
 
-  const response = await esClient.search<any>({
+  const searchRequest: any = {
     index,
     size,
     retriever: {
       rrf: {
         rank_window_size: size * 2,
-        retrievers: [
-          ...(textFields.length > 0
-            ? [
-                {
-                  standard: {
-                    query: {
-                      multi_match: {
-                        query: term,
-                        fields: textFields.map((field) => field.path),
-                      },
-                    },
-                  },
-                },
-              ]
-            : []),
-          ...semanticTextFields.map((field) => {
-            return {
-              standard: {
-                query: {
-                  match: {
-                    [field.path]: term,
-                  },
-                },
-              },
-            };
-          }),
-        ],
+        query: term,
+        fields: allSearchableFields.map((field) => field.path),
       },
     },
     highlight: {
       number_of_fragments: 5,
       fields: fields.reduce((memo, field) => ({ ...memo, [field.path]: {} }), {}),
     },
-  });
+  };
+
+  logger.debug(`Elasticsearch search request: ${JSON.stringify(searchRequest, null, 2)}`);
+
+  let response;
+  try {
+    response = await esClient.search<any>(searchRequest);
+  } catch (error) {
+    logger.debug(
+      `Elasticsearch search failed for index="${index}", term="${term}": ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    throw error;
+  }
 
   const results = response.hits.hits.map<MatchResult>((hit) => {
     return {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/steps/perform_match_search.ts
@@ -38,6 +38,7 @@ export const performMatchSearch = async ({
   const semanticTextFields = fields.filter((field) => field.type === 'semantic_text');
   const allSearchableFields = [...textFields, ...semanticTextFields];
 
+  // should replace `any` with `SearchRequest` type when the simplified retriever syntax is supported in @elastic/elasticsearch`
   const searchRequest: any = {
     index,
     size,


### PR DESCRIPTION
## Summary

I'd noticed that when using a Search Index tool on an Alias that used a semantic text field, I'd get errors like:
```
{
  "results": [
    {
      "tool_result_id": "s4Ygvl",
      "type": "error",
      "data": {
        "message": """Error: status_exception
	Root causes:
		status_exception: [rrf] search failed - retrievers '[standard]' returned errors. All failures are attached as suppressed exceptions.
 Please fix your mistakes."""
      }
    }
  ]
}
```


This was easily reproducible with:
```
PUT test-1
{
    "mappings": {
        "properties": {
            "test": {
                "type": "semantic_text"
            }
        }
    }
}
PUT test-1/_doc/1
{
    "test": "test"
}
PUT test-1/_alias/test
GET test/_search
{
  "size": 10,
    "retriever": {
        "rrf": {
        "rank_window_size": 20,
        "retrievers": [
            {
            "standard": {
                "query": {
                "multi_match": {
                    "query": "test",
                    "fields": [
                    "test"
                    ]
                }
                }
            }
            }
        ]
        }
    },
    "highlight": {
        "number_of_fragments": 5,
        "fields": {
        "test": {}
        }
    }
}
```

@pgayvallet realized that we had a logical error, where using `field_caps` with aliases lead to semantic_text fields being mis-identified as text fields.

@kderusso suggested that we could avoid this separate handling, because with the new simplified retriever format, both field types can be handled the same way.

This PR swiches us to that simplified retriever format, and also introduces a logger to capture the request and any error responses, for better debugging in the future. 

### Release note
Fixes a bug where Agent Builder Index Search tools would fail on aliases that contained semantic_text fields





