### PR TITLE
[Actionable-Obs][BUG][Synthetics] Preserve maintenance windows when editing multi-space Synthetics monitors

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/maintenance_windows/maintenance_windows.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/fields/maintenance_windows/maintenance_windows.tsx
@@ -4,17 +4,24 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
+import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
-import { EuiComboBox } from '@elastic/eui';
+import { EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiBadge, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useMaintenanceWindows } from './use_maintenance_windows';
+import {
+  getMaintenanceWindowsForMonitor,
+  type MaintenanceWindowInfo,
+} from '../../../../state/maintenance_windows/api';
+
+const CROSS_SPACE_MARKER = '__cross_space__';
 
 export interface MaintenanceWindowsFieldProps {
   fullWidth?: boolean;
   onChange: (value: string[]) => void;
   value?: string[];
   readOnly?: boolean;
+  monitorId?: string;
 }
 
 export const MaintenanceWindowsField = ({
@@ -22,13 +29,60 @@ export const MaintenanceWindowsField = ({
   readOnly,
   onChange,
   fullWidth,
+  monitorId,
 }: MaintenanceWindowsFieldProps) => {
   const { data } = useMaintenanceWindows();
-  const options: Array<EuiComboBoxOptionOption<string>> =
-    data?.data?.map((option) => ({
-      value: option.id,
-      label: option.title,
-    })) ?? [];
+  const [crossSpaceMWDetails, setCrossSpaceMWDetails] = useState<MaintenanceWindowInfo[]>([]);
+  const hasFetchedRef = useRef(false);
+
+  const currentSpaceOptions: Array<EuiComboBoxOptionOption<string>> = useMemo(
+    () =>
+      data?.data?.map((option) => ({
+        value: option.id,
+        label: option.title,
+      })) ?? [],
+    [data]
+  );
+
+  const currentSpaceMWIds = useMemo(
+    () => new Set(currentSpaceOptions.map((o) => o.value)),
+    [currentSpaceOptions]
+  );
+
+  useEffect(() => {
+    if (hasFetchedRef.current) return;
+    if (!monitorId) return;
+
+    hasFetchedRef.current = true;
+    getMaintenanceWindowsForMonitor(monitorId)
+      .then((response) => {
+        setCrossSpaceMWDetails(response.maintenanceWindows);
+      })
+      .catch(() => {});
+  }, [monitorId]);
+
+  const crossSpaceOptions: Array<EuiComboBoxOptionOption<string>> = useMemo(() => {
+    return crossSpaceMWDetails
+      .filter((mw) => !currentSpaceMWIds.has(mw.id))
+      .map((mw) => ({
+        value: mw.id,
+        label: mw.title,
+        'data-cross-space': CROSS_SPACE_MARKER,
+        'data-space-id': mw.spaceId,
+      }));
+  }, [crossSpaceMWDetails, currentSpaceMWIds]);
+
+  const allOptions = useMemo(() => {
+    if (crossSpaceOptions.length === 0) {
+      return currentSpaceOptions;
+    }
+    return [...currentSpaceOptions, ...crossSpaceOptions];
+  }, [currentSpaceOptions, crossSpaceOptions]);
+
+  const selectedOptions = useMemo(() => {
+    if (!value) return [];
+    return allOptions.filter((option) => value.includes(option.value as string));
+  }, [allOptions, value]);
 
   const maintenanceWindowsPlaceholder = i18n.translate(
     'xpack.synthetics.monitorConfig.maintenanceWindows.placeholder',
@@ -37,18 +91,54 @@ export const MaintenanceWindowsField = ({
     }
   );
 
+  const handleChange = (newValue: Array<EuiComboBoxOptionOption<string>>) => {
+    const selectedIds = newValue.map((option) => option.value as string);
+    onChange(selectedIds);
+  };
+
+  const renderOption = useCallback(
+    (option: EuiComboBoxOptionOption<string>, searchValue: string, contentClassName: string) => {
+      const isCrossSpace = (option as any)['data-cross-space'] === CROSS_SPACE_MARKER;
+      const spaceId = (option as any)['data-space-id'] as string | undefined;
+
+      return (
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <span className={contentClassName}>{option.label}</span>
+          </EuiFlexItem>
+          {isCrossSpace && spaceId && (
+            <EuiFlexItem grow={false}>
+              <EuiToolTip
+                content={i18n.translate(
+                  'xpack.synthetics.monitorConfig.maintenanceWindows.crossSpaceTooltip',
+                  {
+                    defaultMessage: 'This maintenance window belongs to space: {spaceId}',
+                    values: { spaceId },
+                  }
+                )}
+              >
+                <EuiBadge color="hollow" iconType="spaces" tabIndex={0}>
+                  {spaceId}
+                </EuiBadge>
+              </EuiToolTip>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      );
+    },
+    []
+  );
+
   return (
     <EuiComboBox<string>
       placeholder={maintenanceWindowsPlaceholder}
       aria-label={maintenanceWindowsPlaceholder}
-      options={options}
-      onChange={(newValue) => {
-        onChange(newValue.map((option) => option.value as string));
-      }}
-      defaultValue={[]}
-      selectedOptions={options.filter((option) => value?.includes(option.value as string))}
+      options={allOptions}
+      onChange={handleChange}
+      selectedOptions={selectedOptions}
       fullWidth={fullWidth}
       isDisabled={readOnly}
+      renderOption={renderOption}
     />
   );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
@@ -1696,7 +1696,7 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
       defaultMessage:
         'A list of maintenance windows to apply to this monitor. The monitor will not run during these times.',
     }),
-    props: ({ field, setValue, trigger }): MaintenanceWindowsFieldProps => ({
+    props: ({ field, setValue, trigger, formState }): MaintenanceWindowsFieldProps => ({
       readOnly,
       onChange: async (value) => {
         setValue(ConfigKey.MAINTENANCE_WINDOWS, value);
@@ -1704,6 +1704,7 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
       },
       fullWidth: true,
       value: field?.value as string[],
+      monitorId: formState.defaultValues?.[ConfigKey.CONFIG_ID] as string | undefined,
     }),
     labelAppend: <MaintenanceWindowsLink />,
   },

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/maintenance_windows/api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/maintenance_windows/api.ts
@@ -6,7 +6,7 @@
  */
 
 import type { FindMaintenanceWindowsResult } from '@kbn/maintenance-windows-plugin/common';
-import { INITIAL_REST_VERSION } from '../../../../../common/constants';
+import { INITIAL_REST_VERSION, SYNTHETICS_API_URLS } from '../../../../../common/constants';
 import { apiService } from '../../../../utils/api_service/api_service';
 
 export const getMaintenanceWindows = async (): Promise<FindMaintenanceWindowsResult> => {
@@ -16,4 +16,22 @@ export const getMaintenanceWindows = async (): Promise<FindMaintenanceWindowsRes
       version: INITIAL_REST_VERSION,
     }
   );
+};
+
+export interface MaintenanceWindowInfo {
+  id: string;
+  title: string;
+  spaceId?: string;
+}
+
+export interface GetMaintenanceWindowsResponse {
+  maintenanceWindows: MaintenanceWindowInfo[];
+}
+
+export const getMaintenanceWindowsForMonitor = async (
+  monitorId: string
+): Promise<GetMaintenanceWindowsResponse> => {
+  return apiService.post<GetMaintenanceWindowsResponse>(SYNTHETICS_API_URLS.MAINTENANCE_WINDOWS, {
+    monitorId,
+  });
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
@@ -67,6 +67,7 @@ import { getLocationMonitors } from './settings/private_locations/get_location_m
 import { addSyntheticsParamsRoute } from './settings/params/add_param';
 import { deleteSyntheticsParamsRoute } from './settings/params/delete_param';
 import { createOverviewTrendsRoute } from './overview_trends/overview_trends';
+import { getMaintenanceWindowsRoute } from './settings/get_maintenance_windows';
 
 export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   addSyntheticsProjectMonitorRoute,
@@ -111,6 +112,7 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   cleanupPrivateLocationRoute,
   syncParamsSyntheticsParamsRoute,
   syncParamsSettingsParamsRoute,
+  getMaintenanceWindowsRoute,
 ];
 
 export const syntheticsAppPublicRestApiRoutes: SyntheticsRestApiRouteFactory[] = [

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/get_maintenance_windows.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/get_maintenance_windows.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getMaintenanceWindowsRoute } from './get_maintenance_windows';
+
+describe('getMaintenanceWindowsRoute', () => {
+  const mockMonitorConfigRepository = {
+    get: jest.fn(),
+  };
+
+  const mockMaintenanceWindowClient = {
+    find: jest.fn(),
+  };
+
+  const mockServer = {
+    pluginsStart: {
+      maintenanceWindows: {
+        getMaintenanceWindowClientWithAuth: jest.fn().mockReturnValue(mockMaintenanceWindowClient),
+      },
+    },
+  };
+
+  const mockRequest = {
+    body: { monitorId: 'test-monitor-id' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns route configuration', () => {
+    const route = getMaintenanceWindowsRoute();
+    expect(route.method).toBe('POST');
+    expect(route.path).toBeDefined();
+    expect(route.validate).toBeDefined();
+  });
+
+  it('returns empty array when monitor has no other namespaces', async () => {
+    mockMonitorConfigRepository.get.mockResolvedValue({
+      namespaces: ['space-a'],
+    });
+
+    const route = getMaintenanceWindowsRoute();
+    const result = await route.handler({
+      request: mockRequest,
+      server: mockServer,
+      spaceId: 'space-a',
+      monitorConfigRepository: mockMonitorConfigRepository,
+    } as any);
+
+    expect(result).toEqual({ maintenanceWindows: [] });
+    expect(mockMaintenanceWindowClient.find).not.toHaveBeenCalled();
+  });
+
+  it('fetches MWs only from other spaces the monitor is shared with', async () => {
+    mockMonitorConfigRepository.get.mockResolvedValue({
+      namespaces: ['space-a', 'space-b', 'space-c'],
+    });
+
+    mockMaintenanceWindowClient.find
+      .mockResolvedValueOnce({
+        data: [{ id: 'mw-b-1', title: 'MW B1' }],
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'mw-c-1', title: 'MW C1' }],
+      });
+
+    const route = getMaintenanceWindowsRoute();
+    const result = await route.handler({
+      request: mockRequest,
+      server: mockServer,
+      spaceId: 'space-a',
+      monitorConfigRepository: mockMonitorConfigRepository,
+    } as any);
+
+    expect(mockMaintenanceWindowClient.find).toHaveBeenCalledTimes(2);
+    expect(mockMaintenanceWindowClient.find).toHaveBeenCalledWith({
+      page: 0,
+      perPage: 1000,
+      namespaces: ['space-b'],
+    });
+    expect(mockMaintenanceWindowClient.find).toHaveBeenCalledWith({
+      page: 0,
+      perPage: 1000,
+      namespaces: ['space-c'],
+    });
+
+    expect(result).toEqual({
+      maintenanceWindows: [
+        { id: 'mw-b-1', title: 'MW B1', spaceId: 'space-b' },
+        { id: 'mw-c-1', title: 'MW C1', spaceId: 'space-c' },
+      ],
+    });
+  });
+
+  it('returns empty array when MW client is not available', async () => {
+    mockMonitorConfigRepository.get.mockResolvedValue({
+      namespaces: ['space-a', 'space-b'],
+    });
+
+    const serverWithoutMWClient = {
+      pluginsStart: {
+        maintenanceWindows: {
+          getMaintenanceWindowClientWithAuth: jest.fn().mockReturnValue(null),
+        },
+      },
+    };
+
+    const route = getMaintenanceWindowsRoute();
+    const result = await route.handler({
+      request: mockRequest,
+      server: serverWithoutMWClient,
+      spaceId: 'space-a',
+      monitorConfigRepository: mockMonitorConfigRepository,
+    } as any);
+
+    expect(result).toEqual({ maintenanceWindows: [] });
+  });
+
+  it('excludes current space from MW query', async () => {
+    mockMonitorConfigRepository.get.mockResolvedValue({
+      namespaces: ['current-space', 'other-space'],
+    });
+
+    mockMaintenanceWindowClient.find.mockResolvedValue({
+      data: [{ id: 'mw-1', title: 'Other MW' }],
+    });
+
+    const route = getMaintenanceWindowsRoute();
+    await route.handler({
+      request: mockRequest,
+      server: mockServer,
+      spaceId: 'current-space',
+      monitorConfigRepository: mockMonitorConfigRepository,
+    } as any);
+
+    expect(mockMaintenanceWindowClient.find).toHaveBeenCalledTimes(1);
+    expect(mockMaintenanceWindowClient.find).toHaveBeenCalledWith({
+      page: 0,
+      perPage: 1000,
+      namespaces: ['other-space'],
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/get_maintenance_windows.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/get_maintenance_windows.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { SyntheticsRestApiRouteFactory } from '../types';
+import { SYNTHETICS_API_URLS } from '../../../common/constants';
+
+export interface MaintenanceWindowInfo {
+  id: string;
+  title: string;
+  spaceId?: string;
+}
+
+export interface GetMaintenanceWindowsResponse {
+  maintenanceWindows: MaintenanceWindowInfo[];
+}
+
+export const getMaintenanceWindowsRoute: SyntheticsRestApiRouteFactory<
+  GetMaintenanceWindowsResponse
+> = () => ({
+  method: 'POST',
+  path: SYNTHETICS_API_URLS.MAINTENANCE_WINDOWS,
+  validate: {
+    body: schema.object({
+      monitorId: schema.string(),
+    }),
+  },
+  handler: async ({ request, server, spaceId, monitorConfigRepository }) => {
+    const { monitorId } = request.body as { monitorId: string };
+
+    const monitor = await monitorConfigRepository.get(monitorId);
+    const monitorNamespaces = monitor.namespaces ?? [];
+
+    const maintenanceWindowClient =
+      server.pluginsStart.maintenanceWindows?.getMaintenanceWindowClientWithAuth(request);
+
+    if (!maintenanceWindowClient) {
+      return { maintenanceWindows: [] };
+    }
+
+    // Only query spaces the monitor is actually shared with (excluding current space)
+    const otherSpaces = monitorNamespaces.filter((ns) => ns !== spaceId);
+
+    const otherSpaceMWs: MaintenanceWindowInfo[] = [];
+    for (const otherSpace of otherSpaces) {
+      const result = await maintenanceWindowClient.find({
+        page: 0,
+        perPage: 1000,
+        namespaces: [otherSpace],
+      });
+      for (const mw of result.data) {
+        otherSpaceMWs.push({ id: mw.id, title: mw.title, spaceId: otherSpace });
+      }
+    }
+
+    return { maintenanceWindows: otherSpaceMWs };
+  },
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.test.ts
@@ -152,6 +152,34 @@ describe('SyntheticsMonitorClient', () => {
     expect(client.privateLocationAPI.editMonitors).toHaveBeenCalledTimes(1);
   });
 
+  it('should pass all monitor namespaces to getMaintenanceWindows', async () => {
+    const id = 'test-id-1';
+    const client = new SyntheticsMonitorClient(syntheticsService, serverMock);
+    client.privateLocationAPI.editMonitors = jest.fn().mockResolvedValue({});
+
+    const monitorWithNamespaces = {
+      ...previousMonitor,
+      namespaces: ['space-a', 'space-b'],
+    };
+
+    await client.editMonitors(
+      [
+        {
+          id,
+          monitor,
+          decryptedPreviousMonitor: monitorWithNamespaces,
+        },
+      ],
+      privateLocations,
+      'space-a'
+    );
+
+    expect(syntheticsService.getMaintenanceWindows).toHaveBeenCalledWith('space-a', [
+      'space-a',
+      'space-b',
+    ]);
+  });
+
   it('deletes a monitor from location, if location is removed from monitor', async () => {
     locations[1].isServiceManaged = false;
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.ts
@@ -93,6 +93,11 @@ export class SyntheticsMonitorClient {
     allPrivateLocations: SyntheticsPrivateLocations,
     spaceId: string
   ) {
+    // Collect all namespaces from monitors to fetch MWs from all shared spaces
+    const allMonitorNamespaces = monitors.flatMap(
+      (m) => m.decryptedPreviousMonitor.namespaces ?? []
+    );
+
     const privateConfigs: Array<{ config: HeartbeatConfig; globalParams: Record<string, string> }> =
       [];
 
@@ -100,7 +105,10 @@ export class SyntheticsMonitorClient {
     const deletedPublicConfigs: ConfigData[] = [];
 
     const paramsBySpace = await this.syntheticsService.getSyntheticsParams({ spaceId });
-    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows(spaceId);
+    const maintenanceWindows = await this.syntheticsService.getMaintenanceWindows(
+      spaceId,
+      allMonitorNamespaces
+    );
 
     for (const editedMonitor of monitors) {
       const { str: paramsString, params } = mixParamsWithGlobalParams(

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -669,7 +669,7 @@ export class SyntheticsService {
     return paramsBySpace;
   }
 
-  async getMaintenanceWindows(spaceId: string) {
+  async getMaintenanceWindows(spaceId: string, additionalSpaces?: string[]) {
     const maintenanceWindowClient = this.server.getMaintenanceWindowClientInternal(
       {} as KibanaRequest
     );
@@ -678,11 +678,16 @@ export class SyntheticsService {
       return [];
     }
 
+    const namespacesToQuery = additionalSpaces?.length
+      ? [...new Set([spaceId, ...additionalSpaces])]
+      : [spaceId];
+
     const mws = await maintenanceWindowClient.find({
       page: 0,
       perPage: 1000,
-      namespaces: [spaceId],
+      namespaces: namespacesToQuery,
     });
+
     return mws.data;
   }
 


### PR DESCRIPTION
## Summary

It fixes https://github.com/elastic/kibana/issues/246256
### Problem

When a Synthetics monitor is shared across multiple Kibana spaces (e.g., `space-a` and `space-b`), editing it from one space would silently remove maintenance windows associated with it from other spaces.

For example:
- Monitor shared with `space-a` and `space-b`
- MW-A linked in `space-a`, MW-B linked in `space-b`
- User edits monitor from `space-a`
- After save, MW-B is gone because the edit only loaded MWs from the current space

Users had no visibility into cross-space MW associations and no way to manage them.

### Root Cause

`SyntheticsService.getMaintenanceWindows()` was only querying the current space's namespace, ignoring that the monitor might be shared with other spaces.

### Solution

1. Modified `getMaintenanceWindows()` to accept an optional `additionalSpaces` parameter
2. Updated `editMonitors()` to collect all namespaces from the monitor's saved object and pass them through
3. Added a new internal API endpoint that fetches MW details from the monitor's shared spaces (for UI display)
4. ✨ Enhanced the MW dropdown to show cross-space MWs with a badge indicating which space they belong to
5. ✨ If a Kibana space is removed from the monitor while editing, any maintenance windows from that removed space will be automatically cleaned up when saving


### Security
The new API endpoint validates that requested spaces match the monitor's actual namespaces - prevents arbitrary space enumeration.


**Checklist**
- [x] Unit tests added


https://github.com/user-attachments/assets/4e454d7b-c7ef-41a6-8f92-57bb3be10eaf


