### PR TITLE
Transfering ownership of previously owned by obs-knowledge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,7 +60,7 @@ packages/kbn-docs-utils @elastic/kibana-operations
 packages/kbn-eslint-config @elastic/kibana-operations
 packages/kbn-eslint-plugin-disable @elastic/kibana-operations
 packages/kbn-eslint-plugin-eslint @elastic/kibana-operations
-packages/kbn-eslint-plugin-i18n @elastic/obs-knowledge-team @elastic/kibana-operations
+packages/kbn-eslint-plugin-i18n @elastic/kibana-operations
 packages/kbn-eslint-plugin-imports @elastic/kibana-operations
 packages/kbn-eslint-plugin-telemetry @elastic/obs-knowledge-team
 packages/kbn-extract-plugin-translations @elastic/kibana-core
@@ -508,7 +508,7 @@ src/platform/packages/shared/kbn-es-mappings @elastic/kibana-core
 src/platform/packages/shared/kbn-es-query @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-es-query-constants @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-es-query-server @elastic/kibana-data-discovery
-src/platform/packages/shared/kbn-es-types @elastic/kibana-core @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-es-types @elastic/kibana-core
 src/platform/packages/shared/kbn-esql-composer @elastic/obs-presentation-team @elastic/obs-ai-team
 src/platform/packages/shared/kbn-esql-language @elastic/kibana-esql
 src/platform/packages/shared/kbn-esql-types @elastic/kibana-esql
@@ -565,7 +565,7 @@ src/platform/packages/shared/kbn-osquery-io-ts-types @elastic/security-defend-wo
 src/platform/packages/shared/kbn-otel-demo @elastic/obs-onboarding-team
 src/platform/packages/shared/kbn-otel-semantic-conventions @elastic/obs-onboarding-team
 src/platform/packages/shared/kbn-palettes @elastic/kibana-visualizations
-src/platform/packages/shared/kbn-profiler @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-profiler @elastic/obs-ui-devex-team
 src/platform/packages/shared/kbn-profiling-utils @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-react-field @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-react-hooks @elastic/obs-onboarding-team
@@ -594,16 +594,16 @@ src/platform/packages/shared/kbn-securitysolution-io-ts-types @elastic/security-
 src/platform/packages/shared/kbn-securitysolution-io-ts-utils @elastic/security-detection-engine
 src/platform/packages/shared/kbn-securitysolution-rules @elastic/security-detection-engine
 src/platform/packages/shared/kbn-server-http-tools @elastic/kibana-core
-src/platform/packages/shared/kbn-server-route-repository @elastic/obs-knowledge-team
-src/platform/packages/shared/kbn-server-route-repository-client @elastic/obs-knowledge-team
-src/platform/packages/shared/kbn-server-route-repository-utils @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-server-route-repository @elastic/observability-ui
+src/platform/packages/shared/kbn-server-route-repository-client @elastic/observability-ui
+src/platform/packages/shared/kbn-server-route-repository-utils @elastic/observability-ui
 src/platform/packages/shared/kbn-shared-svg @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-shared-ux-utility @elastic/appex-sharedux
 src/platform/packages/shared/kbn-sort-predicates @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-spaces-utils @elastic/kibana-security
-src/platform/packages/shared/kbn-sse-utils @elastic/obs-knowledge-team
-src/platform/packages/shared/kbn-sse-utils-client @elastic/obs-knowledge-team
-src/platform/packages/shared/kbn-sse-utils-server @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-sse-utils @elastic/obs-ai-team
+src/platform/packages/shared/kbn-sse-utils-client @elastic/obs-ai-team
+src/platform/packages/shared/kbn-sse-utils-server @elastic/obs-ai-team
 src/platform/packages/shared/kbn-std @elastic/kibana-core
 src/platform/packages/shared/kbn-storage-adapter @elastic/observability-ui @elastic/kibana-core
 src/platform/packages/shared/kbn-storybook @elastic/kibana-operations
