### PR TITLE
[9.2][Fleet] add maxSize to schema arrays (#247093)

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -9262,6 +9262,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "key": {
@@ -9278,6 +9279,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -9420,6 +9422,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       },
                       "key": {
@@ -9508,6 +9511,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "key": {
@@ -9736,6 +9740,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "key": {
@@ -9888,6 +9893,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       },
                       "key": {
@@ -9976,6 +9982,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "key": {
@@ -10202,6 +10209,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "agentless": {
@@ -10289,6 +10297,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "has_fleet_server": {
@@ -10366,6 +10375,7 @@
                               ],
                               "type": "string"
                             },
+                            "maxItems": 3,
                             "type": "array"
                           },
                           "monitoring_http": {
@@ -10422,6 +10432,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               {
@@ -10434,6 +10445,7 @@
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 1000,
                                       "nullable": true,
                                       "type": "array"
                                     },
@@ -10465,6 +10477,7 @@
                                               "items": {
                                                 "type": "string"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             }
                                           },
@@ -10565,6 +10578,7 @@
                                                                   "items": {
                                                                     "type": "string"
                                                                   },
+                                                                  "maxItems": 100,
                                                                   "type": "array"
                                                                 }
                                                               },
@@ -10628,6 +10642,7 @@
                                                   ],
                                                   "type": "object"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               "type": {
@@ -10662,6 +10677,7 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -10696,12 +10712,14 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
+                                                            "maxItems": 100,
                                                             "type": "array"
                                                           },
                                                           {
                                                             "items": {
                                                               "type": "number"
                                                             },
+                                                            "maxItems": 100,
                                                             "type": "array"
                                                           },
                                                           {
@@ -10748,12 +10766,14 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     },
                                                     {
                                                       "items": {
                                                         "type": "number"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     },
                                                     {
@@ -10849,6 +10869,7 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         "fips_compatible": {
@@ -10904,12 +10925,14 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "spaceIds": {
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "supports_agentless": {
@@ -10968,12 +10991,14 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -11018,6 +11043,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               }
                             ]
@@ -11043,6 +11069,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "nullable": true,
                             "type": "array"
                           },
@@ -11056,6 +11083,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "status": {
@@ -11101,6 +11129,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -11244,6 +11273,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 100,
                     "type": "array"
                   },
                   "agentless": {
@@ -11328,6 +11358,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "has_fleet_server": {
@@ -11401,6 +11432,7 @@
                       ],
                       "type": "string"
                     },
+                    "maxItems": 3,
                     "type": "array"
                   },
                   "monitoring_http": {
@@ -11472,6 +11504,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 100,
                     "nullable": true,
                     "type": "array"
                   },
@@ -11479,6 +11512,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 100,
                     "type": "array"
                   },
                   "supports_agentless": {
@@ -11564,6 +11598,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "agentless": {
@@ -11651,6 +11686,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "has_fleet_server": {
@@ -11728,6 +11764,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 3,
                           "type": "array"
                         },
                         "monitoring_http": {
@@ -11784,6 +11821,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             {
@@ -11796,6 +11834,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 1000,
                                     "nullable": true,
                                     "type": "array"
                                   },
@@ -11827,6 +11866,7 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           }
                                         },
@@ -11927,6 +11967,7 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
+                                                                "maxItems": 100,
                                                                 "type": "array"
                                                               }
                                                             },
@@ -11990,6 +12031,7 @@
                                                 ],
                                                 "type": "object"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             "type": {
@@ -12024,6 +12066,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       {
@@ -12058,12 +12101,14 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
                                                           "items": {
                                                             "type": "number"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
@@ -12110,12 +12155,14 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
                                                     "items": {
                                                       "type": "number"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
@@ -12211,6 +12258,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "fips_compatible": {
@@ -12266,12 +12314,14 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "spaceIds": {
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "supports_agentless": {
@@ -12330,12 +12380,14 @@
                                               "items": {
                                                 "type": "string"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
                                               "items": {
                                                 "type": "number"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
@@ -12380,6 +12432,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             }
                           ]
@@ -12405,6 +12458,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "nullable": true,
                           "type": "array"
                         },
@@ -12418,6 +12472,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "status": {
@@ -12554,6 +12609,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   },
                   "ignoreMissing": {
@@ -12632,6 +12688,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "agentless": {
@@ -12719,6 +12776,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "has_fleet_server": {
@@ -12796,6 +12854,7 @@
                               ],
                               "type": "string"
                             },
+                            "maxItems": 3,
                             "type": "array"
                           },
                           "monitoring_http": {
@@ -12852,6 +12911,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               {
@@ -12864,6 +12924,7 @@
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 1000,
                                       "nullable": true,
                                       "type": "array"
                                     },
@@ -12895,6 +12956,7 @@
                                               "items": {
                                                 "type": "string"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             }
                                           },
@@ -12995,6 +13057,7 @@
                                                                   "items": {
                                                                     "type": "string"
                                                                   },
+                                                                  "maxItems": 100,
                                                                   "type": "array"
                                                                 }
                                                               },
@@ -13058,6 +13121,7 @@
                                                   ],
                                                   "type": "object"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               "type": {
@@ -13092,6 +13156,7 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -13126,12 +13191,14 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
+                                                            "maxItems": 100,
                                                             "type": "array"
                                                           },
                                                           {
                                                             "items": {
                                                               "type": "number"
                                                             },
+                                                            "maxItems": 100,
                                                             "type": "array"
                                                           },
                                                           {
@@ -13178,12 +13245,14 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     },
                                                     {
                                                       "items": {
                                                         "type": "number"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     },
                                                     {
@@ -13279,6 +13348,7 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         "fips_compatible": {
@@ -13334,12 +13404,14 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "spaceIds": {
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "supports_agentless": {
@@ -13398,12 +13470,14 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -13448,6 +13522,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               }
                             ]
@@ -13473,6 +13548,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "nullable": true,
                             "type": "array"
                           },
@@ -13486,6 +13562,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "status": {
@@ -13531,6 +13608,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -13708,6 +13786,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   }
                 },
@@ -13755,6 +13834,7 @@
                                   },
                                   "type": "object"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "output": {
@@ -13811,6 +13891,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -13950,6 +14031,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "agentless": {
@@ -14037,6 +14119,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "has_fleet_server": {
@@ -14114,6 +14197,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 3,
                           "type": "array"
                         },
                         "monitoring_http": {
@@ -14170,6 +14254,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             {
@@ -14182,6 +14267,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 1000,
                                     "nullable": true,
                                     "type": "array"
                                   },
@@ -14213,6 +14299,7 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           }
                                         },
@@ -14313,6 +14400,7 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
+                                                                "maxItems": 100,
                                                                 "type": "array"
                                                               }
                                                             },
@@ -14376,6 +14464,7 @@
                                                 ],
                                                 "type": "object"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             "type": {
@@ -14410,6 +14499,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       {
@@ -14444,12 +14534,14 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
                                                           "items": {
                                                             "type": "number"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
@@ -14496,12 +14588,14 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
                                                     "items": {
                                                       "type": "number"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
@@ -14597,6 +14691,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "fips_compatible": {
@@ -14652,12 +14747,14 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "spaceIds": {
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "supports_agentless": {
@@ -14716,12 +14813,14 @@
                                               "items": {
                                                 "type": "string"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
                                               "items": {
                                                 "type": "number"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
@@ -14766,6 +14865,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             }
                           ]
@@ -14791,6 +14891,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "nullable": true,
                           "type": "array"
                         },
@@ -14804,6 +14905,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "status": {
@@ -14990,6 +15092,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 100,
                     "type": "array"
                   },
                   "agentless": {
@@ -15077,6 +15180,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "has_fleet_server": {
@@ -15150,6 +15254,7 @@
                       ],
                       "type": "string"
                     },
+                    "maxItems": 3,
                     "type": "array"
                   },
                   "monitoring_http": {
@@ -15221,6 +15326,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 100,
                     "nullable": true,
                     "type": "array"
                   },
@@ -15228,6 +15334,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 100,
                     "type": "array"
                   },
                   "supports_agentless": {
@@ -15313,6 +15420,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "agentless": {
@@ -15400,6 +15508,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "has_fleet_server": {
@@ -15477,6 +15586,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 3,
                           "type": "array"
                         },
                         "monitoring_http": {
@@ -15533,6 +15643,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             {
@@ -15545,6 +15656,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 1000,
                                     "nullable": true,
                                     "type": "array"
                                   },
@@ -15576,6 +15688,7 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           }
                                         },
@@ -15676,6 +15789,7 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
+                                                                "maxItems": 100,
                                                                 "type": "array"
                                                               }
                                                             },
@@ -15739,6 +15853,7 @@
                                                 ],
                                                 "type": "object"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             "type": {
@@ -15773,6 +15888,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       {
@@ -15807,12 +15923,14 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
                                                           "items": {
                                                             "type": "number"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
@@ -15859,12 +15977,14 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
                                                     "items": {
                                                       "type": "number"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
@@ -15960,6 +16080,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "fips_compatible": {
@@ -16015,12 +16136,14 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "spaceIds": {
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "supports_agentless": {
@@ -16079,12 +16202,14 @@
                                               "items": {
                                                 "type": "string"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
                                               "items": {
                                                 "type": "number"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
@@ -16129,6 +16254,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             }
                           ]
@@ -16154,6 +16280,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "nullable": true,
                           "type": "array"
                         },
@@ -16167,6 +16294,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "status": {
@@ -16302,6 +16430,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "totalAgents": {
@@ -16477,6 +16606,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "agentless": {
@@ -16564,6 +16694,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "has_fleet_server": {
@@ -16641,6 +16772,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 3,
                           "type": "array"
                         },
                         "monitoring_http": {
@@ -16697,6 +16829,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             {
@@ -16709,6 +16842,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 1000,
                                     "nullable": true,
                                     "type": "array"
                                   },
@@ -16740,6 +16874,7 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           }
                                         },
@@ -16840,6 +16975,7 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
+                                                                "maxItems": 100,
                                                                 "type": "array"
                                                               }
                                                             },
@@ -16903,6 +17039,7 @@
                                                 ],
                                                 "type": "object"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             "type": {
@@ -16937,6 +17074,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       {
@@ -16971,12 +17109,14 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
                                                           "items": {
                                                             "type": "number"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
@@ -17023,12 +17163,14 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
                                                     "items": {
                                                       "type": "number"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
@@ -17124,6 +17266,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "fips_compatible": {
@@ -17179,12 +17322,14 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "spaceIds": {
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "supports_agentless": {
@@ -17243,12 +17388,14 @@
                                               "items": {
                                                 "type": "string"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
                                               "items": {
                                                 "type": "number"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
@@ -17293,6 +17440,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             }
                           ]
@@ -17318,6 +17466,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "nullable": true,
                           "type": "array"
                         },
@@ -17331,6 +17480,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "status": {
@@ -17658,6 +17808,7 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 10,
                                           "type": "array"
                                         },
                                         "key": {
@@ -17828,6 +17979,7 @@
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "proxy_headers": {
@@ -17884,6 +18036,7 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 10,
                                           "type": "array"
                                         },
                                         "key": {
@@ -17914,6 +18067,7 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         "path": {
@@ -18023,6 +18177,7 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 10000,
                                     "type": "array"
                                   },
                                   "revision": {
@@ -18057,6 +18212,7 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 10000,
                                     "type": "array"
                                   },
                                   "type": {
@@ -18077,12 +18233,14 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             "namespaces": {
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "output_permissions": {
@@ -18104,6 +18262,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "proxy_headers": {
@@ -18161,6 +18320,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "service": {
@@ -18170,6 +18330,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 1000,
                                   "type": "array"
                                 },
                                 "pipelines": {
@@ -18180,18 +18341,21 @@
                                         "items": {
                                           "type": "string"
                                         },
+                                        "maxItems": 1000,
                                         "type": "array"
                                       },
                                       "processors": {
                                         "items": {
                                           "type": "string"
                                         },
+                                        "maxItems": 1000,
                                         "type": "array"
                                       },
                                       "receivers": {
                                         "items": {
                                           "type": "string"
                                         },
+                                        "maxItems": 1000,
                                         "type": "array"
                                       }
                                     },
@@ -18326,6 +18490,7 @@
                                 },
                                 "type": "object"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "output": {
@@ -18452,6 +18617,7 @@
                   "items": {
                     "type": "string"
                   },
+                  "maxItems": 1000,
                   "type": "array"
                 },
                 {
@@ -18593,6 +18759,7 @@
                   "items": {
                     "type": "string"
                   },
+                  "maxItems": 10000,
                   "type": "array"
                 },
                 {
@@ -18636,6 +18803,7 @@
                   "properties": {
                     "dataPreview": {
                       "items": {},
+                      "maxItems": 1000,
                       "type": "array"
                     },
                     "items": {
@@ -18654,6 +18822,7 @@
                         },
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -18940,6 +19109,7 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 1000,
                                   "type": "array"
                                 }
                               },
@@ -18951,6 +19121,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 1000,
                             "type": "array"
                           },
                           "default_api_key": {
@@ -18974,6 +19145,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "default_api_key_id": {
@@ -19037,6 +19209,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "outputs": {
@@ -19063,6 +19236,7 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "type": {
@@ -19077,6 +19251,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 1000,
                             "type": "array"
                           },
                           "policy_id": {
@@ -19088,6 +19263,7 @@
                           },
                           "sort": {
                             "items": {},
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "status": {
@@ -19110,6 +19286,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "type": {
@@ -19135,6 +19312,7 @@
                               ],
                               "type": "string"
                             },
+                            "maxItems": 3,
                             "nullable": true,
                             "type": "array"
                           },
@@ -19142,6 +19320,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 1000,
                             "nullable": true,
                             "type": "array"
                           },
@@ -19238,6 +19417,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "nextSearchAfter": {
@@ -19336,6 +19516,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   }
                 },
@@ -19358,6 +19539,7 @@
                       "items": {
                         "type": "string"
                       },
+                      "maxItems": 1000,
                       "type": "array"
                     }
                   },
@@ -19515,6 +19697,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "nbAgentsAck": {
@@ -19594,6 +19777,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 1000,
                       "type": "array"
                     }
                   },
@@ -19683,6 +19867,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10000,
                           "type": "array"
                         },
                         "created_at": {
@@ -19702,6 +19887,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "rollout_duration_seconds": {
@@ -19796,6 +19982,7 @@
                       "items": {
                         "type": "string"
                       },
+                      "maxItems": 1000,
                       "type": "array"
                     }
                   },
@@ -19874,6 +20061,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       {
@@ -19933,6 +20121,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       }
                     },
@@ -20039,6 +20228,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       {
@@ -20153,6 +20343,7 @@
                       ],
                       "type": "string"
                     },
+                    "maxItems": 1,
                     "type": "array"
                   },
                   "agents": {
@@ -20161,6 +20352,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       {
@@ -20264,13 +20456,14 @@
                     "anyOf": [
                       {
                         "items": {
-                          "description": "KQL query string, leave empty to action all agents",
+                          "description": "list of agent IDs",
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       {
-                        "description": "list of agent IDs",
+                        "description": "KQL query string, leave empty to action all agents",
                         "type": "string"
                       }
                     ]
@@ -20385,6 +20578,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       {
@@ -20403,12 +20597,14 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "tagsToRemove": {
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   }
                 },
@@ -20506,6 +20702,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       {
@@ -20793,6 +20990,7 @@
                         ],
                         "type": "string"
                       },
+                      "maxItems": 1,
                       "type": "array"
                     },
                     "missing_requirements": {
@@ -20806,6 +21004,7 @@
                         ],
                         "type": "string"
                       },
+                      "maxItems": 5,
                       "type": "array"
                     },
                     "package_verification_key_id": {
@@ -20903,6 +21102,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -20988,6 +21188,7 @@
                       "items": {
                         "type": "string"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -21250,6 +21451,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               }
                             },
@@ -21261,6 +21463,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "default_api_key": {
@@ -21284,6 +21487,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "default_api_key_id": {
@@ -21347,6 +21551,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "outputs": {
@@ -21373,6 +21578,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "type": {
@@ -21387,6 +21593,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "policy_id": {
@@ -21398,6 +21605,7 @@
                         },
                         "sort": {
                           "items": {},
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "status": {
@@ -21420,6 +21628,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "type": {
@@ -21445,6 +21654,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 3,
                           "nullable": true,
                           "type": "array"
                         },
@@ -21452,6 +21662,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -21628,6 +21839,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "user_provided_metadata": {
@@ -21746,6 +21958,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               }
                             },
@@ -21757,6 +21970,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "default_api_key": {
@@ -21780,6 +21994,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "default_api_key_id": {
@@ -21843,6 +22058,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "outputs": {
@@ -21869,6 +22085,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "type": {
@@ -21883,6 +22100,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "policy_id": {
@@ -21894,6 +22112,7 @@
                         },
                         "sort": {
                           "items": {},
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "status": {
@@ -21916,6 +22135,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "type": {
@@ -21941,6 +22161,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 3,
                           "nullable": true,
                           "type": "array"
                         },
@@ -21948,6 +22169,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -22206,6 +22428,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10000,
                           "type": "array"
                         },
                         "created_at": {
@@ -22225,6 +22448,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "rollout_duration_seconds": {
@@ -22385,6 +22609,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       }
                     },
@@ -22593,6 +22818,7 @@
                       ],
                       "type": "string"
                     },
+                    "maxItems": 1,
                     "type": "array"
                   }
                 },
@@ -22876,6 +23102,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 1000,
                       "type": "array"
                     }
                   },
@@ -23075,6 +23302,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -23751,6 +23979,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 10000,
                             "type": "array"
                           },
                           "dataset": {
@@ -23820,6 +24049,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -23952,6 +24182,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "list": {
@@ -23998,6 +24229,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -24436,6 +24668,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   }
                 },
@@ -24493,6 +24726,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -24599,6 +24833,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 1000,
                       "type": "array"
                     }
                   },
@@ -24695,6 +24930,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "force": {
@@ -24817,6 +25053,7 @@
                           }
                         ]
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -24902,6 +25139,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "readMeData": {
@@ -25029,6 +25267,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -25132,6 +25371,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "conditions": {
@@ -25144,6 +25384,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 10,
                                     "type": "array"
                                   },
                                   "subscription": {
@@ -25169,6 +25410,7 @@
                               "additionalProperties": {},
                               "type": "object"
                             },
+                            "maxItems": 1000,
                             "type": "array"
                           },
                           "description": {
@@ -25190,6 +25432,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "fields": {
@@ -25205,6 +25448,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               }
                             },
@@ -25244,6 +25488,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "id": {
@@ -25297,6 +25542,7 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "type": "object"
@@ -25336,6 +25582,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "install_format_schema_version": {
@@ -25392,6 +25639,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "installed_kibana": {
@@ -25438,6 +25686,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "installed_kibana_space_id": {
@@ -25495,6 +25744,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "name": {
@@ -25504,6 +25754,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "previous_version": {
@@ -25584,6 +25835,7 @@
                               "additionalProperties": {},
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "readme": {
@@ -25648,6 +25900,7 @@
                               "additionalProperties": {},
                               "type": "object"
                             },
+                            "maxItems": 1000,
                             "type": "array"
                           },
                           "version": {
@@ -25662,6 +25915,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 1000,
                       "type": "array"
                     }
                   },
@@ -25858,6 +26112,7 @@
                           }
                         ]
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -25970,6 +26225,7 @@
                         }
                       ]
                     },
+                    "maxItems": 1000,
                     "minItems": 1,
                     "type": "array"
                   }
@@ -26082,6 +26338,7 @@
                                         }
                                       ]
                                     },
+                                    "maxItems": 1000,
                                     "type": "array"
                                   },
                                   "error": {},
@@ -26143,6 +26400,7 @@
                           }
                         ]
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -26236,6 +26494,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 1000,
                     "minItems": 1,
                     "type": "array"
                   }
@@ -26368,6 +26627,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "status": {
@@ -26463,6 +26723,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 1000,
                     "minItems": 1,
                     "type": "array"
                   },
@@ -26602,6 +26863,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "status": {
@@ -26706,6 +26968,7 @@
                   }
                 ]
               },
+              "maxItems": 10,
               "type": "array"
             }
           },
