### PR TITLE
[inference] OTEL tracing: add model name

### DIFF
--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/api.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/api.ts
@@ -209,6 +209,10 @@ export interface ChatCompleteResponse<
    * Token counts
    */
   tokens?: ChatCompletionTokenCount;
+  /**
+   * Model effectively used, as specified by the response
+   */
+  model?: string;
 }
 
 /**

--- a/x-pack/platform/packages/shared/kbn-inference-tracing/src/types.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-tracing/src/types.ts
@@ -14,7 +14,9 @@ export enum GenAISemanticConventions {
   GenAIUsageOutputTokens = 'gen_ai.usage.output_tokens',
   GenAIOperationName = 'gen_ai.operation.name',
   GenAIResponseModel = 'gen_ai.response.model',
+  GenAIRequestModel = 'gen_ai.request.model',
   GenAISystem = 'gen_ai.system',
+  GenAIProviderName = 'gen_ai.provider.name',
   GenAIOutputType = 'gen_ai.output.type',
   GenAIToolCallId = 'gen_ai.tool.call.id',
   GenAIToolName = 'gen_ai.tool.name',
@@ -23,6 +25,8 @@ export enum GenAISemanticConventions {
   GenAIAssistantMessage = 'gen_ai.assistant.message',
   GenAIToolMessage = 'gen_ai.tool.message',
   GenAIChoice = 'gen_ai.choice',
+  GenAIAgentId = 'gen_ai.agent.id',
+  GenAIConversationId = 'gen_ai.conversation.id',
 }
 
 export enum ElasticGenAIAttributes {
@@ -43,6 +47,7 @@ export interface GenAISemConvAttributes {
   [GenAISemanticConventions.GenAIUsageCachedInputTokens]?: number;
   [GenAISemanticConventions.GenAIUsageOutputTokens]?: number;
   [GenAISemanticConventions.GenAIOperationName]?: 'chat' | 'execute_tool';
+  [GenAISemanticConventions.GenAIRequestModel]?: string;
   [GenAISemanticConventions.GenAIResponseModel]?: string;
   [GenAISemanticConventions.GenAISystem]?: string;
   'error.type'?: string;

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_agent_span.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_agent_span.ts
@@ -7,7 +7,11 @@
 
 import type { Span } from '@opentelemetry/api';
 import { safeJsonStringify } from '@kbn/std';
-import { withActiveInferenceSpan, ElasticGenAIAttributes } from '@kbn/inference-tracing';
+import {
+  withActiveInferenceSpan,
+  ElasticGenAIAttributes,
+  GenAISemanticConventions,
+} from '@kbn/inference-tracing';
 import type { AgentDefinition } from '@kbn/agent-builder-common';
 import type { AgentHandlerReturn } from '@kbn/agent-builder-server';
 
@@ -26,6 +30,7 @@ export function withAgentSpan(
       attributes: {
         [ElasticGenAIAttributes.InferenceSpanKind]: 'AGENT',
         [ElasticGenAIAttributes.AgentId]: agentId,
+        [GenAISemanticConventions.GenAIAgentId]: agentId,
         [ElasticGenAIAttributes.AgentConfig]: safeJsonStringify(configuration),
       },
     },

--- a/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_converse_span.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/tracing/with_converse_span.ts
@@ -9,7 +9,11 @@ import type { Span } from '@opentelemetry/api';
 import type { Observable } from 'rxjs';
 import { tap } from 'rxjs';
 import { safeJsonStringify } from '@kbn/std';
-import { withActiveInferenceSpan, ElasticGenAIAttributes } from '@kbn/inference-tracing';
+import {
+  withActiveInferenceSpan,
+  ElasticGenAIAttributes,
+  GenAISemanticConventions,
+} from '@kbn/inference-tracing';
 import type { ChatEvent } from '@kbn/agent-builder-common';
 import { isRoundCompleteEvent } from '@kbn/agent-builder-common';
 
@@ -29,6 +33,7 @@ export function withConverseSpan(
         [ElasticGenAIAttributes.InferenceSpanKind]: 'CHAIN',
         [ElasticGenAIAttributes.AgentId]: agentId,
         [ElasticGenAIAttributes.AgentConversationId]: conversationId,
+        [GenAISemanticConventions.GenAIConversationId]: conversationId,
       },
     },
     (span) => {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/callback_api.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/callback_api.ts
@@ -12,6 +12,7 @@ import {
   createInferenceRequestError,
   getConnectorFamily,
   getConnectorProvider,
+  getConnectorDefaultModel,
   type ChatCompleteCompositeResponse,
   MessageRole,
 } from '@kbn/inference-common';
@@ -155,6 +156,7 @@ export function createChatCompleteCallbackApi({
                   tools,
                   toolChoice,
                   model: {
+                    id: modelName ?? getConnectorDefaultModel(connector),
                     family: getConnectorFamily(connector),
                     provider: getConnectorProvider(connector),
                   },

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/stream_to_response.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/stream_to_response.test.ts
@@ -37,6 +37,19 @@ describe('streamToResponse', () => {
     });
   });
 
+  it('returns a response with model if present in the token event', async () => {
+    const response = await streamToResponse(
+      fromEvents(
+        chunkEvent('chunk_1'),
+        chunkEvent('chunk_2'),
+        tokensEvent({ prompt: 1, completion: 2, total: 3 }, { model: 'my_model' }),
+        messageEvent('message')
+      )
+    );
+
+    expect(response.model).toEqual('my_model');
+  });
+
   it('returns a response with tool calls if present', async () => {
     const someToolCall = {
       toolCallId: '42',

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/stream_to_response.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/stream_to_response.ts
@@ -40,6 +40,7 @@ export const streamToResponse = <TToolOptions extends ToolOptions = ToolOptions>
           tokens: tokenEvent?.tokens,
           deanonymized_input: messageEvent.deanonymized_input,
           deanonymized_output: messageEvent.deanonymized_output,
+          model: tokenEvent?.model,
         };
       })
     )

--- a/x-pack/platform/plugins/shared/inference/server/test_utils/chat_complete_events.ts
+++ b/x-pack/platform/plugins/shared/inference/server/test_utils/chat_complete_events.ts
@@ -33,11 +33,15 @@ export const messageEvent = (
   toolCalls,
 });
 
-export const tokensEvent = (tokens?: ChatCompletionTokenCount): ChatCompletionTokenCountEvent => ({
+export const tokensEvent = (
+  tokens?: ChatCompletionTokenCount,
+  { model }: { model?: string } = {}
+): ChatCompletionTokenCountEvent => ({
   type: ChatCompletionEventType.ChatCompletionTokenCount,
   tokens: {
     prompt: tokens?.prompt ?? 10,
     completion: tokens?.completion ?? 20,
     total: tokens?.total ?? 30,
   },
+  model,
 });


### PR DESCRIPTION
## Summary

- Add request/response model name to the inference tracing
- Add GenAI convention fields for AB agentId / conversationId

### Examples

**Claude**

<img width="604" height="375" alt="Screenshot 2026-01-06 at 09 16 44" src="https://github.com/user-attachments/assets/a465c545-13c1-4745-9c86-fca591aeab26" />


**OpenAI**

<img width="666" height="386" alt="Screenshot 2026-01-06 at 09 17 18" src="https://github.com/user-attachments/assets/00b1f70f-63d1-464e-a897-a1f82a24ef8e" />

