### PR TITLE
[9.3] [Obs AI] Improvements to tool descriptions and params (#247723)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_alerts/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_alerts/tool.ts
@@ -77,7 +77,14 @@ export function createGetAlertsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getAlertsSchema> = {
     id: OBSERVABILITY_GET_ALERTS_TOOL_ID,
     type: ToolType.builtin,
-    description: `Retrieves Observability alerts within a specified time range. Supports filtering by status (active/recovered) and KQL queries to find specific alert instances.`,
+    description: `Retrieves Observability alerts within a specified time range.
+
+When to use:
+- Checking if there are active alerts for a service or host
+- Investigating what triggered during an incident
+- Finding alerts related to specific infrastructure or services
+
+Supports filtering by status (active/recovered) and KQL queries.`,
     schema: getAlertsSchema,
     tags: ['observability', 'alerts'],
     availability: {
@@ -86,16 +93,15 @@ export function createGetAlertsTool({
         return getAgentBuilderResourceAvailability({ core, request, logger });
       },
     },
-    handler: async (
-      {
+    handler: async (toolParams, { request }) => {
+      const {
         start = DEFAULT_TIME_RANGE.start,
         end = DEFAULT_TIME_RANGE.end,
         kqlFilter,
         includeRecovered,
         query,
-      },
-      { request }
-    ) => {
+      } = toolParams;
+
       try {
         const { alerts, selectedFields, total } = await getToolHandler({
           core,

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_correlated_logs/README.md
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_correlated_logs/README.md
@@ -1,70 +1,54 @@
 # get_correlated_logs
 
-Retrieves logs and their surrounding context based on shared correlation identifiers (e.g. trace.id). Can start from a specific log ID or find error logs within a time range to use as anchors. Returns chronologically sorted groups of logs, providing visibility into the sequence of events leading up to and following the anchor log.
+Retrieves log sequences around error events to understand what happened. By default, anchors on error logs (ERROR, WARN, FATAL, HTTP 5xx). Set `errorLogsOnly: false` to anchor on any (non-error) logs.
 
 ## Examples
 
 ### Find correlated logs for errors in the payment-service
 
-```
+```jsonc
 POST kbn://api/agent_builder/tools/_execute
 {
   "tool_id": "observability.get_correlated_logs",
   "tool_params": {
-    "logsFilter": "service.name: \"payment-service\""
+    "kqlFilter": "service.name: payment-service"
+  }
+}
+```
+
+### Find correlated logs for slow requests (non-errors)
+
+```jsonc
+POST kbn://api/agent_builder/tools/_execute
+{
+  "tool_id": "observability.get_correlated_logs",
+  "tool_params": {
+    "kqlFilter": "service.name: payment-service AND event.duration > 1000000",
+    "errorLogsOnly": false
   }
 }
 ```
 
 ### Find correlated logs for a specific log ID
 
-```
+```jsonc
 POST kbn://api/agent_builder/tools/_execute
 {
   "tool_id": "observability.get_correlated_logs",
   "tool_params": {
-    "logId": "c8f9d2a1-4b3e-4a1c-9d8e-7f6a5b4c3d2e",
-    "index": "logs-payment-service"
+    "logId": "c8f9d2a1-4b3e-4a1c-9d8e-7f6a5b4c3d2e"
   }
 }
 ```
 
-### Limit the returned logs to specific fields only
+### Use custom correlation fields
 
-```
+```jsonc
 POST kbn://api/agent_builder/tools/_execute
 {
   "tool_id": "observability.get_correlated_logs",
   "tool_params": {
-    "start": "now-15m",
-    "end": "now",
-    "logSourceFields": ["@timestamp", "message", "log.level", "service.name"],
-    "maxSequences": 20
-  }
-}
-```
-
-### Specify non-standard correlation identifiers to correlate by
-
-```
-POST kbn://api/agent_builder/tools/_execute
-{
-  "tool_id": "observability.get_correlated_logs",
-  "tool_params": {
-    "correlationFields": ["my_custom_correlation_identifier"]
-  }
-}
-```
-
-### Find correlated logs for non-error events (e.g. slow transactions)
-
-```
-POST kbn://api/agent_builder/tools/_execute
-{
-  "tool_id": "observability.get_correlated_logs",
-  "tool_params": {
-    "logsFilter": "service.name: \"payment-service\"",
-    "interestingEventFilter": "event.duration > 1000000000"
+    "correlationFields": ["my_custom_correlation_id"]
   }
 }
 ```

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_correlated_logs/fetch_anchor_logs/fetch_anchor_logs.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_correlated_logs/fetch_anchor_logs/fetch_anchor_logs.ts
@@ -15,8 +15,8 @@ export async function getAnchorLogs({
   logsIndices,
   startTime,
   endTime,
-  logsFilter,
-  interestingEventFilter,
+  kqlFilter,
+  errorLogsOnly,
   correlationFields,
   logger,
   logId,
@@ -26,8 +26,8 @@ export async function getAnchorLogs({
   logsIndices: string[];
   startTime: number;
   endTime: number;
-  logsFilter: string | undefined;
-  interestingEventFilter: string | undefined;
+  kqlFilter: string | undefined;
+  errorLogsOnly: boolean;
   correlationFields: string[];
   logger: Logger;
   logId?: string;
@@ -49,8 +49,8 @@ export async function getAnchorLogs({
     logsIndices,
     startTime,
     endTime,
-    logsFilter,
-    interestingEventFilter,
+    kqlFilter,
+    errorLogsOnly,
     correlationFields,
     logger,
     maxSequences,

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_correlated_logs/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_correlated_logs/tool.ts
@@ -21,7 +21,7 @@ import {
   DEFAULT_LOG_SOURCE_FIELDS,
 } from './constants';
 import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
-import { getToolHandler } from './handler';
+import { getNoResultsMessage, getToolHandler } from './handler';
 
 export const OBSERVABILITY_GET_CORRELATED_LOGS_TOOL_ID = 'observability.get_correlated_logs';
 
@@ -32,19 +32,19 @@ const getCorrelatedLogsSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Optional ID of a specific log entry. If provided, the tool will fetch this log and find correlated logs based on its correlation identifier (e.g., trace.id). NOTE: When logId is provided, "start", "end", "logsFilter", and "interestingEventFilter" are ignored.'
+      'Optional ID of a specific log entry. If provided, the tool will fetch this log and find correlated logs based on its correlation identifier (e.g., trace.id). NOTE: When logId is provided, other filter parameters are ignored.'
     ),
-  logsFilter: z
+  kqlFilter: z
     .string()
     .optional()
     .describe(
-      'Optional KQL query to filter the scope of logs to search. Example: "service.name: payment AND host.name: web-server-01". Ignored if logId is provided.'
+      'Optional KQL filter to narrow down logs. Example: "service.name: payment AND host.name: web-server-01". Ignored if logId is provided.'
     ),
-  interestingEventFilter: z
-    .string()
+  errorLogsOnly: z
+    .boolean()
     .optional()
     .describe(
-      'Optional KQL query to define what constitutes an "interesting event" - the starting point for correlation. Defaults to matching error logs (ERROR, WARN, FATAL, HTTP 5xx, etc.). Use this to find non-error events (e.g. "event.duration > 1000000" for slow requests) or specific errors. Ignored if logId is provided.'
+      'When true (default), only anchors on error logs (ERROR, WARN, FATAL, HTTP 5xx). Set to false to anchor on any log. For slow requests: kqlFilter="event.duration > 1000000", errorLogsOnly=false.'
     ),
   correlationFields: z
     .array(z.string())
@@ -83,24 +83,21 @@ export function createGetCorrelatedLogsTool({
   const toolDefinition: BuiltinToolDefinition<typeof getCorrelatedLogsSchema> = {
     id: OBSERVABILITY_GET_CORRELATED_LOGS_TOOL_ID,
     type: ToolType.builtin,
-    description: `Retrieves complete log sequences around events of interest (errors, slow requests, anomalies) to understand what happened.
+    description: `Retrieves complete log sequences around error events to understand what happened. By default, anchors on error logs (ERROR, WARN, FATAL, HTTP 5xx). Set errorLogsOnly=false to anchor on non-error events like slow requests.
 
 When to use:
 - Investigating WHY something failed or behaved unexpectedly
-- Understanding the sequence of events leading to an error or incident
+- Understanding the sequence of events leading to an error
 - Following a request/transaction across services using correlation IDs (trace.id, request.id, etc.)
-- An alert fired and you need to understand the root cause
 
 How it works:
-1. Finds "anchor" logs matching your criteria (default: errors with severity ERROR, WARN, FATAL, HTTP 5xx, etc.)
-2. Groups logs by correlation ID - a shared identifier that links related logs across a distributed system
-3. Returns chronologically sorted sequences showing the full story before and after each anchor
-
-Returns: { sequences: [{ correlation: { field, value }, logs: [...] }] }
+1. Finds "anchor" logs (errors by default, or any log if errorLogsOnly=false)
+2. Groups logs by correlation ID (trace.id, request.id, etc.)
+3. Returns chronologically sorted sequences showing context before and after each anchor
 
 Do NOT use for:
-- Getting a high-level overview of log patterns (use get_log_categories)
-- Analyzing why log volume changed (use run_log_rate_analysis)`,
+- High-level overview of log patterns (use get_log_categories)
+- Analyzing log volume changes (use run_log_rate_analysis)`,
     schema: getCorrelatedLogsSchema,
     tags: ['observability', 'logs'],
     availability: {
@@ -109,30 +106,29 @@ Do NOT use for:
         return getAgentBuilderResourceAvailability({ core, request, logger });
       },
     },
-    handler: async (
-      {
+    handler: async (toolParams, { esClient }) => {
+      const {
         start = DEFAULT_TIME_RANGE.start,
         end = DEFAULT_TIME_RANGE.end,
-        logsFilter,
-        interestingEventFilter,
+        kqlFilter,
+        errorLogsOnly = true,
         index,
         correlationFields = DEFAULT_CORRELATION_IDENTIFIER_FIELDS,
         logId,
         logSourceFields = DEFAULT_LOG_SOURCE_FIELDS,
         maxSequences = 10,
         maxLogsPerSequence = 200,
-      },
-      { esClient }
-    ) => {
+      } = toolParams;
+
       try {
-        const { sequences, message } = await getToolHandler({
+        const { sequences } = await getToolHandler({
           core,
           logger,
           esClient,
           start,
           end,
-          logsFilter,
-          interestingEventFilter,
+          kqlFilter,
+          errorLogsOnly,
           index,
           correlationFields,
           logId,
@@ -141,8 +137,31 @@ Do NOT use for:
           maxLogsPerSequence,
         });
 
+        if (sequences.length === 0) {
+          const message = getNoResultsMessage({
+            logId,
+            kqlFilter,
+            errorLogsOnly,
+            correlationFields,
+            start,
+            end,
+          });
+
+          return {
+            results: [
+              {
+                type: ToolResultType.other,
+                data: {
+                  sequences: [],
+                  message,
+                },
+              },
+            ],
+          };
+        }
+
         return {
-          results: [{ type: ToolResultType.other, data: { sequences, message } }],
+          results: [{ type: ToolResultType.other, data: { sequences } }],
         };
       } catch (error) {
         logger.error(`Error fetching errors and surrounding logs: ${error.message}`);

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_hosts/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_hosts/tool.ts
@@ -95,14 +95,16 @@ Returns host names, metrics (CPU percentage, memory usage, disk space, network r
       },
     },
     handler: async (
-      {
+      toolParams,
+      { request }
+    ): Promise<ToolHandlerReturn<GetHostsToolResult | ErrorResult>> => {
+      const {
         start = DEFAULT_TIME_RANGE.start,
         end = DEFAULT_TIME_RANGE.end,
         limit = DEFAULT_LIMIT,
         kqlFilter,
-      },
-      { request }
-    ): Promise<ToolHandlerReturn<GetHostsToolResult | ErrorResult>> => {
+      } = toolParams;
+
       try {
         const { hosts, total } = await getToolHandler({
           request,

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_log_categories/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_log_categories/tool.ts
@@ -81,10 +81,14 @@ Do NOT use for:
         return getAgentBuilderResourceAvailability({ core, request, logger });
       },
     },
-    handler: async (
-      { index, start = DEFAULT_TIME_RANGE.start, end = DEFAULT_TIME_RANGE.end, terms },
-      { esClient }
-    ) => {
+    handler: async (toolParams, { esClient }) => {
+      const {
+        index,
+        start = DEFAULT_TIME_RANGE.start,
+        end = DEFAULT_TIME_RANGE.end,
+        terms,
+      } = toolParams;
+
       try {
         const { highSeverityCategories, lowSeverityCategories } = await getToolHandler({
           core,

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/run_log_rate_analysis/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/run_log_rate_analysis/tool.ts
@@ -81,10 +81,9 @@ Do NOT use for:
         return getAgentBuilderResourceAvailability({ core, request, logger });
       },
     },
-    handler: async (
-      { index, timeFieldName = '@timestamp', baseline, deviation, searchQuery },
-      context
-    ) => {
+    handler: async (toolParams, context) => {
+      const { index, timeFieldName = '@timestamp', baseline, deviation, searchQuery } = toolParams;
+
       try {
         const esClient = context.esClient.asCurrentUser;
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_anomaly_detection_jobs.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_anomaly_detection_jobs.spec.ts
@@ -174,9 +174,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         });
 
       expect(toolResults[0].data.jobs).to.be.empty();
-      expect(toolResults[0].data.message).to.contain(
-        'No anomaly detection jobs found for the provided filters'
-      );
+      expect(toolResults[0].data.total).to.be(0);
     });
 
     it('returns job without anomalies when time range excludes them', async () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_correlated_logs.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_correlated_logs.spec.ts
@@ -78,7 +78,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           params: {
             start: 'now-10m',
             end: 'now',
-            logsFilter: 'service.name: "payment-service"',
+            kqlFilter: 'service.name: "payment-service"',
           },
         });
 
@@ -97,7 +97,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           params: {
             start: 'now-10m',
             end: 'now',
-            logsFilter: 'service.name: "payment-service"',
+            kqlFilter: 'service.name: "payment-service"',
           },
         });
 
@@ -119,7 +119,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           params: {
             start: 'now-10m',
             end: 'now',
-            logsFilter: 'service.name: "non-existing-service"',
+            kqlFilter: 'service.name: "non-existing-service"',
           },
         });
 
@@ -153,7 +153,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           params: {
             start: 'now-10m',
             end: 'now',
-            logsFilter: 'service.name: "checkout-service"',
+            kqlFilter: 'service.name: "checkout-service"',
           },
         });
 
@@ -167,7 +167,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           params: {
             start: 'now-10m',
             end: 'now',
-            logsFilter: 'service.name: "checkout-service"',
+            kqlFilter: 'service.name: "checkout-service"',
           },
         });
 
@@ -222,7 +222,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           params: {
             start: 'now-10m',
             end: 'now',
-            logsFilter: 'service.name: "multi-service"',
+            kqlFilter: 'service.name: "multi-service"',
           },
         });
 
@@ -236,7 +236,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           params: {
             start: 'now-10m',
             end: 'now',
-            logsFilter: 'service.name: "multi-service"',
+            kqlFilter: 'service.name: "multi-service"',
           },
         });
 
@@ -292,15 +292,13 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           params: {
             start: 'now-10m',
             end: 'now',
-            logsFilter: 'service.name: "no-correlation-service"',
+            kqlFilter: 'service.name: "no-correlation-service"',
           },
         });
 
         const { sequences, message } = results[0].data;
         expect(sequences.length).to.be(0);
-        expect(message).to.contain('No log sequences found');
-        expect(message).to.contain('No matching logs exist in this time range');
-        expect(message).to.contain('`logsFilter` is too restrictive');
+        expect(message).to.contain('No log sequences found.');
       });
     });
 
@@ -333,7 +331,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           params: {
             start: 'now-10m',
             end: 'now',
-            logsFilter: 'service.name: "service-a"',
+            kqlFilter: 'service.name: "service-a"',
           },
         });
 
@@ -408,7 +406,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             params: {
               start: 'now-10m',
               end: 'now',
-              logsFilter: `service.name: "${service}"`,
+              kqlFilter: `service.name: "${service}"`,
             },
           });
 
@@ -444,7 +442,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           params: {
             start: 'now-10m',
             end: 'now',
-            logsFilter: 'service.name: "priority-service"',
+            kqlFilter: 'service.name: "priority-service"',
           },
         });
 
@@ -505,7 +503,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             params: {
               start: 'now-10m',
               end: 'now',
-              logsFilter: `service.name: "${service}"`,
+              kqlFilter: `service.name: "${service}"`,
             },
           });
 
@@ -636,7 +634,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             params: {
               start: 'now-10m',
               end: 'now',
-              logsFilter: `service.name: "${service}"`,
+              kqlFilter: `service.name: "${service}"`,
             },
           });
 
@@ -732,7 +730,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           params: {
             start: 'now-10m',
             end: 'now',
-            logsFilter: 'service.name: "fields-service"',
+            kqlFilter: 'service.name: "fields-service"',
             logSourceFields: ['message', 'service.name'],
           },
         });
@@ -776,7 +774,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             params: {
               start: 'now-10m',
               end: 'now',
-              logsFilter: 'service.name: "limit-service"',
+              kqlFilter: 'service.name: "limit-service"',
               maxSequences: 3,
             },
           });
@@ -820,7 +818,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             params: {
               start: 'now-10m',
               end: 'now',
-              logsFilter: 'service.name: "limit-logs-service"',
+              kqlFilter: 'service.name: "limit-logs-service"',
               maxLogsPerSequence: 5,
             },
           });
@@ -866,7 +864,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           params: {
             start: 'now-5m',
             end: 'now',
-            logsFilter: 'service.name: "starvation-service"',
+            kqlFilter: 'service.name: "starvation-service"',
             maxSequences: 10,
           },
         });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Obs AI] Improvements to tool descriptions and params (#247723)](https://github.com/elastic/kibana/pull/247723)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Søren Louv-Jansen","email":"soren.louv@elastic.co"},"sourceCommit":{"committedDate":"2026-01-05T11:39:27Z","message":"[Obs AI] Improvements to tool descriptions and params (#247723)\n\nThis PR makes various improvements the o11y tools: better descriptions,\nsummary, and consistent terminology.\n\n### Enhanced descriptions\nAdded \"When to use\" guidance to help the LLM select the right tool\n(`get_alerts`, `get_anomaly_detection_jobs`, `get_correlated_logs`,\n`get_downstream_dependencies`, `get_services`)\n\n### Simplified `get_correlated_logs` API\n  - `logsFilter` → `kqlFilter` (consistent with other tools)\n  - `interestingEventFilter` → `errorLogsOnly`\n\n### Optional time range\n`get_downstream_dependencies` and `get_services` now defaults to last\nhour instead of requiring a time range\n\n---------\n\nCo-authored-by: Arturo Lidueña <arturo.liduena@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6082c4acdeb95d493794a1e6b892fb7d61f7d823","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.3.0","v9.4.0"],"title":"[Obs AI] Improvements to tool descriptions and params","number":247723,"url":"https://github.com/elastic/kibana/pull/247723","mergeCommit":{"message":"[Obs AI] Improvements to tool descriptions and params (#247723)\n\nThis PR makes various improvements the o11y tools: better descriptions,\nsummary, and consistent terminology.\n\n### Enhanced descriptions\nAdded \"When to use\" guidance to help the LLM select the right tool\n(`get_alerts`, `get_anomaly_detection_jobs`, `get_correlated_logs`,\n`get_downstream_dependencies`, `get_services`)\n\n### Simplified `get_correlated_logs` API\n  - `logsFilter` → `kqlFilter` (consistent with other tools)\n  - `interestingEventFilter` → `errorLogsOnly`\n\n### Optional time range\n`get_downstream_dependencies` and `get_services` now defaults to last\nhour instead of requiring a time range\n\n---------\n\nCo-authored-by: Arturo Lidueña <arturo.liduena@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6082c4acdeb95d493794a1e6b892fb7d61f7d823"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247723","number":247723,"mergeCommit":{"message":"[Obs AI] Improvements to tool descriptions and params (#247723)\n\nThis PR makes various improvements the o11y tools: better descriptions,\nsummary, and consistent terminology.\n\n### Enhanced descriptions\nAdded \"When to use\" guidance to help the LLM select the right tool\n(`get_alerts`, `get_anomaly_detection_jobs`, `get_correlated_logs`,\n`get_downstream_dependencies`, `get_services`)\n\n### Simplified `get_correlated_logs` API\n  - `logsFilter` → `kqlFilter` (consistent with other tools)\n  - `interestingEventFilter` → `errorLogsOnly`\n\n### Optional time range\n`get_downstream_dependencies` and `get_services` now defaults to last\nhour instead of requiring a time range\n\n---------\n\nCo-authored-by: Arturo Lidueña <arturo.liduena@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6082c4acdeb95d493794a1e6b892fb7d61f7d823"}}]}] BACKPORT-->