@@ -26760,6 +27023,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 1000,
                             "type": "array"
                           },
                           "description": {
@@ -26793,6 +27057,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "name": {
@@ -26816,6 +27081,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "searchAfter": {
@@ -26837,6 +27103,7 @@
                           {}
                         ]
                       },
+                      "maxItems": 2,
                       "type": "array"
                     },
                     "total": {
@@ -26907,6 +27174,7 @@
                       "items": {
                         "type": "string"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -27170,6 +27438,7 @@
                           }
                         ]
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -27305,12 +27574,14 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "asset_types": {
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "text": {
@@ -27322,6 +27593,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "assets": {
@@ -27332,6 +27604,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "conditions": {
@@ -27344,6 +27617,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "subscription": {
@@ -27369,6 +27643,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "description": {
@@ -27390,6 +27665,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "fields": {
@@ -27405,6 +27681,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             }
                           },
@@ -27448,6 +27725,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "installationInfo": {
@@ -27498,6 +27776,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "type": "object"
@@ -27537,6 +27816,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "install_format_schema_version": {
@@ -27593,6 +27873,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "installed_kibana": {
@@ -27639,6 +27920,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "installed_kibana_space_id": {
@@ -27696,6 +27978,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "name": {
@@ -27705,6 +27988,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "previous_version": {
@@ -27794,6 +28078,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "readme": {
@@ -27835,6 +28120,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "signature_path": {
@@ -27888,6 +28174,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "version": {
@@ -28143,6 +28430,7 @@
                           }
                         ]
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -28275,12 +28563,14 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "asset_types": {
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "text": {
@@ -28292,6 +28582,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "assets": {
@@ -28302,6 +28593,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "conditions": {
@@ -28314,6 +28606,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "subscription": {
@@ -28339,6 +28632,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "description": {
@@ -28360,6 +28654,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "fields": {
@@ -28375,6 +28670,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             }
                           },
@@ -28418,6 +28714,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "installationInfo": {
@@ -28468,6 +28765,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "type": "object"
@@ -28507,6 +28805,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "install_format_schema_version": {
@@ -28563,6 +28862,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "installed_kibana": {
@@ -28609,6 +28909,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "installed_kibana_space_id": {
@@ -28666,6 +28967,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "name": {
@@ -28675,6 +28977,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "previous_version": {
@@ -28764,6 +29067,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "readme": {
@@ -28805,6 +29109,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "signature_path": {
@@ -28858,6 +29163,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "version": {
@@ -29153,6 +29459,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 100,
                     "minItems": 1,
                     "type": "array"
                   }
@@ -29384,6 +29691,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   }
                 },
@@ -29420,6 +29728,7 @@
                     ],
                     "type": "object"
                   },
+                  "maxItems": 10000,
                   "type": "array"
                 }
               }
@@ -29641,6 +29950,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               "type": {
@@ -29653,6 +29963,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10000,
                           "type": "array"
                         }
                       },
@@ -29789,6 +30100,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "minItems": 1,
                             "type": "array"
                           },
@@ -29874,6 +30186,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "client_auth": {
@@ -29891,6 +30204,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "es_key": {
@@ -29910,6 +30224,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -29996,6 +30311,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "minItems": 1,
                     "type": "array"
                   },
@@ -30081,6 +30397,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       },
                       "client_auth": {
@@ -30098,6 +30415,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       },
                       "es_key": {
@@ -30133,6 +30451,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10,
                           "minItems": 1,
                           "type": "array"
                         },
@@ -30218,6 +30537,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "client_auth": {
@@ -30235,6 +30555,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "es_key": {
@@ -30410,6 +30731,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10,
                           "minItems": 1,
                           "type": "array"
                         },
@@ -30495,6 +30817,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "client_auth": {
@@ -30512,6 +30835,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "es_key": {
@@ -30611,6 +30935,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "minItems": 1,
                     "type": "array"
                   },
@@ -30688,6 +31013,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       },
                       "client_auth": {
@@ -30705,6 +31031,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       },
                       "es_key": {
@@ -30739,6 +31066,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10,
                           "minItems": 1,
                           "type": "array"
                         },
@@ -30824,6 +31152,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "client_auth": {
@@ -30841,6 +31170,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "es_key": {
@@ -31445,6 +31775,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "ca_sha256": {
@@ -31464,6 +31795,7 @@
                                   "format": "uri",
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "minItems": 1,
                                 "type": "array"
                               },
@@ -31605,6 +31937,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 10,
                                     "type": "array"
                                   },
                                   "key": {
@@ -31647,6 +31980,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "ca_sha256": {
@@ -31666,6 +32000,7 @@
                                   "format": "uri",
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "minItems": 1,
                                 "type": "array"
                               },
@@ -31841,6 +32176,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 10,
                                     "type": "array"
                                   },
                                   "key": {
@@ -31889,6 +32225,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "ca_sha256": {
@@ -31907,6 +32244,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "minItems": 1,
                                 "type": "array"
                               },
@@ -32038,6 +32376,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 10,
                                     "type": "array"
                                   },
                                   "key": {
@@ -32076,6 +32415,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "auth_type": {
@@ -32205,12 +32545,14 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "hosts": {
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "minItems": 1,
                                 "type": "array"
                               },
@@ -32474,6 +32816,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 10,
                                     "type": "array"
                                   },
                                   "key": {
@@ -32550,6 +32893,7 @@
                           }
                         ]
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -32638,6 +32982,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "ca_sha256": {
@@ -32657,6 +33002,7 @@
                           "format": "uri",
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -32798,6 +33144,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -32840,6 +33187,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "ca_sha256": {
@@ -32859,6 +33207,7 @@
                           "format": "uri",
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -33034,6 +33383,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -33082,6 +33432,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "ca_sha256": {
@@ -33100,6 +33451,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -33231,6 +33583,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -33269,6 +33622,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "auth_type": {
@@ -33398,12 +33752,14 @@
                           ],
                           "type": "object"
                         },
+                        "maxItems": 100,
                         "type": "array"
                       },
                       "hosts": {
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -33667,6 +34023,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -33762,6 +34119,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -33781,6 +34139,7 @@
                                 "format": "uri",
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -33922,6 +34281,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -33964,6 +34324,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -33983,6 +34344,7 @@
                                 "format": "uri",
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -34158,6 +34520,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -34206,6 +34569,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -34224,6 +34588,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -34355,6 +34720,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -34393,6 +34759,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "auth_type": {
@@ -34522,12 +34889,14 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "hosts": {
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -34791,6 +35160,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -35056,6 +35426,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -35075,6 +35446,7 @@
                                 "format": "uri",
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -35216,6 +35588,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -35258,6 +35631,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -35277,6 +35651,7 @@
                                 "format": "uri",
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -35452,6 +35827,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -35500,6 +35876,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -35518,6 +35895,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -35649,6 +36027,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -35687,6 +36066,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "auth_type": {
@@ -35816,12 +36196,14 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "hosts": {
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -36085,6 +36467,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -36243,6 +36626,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "ca_sha256": {
@@ -36262,6 +36646,7 @@
                           "format": "uri",
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -36401,6 +36786,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -36438,6 +36824,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "ca_sha256": {
@@ -36457,6 +36844,7 @@
                           "format": "uri",
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -36630,6 +37018,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -36673,6 +37062,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "ca_sha256": {
@@ -36691,6 +37081,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -36820,6 +37211,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -36853,6 +37245,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "auth_type": {
@@ -36982,12 +37375,14 @@
                           ],
                           "type": "object"
                         },
+                        "maxItems": 100,
                         "type": "array"
                       },
                       "hosts": {
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -37251,6 +37646,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -37343,6 +37739,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -37362,6 +37759,7 @@
                                 "format": "uri",
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -37503,6 +37901,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -37545,6 +37944,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -37564,6 +37964,7 @@
                                 "format": "uri",
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -37739,6 +38140,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -37787,6 +38189,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -37805,6 +38208,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -37936,6 +38340,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -37974,6 +38379,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "auth_type": {
@@ -38103,12 +38509,14 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "hosts": {
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -38372,6 +38780,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -38672,6 +39081,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 1000,
                             "nullable": true,
                             "type": "array"
                           },
@@ -38703,6 +39113,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   }
                                 },
@@ -38803,6 +39214,7 @@
                                                         "items": {
                                                           "type": "string"
                                                         },
+                                                        "maxItems": 100,
                                                         "type": "array"
                                                       }
                                                     },
@@ -38866,6 +39278,7 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "type": {
@@ -38900,6 +39313,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               {
@@ -38934,12 +39348,14 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
+                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
                                                   "items": {
                                                     "type": "number"
                                                   },
+                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
@@ -38986,12 +39402,14 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
                                             "items": {
                                               "type": "number"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
@@ -39087,6 +39505,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "fips_compatible": {
@@ -39142,12 +39561,14 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "spaceIds": {
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "supports_agentless": {
@@ -39206,12 +39627,14 @@
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
                                       "items": {
                                         "type": "number"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
@@ -39256,6 +39679,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -39356,6 +39780,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "nullable": true,
                         "type": "array"
                       },
@@ -39462,6 +39887,7 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               }
                                             },
@@ -39525,6 +39951,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "type": {
@@ -39557,6 +39984,7 @@
                           ],
                           "type": "object"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "is_managed": {
@@ -39621,6 +40049,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -39664,6 +40093,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 100,
                         "type": "array"
                       },
                       "supports_agentless": {
@@ -39713,6 +40143,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 100,
                         "nullable": true,
                         "type": "array"
                       },
@@ -39757,12 +40188,14 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -39809,12 +40242,14 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -39890,6 +40325,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -39948,12 +40384,14 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
                               "items": {
                                 "type": "number"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -40006,6 +40444,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -40037,6 +40476,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 }
                               },
@@ -40137,6 +40577,7 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     }
                                                   },
@@ -40200,6 +40641,7 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "type": {
@@ -40234,6 +40676,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -40268,12 +40711,14 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -40320,12 +40765,14 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -40421,6 +40868,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "fips_compatible": {
@@ -40476,12 +40924,14 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "spaceIds": {
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "supports_agentless": {
@@ -40540,12 +40990,14 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -40707,6 +41159,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   },
                   "ignoreMissing": {
@@ -40737,6 +41190,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 1000,
                             "nullable": true,
                             "type": "array"
                           },
@@ -40768,6 +41222,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   }
                                 },
@@ -40868,6 +41323,7 @@
                                                         "items": {
                                                           "type": "string"
                                                         },
+                                                        "maxItems": 100,
                                                         "type": "array"
                                                       }
                                                     },
@@ -40931,6 +41387,7 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "type": {
@@ -40965,6 +41422,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               {
@@ -40999,12 +41457,14 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
+                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
                                                   "items": {
                                                     "type": "number"
                                                   },
+                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
@@ -41051,12 +41511,14 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
                                             "items": {
                                               "type": "number"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
@@ -41152,6 +41614,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "fips_compatible": {
@@ -41207,12 +41670,14 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "spaceIds": {
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "supports_agentless": {
@@ -41271,12 +41736,14 @@
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
                                       "items": {
                                         "type": "number"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
@@ -41321,6 +41788,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -41419,6 +41887,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   }
                 },
@@ -41495,6 +41964,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -41531,6 +42001,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       "statusCode": {
@@ -41548,6 +42019,7 @@
                     ],
                     "type": "object"
                   },
+                  "maxItems": 10000,
                   "type": "array"
                 }
               }
@@ -41618,6 +42090,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   }
                 },
@@ -41668,6 +42141,7 @@
                     ],
                     "type": "object"
                   },
+                  "maxItems": 10000,
                   "type": "array"
                 }
               }
@@ -41738,6 +42212,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   },
                   "packageVersion": {
@@ -41847,6 +42322,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               "revision": {
@@ -41880,6 +42356,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               "type": {
@@ -41900,8 +42377,10 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10000,
                           "type": "array"
                         },
+                        "maxItems": 1,
                         "type": "array"
                       },
                       "body": {
@@ -41927,6 +42406,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 1000,
                                   "nullable": true,
                                   "type": "array"
                                 },
@@ -41958,6 +42438,7 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         }
                                       },
@@ -42058,6 +42539,7 @@
                                                               "items": {
                                                                 "type": "string"
                                                               },
+                                                              "maxItems": 100,
                                                               "type": "array"
                                                             }
                                                           },
@@ -42121,6 +42603,7 @@
                                               ],
                                               "type": "object"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           "type": {
@@ -42155,6 +42638,7 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
@@ -42189,12 +42673,14 @@
                                                         "items": {
                                                           "type": "string"
                                                         },
+                                                        "maxItems": 100,
                                                         "type": "array"
                                                       },
                                                       {
                                                         "items": {
                                                           "type": "number"
                                                         },
+                                                        "maxItems": 100,
                                                         "type": "array"
                                                       },
                                                       {
@@ -42241,12 +42727,14 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
+                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
                                                   "items": {
                                                     "type": "number"
                                                   },
+                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
@@ -42342,6 +42830,7 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "fips_compatible": {
@@ -42397,12 +42886,14 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "spaceIds": {
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "supports_agentless": {
@@ -42461,12 +42952,14 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
                                             "items": {
                                               "type": "number"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
@@ -42518,6 +43011,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 1000,
                                   "nullable": true,
                                   "type": "array"
                                 },
@@ -42546,6 +43040,7 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         }
                                       },
@@ -42573,6 +43068,7 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "force": {
@@ -42665,6 +43161,7 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         }
                                                       },
@@ -42728,6 +43225,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "type": {
@@ -42762,6 +43260,7 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "is_managed": {
@@ -42771,6 +43270,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "name": {
@@ -42832,6 +43332,7 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "fips_compatible": {
@@ -42887,6 +43388,7 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "supports_agentless": {
@@ -42940,6 +43442,7 @@
                             }
                           ]
                         },
+                        "maxItems": 2,
                         "type": "array"
                       },
                       "hasErrors": {
@@ -42957,6 +43460,7 @@
                     ],
                     "type": "object"
                   },
+                  "maxItems": 10000,
                   "type": "array"
                 }
               }
@@ -43130,6 +43634,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -43161,6 +43666,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 }
                               },
@@ -43261,6 +43767,7 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     }
                                                   },
@@ -43324,6 +43831,7 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "type": {
@@ -43358,6 +43866,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -43392,12 +43901,14 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -43444,12 +43955,14 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -43545,6 +44058,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "fips_compatible": {
@@ -43600,12 +44114,14 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "spaceIds": {
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "supports_agentless": {
@@ -43664,12 +44180,14 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -43828,6 +44346,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "nullable": true,
                         "type": "array"
                       },
@@ -43929,6 +44448,7 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               }
                                             },
@@ -43992,6 +44512,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "type": {
@@ -44024,6 +44545,7 @@
                           ],
                           "type": "object"
                         },
+                        "maxItems": 100,
                         "type": "array"
                       },
                       "is_managed": {
@@ -44087,6 +44609,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -44130,6 +44653,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 100,
                         "type": "array"
                       },
                       "supports_agentless": {
@@ -44178,6 +44702,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 100,
                         "nullable": true,
                         "type": "array"
                       },
@@ -44222,12 +44747,14 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -44274,12 +44801,14 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -44355,6 +44884,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -44413,12 +44943,14 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
                               "items": {
                                 "type": "number"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -44470,6 +45002,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -44501,6 +45034,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 }
                               },
@@ -44601,6 +45135,7 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     }
                                                   },
@@ -44664,6 +45199,7 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "type": {
@@ -44698,6 +45234,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -44732,12 +45269,14 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -44784,12 +45323,14 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -44885,6 +45426,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "fips_compatible": {
@@ -44940,12 +45482,14 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "spaceIds": {
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "supports_agentless": {
@@ -45004,12 +45548,14 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -45199,6 +45745,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -45963,6 +46510,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "warning": {
@@ -46176,6 +46724,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "warning": {
@@ -46387,6 +46936,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 1,
                           "type": "array"
                         },
                         "prerelease_integrations_enabled": {
@@ -46537,6 +47087,7 @@
                       "format": "uri",
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "prerelease_integrations_enabled": {
@@ -46593,6 +47144,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 1,
                           "type": "array"
                         },
                         "prerelease_integrations_enabled": {
@@ -46733,6 +47285,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -46822,6 +47375,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "managed_by": {
@@ -46873,6 +47427,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   }
                 },
@@ -46895,6 +47450,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "managed_by": {
@@ -46987,6 +47543,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "policy_id": {
@@ -47004,6 +47561,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -47100,6 +47658,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "policy_id": {

--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -10445,7 +10445,6 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "maxItems": 1000,
                                       "nullable": true,
                                       "type": "array"
                                     },
@@ -10477,7 +10476,6 @@
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             }
                                           },
@@ -10578,7 +10576,6 @@
                                                                   "items": {
                                                                     "type": "string"
                                                                   },
-                                                                  "maxItems": 100,
                                                                   "type": "array"
                                                                 }
                                                               },
@@ -10642,7 +10639,6 @@
                                                   ],
                                                   "type": "object"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               "type": {
@@ -10677,7 +10673,6 @@
                                             ],
                                             "type": "object"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -10712,14 +10707,12 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "maxItems": 100,
                                                             "type": "array"
                                                           },
                                                           {
                                                             "items": {
                                                               "type": "number"
                                                             },
-                                                            "maxItems": 100,
                                                             "type": "array"
                                                           },
                                                           {
@@ -10766,14 +10759,12 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "maxItems": 100,
                                                       "type": "array"
                                                     },
                                                     {
                                                       "items": {
                                                         "type": "number"
                                                       },
-                                                      "maxItems": 100,
                                                       "type": "array"
                                                     },
                                                     {
@@ -10869,7 +10860,6 @@
                                             ],
                                             "type": "object"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         "fips_compatible": {
@@ -10925,14 +10915,12 @@
                                         ],
                                         "type": "object"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "spaceIds": {
                                       "items": {
                                         "type": "string"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "supports_agentless": {
@@ -10991,14 +10979,12 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -11834,7 +11820,6 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 1000,
                                     "nullable": true,
                                     "type": "array"
                                   },
@@ -11866,7 +11851,6 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "maxItems": 100,
                                             "type": "array"
                                           }
                                         },
@@ -11967,7 +11951,6 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "maxItems": 100,
                                                                 "type": "array"
                                                               }
                                                             },
@@ -12031,7 +12014,6 @@
                                                 ],
                                                 "type": "object"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             "type": {
@@ -12066,7 +12048,6 @@
                                           ],
                                           "type": "object"
                                         },
-                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       {
@@ -12101,14 +12082,12 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
-                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
                                                           "items": {
                                                             "type": "number"
                                                           },
-                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
@@ -12155,14 +12134,12 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
-                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
                                                     "items": {
                                                       "type": "number"
                                                     },
-                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
@@ -12258,7 +12235,6 @@
                                           ],
                                           "type": "object"
                                         },
-                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "fips_compatible": {
@@ -12314,14 +12290,12 @@
                                       ],
                                       "type": "object"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "spaceIds": {
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "supports_agentless": {
@@ -12380,14 +12354,12 @@
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
                                               "items": {
                                                 "type": "number"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
@@ -12924,7 +12896,6 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "maxItems": 1000,
                                       "nullable": true,
                                       "type": "array"
                                     },
@@ -12956,7 +12927,6 @@
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             }
                                           },
@@ -13057,7 +13027,6 @@
                                                                   "items": {
                                                                     "type": "string"
                                                                   },
-                                                                  "maxItems": 100,
                                                                   "type": "array"
                                                                 }
                                                               },
@@ -13121,7 +13090,6 @@
                                                   ],
                                                   "type": "object"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               "type": {
@@ -13156,7 +13124,6 @@
                                             ],
                                             "type": "object"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -13191,14 +13158,12 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "maxItems": 100,
                                                             "type": "array"
                                                           },
                                                           {
                                                             "items": {
                                                               "type": "number"
                                                             },
-                                                            "maxItems": 100,
                                                             "type": "array"
                                                           },
                                                           {
@@ -13245,14 +13210,12 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "maxItems": 100,
                                                       "type": "array"
                                                     },
                                                     {
                                                       "items": {
                                                         "type": "number"
                                                       },
-                                                      "maxItems": 100,
                                                       "type": "array"
                                                     },
                                                     {
@@ -13348,7 +13311,6 @@
                                             ],
                                             "type": "object"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         "fips_compatible": {
@@ -13404,14 +13366,12 @@
                                         ],
                                         "type": "object"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "spaceIds": {
                                       "items": {
                                         "type": "string"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "supports_agentless": {
@@ -13470,14 +13430,12 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -14267,7 +14225,6 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 1000,
                                     "nullable": true,
                                     "type": "array"
                                   },
@@ -14299,7 +14256,6 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "maxItems": 100,
                                             "type": "array"
                                           }
                                         },
@@ -14400,7 +14356,6 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "maxItems": 100,
                                                                 "type": "array"
                                                               }
                                                             },
@@ -14464,7 +14419,6 @@
                                                 ],
                                                 "type": "object"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             "type": {
@@ -14499,7 +14453,6 @@
                                           ],
                                           "type": "object"
                                         },
-                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       {
@@ -14534,14 +14487,12 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
-                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
                                                           "items": {
                                                             "type": "number"
                                                           },
-                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
@@ -14588,14 +14539,12 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
-                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
                                                     "items": {
                                                       "type": "number"
                                                     },
-                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
@@ -14691,7 +14640,6 @@
                                           ],
                                           "type": "object"
                                         },
-                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "fips_compatible": {
@@ -14747,14 +14695,12 @@
                                       ],
                                       "type": "object"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "spaceIds": {
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "supports_agentless": {
@@ -14813,14 +14759,12 @@
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
                                               "items": {
                                                 "type": "number"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
@@ -15656,7 +15600,6 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 1000,
                                     "nullable": true,
                                     "type": "array"
                                   },
@@ -15688,7 +15631,6 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "maxItems": 100,
                                             "type": "array"
                                           }
                                         },
@@ -15789,7 +15731,6 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "maxItems": 100,
                                                                 "type": "array"
                                                               }
                                                             },
@@ -15853,7 +15794,6 @@
                                                 ],
                                                 "type": "object"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             "type": {
@@ -15888,7 +15828,6 @@
                                           ],
                                           "type": "object"
                                         },
-                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       {
@@ -15923,14 +15862,12 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
-                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
                                                           "items": {
                                                             "type": "number"
                                                           },
-                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
@@ -15977,14 +15914,12 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
-                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
                                                     "items": {
                                                       "type": "number"
                                                     },
-                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
@@ -16080,7 +16015,6 @@
                                           ],
                                           "type": "object"
                                         },
-                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "fips_compatible": {
@@ -16136,14 +16070,12 @@
                                       ],
                                       "type": "object"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "spaceIds": {
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "supports_agentless": {
@@ -16202,14 +16134,12 @@
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
                                               "items": {
                                                 "type": "number"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
@@ -16430,7 +16360,6 @@
                         ],
                         "type": "object"
                       },
-                      "maxItems": 10000,
                       "type": "array"
                     },
                     "totalAgents": {
@@ -16842,7 +16771,6 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 1000,
                                     "nullable": true,
                                     "type": "array"
                                   },
@@ -16874,7 +16802,6 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "maxItems": 100,
                                             "type": "array"
                                           }
                                         },
@@ -16975,7 +16902,6 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "maxItems": 100,
                                                                 "type": "array"
                                                               }
                                                             },
@@ -17039,7 +16965,6 @@
                                                 ],
                                                 "type": "object"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             "type": {
@@ -17074,7 +16999,6 @@
                                           ],
                                           "type": "object"
                                         },
-                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       {
@@ -17109,14 +17033,12 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
-                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
                                                           "items": {
                                                             "type": "number"
                                                           },
-                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
@@ -17163,14 +17085,12 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
-                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
                                                     "items": {
                                                       "type": "number"
                                                     },
-                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
@@ -17266,7 +17186,6 @@
                                           ],
                                           "type": "object"
                                         },
-                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "fips_compatible": {
@@ -17322,14 +17241,12 @@
                                       ],
                                       "type": "object"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "spaceIds": {
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "supports_agentless": {
@@ -17388,14 +17305,12 @@
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
                                               "items": {
                                                 "type": "number"
                                               },
-                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
@@ -25582,7 +25497,6 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 100,
                                 "type": "array"
                               },
                               "install_format_schema_version": {
@@ -27816,7 +27730,6 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             "install_format_schema_version": {
@@ -28805,7 +28718,6 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             "install_format_schema_version": {
@@ -39081,7 +38993,6 @@
                             "items": {
                               "type": "string"
                             },
-                            "maxItems": 1000,
                             "nullable": true,
                             "type": "array"
                           },
@@ -39113,7 +39024,6 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   }
                                 },
@@ -39214,7 +39124,6 @@
                                                         "items": {
                                                           "type": "string"
                                                         },
-                                                        "maxItems": 100,
                                                         "type": "array"
                                                       }
                                                     },
@@ -39278,7 +39187,6 @@
                                         ],
                                         "type": "object"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "type": {
@@ -39313,7 +39221,6 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 100,
                                 "type": "array"
                               },
                               {
@@ -39348,14 +39255,12 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
                                                   "items": {
                                                     "type": "number"
                                                   },
-                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
@@ -39402,14 +39307,12 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
                                             "items": {
                                               "type": "number"
                                             },
-                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
@@ -39505,7 +39408,6 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 100,
                                 "type": "array"
                               },
                               "fips_compatible": {
@@ -39561,14 +39463,12 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 100,
                             "type": "array"
                           },
                           "spaceIds": {
                             "items": {
                               "type": "string"
                             },
-                            "maxItems": 100,
                             "type": "array"
                           },
                           "supports_agentless": {
@@ -39627,14 +39527,12 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
                                       "items": {
                                         "type": "number"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
@@ -39780,7 +39678,6 @@
                         "items": {
                           "type": "string"
                         },
-                        "maxItems": 1000,
                         "nullable": true,
                         "type": "array"
                       },
@@ -39887,7 +39784,6 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               }
                                             },
@@ -39951,7 +39847,6 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             "type": {
@@ -39984,7 +39879,6 @@
                           ],
                           "type": "object"
                         },
-                        "maxItems": 1000,
                         "type": "array"
                       },
                       "is_managed": {
@@ -40049,7 +39943,6 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -40093,7 +39986,6 @@
                         "items": {
                           "type": "string"
                         },
-                        "maxItems": 100,
                         "type": "array"
                       },
                       "supports_agentless": {
@@ -40143,7 +40035,6 @@
                         "items": {
                           "type": "string"
                         },
-                        "maxItems": 100,
                         "nullable": true,
                         "type": "array"
                       },
@@ -40188,14 +40079,12 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -40242,14 +40131,12 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -40325,7 +40212,6 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -40384,14 +40270,12 @@
                               "items": {
                                 "type": "string"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             {
                               "items": {
                                 "type": "number"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -40444,7 +40328,6 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -40476,7 +40359,6 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "maxItems": 100,
                                   "type": "array"
                                 }
                               },
@@ -40577,7 +40459,6 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "maxItems": 100,
                                                       "type": "array"
                                                     }
                                                   },
@@ -40641,7 +40522,6 @@
                                       ],
                                       "type": "object"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "type": {
@@ -40676,7 +40556,6 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -40711,14 +40590,12 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -40765,14 +40642,12 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -40868,7 +40743,6 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             "fips_compatible": {
@@ -40924,14 +40798,12 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 100,
                           "type": "array"
                         },
                         "spaceIds": {
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 100,
                           "type": "array"
                         },
                         "supports_agentless": {
@@ -40990,14 +40862,12 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -41190,7 +41060,6 @@
                             "items": {
                               "type": "string"
                             },
-                            "maxItems": 1000,
                             "nullable": true,
                             "type": "array"
                           },
@@ -41222,7 +41091,6 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   }
                                 },
@@ -41323,7 +41191,6 @@
                                                         "items": {
                                                           "type": "string"
                                                         },
-                                                        "maxItems": 100,
                                                         "type": "array"
                                                       }
                                                     },
@@ -41387,7 +41254,6 @@
                                         ],
                                         "type": "object"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "type": {
@@ -41422,7 +41288,6 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 100,
                                 "type": "array"
                               },
                               {
@@ -41457,14 +41322,12 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
                                                   "items": {
                                                     "type": "number"
                                                   },
-                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
@@ -41511,14 +41374,12 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
                                             "items": {
                                               "type": "number"
                                             },
-                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
@@ -41614,7 +41475,6 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 100,
                                 "type": "array"
                               },
                               "fips_compatible": {
@@ -41670,14 +41530,12 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 100,
                             "type": "array"
                           },
                           "spaceIds": {
                             "items": {
                               "type": "string"
                             },
-                            "maxItems": 100,
                             "type": "array"
                           },
                           "supports_agentless": {
@@ -41736,14 +41594,12 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
                                       "items": {
                                         "type": "number"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
@@ -41964,7 +41820,6 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -42406,7 +42261,6 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "maxItems": 1000,
                                   "nullable": true,
                                   "type": "array"
                                 },
@@ -42438,7 +42292,6 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         }
                                       },
@@ -42539,7 +42392,6 @@
                                                               "items": {
                                                                 "type": "string"
                                                               },
-                                                              "maxItems": 100,
                                                               "type": "array"
                                                             }
                                                           },
@@ -42603,7 +42455,6 @@
                                               ],
                                               "type": "object"
                                             },
-                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           "type": {
@@ -42638,7 +42489,6 @@
                                         ],
                                         "type": "object"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
@@ -42673,14 +42523,12 @@
                                                         "items": {
                                                           "type": "string"
                                                         },
-                                                        "maxItems": 100,
                                                         "type": "array"
                                                       },
                                                       {
                                                         "items": {
                                                           "type": "number"
                                                         },
-                                                        "maxItems": 100,
                                                         "type": "array"
                                                       },
                                                       {
@@ -42727,14 +42575,12 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
                                                   "items": {
                                                     "type": "number"
                                                   },
-                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
@@ -42830,7 +42676,6 @@
                                         ],
                                         "type": "object"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "fips_compatible": {
@@ -42886,14 +42731,12 @@
                                     ],
                                     "type": "object"
                                   },
-                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "spaceIds": {
                                   "items": {
                                     "type": "string"
                                   },
-                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "supports_agentless": {
@@ -42952,14 +42795,12 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
                                             "items": {
                                               "type": "number"
                                             },
-                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
@@ -43011,7 +42852,6 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "maxItems": 1000,
                                   "nullable": true,
                                   "type": "array"
                                 },
@@ -43040,7 +42880,6 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         }
                                       },
@@ -43068,7 +42907,6 @@
                                     ],
                                     "type": "object"
                                   },
-                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "force": {
@@ -43161,7 +42999,6 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
-                                                          "maxItems": 100,
                                                           "type": "array"
                                                         }
                                                       },
@@ -43225,7 +43062,6 @@
                                           ],
                                           "type": "object"
                                         },
-                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "type": {
@@ -43260,7 +43096,6 @@
                                     ],
                                     "type": "object"
                                   },
-                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "is_managed": {
@@ -43270,7 +43105,6 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "name": {
@@ -43332,7 +43166,6 @@
                                         ],
                                         "type": "object"
                                       },
-                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "fips_compatible": {
@@ -43388,7 +43221,6 @@
                                     ],
                                     "type": "object"
                                   },
-                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "supports_agentless": {
@@ -43634,7 +43466,6 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -43666,7 +43497,6 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "maxItems": 100,
                                   "type": "array"
                                 }
                               },
@@ -43767,7 +43597,6 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "maxItems": 100,
                                                       "type": "array"
                                                     }
                                                   },
@@ -43831,7 +43660,6 @@
                                       ],
                                       "type": "object"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "type": {
@@ -43866,7 +43694,6 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -43901,14 +43728,12 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -43955,14 +43780,12 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -44058,7 +43881,6 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             "fips_compatible": {
@@ -44114,14 +43936,12 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 100,
                           "type": "array"
                         },
                         "spaceIds": {
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 100,
                           "type": "array"
                         },
                         "supports_agentless": {
@@ -44180,14 +44000,12 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -44346,7 +44164,6 @@
                         "items": {
                           "type": "string"
                         },
-                        "maxItems": 1000,
                         "nullable": true,
                         "type": "array"
                       },
@@ -44448,7 +44265,6 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               }
                                             },
@@ -44512,7 +44328,6 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             "type": {
@@ -44545,7 +44360,6 @@
                           ],
                           "type": "object"
                         },
-                        "maxItems": 100,
                         "type": "array"
                       },
                       "is_managed": {
@@ -44609,7 +44423,6 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -44653,7 +44466,6 @@
                         "items": {
                           "type": "string"
                         },
-                        "maxItems": 100,
                         "type": "array"
                       },
                       "supports_agentless": {
@@ -44702,7 +44514,6 @@
                         "items": {
                           "type": "string"
                         },
-                        "maxItems": 100,
                         "nullable": true,
                         "type": "array"
                       },
@@ -44747,14 +44558,12 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -44801,14 +44610,12 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -44884,7 +44691,6 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -44943,14 +44749,12 @@
                               "items": {
                                 "type": "string"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             {
                               "items": {
                                 "type": "number"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -45002,7 +44806,6 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -45034,7 +44837,6 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "maxItems": 100,
                                   "type": "array"
                                 }
                               },
@@ -45135,7 +44937,6 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "maxItems": 100,
                                                       "type": "array"
                                                     }
                                                   },
@@ -45199,7 +45000,6 @@
                                       ],
                                       "type": "object"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "type": {
@@ -45234,7 +45034,6 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -45269,14 +45068,12 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
-                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -45323,14 +45120,12 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
-                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -45426,7 +45221,6 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 100,
                               "type": "array"
                             },
                             "fips_compatible": {
@@ -45482,14 +45276,12 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 100,
                           "type": "array"
                         },
                         "spaceIds": {
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 100,
                           "type": "array"
                         },
                         "supports_agentless": {
@@ -45548,14 +45340,12 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
-                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -46936,7 +46726,6 @@
                             ],
                             "type": "string"
                           },
-                          "maxItems": 1,
                           "type": "array"
                         },
                         "prerelease_integrations_enabled": {
@@ -47144,7 +46933,6 @@
                             ],
                             "type": "string"
                           },
-                          "maxItems": 1,
                           "type": "array"
                         },
                         "prerelease_integrations_enabled": {

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -9262,6 +9262,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "key": {
@@ -9278,6 +9279,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -9418,6 +9420,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       },
                       "key": {
@@ -9506,6 +9509,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "key": {
@@ -9730,6 +9734,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "key": {
@@ -9880,6 +9885,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       },
                       "key": {
@@ -9968,6 +9974,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "key": {
@@ -10192,6 +10199,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "agentless": {
@@ -10279,6 +10287,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "has_fleet_server": {
@@ -10356,6 +10365,7 @@
                               ],
                               "type": "string"
                             },
+                            "maxItems": 3,
                             "type": "array"
                           },
                           "monitoring_http": {
@@ -10412,6 +10422,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               {
@@ -10424,6 +10435,7 @@
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 1000,
                                       "nullable": true,
                                       "type": "array"
                                     },
@@ -10455,6 +10467,7 @@
                                               "items": {
                                                 "type": "string"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             }
                                           },
@@ -10555,6 +10568,7 @@
                                                                   "items": {
                                                                     "type": "string"
                                                                   },
+                                                                  "maxItems": 100,
                                                                   "type": "array"
                                                                 }
                                                               },
@@ -10618,6 +10632,7 @@
                                                   ],
                                                   "type": "object"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               "type": {
@@ -10652,6 +10667,7 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -10686,12 +10702,14 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
+                                                            "maxItems": 100,
                                                             "type": "array"
                                                           },
                                                           {
                                                             "items": {
                                                               "type": "number"
                                                             },
+                                                            "maxItems": 100,
                                                             "type": "array"
                                                           },
                                                           {
@@ -10738,12 +10756,14 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     },
                                                     {
                                                       "items": {
                                                         "type": "number"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     },
                                                     {
@@ -10839,6 +10859,7 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         "fips_compatible": {
@@ -10894,12 +10915,14 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "spaceIds": {
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "supports_agentless": {
@@ -10958,12 +10981,14 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -11008,6 +11033,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               }
                             ]
@@ -11033,6 +11059,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "nullable": true,
                             "type": "array"
                           },
@@ -11046,6 +11073,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "status": {
@@ -11091,6 +11119,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -11232,6 +11261,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 100,
                     "type": "array"
                   },
                   "agentless": {
@@ -11316,6 +11346,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "has_fleet_server": {
@@ -11389,6 +11420,7 @@
                       ],
                       "type": "string"
                     },
+                    "maxItems": 3,
                     "type": "array"
                   },
                   "monitoring_http": {
@@ -11460,6 +11492,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 100,
                     "nullable": true,
                     "type": "array"
                   },
@@ -11467,6 +11500,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 100,
                     "type": "array"
                   },
                   "supports_agentless": {
@@ -11552,6 +11586,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "agentless": {
@@ -11639,6 +11674,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "has_fleet_server": {
@@ -11716,6 +11752,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 3,
                           "type": "array"
                         },
                         "monitoring_http": {
@@ -11772,6 +11809,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             {
@@ -11784,6 +11822,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 1000,
                                     "nullable": true,
                                     "type": "array"
                                   },
@@ -11815,6 +11854,7 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           }
                                         },
@@ -11915,6 +11955,7 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
+                                                                "maxItems": 100,
                                                                 "type": "array"
                                                               }
                                                             },
