### PR TITLE
[UnifiedDataTable] Fix the output when copying rows as Markdown

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/__mocks__/es_hits_complex.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/__mocks__/es_hits_complex.ts
@@ -125,7 +125,7 @@ export const esHitsComplex = [
         },
       ],
       binary_blob: ['U29tZSBiaW5hcnkgYmxvYg=='],
-      text_message: ["I'm multiline\n*&%$#|@"],
+      text_message: ["I'm multiline\n*&%$\\#|@"],
       'object_user.first': ['Jane'],
       keyword_key: ['=1+2";=1+2'],
       'array_objects.name': ['elastic_list'],

--- a/src/platform/packages/shared/kbn-unified-data-table/src/utils/convert_value_to_string.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/utils/convert_value_to_string.test.tsx
@@ -64,7 +64,7 @@ describe('convertValueToString', () => {
       },
     });
 
-    expect(result.formattedString).toBe('"I\'m multiline\n*&%$#|@"');
+    expect(result.formattedString).toBe('"I\'m multiline\n*&%$\\#|@"');
     expect(result.withFormula).toBe(false);
   });
 

--- a/src/platform/packages/shared/kbn-unified-data-table/src/utils/copy_value_to_clipboard.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/utils/copy_value_to_clipboard.test.tsx
@@ -185,14 +185,14 @@ describe('copyValueToClipboard', () => {
   });
 
   const textOutputTabular = '"bool_enabled"\t"keyword_key"\nfalse\tabcd1';
-  const textOutputEscapedTabular = `"text_message"\n"Hi there! I am a sample string."\n"I'm multiline\n*&%$#|@"`;
+  const textOutputEscapedTabular = `"text_message"\n"Hi there! I am a sample string."\n"I'm multiline\n*&%$\\#|@"`;
   const textOutputMarkdown = `| bool_enabled | keyword_key |
 | --- | --- |
 | false | abcd1 |`;
   const textOutputEscapedMarkdown = `| text_message |
 | --- |
 | Hi there! I am a sample string. |
-| I'm multiline *&%$#\\|@ |`;
+| I'm multiline *&%$\\\\#\\|@ |`;
   describe.each([
     [CopyAsTextFormat.tabular, textOutputTabular, textOutputEscapedTabular],
     [CopyAsTextFormat.markdown, textOutputMarkdown, textOutputEscapedMarkdown],

--- a/src/platform/packages/shared/kbn-unified-data-table/src/utils/copy_value_to_clipboard.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/utils/copy_value_to_clipboard.ts
@@ -193,7 +193,7 @@ export const copyRowsAsTextToClipboard = async ({
     const isLast = index === columns.length - 1;
 
     if (format === CopyAsTextFormat.markdown) {
-      const escapedText = text.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+      const escapedText = text.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ');
       const start = isFirst ? '| ' : ' | ';
       const end = isLast ? ' |' : '';
       return `${start}${escapedText}${end}`;


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-team/issues/2486

## Summary

Makes the output more predictable when copying rows as Markdown.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.






<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->