@@ -623,7 +623,7 @@ src/platform/packages/shared/kbn-tracing-config @elastic/kibana-core
 src/platform/packages/shared/kbn-tracing-utils @elastic/kibana-core
 src/platform/packages/shared/kbn-triggers-actions-ui-types @elastic/response-ops
 src/platform/packages/shared/kbn-try-in-console @elastic/search-kibana
-src/platform/packages/shared/kbn-typed-react-router-config @elastic/obs-knowledge-team @elastic/obs-presentation-team
+src/platform/packages/shared/kbn-typed-react-router-config @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-ui-actions-browser @elastic/appex-sharedux
 src/platform/packages/shared/kbn-ui-theme @elastic/kibana-operations
 src/platform/packages/shared/kbn-unified-data-table @elastic/kibana-data-discovery @elastic/security-threat-hunting-investigations
@@ -970,7 +970,7 @@ x-pack/platform/packages/shared/kbn-kibana-api-cli @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-langchain @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-mcp-client @elastic/workchat-eng
-x-pack/platform/packages/shared/kbn-profiler-cli @elastic/obs-knowledge-team
+x-pack/platform/packages/shared/kbn-profiler-cli @elastic/obs-ui-devex-team
 x-pack/platform/packages/shared/kbn-sample-parser @elastic/obs-onboarding-team @elastic/obs-sig-events-team
 x-pack/platform/packages/shared/kbn-search-index-documents @elastic/search-kibana
 x-pack/platform/packages/shared/kbn-slo-schema @elastic/actionable-obs-team
@@ -1145,7 +1145,7 @@ x-pack/solutions/observability/packages/alerting-test-data @elastic/actionable-o
 x-pack/solutions/observability/packages/get-padded-alert-time-range-util @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/kbn-alerts-grouping @elastic/response-ops
 x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant @elastic/obs-ai-team
-x-pack/solutions/observability/packages/kbn-genai-cli @elastic/obs-knowledge-team
+x-pack/solutions/observability/packages/kbn-genai-cli @elastic/obs-ai-team
 x-pack/solutions/observability/packages/kbn-observability-schema @elastic/obs-presentation-team
 x-pack/solutions/observability/packages/kbn-scout-oblt @elastic/appex-qa
 x-pack/solutions/observability/packages/nav-icons @elastic/obs-presentation-team
@@ -1604,7 +1604,7 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/infra/server/routes/log_analysis @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/services/rules @elastic/obs-presentation-team @elastic/obs-exploration-team
 /x-pack/solutions/observability/test/common/utils/synthtrace @elastic/obs-presentation-team @elastic/obs-exploration-team
-/x-pack/platform/test/common/utils/server_route_repository @elastic/obs-knowledge-team
+/x-pack/platform/test/common/utils/server_route_repository @elastic/obs-onboarding-team @elastic/obs-sig-events-team
 /src/platform/test/functional/services/synthtrace/logs_synthtrace_es_client.ts @elastic/obs-presentation-team @elastic/obs-exploration-team
 
 ## Streams parts owned by Logs UX

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,7 +60,7 @@ packages/kbn-docs-utils @elastic/kibana-operations
 packages/kbn-eslint-config @elastic/kibana-operations
 packages/kbn-eslint-plugin-disable @elastic/kibana-operations
 packages/kbn-eslint-plugin-eslint @elastic/kibana-operations
-packages/kbn-eslint-plugin-i18n @elastic/kibana-operations
+packages/kbn-eslint-plugin-i18n @elastic/obs-knowledge-team @elastic/kibana-operations
 packages/kbn-eslint-plugin-imports @elastic/kibana-operations
 packages/kbn-eslint-plugin-telemetry @elastic/obs-knowledge-team
 packages/kbn-extract-plugin-translations @elastic/kibana-core
@@ -508,7 +508,7 @@ src/platform/packages/shared/kbn-es-mappings @elastic/kibana-core
 src/platform/packages/shared/kbn-es-query @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-es-query-constants @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-es-query-server @elastic/kibana-data-discovery
