### PR TITLE
[One Workflow] feat: add input and output schemas for MCP sub actions

### DIFF
--- a/src/platform/plugins/shared/workflows_management/common/connector_action_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/connector_action_schema.ts
@@ -61,6 +61,12 @@ import {
   JiraServiceManagementCloseAlertParamsSchema,
   JiraServiceManagementCreateAlertParamsSchema,
   JiraServiceManagementResponseSchema,
+  McpCallToolParamsSchema,
+  McpCallToolResponseSchema,
+  McpListToolsParamsSchema,
+  McpListToolsResponseSchema,
+  McpTestParamsSchema,
+  McpTestResponseSchema,
   OpenAIParamsSchema,
   OpenAIResponseSchema,
   OpsgenieCloseAlertParamsSchema,
@@ -272,6 +278,14 @@ export const ConnectorActionInputSchemas = new Map<string, Record<string, z.ZodS
       test: GenAITestParamsSchema,
     },
   ],
+  [
+    '.mcp',
+    {
+      listTools: McpListToolsParamsSchema,
+      callTool: McpCallToolParamsSchema,
+      test: McpTestParamsSchema,
+    },
+  ],
 ]);
 
 /**
@@ -420,6 +434,14 @@ export const ConnectorActionOutputSchemas = new Map<string, Record<string, z.Zod
       stream: GenAIStreamResponseSchema,
       getDashboard: GenAIDashboardResponseSchema,
       test: GenAITestResponseSchema,
+    },
+  ],
+  [
+    '.mcp',
+    {
+      listTools: McpListToolsResponseSchema,
+      callTool: McpCallToolResponseSchema,
+      test: McpTestResponseSchema,
     },
   ],
 ]);

--- a/src/platform/plugins/shared/workflows_management/common/connector_sub_actions_map.ts
+++ b/src/platform/plugins/shared/workflows_management/common/connector_sub_actions_map.ts
@@ -28,6 +28,10 @@ import {
   SUB_ACTION as JiraServiceManagementSubActions,
 } from '@kbn/connector-schemas/jira-service-management/constants';
 import {
+  CONNECTOR_ID as MCP_CONNECTOR_ID,
+  SUB_ACTION as MCP_SUB_ACTION,
+} from '@kbn/connector-schemas/mcp/constants';
+import {
   CONNECTOR_ID as OPENAI_CONNECTOR_ID,
   SUB_ACTION as OPENAI_SUB_ACTION,
 } from '@kbn/connector-schemas/openai/constants';
@@ -120,6 +124,7 @@ function createSubActionsMapping() {
     { id: D3_SECURITY_CONNECTOR_ID, actions: D3SECURITY_SUB_ACTION },
     { id: JIRA_SERVICE_MANAGEMENT_CONNECTOR_TYPE_ID, actions: JiraServiceManagementSubActions },
     { id: OpsgenieConnectorTypeId, actions: OpsgenieSubActions },
+    { id: MCP_CONNECTOR_ID, actions: MCP_SUB_ACTION },
     // Legacy connectors (using older ActionType pattern)
     { id: '.jira', actions: JIRA_SUB_ACTIONS },
     { id: '.servicenow-itsm', actions: SERVICENOW_ITSM_SUB_ACTIONS },

--- a/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/index.ts
+++ b/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/index.ts
@@ -169,3 +169,13 @@ export {
 
 // Torq connector schemas
 export { TorqParamsSchema, TorqResponseSchema } from './torq';
+
+// MCP connector schemas
+export {
+  McpTestParamsSchema,
+  McpListToolsParamsSchema,
+  McpCallToolParamsSchema,
+  McpTestResponseSchema,
+  McpListToolsResponseSchema,
+  McpCallToolResponseSchema,
+} from './mcp';

--- a/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/mcp.ts
+++ b/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/mcp.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { z } from '@kbn/zod/v4';
+
+/**
+ * These schemas were copied Zod v3 schemas from src/platform/packages/shared/kbn-connector-schemas/mcp/schemas/v1.ts
+ * and will be deprecated once kbn-connector-schemas will switch to Zod v4 or
+ * the MCP connector will be refactored as a single-file connector.
+ */
+
+// Input/Params Schemas
+export const McpTestParamsSchema = z.object({}).strict();
+export const McpListToolsParamsSchema = z.object({
+  forceRefresh: z.boolean().optional(),
+});
+export const McpCallToolParamsSchema = z.object({
+  name: z.string(),
+  arguments: z.record(z.string(), z.any()).optional(),
+});
+
+// Response/Output Schemas
+
+/**
+ * Metadata about the provider of a tool.
+ * Used for attribution, audit trails, and UI display.
+ */
+export const ToolProviderMetadataSchema = z.object({
+  /** Provider identifier (e.g., 'mcp.github') */
+  id: z.string(),
+  /** Human-readable provider name (e.g., 'GitHub MCP Server') */
+  name: z.string(),
+  /** Provider type constant */
+  type: z.literal('mcp'),
+  /** Unique ID of the MCP connector (from config.uniqueId) */
+  uniqueId: z.string(),
+  /** Optional description of when to use this MCP server (for LLM context) */
+  description: z.string().optional(),
+});
+
+/**
+ * A text content as part of a tool call response.
+ */
+export const TextPartSchema = z.object({
+  type: z.literal('text'),
+  text: z.string(),
+});
+
+/**
+ * Non-text content as part of a tool call response.
+ */
+export const NonTextPartSchema = z
+  .object({
+    type: z.string(),
+  })
+  .loose();
+
+/**
+ * Content part - either text or non-text content.
+ */
+export const ContentPartSchema = z.union([TextPartSchema, NonTextPartSchema]);
+
+/**
+ * Response from calling a tool on the MCP client.
+ */
+export const McpCallToolResponseSchema = z.object({
+  content: z.array(ContentPartSchema),
+  /**
+   * Optional provider metadata for attribution and audit trails.
+   * Included in tool execution results for tracking and logging.
+   */
+  provider: ToolProviderMetadataSchema.optional(),
+});
+
+/**
+ * A tool available on the MCP client.
+ */
+export const ToolSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  inputSchema: z.record(z.string(), z.any()),
+  /**
+   * Optional provider metadata for attribution and audit trails.
+   * When present, indicates the source of the tool (e.g., which MCP connector).
+   */
+  provider: ToolProviderMetadataSchema.optional(),
+});
+
+/**
+ * Response from listing the tools available on the MCP client.
+ */
+export const McpListToolsResponseSchema = z.object({
+  /** The tools available on the MCP client. */
+  tools: z.array(ToolSchema),
+});
+
+/**
+ * Response from testing the MCP connection.
+ */
+export const McpTestResponseSchema = z.object({
+  connected: z.boolean(),
+  capabilities: z.record(z.string(), z.any()).optional(),
+});