@@ -11978,6 +12019,7 @@
                                                 ],
                                                 "type": "object"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             "type": {
@@ -12012,6 +12054,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       {
@@ -12046,12 +12089,14 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
                                                           "items": {
                                                             "type": "number"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
@@ -12098,12 +12143,14 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
                                                     "items": {
                                                       "type": "number"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
@@ -12199,6 +12246,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "fips_compatible": {
@@ -12254,12 +12302,14 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "spaceIds": {
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "supports_agentless": {
@@ -12318,12 +12368,14 @@
                                               "items": {
                                                 "type": "string"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
                                               "items": {
                                                 "type": "number"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
@@ -12368,6 +12420,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             }
                           ]
@@ -12393,6 +12446,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "nullable": true,
                           "type": "array"
                         },
@@ -12406,6 +12460,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "status": {
@@ -12540,6 +12595,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   },
                   "ignoreMissing": {
@@ -12618,6 +12674,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "agentless": {
@@ -12705,6 +12762,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "has_fleet_server": {
@@ -12782,6 +12840,7 @@
                               ],
                               "type": "string"
                             },
+                            "maxItems": 3,
                             "type": "array"
                           },
                           "monitoring_http": {
@@ -12838,6 +12897,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               {
@@ -12850,6 +12910,7 @@
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 1000,
                                       "nullable": true,
                                       "type": "array"
                                     },
@@ -12881,6 +12942,7 @@
                                               "items": {
                                                 "type": "string"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             }
                                           },
@@ -12981,6 +13043,7 @@
                                                                   "items": {
                                                                     "type": "string"
                                                                   },
+                                                                  "maxItems": 100,
                                                                   "type": "array"
                                                                 }
                                                               },
@@ -13044,6 +13107,7 @@
                                                   ],
                                                   "type": "object"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               "type": {
@@ -13078,6 +13142,7 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -13112,12 +13177,14 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
+                                                            "maxItems": 100,
                                                             "type": "array"
                                                           },
                                                           {
                                                             "items": {
                                                               "type": "number"
                                                             },
+                                                            "maxItems": 100,
                                                             "type": "array"
                                                           },
                                                           {
@@ -13164,12 +13231,14 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     },
                                                     {
                                                       "items": {
                                                         "type": "number"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     },
                                                     {
@@ -13265,6 +13334,7 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         "fips_compatible": {
@@ -13320,12 +13390,14 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "spaceIds": {
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "supports_agentless": {
@@ -13384,12 +13456,14 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -13434,6 +13508,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               }
                             ]
@@ -13459,6 +13534,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "nullable": true,
                             "type": "array"
                           },
@@ -13472,6 +13548,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "status": {
@@ -13517,6 +13594,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -13690,6 +13768,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   }
                 },
@@ -13737,6 +13816,7 @@
                                   },
                                   "type": "object"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "output": {
@@ -13793,6 +13873,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -13930,6 +14011,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "agentless": {
@@ -14017,6 +14099,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "has_fleet_server": {
@@ -14094,6 +14177,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 3,
                           "type": "array"
                         },
                         "monitoring_http": {
@@ -14150,6 +14234,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             {
@@ -14162,6 +14247,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 1000,
                                     "nullable": true,
                                     "type": "array"
                                   },
@@ -14193,6 +14279,7 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           }
                                         },
@@ -14293,6 +14380,7 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
+                                                                "maxItems": 100,
                                                                 "type": "array"
                                                               }
                                                             },
@@ -14356,6 +14444,7 @@
                                                 ],
                                                 "type": "object"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             "type": {
@@ -14390,6 +14479,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       {
@@ -14424,12 +14514,14 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
                                                           "items": {
                                                             "type": "number"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
@@ -14476,12 +14568,14 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
                                                     "items": {
                                                       "type": "number"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
@@ -14577,6 +14671,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "fips_compatible": {
@@ -14632,12 +14727,14 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "spaceIds": {
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "supports_agentless": {
@@ -14696,12 +14793,14 @@
                                               "items": {
                                                 "type": "string"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
                                               "items": {
                                                 "type": "number"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
@@ -14746,6 +14845,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             }
                           ]
@@ -14771,6 +14871,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "nullable": true,
                           "type": "array"
                         },
@@ -14784,6 +14885,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "status": {
@@ -14968,6 +15070,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 100,
                     "type": "array"
                   },
                   "agentless": {
@@ -15055,6 +15158,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "has_fleet_server": {
@@ -15128,6 +15232,7 @@
                       ],
                       "type": "string"
                     },
+                    "maxItems": 3,
                     "type": "array"
                   },
                   "monitoring_http": {
@@ -15199,6 +15304,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 100,
                     "nullable": true,
                     "type": "array"
                   },
@@ -15206,6 +15312,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 100,
                     "type": "array"
                   },
                   "supports_agentless": {
@@ -15291,6 +15398,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "agentless": {
@@ -15378,6 +15486,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "has_fleet_server": {
@@ -15455,6 +15564,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 3,
                           "type": "array"
                         },
                         "monitoring_http": {
@@ -15511,6 +15621,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             {
@@ -15523,6 +15634,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 1000,
                                     "nullable": true,
                                     "type": "array"
                                   },
@@ -15554,6 +15666,7 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           }
                                         },
@@ -15654,6 +15767,7 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
+                                                                "maxItems": 100,
                                                                 "type": "array"
                                                               }
                                                             },
@@ -15717,6 +15831,7 @@
                                                 ],
                                                 "type": "object"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             "type": {
@@ -15751,6 +15866,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       {
@@ -15785,12 +15901,14 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
                                                           "items": {
                                                             "type": "number"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
@@ -15837,12 +15955,14 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
                                                     "items": {
                                                       "type": "number"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
@@ -15938,6 +16058,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "fips_compatible": {
@@ -15993,12 +16114,14 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "spaceIds": {
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "supports_agentless": {
@@ -16057,12 +16180,14 @@
                                               "items": {
                                                 "type": "string"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
                                               "items": {
                                                 "type": "number"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
@@ -16107,6 +16232,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             }
                           ]
@@ -16132,6 +16258,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "nullable": true,
                           "type": "array"
                         },
@@ -16145,6 +16272,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "status": {
@@ -16278,6 +16406,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "totalAgents": {
@@ -16451,6 +16580,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "agentless": {
@@ -16538,6 +16668,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "has_fleet_server": {
@@ -16615,6 +16746,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 3,
                           "type": "array"
                         },
                         "monitoring_http": {
@@ -16671,6 +16803,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             {
@@ -16683,6 +16816,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 1000,
                                     "nullable": true,
                                     "type": "array"
                                   },
@@ -16714,6 +16848,7 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           }
                                         },
@@ -16814,6 +16949,7 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
+                                                                "maxItems": 100,
                                                                 "type": "array"
                                                               }
                                                             },
@@ -16877,6 +17013,7 @@
                                                 ],
                                                 "type": "object"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             "type": {
@@ -16911,6 +17048,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       {
@@ -16945,12 +17083,14 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
                                                           "items": {
                                                             "type": "number"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         },
                                                         {
@@ -16997,12 +17137,14 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
                                                     "items": {
                                                       "type": "number"
                                                     },
+                                                    "maxItems": 100,
                                                     "type": "array"
                                                   },
                                                   {
@@ -17098,6 +17240,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "fips_compatible": {
@@ -17153,12 +17296,14 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "spaceIds": {
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "supports_agentless": {
@@ -17217,12 +17362,14 @@
                                               "items": {
                                                 "type": "string"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
                                               "items": {
                                                 "type": "number"
                                               },
+                                              "maxItems": 100,
                                               "type": "array"
                                             },
                                             {
@@ -17267,6 +17414,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             }
                           ]
@@ -17292,6 +17440,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "nullable": true,
                           "type": "array"
                         },
@@ -17305,6 +17454,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "status": {
@@ -17627,6 +17777,7 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 10,
                                           "type": "array"
                                         },
                                         "key": {
@@ -17797,6 +17948,7 @@
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "proxy_headers": {
@@ -17853,6 +18005,7 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 10,
                                           "type": "array"
                                         },
                                         "key": {
@@ -17883,6 +18036,7 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         "path": {
@@ -17992,6 +18146,7 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 10000,
                                     "type": "array"
                                   },
                                   "revision": {
@@ -18026,6 +18181,7 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 10000,
                                     "type": "array"
                                   },
                                   "type": {
@@ -18046,12 +18202,14 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             "namespaces": {
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "output_permissions": {
@@ -18073,6 +18231,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "proxy_headers": {
@@ -18130,6 +18289,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "service": {
@@ -18139,6 +18299,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 1000,
                                   "type": "array"
                                 },
                                 "pipelines": {
@@ -18149,18 +18310,21 @@
                                         "items": {
                                           "type": "string"
                                         },
+                                        "maxItems": 1000,
                                         "type": "array"
                                       },
                                       "processors": {
                                         "items": {
                                           "type": "string"
                                         },
+                                        "maxItems": 1000,
                                         "type": "array"
                                       },
                                       "receivers": {
                                         "items": {
                                           "type": "string"
                                         },
+                                        "maxItems": 1000,
                                         "type": "array"
                                       }
                                     },
@@ -18293,6 +18457,7 @@
                                 },
                                 "type": "object"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "output": {
@@ -18417,6 +18582,7 @@
                   "items": {
                     "type": "string"
                   },
+                  "maxItems": 1000,
                   "type": "array"
                 },
                 {
@@ -18556,6 +18722,7 @@
                   "items": {
                     "type": "string"
                   },
+                  "maxItems": 10000,
                   "type": "array"
                 },
                 {
@@ -18599,6 +18766,7 @@
                   "properties": {
                     "dataPreview": {
                       "items": {},
+                      "maxItems": 1000,
                       "type": "array"
                     },
                     "items": {
@@ -18617,6 +18785,7 @@
                         },
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -18901,6 +19070,7 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 1000,
                                   "type": "array"
                                 }
                               },
@@ -18912,6 +19082,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 1000,
                             "type": "array"
                           },
                           "default_api_key": {
@@ -18935,6 +19106,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "default_api_key_id": {
@@ -18998,6 +19170,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "outputs": {
@@ -19024,6 +19197,7 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "type": {
@@ -19038,6 +19212,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 1000,
                             "type": "array"
                           },
                           "policy_id": {
@@ -19049,6 +19224,7 @@
                           },
                           "sort": {
                             "items": {},
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "status": {
@@ -19071,6 +19247,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "type": {
@@ -19096,6 +19273,7 @@
                               ],
                               "type": "string"
                             },
+                            "maxItems": 3,
                             "nullable": true,
                             "type": "array"
                           },
@@ -19103,6 +19281,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 1000,
                             "nullable": true,
                             "type": "array"
                           },
@@ -19199,6 +19378,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "nextSearchAfter": {
@@ -19295,6 +19475,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   }
                 },
@@ -19317,6 +19498,7 @@
                       "items": {
                         "type": "string"
                       },
+                      "maxItems": 1000,
                       "type": "array"
                     }
                   },
@@ -19472,6 +19654,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "nbAgentsAck": {
@@ -19551,6 +19734,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 1000,
                       "type": "array"
                     }
                   },
@@ -19638,6 +19822,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10000,
                           "type": "array"
                         },
                         "created_at": {
@@ -19657,6 +19842,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "rollout_duration_seconds": {
@@ -19749,6 +19935,7 @@
                       "items": {
                         "type": "string"
                       },
+                      "maxItems": 1000,
                       "type": "array"
                     }
                   },
@@ -19825,6 +20012,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       {
@@ -19884,6 +20072,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       }
                     },
@@ -19990,6 +20179,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       {
@@ -20102,6 +20292,7 @@
                       ],
                       "type": "string"
                     },
+                    "maxItems": 1,
                     "type": "array"
                   },
                   "agents": {
@@ -20110,6 +20301,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       {
@@ -20211,13 +20403,14 @@
                     "anyOf": [
                       {
                         "items": {
-                          "description": "KQL query string, leave empty to action all agents",
+                          "description": "list of agent IDs",
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       {
-                        "description": "list of agent IDs",
+                        "description": "KQL query string, leave empty to action all agents",
                         "type": "string"
                       }
                     ]
@@ -20330,6 +20523,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       {
@@ -20348,12 +20542,14 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "tagsToRemove": {
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   }
                 },
@@ -20449,6 +20645,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       {
@@ -20730,6 +20927,7 @@
                         ],
                         "type": "string"
                       },
+                      "maxItems": 1,
                       "type": "array"
                     },
                     "missing_requirements": {
@@ -20743,6 +20941,7 @@
                         ],
                         "type": "string"
                       },
+                      "maxItems": 5,
                       "type": "array"
                     },
                     "package_verification_key_id": {
@@ -20838,6 +21037,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -20921,6 +21121,7 @@
                       "items": {
                         "type": "string"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -21179,6 +21380,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               }
                             },
@@ -21190,6 +21392,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "default_api_key": {
@@ -21213,6 +21416,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "default_api_key_id": {
@@ -21276,6 +21480,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "outputs": {
@@ -21302,6 +21507,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "type": {
@@ -21316,6 +21522,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "policy_id": {
@@ -21327,6 +21534,7 @@
                         },
                         "sort": {
                           "items": {},
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "status": {
@@ -21349,6 +21557,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "type": {
@@ -21374,6 +21583,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 3,
                           "nullable": true,
                           "type": "array"
                         },
@@ -21381,6 +21591,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -21555,6 +21766,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "user_provided_metadata": {
@@ -21673,6 +21885,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               }
                             },
@@ -21684,6 +21897,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "default_api_key": {
@@ -21707,6 +21921,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "default_api_key_id": {
@@ -21770,6 +21985,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "outputs": {
@@ -21796,6 +22012,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "type": {
@@ -21810,6 +22027,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "policy_id": {
@@ -21821,6 +22039,7 @@
                         },
                         "sort": {
                           "items": {},
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "status": {
@@ -21843,6 +22062,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "type": {
@@ -21868,6 +22088,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 3,
                           "nullable": true,
                           "type": "array"
                         },
@@ -21875,6 +22096,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -22131,6 +22353,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10000,
                           "type": "array"
                         },
                         "created_at": {
@@ -22150,6 +22373,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "rollout_duration_seconds": {
@@ -22308,6 +22532,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       }
                     },
@@ -22514,6 +22739,7 @@
                       ],
                       "type": "string"
                     },
+                    "maxItems": 1,
                     "type": "array"
                   }
                 },
@@ -22793,6 +23019,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 1000,
                       "type": "array"
                     }
                   },
@@ -22988,6 +23215,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -23664,6 +23892,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 10000,
                             "type": "array"
                           },
                           "dataset": {
@@ -23733,6 +23962,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -23863,6 +24093,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "list": {
@@ -23909,6 +24140,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -24339,6 +24571,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   }
                 },
@@ -24396,6 +24629,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -24500,6 +24734,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 1000,
                       "type": "array"
                     }
                   },
@@ -24594,6 +24829,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "force": {
@@ -24716,6 +24952,7 @@
                           }
                         ]
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -24799,6 +25036,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "readMeData": {
@@ -24923,6 +25161,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -25024,6 +25263,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "conditions": {
@@ -25036,6 +25276,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 10,
                                     "type": "array"
                                   },
                                   "subscription": {
@@ -25061,6 +25302,7 @@
                               "additionalProperties": {},
                               "type": "object"
                             },
+                            "maxItems": 1000,
                             "type": "array"
                           },
                           "description": {
@@ -25082,6 +25324,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "fields": {
@@ -25097,6 +25340,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               }
                             },
@@ -25136,6 +25380,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "id": {
@@ -25189,6 +25434,7 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "type": "object"
@@ -25228,6 +25474,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "install_format_schema_version": {
@@ -25284,6 +25531,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "installed_kibana": {
@@ -25330,6 +25578,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "installed_kibana_space_id": {
@@ -25387,6 +25636,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "name": {
@@ -25396,6 +25646,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "previous_version": {
@@ -25476,6 +25727,7 @@
                               "additionalProperties": {},
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "readme": {
@@ -25540,6 +25792,7 @@
                               "additionalProperties": {},
                               "type": "object"
                             },
+                            "maxItems": 1000,
                             "type": "array"
                           },
                           "version": {
@@ -25554,6 +25807,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 1000,
                       "type": "array"
                     }
                   },
@@ -25748,6 +26002,7 @@
                           }
                         ]
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -25858,6 +26113,7 @@
                         }
                       ]
                     },
+                    "maxItems": 1000,
                     "minItems": 1,
                     "type": "array"
                   }
@@ -25970,6 +26226,7 @@
                                         }
                                       ]
                                     },
+                                    "maxItems": 1000,
                                     "type": "array"
                                   },
                                   "error": {},
@@ -26031,6 +26288,7 @@
                           }
                         ]
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -26124,6 +26382,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 1000,
                     "minItems": 1,
                     "type": "array"
                   }
@@ -26256,6 +26515,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "status": {
@@ -26351,6 +26611,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 1000,
                     "minItems": 1,
                     "type": "array"
                   },
@@ -26490,6 +26751,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "status": {
@@ -26594,6 +26856,7 @@
                   }
                 ]
               },
+              "maxItems": 10,
               "type": "array"
             }
           },
@@ -26648,6 +26911,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 1000,
                             "type": "array"
                           },
                           "description": {
@@ -26681,6 +26945,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "name": {
@@ -26704,6 +26969,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "searchAfter": {
@@ -26725,6 +26991,7 @@
                           {}
                         ]
                       },
+                      "maxItems": 2,
                       "type": "array"
                     },
                     "total": {
@@ -26793,6 +27060,7 @@
                       "items": {
                         "type": "string"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -27052,6 +27320,7 @@
                           }
                         ]
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -27185,12 +27454,14 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "asset_types": {
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "text": {
@@ -27202,6 +27473,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "assets": {
@@ -27212,6 +27484,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "conditions": {
@@ -27224,6 +27497,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "subscription": {
@@ -27249,6 +27523,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "description": {
@@ -27270,6 +27545,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "fields": {
@@ -27285,6 +27561,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             }
                           },
@@ -27328,6 +27605,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "installationInfo": {
@@ -27378,6 +27656,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "type": "object"
@@ -27417,6 +27696,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "install_format_schema_version": {
@@ -27473,6 +27753,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "installed_kibana": {
@@ -27519,6 +27800,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "installed_kibana_space_id": {
@@ -27576,6 +27858,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "name": {
@@ -27585,6 +27868,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "previous_version": {
@@ -27674,6 +27958,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "readme": {
@@ -27715,6 +28000,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "signature_path": {
@@ -27768,6 +28054,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "version": {
@@ -28021,6 +28308,7 @@
                           }
                         ]
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -28153,12 +28441,14 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "asset_types": {
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "text": {
@@ -28170,6 +28460,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "assets": {
@@ -28180,6 +28471,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "conditions": {
@@ -28192,6 +28484,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "subscription": {
@@ -28217,6 +28510,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "description": {
@@ -28238,6 +28532,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "fields": {
@@ -28253,6 +28548,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             }
                           },
@@ -28296,6 +28592,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "installationInfo": {
@@ -28346,6 +28643,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "type": "object"
@@ -28385,6 +28683,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "install_format_schema_version": {
@@ -28441,6 +28740,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "installed_kibana": {
@@ -28487,6 +28787,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "installed_kibana_space_id": {
@@ -28544,6 +28845,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "name": {
@@ -28553,6 +28855,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "previous_version": {
@@ -28642,6 +28945,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "readme": {
@@ -28683,6 +28987,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10,
                           "type": "array"
                         },
                         "signature_path": {
@@ -28736,6 +29041,7 @@
                             "additionalProperties": {},
                             "type": "object"
                           },
+                          "maxItems": 1000,
                           "type": "array"
                         },
                         "version": {
@@ -29027,6 +29333,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 100,
                     "minItems": 1,
                     "type": "array"
                   }
@@ -29258,6 +29565,7 @@
                       ],
                       "type": "object"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   }
                 },
@@ -29294,6 +29602,7 @@
                     ],
                     "type": "object"
                   },
+                  "maxItems": 10000,
                   "type": "array"
                 }
               }
@@ -29511,6 +29820,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               "type": {
@@ -29523,6 +29833,7 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10000,
                           "type": "array"
                         }
                       },
@@ -29655,6 +29966,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "minItems": 1,
                             "type": "array"
                           },
@@ -29740,6 +30052,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "client_auth": {
@@ -29757,6 +30070,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "type": "array"
                               },
                               "es_key": {
@@ -29776,6 +30090,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -29860,6 +30175,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "minItems": 1,
                     "type": "array"
                   },
@@ -29945,6 +30261,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       },
                       "client_auth": {
@@ -29962,6 +30279,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       },
                       "es_key": {
@@ -29997,6 +30315,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10,
                           "minItems": 1,
                           "type": "array"
                         },
@@ -30082,6 +30401,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "client_auth": {
@@ -30099,6 +30419,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "es_key": {
@@ -30270,6 +30591,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10,
                           "minItems": 1,
                           "type": "array"
                         },
@@ -30355,6 +30677,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "client_auth": {
@@ -30372,6 +30695,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "es_key": {
@@ -30469,6 +30793,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "minItems": 1,
                     "type": "array"
                   },
@@ -30546,6 +30871,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       },
                       "client_auth": {
@@ -30563,6 +30889,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "type": "array"
                       },
                       "es_key": {
@@ -30597,6 +30924,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 10,
                           "minItems": 1,
                           "type": "array"
                         },
@@ -30682,6 +31010,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "client_auth": {
@@ -30699,6 +31028,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "type": "array"
                             },
                             "es_key": {
@@ -31288,6 +31618,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "ca_sha256": {
@@ -31307,6 +31638,7 @@
                                   "format": "uri",
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "minItems": 1,
                                 "type": "array"
                               },
@@ -31448,6 +31780,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 10,
                                     "type": "array"
                                   },
                                   "key": {
@@ -31490,6 +31823,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "ca_sha256": {
@@ -31509,6 +31843,7 @@
                                   "format": "uri",
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "minItems": 1,
                                 "type": "array"
                               },
@@ -31684,6 +32019,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 10,
                                     "type": "array"
                                   },
                                   "key": {
@@ -31732,6 +32068,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "ca_sha256": {
@@ -31750,6 +32087,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "minItems": 1,
                                 "type": "array"
                               },
@@ -31881,6 +32219,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 10,
                                     "type": "array"
                                   },
                                   "key": {
@@ -31919,6 +32258,7 @@
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 1000,
                                 "type": "array"
                               },
                               "auth_type": {
@@ -32048,12 +32388,14 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "hosts": {
                                 "items": {
                                   "type": "string"
                                 },
+                                "maxItems": 10,
                                 "minItems": 1,
                                 "type": "array"
                               },
@@ -32317,6 +32659,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 10,
                                     "type": "array"
                                   },
                                   "key": {
@@ -32393,6 +32736,7 @@
                           }
                         ]
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -32479,6 +32823,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "ca_sha256": {
@@ -32498,6 +32843,7 @@
                           "format": "uri",
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -32639,6 +32985,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -32681,6 +33028,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "ca_sha256": {
@@ -32700,6 +33048,7 @@
                           "format": "uri",
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -32875,6 +33224,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -32923,6 +33273,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "ca_sha256": {
@@ -32941,6 +33292,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -33072,6 +33424,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -33110,6 +33463,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "auth_type": {
@@ -33239,12 +33593,14 @@
                           ],
                           "type": "object"
                         },
+                        "maxItems": 100,
                         "type": "array"
                       },
                       "hosts": {
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -33508,6 +33864,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -33603,6 +33960,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -33622,6 +33980,7 @@
                                 "format": "uri",
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -33763,6 +34122,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -33805,6 +34165,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -33824,6 +34185,7 @@
                                 "format": "uri",
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -33999,6 +34361,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -34047,6 +34410,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -34065,6 +34429,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -34196,6 +34561,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -34234,6 +34600,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "auth_type": {
@@ -34363,12 +34730,14 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "hosts": {
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -34632,6 +35001,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -34892,6 +35262,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -34911,6 +35282,7 @@
                                 "format": "uri",
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -35052,6 +35424,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -35094,6 +35467,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -35113,6 +35487,7 @@
                                 "format": "uri",
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -35288,6 +35663,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -35336,6 +35712,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -35354,6 +35731,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -35485,6 +35863,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -35523,6 +35902,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "auth_type": {
@@ -35652,12 +36032,14 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "hosts": {
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -35921,6 +36303,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -36077,6 +36460,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "ca_sha256": {
@@ -36096,6 +36480,7 @@
                           "format": "uri",
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -36235,6 +36620,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -36272,6 +36658,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "ca_sha256": {
@@ -36291,6 +36678,7 @@
                           "format": "uri",
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -36464,6 +36852,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -36507,6 +36896,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "ca_sha256": {
@@ -36525,6 +36915,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -36654,6 +37045,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -36687,6 +37079,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "auth_type": {
@@ -36816,12 +37209,14 @@
                           ],
                           "type": "object"
                         },
+                        "maxItems": 100,
                         "type": "array"
                       },
                       "hosts": {
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10,
                         "minItems": 1,
                         "type": "array"
                       },
@@ -37085,6 +37480,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 10,
                             "type": "array"
                           },
                           "key": {
@@ -37177,6 +37573,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -37196,6 +37593,7 @@
                                 "format": "uri",
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -37337,6 +37735,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -37379,6 +37778,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -37398,6 +37798,7 @@
                                 "format": "uri",
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -37573,6 +37974,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -37621,6 +38023,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "ca_sha256": {
@@ -37639,6 +38042,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -37770,6 +38174,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -37808,6 +38213,7 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 1000,
                               "type": "array"
                             },
                             "auth_type": {
@@ -37937,12 +38343,14 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "hosts": {
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 10,
                               "minItems": 1,
                               "type": "array"
                             },
@@ -38206,6 +38614,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "key": {
@@ -38502,6 +38911,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 1000,
                             "nullable": true,
                             "type": "array"
                           },
@@ -38533,6 +38943,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   }
                                 },
@@ -38633,6 +39044,7 @@
                                                         "items": {
                                                           "type": "string"
                                                         },
+                                                        "maxItems": 100,
                                                         "type": "array"
                                                       }
                                                     },
@@ -38696,6 +39108,7 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "type": {
@@ -38730,6 +39143,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               {
@@ -38764,12 +39178,14 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
+                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
                                                   "items": {
                                                     "type": "number"
                                                   },
+                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
@@ -38816,12 +39232,14 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
                                             "items": {
                                               "type": "number"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
@@ -38917,6 +39335,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "fips_compatible": {
@@ -38972,12 +39391,14 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "spaceIds": {
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "supports_agentless": {
@@ -39036,12 +39457,14 @@
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
                                       "items": {
                                         "type": "number"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
@@ -39086,6 +39509,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -39184,6 +39608,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "nullable": true,
                         "type": "array"
                       },
@@ -39290,6 +39715,7 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               }
                                             },
@@ -39353,6 +39779,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "type": {
@@ -39385,6 +39812,7 @@
                           ],
                           "type": "object"
                         },
+                        "maxItems": 1000,
                         "type": "array"
                       },
                       "is_managed": {
@@ -39449,6 +39877,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -39492,6 +39921,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 100,
                         "type": "array"
                       },
                       "supports_agentless": {
@@ -39541,6 +39971,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 100,
                         "nullable": true,
                         "type": "array"
                       },
@@ -39585,12 +40016,14 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -39637,12 +40070,14 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -39718,6 +40153,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -39776,12 +40212,14 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
                               "items": {
                                 "type": "number"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -39834,6 +40272,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -39865,6 +40304,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 }
                               },
@@ -39965,6 +40405,7 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     }
                                                   },
@@ -40028,6 +40469,7 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "type": {
@@ -40062,6 +40504,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -40096,12 +40539,14 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -40148,12 +40593,14 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -40249,6 +40696,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "fips_compatible": {
@@ -40304,12 +40752,14 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "spaceIds": {
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "supports_agentless": {
@@ -40368,12 +40818,14 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -40532,6 +40984,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   },
                   "ignoreMissing": {
@@ -40562,6 +41015,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 1000,
                             "nullable": true,
                             "type": "array"
                           },
@@ -40593,6 +41047,7 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   }
                                 },
@@ -40693,6 +41148,7 @@
                                                         "items": {
                                                           "type": "string"
                                                         },
+                                                        "maxItems": 100,
                                                         "type": "array"
                                                       }
                                                     },
@@ -40756,6 +41212,7 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "type": {
@@ -40790,6 +41247,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               {
@@ -40824,12 +41282,14 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
+                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
                                                   "items": {
                                                     "type": "number"
                                                   },
+                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
@@ -40876,12 +41336,14 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
                                             "items": {
                                               "type": "number"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
@@ -40977,6 +41439,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 100,
                                 "type": "array"
                               },
                               "fips_compatible": {
@@ -41032,12 +41495,14 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "spaceIds": {
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "supports_agentless": {
@@ -41096,12 +41561,14 @@
                                       "items": {
                                         "type": "string"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
                                       "items": {
                                         "type": "number"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
@@ -41146,6 +41613,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -41241,6 +41709,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   }
                 },
@@ -41317,6 +41786,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -41353,6 +41823,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 10000,
                         "type": "array"
                       },
                       "statusCode": {
@@ -41370,6 +41841,7 @@
                     ],
                     "type": "object"
                   },
+                  "maxItems": 10000,
                   "type": "array"
                 }
               }
@@ -41438,6 +41910,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   }
                 },
@@ -41488,6 +41961,7 @@
                     ],
                     "type": "object"
                   },
+                  "maxItems": 10000,
                   "type": "array"
                 }
               }
@@ -41556,6 +42030,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 1000,
                     "type": "array"
                   },
                   "packageVersion": {
@@ -41665,6 +42140,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               "revision": {
@@ -41698,6 +42174,7 @@
                                   ],
                                   "type": "object"
                                 },
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               "type": {
@@ -41718,8 +42195,10 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 10000,
                           "type": "array"
                         },
+                        "maxItems": 1,
                         "type": "array"
                       },
                       "body": {
@@ -41745,6 +42224,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 1000,
                                   "nullable": true,
                                   "type": "array"
                                 },
@@ -41776,6 +42256,7 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         }
                                       },
@@ -41876,6 +42357,7 @@
                                                               "items": {
                                                                 "type": "string"
                                                               },
+                                                              "maxItems": 100,
                                                               "type": "array"
                                                             }
                                                           },
@@ -41939,6 +42421,7 @@
                                               ],
                                               "type": "object"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           "type": {
@@ -41973,6 +42456,7 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     {
@@ -42007,12 +42491,14 @@
                                                         "items": {
                                                           "type": "string"
                                                         },
+                                                        "maxItems": 100,
                                                         "type": "array"
                                                       },
                                                       {
                                                         "items": {
                                                           "type": "number"
                                                         },
+                                                        "maxItems": 100,
                                                         "type": "array"
                                                       },
                                                       {
@@ -42059,12 +42545,14 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
+                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
                                                   "items": {
                                                     "type": "number"
                                                   },
+                                                  "maxItems": 100,
                                                   "type": "array"
                                                 },
                                                 {
@@ -42160,6 +42648,7 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "fips_compatible": {
@@ -42215,12 +42704,14 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "spaceIds": {
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "supports_agentless": {
@@ -42279,12 +42770,14 @@
                                             "items": {
                                               "type": "string"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
                                             "items": {
                                               "type": "number"
                                             },
+                                            "maxItems": 100,
                                             "type": "array"
                                           },
                                           {
@@ -42336,6 +42829,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 1000,
                                   "nullable": true,
                                   "type": "array"
                                 },
@@ -42364,6 +42858,7 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         }
                                       },
@@ -42391,6 +42886,7 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 10,
                                   "type": "array"
                                 },
                                 "force": {
@@ -42483,6 +42979,7 @@
                                                           "items": {
                                                             "type": "string"
                                                           },
+                                                          "maxItems": 100,
                                                           "type": "array"
                                                         }
                                                       },
@@ -42546,6 +43043,7 @@
                                           ],
                                           "type": "object"
                                         },
+                                        "maxItems": 100,
                                         "type": "array"
                                       },
                                       "type": {
@@ -42580,6 +43078,7 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "is_managed": {
@@ -42589,6 +43088,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "name": {
@@ -42650,6 +43150,7 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "maxItems": 100,
                                       "type": "array"
                                     },
                                     "fips_compatible": {
@@ -42705,6 +43206,7 @@
                                     ],
                                     "type": "object"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 },
                                 "supports_agentless": {
@@ -42758,6 +43260,7 @@
                             }
                           ]
                         },