-src/platform/packages/shared/kbn-es-types @elastic/kibana-core
+src/platform/packages/shared/kbn-es-types @elastic/kibana-core @elastic/obs-knowledge-team
 src/platform/packages/shared/kbn-esql-composer @elastic/obs-presentation-team @elastic/obs-ai-team
 src/platform/packages/shared/kbn-esql-language @elastic/kibana-esql
 src/platform/packages/shared/kbn-esql-types @elastic/kibana-esql
@@ -565,7 +565,7 @@ src/platform/packages/shared/kbn-osquery-io-ts-types @elastic/security-defend-wo
 src/platform/packages/shared/kbn-otel-demo @elastic/obs-onboarding-team
 src/platform/packages/shared/kbn-otel-semantic-conventions @elastic/obs-onboarding-team
 src/platform/packages/shared/kbn-palettes @elastic/kibana-visualizations
-src/platform/packages/shared/kbn-profiler @elastic/obs-ui-devex-team
+src/platform/packages/shared/kbn-profiler @elastic/obs-knowledge-team
 src/platform/packages/shared/kbn-profiling-utils @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-react-field @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-react-hooks @elastic/obs-onboarding-team
@@ -594,16 +594,16 @@ src/platform/packages/shared/kbn-securitysolution-io-ts-types @elastic/security-
 src/platform/packages/shared/kbn-securitysolution-io-ts-utils @elastic/security-detection-engine
 src/platform/packages/shared/kbn-securitysolution-rules @elastic/security-detection-engine
 src/platform/packages/shared/kbn-server-http-tools @elastic/kibana-core
-src/platform/packages/shared/kbn-server-route-repository @elastic/observability-ui
-src/platform/packages/shared/kbn-server-route-repository-client @elastic/observability-ui
-src/platform/packages/shared/kbn-server-route-repository-utils @elastic/observability-ui
+src/platform/packages/shared/kbn-server-route-repository @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-server-route-repository-client @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-server-route-repository-utils @elastic/obs-knowledge-team
 src/platform/packages/shared/kbn-shared-svg @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-shared-ux-utility @elastic/appex-sharedux
 src/platform/packages/shared/kbn-sort-predicates @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-spaces-utils @elastic/kibana-security
-src/platform/packages/shared/kbn-sse-utils @elastic/obs-ai-team
-src/platform/packages/shared/kbn-sse-utils-client @elastic/obs-ai-team
-src/platform/packages/shared/kbn-sse-utils-server @elastic/obs-ai-team
+src/platform/packages/shared/kbn-sse-utils @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-sse-utils-client @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-sse-utils-server @elastic/obs-knowledge-team
 src/platform/packages/shared/kbn-std @elastic/kibana-core
 src/platform/packages/shared/kbn-storage-adapter @elastic/observability-ui @elastic/kibana-core
 src/platform/packages/shared/kbn-storybook @elastic/kibana-operations
@@ -623,7 +623,7 @@ src/platform/packages/shared/kbn-tracing-config @elastic/kibana-core
 src/platform/packages/shared/kbn-tracing-utils @elastic/kibana-core
 src/platform/packages/shared/kbn-triggers-actions-ui-types @elastic/response-ops
 src/platform/packages/shared/kbn-try-in-console @elastic/search-kibana
-src/platform/packages/shared/kbn-typed-react-router-config @elastic/obs-presentation-team
+src/platform/packages/shared/kbn-typed-react-router-config @elastic/obs-knowledge-team @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-ui-actions-browser @elastic/appex-sharedux
 src/platform/packages/shared/kbn-ui-theme @elastic/kibana-operations
 src/platform/packages/shared/kbn-unified-data-table @elastic/kibana-data-discovery @elastic/security-threat-hunting-investigations
@@ -970,7 +970,7 @@ x-pack/platform/packages/shared/kbn-kibana-api-cli @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-langchain @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-mcp-client @elastic/workchat-eng
-x-pack/platform/packages/shared/kbn-profiler-cli @elastic/obs-ui-devex-team
+x-pack/platform/packages/shared/kbn-profiler-cli @elastic/obs-knowledge-team
 x-pack/platform/packages/shared/kbn-sample-parser @elastic/obs-onboarding-team @elastic/obs-sig-events-team
 x-pack/platform/packages/shared/kbn-search-index-documents @elastic/search-kibana
 x-pack/platform/packages/shared/kbn-slo-schema @elastic/actionable-obs-team
