### PR TITLE
[Agent Builder] Add custom mask to bottom of conversation

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation.tsx
@@ -50,16 +50,12 @@ export const Conversation: React.FC<{}> = () => {
   });
 
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
-  const {
-    showScrollButton,
-    scrollToMostRecentRoundBottom,
-    scrollToMostRecentRoundTop,
-    stickToBottom,
-  } = useConversationScrollActions({
-    isResponseLoading,
-    conversationId: conversationId || '',
-    scrollContainer: scrollContainerRef.current,
-  });
+  const { showScrollButton, smoothScrollToBottom, scrollToMostRecentRoundTop, stickToBottom } =
+    useConversationScrollActions({
+      isResponseLoading,
+      conversationId: conversationId || '',
+      scrollContainer: scrollContainerRef.current,
+    });
 
   const scrollContainerHeight = scrollContainerRef.current?.clientHeight ?? 0;
 
@@ -76,14 +72,27 @@ export const Conversation: React.FC<{}> = () => {
     ${fullWidthAndHeightStyles}
   `;
 
+  const scrollMaskHeight = euiTheme.size.l;
+
   // Necessary to position the scroll button absolute to the container.
   const scrollWrapperStyles = css`
     ${fullWidthAndHeightStyles}
     position: relative;
     min-height: 0;
+
+    &::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: ${scrollMaskHeight};
+      pointer-events: none;
+      z-index: 1;
+      background: linear-gradient(to top, ${euiTheme.colors.backgroundBasePlain}, transparent);
+    }
   `;
 
-  // TODO: Add custom mask for overflow scroll top and bottom
   const scrollableStyles = css`
     ${useEuiScrollBar()}
     ${useEuiOverflowScroll('y')}
@@ -98,7 +107,7 @@ export const Conversation: React.FC<{}> = () => {
   }
 
   return (
-    <EuiFlexGroup direction="column" alignItems="center" css={containerStyles}>
+    <EuiFlexGroup direction="column" alignItems="center" css={containerStyles} gutterSize="s">
       <EuiFlexItem grow={true} css={scrollWrapperStyles}>
         <EuiFlexGroup
           direction="column"
@@ -110,7 +119,7 @@ export const Conversation: React.FC<{}> = () => {
             <ConversationRounds scrollContainerHeight={scrollContainerHeight} />
           </EuiFlexItem>
         </EuiFlexGroup>
-        {showScrollButton && <ScrollButton onClick={scrollToMostRecentRoundBottom} />}
+        {showScrollButton && <ScrollButton onClick={smoothScrollToBottom} />}
       </EuiFlexItem>
       <EuiFlexItem
         css={[conversationElementWidthStyles, conversationElementPaddingStyles, inputPaddingStyles]}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useEffect, useState, useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
@@ -146,6 +146,9 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
           </EuiFlexItem>
         </EuiFlexItem>
       )}
+
+      {/* Add spacing after the final round so that text is not cut off by the scroll mask */}
+      {isCurrentRound && <EuiSpacer size="l" />}
     </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/scroll_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/scroll_button.tsx
@@ -18,7 +18,7 @@ export const ScrollButton: React.FC<ScrollButtonProps> = ({ onClick }) => {
 
   const scrollDownButtonStyles = css`
     position: absolute;
-    bottom: ${euiTheme.size.s};
+    bottom: ${euiTheme.size.l};
     left: 50%;
     transform: translateX(-50%);
     z-index: 1;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_conversation_scroll_actions.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_conversation_scroll_actions.ts
@@ -117,16 +117,19 @@ export const useConversationScrollActions = ({
     });
   }, [scrollContainer]);
 
-  // Scrolls the most recent round to the bottom of it's parent scroll container
-  const scrollToMostRecentRoundBottom = useCallback(() => {
+  // Smoothly scrolls to the bottom of the scroll container
+  const smoothScrollToBottom = useCallback(() => {
     if (!scrollContainer) return;
-    scrollToMostRecentRound({ scrollContainer, position: 'end' });
+    scrollContainer.scrollTo({
+      top: scrollContainer.scrollHeight,
+      behavior: 'smooth',
+    });
   }, [scrollContainer]);
 
   return {
     showScrollButton,
     scrollToMostRecentRoundTop,
-    scrollToMostRecentRoundBottom,
+    smoothScrollToBottom,
     stickToBottom,
   };
 };


### PR DESCRIPTION
relates to https://github.com/elastic/search-team/issues/12210

https://github.com/user-attachments/assets/fe611b37-9fd8-49c5-8f91-dcdecbb25c83

- [x] Explore how to bring back the gradient above the chat input. The response rounds should look like they are disappearing right before they hit the chat input as per the Figma, not have a hard cut off.