+                        "maxItems": 2,
                         "type": "array"
                       },
                       "hasErrors": {
@@ -42775,6 +43278,7 @@
                     ],
                     "type": "object"
                   },
+                  "maxItems": 10000,
                   "type": "array"
                 }
               }
@@ -42944,6 +43448,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -42975,6 +43480,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 }
                               },
@@ -43075,6 +43581,7 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     }
                                                   },
@@ -43138,6 +43645,7 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "type": {
@@ -43172,6 +43680,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -43206,12 +43715,14 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -43258,12 +43769,14 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -43359,6 +43872,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "fips_compatible": {
@@ -43414,12 +43928,14 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "spaceIds": {
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "supports_agentless": {
@@ -43478,12 +43994,14 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -43639,6 +44157,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 1000,
                         "nullable": true,
                         "type": "array"
                       },
@@ -43740,6 +44259,7 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               }
                                             },
@@ -43803,6 +44323,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "type": {
@@ -43835,6 +44356,7 @@
                           ],
                           "type": "object"
                         },
+                        "maxItems": 100,
                         "type": "array"
                       },
                       "is_managed": {
@@ -43898,6 +44420,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -43941,6 +44464,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 100,
                         "type": "array"
                       },
                       "supports_agentless": {
@@ -43989,6 +44513,7 @@
                         "items": {
                           "type": "string"
                         },
+                        "maxItems": 100,
                         "nullable": true,
                         "type": "array"
                       },
@@ -44033,12 +44558,14 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -44085,12 +44612,14 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -44166,6 +44695,7 @@
                               ],
                               "type": "object"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "fips_compatible": {
@@ -44224,12 +44754,14 @@
                               "items": {
                                 "type": "string"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
                               "items": {
                                 "type": "number"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -44281,6 +44813,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 1000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -44312,6 +44845,7 @@
                                   "items": {
                                     "type": "string"
                                   },
+                                  "maxItems": 100,
                                   "type": "array"
                                 }
                               },
@@ -44412,6 +44946,7 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
+                                                      "maxItems": 100,
                                                       "type": "array"
                                                     }
                                                   },
@@ -44475,6 +45010,7 @@
                                       ],
                                       "type": "object"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   "type": {
@@ -44509,6 +45045,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             {
@@ -44543,12 +45080,14 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
                                                 "items": {
                                                   "type": "number"
                                                 },
+                                                "maxItems": 100,
                                                 "type": "array"
                                               },
                                               {
@@ -44595,12 +45134,14 @@
                                           "items": {
                                             "type": "string"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
                                           "items": {
                                             "type": "number"
                                           },
+                                          "maxItems": 100,
                                           "type": "array"
                                         },
                                         {
@@ -44696,6 +45237,7 @@
                                 ],
                                 "type": "object"
                               },
+                              "maxItems": 100,
                               "type": "array"
                             },
                             "fips_compatible": {
@@ -44751,12 +45293,14 @@
                             ],
                             "type": "object"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "spaceIds": {
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "supports_agentless": {
@@ -44815,12 +45359,14 @@
                                     "items": {
                                       "type": "string"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
                                     "items": {
                                       "type": "number"
                                     },
+                                    "maxItems": 100,
                                     "type": "array"
                                   },
                                   {
@@ -45007,6 +45553,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -45673,6 +46220,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 1,
                           "type": "array"
                         },
                         "prerelease_integrations_enabled": {
@@ -45820,6 +46368,7 @@
                       "format": "uri",
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   },
                   "prerelease_integrations_enabled": {
@@ -45876,6 +46425,7 @@
                             ],
                             "type": "string"
                           },
+                          "maxItems": 1,
                           "type": "array"
                         },
                         "prerelease_integrations_enabled": {
@@ -46013,6 +46563,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -46099,6 +46650,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "managed_by": {
@@ -46149,6 +46701,7 @@
                     "items": {
                       "type": "string"
                     },
+                    "maxItems": 10,
                     "type": "array"
                   }
                 },