@@ -1145,7 +1145,7 @@ x-pack/solutions/observability/packages/alerting-test-data @elastic/actionable-o
 x-pack/solutions/observability/packages/get-padded-alert-time-range-util @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/kbn-alerts-grouping @elastic/response-ops
 x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant @elastic/obs-ai-team
-x-pack/solutions/observability/packages/kbn-genai-cli @elastic/obs-ai-team
+x-pack/solutions/observability/packages/kbn-genai-cli @elastic/obs-knowledge-team
 x-pack/solutions/observability/packages/kbn-observability-schema @elastic/obs-presentation-team
 x-pack/solutions/observability/packages/kbn-scout-oblt @elastic/appex-qa
 x-pack/solutions/observability/packages/nav-icons @elastic/obs-presentation-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,7 +60,7 @@ packages/kbn-docs-utils @elastic/kibana-operations
 packages/kbn-eslint-config @elastic/kibana-operations
 packages/kbn-eslint-plugin-disable @elastic/kibana-operations
 packages/kbn-eslint-plugin-eslint @elastic/kibana-operations
-packages/kbn-eslint-plugin-i18n @elastic/obs-knowledge-team @elastic/kibana-operations
+packages/kbn-eslint-plugin-i18n @elastic/kibana-operations
 packages/kbn-eslint-plugin-imports @elastic/kibana-operations
 packages/kbn-eslint-plugin-telemetry @elastic/obs-knowledge-team
 packages/kbn-extract-plugin-translations @elastic/kibana-core
@@ -508,7 +508,7 @@ src/platform/packages/shared/kbn-es-mappings @elastic/kibana-core
 src/platform/packages/shared/kbn-es-query @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-es-query-constants @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-es-query-server @elastic/kibana-data-discovery
-src/platform/packages/shared/kbn-es-types @elastic/kibana-core @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-es-types @elastic/kibana-core
 src/platform/packages/shared/kbn-esql-composer @elastic/obs-presentation-team @elastic/obs-ai-team
 src/platform/packages/shared/kbn-esql-language @elastic/kibana-esql
 src/platform/packages/shared/kbn-esql-types @elastic/kibana-esql
@@ -565,7 +565,7 @@ src/platform/packages/shared/kbn-osquery-io-ts-types @elastic/security-defend-wo
 src/platform/packages/shared/kbn-otel-demo @elastic/obs-onboarding-team
 src/platform/packages/shared/kbn-otel-semantic-conventions @elastic/obs-onboarding-team
 src/platform/packages/shared/kbn-palettes @elastic/kibana-visualizations
-src/platform/packages/shared/kbn-profiler @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-profiler @elastic/observability-ui
 src/platform/packages/shared/kbn-profiling-utils @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-react-field @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-react-hooks @elastic/obs-onboarding-team
@@ -594,16 +594,16 @@ src/platform/packages/shared/kbn-securitysolution-io-ts-types @elastic/security-
 src/platform/packages/shared/kbn-securitysolution-io-ts-utils @elastic/security-detection-engine
 src/platform/packages/shared/kbn-securitysolution-rules @elastic/security-detection-engine
 src/platform/packages/shared/kbn-server-http-tools @elastic/kibana-core
-src/platform/packages/shared/kbn-server-route-repository @elastic/obs-knowledge-team
-src/platform/packages/shared/kbn-server-route-repository-client @elastic/obs-knowledge-team
-src/platform/packages/shared/kbn-server-route-repository-utils @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-server-route-repository @elastic/observability-ui
+src/platform/packages/shared/kbn-server-route-repository-client @elastic/observability-ui
+src/platform/packages/shared/kbn-server-route-repository-utils @elastic/observability-ui
 src/platform/packages/shared/kbn-shared-svg @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-shared-ux-utility @elastic/appex-sharedux
 src/platform/packages/shared/kbn-sort-predicates @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-spaces-utils @elastic/kibana-security
