### PR TITLE
[Security Solution] Change alert suppression icon

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/alert_suppression_label.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/alert_suppression_label.tsx
@@ -34,7 +34,9 @@ export const AlertSuppressionLabel = ({ label, ruleType }: AlertSuppressionLabel
           position="top"
           type="lock"
           size="l"
-          css={{ marginLeft: '8px' }}
+          anchorProps={{
+            css: { marginLeft: '8px' },
+          }}
           iconProps={{
             'data-test-subj': 'alertSuppressionInsufficientLicensingIcon',
           }}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/alert_suppression_label.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/alert_suppression_label.tsx
@@ -32,9 +32,8 @@ export const AlertSuppressionLabel = ({ label, ruleType }: AlertSuppressionLabel
         <EuiIconTip
           content={alertSuppressionUpsellingMessage}
           position="top"
-          type="warning"
+          type="lock"
           size="l"
-          color="danger"
           css={{ marginLeft: '8px' }}
           iconProps={{
             'data-test-subj': 'alertSuppressionInsufficientLicensingIcon',


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/247884**

## Summary

This PR changes the icon that is shown when alert suppression is not available because of insufficient license.

This previous "warning" icon looks confusing and misleading, as if something is broken and needed to be fixed. We are updating the icon to the one that aligns more with the designs for upgrade call-outs.

**Before**
<img width="672" height="126" alt="Screenshot 2026-01-08 at 21 50 56" src="https://github.com/user-attachments/assets/cd5182e4-ca61-4698-99f3-adfc556ef36a" />

**After** 
<img width="672" height="126" alt="Screenshot 2026-01-08 at 21 51 30" src="https://github.com/user-attachments/assets/221e124c-8ee4-4c80-abdd-581393268183" />



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->