@@ -46171,6 +46724,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "managed_by": {
@@ -46262,6 +46816,7 @@
                             "items": {
                               "type": "string"
                             },
+                            "maxItems": 100,
                             "type": "array"
                           },
                           "policy_id": {
@@ -46279,6 +46834,7 @@
                         ],
                         "type": "object"
                       },
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "page": {
@@ -46373,6 +46929,7 @@
                           "items": {
                             "type": "string"
                           },
+                          "maxItems": 100,
                           "type": "array"
                         },
                         "policy_id": {

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -19973,6 +19973,7 @@ paths:
                             certificate_authorities:
                               items:
                                 type: string
+                              maxItems: 10
                               type: array
                             key:
                               type: string
@@ -19980,6 +19981,7 @@ paths:
                         - id
                         - name
                         - host
+                    maxItems: 10000
                     type: array
                   page:
                     type: number
@@ -20084,6 +20086,7 @@ paths:
                     certificate_authorities:
                       items:
                         type: string
+                      maxItems: 10
                       type: array
                     key:
                       type: string
@@ -20143,6 +20146,7 @@ paths:
                           certificate_authorities:
                             items:
                               type: string
+                            maxItems: 10
                             type: array
                           key:
                             type: string
@@ -20309,6 +20313,7 @@ paths:
                           certificate_authorities:
                             items:
                               type: string
+                            maxItems: 10
                             type: array
                           key:
                             type: string
@@ -20415,6 +20420,7 @@ paths:
                     certificate_authorities:
                       items:
                         type: string
+                      maxItems: 10
                       type: array
                     key:
                       type: string
@@ -20474,6 +20480,7 @@ paths:
                           certificate_authorities:
                             items:
                               type: string
+                            maxItems: 10
                             type: array
                           key:
                             type: string
@@ -20630,6 +20637,7 @@ paths:
                             required:
                               - name
                               - enabled
+                          maxItems: 100
                           type: array
                         agentless:
                           additionalProperties: false
@@ -20687,6 +20695,7 @@ paths:
                             required:
                               - name
                               - value
+                          maxItems: 10
                           type: array
                         has_fleet_server:
                           type: boolean
@@ -20741,6 +20750,7 @@ paths:
                               - metrics
                               - traces
                             type: string
+                          maxItems: 3
                           type: array
                         monitoring_http:
                           additionalProperties: false
@@ -20781,6 +20791,7 @@ paths:
                           anyOf:
                             - items:
                                 type: string
+                              maxItems: 10000
                               type: array
                             - description: This field is present only when retrieving a single agent policy, or when retrieving a list of agent policies with the ?full=true parameter
                               items:
@@ -20791,6 +20802,7 @@ paths:
                                     description: Additional datastream permissions, that will be added to the agent policy.
                                     items:
                                       type: string
+                                    maxItems: 1000
                                     nullable: true
                                     type: array
                                   agents:
@@ -20817,6 +20829,7 @@ paths:
                                           cluster:
                                             items:
                                               type: string
+                                            maxItems: 100
                                             type: array
                                   enabled:
                                     type: boolean
@@ -20892,6 +20905,7 @@ paths:
                                                               indices:
                                                                 items:
                                                                   type: string
+                                                                maxItems: 100
                                                                 type: array
                                                       type:
                                                         type: string
@@ -20928,6 +20942,7 @@ paths:
                                                   - enabled
                                                   - data_stream
                                                   - compiled_stream
+                                              maxItems: 100
                                               type: array
                                             type:
                                               type: string
@@ -20950,6 +20965,7 @@ paths:
                                             - enabled
                                             - streams
                                             - compiled_input
+                                        maxItems: 100
                                         type: array
                                       - additionalProperties:
                                           additionalProperties: false
@@ -20974,9 +20990,11 @@ paths:
                                                         - type: number
                                                         - items:
                                                             type: string
+                                                          maxItems: 100
                                                           type: array
                                                         - items:
                                                             type: number
+                                                          maxItems: 100
                                                           type: array
                                                         - additionalProperties: false
                                                           type: object
@@ -21001,9 +21019,11 @@ paths:
                                                   - type: number
                                                   - items:
                                                       type: string
+                                                    maxItems: 100
                                                     type: array
                                                   - items:
                                                       type: number
+                                                    maxItems: 100
                                                     type: array
                                                   - additionalProperties: false
                                                     type: object
@@ -21067,6 +21087,7 @@ paths:
                                           required:
                                             - data_stream
                                             - features
+                                        maxItems: 100
                                         type: array
                                       fips_compatible:
                                         type: boolean
@@ -21104,10 +21125,12 @@ paths:
                                           type: string
                                       required:
                                         - id
+                                    maxItems: 100
                                     type: array
                                   spaceIds:
                                     items:
                                       type: string
+                                    maxItems: 100
                                     type: array
                                   supports_agentless:
                                     default: false
@@ -21145,9 +21168,11 @@ paths:
                                             - type: number
                                             - items:
                                                 type: string
+                                              maxItems: 100
                                               type: array
                                             - items:
                                                 type: number
+                                              maxItems: 100
                                               type: array
                                             - additionalProperties: false
                                               type: object
@@ -21175,6 +21200,7 @@ paths:
                                   - updated_by
                                   - created_at
                                   - created_by
+                              maxItems: 10000
                               type: array
                         required_versions:
                           items:
@@ -21192,6 +21218,7 @@ paths:
                             required:
                               - version
                               - percentage
+                          maxItems: 100
                           nullable: true
                           type: array
                         revision:
@@ -21201,6 +21228,7 @@ paths:
                         space_ids:
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                         status:
                           enum:
@@ -21233,6 +21261,7 @@ paths:
                         - updated_at
                         - updated_by
                         - revision
+                    maxItems: 10000
                     type: array
                   page:
                     type: number
@@ -21337,6 +21366,7 @@ paths:
                     required:
                       - name
                       - enabled
+                  maxItems: 100
                   type: array
                 agentless:
                   additionalProperties: false
@@ -21392,6 +21422,7 @@ paths:
                     required:
                       - name
                       - value
+                  maxItems: 10
                   type: array
                 has_fleet_server:
                   type: boolean
@@ -21443,6 +21474,7 @@ paths:
                       - metrics
                       - traces
                     type: string
+                  maxItems: 3
                   type: array
                 monitoring_http:
                   additionalProperties: false
@@ -21495,11 +21527,13 @@ paths:
                     required:
                       - version
                       - percentage
+                  maxItems: 100
                   nullable: true
                   type: array
                 space_ids:
                   items:
                     type: string
+                  maxItems: 100
                   type: array
                 supports_agentless:
                   default: false
@@ -21560,6 +21594,7 @@ paths:
                           required:
                             - name
                             - enabled
+                        maxItems: 100
                         type: array
                       agentless:
                         additionalProperties: false
@@ -21617,6 +21652,7 @@ paths:
                           required:
                             - name
                             - value
+                        maxItems: 10
                         type: array
                       has_fleet_server:
                         type: boolean
@@ -21671,6 +21707,7 @@ paths:
                             - metrics
                             - traces
                           type: string
+                        maxItems: 3
                         type: array
                       monitoring_http:
                         additionalProperties: false
@@ -21711,6 +21748,7 @@ paths:
                         anyOf:
                           - items:
                               type: string
+                            maxItems: 10000
                             type: array
                           - description: This field is present only when retrieving a single agent policy, or when retrieving a list of agent policies with the ?full=true parameter
                             items:
@@ -21721,6 +21759,7 @@ paths:
                                   description: Additional datastream permissions, that will be added to the agent policy.
                                   items:
                                     type: string
+                                  maxItems: 1000
                                   nullable: true
                                   type: array
                                 agents:
@@ -21747,6 +21786,7 @@ paths:
                                         cluster:
                                           items:
                                             type: string
+                                          maxItems: 100
                                           type: array
                                 enabled:
                                   type: boolean
@@ -21822,6 +21862,7 @@ paths:
                                                             indices:
                                                               items:
                                                                 type: string
+                                                              maxItems: 100
                                                               type: array
                                                     type:
                                                       type: string
@@ -21858,6 +21899,7 @@ paths:
                                                 - enabled
                                                 - data_stream
                                                 - compiled_stream
+                                            maxItems: 100
                                             type: array
                                           type:
                                             type: string
@@ -21880,6 +21922,7 @@ paths:
                                           - enabled
                                           - streams
                                           - compiled_input
+                                      maxItems: 100
                                       type: array
                                     - additionalProperties:
                                         additionalProperties: false
@@ -21904,9 +21947,11 @@ paths:
                                                       - type: number
                                                       - items:
                                                           type: string
+                                                        maxItems: 100
                                                         type: array
                                                       - items:
                                                           type: number
+                                                        maxItems: 100
                                                         type: array
                                                       - additionalProperties: false
                                                         type: object
@@ -21931,9 +21976,11 @@ paths:
                                                 - type: number
                                                 - items:
                                                     type: string
+                                                  maxItems: 100
                                                   type: array
                                                 - items:
                                                     type: number
+                                                  maxItems: 100
                                                   type: array
                                                 - additionalProperties: false
                                                   type: object
@@ -21997,6 +22044,7 @@ paths:
                                         required:
                                           - data_stream
                                           - features
+                                      maxItems: 100
                                       type: array
                                     fips_compatible:
                                       type: boolean
@@ -22034,10 +22082,12 @@ paths:
                                         type: string
                                     required:
                                       - id
+                                  maxItems: 100
                                   type: array
                                 spaceIds:
                                   items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 supports_agentless:
                                   default: false
@@ -22075,9 +22125,11 @@ paths:
                                           - type: number
                                           - items:
                                               type: string
+                                            maxItems: 100
                                             type: array
                                           - items:
                                               type: number
+                                            maxItems: 100
                                             type: array
                                           - additionalProperties: false
                                             type: object
@@ -22105,6 +22157,7 @@ paths:
                                 - updated_by
                                 - created_at
                                 - created_by
+                            maxItems: 10000
                             type: array
                       required_versions:
                         items:
@@ -22122,6 +22175,7 @@ paths:
                           required:
                             - version
                             - percentage
+                        maxItems: 100
                         nullable: true
                         type: array
                       revision:
@@ -22131,6 +22185,7 @@ paths:
                       space_ids:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       status:
                         enum:
@@ -22232,6 +22287,7 @@ paths:
                   description: list of package policy ids
                   items:
                     type: string
+                  maxItems: 1000
                   type: array
                 ignoreMissing:
                   type: boolean
@@ -22286,6 +22342,7 @@ paths:
                             required:
                               - name
                               - enabled
+                          maxItems: 100
                           type: array
                         agentless:
                           additionalProperties: false
@@ -22343,6 +22400,7 @@ paths:
                             required:
                               - name
                               - value
+                          maxItems: 10
                           type: array
                         has_fleet_server:
                           type: boolean
@@ -22397,6 +22455,7 @@ paths:
                               - metrics
                               - traces
                             type: string
+                          maxItems: 3
                           type: array
                         monitoring_http:
                           additionalProperties: false
@@ -22437,6 +22496,7 @@ paths:
                           anyOf:
                             - items:
                                 type: string
+                              maxItems: 10000
                               type: array
                             - description: This field is present only when retrieving a single agent policy, or when retrieving a list of agent policies with the ?full=true parameter
                               items:
@@ -22447,6 +22507,7 @@ paths:
                                     description: Additional datastream permissions, that will be added to the agent policy.
                                     items:
                                       type: string
+                                    maxItems: 1000
                                     nullable: true
                                     type: array
                                   agents:
@@ -22473,6 +22534,7 @@ paths:
                                           cluster:
                                             items:
                                               type: string
+                                            maxItems: 100
                                             type: array
                                   enabled:
                                     type: boolean
@@ -22548,6 +22610,7 @@ paths:
                                                               indices:
                                                                 items:
                                                                   type: string
+                                                                maxItems: 100
                                                                 type: array
                                                       type:
                                                         type: string
@@ -22584,6 +22647,7 @@ paths:
                                                   - enabled
                                                   - data_stream
                                                   - compiled_stream
+                                              maxItems: 100
                                               type: array
                                             type:
                                               type: string
@@ -22606,6 +22670,7 @@ paths:
                                             - enabled
                                             - streams
                                             - compiled_input
+                                        maxItems: 100
                                         type: array
                                       - additionalProperties:
                                           additionalProperties: false
@@ -22630,9 +22695,11 @@ paths:
                                                         - type: number
                                                         - items:
                                                             type: string
+                                                          maxItems: 100
                                                           type: array
                                                         - items:
                                                             type: number
+                                                          maxItems: 100
                                                           type: array
                                                         - additionalProperties: false
                                                           type: object
@@ -22657,9 +22724,11 @@ paths:
                                                   - type: number
                                                   - items:
                                                       type: string
+                                                    maxItems: 100
                                                     type: array
                                                   - items:
                                                       type: number
+                                                    maxItems: 100
                                                     type: array
                                                   - additionalProperties: false
                                                     type: object
@@ -22723,6 +22792,7 @@ paths:
                                           required:
                                             - data_stream
                                             - features
+                                        maxItems: 100
                                         type: array
                                       fips_compatible:
                                         type: boolean
@@ -22760,10 +22830,12 @@ paths:
                                           type: string
                                       required:
                                         - id
+                                    maxItems: 100
                                     type: array
                                   spaceIds:
                                     items:
                                       type: string
+                                    maxItems: 100
                                     type: array
                                   supports_agentless:
                                     default: false
@@ -22801,9 +22873,11 @@ paths:
                                             - type: number
                                             - items:
                                                 type: string
+                                              maxItems: 100
                                               type: array
                                             - items:
                                                 type: number
+                                              maxItems: 100
                                               type: array
                                             - additionalProperties: false
                                               type: object
@@ -22831,6 +22905,7 @@ paths:
                                   - updated_by
                                   - created_at
                                   - created_by
+                              maxItems: 10000
                               type: array
                         required_versions:
                           items:
@@ -22848,6 +22923,7 @@ paths:
                             required:
                               - version
                               - percentage
+                          maxItems: 100
                           nullable: true
                           type: array
                         revision:
@@ -22857,6 +22933,7 @@ paths:
                         space_ids:
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                         status:
                           enum:
@@ -22889,6 +22966,7 @@ paths:
                         - updated_at
                         - updated_by
                         - revision
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -22991,6 +23069,7 @@ paths:
                           required:
                             - name
                             - enabled
+                        maxItems: 100
                         type: array
                       agentless:
                         additionalProperties: false
@@ -23048,6 +23127,7 @@ paths:
                           required:
                             - name
                             - value
+                        maxItems: 10
                         type: array
                       has_fleet_server:
                         type: boolean
@@ -23102,6 +23182,7 @@ paths:
                             - metrics
                             - traces
                           type: string
+                        maxItems: 3
                         type: array
                       monitoring_http:
                         additionalProperties: false
@@ -23142,6 +23223,7 @@ paths:
                         anyOf:
                           - items:
                               type: string
+                            maxItems: 10000
                             type: array
                           - description: This field is present only when retrieving a single agent policy, or when retrieving a list of agent policies with the ?full=true parameter
                             items:
@@ -23152,6 +23234,7 @@ paths:
                                   description: Additional datastream permissions, that will be added to the agent policy.
                                   items:
                                     type: string
+                                  maxItems: 1000
                                   nullable: true
                                   type: array
                                 agents:
@@ -23178,6 +23261,7 @@ paths:
                                         cluster:
                                           items:
                                             type: string
+                                          maxItems: 100
                                           type: array
                                 enabled:
                                   type: boolean
@@ -23253,6 +23337,7 @@ paths:
                                                             indices:
                                                               items:
                                                                 type: string
+                                                              maxItems: 100
                                                               type: array
                                                     type:
                                                       type: string
@@ -23289,6 +23374,7 @@ paths:
                                                 - enabled
                                                 - data_stream
                                                 - compiled_stream
+                                            maxItems: 100
                                             type: array
                                           type:
                                             type: string
@@ -23311,6 +23397,7 @@ paths:
                                           - enabled
                                           - streams
                                           - compiled_input
+                                      maxItems: 100
                                       type: array
                                     - additionalProperties:
                                         additionalProperties: false
@@ -23335,9 +23422,11 @@ paths:
                                                       - type: number
                                                       - items:
                                                           type: string
+                                                        maxItems: 100
                                                         type: array
                                                       - items:
                                                           type: number
+                                                        maxItems: 100
                                                         type: array
                                                       - additionalProperties: false
                                                         type: object
@@ -23362,9 +23451,11 @@ paths:
                                                 - type: number
                                                 - items:
                                                     type: string
+                                                  maxItems: 100
                                                   type: array
                                                 - items:
                                                     type: number
+                                                  maxItems: 100
                                                   type: array
                                                 - additionalProperties: false
                                                   type: object
@@ -23428,6 +23519,7 @@ paths:
                                         required:
                                           - data_stream
                                           - features
+                                      maxItems: 100
                                       type: array
                                     fips_compatible:
                                       type: boolean
@@ -23465,10 +23557,12 @@ paths:
                                         type: string
                                     required:
                                       - id
+                                  maxItems: 100
                                   type: array
                                 spaceIds:
                                   items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 supports_agentless:
                                   default: false
@@ -23506,9 +23600,11 @@ paths:
                                           - type: number
                                           - items:
                                               type: string
+                                            maxItems: 100
                                             type: array
                                           - items:
                                               type: number
+                                            maxItems: 100
                                             type: array
                                           - additionalProperties: false
                                             type: object
@@ -23536,6 +23632,7 @@ paths:
                                 - updated_by
                                 - created_at
                                 - created_by
+                            maxItems: 10000
                             type: array
                       required_versions:
                         items:
@@ -23553,6 +23650,7 @@ paths:
                           required:
                             - version
                             - percentage
+                        maxItems: 100
                         nullable: true
                         type: array
                       revision:
@@ -23562,6 +23660,7 @@ paths:
                       space_ids:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       status:
                         enum:
@@ -23696,6 +23795,7 @@ paths:
                     required:
                       - name
                       - enabled
+                  maxItems: 100
                   type: array
                 agentless:
                   additionalProperties: false
@@ -23753,6 +23853,7 @@ paths:
                     required:
                       - name
                       - value
+                  maxItems: 10
                   type: array
                 has_fleet_server:
                   type: boolean
@@ -23804,6 +23905,7 @@ paths:
                       - metrics
                       - traces
                     type: string
+                  maxItems: 3
                   type: array
                 monitoring_http:
                   additionalProperties: false
@@ -23856,11 +23958,13 @@ paths:
                     required:
                       - version
                       - percentage
+                  maxItems: 100
                   nullable: true
                   type: array
                 space_ids:
                   items:
                     type: string
+                  maxItems: 100
                   type: array
                 supports_agentless:
                   default: false
@@ -23921,6 +24025,7 @@ paths:
                           required:
                             - name
                             - enabled
+                        maxItems: 100
                         type: array
                       agentless:
                         additionalProperties: false
@@ -23978,6 +24083,7 @@ paths:
                           required:
                             - name
                             - value
+                        maxItems: 10
                         type: array
                       has_fleet_server:
                         type: boolean
@@ -24032,6 +24138,7 @@ paths:
                             - metrics
                             - traces
                           type: string
+                        maxItems: 3
                         type: array
                       monitoring_http:
                         additionalProperties: false
@@ -24072,6 +24179,7 @@ paths:
                         anyOf:
                           - items:
                               type: string
+                            maxItems: 10000
                             type: array
                           - description: This field is present only when retrieving a single agent policy, or when retrieving a list of agent policies with the ?full=true parameter
                             items:
@@ -24082,6 +24190,7 @@ paths:
                                   description: Additional datastream permissions, that will be added to the agent policy.
                                   items:
                                     type: string
+                                  maxItems: 1000
                                   nullable: true
                                   type: array
                                 agents:
@@ -24108,6 +24217,7 @@ paths:
                                         cluster:
                                           items:
                                             type: string
+                                          maxItems: 100
                                           type: array
                                 enabled:
                                   type: boolean
@@ -24183,6 +24293,7 @@ paths:
                                                             indices:
                                                               items:
                                                                 type: string
+                                                              maxItems: 100
                                                               type: array
                                                     type:
                                                       type: string
@@ -24219,6 +24330,7 @@ paths:
                                                 - enabled
                                                 - data_stream
                                                 - compiled_stream
+                                            maxItems: 100
                                             type: array
                                           type:
                                             type: string
@@ -24241,6 +24353,7 @@ paths:
                                           - enabled
                                           - streams
                                           - compiled_input
+                                      maxItems: 100
                                       type: array
                                     - additionalProperties:
                                         additionalProperties: false
@@ -24265,9 +24378,11 @@ paths:
                                                       - type: number
                                                       - items:
                                                           type: string
+                                                        maxItems: 100
                                                         type: array
                                                       - items:
                                                           type: number
+                                                        maxItems: 100
                                                         type: array
                                                       - additionalProperties: false
                                                         type: object
@@ -24292,9 +24407,11 @@ paths:
                                                 - type: number
                                                 - items:
                                                     type: string
+                                                  maxItems: 100
                                                   type: array
                                                 - items:
                                                     type: number
+                                                  maxItems: 100
                                                   type: array
                                                 - additionalProperties: false
                                                   type: object
@@ -24358,6 +24475,7 @@ paths:
                                         required:
                                           - data_stream
                                           - features
+                                      maxItems: 100
                                       type: array
                                     fips_compatible:
                                       type: boolean
@@ -24395,10 +24513,12 @@ paths:
                                         type: string
                                     required:
                                       - id
+                                  maxItems: 100
                                   type: array
                                 spaceIds:
                                   items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 supports_agentless:
                                   default: false
@@ -24436,9 +24556,11 @@ paths:
                                           - type: number
                                           - items:
                                               type: string
+                                            maxItems: 100
                                             type: array
                                           - items:
                                               type: number
+                                            maxItems: 100
                                             type: array
                                           - additionalProperties: false
                                             type: object
@@ -24466,6 +24588,7 @@ paths:
                                 - updated_by
                                 - created_at
                                 - created_by
+                            maxItems: 10000
                             type: array
                       required_versions:
                         items:
@@ -24483,6 +24606,7 @@ paths:
                           required:
                             - version
                             - percentage
+                        maxItems: 100
                         nullable: true
                         type: array
                       revision:
@@ -24492,6 +24616,7 @@ paths:
                       space_ids:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       status:
                         enum:
@@ -24592,6 +24717,7 @@ paths:
                         - version
                         - agents
                         - failedUpgradeAgents
+                    maxItems: 10000
                     type: array
                   totalAgents:
                     type: number
@@ -24718,6 +24844,7 @@ paths:
                           required:
                             - name
                             - enabled
+                        maxItems: 100
                         type: array
                       agentless:
                         additionalProperties: false
@@ -24775,6 +24902,7 @@ paths:
                           required:
                             - name
                             - value
+                        maxItems: 10
                         type: array
                       has_fleet_server:
                         type: boolean
@@ -24829,6 +24957,7 @@ paths:
                             - metrics
                             - traces
                           type: string
+                        maxItems: 3
                         type: array
                       monitoring_http:
                         additionalProperties: false
@@ -24869,6 +24998,7 @@ paths:
                         anyOf:
                           - items:
                               type: string
+                            maxItems: 10000
                             type: array
                           - description: This field is present only when retrieving a single agent policy, or when retrieving a list of agent policies with the ?full=true parameter
                             items:
@@ -24879,6 +25009,7 @@ paths:
                                   description: Additional datastream permissions, that will be added to the agent policy.
                                   items:
                                     type: string
+                                  maxItems: 1000
                                   nullable: true
                                   type: array
                                 agents:
@@ -24905,6 +25036,7 @@ paths:
                                         cluster:
                                           items:
                                             type: string
+                                          maxItems: 100
                                           type: array
                                 enabled:
                                   type: boolean
@@ -24980,6 +25112,7 @@ paths:
                                                             indices:
                                                               items:
                                                                 type: string
+                                                              maxItems: 100
                                                               type: array
                                                     type:
                                                       type: string
@@ -25016,6 +25149,7 @@ paths:
                                                 - enabled
                                                 - data_stream
                                                 - compiled_stream
+                                            maxItems: 100
                                             type: array
                                           type:
                                             type: string
@@ -25038,6 +25172,7 @@ paths:
                                           - enabled
                                           - streams
                                           - compiled_input
+                                      maxItems: 100
                                       type: array
                                     - additionalProperties:
                                         additionalProperties: false
@@ -25062,9 +25197,11 @@ paths:
                                                       - type: number
                                                       - items:
                                                           type: string
+                                                        maxItems: 100
                                                         type: array
                                                       - items:
                                                           type: number
+                                                        maxItems: 100
                                                         type: array
                                                       - additionalProperties: false
                                                         type: object
@@ -25089,9 +25226,11 @@ paths:
                                                 - type: number
                                                 - items:
                                                     type: string
+                                                  maxItems: 100
                                                   type: array
                                                 - items:
                                                     type: number
+                                                  maxItems: 100
                                                   type: array
                                                 - additionalProperties: false
                                                   type: object
@@ -25155,6 +25294,7 @@ paths:
                                         required:
                                           - data_stream
                                           - features
+                                      maxItems: 100
                                       type: array
                                     fips_compatible:
                                       type: boolean
@@ -25192,10 +25332,12 @@ paths:
                                         type: string
                                     required:
                                       - id
+                                  maxItems: 100
                                   type: array
                                 spaceIds:
                                   items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 supports_agentless:
                                   default: false
@@ -25233,9 +25375,11 @@ paths:
                                           - type: number
                                           - items:
                                               type: string
+                                            maxItems: 100
                                             type: array
                                           - items:
                                               type: number
+                                            maxItems: 100
                                             type: array
                                           - additionalProperties: false
                                             type: object
@@ -25263,6 +25407,7 @@ paths:
                                 - updated_by
                                 - created_at
                                 - created_by
+                            maxItems: 10000
                             type: array
                       required_versions:
                         items:
@@ -25280,6 +25425,7 @@ paths:
                           required:
                             - version
                             - percentage
+                        maxItems: 100
                         nullable: true
                         type: array
                       revision:
@@ -25289,6 +25435,7 @@ paths:
                       space_ids:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       status:
                         enum:
@@ -25524,6 +25671,7 @@ paths:
                                       certificate_authorities:
                                         items:
                                           type: string
+                                        maxItems: 10
                                         type: array
                                       key:
                                         type: string
@@ -25637,6 +25785,7 @@ paths:
                                   hosts:
                                     items:
                                       type: string
+                                    maxItems: 100
                                     type: array
                                   proxy_headers:
                                     additionalProperties:
@@ -25673,6 +25822,7 @@ paths:
                                       certificate_authorities:
                                         items:
                                           type: string
+                                        maxItems: 10
                                         type: array
                                       key:
                                         type: string
@@ -25692,6 +25842,7 @@ paths:
                                       hosts:
                                         items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                                       path:
                                         type: string
@@ -25760,6 +25911,7 @@ paths:
                                           - fields
                                     required:
                                       - add_fields
+                                  maxItems: 10000
                                   type: array
                                 revision:
                                   type: number
@@ -25783,6 +25935,7 @@ paths:
                                     required:
                                       - id
                                       - data_stream
+                                  maxItems: 10000
                                   type: array
                                 type:
                                   type: string
@@ -25796,10 +25949,12 @@ paths:
                                 - data_stream
                                 - use_output
                                 - package_policy_id
+                            maxItems: 10000
                             type: array
                           namespaces:
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                           output_permissions:
                             additionalProperties:
@@ -25817,6 +25972,7 @@ paths:
                                 hosts:
                                   items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 proxy_headers:
                                   additionalProperties:
@@ -25850,6 +26006,7 @@ paths:
                                   type: string
                               required:
                                 - id
+                            maxItems: 1000
                             type: array
                           service:
                             additionalProperties: false
@@ -25858,6 +26015,7 @@ paths:
                               extensions:
                                 items:
                                   type: string
+                                maxItems: 1000
                                 type: array
                               pipelines:
                                 additionalProperties:
@@ -25867,14 +26025,17 @@ paths:
                                     exporters:
                                       items:
                                         type: string
+                                      maxItems: 1000
                                       type: array
                                     processors:
                                       items:
                                         type: string
+                                      maxItems: 1000
                                       type: array
                                     receivers:
                                       items:
                                         type: string
+                                      maxItems: 1000
                                       type: array
                                   x-oas-optional: true
                                 type: object
@@ -25969,6 +26130,7 @@ paths:
                                   type: string
                                 pkgName:
                                   type: string
+                            maxItems: 1000
                             type: array
                           output:
                             additionalProperties: false
@@ -26135,6 +26297,7 @@ paths:
                   description: list of package policy ids
                   items:
                     type: string
+                  maxItems: 1000
                   type: array
               required:
                 - ids
@@ -26170,6 +26333,7 @@ paths:
                                     type: string
                                   pkgName:
                                     type: string
+                              maxItems: 1000
                               type: array
                             output:
                               additionalProperties: false
@@ -26204,6 +26368,7 @@ paths:
                       required:
                         - monitoring
                         - data
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -26249,6 +26414,7 @@ paths:
             anyOf:
               - items:
                   type: string
+                maxItems: 1000
                 type: array
               - type: string
         - in: query
@@ -26356,6 +26522,7 @@ paths:
             anyOf:
               - items:
                   type: string
+                maxItems: 10000
                 type: array
               - type: string
         - in: query
@@ -26384,6 +26551,7 @@ paths:
                 properties:
                   dataPreview:
                     items: {}
+                    maxItems: 1000
                     type: array
                   items:
                     items:
@@ -26396,6 +26564,7 @@ paths:
                         required:
                           - data
                       type: object
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -26603,12 +26772,14 @@ paths:
                                     - type
                                     - status
                                     - message
+                                maxItems: 1000
                                 type: array
                             required:
                               - id
                               - type
                               - status
                               - message
+                          maxItems: 1000
                           type: array
                         default_api_key:
                           type: string
@@ -26625,6 +26796,7 @@ paths:
                             required:
                               - id
                               - retired_at
+                          maxItems: 100
                           type: array
                         default_api_key_id:
                           type: string
@@ -26672,6 +26844,7 @@ paths:
                         namespaces:
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                         outputs:
                           additionalProperties:
@@ -26692,6 +26865,7 @@ paths:
                                   required:
                                     - id
                                     - retired_at
+                                maxItems: 100
                                 type: array
                               type:
                                 type: string
@@ -26699,6 +26873,7 @@ paths:
                         packages:
                           items:
                             type: string
+                          maxItems: 1000
                           type: array
                         policy_id:
                           type: string
@@ -26707,6 +26882,7 @@ paths:
                           type: number
                         sort:
                           items: {}
+                          maxItems: 10
                           type: array
                         status:
                           enum:
@@ -26725,6 +26901,7 @@ paths:
                         tags:
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                         type:
                           enum:
@@ -26743,11 +26920,13 @@ paths:
                               - output
                               - other
                             type: string
+                          maxItems: 3
                           nullable: true
                           type: array
                         upgrade_attempts:
                           items:
                             type: string
+                          maxItems: 1000
                           nullable: true
                           type: array
                         upgrade_details:
@@ -26819,6 +26998,7 @@ paths:
                         - active
                         - enrolled_at
                         - local_metadata
+                    maxItems: 10000
                     type: array
                   nextSearchAfter:
                     type: string
@@ -26893,6 +27073,7 @@ paths:
                 actionIds:
                   items:
                     type: string
+                  maxItems: 1000
                   type: array
               required:
                 - actionIds
@@ -26907,6 +27088,7 @@ paths:
                   items:
                     items:
                       type: string
+                    maxItems: 1000
                     type: array
                 required:
                   - items
@@ -27107,12 +27289,14 @@ paths:
                                   - type
                                   - status
                                   - message
+                              maxItems: 1000
                               type: array
                           required:
                             - id
                             - type
                             - status
                             - message
+                        maxItems: 1000
                         type: array
                       default_api_key:
                         type: string
@@ -27129,6 +27313,7 @@ paths:
                           required:
                             - id
                             - retired_at
+                        maxItems: 100
                         type: array
                       default_api_key_id:
                         type: string
@@ -27176,6 +27361,7 @@ paths:
                       namespaces:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       outputs:
                         additionalProperties:
@@ -27196,6 +27382,7 @@ paths:
                                 required:
                                   - id
                                   - retired_at
+                              maxItems: 100
                               type: array
                             type:
                               type: string
@@ -27203,6 +27390,7 @@ paths:
                       packages:
                         items:
                           type: string
+                        maxItems: 1000
                         type: array
                       policy_id:
                         type: string
@@ -27211,6 +27399,7 @@ paths:
                         type: number
                       sort:
                         items: {}
+                        maxItems: 10
                         type: array
                       status:
                         enum:
@@ -27229,6 +27418,7 @@ paths:
                       tags:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       type:
                         enum:
@@ -27247,11 +27437,13 @@ paths:
                             - output
                             - other
                           type: string
+                        maxItems: 3
                         nullable: true
                         type: array
                       upgrade_attempts:
                         items:
                           type: string
+                        maxItems: 1000
                         nullable: true
                         type: array
                       upgrade_details:
@@ -27384,6 +27576,7 @@ paths:
                 tags:
                   items:
                     type: string
+                  maxItems: 10
                   type: array
                 user_provided_metadata:
                   additionalProperties: {}
@@ -27473,12 +27666,14 @@ paths:
                                   - type
                                   - status
                                   - message
+                              maxItems: 1000
                               type: array
                           required:
                             - id
                             - type
                             - status
                             - message
+                        maxItems: 1000
                         type: array
                       default_api_key:
                         type: string
@@ -27495,6 +27690,7 @@ paths:
                           required:
                             - id
                             - retired_at
+                        maxItems: 100
                         type: array
                       default_api_key_id:
                         type: string
@@ -27542,6 +27738,7 @@ paths:
                       namespaces:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       outputs:
                         additionalProperties:
@@ -27562,6 +27759,7 @@ paths:
                                 required:
                                   - id
                                   - retired_at
+                              maxItems: 100
                               type: array
                             type:
                               type: string
@@ -27569,6 +27767,7 @@ paths:
                       packages:
                         items:
                           type: string
+                        maxItems: 1000
                         type: array
                       policy_id:
                         type: string
@@ -27577,6 +27776,7 @@ paths:
                         type: number
                       sort:
                         items: {}
+                        maxItems: 10
                         type: array
                       status:
                         enum:
@@ -27595,6 +27795,7 @@ paths:
                       tags:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       type:
                         enum:
@@ -27613,11 +27814,13 @@ paths:
                             - output
                             - other
                           type: string
+                        maxItems: 3
                         nullable: true
                         type: array
                       upgrade_attempts:
                         items:
                           type: string
+                        maxItems: 1000
                         nullable: true
                         type: array
                       upgrade_details:
@@ -27807,6 +28010,7 @@ paths:
                       agents:
                         items:
                           type: string
+                        maxItems: 10000
                         type: array
                       created_at:
                         type: string
@@ -27820,6 +28024,7 @@ paths:
                       namespaces:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       rollout_duration_seconds:
                         type: number
@@ -27935,6 +28140,7 @@ paths:
                     tags:
                       items:
                         type: string
+                      maxItems: 10
                       type: array
                 uri:
                   format: uri
@@ -28088,6 +28294,7 @@ paths:
                     enum:
                       - CPU
                     type: string
+                  maxItems: 1
                   type: array
       responses:
         '200':
@@ -28303,6 +28510,7 @@ paths:
                         - createTime
                         - status
                         - actionId
+                    maxItems: 1000
                     type: array
                 required:
                   - items
@@ -28418,6 +28626,7 @@ paths:
                               - agentId
                               - error
                               - timestamp
+                          maxItems: 10
                           type: array
                         nbAgentsAck:
                           description: number of agents that acknowledged the action
@@ -28479,6 +28688,7 @@ paths:
                         - nbAgentsActioned
                         - status
                         - creationTime
+                    maxItems: 1000
                     type: array
                 required:
                   - items
@@ -28548,6 +28758,7 @@ paths:
                       agents:
                         items:
                           type: string
+                        maxItems: 10000
                         type: array
                       created_at:
                         type: string
@@ -28561,6 +28772,7 @@ paths:
                       namespaces:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       rollout_duration_seconds:
                         type: number
@@ -28631,6 +28843,7 @@ paths:
                   items:
                     items:
                       type: string
+                    maxItems: 1000
                     type: array
                 required:
                   - items
@@ -28690,6 +28903,7 @@ paths:
                   anyOf:
                     - items:
                         type: string
+                      maxItems: 10000
                       type: array
                     - type: string
                 batchSize:
@@ -28729,6 +28943,7 @@ paths:
                     tags:
                       items:
                         type: string
+                      maxItems: 10
                       type: array
                 uri:
                   format: uri
@@ -28807,6 +29022,7 @@ paths:
                   anyOf:
                     - items:
                         type: string
+                      maxItems: 10000
                       type: array
                     - type: string
                 batchSize:
@@ -28888,11 +29104,13 @@ paths:
                     enum:
                       - CPU
                     type: string
+                  maxItems: 1
                   type: array
                 agents:
                   anyOf:
                     - items:
                         type: string
+                      maxItems: 10000
                       type: array
                     - type: string
                 batchSize:
@@ -28966,10 +29184,11 @@ paths:
                 agents:
                   anyOf:
                     - items:
-                        description: KQL query string, leave empty to action all agents
+                        description: list of agent IDs
                         type: string
+                      maxItems: 10000
                       type: array
-                    - description: list of agent IDs
+                    - description: KQL query string, leave empty to action all agents
                       type: string
                 batchSize:
                   type: number
@@ -29052,6 +29271,7 @@ paths:
                   anyOf:
                     - items:
                         type: string
+                      maxItems: 10000
                       type: array
                     - type: string
                 batchSize:
@@ -29062,10 +29282,12 @@ paths:
                 tagsToAdd:
                   items:
                     type: string
+                  maxItems: 10
                   type: array
                 tagsToRemove:
                   items:
                     type: string
+                  maxItems: 10
                   type: array
               required:
                 - agents
@@ -29137,6 +29359,7 @@ paths:
                   anyOf:
                     - items:
                         type: string
+                      maxItems: 10000
                       type: array
                     - type: string
                 batchSize:
@@ -29349,6 +29572,7 @@ paths:
                       enum:
                         - encrypted_saved_object_encryption_key_required
                       type: string
+                    maxItems: 1
                     type: array
                   missing_requirements:
                     items:
@@ -29359,6 +29583,7 @@ paths:
                         - fleet_admin_user
                         - fleet_server
                       type: string
+                    maxItems: 5
                     type: array
                   package_verification_key_id:
                     type: string
@@ -29433,6 +29658,7 @@ paths:
                       required:
                         - name
                         - message
+                    maxItems: 10000
                     type: array
                 required:
                   - isInitialized
@@ -29497,6 +29723,7 @@ paths:
                   items:
                     items:
                       type: string
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -29645,6 +29872,7 @@ paths:
                         - packagePolicyCount
                         - created_at
                         - updated_at
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -30145,6 +30373,7 @@ paths:
                             required:
                               - id
                               - title
+                          maxItems: 10000
                           type: array
                         dataset:
                           type: string
@@ -30190,6 +30419,7 @@ paths:
                         - size_in_bytes_formatted
                         - dashboards
                         - serviceDetails
+                    maxItems: 10000
                     type: array
                 required:
                   - data_streams
@@ -30288,6 +30518,7 @@ paths:
                         - api_key
                         - active
                         - created_at
+                    maxItems: 10000
                     type: array
                   list:
                     deprecated: true
@@ -30322,6 +30553,7 @@ paths:
                         - api_key
                         - active
                         - created_at
+                    maxItems: 10000
                     type: array
                   page:
                     type: number
@@ -30651,6 +30883,7 @@ paths:
                     required:
                       - id
                       - type
+                  maxItems: 1000
                   type: array
               required:
                 - assetIds
@@ -30689,6 +30922,7 @@ paths:
                         - id
                         - type
                         - attributes
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -30767,6 +31001,7 @@ paths:
                         - id
                         - title
                         - count
+                    maxItems: 1000
                     type: array
                 required:
                   - items
@@ -30840,6 +31075,7 @@ paths:
                     required:
                       - name
                       - type
+                  maxItems: 10
                   type: array
                 force:
                   type: boolean
@@ -30923,6 +31159,7 @@ paths:
                           required:
                             - id
                             - type
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -30987,6 +31224,7 @@ paths:
                 categories:
                   items:
                     type: string
+                  maxItems: 10
                   type: array
                 readMeData:
                   type: string
@@ -31080,6 +31318,7 @@ paths:
                           type: string
                       required:
                         - name
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -31157,6 +31396,7 @@ paths:
                         categories:
                           items:
                             type: string
+                          maxItems: 10
                           type: array
                         conditions:
                           additionalProperties: true
@@ -31169,6 +31409,7 @@ paths:
                                 capabilities:
                                   items:
                                     type: string
+                                  maxItems: 10
                                   type: array
                                 subscription:
                                   type: string
@@ -31182,6 +31423,7 @@ paths:
                           items:
                             additionalProperties: {}
                             type: object
+                          maxItems: 1000
                           type: array
                         description:
                           type: string
@@ -31198,6 +31440,7 @@ paths:
                                     type: string
                                 required:
                                   - name
+                              maxItems: 10
                               type: array
                             fields:
                               items:
@@ -31208,6 +31451,7 @@ paths:
                                     type: string
                                 required:
                                   - name
+                              maxItems: 10
                               type: array
                         download:
                           type: string
@@ -31232,6 +31476,7 @@ paths:
                                 type: string
                             required:
                               - src
+                          maxItems: 10
                           type: array
                         id:
                           type: string
@@ -31271,6 +31516,7 @@ paths:
                                   required:
                                     - id
                                     - type
+                                maxItems: 100
                                 type: array
                               type: object
                             created_at:
@@ -31297,6 +31543,7 @@ paths:
                                 required:
                                   - data_stream
                                   - features
+                              maxItems: 100
                               type: array
                             install_format_schema_version:
                               type: string
@@ -31339,6 +31586,7 @@ paths:
                                 required:
                                   - id
                                   - type
+                              maxItems: 1000
                               type: array
                             installed_kibana:
                               items:
@@ -31371,6 +31619,7 @@ paths:
                                 required:
                                   - id
                                   - type
+                              maxItems: 1000
                               type: array
                             installed_kibana_space_id:
                               type: string
@@ -31410,12 +31659,14 @@ paths:
                                   - created_at
                                   - target_version
                                   - error
+                              maxItems: 10
                               type: array
                             name:
                               type: string
                             namespaces:
                               items:
                                 type: string
+                              maxItems: 100
                               type: array
                             previous_version:
                               nullable: true
@@ -31472,6 +31723,7 @@ paths:
                           items:
                             additionalProperties: {}
                             type: object
+                          maxItems: 100
                           type: array
                         readme:
                           type: string
@@ -31511,6 +31763,7 @@ paths:
                           items:
                             additionalProperties: {}
                             type: object
+                          maxItems: 1000
                           type: array
                         version:
                           type: string
@@ -31519,6 +31772,7 @@ paths:
                         - version
                         - title
                         - id
+                    maxItems: 1000
                     type: array
                 required:
                   - items
@@ -31659,6 +31913,7 @@ paths:
                           required:
                             - id
                             - type
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -31739,6 +31994,7 @@ paths:
                         required:
                           - name
                           - version
+                  maxItems: 1000
                   minItems: 1
                   type: array
               required:
@@ -31819,6 +32075,7 @@ paths:
                                         required:
                                           - id
                                           - type
+                                  maxItems: 1000
                                   type: array
                                 error: {}
                                 installSource:
@@ -31854,6 +32111,7 @@ paths:
                             - name
                             - statusCode
                             - error
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -31926,6 +32184,7 @@ paths:
                     required:
                       - name
                       - version
+                  maxItems: 1000
                   minItems: 1
                   type: array
               required:
@@ -32023,6 +32282,7 @@ paths:
                       required:
                         - name
                         - success
+                    maxItems: 10000
                     type: array
                   status:
                     type: string
@@ -32096,6 +32356,7 @@ paths:
                         type: string
                     required:
                       - name
+                  maxItems: 1000
                   minItems: 1
                   type: array
                 prerelease:
@@ -32198,6 +32459,7 @@ paths:
                       required:
                         - name
                         - success
+                    maxItems: 10000
                     type: array
                   status:
                     type: string
@@ -32329,6 +32591,7 @@ paths:
                           required:
                             - id
                             - type
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -32422,15 +32685,18 @@ paths:
                             asset_ids:
                               items:
                                 type: string
+                              maxItems: 100
                               type: array
                             asset_types:
                               items:
                                 type: string
+                              maxItems: 10
                               type: array
                             text:
                               type: string
                           required:
                             - text
+                        maxItems: 1000
                         type: array
                       assets:
                         additionalProperties: {}
@@ -32438,6 +32704,7 @@ paths:
                       categories:
                         items:
                           type: string
+                        maxItems: 10
                         type: array
                       conditions:
                         additionalProperties: true
@@ -32450,6 +32717,7 @@ paths:
                               capabilities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               subscription:
                                 type: string
@@ -32463,6 +32731,7 @@ paths:
                         items:
                           additionalProperties: {}
                           type: object
+                        maxItems: 1000
                         type: array
                       description:
                         type: string
@@ -32479,6 +32748,7 @@ paths:
                                   type: string
                               required:
                                 - name
+                            maxItems: 10
                             type: array
                           fields:
                             items:
@@ -32489,6 +32759,7 @@ paths:
                                   type: string
                               required:
                                 - name
+                            maxItems: 10
                             type: array
                       download:
                         type: string
@@ -32516,6 +32787,7 @@ paths:
                               type: string
                           required:
                             - src
+                        maxItems: 10
                         type: array
                       installationInfo:
                         additionalProperties: true
@@ -32553,6 +32825,7 @@ paths:
                                 required:
                                   - id
                                   - type
+                              maxItems: 100
                               type: array
                             type: object
                           created_at:
@@ -32579,6 +32852,7 @@ paths:
                               required:
                                 - data_stream
                                 - features
+                            maxItems: 100
                             type: array
                           install_format_schema_version:
                             type: string
@@ -32621,6 +32895,7 @@ paths:
                               required:
                                 - id
                                 - type
+                            maxItems: 1000
                             type: array
                           installed_kibana:
                             items:
@@ -32653,6 +32928,7 @@ paths:
                               required:
                                 - id
                                 - type
+                            maxItems: 1000
                             type: array
                           installed_kibana_space_id:
                             type: string
@@ -32692,12 +32968,14 @@ paths:
                                 - created_at
                                 - target_version
                                 - error
+                            maxItems: 10
                             type: array
                           name:
                             type: string
                           namespaces:
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                           previous_version:
                             nullable: true
@@ -32760,6 +33038,7 @@ paths:
                         items:
                           additionalProperties: {}
                           type: object
+                        maxItems: 100
                         type: array
                       readme:
                         type: string
@@ -32788,6 +33067,7 @@ paths:
                               type: string
                           required:
                             - src
+                        maxItems: 10
                         type: array
                       signature_path:
                         type: string
@@ -32819,6 +33099,7 @@ paths:
                         items:
                           additionalProperties: {}
                           type: object
+                        maxItems: 1000
                         type: array
                       version:
                         type: string
@@ -33003,6 +33284,7 @@ paths:
                           required:
                             - id
                             - type
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -33104,15 +33386,18 @@ paths:
                             asset_ids:
                               items:
                                 type: string
+                              maxItems: 100
                               type: array
                             asset_types:
                               items:
                                 type: string
+                              maxItems: 10
                               type: array
                             text:
                               type: string
                           required:
                             - text
+                        maxItems: 1000
                         type: array
                       assets:
                         additionalProperties: {}
@@ -33120,6 +33405,7 @@ paths:
                       categories:
                         items:
                           type: string
+                        maxItems: 10
                         type: array
                       conditions:
                         additionalProperties: true
@@ -33132,6 +33418,7 @@ paths:
                               capabilities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               subscription:
                                 type: string
@@ -33145,6 +33432,7 @@ paths:
                         items:
                           additionalProperties: {}
                           type: object
+                        maxItems: 1000
                         type: array
                       description:
                         type: string
@@ -33161,6 +33449,7 @@ paths:
                                   type: string
                               required:
                                 - name
+                            maxItems: 10
                             type: array
                           fields:
                             items:
@@ -33171,6 +33460,7 @@ paths:
                                   type: string
                               required:
                                 - name
+                            maxItems: 10
                             type: array
                       download:
                         type: string
@@ -33198,6 +33488,7 @@ paths:
                               type: string
                           required:
                             - src
+                        maxItems: 10
                         type: array
                       installationInfo:
                         additionalProperties: true
@@ -33235,6 +33526,7 @@ paths:
                                 required:
                                   - id
                                   - type
+                              maxItems: 100
                               type: array
                             type: object
                           created_at:
@@ -33261,6 +33553,7 @@ paths:
                               required:
                                 - data_stream
                                 - features
+                            maxItems: 100
                             type: array
                           install_format_schema_version:
                             type: string
@@ -33303,6 +33596,7 @@ paths:
                               required:
                                 - id
                                 - type
+                            maxItems: 1000
                             type: array
                           installed_kibana:
                             items:
@@ -33335,6 +33629,7 @@ paths:
                               required:
                                 - id
                                 - type
+                            maxItems: 1000
                             type: array
                           installed_kibana_space_id:
                             type: string
@@ -33374,12 +33669,14 @@ paths:
                                 - created_at
                                 - target_version
                                 - error
+                            maxItems: 10
                             type: array
                           name:
                             type: string
                           namespaces:
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                           previous_version:
                             nullable: true
@@ -33442,6 +33739,7 @@ paths:
                         items:
                           additionalProperties: {}
                           type: object
+                        maxItems: 100
                         type: array
                       readme:
                         type: string
@@ -33470,6 +33768,7 @@ paths:
                               type: string
                           required:
                             - src
+                        maxItems: 10
                         type: array
                       signature_path:
                         type: string
@@ -33501,6 +33800,7 @@ paths:
                         items:
                           additionalProperties: {}
                           type: object
+                        maxItems: 1000
                         type: array
                       version:
                         type: string
@@ -33778,6 +34078,7 @@ paths:
                   description: When provided install assets in the specified spaces instead of the current space.
                   items:
                     type: string
+                  maxItems: 100
                   minItems: 1
                   type: array
       responses:
@@ -33941,6 +34242,7 @@ paths:
                         type: string
                     required:
                       - transformId
+                  maxItems: 1000
                   type: array
               required:
                 - transforms
@@ -33963,6 +34265,7 @@ paths:
                     - transformId
                     - success
                     - error
+                maxItems: 10000
                 type: array
         '400':
           content:
@@ -34101,6 +34404,7 @@ paths:
               anyOf:
                 - type: string
                 - type: number
+            maxItems: 10
             type: array
         - in: query
           name: perPage
@@ -34142,6 +34446,7 @@ paths:
                             required:
                               - name
                               - title
+                          maxItems: 1000
                           type: array
                         description:
                           type: string
@@ -34164,6 +34469,7 @@ paths:
                                 type: string
                             required:
                               - src
+                          maxItems: 10
                           type: array
                         name:
                           type: string
@@ -34178,6 +34484,7 @@ paths:
                         - version
                         - status
                         - dataStreams
+                    maxItems: 10000
                     type: array
                   searchAfter:
                     items:
@@ -34188,6 +34495,7 @@ paths:
                         - enum: []
                           nullable: true
                         - {}
+                    maxItems: 2
                     type: array
                   total:
                     type: number
@@ -34243,6 +34551,7 @@ paths:
                   items:
                     items:
                       type: string
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -34351,12 +34660,14 @@ paths:
                                 required:
                                   - id
                                   - data_stream
+                              maxItems: 10000
                               type: array
                             type:
                               type: string
                           required:
                             - id
                             - type
+                        maxItems: 10000
                         type: array
                     required:
                       - inputs
@@ -34465,6 +34776,7 @@ paths:
                         host_urls:
                           items:
                             type: string
+                          maxItems: 10
                           minItems: 1
                           type: array
                         id:
@@ -34520,6 +34832,7 @@ paths:
                             certificate_authorities:
                               items:
                                 type: string
+                              maxItems: 10
                               type: array
                             client_auth:
                               enum:
@@ -34532,6 +34845,7 @@ paths:
                             es_certificate_authorities:
                               items:
                                 type: string
+                              maxItems: 10
                               type: array
                             es_key:
                               type: string
@@ -34541,6 +34855,7 @@ paths:
                         - name
                         - host_urls
                         - id
+                    maxItems: 10000
                     type: array
                   page:
                     type: number
@@ -34607,6 +34922,7 @@ paths:
                 host_urls:
                   items:
                     type: string
+                  maxItems: 10
                   minItems: 1
                   type: array
                 id:
@@ -34662,6 +34978,7 @@ paths:
                     certificate_authorities:
                       items:
                         type: string
+                      maxItems: 10
                       type: array
                     client_auth:
                       enum:
@@ -34674,6 +34991,7 @@ paths:
                     es_certificate_authorities:
                       items:
                         type: string
+                      maxItems: 10
                       type: array
                     es_key:
                       type: string
@@ -34697,6 +35015,7 @@ paths:
                       host_urls:
                         items:
                           type: string
+                        maxItems: 10
                         minItems: 1
                         type: array
                       id:
@@ -34752,6 +35071,7 @@ paths:
                           certificate_authorities:
                             items:
                               type: string
+                            maxItems: 10
                             type: array
                           client_auth:
                             enum:
@@ -34764,6 +35084,7 @@ paths:
                           es_certificate_authorities:
                             items:
                               type: string
+                            maxItems: 10
                             type: array
                           es_key:
                             type: string
@@ -34894,6 +35215,7 @@ paths:
                       host_urls:
                         items:
                           type: string
+                        maxItems: 10
                         minItems: 1
                         type: array
                       id:
@@ -34949,6 +35271,7 @@ paths:
                           certificate_authorities:
                             items:
                               type: string
+                            maxItems: 10
                             type: array
                           client_auth:
                             enum:
@@ -34961,6 +35284,7 @@ paths:
                           es_certificate_authorities:
                             items:
                               type: string
+                            maxItems: 10
                             type: array
                           es_key:
                             type: string
@@ -35031,6 +35355,7 @@ paths:
                 host_urls:
                   items:
                     type: string
+                  maxItems: 10
                   minItems: 1
                   type: array
                 is_default:
@@ -35080,6 +35405,7 @@ paths:
                     certificate_authorities:
                       items:
                         type: string
+                      maxItems: 10
                       type: array
                     client_auth:
                       enum:
@@ -35092,6 +35418,7 @@ paths:
                     es_certificate_authorities:
                       items:
                         type: string
+                      maxItems: 10
                       type: array
                     es_key:
                       type: string
@@ -35114,6 +35441,7 @@ paths:
                       host_urls:
                         items:
                           type: string
+                        maxItems: 10
                         minItems: 1
                         type: array
                       id:
@@ -35169,6 +35497,7 @@ paths:
                           certificate_authorities:
                             items:
                               type: string
+                            maxItems: 10
                             type: array
                           client_auth:
                             enum:
@@ -35181,6 +35510,7 @@ paths:
                           es_certificate_authorities:
                             items:
                               type: string
+                            maxItems: 10
                             type: array
                           es_key:
                             type: string
@@ -35623,6 +35953,7 @@ paths:
                             allow_edit:
                               items:
                                 type: string
+                              maxItems: 1000
                               type: array
                             ca_sha256:
                               nullable: true
@@ -35637,6 +35968,7 @@ paths:
                               items:
                                 format: uri
                                 type: string
+                              maxItems: 10
                               minItems: 1
                               type: array
                             id:
@@ -35740,6 +36072,7 @@ paths:
                                 certificate_authorities:
                                   items:
                                     type: string
+                                  maxItems: 10
                                   type: array
                                 key:
                                   type: string
@@ -35767,6 +36100,7 @@ paths:
                             allow_edit:
                               items:
                                 type: string
+                              maxItems: 1000
                               type: array
                             ca_sha256:
                               nullable: true
@@ -35781,6 +36115,7 @@ paths:
                               items:
                                 format: uri
                                 type: string
+                              maxItems: 10
                               minItems: 1
                               type: array
                             id:
@@ -35905,6 +36240,7 @@ paths:
                                 certificate_authorities:
                                   items:
                                     type: string
+                                  maxItems: 10
                                   type: array
                                 key:
                                   type: string
@@ -35936,6 +36272,7 @@ paths:
                             allow_edit:
                               items:
                                 type: string
+                              maxItems: 1000
                               type: array
                             ca_sha256:
                               nullable: true
@@ -35949,6 +36286,7 @@ paths:
                             hosts:
                               items:
                                 type: string
+                              maxItems: 10
                               minItems: 1
                               type: array
                             id:
@@ -36044,6 +36382,7 @@ paths:
                                 certificate_authorities:
                                   items:
                                     type: string
+                                  maxItems: 10
                                   type: array
                                 key:
                                   type: string
@@ -36068,6 +36407,7 @@ paths:
                             allow_edit:
                               items:
                                 type: string
+                              maxItems: 1000
                               type: array
                             auth_type:
                               enum:
@@ -36143,10 +36483,12 @@ paths:
                                 required:
                                   - key
                                   - value
+                              maxItems: 100
                               type: array
                             hosts:
                               items:
                                 type: string
+                              maxItems: 10
                               minItems: 1
                               type: array
                             id:
@@ -36315,6 +36657,7 @@ paths:
                                 certificate_authorities:
                                   items:
                                     type: string
+                                  maxItems: 10
                                   type: array
                                 key:
                                   type: string
@@ -36356,6 +36699,7 @@ paths:
                             - connection_type
                             - username
                             - password
+                    maxItems: 10000
                     type: array
                   page:
                     type: number
@@ -36423,6 +36767,7 @@ paths:
                     allow_edit:
                       items:
                         type: string
+                      maxItems: 1000
                       type: array
                     ca_sha256:
                       nullable: true
@@ -36437,6 +36782,7 @@ paths:
                       items:
                         format: uri
                         type: string
+                      maxItems: 10
                       minItems: 1
                       type: array
                     id:
@@ -36540,6 +36886,7 @@ paths:
                         certificate_authorities:
                           items:
                             type: string
+                          maxItems: 10
                           type: array
                         key:
                           type: string
@@ -36567,6 +36914,7 @@ paths:
                     allow_edit:
                       items:
                         type: string
+                      maxItems: 1000
                       type: array
                     ca_sha256:
                       nullable: true
@@ -36581,6 +36929,7 @@ paths:
                       items:
                         format: uri
                         type: string
+                      maxItems: 10
                       minItems: 1
                       type: array
                     id:
@@ -36705,6 +37054,7 @@ paths:
                         certificate_authorities:
                           items:
                             type: string
+                          maxItems: 10
                           type: array
                         key:
                           type: string
@@ -36736,6 +37086,7 @@ paths:
                     allow_edit:
                       items:
                         type: string
+                      maxItems: 1000
                       type: array
                     ca_sha256:
                       nullable: true
@@ -36749,6 +37100,7 @@ paths:
                     hosts:
                       items:
                         type: string
+                      maxItems: 10
                       minItems: 1
                       type: array
                     id:
@@ -36844,6 +37196,7 @@ paths:
                         certificate_authorities:
                           items:
                             type: string
+                          maxItems: 10
                           type: array
                         key:
                           type: string
@@ -36868,6 +37221,7 @@ paths:
                     allow_edit:
                       items:
                         type: string
+                      maxItems: 1000
                       type: array
                     auth_type:
                       enum:
@@ -36943,10 +37297,12 @@ paths:
                         required:
                           - key
                           - value
+                      maxItems: 100
                       type: array
                     hosts:
                       items:
                         type: string
+                      maxItems: 10
                       minItems: 1
                       type: array
                     id:
@@ -37115,6 +37471,7 @@ paths:
                         certificate_authorities:
                           items:
                             type: string
+                          maxItems: 10
                           type: array
                         key:
                           type: string
@@ -37172,6 +37529,7 @@ paths:
                           allow_edit:
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           ca_sha256:
                             nullable: true
@@ -37186,6 +37544,7 @@ paths:
                             items:
                               format: uri
                               type: string
+                            maxItems: 10
                             minItems: 1
                             type: array
                           id:
@@ -37289,6 +37648,7 @@ paths:
                               certificate_authorities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               key:
                                 type: string
@@ -37316,6 +37676,7 @@ paths:
                           allow_edit:
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           ca_sha256:
                             nullable: true
@@ -37330,6 +37691,7 @@ paths:
                             items:
                               format: uri
                               type: string
+                            maxItems: 10
                             minItems: 1
                             type: array
                           id:
@@ -37454,6 +37816,7 @@ paths:
                               certificate_authorities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               key:
                                 type: string
@@ -37485,6 +37848,7 @@ paths:
                           allow_edit:
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           ca_sha256:
                             nullable: true
@@ -37498,6 +37862,7 @@ paths:
                           hosts:
                             items:
                               type: string
+                            maxItems: 10
                             minItems: 1
                             type: array
                           id:
@@ -37593,6 +37958,7 @@ paths:
                               certificate_authorities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               key:
                                 type: string
@@ -37617,6 +37983,7 @@ paths:
                           allow_edit:
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           auth_type:
                             enum:
@@ -37692,10 +38059,12 @@ paths:
                               required:
                                 - key
                                 - value
+                            maxItems: 100
                             type: array
                           hosts:
                             items:
                               type: string
+                            maxItems: 10
                             minItems: 1
                             type: array
                           id:
@@ -37864,6 +38233,7 @@ paths:
                               certificate_authorities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               key:
                                 type: string
@@ -38047,6 +38417,7 @@ paths:
                           allow_edit:
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           ca_sha256:
                             nullable: true
@@ -38061,6 +38432,7 @@ paths:
                             items:
                               format: uri
                               type: string
+                            maxItems: 10
                             minItems: 1
                             type: array
                           id:
@@ -38164,6 +38536,7 @@ paths:
                               certificate_authorities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               key:
                                 type: string
@@ -38191,6 +38564,7 @@ paths:
                           allow_edit:
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           ca_sha256:
                             nullable: true
@@ -38205,6 +38579,7 @@ paths:
                             items:
                               format: uri
                               type: string
+                            maxItems: 10
                             minItems: 1
                             type: array
                           id:
@@ -38329,6 +38704,7 @@ paths:
                               certificate_authorities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               key:
                                 type: string
@@ -38360,6 +38736,7 @@ paths:
                           allow_edit:
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           ca_sha256:
                             nullable: true
@@ -38373,6 +38750,7 @@ paths:
                           hosts:
                             items:
                               type: string
+                            maxItems: 10
                             minItems: 1
                             type: array
                           id:
@@ -38468,6 +38846,7 @@ paths:
                               certificate_authorities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               key:
                                 type: string
@@ -38492,6 +38871,7 @@ paths:
                           allow_edit:
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           auth_type:
                             enum:
@@ -38567,10 +38947,12 @@ paths:
                               required:
                                 - key
                                 - value
+                            maxItems: 100
                             type: array
                           hosts:
                             items:
                               type: string
+                            maxItems: 10
                             minItems: 1
                             type: array
                           id:
@@ -38739,6 +39121,7 @@ paths:
                               certificate_authorities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               key:
                                 type: string
@@ -38842,6 +39225,7 @@ paths:
                     allow_edit:
                       items:
                         type: string
+                      maxItems: 1000
                       type: array
                     ca_sha256:
                       nullable: true
@@ -38856,6 +39240,7 @@ paths:
                       items:
                         format: uri
                         type: string
+                      maxItems: 10
                       minItems: 1
                       type: array
                     id:
@@ -38957,6 +39342,7 @@ paths:
                         certificate_authorities:
                           items:
                             type: string
+                          maxItems: 10
                           type: array
                         key:
                           type: string
@@ -38980,6 +39366,7 @@ paths:
                     allow_edit:
                       items:
                         type: string
+                      maxItems: 1000
                       type: array
                     ca_sha256:
                       nullable: true
@@ -38994,6 +39381,7 @@ paths:
                       items:
                         format: uri
                         type: string
+                      maxItems: 10
                       minItems: 1
                       type: array
                     id:
@@ -39116,6 +39504,7 @@ paths:
                         certificate_authorities:
                           items:
                             type: string
+                          maxItems: 10
                           type: array
                         key:
                           type: string
@@ -39143,6 +39532,7 @@ paths:
                     allow_edit:
                       items:
                         type: string
+                      maxItems: 1000
                       type: array
                     ca_sha256:
                       nullable: true
@@ -39156,6 +39546,7 @@ paths:
                     hosts:
                       items:
                         type: string
+                      maxItems: 10
                       minItems: 1
                       type: array
                     id:
@@ -39249,6 +39640,7 @@ paths:
                         certificate_authorities:
                           items:
                             type: string
+                          maxItems: 10
                           type: array
                         key:
                           type: string
@@ -39269,6 +39661,7 @@ paths:
                     allow_edit:
                       items:
                         type: string
+                      maxItems: 1000
                       type: array
                     auth_type:
                       enum:
@@ -39344,10 +39737,12 @@ paths:
                         required:
                           - key
                           - value
+                      maxItems: 100
                       type: array
                     hosts:
                       items:
                         type: string
+                      maxItems: 10
                       minItems: 1
                       type: array
                     id:
@@ -39516,6 +39911,7 @@ paths:
                         certificate_authorities:
                           items:
                             type: string
+                          maxItems: 10
                           type: array
                         key:
                           type: string
@@ -39570,6 +39966,7 @@ paths:
                           allow_edit:
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           ca_sha256:
                             nullable: true
@@ -39584,6 +39981,7 @@ paths:
                             items:
                               format: uri
                               type: string
+                            maxItems: 10
                             minItems: 1
                             type: array
                           id:
@@ -39687,6 +40085,7 @@ paths:
                               certificate_authorities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               key:
                                 type: string
@@ -39714,6 +40113,7 @@ paths:
                           allow_edit:
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           ca_sha256:
                             nullable: true
@@ -39728,6 +40128,7 @@ paths:
                             items:
                               format: uri
                               type: string
+                            maxItems: 10
                             minItems: 1
                             type: array
                           id:
@@ -39852,6 +40253,7 @@ paths:
                               certificate_authorities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               key:
                                 type: string
@@ -39883,6 +40285,7 @@ paths:
                           allow_edit:
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           ca_sha256:
                             nullable: true
@@ -39896,6 +40299,7 @@ paths:
                           hosts:
                             items:
                               type: string
+                            maxItems: 10
                             minItems: 1
                             type: array
                           id:
@@ -39991,6 +40395,7 @@ paths:
                               certificate_authorities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               key:
                                 type: string
@@ -40015,6 +40420,7 @@ paths:
                           allow_edit:
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           auth_type:
                             enum:
@@ -40090,10 +40496,12 @@ paths:
                               required:
                                 - key
                                 - value
+                            maxItems: 100
                             type: array
                           hosts:
                             items:
                               type: string
+                            maxItems: 10
                             minItems: 1
                             type: array
                           id:
@@ -40262,6 +40670,7 @@ paths:
                               certificate_authorities:
                                 items:
                                   type: string
+                                maxItems: 10
                                 type: array
                               key:
                                 type: string
@@ -40462,6 +40871,7 @@ paths:
                           description: Additional datastream permissions, that will be added to the agent policy.
                           items:
                             type: string
+                          maxItems: 1000
                           nullable: true
                           type: array
                         agents:
@@ -40488,6 +40898,7 @@ paths:
                                 cluster:
                                   items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                         enabled:
                           type: boolean
@@ -40563,6 +40974,7 @@ paths:
                                                     indices:
                                                       items:
                                                         type: string
+                                                      maxItems: 100
                                                       type: array
                                             type:
                                               type: string
@@ -40599,6 +41011,7 @@ paths:
                                         - enabled
                                         - data_stream
                                         - compiled_stream
+                                    maxItems: 100
                                     type: array
                                   type:
                                     type: string
@@ -40621,6 +41034,7 @@ paths:
                                   - enabled
                                   - streams
                                   - compiled_input
+                              maxItems: 100
                               type: array
                             - additionalProperties:
                                 additionalProperties: false
@@ -40645,9 +41059,11 @@ paths:
                                               - type: number
                                               - items:
                                                   type: string
+                                                maxItems: 100
                                                 type: array
                                               - items:
                                                   type: number
+                                                maxItems: 100
                                                 type: array
                                               - additionalProperties: false
                                                 type: object
@@ -40672,9 +41088,11 @@ paths:
                                         - type: number
                                         - items:
                                             type: string
+                                          maxItems: 100
                                           type: array
                                         - items:
                                             type: number
+                                          maxItems: 100
                                           type: array
                                         - additionalProperties: false
                                           type: object
@@ -40738,6 +41156,7 @@ paths:
                                 required:
                                   - data_stream
                                   - features
+                              maxItems: 100
                               type: array
                             fips_compatible:
                               type: boolean
@@ -40775,10 +41194,12 @@ paths:
                                 type: string
                             required:
                               - id
+                          maxItems: 100
                           type: array
                         spaceIds:
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                         supports_agentless:
                           default: false
@@ -40816,9 +41237,11 @@ paths:
                                   - type: number
                                   - items:
                                       type: string
+                                    maxItems: 100
                                     type: array
                                   - items:
                                       type: number
+                                    maxItems: 100
                                     type: array
                                   - additionalProperties: false
                                     type: object
@@ -40846,6 +41269,7 @@ paths:
                         - updated_by
                         - created_at
                         - created_by
+                    maxItems: 10000
                     type: array
                   page:
                     type: number
@@ -40920,6 +41344,7 @@ paths:
                       description: Additional datastream permissions, that will be added to the agent policy.
                       items:
                         type: string
+                      maxItems: 1000
                       nullable: true
                       type: array
                     cloud_connector_id:
@@ -41005,6 +41430,7 @@ paths:
                                             indices:
                                               items:
                                                 type: string
+                                              maxItems: 100
                                               type: array
                                     type:
                                       type: string
@@ -41041,6 +41467,7 @@ paths:
                                 - enabled
                                 - data_stream
                                 - compiled_stream
+                            maxItems: 100
                             type: array
                           type:
                             type: string
@@ -41061,6 +41488,7 @@ paths:
                         required:
                           - type
                           - enabled
+                      maxItems: 1000
                       type: array
                     is_managed:
                       type: boolean
@@ -41108,6 +41536,7 @@ paths:
                             required:
                               - data_stream
                               - features
+                          maxItems: 100
                           type: array
                         fips_compatible:
                           type: boolean
@@ -41137,6 +41566,7 @@ paths:
                     spaceIds:
                       items:
                         type: string
+                      maxItems: 100
                       type: array
                     supports_agentless:
                       default: false
@@ -41172,6 +41602,7 @@ paths:
                       description: Additional datastream permissions, that will be added to the agent policy.
                       items:
                         type: string
+                      maxItems: 100
                       nullable: true
                       type: array
                     description:
@@ -41204,9 +41635,11 @@ paths:
                                       - type: number
                                       - items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                                       - items:
                                           type: number
+                                        maxItems: 100
                                         type: array
                                       - additionalProperties: false
                                         type: object
@@ -41231,9 +41664,11 @@ paths:
                                 - type: number
                                 - items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 - items:
                                     type: number
+                                  maxItems: 100
                                   type: array
                                 - additionalProperties: false
                                   type: object
@@ -41283,6 +41718,7 @@ paths:
                             required:
                               - data_stream
                               - features
+                          maxItems: 100
                           type: array
                         fips_compatible:
                           type: boolean
@@ -41319,9 +41755,11 @@ paths:
                           - type: number
                           - items:
                               type: string
+                            maxItems: 100
                             type: array
                           - items:
                               type: number
+                            maxItems: 100
                             type: array
                           - additionalProperties: false
                             type: object
@@ -41356,6 +41794,7 @@ paths:
                         description: Additional datastream permissions, that will be added to the agent policy.
                         items:
                           type: string
+                        maxItems: 1000
                         nullable: true
                         type: array
                       agents:
@@ -41382,6 +41821,7 @@ paths:
                               cluster:
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                       enabled:
                         type: boolean
@@ -41457,6 +41897,7 @@ paths:
                                                   indices:
                                                     items:
                                                       type: string
+                                                    maxItems: 100
                                                     type: array
                                           type:
                                             type: string
@@ -41493,6 +41934,7 @@ paths:
                                       - enabled
                                       - data_stream
                                       - compiled_stream
+                                  maxItems: 100
                                   type: array
                                 type:
                                   type: string
@@ -41515,6 +41957,7 @@ paths:
                                 - enabled
                                 - streams
                                 - compiled_input
+                            maxItems: 100
                             type: array
                           - additionalProperties:
                               additionalProperties: false
@@ -41539,9 +41982,11 @@ paths:
                                             - type: number
                                             - items:
                                                 type: string
+                                              maxItems: 100
                                               type: array
                                             - items:
                                                 type: number
+                                              maxItems: 100
                                               type: array
                                             - additionalProperties: false
                                               type: object
@@ -41566,9 +42011,11 @@ paths:
                                       - type: number
                                       - items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                                       - items:
                                           type: number
+                                        maxItems: 100
                                         type: array
                                       - additionalProperties: false
                                         type: object
@@ -41632,6 +42079,7 @@ paths:
                               required:
                                 - data_stream
                                 - features
+                            maxItems: 100
                             type: array
                           fips_compatible:
                             type: boolean
@@ -41669,10 +42117,12 @@ paths:
                               type: string
                           required:
                             - id
+                        maxItems: 100
                         type: array
                       spaceIds:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       supports_agentless:
                         default: false
@@ -41710,9 +42160,11 @@ paths:
                                 - type: number
                                 - items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 - items:
                                     type: number
+                                  maxItems: 100
                                   type: array
                                 - additionalProperties: false
                                   type: object
@@ -41824,6 +42276,7 @@ paths:
                   description: list of package policy ids
                   items:
                     type: string
+                  maxItems: 1000
                   type: array
                 ignoreMissing:
                   type: boolean
@@ -41846,6 +42299,7 @@ paths:
                           description: Additional datastream permissions, that will be added to the agent policy.
                           items:
                             type: string
+                          maxItems: 1000
                           nullable: true
                           type: array
                         agents:
@@ -41872,6 +42326,7 @@ paths:
                                 cluster:
                                   items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                         enabled:
                           type: boolean
@@ -41947,6 +42402,7 @@ paths:
                                                     indices:
                                                       items:
                                                         type: string
+                                                      maxItems: 100
                                                       type: array
                                             type:
                                               type: string
@@ -41983,6 +42439,7 @@ paths:
                                         - enabled
                                         - data_stream
                                         - compiled_stream
+                                    maxItems: 100
                                     type: array
                                   type:
                                     type: string
@@ -42005,6 +42462,7 @@ paths:
                                   - enabled
                                   - streams
                                   - compiled_input
+                              maxItems: 100
                               type: array
                             - additionalProperties:
                                 additionalProperties: false
@@ -42029,9 +42487,11 @@ paths:
                                               - type: number
                                               - items:
                                                   type: string
+                                                maxItems: 100
                                                 type: array
                                               - items:
                                                   type: number
+                                                maxItems: 100
                                                 type: array
                                               - additionalProperties: false
                                                 type: object
@@ -42056,9 +42516,11 @@ paths:
                                         - type: number
                                         - items:
                                             type: string
+                                          maxItems: 100
                                           type: array
                                         - items:
                                             type: number
+                                          maxItems: 100
                                           type: array
                                         - additionalProperties: false
                                           type: object
@@ -42122,6 +42584,7 @@ paths:
                                 required:
                                   - data_stream
                                   - features
+                              maxItems: 100
                               type: array
                             fips_compatible:
                               type: boolean
@@ -42159,10 +42622,12 @@ paths:
                                 type: string
                             required:
                               - id
+                          maxItems: 100
                           type: array
                         spaceIds:
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                         supports_agentless:
                           default: false
@@ -42200,9 +42665,11 @@ paths:
                                   - type: number
                                   - items:
                                       type: string
+                                    maxItems: 100
                                     type: array
                                   - items:
                                       type: number
+                                    maxItems: 100
                                     type: array
                                   - additionalProperties: false
                                     type: object
@@ -42230,6 +42697,7 @@ paths:
                         - updated_by
                         - created_at
                         - created_by
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -42383,6 +42851,7 @@ paths:
                         description: Additional datastream permissions, that will be added to the agent policy.
                         items:
                           type: string
+                        maxItems: 1000
                         nullable: true
                         type: array
                       agents:
@@ -42409,6 +42878,7 @@ paths:
                               cluster:
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                       enabled:
                         type: boolean
@@ -42484,6 +42954,7 @@ paths:
                                                   indices:
                                                     items:
                                                       type: string
+                                                    maxItems: 100
                                                     type: array
                                           type:
                                             type: string
@@ -42520,6 +42991,7 @@ paths:
                                       - enabled
                                       - data_stream
                                       - compiled_stream
+                                  maxItems: 100
                                   type: array
                                 type:
                                   type: string
@@ -42542,6 +43014,7 @@ paths:
                                 - enabled
                                 - streams
                                 - compiled_input
+                            maxItems: 100
                             type: array
                           - additionalProperties:
                               additionalProperties: false
@@ -42566,9 +43039,11 @@ paths:
                                             - type: number
                                             - items:
                                                 type: string
+                                              maxItems: 100
                                               type: array
                                             - items:
                                                 type: number
+                                              maxItems: 100
                                               type: array
                                             - additionalProperties: false
                                               type: object
@@ -42593,9 +43068,11 @@ paths:
                                       - type: number
                                       - items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                                       - items:
                                           type: number
+                                        maxItems: 100
                                         type: array
                                       - additionalProperties: false
                                         type: object
@@ -42659,6 +43136,7 @@ paths:
                               required:
                                 - data_stream
                                 - features
+                            maxItems: 100
                             type: array
                           fips_compatible:
                             type: boolean
@@ -42696,10 +43174,12 @@ paths:
                               type: string
                           required:
                             - id
+                        maxItems: 100
                         type: array
                       spaceIds:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       supports_agentless:
                         default: false
@@ -42737,9 +43217,11 @@ paths:
                                 - type: number
                                 - items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 - items:
                                     type: number
+                                  maxItems: 100
                                   type: array
                                 - additionalProperties: false
                                   type: object
@@ -42849,6 +43331,7 @@ paths:
                       description: Additional datastream permissions, that will be added to the agent policy.
                       items:
                         type: string
+                      maxItems: 1000
                       nullable: true
                       type: array
                     cloud_connector_id:
@@ -42930,6 +43413,7 @@ paths:
                                             indices:
                                               items:
                                                 type: string
+                                              maxItems: 100
                                               type: array
                                     type:
                                       type: string
@@ -42966,6 +43450,7 @@ paths:
                                 - enabled
                                 - data_stream
                                 - compiled_stream
+                            maxItems: 100
                             type: array
                           type:
                             type: string
@@ -42986,6 +43471,7 @@ paths:
                         required:
                           - type
                           - enabled
+                      maxItems: 100
                       type: array
                     is_managed:
                       type: boolean
@@ -43032,6 +43518,7 @@ paths:
                             required:
                               - data_stream
                               - features
+                          maxItems: 100
                           type: array
                         fips_compatible:
                           type: boolean
@@ -43061,6 +43548,7 @@ paths:
                     spaceIds:
                       items:
                         type: string
+                      maxItems: 100
                       type: array
                     supports_agentless:
                       default: false
@@ -43095,6 +43583,7 @@ paths:
                       description: Additional datastream permissions, that will be added to the agent policy.
                       items:
                         type: string
+                      maxItems: 100
                       nullable: true
                       type: array
                     description:
@@ -43127,9 +43616,11 @@ paths:
                                       - type: number
                                       - items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                                       - items:
                                           type: number
+                                        maxItems: 100
                                         type: array
                                       - additionalProperties: false
                                         type: object
@@ -43154,9 +43645,11 @@ paths:
                                 - type: number
                                 - items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 - items:
                                     type: number
+                                  maxItems: 100
                                   type: array
                                 - additionalProperties: false
                                   type: object
@@ -43206,6 +43699,7 @@ paths:
                             required:
                               - data_stream
                               - features
+                          maxItems: 100
                           type: array
                         fips_compatible:
                           type: boolean
@@ -43242,9 +43736,11 @@ paths:
                           - type: number
                           - items:
                               type: string
+                            maxItems: 100
                             type: array
                           - items:
                               type: number
+                            maxItems: 100
                             type: array
                           - additionalProperties: false
                             type: object
@@ -43278,6 +43774,7 @@ paths:
                         description: Additional datastream permissions, that will be added to the agent policy.
                         items:
                           type: string
+                        maxItems: 1000
                         nullable: true
                         type: array
                       agents:
@@ -43304,6 +43801,7 @@ paths:
                               cluster:
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                       enabled:
                         type: boolean
@@ -43379,6 +43877,7 @@ paths:
                                                   indices:
                                                     items:
                                                       type: string
+                                                    maxItems: 100
                                                     type: array
                                           type:
                                             type: string
@@ -43415,6 +43914,7 @@ paths:
                                       - enabled
                                       - data_stream
                                       - compiled_stream
+                                  maxItems: 100
                                   type: array
                                 type:
                                   type: string
@@ -43437,6 +43937,7 @@ paths:
                                 - enabled
                                 - streams
                                 - compiled_input
+                            maxItems: 100
                             type: array
                           - additionalProperties:
                               additionalProperties: false
@@ -43461,9 +43962,11 @@ paths:
                                             - type: number
                                             - items:
                                                 type: string
+                                              maxItems: 100
                                               type: array
                                             - items:
                                                 type: number
+                                              maxItems: 100
                                               type: array
                                             - additionalProperties: false
                                               type: object
@@ -43488,9 +43991,11 @@ paths:
                                       - type: number
                                       - items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                                       - items:
                                           type: number
+                                        maxItems: 100
                                         type: array
                                       - additionalProperties: false
                                         type: object
@@ -43554,6 +44059,7 @@ paths:
                               required:
                                 - data_stream
                                 - features
+                            maxItems: 100
                             type: array
                           fips_compatible:
                             type: boolean
@@ -43591,10 +44097,12 @@ paths:
                               type: string
                           required:
                             - id
+                        maxItems: 100
                         type: array
                       spaceIds:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       supports_agentless:
                         default: false
@@ -43632,9 +44140,11 @@ paths:
                                 - type: number
                                 - items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 - items:
                                     type: number
+                                  maxItems: 100
                                   type: array
                                 - additionalProperties: false
                                   type: object
@@ -43741,6 +44251,7 @@ paths:
                 packagePolicyIds:
                   items:
                     type: string
+                  maxItems: 1000
                   type: array
               required:
                 - packagePolicyIds
@@ -43794,6 +44305,7 @@ paths:
                             required:
                               - data_stream
                               - features
+                          maxItems: 100
                           type: array
                         fips_compatible:
                           type: boolean
@@ -43818,6 +44330,7 @@ paths:
                     policy_ids:
                       items:
                         type: string
+                      maxItems: 10000
                       type: array
                     statusCode:
                       type: number
@@ -43828,6 +44341,7 @@ paths:
                     - success
                     - policy_ids
                     - package
+                maxItems: 10000
                 type: array
         '400':
           content:
@@ -43884,6 +44398,7 @@ paths:
                 packagePolicyIds:
                   items:
                     type: string
+                  maxItems: 1000
                   type: array
               required:
                 - packagePolicyIds
@@ -43915,6 +44430,7 @@ paths:
                   required:
                     - id
                     - success
+                maxItems: 10000
                 type: array
         '400':
           content:
@@ -43971,6 +44487,7 @@ paths:
                 packagePolicyIds:
                   items:
                     type: string
+                  maxItems: 1000
                   type: array
                 packageVersion:
                   type: string
@@ -44044,6 +44561,7 @@ paths:
                                       - fields
                                 required:
                                   - add_fields
+                              maxItems: 10000
                               type: array
                             revision:
                               type: number
@@ -44066,6 +44584,7 @@ paths:
                                     type: string
                                 required:
                                   - data_stream
+                              maxItems: 10000
                               type: array
                             type:
                               type: string
@@ -44079,7 +44598,9 @@ paths:
                             - data_stream
                             - use_output
                             - package_policy_id
+                        maxItems: 10000
                         type: array
+                      maxItems: 1
                       type: array
                     body:
                       additionalProperties: false
@@ -44099,6 +44620,7 @@ paths:
                                 description: Additional datastream permissions, that will be added to the agent policy.
                                 items:
                                   type: string
+                                maxItems: 1000
                                 nullable: true
                                 type: array
                               agents:
@@ -44125,6 +44647,7 @@ paths:
                                       cluster:
                                         items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                               enabled:
                                 type: boolean
@@ -44200,6 +44723,7 @@ paths:
                                                           indices:
                                                             items:
                                                               type: string
+                                                            maxItems: 100
                                                             type: array
                                                   type:
                                                     type: string
@@ -44236,6 +44760,7 @@ paths:
                                               - enabled
                                               - data_stream
                                               - compiled_stream
+                                          maxItems: 100
                                           type: array
                                         type:
                                           type: string
@@ -44258,6 +44783,7 @@ paths:
                                         - enabled
                                         - streams
                                         - compiled_input
+                                    maxItems: 100
                                     type: array
                                   - additionalProperties:
                                       additionalProperties: false
@@ -44282,9 +44808,11 @@ paths:
                                                     - type: number
                                                     - items:
                                                         type: string
+                                                      maxItems: 100
                                                       type: array
                                                     - items:
                                                         type: number
+                                                      maxItems: 100
                                                       type: array
                                                     - additionalProperties: false
                                                       type: object
@@ -44309,9 +44837,11 @@ paths:
                                               - type: number
                                               - items:
                                                   type: string
+                                                maxItems: 100
                                                 type: array
                                               - items:
                                                   type: number
+                                                maxItems: 100
                                                 type: array
                                               - additionalProperties: false
                                                 type: object
@@ -44375,6 +44905,7 @@ paths:
                                       required:
                                         - data_stream
                                         - features
+                                    maxItems: 100
                                     type: array
                                   fips_compatible:
                                     type: boolean
@@ -44412,10 +44943,12 @@ paths:
                                       type: string
                                   required:
                                     - id
+                                maxItems: 100
                                 type: array
                               spaceIds:
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                               supports_agentless:
                                 default: false
@@ -44453,9 +44986,11 @@ paths:
                                         - type: number
                                         - items:
                                             type: string
+                                          maxItems: 100
                                           type: array
                                         - items:
                                             type: number
+                                          maxItems: 100
                                           type: array
                                         - additionalProperties: false
                                           type: object
@@ -44489,6 +45024,7 @@ paths:
                                 description: Additional datastream permissions, that will be added to the agent policy.
                                 items:
                                   type: string
+                                maxItems: 1000
                                 nullable: true
                                 type: array
                               cloud_connector_id:
@@ -44513,6 +45049,7 @@ paths:
                                       cluster:
                                         items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                               enabled:
                                 type: boolean
@@ -44527,6 +45064,7 @@ paths:
                                       type: string
                                   required:
                                     - message
+                                maxItems: 10
                                 type: array
                               force:
                                 type: boolean
@@ -44601,6 +45139,7 @@ paths:
                                                       indices:
                                                         items:
                                                           type: string
+                                                        maxItems: 100
                                                         type: array
                                               type:
                                                 type: string
@@ -44637,6 +45176,7 @@ paths:
                                           - enabled
                                           - data_stream
                                           - compiled_stream
+                                      maxItems: 100
                                       type: array
                                     type:
                                       type: string
@@ -44659,12 +45199,14 @@ paths:
                                     - enabled
                                     - streams
                                     - compiled_input
+                                maxItems: 100
                                 type: array
                               is_managed:
                                 type: boolean
                               missingVars:
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                               name:
                                 description: Package policy name (should be unique)
@@ -44710,6 +45252,7 @@ paths:
                                       required:
                                         - data_stream
                                         - features
+                                    maxItems: 100
                                     type: array
                                   fips_compatible:
                                     type: boolean
@@ -44747,6 +45290,7 @@ paths:
                                       type: string
                                   required:
                                     - id
+                                maxItems: 100
                                 type: array
                               supports_agentless:
                                 default: false
@@ -44782,6 +45326,7 @@ paths:
                               - name
                               - enabled
                               - inputs
+                      maxItems: 2
                       type: array
                     hasErrors:
                       type: boolean
@@ -44791,6 +45336,7 @@ paths:
                       type: number
                   required:
                     - hasErrors
+                maxItems: 10000
                 type: array
         '400':
           content:
@@ -44873,6 +45419,7 @@ paths:
                         - id
                         - url
                         - name
+                    maxItems: 10000
                     type: array
                   page:
                     type: number
@@ -45356,6 +45903,7 @@ paths:
                           enum:
                             - fleet_server_hosts
                           type: string
+                        maxItems: 1
                         type: array
                       prerelease_integrations_enabled:
                         type: boolean
@@ -45463,6 +46011,7 @@ paths:
                   items:
                     format: uri
                     type: string
+                  maxItems: 10
                   type: array
                 prerelease_integrations_enabled:
                   type: boolean
@@ -45502,6 +46051,7 @@ paths:
                           enum:
                             - fleet_server_hosts
                           type: string
+                        maxItems: 1
                         type: array
                       prerelease_integrations_enabled:
                         type: boolean
@@ -45601,6 +46151,7 @@ paths:
                       required:
                         - name
                         - message
+                    maxItems: 10000
                     type: array
                 required:
                   - isInitialized
@@ -45662,6 +46213,7 @@ paths:
                       allowed_namespace_prefixes:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       managed_by:
                         type: string
@@ -45709,6 +46261,7 @@ paths:
                 allowed_namespace_prefixes:
                   items:
                     type: string
+                  maxItems: 10
                   type: array
       responses:
         '200':
@@ -45725,6 +46278,7 @@ paths:
                       allowed_namespace_prefixes:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       managed_by:
                         type: string
@@ -45796,6 +46350,7 @@ paths:
                         namespaces:
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                         policy_id:
                           type: string
@@ -45806,6 +46361,7 @@ paths:
                         - id
                         - policy_id
                         - created_at
+                    maxItems: 10000
                     type: array
                   page:
                     type: number
@@ -45880,6 +46436,7 @@ paths:
                       namespaces:
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       policy_id:
                         type: string

--- a/x-pack/platform/plugins/shared/fleet/server/routes/data_streams/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/data_streams/index.ts
@@ -32,7 +32,8 @@ export const ListDataStreamsResponseSchema = schema.object({
         schema.object({
           id: schema.string(),
           title: schema.string(),
-        })
+        }),
+        { maxSize: 10000 }
       ),
       serviceDetails: schema.nullable(
         schema.object({
@@ -40,7 +41,8 @@ export const ListDataStreamsResponseSchema = schema.object({
           serviceName: schema.string(),
         })
       ),
-    })
+    }),
+    { maxSize: 10000 }
   ),
 });
 