-src/platform/packages/shared/kbn-sse-utils @elastic/obs-knowledge-team
-src/platform/packages/shared/kbn-sse-utils-client @elastic/obs-knowledge-team
-src/platform/packages/shared/kbn-sse-utils-server @elastic/obs-knowledge-team
+src/platform/packages/shared/kbn-sse-utils @elastic/obs-ai-team
+src/platform/packages/shared/kbn-sse-utils-client @elastic/obs-ai-team
+src/platform/packages/shared/kbn-sse-utils-server @elastic/obs-ai-team
 src/platform/packages/shared/kbn-std @elastic/kibana-core
 src/platform/packages/shared/kbn-storage-adapter @elastic/observability-ui @elastic/kibana-core
 src/platform/packages/shared/kbn-storybook @elastic/kibana-operations
@@ -623,7 +623,7 @@ src/platform/packages/shared/kbn-tracing-config @elastic/kibana-core
 src/platform/packages/shared/kbn-tracing-utils @elastic/kibana-core
 src/platform/packages/shared/kbn-triggers-actions-ui-types @elastic/response-ops
 src/platform/packages/shared/kbn-try-in-console @elastic/search-kibana
-src/platform/packages/shared/kbn-typed-react-router-config @elastic/obs-knowledge-team @elastic/obs-presentation-team
+src/platform/packages/shared/kbn-typed-react-router-config @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-ui-actions-browser @elastic/appex-sharedux
 src/platform/packages/shared/kbn-ui-theme @elastic/kibana-operations
 src/platform/packages/shared/kbn-unified-data-table @elastic/kibana-data-discovery @elastic/security-threat-hunting-investigations
@@ -970,7 +970,7 @@ x-pack/platform/packages/shared/kbn-kibana-api-cli @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-langchain @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver @elastic/security-generative-ai
 x-pack/platform/packages/shared/kbn-mcp-client @elastic/workchat-eng
-x-pack/platform/packages/shared/kbn-profiler-cli @elastic/obs-knowledge-team
+x-pack/platform/packages/shared/kbn-profiler-cli @elastic/observability-ui
 x-pack/platform/packages/shared/kbn-sample-parser @elastic/obs-onboarding-team @elastic/obs-sig-events-team
 x-pack/platform/packages/shared/kbn-search-index-documents @elastic/search-kibana
 x-pack/platform/packages/shared/kbn-slo-schema @elastic/actionable-obs-team
@@ -1145,7 +1145,7 @@ x-pack/solutions/observability/packages/alerting-test-data @elastic/actionable-o
 x-pack/solutions/observability/packages/get-padded-alert-time-range-util @elastic/actionable-obs-team
 x-pack/solutions/observability/packages/kbn-alerts-grouping @elastic/response-ops
 x-pack/solutions/observability/packages/kbn-evals-suite-obs-ai-assistant @elastic/obs-ai-team
-x-pack/solutions/observability/packages/kbn-genai-cli @elastic/obs-knowledge-team
+x-pack/solutions/observability/packages/kbn-genai-cli @elastic/obs-ai-team
 x-pack/solutions/observability/packages/kbn-observability-schema @elastic/obs-presentation-team
 x-pack/solutions/observability/packages/kbn-scout-oblt @elastic/appex-qa
 x-pack/solutions/observability/packages/nav-icons @elastic/obs-presentation-team

--- a/packages/kbn-eslint-plugin-i18n/kibana.jsonc
+++ b/packages/kbn-eslint-plugin-i18n/kibana.jsonc
@@ -2,7 +2,6 @@
   "type": "shared-common",
   "id": "@kbn/eslint-plugin-i18n",
   "owner": [
-    "@elastic/obs-knowledge-team",
     "@elastic/kibana-operations"
   ],
   "group": "platform",

