### PR TITLE
[scripts/otel_demo] unflatten config and pass kibana basePath

### DIFF
--- a/src/platform/packages/shared/kbn-otel-demo/moon.yml
+++ b/src/platform/packages/shared/kbn-otel-demo/moon.yml
@@ -21,6 +21,7 @@ dependsOn:
   - '@kbn/tooling-log'
   - '@kbn/dev-cli-runner'
   - '@kbn/repo-info'
+  - '@kbn/object-utils'
 tags:
   - shared-server
   - package

--- a/src/platform/packages/shared/kbn-otel-demo/src/ensure_otel_demo.ts
+++ b/src/platform/packages/shared/kbn-otel-demo/src/ensure_otel_demo.ts
@@ -125,7 +125,7 @@ export async function ensureOtelDemo({
   const elasticsearchUsername = elasticsearchConfig.username;
   const elasticsearchPassword = elasticsearchConfig.password;
 
-  const kibanaUrl = `http://${serverConfig.host}:${serverConfig.port}`;
+  const kibanaUrl = `http://${serverConfig.host}:${serverConfig.port}${serverConfig.basePath}`;
 
   log.info(`Kibana: ${kibanaUrl}`);
   log.info(`Elasticsearch: ${elasticsearchHost}`);

--- a/src/platform/packages/shared/kbn-otel-demo/src/read_kibana_config.ts
+++ b/src/platform/packages/shared/kbn-otel-demo/src/read_kibana_config.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ToolingLog } from '@kbn/tooling-log';
+import { unflattenObject } from '@kbn/object-utils';
 import fs from 'fs';
 import yaml from 'js-yaml';
 import { pickBy, identity } from 'lodash';
@@ -22,6 +23,7 @@ interface ElasticsearchConfig {
 interface KibanaServerConfig {
   host: string;
   port: number;
+  basePath: string;
 }
 
 interface KibanaConfig {
@@ -41,10 +43,11 @@ export const readKibanaConfig = (log: ToolingLog, configPath?: string): KibanaCo
   let serverConfigValues = {};
 
   if (fs.existsSync(configPathToUse)) {
-    const config = (yaml.load(fs.readFileSync(configPathToUse, 'utf8')) || {}) as Record<
+    const loaded = (yaml.load(fs.readFileSync(configPathToUse, 'utf8')) || {}) as Record<
       string,
       any
     >;
+    const config = unflattenObject(loaded);
     esConfigValues = config.elasticsearch || {};
     serverConfigValues = config.server || {};
   } else {
@@ -82,6 +85,7 @@ export const readKibanaConfig = (log: ToolingLog, configPath?: string): KibanaCo
   const serverConfig = {
     host: 'localhost',
     port: 5601,
+    basePath: '',
     ...serverConfigValues,
     ...serverEnvOverrides,
   };

--- a/src/platform/packages/shared/kbn-otel-demo/tsconfig.json
+++ b/src/platform/packages/shared/kbn-otel-demo/tsconfig.json
@@ -10,6 +10,7 @@
     "@kbn/tooling-log",
     "@kbn/dev-cli-runner",
     "@kbn/repo-info",
+    "@kbn/object-utils",
   ]
 }
 


### PR DESCRIPTION
## Summary

- we didn't consider the basePath when constructing the kibana url
- the parsed kibana yaml config was kept as-is, so flattened keys like `server.basePath: /foo` would not be defined in the `parsedConfig.server` object