--- a/x-pack/platform/plugins/shared/fleet/server/routes/enrollment_api_key/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/enrollment_api_key/index.ts
@@ -132,7 +132,10 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
               description: 'OK: A successful request.',
               body: () =>
                 ListResponseSchema(EnrollmentAPIKeySchema).extends({
-                  list: schema.arrayOf(EnrollmentAPIKeySchema, { meta: { deprecated: true } }),
+                  list: schema.arrayOf(EnrollmentAPIKeySchema, {
+                    meta: { deprecated: true },
+                    maxSize: 10000,
+                  }),
                 }),
             },
             400: {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/schema/utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/schema/utils.ts
@@ -9,7 +9,7 @@ import type { Type } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 export const ListResponseSchema = (itemSchema: Type<any>) =>
   schema.object({
-    items: schema.arrayOf(itemSchema),
+    items: schema.arrayOf(itemSchema, { maxSize: 10000 }),
     total: schema.number(),
     page: schema.number(),
     perPage: schema.number(),

--- a/x-pack/platform/plugins/shared/fleet/server/routes/setup/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/setup/index.ts
@@ -24,7 +24,8 @@ export const FleetSetupResponseSchema = schema.object(
       schema.object({
         name: schema.string(),
         message: schema.string(),
-      })
+      }),
+      { maxSize: 10000 }
     ),
   },
   {
@@ -93,10 +94,12 @@ export const GetAgentsSetupResponseSchema = schema.object(
         schema.literal('api_keys'),
         schema.literal('fleet_admin_user'),
         schema.literal('fleet_server'),
-      ])
+      ]),
+      { maxSize: 5 }
     ),
     missing_optional_features: schema.arrayOf(
-      schema.oneOf([schema.literal('encrypted_saved_object_encryption_key_required')])
+      schema.oneOf([schema.literal('encrypted_saved_object_encryption_key_required')]),
+      { maxSize: 1 }
     ),
     package_verification_key_id: schema.maybe(schema.string()),
     is_space_awareness_enabled: schema.maybe(schema.boolean()),

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
@@ -64,7 +64,7 @@ function validateCloudProvider(s: string) {
 
 export const AgentPolicyBaseSchema = {
   id: schema.maybe(schema.string()),
-  space_ids: schema.maybe(schema.arrayOf(schema.string())),
+  space_ids: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
   name: schema.string({ minLength: 1, validate: validateNonEmptyString }),
   namespace: AgentPolicyNamespaceSchema,
   description: schema.maybe(schema.string()),
@@ -84,7 +84,8 @@ export const AgentPolicyBaseSchema = {
         schema.literal(dataTypes.Logs),
         schema.literal(dataTypes.Metrics),
         schema.literal(dataTypes.Traces),
-      ])
+      ]),
+      { maxSize: 3 }
     )
   ),
   keep_monitoring_alive: schema.maybe(
@@ -108,7 +109,8 @@ export const AgentPolicyBaseSchema = {
       schema.object({
         name: schema.string(),
         enabled: schema.boolean(),
-      })
+      }),
+      { maxSize: 100 }
     )
   ),
   is_protected: schema.maybe(schema.boolean()),