--- a/packages/kbn-eslint-plugin-i18n/moon.yml
+++ b/packages/kbn-eslint-plugin-i18n/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/eslint-plugin-i18n'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-knowledge-team'
+  defaultOwner: '@elastic/kibana-operations'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/eslint-plugin-i18n'
   description: Moon project for @kbn/eslint-plugin-i18n
   channel: ''
-  owner: '@elastic/obs-knowledge-team'
+  owner: '@elastic/kibana-operations'
   metadata:
     sourceRoot: packages/kbn-eslint-plugin-i18n
 dependsOn:

--- a/src/platform/packages/shared/kbn-es-types/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-es-types/kibana.jsonc
@@ -2,8 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/es-types",
   "owner": [
-    "@elastic/kibana-core",
-    "@elastic/obs-knowledge-team"
+    "@elastic/kibana-core"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-profiler/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-profiler/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/profiler",
-  "owner": "@elastic/obs-knowledge-team",
+  "owner": "@elastic/observability-ui",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/src/platform/packages/shared/kbn-profiler/moon.yml
+++ b/src/platform/packages/shared/kbn-profiler/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/profiler'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-knowledge-team'
+  defaultOwner: '@elastic/observability-ui'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/profiler'
   description: Moon project for @kbn/profiler
   channel: ''
-  owner: '@elastic/obs-knowledge-team'
+  owner: '@elastic/observability-ui'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-profiler
 dependsOn:

--- a/src/platform/packages/shared/kbn-server-route-repository-client/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-server-route-repository-client/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-browser",
   "id": "@kbn/server-route-repository-client",
   "owner": [
-    "@elastic/obs-knowledge-team"
+    "@elastic/observability-ui"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-server-route-repository-client/moon.yml
+++ b/src/platform/packages/shared/kbn-server-route-repository-client/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/server-route-repository-client'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-knowledge-team'
+  defaultOwner: '@elastic/observability-ui'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/server-route-repository-client'
   description: Moon project for @kbn/server-route-repository-client
   channel: ''
-  owner: '@elastic/obs-knowledge-team'
+  owner: '@elastic/observability-ui'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-server-route-repository-client
 dependsOn:

--- a/src/platform/packages/shared/kbn-server-route-repository-utils/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-server-route-repository-utils/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/server-route-repository-utils",
   "owner": [
-    "@elastic/obs-knowledge-team"
+    "@elastic/observability-ui"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-server-route-repository-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-server-route-repository-utils/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/server-route-repository-utils'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-knowledge-team'
+  defaultOwner: '@elastic/observability-ui'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/server-route-repository-utils'
   description: Moon project for @kbn/server-route-repository-utils
   channel: ''
-  owner: '@elastic/obs-knowledge-team'
+  owner: '@elastic/observability-ui'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-server-route-repository-utils
 dependsOn:

--- a/src/platform/packages/shared/kbn-server-route-repository/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-server-route-repository/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-server",
   "id": "@kbn/server-route-repository",
   "owner": [
-    "@elastic/obs-knowledge-team"
+    "@elastic/observability-ui"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-server-route-repository/moon.yml
+++ b/src/platform/packages/shared/kbn-server-route-repository/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/server-route-repository'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-knowledge-team'
+  defaultOwner: '@elastic/observability-ui'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/server-route-repository'
   description: Moon project for @kbn/server-route-repository
   channel: ''
-  owner: '@elastic/obs-knowledge-team'
+  owner: '@elastic/observability-ui'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-server-route-repository
 dependsOn:

--- a/src/platform/packages/shared/kbn-sse-utils-client/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-sse-utils-client/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/sse-utils-client",
   "owner": [
-    "@elastic/obs-knowledge-team"
+    "@elastic/obs-ai-team"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-sse-utils-client/moon.yml
+++ b/src/platform/packages/shared/kbn-sse-utils-client/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/sse-utils-client'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-knowledge-team'
+  defaultOwner: '@elastic/obs-ai-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/sse-utils-client'
   description: Moon project for @kbn/sse-utils-client
   channel: ''
-  owner: '@elastic/obs-knowledge-team'
+  owner: '@elastic/obs-ai-team'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-sse-utils-client
 dependsOn:

--- a/src/platform/packages/shared/kbn-sse-utils-server/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-sse-utils-server/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/sse-utils-server",
   "owner": [
-    "@elastic/obs-knowledge-team"
+    "@elastic/obs-ai-team"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-sse-utils-server/moon.yml
+++ b/src/platform/packages/shared/kbn-sse-utils-server/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/sse-utils-server'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-knowledge-team'
+  defaultOwner: '@elastic/obs-ai-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/sse-utils-server'
   description: Moon project for @kbn/sse-utils-server
   channel: ''
-  owner: '@elastic/obs-knowledge-team'
+  owner: '@elastic/obs-ai-team'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-sse-utils-server
 dependsOn:

--- a/src/platform/packages/shared/kbn-sse-utils/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-sse-utils/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/sse-utils",
   "owner": [
-    "@elastic/obs-knowledge-team"
+    "@elastic/obs-ai-team"
   ],
   "group": "platform",
   "visibility": "shared"

--- a/src/platform/packages/shared/kbn-sse-utils/moon.yml
+++ b/src/platform/packages/shared/kbn-sse-utils/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/sse-utils'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-knowledge-team'
+  defaultOwner: '@elastic/obs-ai-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/sse-utils'
   description: Moon project for @kbn/sse-utils
   channel: ''
-  owner: '@elastic/obs-knowledge-team'
+  owner: '@elastic/obs-ai-team'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-sse-utils
 dependsOn:

--- a/src/platform/packages/shared/kbn-typed-react-router-config/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/kibana.jsonc
@@ -2,7 +2,6 @@
   "type": "shared-browser",
   "id": "@kbn/typed-react-router-config",
   "owner": [
-    "@elastic/obs-knowledge-team",
     "@elastic/obs-presentation-team"
   ],
   "group": "platform",

--- a/src/platform/packages/shared/kbn-typed-react-router-config/moon.yml
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/typed-react-router-config'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-knowledge-team'
+  defaultOwner: '@elastic/obs-presentation-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/typed-react-router-config'
   description: Moon project for @kbn/typed-react-router-config
   channel: ''
-  owner: '@elastic/obs-knowledge-team'
+  owner: '@elastic/obs-presentation-team'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-typed-react-router-config
 dependsOn:

--- a/x-pack/platform/packages/shared/kbn-profiler-cli/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-profiler-cli/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/profiler-cli",
-  "owner": "@elastic/obs-knowledge-team",
+  "owner": "@elastic/observability-ui",
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/kbn-profiler-cli/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-profiler-cli/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/profiler-cli'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-knowledge-team'
+  defaultOwner: '@elastic/observability-ui'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/profiler-cli'
   description: Moon project for @kbn/profiler-cli
   channel: ''
-  owner: '@elastic/obs-knowledge-team'
+  owner: '@elastic/observability-ui'
   metadata:
     sourceRoot: x-pack/platform/packages/shared/kbn-profiler-cli
 dependsOn:

--- a/x-pack/solutions/observability/packages/kbn-genai-cli/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/kbn-genai-cli/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/kbn-genai-cli",
-  "owner": "@elastic/obs-knowledge-team",
+  "owner": "@elastic/obs-ai-team",
   "group": "observability",
   "visibility": "private",
   "devOnly": true

--- a/x-pack/solutions/observability/packages/kbn-genai-cli/moon.yml
+++ b/x-pack/solutions/observability/packages/kbn-genai-cli/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/kbn-genai-cli'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-knowledge-team'
+  defaultOwner: '@elastic/obs-ai-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/kbn-genai-cli'
   description: Moon project for @kbn/kbn-genai-cli
   channel: ''
-  owner: '@elastic/obs-knowledge-team'
+  owner: '@elastic/obs-ai-team'
   metadata:
     sourceRoot: x-pack/solutions/observability/packages/kbn-genai-cli
 dependsOn:


### PR DESCRIPTION
This PR:

- Changes ownership of code previously owned by the former Observability Knowledge team to other teams on Observability. 
- Removes `obs-knowledge-team` for code co-owned with other team