--- a/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/mcp.ts
+++ b/src/platform/plugins/shared/workflows_management/common/stack_connectors_schema/mcp.ts
@@ -10,7 +10,7 @@
 import { z } from '@kbn/zod/v4';
 
 /**
- * These schemas were copied Zod v3 schemas from src/platform/packages/shared/kbn-connector-schemas/mcp/schemas/v1.ts
+ * These schemas were copied from Zod v3 schemas in src/platform/packages/shared/kbn-connector-schemas/mcp/schemas/v1.ts
  * and will be deprecated once kbn-connector-schemas will switch to Zod v4 or
  * the MCP connector will be refactored as a single-file connector.
  */


### PR DESCRIPTION
Close https://github.com/elastic/security-team/issues/15280

## Before
<img width="436" height="300" alt="Screenshot 2026-01-06 at 15 47 57" src="https://github.com/user-attachments/assets/64fef5b3-8d54-4058-b8fe-a0d71a23390e" />


## After

<img width="557" height="203" alt="Screenshot 2026-01-06 at 15 48 33" src="https://github.com/user-attachments/assets/a8fb966c-84f7-4b20-8bda-c39b3e38d7a8" />

<img width="1106" height="825" alt="Screenshot 2026-01-06 at 15 46 11" src="https://github.com/user-attachments/assets/9d498c29-1907-4357-a516-55d05bcc502a" />