@@ -152,6 +154,7 @@ export const AgentPolicyBaseSchema = {
           description:
             'User defined data tags that are added to all of the inputs. The values can be strings or numbers.',
         },
+        maxSize: 10,
       }
     )
   ),
@@ -218,7 +221,8 @@ export const AgentPolicyBaseSchema = {
               description: 'Target percentage of agents to auto upgrade',
             },
           }),
-        })
+        }),
+        { maxSize: 100 }
       ),
     ])
   ),
@@ -262,7 +266,7 @@ function validateGlobalDataTagInput(tags: GlobalDataTag[]): string | undefined {
 
 const BaseSSLSchema = schema.object({
   verification_mode: schema.maybe(schema.string()),
-  certificate_authorities: schema.maybe(schema.arrayOf(schema.string())),
+  certificate_authorities: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
   certificate: schema.maybe(schema.string()),
   key: schema.maybe(schema.string()),
   renegotiation: schema.maybe(schema.string()),
@@ -296,7 +300,10 @@ export const AgentPolicySchema = schema.object({
     schema.literal(agentPolicyStatuses.Inactive),
   ]),
   package_policies: schema.maybe(
-    schema.oneOf([schema.arrayOf(schema.string()), schema.arrayOf(PackagePolicySchema)])
+    schema.oneOf([
+      schema.arrayOf(schema.string(), { maxSize: 1000 }),
+      schema.arrayOf(PackagePolicySchema, { maxSize: 1000 }),
+    ])
   ),
   updated_at: schema.string(),
   updated_by: schema.string(),
@@ -318,12 +325,13 @@ export const AgentPolicyResponseSchema = AgentPolicySchema.extends({
   schema_version: schema.maybe(schema.string()),
   package_policies: schema.maybe(
     schema.oneOf([
-      schema.arrayOf(schema.string()),
+      schema.arrayOf(schema.string(), { maxSize: 10000 }),
       schema.arrayOf(PackagePolicyResponseSchema, {
         meta: {
           description:
             'This field is present only when retrieving a single agent policy, or when retrieving a list of agent policies with the ?full=true parameter',
         },
+        maxSize: 10000,
       }),
     ])
   ),
@@ -353,9 +361,9 @@ export const OTelCollectorPipelineIDSchema = schema.oneOf([
 
 export const OTelCollectorPipelineSchema = schema.maybe(
   schema.object({
-    receivers: schema.maybe(schema.arrayOf(schema.string())),
-    processors: schema.maybe(schema.arrayOf(schema.string())),
-    exporters: schema.maybe(schema.arrayOf(schema.string())),
+    receivers: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 1000 })),
+    processors: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 1000 })),
+    exporters: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 1000 })),
   })
 );
 export const OtelCollectorConfigSchema = {
@@ -366,7 +374,7 @@ export const OtelCollectorConfigSchema = {
   exporters: schema.maybe(schema.recordOf(schema.string(), schema.any())),
   service: schema.maybe(
     schema.object({
-      extensions: schema.maybe(schema.arrayOf(schema.string())),
+      extensions: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 1000 })),
       pipelines: schema.maybe(
         schema.recordOf(OTelCollectorPipelineIDSchema, OTelCollectorPipelineSchema)
       ),
@@ -376,13 +384,13 @@ export const OtelCollectorConfigSchema = {
 
 export const FullAgentPolicyResponseSchema = schema.object({
   id: schema.string(),
-  namespaces: schema.maybe(schema.arrayOf(schema.string())),
+  namespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
   outputs: schema
     .recordOf(
       schema.string(),
       schema.object({
         type: schema.string(),
-        hosts: schema.maybe(schema.arrayOf(schema.string())),
+        hosts: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
         ca_sha256: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
         proxy_url: schema.maybe(schema.string()),
         proxy_headers: schema.maybe(ProxyHeadersSchema),
@@ -397,7 +405,7 @@ export const FullAgentPolicyResponseSchema = schema.object({
   fleet: schema.maybe(
     schema.oneOf([
       schema.object({
-        hosts: schema.arrayOf(schema.string()),
+        hosts: schema.arrayOf(schema.string(), { maxSize: 100 }),
         proxy_url: schema.maybe(schema.string()),
         proxy_headers: schema.maybe(ProxyHeadersSchema),
         ssl: schema.maybe(BaseSSLSchema),
@@ -405,7 +413,7 @@ export const FullAgentPolicyResponseSchema = schema.object({
       }),
       schema.object({
         kibana: schema.object({
-          hosts: schema.arrayOf(schema.string()),
+          hosts: schema.arrayOf(schema.string(), { maxSize: 100 }),
           protocol: schema.string(),
           path: schema.maybe(schema.string()),
         }),
@@ -447,7 +455,8 @@ export const FullAgentPolicyResponseSchema = schema.object({
                   dataset: schema.string(),
                   type: schema.maybe(schema.string()),
                 }),
-              })
+              }),
+              { maxSize: 10000 }
             )
             .extendsDeep({
               unknowns: 'allow',
@@ -463,13 +472,15 @@ export const FullAgentPolicyResponseSchema = schema.object({
                   schema.oneOf([schema.string(), schema.number()])
                 ),
               }),
-            })
+            }),
+            { maxSize: 10000 }
           )
         ),
       })
       .extendsDeep({
         unknowns: 'allow',
-      })
+      }),
+    { maxSize: 10000 }
   ),
   revision: schema.maybe(schema.number()),
   agent: schema.maybe(
@@ -535,7 +546,8 @@ export const FullAgentPolicyResponseSchema = schema.object({
     schema.arrayOf(
       schema.object({
         id: schema.string(),
-      })
+      }),
+      { maxSize: 1000 }
     )
   ),
   signed: schema.maybe(
@@ -557,7 +569,8 @@ const IntegrationsOutputSchema = schema.arrayOf(
     integrationPolicyName: schema.maybe(schema.string()),
     id: schema.maybe(schema.string()),
     name: schema.maybe(schema.string()),
-  })
+  }),
+  { maxSize: 1000 }
 );
 
 const OutputsForAgentPolicySchema = schema.object({
@@ -576,5 +589,5 @@ export const GetAgentPolicyOutputsResponseSchema = schema.object({
 });
 
 export const GetListAgentPolicyOutputsResponseSchema = schema.object({
-  items: schema.arrayOf(OutputsForAgentPolicySchema),
+  items: schema.arrayOf(OutputsForAgentPolicySchema, { maxSize: 10000 }),
 });

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/custom_integrations.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/custom_integrations.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 
 const CustomIntegrationFieldsSchema = schema.object({
   readMeData: schema.string(),
-  categories: schema.maybe(schema.arrayOf(schema.string())),
+  categories: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
 });
 
 export const CustomIntegrationRequestSchema = {

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/download_sources.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/download_sources.ts
@@ -32,7 +32,7 @@ const DownloadSourceBaseSchema = {
   ),
   ssl: schema.maybe(
     schema.object({
-      certificate_authorities: schema.maybe(schema.arrayOf(schema.string())),
+      certificate_authorities: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
       certificate: schema.maybe(schema.string()),
       key: schema.maybe(schema.string()),
     })

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/output.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/output.ts
@@ -74,7 +74,7 @@ const BaseSchema = {
     schema.oneOf([
       schema.literal(null),
       schema.object({
-        certificate_authorities: schema.maybe(schema.arrayOf(schema.string())),
+        certificate_authorities: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
         certificate: schema.maybe(schema.string()),
         key: schema.maybe(schema.string()),
         verification_mode: schema.maybe(
@@ -106,7 +106,7 @@ const BaseSchema = {
       }),
     ])
   ),
-  allow_edit: schema.maybe(schema.arrayOf(schema.string())),
+  allow_edit: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 1000 })),
   secrets: schema.maybe(
     schema.object({
       ssl: schema.maybe(schema.object({ key: schema.maybe(secretRefSchema) })),
@@ -136,7 +136,7 @@ const PresetSchema = schema.oneOf([
 export const ElasticSearchSchema = {
   ...BaseSchema,
   type: schema.literal(outputType.Elasticsearch),
-  hosts: schema.arrayOf(schema.uri({ scheme: ['http', 'https'] }), { minSize: 1 }),
+  hosts: schema.arrayOf(schema.uri({ scheme: ['http', 'https'] }), { minSize: 1, maxSize: 10 }),
   preset: schema.maybe(PresetSchema),
   write_to_logs_streams: schema.maybe(schema.oneOf([schema.literal(null), schema.boolean()])),
 };
@@ -144,7 +144,9 @@ export const ElasticSearchSchema = {
 const ElasticSearchUpdateSchema = {
   ...UpdateSchema,
   type: schema.maybe(schema.literal(outputType.Elasticsearch)),
-  hosts: schema.maybe(schema.arrayOf(schema.uri({ scheme: ['http', 'https'] }), { minSize: 1 })),
+  hosts: schema.maybe(
+    schema.arrayOf(schema.uri({ scheme: ['http', 'https'] }), { minSize: 1, maxSize: 10 })
+  ),
   preset: schema.maybe(PresetSchema),
   write_to_logs_streams: schema.maybe(schema.oneOf([schema.literal(null), schema.boolean()])),
 };
@@ -192,14 +194,17 @@ const RemoteElasticSearchUpdateSchema = {
 export const LogstashSchema = {
   ...BaseSchema,
   type: schema.literal(outputType.Logstash),
-  hosts: schema.arrayOf(schema.string({ validate: validateLogstashHost }), { minSize: 1 }),
+  hosts: schema.arrayOf(schema.string({ validate: validateLogstashHost }), {
+    minSize: 1,
+    maxSize: 10,
+  }),
 };
 
 const LogstashUpdateSchema = {
   ...UpdateSchema,
   type: schema.maybe(schema.literal(outputType.Logstash)),
   hosts: schema.maybe(
-    schema.arrayOf(schema.string({ validate: validateLogstashHost }), { minSize: 1 })
+    schema.arrayOf(schema.string({ validate: validateLogstashHost }), { minSize: 1, maxSize: 10 })
   ),
   secrets: schema.maybe(
     schema.object({
@@ -211,7 +216,10 @@ const LogstashUpdateSchema = {
 export const KafkaSchema = {
   ...BaseSchema,
   type: schema.literal(outputType.Kafka),
-  hosts: schema.arrayOf(schema.string({ validate: validateKafkaHost }), { minSize: 1 }),
+  hosts: schema.arrayOf(schema.string({ validate: validateKafkaHost }), {
+    minSize: 1,
+    maxSize: 10,
+  }),
   version: schema.maybe(schema.string()),
   key: schema.maybe(schema.string()),
   compression: schema.maybe(
@@ -293,7 +301,9 @@ export const KafkaSchema = {
   ),
   topic: schema.maybe(schema.string()),
   headers: schema.maybe(
-    schema.arrayOf(schema.object({ key: schema.string(), value: schema.string() }))
+    schema.arrayOf(schema.object({ key: schema.string(), value: schema.string() }), {
+      maxSize: 100,
+    })
   ),
   timeout: schema.maybe(schema.number()),
   broker_timeout: schema.maybe(schema.number()),
@@ -313,7 +323,7 @@ const KafkaUpdateSchema = {
   ...KafkaSchema,
   type: schema.maybe(schema.literal(outputType.Kafka)),
   hosts: schema.maybe(
-    schema.arrayOf(schema.string({ validate: validateKafkaHost }), { minSize: 1 })
+    schema.arrayOf(schema.string({ validate: validateKafkaHost }), { minSize: 1, maxSize: 10 })
   ),
   auth_type: schema.maybe(
     schema.oneOf([

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/preconfiguration.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/preconfiguration.ts
@@ -31,7 +31,8 @@ const varsSchema = schema.maybe(
       type: schema.maybe(schema.string()),
       value: schema.maybe(schema.any()),
       frozen: schema.maybe(schema.boolean()),
-    })
+    }),
+    { maxSize: 1000 }
   )
 );
 
@@ -59,6 +60,7 @@ export const PreconfiguredPackagesSchema = schema.arrayOf(
   }),
   {
     defaultValue: [],
+    maxSize: 1000,
   }
 );
 
@@ -95,7 +97,7 @@ const PreconfiguredOutputBaseSchema = {
   id: schema.string(),
   config: schema.maybe(schema.object({}, { unknowns: 'allow' })),
   config_yaml: schema.never(),
-  allow_edit: schema.maybe(schema.arrayOf(schema.string())),
+  allow_edit: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 1000 })),
 };
 
 export const PreconfiguredOutputsSchema = schema.arrayOf(
@@ -105,7 +107,7 @@ export const PreconfiguredOutputsSchema = schema.arrayOf(
     schema.object({ ...KafkaSchema }).extends(PreconfiguredOutputBaseSchema),
     schema.object({ ...RemoteElasticSearchSchema }).extends(PreconfiguredOutputBaseSchema),
   ]),
-  { defaultValue: [], validate: validatePreconfiguredOutputs }
+  { defaultValue: [], validate: validatePreconfiguredOutputs, maxSize: 100 }
 );
 
 export const PreconfiguredFleetServerHostsSchema = schema.arrayOf(
@@ -114,7 +116,7 @@ export const PreconfiguredFleetServerHostsSchema = schema.arrayOf(
     name: schema.string(),
     is_default: schema.boolean({ defaultValue: false }),
     is_internal: schema.maybe(schema.boolean()),
-    host_urls: schema.arrayOf(schema.string(), { minSize: 1 }),
+    host_urls: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 10 }),
     proxy_id: schema.nullable(schema.string()),
     secrets: schema.maybe(
       schema.object({
@@ -125,10 +127,12 @@ export const PreconfiguredFleetServerHostsSchema = schema.arrayOf(
       schema.oneOf([
         schema.literal(null),
         schema.object({
-          certificate_authorities: schema.maybe(schema.arrayOf(schema.string())),
+          certificate_authorities: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
           certificate: schema.maybe(schema.string()),
           key: schema.maybe(schema.string()),
-          es_certificate_authorities: schema.maybe(schema.arrayOf(schema.string())),
+          es_certificate_authorities: schema.maybe(
+            schema.arrayOf(schema.string(), { maxSize: 10 })
+          ),
           es_certificate: schema.maybe(schema.string()),
           es_key: schema.maybe(schema.string()),
           client_auth: schema.maybe(
@@ -142,7 +146,7 @@ export const PreconfiguredFleetServerHostsSchema = schema.arrayOf(
       ])
     ),
   }),
-  { defaultValue: [] }
+  { defaultValue: [], maxSize: 100 }
 );
 
 export const PreconfiguredFleetProxiesSchema = schema.arrayOf(
@@ -160,7 +164,7 @@ export const PreconfiguredFleetProxiesSchema = schema.arrayOf(
     certificate: schema.maybe(schema.string()),
     certificate_key: schema.maybe(schema.string()),
   }),
-  { defaultValue: [] }
+  { defaultValue: [], maxSize: 10 }
 );
 
 export const PreconfiguredAgentPoliciesSchema = schema.arrayOf(
@@ -212,20 +216,24 @@ export const PreconfiguredAgentPoliciesSchema = schema.arrayOf(
                         enabled: schema.maybe(schema.boolean()),
                         keep_enabled: schema.maybe(schema.boolean()),
                         vars: varsSchema,
-                      })
+                      }),
+                      { maxSize: 1000 }
                     )
                   ),
-                })
+                }),
+                { maxSize: 1000 }
               )
             ),
           }),
           SimplifiedPackagePolicyPreconfiguredSchema,
-        ])
+        ]),
+        { maxSize: 1000 }
       )
     ),
   }),
   {
     defaultValue: [],
+    maxSize: 1000,
   }
 );
 
@@ -240,11 +248,13 @@ export const PreconfiguredSpaceSettingsSchema = schema.arrayOf(
               return 'Must not contain -';
             }
           },
-        })
+        }),
+        { maxSize: 10 }
       )
     ),
   }),
   {
     defaultValue: [],
+    maxSize: 100,
   }
 );

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/synced_integrations.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/synced_integrations.ts
@@ -58,7 +58,7 @@ export const CustomAssetsDataSchema = schema.object({
 });
 
 export const GetRemoteSyncedIntegrationsStatusResponseSchema = schema.object({
-  integrations: schema.arrayOf(RemoteSyncedIntegrationsStatusSchema),
+  integrations: schema.arrayOf(RemoteSyncedIntegrationsStatusSchema, { maxSize: 10000 }),
   custom_assets: schema.maybe(schema.recordOf(schema.string(), CustomAssetsDataSchema)),
   error: schema.maybe(schema.string()),
   warning: schema.maybe(

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agent.ts
@@ -99,7 +99,7 @@ export const MigrateOptionsSchema = {
   proxy_headers: schema.maybe(schema.recordOf(schema.string(), schema.string())),
   proxy_url: schema.maybe(schema.string()),
   staging: schema.maybe(schema.string()),
-  tags: schema.maybe(schema.arrayOf(schema.string())),
+  tags: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
   replace_token: schema.maybe(schema.string()),
 };
 export const BulkMigrateOptionsSchema = {
@@ -114,7 +114,7 @@ export const BulkMigrateOptionsSchema = {
   proxy_headers: schema.maybe(schema.recordOf(schema.string(), schema.string())),
   proxy_url: schema.maybe(schema.string()),
   staging: schema.maybe(schema.string()),
-  tags: schema.maybe(schema.arrayOf(schema.string())),
+  tags: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
 };
 export const AgentComponentStateSchema = schema.oneOf([
   schema.literal('STARTING'),
@@ -163,7 +163,8 @@ export const AgentResponseSchema = schema.object({
         {
           meta: { deprecated: true },
         }
-      )
+      ),
+      { maxSize: 100 }
     )
   ),
   outputs: schema.maybe(
@@ -177,7 +178,8 @@ export const AgentResponseSchema = schema.object({
             schema.object({
               id: schema.string(),
               retired_at: schema.string(),
-            })
+            }),
+            { maxSize: 100 }
           )
         ),
       })
@@ -185,8 +187,8 @@ export const AgentResponseSchema = schema.object({
   ),
   status: schema.maybe(AgentStatusSchema),
   last_known_status: schema.maybe(AgentStatusSchema),
-  packages: schema.arrayOf(schema.string()),
-  sort: schema.maybe(schema.arrayOf(schema.any())), // ES can return many different types for `sort` array values, including unsafe numbers
+  packages: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+  sort: schema.maybe(schema.arrayOf(schema.any(), { maxSize: 10 })), // ES can return many different types for `sort` array values, including unsafe numbers
   metrics: schema.maybe(
     schema.object({
       cpu_avg: schema.maybe(schema.number()),
@@ -227,7 +229,7 @@ export const AgentResponseSchema = schema.object({
     ])
   ),
   upgrade_attempts: schema.maybe(
-    schema.oneOf([schema.literal(null), schema.arrayOf(schema.string())])
+    schema.oneOf([schema.literal(null), schema.arrayOf(schema.string(), { maxSize: 1000 })])
   ),
   access_api_key_id: schema.maybe(schema.string()),
   default_api_key: schema.maybe(schema.string()),
@@ -247,7 +249,7 @@ export const AgentResponseSchema = schema.object({
   last_checkin_message: schema.maybe(schema.string()),
   user_provided_metadata: schema.maybe(schema.recordOf(schema.string(), schema.any())),
   local_metadata: schema.recordOf(schema.string(), schema.any()),
-  tags: schema.maybe(schema.arrayOf(schema.string())),
+  tags: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
   components: schema.maybe(
     schema.arrayOf(
       schema.object({
@@ -267,10 +269,12 @@ export const AgentResponseSchema = schema.object({
               status: AgentComponentStateSchema,
               message: schema.string(),
               payload: schema.maybe(schema.recordOf(schema.string(), schema.any())),
-            })
+            }),
+            { maxSize: 1000 }
           )
         ),
-      })
+      }),
+      { maxSize: 1000 }
     )
   ),
   agent: schema.maybe(
@@ -287,11 +291,12 @@ export const AgentResponseSchema = schema.object({
     schema.oneOf([
       schema.literal(null),
       schema.arrayOf(
-        schema.oneOf([schema.literal('input'), schema.literal('output'), schema.literal('other')])
+        schema.oneOf([schema.literal('input'), schema.literal('output'), schema.literal('other')]),
+        { maxSize: 3 }
       ),
     ])
   ),
-  namespaces: schema.maybe(schema.arrayOf(schema.string())),
+  namespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
 });
 
 export const GetAgentsResponseSchema = ListResponseSchema(AgentResponseSchema).extends({
@@ -330,8 +335,8 @@ export const PostNewAgentActionResponseSchema = schema.object({
     sent_at: schema.maybe(schema.string()),
     created_at: schema.string(),
     ack_data: schema.maybe(schema.any()),
-    agents: schema.maybe(schema.arrayOf(schema.string())),
-    namespaces: schema.maybe(schema.arrayOf(schema.string())),
+    agents: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10000 })),
+    namespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
     expiration: schema.maybe(schema.string()),
     start_time: schema.maybe(schema.string()),
     minimum_execution_duration: schema.maybe(schema.number()),
@@ -349,12 +354,12 @@ export const PostCancelActionRequestSchema = {
 
 export const PostRetrieveAgentsByActionsRequestSchema = {
   body: schema.object({
-    actionIds: schema.arrayOf(schema.string()),
+    actionIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
   }),
 };
 
 export const PostRetrieveAgentsByActionsResponseSchema = schema.object({
-  items: schema.arrayOf(schema.string()),
+  items: schema.arrayOf(schema.string(), { maxSize: 1000 }),
 });
 
 export const PostAgentUnenrollRequestSchema = {
@@ -375,13 +380,14 @@ export const PostBulkAgentUnenrollRequestSchema = {
       schema.arrayOf(
         schema.string({
           meta: {
-            description: 'KQL query string, leave empty to action all agents',
+            description: 'list of agent IDs',
           },
-        })
+        }),
+        { maxSize: 10000 }
       ),
       schema.string({
         meta: {
-          description: 'list of agent IDs',
+          description: 'KQL query string, leave empty to action all agents',
         },
       }),
     ]),
