### PR TITLE
[Attack discovery] Improves Attack discovery hallucination detection

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/get_alert_ids_query/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/get_alert_ids_query/index.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAlertIdsQuery } from '.';
+
+describe('getAlertIdsQuery', () => {
+  const alertsIndexPattern = '.alerts-security.alerts-*';
+
+  it('returns the expected query for an empty array', () => {
+    const result = getAlertIdsQuery(alertsIndexPattern, []);
+
+    expect(result).toEqual({
+      _source: false,
+      ignore_unavailable: true,
+      index: alertsIndexPattern,
+      query: {
+        ids: {
+          values: [],
+        },
+      },
+      size: 0,
+    });
+  });
+
+  it('returns the expected query for a single alert ID', () => {
+    const result = getAlertIdsQuery(alertsIndexPattern, ['alert-1']);
+
+    expect(result).toEqual({
+      _source: false,
+      ignore_unavailable: true,
+      index: alertsIndexPattern,
+      query: {
+        ids: {
+          values: ['alert-1'],
+        },
+      },
+      size: 1,
+    });
+  });
+
+  it('returns the expected query for multiple alert IDs', () => {
+    const alertIds = ['alert-1', 'alert-2', 'alert-3'];
+    const result = getAlertIdsQuery(alertsIndexPattern, alertIds);
+
+    expect(result).toEqual({
+      _source: false,
+      ignore_unavailable: true,
+      index: alertsIndexPattern,
+      query: {
+        ids: {
+          values: alertIds,
+        },
+      },
+      size: 3,
+    });
+  });
+
+  it('sets _source to false for performance', () => {
+    const result = getAlertIdsQuery(alertsIndexPattern, ['alert-1']);
+
+    expect(result._source).toBe(false);
+  });
+
+  it('sets ignore_unavailable to true', () => {
+    const result = getAlertIdsQuery(alertsIndexPattern, ['alert-1']);
+
+    expect(result.ignore_unavailable).toBe(true);
+  });
+
+  it('uses the provided index pattern', () => {
+    const customPattern = '.custom-alerts-*';
+    const result = getAlertIdsQuery(customPattern, ['alert-1']);
+
+    expect(result.index).toBe(customPattern);
+  });
+
+  it('sets size to match the number of alert IDs', () => {
+    const alertIds = ['alert-1', 'alert-2', 'alert-3', 'alert-4', 'alert-5'];
+    const result = getAlertIdsQuery(alertsIndexPattern, alertIds);
+
+    expect(result.size).toBe(5);
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/get_alert_ids_query/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/get_alert_ids_query/index.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+interface AlertIdsQuery {
+  _source: false;
+  ignore_unavailable: boolean;
+  index: string;
+  query: {
+    ids: {
+      values: string[];
+    };
+  };
+  size: number;
+}
+
+export const getAlertIdsQuery = (
+  alertsIndexPattern: string,
+  alertIds: string[]
+): AlertIdsQuery => ({
+  _source: false,
+  ignore_unavailable: true,
+  index: alertsIndexPattern,
+  query: {
+    ids: {
+      values: alertIds,
+    },
+  },
+  size: alertIds.length,
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/get_valid_discoveries/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/get_valid_discoveries/index.test.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttackDiscovery } from '@kbn/elastic-assistant-common';
+import { getValidDiscoveries } from '.';
+
+describe('getValidDiscoveries', () => {
+  const mockDiscovery1: AttackDiscovery = {
+    alertIds: ['alert-1', 'alert-2', 'alert-3'],
+    detailsMarkdown: 'Details 1',
+    summaryMarkdown: 'Summary 1',
+    timestamp: '2024-01-01T00:00:00.000Z',
+    title: 'Discovery 1',
+  };
+
+  const mockDiscovery2: AttackDiscovery = {
+    alertIds: ['alert-4', 'alert-5'],
+    detailsMarkdown: 'Details 2',
+    summaryMarkdown: 'Summary 2',
+    timestamp: '2024-01-02T00:00:00.000Z',
+    title: 'Discovery 2',
+  };
+
+  const mockDiscovery3: AttackDiscovery = {
+    alertIds: ['alert-6', 'alert-7', 'alert-8'],
+    detailsMarkdown: 'Details 3',
+    summaryMarkdown: 'Summary 3',
+    timestamp: '2024-01-03T00:00:00.000Z',
+    title: 'Discovery 3',
+  };
+
+  describe('when all alert IDs exist', () => {
+    const existingAlertIds = new Set([
+      'alert-1',
+      'alert-2',
+      'alert-3',
+      'alert-4',
+      'alert-5',
+      'alert-6',
+      'alert-7',
+      'alert-8',
+    ]);
+    const discoveries = [mockDiscovery1, mockDiscovery2, mockDiscovery3];
+
+    it('returns all discoveries', () => {
+      const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+      expect(result).toEqual(discoveries);
+    });
+
+    it('returns the correct number of discoveries', () => {
+      const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe('when some alert IDs are missing', () => {
+    describe('when entire discoveries have missing alert IDs', () => {
+      const existingAlertIds = new Set(['alert-1', 'alert-2', 'alert-3', 'alert-4', 'alert-5']);
+      const discoveries = [mockDiscovery1, mockDiscovery2, mockDiscovery3];
+
+      it('returns only discoveries with all alert IDs present', () => {
+        const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+        expect(result).toEqual([mockDiscovery1, mockDiscovery2]);
+      });
+
+      it('returns the correct number of valid discoveries', () => {
+        const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+        expect(result).toHaveLength(2);
+      });
+    });
+
+    describe('when only one alert ID is missing from a discovery', () => {
+      const existingAlertIds = new Set([
+        'alert-1',
+        'alert-2',
+        // alert-3 missing
+        'alert-4',
+        'alert-5',
+        'alert-6',
+        'alert-7',
+        'alert-8',
+      ]);
+      const discoveries = [mockDiscovery1, mockDiscovery2, mockDiscovery3];
+
+      it('filters out the discovery with the missing alert ID', () => {
+        const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+        expect(result).toEqual([mockDiscovery2, mockDiscovery3]);
+      });
+
+      it('excludes the discovery from results', () => {
+        const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+        expect(result).not.toContain(mockDiscovery1);
+      });
+    });
+
+    describe('when all alert IDs are missing', () => {
+      const existingAlertIds = new Set<string>([]);
+      const discoveries = [mockDiscovery1, mockDiscovery2, mockDiscovery3];
+
+      it('returns an empty array', () => {
+        const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+        expect(result).toEqual([]);
+      });
+    });
+
+    describe('when some discoveries have partial matches', () => {
+      const existingAlertIds = new Set(['alert-1', 'alert-2', 'alert-4']);
+      const discoveries = [mockDiscovery1, mockDiscovery2];
+
+      it('filters out all discoveries with any missing alert IDs', () => {
+        const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+        expect(result).toEqual([]);
+      });
+    });
+  });
+
+  describe('when no discoveries are provided', () => {
+    const existingAlertIds = new Set(['alert-1', 'alert-2']);
+    const discoveries: AttackDiscovery[] = [];
+
+    it('returns an empty array', () => {
+      const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('edge cases', () => {
+    describe('when discoveries contain an empty alertIds array', () => {
+      const discoveryWithNoAlerts: AttackDiscovery = {
+        alertIds: [], // <-- empty alertIds array
+        detailsMarkdown: 'Details',
+        summaryMarkdown: 'Summary',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        title: 'Discovery with no alerts',
+      };
+      const existingAlertIds = new Set(['alert-1', 'alert-2', 'alert-3']);
+      const discoveries = [discoveryWithNoAlerts, mockDiscovery1];
+
+      it('filters out discoveries with empty alertIds arrays', () => {
+        const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+        expect(result).not.toContain(discoveryWithNoAlerts);
+      });
+
+      it('returns only discoveries with non-empty alertIds', () => {
+        const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+        expect(result).toEqual([mockDiscovery1]);
+      });
+    });
+
+    describe('with a single discovery', () => {
+      const existingAlertIds = new Set(['alert-1', 'alert-2', 'alert-3']);
+      const discoveries = [mockDiscovery1];
+
+      it('returns the discovery when all alert IDs exist', () => {
+        const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+        expect(result).toEqual([mockDiscovery1]);
+      });
+    });
+
+    describe('with overlapping alert IDs across discoveries', () => {
+      const discoveryWithOverlap: AttackDiscovery = {
+        alertIds: ['alert-1', 'alert-2'],
+        detailsMarkdown: 'Details',
+        summaryMarkdown: 'Summary',
+        timestamp: '2024-01-04T00:00:00.000Z',
+        title: 'Discovery with overlap',
+      };
+      const existingAlertIds = new Set(['alert-1', 'alert-2', 'alert-3']);
+      const discoveries = [mockDiscovery1, discoveryWithOverlap];
+
+      it('returns all discoveries when their alert IDs exist', () => {
+        const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+        expect(result).toEqual([mockDiscovery1, discoveryWithOverlap]);
+      });
+    });
+  });
+
+  describe('discovery order preservation', () => {
+    const existingAlertIds = new Set([
+      'alert-1',
+      'alert-2',
+      'alert-3',
+      'alert-4',
+      'alert-5',
+      'alert-6',
+      'alert-7',
+      'alert-8',
+    ]);
+    const discoveries = [mockDiscovery3, mockDiscovery1, mockDiscovery2];
+
+    it('preserves the original order of discoveries', () => {
+      const result = getValidDiscoveries({ attackDiscoveries: discoveries, existingAlertIds });
+
+      expect(result).toEqual([mockDiscovery3, mockDiscovery1, mockDiscovery2]);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/get_valid_discoveries/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/get_valid_discoveries/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttackDiscoveries } from '@kbn/elastic-assistant-common';
+
+/**
+ * Filters attack discoveries to keep only those where ALL alert IDs exist in Elasticsearch.
+ * Discoveries with empty alertIds arrays are filtered out.
+ */
+export const getValidDiscoveries = ({
+  attackDiscoveries,
+  existingAlertIds,
+}: {
+  attackDiscoveries: AttackDiscoveries;
+  existingAlertIds: Set<string>;
+}): AttackDiscoveries =>
+  attackDiscoveries.filter(
+    (discovery) =>
+      discovery.alertIds.length > 0 && // filters out discoveries with empty alertIds arrays
+      discovery.alertIds.every((alertId) => existingAlertIds.has(alertId))
+  );

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/index.test.ts
@@ -1,0 +1,411 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import type { AttackDiscovery } from '@kbn/elastic-assistant-common';
+import { loggerMock } from '@kbn/logging-mocks';
+
+import { filterHallucinatedAlerts } from '.';
+
+const mockEsClient = elasticsearchServiceMock.createElasticsearchClient();
+const mockLogger = loggerMock.create();
+
+describe('filterHallucinatedAlerts', () => {
+  const alertsIndexPattern = '.alerts-security.alerts-*';
+
+  // Helper to extract the actual message from a lazy-evaluated logger call
+  const getInfoMessage = () => {
+    const call = mockLogger.info.mock.calls[0][0];
+    return typeof call === 'function' ? call() : call;
+  };
+
+  const getDebugMessage = (callIndex: number = 0) => {
+    const call = mockLogger.debug.mock.calls[callIndex][0];
+    return typeof call === 'function' ? call() : call;
+  };
+
+  const mockDiscovery1: AttackDiscovery = {
+    alertIds: ['alert-1', 'alert-2', 'alert-3'],
+    detailsMarkdown: 'Details 1',
+    summaryMarkdown: 'Summary 1',
+    timestamp: '2024-01-01T00:00:00.000Z',
+    title: 'Discovery 1',
+  };
+
+  const mockDiscovery2: AttackDiscovery = {
+    alertIds: ['alert-4', 'alert-5'],
+    detailsMarkdown: 'Details 2',
+    summaryMarkdown: 'Summary 2',
+    timestamp: '2024-01-02T00:00:00.000Z',
+    title: 'Discovery 2',
+  };
+
+  const mockDiscovery3: AttackDiscovery = {
+    alertIds: ['alert-6', 'alert-7', 'alert-8'],
+    detailsMarkdown: 'Details 3',
+    summaryMarkdown: 'Summary 3',
+    timestamp: '2024-01-03T00:00:00.000Z',
+    title: 'Discovery 3',
+  };
+
+  const defaultProps = {
+    alertsIndexPattern,
+    attackDiscoveries: [mockDiscovery1, mockDiscovery2, mockDiscovery3],
+    esClient: mockEsClient,
+    logger: mockLogger,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: all alerts exist
+    mockEsClient.search.mockResponse({
+      hits: {
+        hits: [
+          { _id: 'alert-1' },
+          { _id: 'alert-2' },
+          { _id: 'alert-3' },
+          { _id: 'alert-4' },
+          { _id: 'alert-5' },
+          { _id: 'alert-6' },
+          { _id: 'alert-7' },
+          { _id: 'alert-8' },
+        ],
+      },
+    } as unknown as estypes.SearchResponse);
+  });
+
+  describe('when no discoveries are provided', () => {
+    it('returns an empty array', async () => {
+      const result = await filterHallucinatedAlerts({
+        ...defaultProps,
+        attackDiscoveries: [],
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it('does NOT call ES when no discoveries are generated', async () => {
+      await filterHallucinatedAlerts({
+        ...defaultProps,
+        attackDiscoveries: [],
+      });
+
+      expect(mockEsClient.search).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when all alert IDs exist', () => {
+    it('returns all discoveries', async () => {
+      const result = await filterHallucinatedAlerts(defaultProps);
+
+      expect(result).toEqual([mockDiscovery1, mockDiscovery2, mockDiscovery3]);
+    });
+
+    it('does NOT log when no discoveries are filtered', async () => {
+      await filterHallucinatedAlerts(defaultProps);
+
+      expect(mockLogger.info).not.toHaveBeenCalled();
+    });
+
+    it('queries ES with the correct index pattern', async () => {
+      await filterHallucinatedAlerts(defaultProps);
+
+      expect(mockEsClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: alertsIndexPattern,
+        })
+      );
+    });
+
+    it('queries ES with the correct size', async () => {
+      await filterHallucinatedAlerts(defaultProps);
+
+      expect(mockEsClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          size: 8,
+        })
+      );
+    });
+
+    it('queries ES with the ids query containing all unique alert IDs', async () => {
+      await filterHallucinatedAlerts(defaultProps);
+
+      const searchCall = mockEsClient.search.mock.calls[0][0] as estypes.SearchRequest;
+      expect(searchCall.query).toEqual({
+        ids: {
+          values: expect.arrayContaining([
+            'alert-1',
+            'alert-2',
+            'alert-3',
+            'alert-4',
+            'alert-5',
+            'alert-6',
+            'alert-7',
+            'alert-8',
+          ]),
+        },
+      });
+    });
+
+    it('queries ES with _source set to false', async () => {
+      await filterHallucinatedAlerts(defaultProps);
+
+      expect(mockEsClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _source: false,
+        })
+      );
+    });
+
+    it('queries ES with ignore_unavailable set to true', async () => {
+      await filterHallucinatedAlerts(defaultProps);
+
+      expect(mockEsClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ignore_unavailable: true,
+        })
+      );
+    });
+  });
+
+  describe('when some alert IDs do not exist', () => {
+    beforeEach(() => {
+      // Only alerts 1, 2, 3, 4, 5 exist (discovery 3's alerts are missing)
+      mockEsClient.search.mockResponse({
+        hits: {
+          hits: [
+            { _id: 'alert-1' },
+            { _id: 'alert-2' },
+            { _id: 'alert-3' },
+            { _id: 'alert-4' },
+            { _id: 'alert-5' },
+            // alert-6, alert-7, alert-8 are missing
+          ],
+        },
+      } as unknown as estypes.SearchResponse);
+    });
+
+    it('returns only discoveries with all alert IDs present', async () => {
+      const result = await filterHallucinatedAlerts(defaultProps);
+
+      expect(result).toEqual([mockDiscovery1, mockDiscovery2]);
+    });
+
+    it('excludes discoveries with missing alert IDs', async () => {
+      const result = await filterHallucinatedAlerts(defaultProps);
+
+      expect(result).not.toContain(mockDiscovery3);
+    });
+
+    it('logs info message with count of filtered discoveries', async () => {
+      await filterHallucinatedAlerts(defaultProps);
+
+      expect(getInfoMessage()).toBe(
+        'Attack discovery: Filtered out 1 discovery(ies) with hallucinated alert IDs'
+      );
+    });
+  });
+
+  describe('when only one alert ID is missing from a discovery', () => {
+    beforeEach(() => {
+      // alert-3 is missing from discovery 1
+      mockEsClient.search.mockResponse({
+        hits: {
+          hits: [
+            { _id: 'alert-1' },
+            { _id: 'alert-2' },
+            // alert-3 is missing
+            { _id: 'alert-4' },
+            { _id: 'alert-5' },
+            { _id: 'alert-6' },
+            { _id: 'alert-7' },
+            { _id: 'alert-8' },
+          ],
+        },
+      } as unknown as estypes.SearchResponse);
+    });
+
+    it('filters out the discovery with the missing alert ID', async () => {
+      const result = await filterHallucinatedAlerts(defaultProps);
+
+      expect(result).toEqual([mockDiscovery2, mockDiscovery3]);
+    });
+
+    it('excludes the discovery from results', async () => {
+      const result = await filterHallucinatedAlerts(defaultProps);
+
+      expect(result).not.toContain(mockDiscovery1);
+    });
+
+    it('logs discovery title in debug message', async () => {
+      await filterHallucinatedAlerts(defaultProps);
+
+      expect(getDebugMessage()).toContain('Discovery 1');
+    });
+
+    it('logs hallucinated alert ID in debug message', async () => {
+      await filterHallucinatedAlerts(defaultProps);
+
+      expect(getDebugMessage()).toContain('alert-3');
+    });
+  });
+
+  describe('when multiple discoveries have missing alert IDs', () => {
+    beforeEach(() => {
+      mockEsClient.search.mockResponse({
+        hits: {
+          hits: [
+            { _id: 'alert-1' },
+            { _id: 'alert-2' },
+            { _id: 'alert-3' },
+            // alert-4, alert-5 missing (discovery 2)
+            // alert-6, alert-7, alert-8 missing (discovery 3)
+          ],
+        },
+      } as unknown as estypes.SearchResponse);
+    });
+
+    it('logs information about filtered discoveries', async () => {
+      await filterHallucinatedAlerts(defaultProps);
+
+      expect(getInfoMessage()).toBe(
+        'Attack discovery: Filtered out 2 discovery(ies) with hallucinated alert IDs'
+      );
+    });
+  });
+
+  describe('when all alert IDs are hallucinated', () => {
+    beforeEach(() => {
+      mockEsClient.search.mockResponse({
+        hits: {
+          hits: [],
+        },
+      } as unknown as estypes.SearchResponse);
+    });
+
+    it('returns empty array', async () => {
+      const result = await filterHallucinatedAlerts(defaultProps);
+
+      expect(result).toEqual([]);
+    });
+
+    it('logs that all discoveries were filtered', async () => {
+      await filterHallucinatedAlerts(defaultProps);
+
+      expect(getInfoMessage()).toBe(
+        'Attack discovery: Filtered out 3 discovery(ies) with hallucinated alert IDs'
+      );
+    });
+  });
+
+  describe('deduplication optimization', () => {
+    describe('with duplicate alert IDs in a single discovery', () => {
+      const discoveryWithDuplicates: AttackDiscovery = {
+        alertIds: ['alert-1', 'alert-1', 'alert-2', 'alert-2', 'alert-3'],
+        detailsMarkdown: 'Details',
+        summaryMarkdown: 'Summary',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        title: 'Discovery with duplicates',
+      };
+
+      it('queries ES with deduplicated alert IDs', async () => {
+        await filterHallucinatedAlerts({
+          ...defaultProps,
+          attackDiscoveries: [discoveryWithDuplicates],
+        });
+
+        const searchCall = mockEsClient.search.mock.calls[0][0] as estypes.SearchRequest;
+        const queryValues = (searchCall.query as { ids: { values: string[] } }).ids.values;
+
+        expect(queryValues).toHaveLength(3);
+      });
+
+      it('ensures all query values are unique', async () => {
+        await filterHallucinatedAlerts({
+          ...defaultProps,
+          attackDiscoveries: [discoveryWithDuplicates],
+        });
+
+        const searchCall = mockEsClient.search.mock.calls[0][0] as estypes.SearchRequest;
+        const queryValues = (searchCall.query as { ids: { values: string[] } }).ids.values;
+
+        expect(new Set(queryValues).size).toBe(3);
+      });
+    });
+
+    describe('with duplicate alert IDs across multiple discoveries', () => {
+      const discovery1: AttackDiscovery = {
+        alertIds: ['alert-1', 'alert-2'],
+        detailsMarkdown: 'Details 1',
+        summaryMarkdown: 'Summary 1',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        title: 'Discovery 1',
+      };
+
+      const discovery2: AttackDiscovery = {
+        alertIds: ['alert-2', 'alert-3'],
+        detailsMarkdown: 'Details 2',
+        summaryMarkdown: 'Summary 2',
+        timestamp: '2024-01-02T00:00:00.000Z',
+        title: 'Discovery 2',
+      };
+
+      it('deduplicates alert IDs across discoveries', async () => {
+        await filterHallucinatedAlerts({
+          ...defaultProps,
+          attackDiscoveries: [discovery1, discovery2],
+        });
+
+        const searchCall = mockEsClient.search.mock.calls[0][0] as estypes.SearchRequest;
+        const queryValues = (searchCall.query as { ids: { values: string[] } }).ids.values;
+
+        expect(queryValues).toHaveLength(3);
+      });
+
+      it('ensures all query values are unique', async () => {
+        await filterHallucinatedAlerts({
+          ...defaultProps,
+          attackDiscoveries: [discovery1, discovery2],
+        });
+
+        const searchCall = mockEsClient.search.mock.calls[0][0] as estypes.SearchRequest;
+        const queryValues = (searchCall.query as { ids: { values: string[] } }).ids.values;
+
+        expect(new Set(queryValues).size).toBe(3);
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws error when ES query fails', async () => {
+      const error = new Error('ES query failed');
+      mockEsClient.search.mockRejectedValue(error);
+
+      await expect(filterHallucinatedAlerts(defaultProps)).rejects.toThrow('ES query failed');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles discoveries with empty alertIds array', async () => {
+      const discoveryWithNoAlerts: AttackDiscovery = {
+        alertIds: [],
+        detailsMarkdown: 'Details',
+        summaryMarkdown: 'Summary',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        title: 'Discovery with no alerts',
+      };
+
+      const result = await filterHallucinatedAlerts({
+        ...defaultProps,
+        attackDiscoveries: [discoveryWithNoAlerts, mockDiscovery1],
+      });
+
+      expect(result).toEqual([mockDiscovery1]);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/index.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { AttackDiscoveries } from '@kbn/elastic-assistant-common';
+
+import { getAlertIdsQuery } from './get_alert_ids_query';
+import { getValidDiscoveries } from './get_valid_discoveries';
+import { logFilteredDiscoveries } from './log_filtered_discoveries';
+
+interface FilterHallucinatedAlertsParams {
+  alertsIndexPattern: string;
+  attackDiscoveries: AttackDiscoveries;
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}
+
+/**
+ * Queries Elasticsearch to filter out generated attack discoveries with hallucinated alert IDs.
+ */
+export const filterHallucinatedAlerts = async ({
+  alertsIndexPattern,
+  attackDiscoveries,
+  esClient,
+  logger,
+}: FilterHallucinatedAlertsParams): Promise<AttackDiscoveries> => {
+  if (attackDiscoveries.length === 0) {
+    return attackDiscoveries;
+  }
+
+  // 1. Collect all unique alert IDs from all discoveries (deduplicate to minimize ES query size)
+  const uniqueAlertIds = new Set(attackDiscoveries.flatMap((discovery) => discovery.alertIds));
+
+  // 2. Query ES once for all unique alert IDs
+  const query = getAlertIdsQuery(alertsIndexPattern, [...uniqueAlertIds]);
+  const searchResult = await esClient.search(query);
+
+  // 3. Build a Set of alert IDs that actually exist and filter discoveries
+  const existingAlertIds = new Set(
+    searchResult.hits.hits.map((hit) => hit._id).filter((id): id is string => id != null)
+  );
+
+  const validDiscoveries = getValidDiscoveries({ attackDiscoveries, existingAlertIds });
+
+  // 4. Log information about filtered discoveries
+  logFilteredDiscoveries(logger, attackDiscoveries, validDiscoveries, existingAlertIds);
+
+  return validDiscoveries;
+};

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/index.ts
@@ -11,6 +11,7 @@ import type { AttackDiscoveries } from '@kbn/elastic-assistant-common';
 import { getAlertIdsQuery } from './get_alert_ids_query';
 import { getValidDiscoveries } from './get_valid_discoveries';
 import { logFilteredDiscoveries } from './log_filtered_discoveries';
+import { logUnverifiableDiscoveries } from './log_unverifiable_discoveries';
 
 interface FilterHallucinatedAlertsParams {
   alertsIndexPattern: string;
@@ -32,21 +33,35 @@ export const filterHallucinatedAlerts = async ({
     return attackDiscoveries;
   }
 
-  // 1. Collect all unique alert IDs from all discoveries (deduplicate to minimize ES query size)
-  const uniqueAlertIds = new Set(attackDiscoveries.flatMap((discovery) => discovery.alertIds));
+  // 1. Filter out discoveries with empty alertIds (cannot be verified)
+  const verifiableDiscoveries = attackDiscoveries.filter(
+    (discovery) => discovery.alertIds.length > 0
+  );
 
-  // 2. Query ES once for all unique alert IDs
+  logUnverifiableDiscoveries(logger, attackDiscoveries, verifiableDiscoveries);
+
+  if (verifiableDiscoveries.length === 0) {
+    return [];
+  }
+
+  // 2. Collect all unique alert IDs from all discoveries (deduplicate to minimize ES query size)
+  const uniqueAlertIds = new Set(verifiableDiscoveries.flatMap((discovery) => discovery.alertIds));
+
+  // 3. Query ES once for all unique alert IDs
   const query = getAlertIdsQuery(alertsIndexPattern, [...uniqueAlertIds]);
   const searchResult = await esClient.search(query);
 
-  // 3. Build a Set of alert IDs that actually exist and filter discoveries
+  // 4. Build a Set of alert IDs that actually exist and filter discoveries
   const existingAlertIds = new Set(
     searchResult.hits.hits.map((hit) => hit._id).filter((id): id is string => id != null)
   );
 
-  const validDiscoveries = getValidDiscoveries({ attackDiscoveries, existingAlertIds });
+  const validDiscoveries = getValidDiscoveries({
+    attackDiscoveries: verifiableDiscoveries,
+    existingAlertIds,
+  });
 
-  // 4. Log information about filtered discoveries
+  // 5. Log information about filtered discoveries
   logFilteredDiscoveries(logger, attackDiscoveries, validDiscoveries, existingAlertIds);
 
   return validDiscoveries;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/log_filtered_discoveries/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/log_filtered_discoveries/index.test.ts
@@ -1,0 +1,329 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import type { AttackDiscovery } from '@kbn/elastic-assistant-common';
+
+import { logFilteredDiscoveries } from '.';
+
+describe('logFilteredDiscoveries', () => {
+  const mockLogger = loggerMock.create();
+
+  // Helper to extract the actual message from a lazy-evaluated logger call
+  const getInfoMessage = () => {
+    const call = mockLogger.info.mock.calls[0][0];
+    return typeof call === 'function' ? call() : call;
+  };
+
+  const getDebugMessage = (callIndex: number = 0) => {
+    const call = mockLogger.debug.mock.calls[callIndex][0];
+    return typeof call === 'function' ? call() : call;
+  };
+
+  const mockDiscovery1: AttackDiscovery = {
+    alertIds: ['alert-1', 'alert-2', 'alert-3'],
+    detailsMarkdown: 'Details 1',
+    summaryMarkdown: 'Summary 1',
+    timestamp: '2024-01-01T00:00:00.000Z',
+    title: 'Discovery 1',
+  };
+
+  const mockDiscovery2: AttackDiscovery = {
+    alertIds: ['alert-4', 'alert-5'],
+    detailsMarkdown: 'Details 2',
+    summaryMarkdown: 'Summary 2',
+    timestamp: '2024-01-02T00:00:00.000Z',
+    title: 'Discovery 2',
+  };
+
+  const mockDiscovery3: AttackDiscovery = {
+    alertIds: ['alert-6', 'alert-7', 'alert-8'],
+    detailsMarkdown: 'Details 3',
+    summaryMarkdown: 'Summary 3',
+    timestamp: '2024-01-03T00:00:00.000Z',
+    title: 'Discovery 3',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when no discoveries are filtered', () => {
+    const allDiscoveries = [mockDiscovery1, mockDiscovery2, mockDiscovery3];
+    const validDiscoveries = [mockDiscovery1, mockDiscovery2, mockDiscovery3];
+    const existingAlertIds = new Set([
+      'alert-1',
+      'alert-2',
+      'alert-3',
+      'alert-4',
+      'alert-5',
+      'alert-6',
+      'alert-7',
+      'alert-8',
+    ]);
+
+    it('does not log info messages', () => {
+      logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+      expect(mockLogger.info).not.toHaveBeenCalled();
+    });
+
+    it('does not log debug messages', () => {
+      logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+      expect(mockLogger.debug).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when discoveries are filtered', () => {
+    describe('with multiple filtered discoveries', () => {
+      const allDiscoveries = [mockDiscovery1, mockDiscovery2, mockDiscovery3];
+      const validDiscoveries = [mockDiscovery1];
+      const existingAlertIds = new Set([
+        'alert-1',
+        'alert-2',
+        'alert-3',
+        // alert-4, alert-5 missing (discovery 2 filtered)
+        // alert-6, alert-7, alert-8 missing (discovery 3 filtered)
+      ]);
+
+      it('logs info message with count of filtered discoveries', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getInfoMessage()).toBe(
+          'Attack discovery: Filtered out 2 discovery(ies) with hallucinated alert IDs'
+        );
+      });
+    });
+
+    describe('with a single filtered discovery', () => {
+      const allDiscoveries = [mockDiscovery1, mockDiscovery2];
+      const validDiscoveries = [mockDiscovery1];
+      const existingAlertIds = new Set([
+        'alert-1',
+        'alert-2',
+        'alert-3',
+        // alert-4, alert-5 missing (discovery 2 filtered)
+      ]);
+
+      it('logs info message with count', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getInfoMessage()).toBe(
+          'Attack discovery: Filtered out 1 discovery(ies) with hallucinated alert IDs'
+        );
+      });
+
+      it('logs debug message once', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(mockLogger.debug).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('debug logging content', () => {
+      const allDiscoveries = [mockDiscovery1, mockDiscovery2];
+      const validDiscoveries = [mockDiscovery1];
+      const existingAlertIds = new Set([
+        'alert-1',
+        'alert-2',
+        'alert-3',
+        // alert-4, alert-5 missing (discovery 2 filtered)
+      ]);
+
+      it('logs discovery title in debug message', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getDebugMessage()).toContain('Discovery 2');
+      });
+
+      it('logs first hallucinated alert ID', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getDebugMessage()).toContain('alert-4');
+      });
+
+      it('logs second hallucinated alert ID', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getDebugMessage()).toContain('alert-5');
+      });
+    });
+
+    describe('with all alert IDs hallucinated', () => {
+      const allDiscoveries = [mockDiscovery1, mockDiscovery2];
+      const validDiscoveries: AttackDiscovery[] = [];
+      const existingAlertIds = new Set<string>([
+        // All alert IDs missing - both discoveries filtered
+      ]);
+
+      it('logs debug messages for each discovery', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      });
+
+      it('logs first discovery hallucinated IDs in JSON format', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getDebugMessage(0)).toContain(JSON.stringify(['alert-1', 'alert-2', 'alert-3']));
+      });
+
+      it('logs second discovery hallucinated IDs in JSON format', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getDebugMessage(1)).toContain(JSON.stringify(['alert-4', 'alert-5']));
+      });
+    });
+
+    describe('with count of hallucinated IDs', () => {
+      const allDiscoveries = [mockDiscovery1, mockDiscovery3];
+      const validDiscoveries: AttackDiscovery[] = [];
+      const existingAlertIds = new Set<string>([
+        // All alert IDs missing - both discoveries filtered
+      ]);
+
+      it('logs count for first discovery', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getDebugMessage(0)).toContain('with 3 hallucinated');
+      });
+
+      it('logs count for second discovery', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getDebugMessage(1)).toContain('with 3 hallucinated');
+      });
+    });
+
+    describe('with partial hallucinated IDs', () => {
+      const allDiscoveries = [mockDiscovery1];
+      const validDiscoveries: AttackDiscovery[] = [];
+      const existingAlertIds = new Set([
+        'alert-1',
+        'alert-2',
+        // alert-3 missing (discovery 1 filtered)
+      ]);
+
+      it('logs count of hallucinated IDs', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getDebugMessage()).toContain('with 1 hallucinated');
+      });
+
+      it('logs the hallucinated alert ID', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getDebugMessage()).toContain(JSON.stringify(['alert-3']));
+      });
+    });
+
+    describe('with custom discovery title', () => {
+      const discoveryWithTitle: AttackDiscovery = {
+        alertIds: ['alert-1'],
+        detailsMarkdown: 'Details',
+        summaryMarkdown: 'Summary',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        title: 'Custom Discovery Title',
+      };
+      const allDiscoveries = [discoveryWithTitle];
+      const validDiscoveries: AttackDiscovery[] = [];
+      const existingAlertIds = new Set<string>([
+        // alert-1 missing (discovery filtered)
+      ]);
+
+      it('logs the custom title in debug message', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getDebugMessage()).toContain('Custom Discovery Title');
+      });
+    });
+
+    describe('lazy evaluation', () => {
+      const allDiscoveries = [mockDiscovery1];
+      const validDiscoveries: AttackDiscovery[] = [];
+      const existingAlertIds = new Set<string>([
+        // All alert IDs missing (discovery filtered)
+      ]);
+
+      it('uses lazy evaluation for debug logging', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(typeof mockLogger.debug.mock.calls[0][0]).toBe('function');
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    describe('with empty arrays', () => {
+      const allDiscoveries: AttackDiscovery[] = [];
+      const validDiscoveries: AttackDiscovery[] = [];
+      const existingAlertIds = new Set<string>([]);
+
+      it('does not log info messages', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(mockLogger.info).not.toHaveBeenCalled();
+      });
+
+      it('does not log debug messages', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(mockLogger.debug).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('with discovery containing empty alertIds', () => {
+      const discoveryWithNoAlerts: AttackDiscovery = {
+        alertIds: [],
+        detailsMarkdown: 'Details',
+        summaryMarkdown: 'Summary',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        title: 'Discovery with no alerts',
+      };
+      const allDiscoveries = [discoveryWithNoAlerts];
+      const validDiscoveries: AttackDiscovery[] = [];
+      const existingAlertIds = new Set<string>([
+        // Discovery has no alert IDs (filtered)
+      ]);
+
+      it('logs info message', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(mockLogger.info).toHaveBeenCalled();
+      });
+
+      it('logs debug message with zero hallucinated count', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getDebugMessage()).toContain('with 0 hallucinated');
+      });
+    });
+
+    describe('when all discoveries are filtered', () => {
+      const allDiscoveries = [mockDiscovery1, mockDiscovery2, mockDiscovery3];
+      const validDiscoveries: AttackDiscovery[] = [];
+      const existingAlertIds = new Set<string>([
+        // All alert IDs missing - all discoveries filtered
+      ]);
+
+      it('logs info message with total count', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(getInfoMessage()).toBe(
+          'Attack discovery: Filtered out 3 discovery(ies) with hallucinated alert IDs'
+        );
+      });
+
+      it('logs debug message for each discovery', () => {
+        logFilteredDiscoveries(mockLogger, allDiscoveries, validDiscoveries, existingAlertIds);
+
+        expect(mockLogger.debug).toHaveBeenCalledTimes(3);
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/log_filtered_discoveries/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/log_filtered_discoveries/index.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { AttackDiscoveries } from '@kbn/elastic-assistant-common';
+
+/**
+ * Logs information about filtered attack discoveries with hallucinated alert IDs.
+ *
+ * @param allDiscoveries - The original array of all attack discoveries
+ * @param validDiscoveries - The filtered array of valid discoveries
+ * @param existingAlertIds - Set of alert IDs that actually exist in Elasticsearch
+ */
+export const logFilteredDiscoveries = (
+  logger: Logger,
+  allDiscoveries: AttackDiscoveries,
+  validDiscoveries: AttackDiscoveries,
+  existingAlertIds: Set<string>
+): void => {
+  const numFiltered = allDiscoveries.length - validDiscoveries.length;
+
+  if (numFiltered === 0) {
+    return;
+  }
+
+  // Log summary at info level
+  logger.info(
+    () => `Attack discovery: Filtered out ${numFiltered} discovery(ies) with hallucinated alert IDs`
+  );
+
+  // Log details at debug level
+  const filteredDiscoveries = allDiscoveries.filter(
+    (discovery) => !validDiscoveries.includes(discovery)
+  );
+
+  filteredDiscoveries.forEach((discovery) => {
+    const hallucinatedIds = discovery.alertIds.filter((alertId) => !existingAlertIds.has(alertId));
+    logger.debug(
+      () =>
+        `Attack discovery: Filtered discovery "${discovery.title}" with ${
+          hallucinatedIds.length
+        } hallucinated alert ID(s): ${JSON.stringify(hallucinatedIds)}`
+    );
+  });
+};

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/log_unverifiable_discoveries/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/log_unverifiable_discoveries/index.test.ts
@@ -1,0 +1,242 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import type { AttackDiscovery } from '@kbn/elastic-assistant-common';
+
+import { logUnverifiableDiscoveries } from '.';
+
+describe('logUnverifiableDiscoveries', () => {
+  const mockLogger = loggerMock.create();
+
+  // Helper to extract the actual message from a lazy-evaluated logger call
+  const getInfoMessage = () => {
+    const call = mockLogger.info.mock.calls[0][0];
+    return typeof call === 'function' ? call() : call;
+  };
+
+  const getDebugMessage = (callIndex: number = 0) => {
+    const call = mockLogger.debug.mock.calls[callIndex][0];
+    return typeof call === 'function' ? call() : call;
+  };
+
+  const mockDiscovery1: AttackDiscovery = {
+    alertIds: ['alert-1', 'alert-2', 'alert-3'],
+    detailsMarkdown: 'Details 1',
+    summaryMarkdown: 'Summary 1',
+    timestamp: '2024-01-01T00:00:00.000Z',
+    title: 'Discovery 1',
+  };
+
+  const mockDiscovery2: AttackDiscovery = {
+    alertIds: ['alert-4', 'alert-5'],
+    detailsMarkdown: 'Details 2',
+    summaryMarkdown: 'Summary 2',
+    timestamp: '2024-01-02T00:00:00.000Z',
+    title: 'Discovery 2',
+  };
+
+  const discoveryWithNoAlerts1: AttackDiscovery = {
+    alertIds: [],
+    detailsMarkdown: 'Details',
+    summaryMarkdown: 'Summary',
+    timestamp: '2024-01-01T00:00:00.000Z',
+    title: 'Discovery with no alerts',
+  };
+
+  const discoveryWithNoAlerts2: AttackDiscovery = {
+    alertIds: [],
+    detailsMarkdown: 'Details 2',
+    summaryMarkdown: 'Summary 2',
+    timestamp: '2024-01-02T00:00:00.000Z',
+    title: 'Another discovery with no alerts',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when no discoveries are unverifiable', () => {
+    const allDiscoveries = [mockDiscovery1, mockDiscovery2];
+    const verifiableDiscoveries = [mockDiscovery1, mockDiscovery2];
+
+    it('does not log an info messages', () => {
+      logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+      expect(mockLogger.info).not.toHaveBeenCalled();
+    });
+
+    it('does not log a debug messages', () => {
+      logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+      expect(mockLogger.debug).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when discoveries are unverifiable', () => {
+    describe('with a single unverifiable discovery', () => {
+      const allDiscoveries = [discoveryWithNoAlerts1, mockDiscovery1];
+      const verifiableDiscoveries = [mockDiscovery1];
+
+      it('logs the expected info message with count', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getInfoMessage()).toBe(
+          'Attack discovery: Filtered out 1 hallucinated discovery(ies) with empty alertIds'
+        );
+      });
+
+      it('logs the expected debug message', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getDebugMessage()).toContain('Discovery with no alerts');
+      });
+    });
+
+    describe('with multiple unverifiable discoveries', () => {
+      const allDiscoveries = [discoveryWithNoAlerts1, mockDiscovery1, discoveryWithNoAlerts2];
+      const verifiableDiscoveries = [mockDiscovery1];
+
+      it('logs the expected info message with count of unverifiable discoveries', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getInfoMessage()).toBe(
+          'Attack discovery: Filtered out 2 hallucinated discovery(ies) with empty alertIds'
+        );
+      });
+
+      it('logs debug messages for each unverifiable discovery', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('debug logging content', () => {
+      const allDiscoveries = [discoveryWithNoAlerts1, mockDiscovery1];
+      const verifiableDiscoveries = [mockDiscovery1];
+
+      it('logs the expected debug message that includes the discovery title', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getDebugMessage()).toContain('Discovery with no alerts');
+      });
+
+      it('mentions empty alertIds in debug message', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getDebugMessage()).toContain('empty alertIds');
+      });
+
+      it('includes the "Filtered discovery" prefix', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getDebugMessage()).toContain('Filtered discovery');
+      });
+    });
+
+    describe('with all discoveries unverifiable', () => {
+      const allDiscoveries = [discoveryWithNoAlerts1, discoveryWithNoAlerts2];
+      const verifiableDiscoveries: AttackDiscovery[] = [];
+
+      it('logs the expected info message with total count', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getInfoMessage()).toBe(
+          'Attack discovery: Filtered out 2 hallucinated discovery(ies) with empty alertIds'
+        );
+      });
+
+      it('logs the expected debug message for the first discovery', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getDebugMessage(0)).toContain('Discovery with no alerts');
+      });
+
+      it('logs the expected debug message for the second discovery', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getDebugMessage(1)).toContain('Another discovery with no alerts');
+      });
+    });
+
+    describe('with custom discovery title', () => {
+      const discoveryWithTitle: AttackDiscovery = {
+        alertIds: [],
+        detailsMarkdown: 'Details',
+        summaryMarkdown: 'Summary',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        title: 'Custom Discovery Title',
+      };
+      const allDiscoveries = [discoveryWithTitle, mockDiscovery1];
+      const verifiableDiscoveries = [mockDiscovery1];
+
+      it('logs the expected debug message that includes the custom title', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getDebugMessage()).toContain('Custom Discovery Title');
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    describe('with empty arrays', () => {
+      const allDiscoveries: AttackDiscovery[] = [];
+      const verifiableDiscoveries: AttackDiscovery[] = [];
+
+      it('does not log an info messages', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(mockLogger.info).not.toHaveBeenCalled();
+      });
+
+      it('does not log a debug messages', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(mockLogger.debug).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when only unverifiable discoveries exist', () => {
+      const allDiscoveries = [discoveryWithNoAlerts1, discoveryWithNoAlerts2];
+      const verifiableDiscoveries: AttackDiscovery[] = [];
+
+      it('logs the expected info message', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getInfoMessage()).toBe(
+          'Attack discovery: Filtered out 2 hallucinated discovery(ies) with empty alertIds'
+        );
+      });
+
+      it('logs a debug message for each unverifiable discovery', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('with mixed verifiable and unverifiable discoveries', () => {
+      const allDiscoveries = [mockDiscovery1, discoveryWithNoAlerts1, mockDiscovery2];
+      const verifiableDiscoveries = [mockDiscovery1, mockDiscovery2];
+
+      it('logs the expected info message with a correct count', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getInfoMessage()).toBe(
+          'Attack discovery: Filtered out 1 hallucinated discovery(ies) with empty alertIds'
+        );
+      });
+
+      it('logs the expected debug message content for the unverifiable discovery', () => {
+        logUnverifiableDiscoveries(mockLogger, allDiscoveries, verifiableDiscoveries);
+
+        expect(getDebugMessage()).toContain('Discovery with no alerts');
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/log_unverifiable_discoveries/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/filter_hallucinated_alerts/log_unverifiable_discoveries/index.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import type { AttackDiscoveries } from '@kbn/elastic-assistant-common';
+
+/**
+ * Logs information about attack discoveries with empty alertIds that cannot be verified.
+ *
+ * @param logger - The logger instance
+ * @param allDiscoveries - The original array of all attack discoveries
+ * @param verifiableDiscoveries - The filtered array of discoveries with non-empty alertIds
+ */
+export const logUnverifiableDiscoveries = (
+  logger: Logger,
+  allDiscoveries: AttackDiscoveries,
+  verifiableDiscoveries: AttackDiscoveries
+): void => {
+  const numUnverifiable = allDiscoveries.length - verifiableDiscoveries.length;
+
+  if (numUnverifiable === 0) {
+    return;
+  }
+
+  // Log summary at info level
+  logger.info(
+    () =>
+      `Attack discovery: Filtered out ${numUnverifiable} hallucinated discovery(ies) with empty alertIds`
+  );
+
+  // Log details at debug level
+  const unverifiableDiscoveries = allDiscoveries.filter(
+    (discovery) => discovery.alertIds.length === 0
+  );
+
+  unverifiableDiscoveries.forEach((discovery) => {
+    logger.debug(
+      () => `Attack discovery: Filtered discovery "${discovery.title}" with empty alertIds`
+    );
+  });
+};


### PR DESCRIPTION
## [Attack discovery] Improves Attack discovery hallucination detection

This PR improves Attack discovery hallucination detection by [implementing a post-generation alert ID verification step](https://github.com/elastic/kibana/issues/246980) that automatically rejects discoveries containing hallucinated (non-existent) alert IDs.

## Details

Some LLMs, especially models designed for faster responses and smaller self-hosted models, generate hallucinated attack discoveries with alert IDs that don't actually exist in Elasticsearch.

Previously, users had to manually detect these hallucinations by clicking the `Alerts` tab on a discovery, which would display `No results match your search criteria` when all alert IDs were hallucinated.

This PR adds an automatic post-generation validation step that queries Elasticsearch to verify all alert IDs in generated discoveries actually exist before persisting them. This enhancement:

1. _Queries Elasticsearch once_ with all unique alert IDs from generated discoveries
2. _Filters out invalid discoveries_ when any alert ID in the discovery doesn't exist in the alerts index

The following example log output illustrates the feature:

```
[2026-01-06T08:57:27.241-05:00][INFO ][plugins.elasticAssistant] Attack discovery: Filtered out 2 discovery(ies) with hallucinated alert IDs
[2026-01-06T08:57:27.242-05:00][DEBUG][plugins.elasticAssistant] Attack discovery: Filtered discovery "Emotet infection via Excel macro" with 2 hallucinated alert ID(s): ["713c38dcd0c89d94ed6b79ac3cc4ca7952f90824b33f2b36db2d27ffff3736eeb","674e188466038b95b5c7f5281ec16fea14ff8591233e5a542a1a5b40e4b76a3779"]
[2026-01-06T08:57:27.242-05:00][DEBUG][plugins.elasticAssistant] Attack discovery: Filtered discovery "Qbot via Office macro and mshta/PowerShell" with 1 hallucinated alert ID(s): ["755c18db0ff150369943e39a361b4c8b7eee0d7ba049ace558db1a923b28fca1d"]
```

In the example log output above, two Attack discoveries, containing 3 hallucinated alert IDs, were filtered out after generation, so they were not persisted.

_PR developed with Cursor + claude-4.5-sonnet_