### PR TITLE
Removed need to explicitly set inference URL

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -960,7 +960,7 @@ x-pack/platform/packages/shared/kbn-event-stacktrace @elastic/obs-presentation-t
 x-pack/platform/packages/shared/kbn-failure-store-modal @elastic/kibana-management
 x-pack/platform/packages/shared/kbn-fs @elastic/kibana-security
 x-pack/platform/packages/shared/kbn-grok-heuristics @elastic/obs-onboarding-team
-x-pack/platform/packages/shared/kbn-inference-cli @elastic/appex-ai-infra
+x-pack/platform/packages/shared/kbn-inference-cli @elastic/appex-ai-infra @elastic/search-inference-team
 x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-inference-prompt-utils @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-inference-tracing @elastic/appex-ai-infra

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1264,6 +1264,10 @@ x-pack/solutions/workplaceai/test @elastic/workchat-eng
 x-pack/platform/test/serverless/api_integration/test_suites/platform_security @elastic/kibana-security
 /src/platform/test/functional/apps/management @elastic/kibana-management
 
+# Utility Scripts
+x-pack/platform/packages/shared/kbn-inference-cli/scripts/eis.ts @elastic/search-inference-team
+x-pack/platform/packages/shared/kbn-inference-cli/src/eis @elastic/search-inference-team
+
 # Data Discovery
 /x-pack/platform/test/api_integration/services/data_view_api.ts @elastic/kibana-data-discovery
 /src/platform/test/functional/page_objects/unified_field_list.ts @elastic/kibana-data-discovery

--- a/x-pack/platform/packages/shared/kbn-inference-cli/README.md
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/README.md
@@ -50,7 +50,9 @@ You can connect your local Elasticsearch to the Elastic Inference Service (EIS) 
 2. **Elasticsearch**: Start Elasticsearch with the CCM URL flag:
 
    ```bash
-   yarn es snapshot --license trial -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
+   yarn es snapshot --license trial
+   # OR
+   yarn es serverless
    ```
 
 3. **Credentials**: The script will automatically detect Elasticsearch credentials from:
@@ -60,12 +62,9 @@ You can connect your local Elasticsearch to the Elastic Inference Service (EIS) 
 ### Usage
 
 ```bash
-# Start Elasticsearch with CCM enabled
-yarn es snapshot --license trial -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
-
-# In a separate terminal, configure CCM 
+# In a separate terminal, configure CCM
 # Use --no-ssl for HTTP connections
 node scripts/eis.js
 ```
 
-The script will fetch the API key from Vault and configure Cloud Connected Mode in your local Elasticsearch instance.
+The script will fetch the API key and inference URL from Vault, configure the inference URL via Elasticsearch cluster settings, and set up Cloud Connected Mode in your local Elasticsearch instance.

--- a/x-pack/platform/packages/shared/kbn-inference-cli/README.md
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/README.md
@@ -63,8 +63,7 @@ You can connect your local Elasticsearch to the Elastic Inference Service (EIS) 
 
 ```bash
 # In a separate terminal, configure CCM
-# Use --no-ssl for HTTP connections
 node scripts/eis.js
 ```
 
-The script will fetch the API key and inference URL from Vault, configure the inference URL via Elasticsearch cluster settings, and set up Cloud Connected Mode in your local Elasticsearch instance.
+The script will automatically try HTTPS first and fall back to HTTP if needed. It will fetch the API key and inference URL from Vault, configure the inference URL via Elasticsearch cluster settings, and set up Cloud Connected Mode in your local Elasticsearch instance.

--- a/x-pack/platform/packages/shared/kbn-inference-cli/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/kibana.jsonc
@@ -1,7 +1,10 @@
 {
   "type": "shared-common",
   "id": "@kbn/inference-cli",
-  "owner": "@elastic/appex-ai-infra",
+  "owner": [
+    "@elastic/appex-ai-infra",
+    "@elastic/search-inference-team"
+  ],
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/x-pack/platform/packages/shared/kbn-inference-cli/scripts/eis.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/scripts/eis.ts
@@ -8,23 +8,12 @@ import { run } from '@kbn/dev-cli-runner';
 import { ensureEis } from '../src/eis/ensure_eis';
 
 run(
-  ({ log, flags }) => {
-    const ssl = flags.ssl as boolean;
-    return ensureEis({ log, ssl }).catch((error) => {
+  ({ log }) => {
+    return ensureEis({ log }).catch((error) => {
       throw new Error('Failed to configure Cloud Connected Mode for EIS', { cause: error });
     });
   },
   {
     description: 'Sets up Cloud Connected Mode for Elastic Inference Service (EIS)',
-    flags: {
-      boolean: ['ssl'],
-      default: {
-        ssl: true,
-      },
-      help: `
-      --ssl               Optional. Use HTTPS/SSL for Elasticsearch connection (Default: true).
-                          Use --no-ssl for HTTP connections.
-`,
-    },
   }
 );


### PR DESCRIPTION
## Summary

Keeps us from needing to hardcode the inference URL, by moving it to vault along with its API key. This was a request from @maxjakob 

EDIT: also makes some codeowners changes. I tried to make these in https://github.com/elastic/kibana/pull/247946, but apparently my changes were overridden by generation code. Trying again.

- [x] Add URL to Vault secret
- [ ] test to make sure it works
- [ ] make sure that `search-inference-team` has been added as kibana contributors