@@ -432,7 +438,7 @@ export const PostAgentUpgradeRequestSchema = {
 
 export const PostBulkAgentUpgradeRequestSchema = {
   body: schema.object({
-    agents: schema.oneOf([schema.arrayOf(schema.string()), schema.string()]),
+    agents: schema.oneOf([schema.arrayOf(schema.string(), { maxSize: 10000 }), schema.string()]),
     source_uri: schema.maybe(schema.string()),
     version: schema.string({ validate: validateVersion }),
     force: schema.maybe(schema.boolean()),
@@ -468,7 +474,9 @@ export const PostRequestDiagnosticsActionRequestSchema = {
   body: schema.nullable(
     schema.object({
       additional_metrics: schema.maybe(
-        schema.arrayOf(schema.oneOf([schema.literal(RequestDiagnosticsAdditionalMetrics.CPU)]))
+        schema.arrayOf(schema.oneOf([schema.literal(RequestDiagnosticsAdditionalMetrics.CPU)]), {
+          maxSize: 1,
+        })
       ),
     })
   ),
@@ -476,10 +484,12 @@ export const PostRequestDiagnosticsActionRequestSchema = {
 
 export const PostBulkRequestDiagnosticsActionRequestSchema = {
   body: schema.object({
-    agents: schema.oneOf([schema.arrayOf(schema.string()), schema.string()]),
+    agents: schema.oneOf([schema.arrayOf(schema.string(), { maxSize: 10000 }), schema.string()]),
     batchSize: schema.maybe(schema.number()),
     additional_metrics: schema.maybe(
-      schema.arrayOf(schema.oneOf([schema.literal(RequestDiagnosticsAdditionalMetrics.CPU)]))
+      schema.arrayOf(schema.oneOf([schema.literal(RequestDiagnosticsAdditionalMetrics.CPU)]), {
+        maxSize: 1,
+      })
     ),
   }),
 };
@@ -507,7 +517,8 @@ export const ListAgentUploadsResponseSchema = schema.object({
       ]),
       actionId: schema.string(),
       error: schema.maybe(schema.string()),
-    })
+    }),
+    { maxSize: 1000 }
   ),
 });
 
@@ -532,7 +543,7 @@ export const DeleteAgentUploadFileResponseSchema = schema.object({
 export const PostBulkAgentReassignRequestSchema = {
   body: schema.object({
     policy_id: schema.string(),
-    agents: schema.oneOf([schema.arrayOf(schema.string()), schema.string()]),
+    agents: schema.oneOf([schema.arrayOf(schema.string(), { maxSize: 10000 }), schema.string()]),
     batchSize: schema.maybe(schema.number()),
     includeInactive: schema.boolean({ defaultValue: false }),
   }),
@@ -554,7 +565,7 @@ export const UpdateAgentRequestSchema = {
   }),
   body: schema.object({
     user_provided_metadata: schema.maybe(schema.recordOf(schema.string(), schema.any())),
-    tags: schema.maybe(schema.arrayOf(schema.string())),
+    tags: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
   }),
 };
 export const MigrateSingleAgentRequestSchema = {
@@ -573,7 +584,7 @@ export const MigrateSingleAgentResponseSchema = schema.object({
 
 export const BulkMigrateAgentsRequestSchema = {
   body: schema.object({
-    agents: schema.oneOf([schema.arrayOf(schema.string()), schema.string()]),
+    agents: schema.oneOf([schema.arrayOf(schema.string(), { maxSize: 10000 }), schema.string()]),
     uri: schema.uri(),
     enrollment_token: schema.string(),
     settings: schema.maybe(schema.object(BulkMigrateOptionsSchema)),
@@ -586,9 +597,9 @@ export const BulkMigrateAgentsResponseSchema = schema.object({
 
 export const PostBulkUpdateAgentTagsRequestSchema = {
   body: schema.object({
-    agents: schema.oneOf([schema.arrayOf(schema.string()), schema.string()]),
-    tagsToAdd: schema.maybe(schema.arrayOf(schema.string())),
-    tagsToRemove: schema.maybe(schema.arrayOf(schema.string())),
+    agents: schema.oneOf([schema.arrayOf(schema.string(), { maxSize: 10000 }), schema.string()]),
+    tagsToAdd: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
+    tagsToRemove: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
     batchSize: schema.maybe(schema.number()),
     includeInactive: schema.boolean({ defaultValue: false }),
   }),
@@ -601,7 +612,9 @@ export const PostBulkActionResponseSchema = schema.object({
 export const GetAgentStatusRequestSchema = {
   query: schema.object({
     policyId: schema.maybe(schema.string()),
-    policyIds: schema.maybe(schema.oneOf([schema.arrayOf(schema.string()), schema.string()])),
+    policyIds: schema.maybe(
+      schema.oneOf([schema.arrayOf(schema.string(), { maxSize: 1000 }), schema.string()])
+    ),
     kuery: schema.maybe(
       schema.string({
         validate: (value: string) => {
@@ -634,7 +647,7 @@ export const GetAgentStatusResponseSchema = schema.object({
 
 export const GetAgentDataRequestSchema = {
   query: schema.object({
-    agentsIds: schema.oneOf([schema.arrayOf(schema.string()), schema.string()]),
+    agentsIds: schema.oneOf([schema.arrayOf(schema.string(), { maxSize: 10000 }), schema.string()]),
     pkgName: schema.maybe(schema.string()),
     pkgVersion: schema.maybe(schema.string()),
     previewData: schema.boolean({ defaultValue: false }),
@@ -648,9 +661,10 @@ export const GetAgentDataResponseSchema = schema.object({
       schema.object({
         data: schema.boolean(),
       })
-    )
+    ),
+    { maxSize: 10000 }
   ),
-  dataPreview: schema.arrayOf(schema.any()),
+  dataPreview: schema.arrayOf(schema.any(), { maxSize: 1000 }),
 });
 
 export const GetActionStatusRequestSchema = {
@@ -763,7 +777,8 @@ export const GetActionStatusResponseSchema = schema.object({
                 description: 'latest errors that happened when the agents executed the action',
               },
             }
-          )
+          ),
+          { maxSize: 10 }
         )
       ),
       revision: schema.maybe(
@@ -780,12 +795,13 @@ export const GetActionStatusResponseSchema = schema.object({
           },
         })
       ),
-    })
+    }),
+    { maxSize: 1000 }
   ),
 });
 
 export const GetAvailableAgentVersionsResponseSchema = schema.object({
-  items: schema.arrayOf(schema.string()),
+  items: schema.arrayOf(schema.string(), { maxSize: 1000 }),
 });
 
 export const ChangeAgentPrivilegeLevelRequestSchema = {

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agent_policy.ts
@@ -92,7 +92,7 @@ export const BulkGetAgentPoliciesRequestSchema = {
 };
 
 export const BulkGetAgentPoliciesResponseSchema = schema.object({
-  items: schema.arrayOf(AgentPolicyResponseSchema),
+  items: schema.arrayOf(AgentPolicyResponseSchema, { maxSize: 10000 }),
 });
 
 export const GetOneAgentPolicyRequestSchema = {
@@ -121,7 +121,7 @@ export const CreateAgentPolicyRequestSchema = {
 
 export const CreateAgentAndPackagePolicyRequestSchema = {
   body: CreateAgentPolicyRequestSchema.body.extends({
-    package_policies: schema.arrayOf(CreatePackagePolicyRequestSchema.body),
+    package_policies: schema.arrayOf(CreatePackagePolicyRequestSchema.body, { maxSize: 1000 }),
   }),
   query: schema.intersection([
     CreateAgentPolicyRequestSchema.query,
@@ -200,6 +200,7 @@ export const GetListAgentPolicyOutputsRequestSchema = {
   body: schema.object({
     ids: schema.arrayOf(schema.string(), {
       meta: { description: 'list of package policy ids' },
+      maxSize: 1000,
     }),
   }),
 };

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/cloud_connector.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/cloud_connector.ts
@@ -71,7 +71,8 @@ export const GetCloudConnectorsResponseSchema = schema.object({
       packagePolicyCount: schema.number(),
       created_at: schema.string(),
       updated_at: schema.string(),
-    })
+    }),
+    { maxSize: 10000 }
   ),
 });
 

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/common.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/common.ts
@@ -26,6 +26,7 @@ export const BulkRequestBodySchema = schema.object({
   ids: schema.arrayOf(schema.string(), {
     // minSize: 1, // TODO, called with 0 ids sometimes
     meta: { description: 'list of package policy ids' },
+    maxSize: 1000,
   }),
   ignoreMissing: schema.maybe(schema.boolean()),
 });

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
@@ -25,7 +25,7 @@ const CategorySummaryItemSchema = schema.object({
 });
 
 export const GetCategoriesResponseSchema = schema.object({
-  items: schema.arrayOf(CategorySummaryItemSchema),
+  items: schema.arrayOf(CategorySummaryItemSchema, { maxSize: 1000 }),
 });
 
 export const GetPackagesRequestSchema = {
@@ -81,12 +81,12 @@ export const InstallationInfoSchema = schema.object({
   type: schema.string(),
   created_at: schema.maybe(schema.string()),
   updated_at: schema.maybe(schema.string()),
-  namespaces: schema.maybe(schema.arrayOf(schema.string())),
-  installed_kibana: schema.arrayOf(KibanaAssetReferenceSchema),
+  namespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
+  installed_kibana: schema.arrayOf(KibanaAssetReferenceSchema, { maxSize: 1000 }),
   additional_spaces_installed_kibana: schema.maybe(
-    schema.recordOf(schema.string(), schema.arrayOf(KibanaAssetReferenceSchema))
+    schema.recordOf(schema.string(), schema.arrayOf(KibanaAssetReferenceSchema, { maxSize: 100 }))
   ),
-  installed_es: schema.arrayOf(EsAssetReferenceSchema),
+  installed_es: schema.arrayOf(EsAssetReferenceSchema, { maxSize: 1000 }),
   name: schema.string(),
   version: schema.string(),
   install_status: schema.oneOf([
@@ -119,7 +119,8 @@ export const InstallationInfoSchema = schema.object({
           message: schema.string(),
           stack: schema.maybe(schema.string()),
         }),
-      })
+      }),
+      { maxSize: 10 }
     )
   ),
   latest_executed_state: schema.maybe(
@@ -150,14 +151,14 @@ export const PackageInfoSchema = schema
     version: schema.string(),
     description: schema.maybe(schema.string()),
     title: schema.string(),
-    icons: schema.maybe(schema.arrayOf(PackageIconSchema)),
+    icons: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 10 })),
     conditions: schema.maybe(
       schema.object({
         kibana: schema.maybe(schema.object({ version: schema.maybe(schema.string()) })),
         elastic: schema.maybe(
           schema.object({
             subscription: schema.maybe(schema.string()),
-            capabilities: schema.maybe(schema.arrayOf(schema.string())),
+            capabilities: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
           })
         ),
       })
@@ -176,9 +177,13 @@ export const PackageInfoSchema = schema
     path: schema.maybe(schema.string()),
     download: schema.maybe(schema.string()),
     internal: schema.maybe(schema.boolean()),
-    data_streams: schema.maybe(schema.arrayOf(schema.recordOf(schema.string(), schema.any()))),
-    policy_templates: schema.maybe(schema.arrayOf(schema.recordOf(schema.string(), schema.any()))),
-    categories: schema.maybe(schema.arrayOf(schema.string())),
+    data_streams: schema.maybe(
+      schema.arrayOf(schema.recordOf(schema.string(), schema.any()), { maxSize: 1000 })
+    ),
+    policy_templates: schema.maybe(
+      schema.arrayOf(schema.recordOf(schema.string(), schema.any()), { maxSize: 100 })
+    ),
+    categories: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
     owner: schema.maybe(
       schema.object({
         github: schema.maybe(schema.string()),
@@ -199,12 +204,18 @@ export const PackageInfoSchema = schema
       })
     ),
     format_version: schema.maybe(schema.string()),
-    vars: schema.maybe(schema.arrayOf(schema.recordOf(schema.string(), schema.any()))),
+    vars: schema.maybe(
+      schema.arrayOf(schema.recordOf(schema.string(), schema.any()), { maxSize: 1000 })
+    ),
     latestVersion: schema.maybe(schema.string()),
     discovery: schema.maybe(
       schema.object({
-        fields: schema.maybe(schema.arrayOf(schema.object({ name: schema.string() }))),
-        datasets: schema.maybe(schema.arrayOf(schema.object({ name: schema.string() }))),
+        fields: schema.maybe(
+          schema.arrayOf(schema.object({ name: schema.string() }), { maxSize: 10 })
+        ),
+        datasets: schema.maybe(
+          schema.arrayOf(schema.object({ name: schema.string() }), { maxSize: 10 })
+        ),
       })
     ),
   })
@@ -219,7 +230,7 @@ export const PackageListItemSchema = PackageInfoSchema.extends({
 });
 
 export const GetPackagesResponseSchema = schema.object({
-  items: schema.arrayOf(PackageListItemSchema),
+  items: schema.arrayOf(PackageListItemSchema, { maxSize: 1000 }),
 });
 
 export const InstalledPackageSchema = schema.object({
@@ -228,17 +239,18 @@ export const InstalledPackageSchema = schema.object({
   status: schema.string(),
   title: schema.maybe(schema.string()),
   description: schema.maybe(schema.string()),
-  icons: schema.maybe(schema.arrayOf(PackageIconSchema)),
+  icons: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 10 })),
   dataStreams: schema.arrayOf(
     schema.object({
       name: schema.string(),
       title: schema.string(),
-    })
+    }),
+    { maxSize: 1000 }
   ),
 });
 
 export const GetInstalledPackagesResponseSchema = schema.object({
-  items: schema.arrayOf(InstalledPackageSchema),
+  items: schema.arrayOf(InstalledPackageSchema, { maxSize: 10000 }),
   total: schema.number(),
   searchAfter: schema.maybe(
     schema.arrayOf(
@@ -248,13 +260,14 @@ export const GetInstalledPackagesResponseSchema = schema.object({
         schema.boolean(),
         schema.literal(null),
         schema.any(),
-      ])
+      ]),
+      { maxSize: 2 }
     )
   ),
 });
 
 export const GetLimitedPackagesResponseSchema = schema.object({
-  items: schema.arrayOf(schema.string()),
+  items: schema.arrayOf(schema.string(), { maxSize: 10000 }),
 });
 
 export const GetStatsResponseSchema = schema.object({
@@ -283,10 +296,12 @@ export const GetInputsResponseSchema = schema.oneOf([
               })
               .extendsDeep({
                 unknowns: 'allow',
-              })
+              }),
+            { maxSize: 10000 }
           )
         ),
-      })
+      }),
+      { maxSize: 10000 }
     ),
   }),
 ]);
@@ -303,7 +318,7 @@ export const GetPackageInfoSchema = PackageInfoSchema.extends({
   licensePath: schema.maybe(schema.string()),
   keepPoliciesUpToDate: schema.maybe(schema.boolean()),
   license: schema.maybe(schema.string()),
-  screenshots: schema.maybe(schema.arrayOf(PackageIconSchema)),
+  screenshots: schema.maybe(schema.arrayOf(PackageIconSchema, { maxSize: 10 })),
   elasticsearch: schema.maybe(schema.recordOf(schema.string(), schema.any())),
   agent: schema.maybe(
     schema.object({
@@ -318,9 +333,10 @@ export const GetPackageInfoSchema = PackageInfoSchema.extends({
     schema.arrayOf(
       schema.object({
         text: schema.string(),
-        asset_types: schema.maybe(schema.arrayOf(schema.string())),
-        asset_ids: schema.maybe(schema.arrayOf(schema.string())),
-      })
+        asset_types: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
+        asset_ids: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
+      }),
+      { maxSize: 1000 }
     )
   ),
 });
@@ -340,7 +356,8 @@ export const GetKnowledgeBaseResponseSchema = schema.object({
       path: schema.string(),
       installed_at: schema.string(),
       version: schema.string(),
-    })
+    }),
+    { maxSize: 10000 }
   ),
 });
 
@@ -354,7 +371,7 @@ export const AssetReferenceSchema = schema.oneOf([
 ]);
 
 export const InstallPackageResponseSchema = schema.object({
-  items: schema.arrayOf(AssetReferenceSchema),
+  items: schema.arrayOf(AssetReferenceSchema, { maxSize: 10000 }),
   _meta: schema.object({
     install_source: schema.string(),
     name: schema.string(),
@@ -374,7 +391,7 @@ export const BulkInstallPackagesResponseItemSchema = schema.oneOf([
     name: schema.string(),
     version: schema.string(),
     result: schema.object({
-      assets: schema.maybe(schema.arrayOf(AssetReferenceSchema)),
+      assets: schema.maybe(schema.arrayOf(AssetReferenceSchema, { maxSize: 1000 })),
       status: schema.maybe(
         schema.oneOf([schema.literal('installed'), schema.literal('already_installed')])
       ),
@@ -391,7 +408,7 @@ export const BulkInstallPackagesResponseItemSchema = schema.oneOf([
 ]);
 
 export const BulkInstallPackagesFromRegistryResponseSchema = schema.object({
-  items: schema.arrayOf(BulkInstallPackagesResponseItemSchema),
+  items: schema.arrayOf(BulkInstallPackagesResponseItemSchema, { maxSize: 10000 }),
 });
 
 export const BulkUpgradePackagesResponseSchema = schema.object({ taskId: schema.string() });
@@ -407,13 +424,14 @@ export const GetOneBulkOperationPackagesResponseSchema = schema.object({
         name: schema.string(),
         success: schema.boolean(),
         error: schema.maybe(schema.object({ message: schema.string() })),
-      })
+      }),
+      { maxSize: 10000 }
     )
   ),
 });
 
 export const DeletePackageResponseSchema = schema.object({
-  items: schema.arrayOf(AssetReferenceSchema),
+  items: schema.arrayOf(AssetReferenceSchema, { maxSize: 10000 }),
 });
 
 export const GetVerificationKeyIdResponseSchema = schema.object({
@@ -424,7 +442,8 @@ export const GetDataStreamsResponseSchema = schema.object({
   items: schema.arrayOf(
     schema.object({
       name: schema.string(),
-    })
+    }),
+    { maxSize: 10000 }
   ),
 });
 
@@ -440,7 +459,8 @@ export const GetBulkAssetsResponseSchema = schema.object({
         title: schema.maybe(schema.string()),
         description: schema.maybe(schema.string()),
       }),
-    })
+    }),
+    { maxSize: 10000 }
   ),
 });
 
@@ -449,7 +469,8 @@ export const ReauthorizeTransformResponseSchema = schema.arrayOf(
     transformId: schema.string(),
     success: schema.boolean(),
     error: schema.oneOf([schema.literal(null), schema.any()]),
-  })
+  }),
+  { maxSize: 10000 }
 );
 
 export const RollbackPackageResponseSchema = schema.object({
@@ -470,7 +491,9 @@ export const GetInstalledPackagesRequestSchema = {
     ),
     showOnlyActiveDataStreams: schema.maybe(schema.boolean()),
     nameQuery: schema.maybe(schema.string()),
-    searchAfter: schema.maybe(schema.arrayOf(schema.oneOf([schema.string(), schema.number()]))),
+    searchAfter: schema.maybe(
+      schema.arrayOf(schema.oneOf([schema.string(), schema.number()]), { maxSize: 10 })
+    ),
     perPage: schema.number({ defaultValue: 15 }),
     sortOrder: schema.oneOf([schema.literal('asc'), schema.literal('desc')], {
       defaultValue: 'asc',
@@ -531,7 +554,9 @@ export const GetKnowledgeBaseRequestSchema = {
 
 export const GetBulkAssetsRequestSchema = {
   body: schema.object({
-    assetIds: schema.arrayOf(schema.object({ id: schema.string(), type: schema.string() })),
+    assetIds: schema.arrayOf(schema.object({ id: schema.string(), type: schema.string() }), {
+      maxSize: 1000,
+    }),
   }),
 };
 
@@ -578,7 +603,7 @@ export const ReauthorizeTransformRequestSchema = {
     prerelease: schema.maybe(schema.boolean()),
   }),
   body: schema.object({
-    transforms: schema.arrayOf(schema.object({ transformId: schema.string() })),
+    transforms: schema.arrayOf(schema.object({ transformId: schema.string() }), { maxSize: 1000 }),
   }),
 };
 
@@ -596,7 +621,7 @@ export const BulkInstallPackagesFromRegistryRequestSchema = {
           prerelease: schema.maybe(schema.boolean()),
         }),
       ]),
-      { minSize: 1 }
+      { minSize: 1, maxSize: 1000 }
     ),
     force: schema.boolean({ defaultValue: false }),
   }),
@@ -615,7 +640,7 @@ export const BulkUpgradePackagesRequestSchema = {
         name: schema.string(),
         version: schema.maybe(schema.string()),
       }),
-      { minSize: 1 }
+      { minSize: 1, maxSize: 1000 }
     ),
     prerelease: schema.maybe(schema.boolean()),
     force: schema.boolean({ defaultValue: false }),
@@ -630,7 +655,7 @@ export const BulkUninstallPackagesRequestSchema = {
         name: schema.string(),
         version: schema.string(),
       }),
-      { minSize: 1 }
+      { minSize: 1, maxSize: 1000 }
     ),
     force: schema.boolean({ defaultValue: false }),
   }),
@@ -642,7 +667,7 @@ export const BulkRollbackPackagesRequestSchema = {
       schema.object({
         name: schema.string(),
       }),
-      { minSize: 1 }
+      { minSize: 1, maxSize: 1000 }
     ),
   }),
 };
@@ -668,7 +693,8 @@ export const CreateCustomIntegrationRequestSchema = {
           schema.literal('synthetics'),
           schema.literal('profiling'),
         ]),
-      })
+      }),
+      { maxSize: 10 }
     ),
     force: schema.maybe(schema.boolean()),
   }),
@@ -695,6 +721,7 @@ export const InstallKibanaAssetsRequestSchema = {
       space_ids: schema.maybe(
         schema.arrayOf(schema.string(), {
           minSize: 1,
+          maxSize: 100,
           meta: {
             description:
               'When provided install assets in the specified spaces instead of the current space.',

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/fleet_server_policy_config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/fleet_server_policy_config.ts
@@ -18,7 +18,7 @@ const secretRefSchema = schema.oneOf([
 
 export const FleetServerHostBaseSchema = schema.object({
   name: schema.maybe(schema.string()),
-  host_urls: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
+  host_urls: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1, maxSize: 10 })),
   is_default: schema.maybe(schema.boolean({ defaultValue: false })),
   is_internal: schema.maybe(schema.boolean()),
   proxy_id: schema.nullable(schema.string()),
@@ -33,10 +33,10 @@ export const FleetServerHostBaseSchema = schema.object({
     schema.oneOf([
       schema.literal(null),
       schema.object({
-        certificate_authorities: schema.maybe(schema.arrayOf(schema.string())),
+        certificate_authorities: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
         certificate: schema.maybe(schema.string()),
         key: schema.maybe(schema.string()),
-        es_certificate_authorities: schema.maybe(schema.arrayOf(schema.string())),
+        es_certificate_authorities: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10 })),
         es_certificate: schema.maybe(schema.string()),
         es_key: schema.maybe(schema.string()),
         client_auth: schema.maybe(
@@ -54,7 +54,7 @@ export const FleetServerHostBaseSchema = schema.object({
 export const FleetServerHostSchema = FleetServerHostBaseSchema.extends({
   id: schema.string(),
   name: schema.string(),
-  host_urls: schema.arrayOf(schema.string(), { minSize: 1 }),
+  host_urls: schema.arrayOf(schema.string(), { minSize: 1, maxSize: 10 }),
   is_default: schema.boolean({ defaultValue: false }),
   is_internal: schema.maybe(schema.boolean()),
   is_preconfigured: schema.boolean({ defaultValue: false }),

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/package_policy.ts
@@ -68,7 +68,7 @@ export const BulkGetPackagePoliciesRequestSchema = {
 };
 
 export const BulkGetPackagePoliciesResponseBodySchema = schema.object({
-  items: schema.arrayOf(PackagePolicyResponseSchema),
+  items: schema.arrayOf(PackagePolicyResponseSchema, { maxSize: 10000 }),
 });
 
 export const GetOnePackagePolicyRequestSchema = {
@@ -117,7 +117,7 @@ export const UpdatePackagePolicyRequestSchema = {
 
 export const DeletePackagePoliciesRequestSchema = {
   body: schema.object({
-    packagePolicyIds: schema.arrayOf(schema.string()),
+    packagePolicyIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
     force: schema.maybe(schema.boolean()),
   }),
 };
@@ -135,10 +135,11 @@ export const DeletePackagePoliciesResponseBodySchema = schema.arrayOf(
         }),
       ])
     ),
-    policy_ids: schema.arrayOf(schema.string()),
+    policy_ids: schema.arrayOf(schema.string(), { maxSize: 10000 }),
     output_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
     package: PackagePolicyPackageSchema,
-  })
+  }),
+  { maxSize: 10000 }
 );
 
 export const DeleteOnePackagePolicyRequestSchema = {
@@ -156,17 +157,18 @@ export const DeleteOnePackagePolicyResponseSchema = schema.object({
 
 export const UpgradePackagePoliciesRequestSchema = {
   body: schema.object({
-    packagePolicyIds: schema.arrayOf(schema.string()),
+    packagePolicyIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
   }),
 };
 
 export const UpgradePackagePoliciesResponseBodySchema = schema.arrayOf(
-  PackagePolicyStatusResponseSchema
+  PackagePolicyStatusResponseSchema,
+  { maxSize: 10000 }
 );
 
 export const DryRunPackagePoliciesRequestSchema = {
   body: schema.object({
-    packagePolicyIds: schema.arrayOf(schema.string()),
+    packagePolicyIds: schema.arrayOf(schema.string(), { maxSize: 1000 }),
     packageVersion: schema.maybe(schema.string()),
   }),
 };
@@ -184,7 +186,8 @@ export const DryRunPackagePoliciesResponseBodySchema = schema.arrayOf(
             id: schema.maybe(schema.string()),
           }),
           DryRunPackagePolicySchema,
-        ])
+        ]),
+        { maxSize: 2 }
       )
     ),
     agent_diff: schema.maybe(
@@ -226,7 +229,8 @@ export const DryRunPackagePoliciesResponseBodySchema = schema.arrayOf(
                     })
                     .extendsDeep({
                       unknowns: 'allow',
-                    })
+                    }),
+                  { maxSize: 10000 }
                 )
               ),
               processors: schema.maybe(
@@ -239,15 +243,19 @@ export const DryRunPackagePoliciesResponseBodySchema = schema.arrayOf(
                         schema.oneOf([schema.string(), schema.number()])
                       ),
                     }),
-                  })
+                  }),
+                  { maxSize: 10000 }
                 )
               ),
             })
             .extendsDeep({
               unknowns: 'allow',
-            })
-        )
+            }),
+          { maxSize: 10000 }
+        ),
+        { maxSize: 1 }
       )
     ),
-  })
+  }),
+  { maxSize: 10000 }
 );

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/settings.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/settings.ts
@@ -43,6 +43,7 @@ export const PutSettingsRequestSchema = {
         meta: {
           deprecated: true,
         },
+        maxSize: 10,
       })
     ),
     kibana_ca_sha256: schema.maybe(
@@ -67,7 +68,7 @@ export const GetSpaceSettingsRequestSchema = {};
 export const SpaceSettingsResponseSchema = schema.object({
   item: schema.object({
     managed_by: schema.maybe(schema.string()),
-    allowed_namespace_prefixes: schema.arrayOf(schema.string()),
+    allowed_namespace_prefixes: schema.arrayOf(schema.string(), { maxSize: 100 }),
   }),
 });
 
@@ -106,7 +107,8 @@ export const PutSpaceSettingsRequestSchema = {
               return 'Must not contain -';
             }
           },
-        })
+        }),
+        { maxSize: 10 }
       )
     ),
   }),
@@ -131,9 +133,10 @@ export const GetEnrollmentSettingsResponseSchema = schema.object({
         has_fleet_server: schema.maybe(schema.boolean()),
         fleet_server_host_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
         download_source_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
-        space_ids: schema.maybe(schema.arrayOf(schema.string())),
+        space_ids: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 1000 })),
         data_output_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
-      })
+      }),
+      { maxSize: 10000 }
     ),
     has_active: schema.boolean(),
     host: schema.maybe(FleetServerHostSchema),

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/tags.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/tags.ts
@@ -28,5 +28,5 @@ export const GetTagsRequestSchema = {
 };
 
 export const GetTagsResponseSchema = schema.object({
-  items: schema.arrayOf(schema.string()),
+  items: schema.arrayOf(schema.string(), { maxSize: 10000 }),
 });

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/uninstall_token.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/uninstall_token.ts
@@ -33,7 +33,7 @@ const UninstallTokenMetadataSchema = schema.object({
   policy_id: schema.string(),
   policy_name: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
   created_at: schema.string(),
-  namespaces: schema.maybe(schema.arrayOf(schema.string())),
+  namespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
 });
 
 export const GetUninstallTokensMetadataResponseSchema = ListResponseSchema(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Fleet] add maxSize to schema arrays (#247093)](https://github.com/elastic/kibana/pull/247093)