### PR TITLE
[Tags] Optimize `/internal/saved_objects_tagging/tags/_find`

### DIFF
--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/lib/get_connection_count.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/lib/get_connection_count.ts
@@ -35,7 +35,7 @@ export const addConnectionCount = async (
     perPage: 1000,
     hasReference: references,
     hasReferenceOperator: 'OR',
-    fields: [], // No need to retrieve any fields
+    fields: ['title'], // No need to retrieve all fields, so we scope it down to just one
   });
 
   for await (const response of pitFinder.find()) {

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/lib/get_connection_count.ts
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/server/routes/lib/get_connection_count.ts
@@ -8,7 +8,6 @@
 import type {
   SavedObjectsClientContract,
   SavedObjectsFindOptionsReference,
-  SavedObject,
 } from '@kbn/core/server';
 import type { Tag, TagAttributes, TagWithRelations } from '../../../common/types';
 import { tagSavedObjectTypeName } from '../../../common/constants';
@@ -18,6 +17,11 @@ export const addConnectionCount = async (
   targetTypes: string[],
   client: SavedObjectsClientContract
 ): Promise<TagWithRelations[]> => {
+  // Early return if no tags - avoid expensive PIT query that would scan all saved objects
+  if (tags.length === 0) {
+    return [];
+  }
+
   const ids = new Set(tags.map((tag) => tag.id));
   const counts: Map<string, number> = new Map(tags.map((tag) => [tag.id, 0]));
 
@@ -31,20 +35,19 @@ export const addConnectionCount = async (
     perPage: 1000,
     hasReference: references,
     hasReferenceOperator: 'OR',
+    fields: [], // No need to retrieve any fields
   });
 
-  const results: SavedObject[] = [];
   for await (const response of pitFinder.find()) {
-    results.push(...response.saved_objects);
-  }
-
-  results.forEach((obj) => {
-    obj.references.forEach((ref) => {
-      if (ref.type === tagSavedObjectTypeName && ids.has(ref.id)) {
-        counts.set(ref.id, counts.get(ref.id)! + 1);
-      }
+    const results = response.saved_objects;
+    results.forEach((so) => {
+      so.references.forEach((ref) => {
+        if (ref.type === tagSavedObjectTypeName && ids.has(ref.id)) {
+          counts.set(ref.id, counts.get(ref.id)! + 1);
+        }
+      });
     });
-  });
+  }
 
   return tags.map((tag) => ({
     ...tag,

--- a/x-pack/platform/test/saved_object_tagging/api_integration/security_and_spaces/apis/_find.ts
+++ b/x-pack/platform/test/saved_object_tagging/api_integration/security_and_spaces/apis/_find.ts
@@ -83,8 +83,8 @@ export default function (ftrContext: FtrProviderContext) {
         USERS.DEFAULT_SPACE_MAPS_READ_USER,
         USERS.DEFAULT_SPACE_ADVANCED_SETTINGS_READ_USER,
       ],
-      noResults: [],
-      unauthorized: [USERS.NOT_A_KIBANA_USER],
+      noResults: [USERS.NOT_A_KIBANA_USER], // find proxies so.find and returns no results for unauthorized users instead of 403
+      unauthorized: [],
     };
 
     const createUserTest = (


### PR DESCRIPTION
## Summary

We observed a couple of OOMs that seemingly were caused by `/internal/saved_objects_tagging/tags/_find`

The route fetches tags saved objects and then also counts how many saved objects references each found tag. For this the route iterates over saved objects in memory. Potentially this iteration can cause OOM. 

This PR includes easy optimizations of the route to significantly reduce the chance of OOM 

### 1. Early return if no tags. 

The method is used as part of tags creation validation flow. A user inputs a name for a new tag and we use this method to check if tags with the name exists. 

In this case `addConnectionCount` is executed with tags: []. 
Looks like there is a bug in core that passing empty array into `hasReferences` during search would act as no-filter, so we iterated over all saved objects. 

This is most likely cause of OOM 

### 2. Don't fetch so fields when counting connections 

We're interested only in references. Reduces network and memory pressure 

### 3. Don't accumulate paginated results 

Reduces memory pressure 



-----


Other potential improvements, but larger scope: 


1. Tag name validation UI uses debounce so fetching tag name can be called more often then needed. This can be optimized 
2. No need to count connections when doing name validation 
3. Can we count tag connections without in-memory so fetching? Some smarter search? 

