### PR TITLE
[Obs Agent] fix failing test: get_log_change_points

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_log_change_points.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_log_change_points.spec.ts
@@ -104,12 +104,12 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
       it('should still detect changes without an explicit index', () => {
         expect(logChangePoints.length).to.be.greaterThan(0);
-        const change = logChangePoints.find((cp: ChangePoint) =>
+        const hasChange = logChangePoints.some((cp: ChangePoint) =>
           ['spike', 'dip', 'step_change', 'trend_change', 'distribution_change'].includes(
             cp.changes?.type as string
           )
         );
-        expect(change).to.be.ok();
+        expect(hasChange).to.be(true);
       });
     });
 
@@ -131,12 +131,12 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       });
 
       it('should not detect changes when only stable info logs are included', () => {
-        const change = logChangePoints.find((cp: ChangePoint) =>
+        const hasChange = logChangePoints.some((cp: ChangePoint) =>
           ['spike', 'dip', 'step_change', 'trend_change', 'distribution_change'].includes(
             cp.changes?.type
           )
         );
-        expect(change).to.be(undefined);
+        expect(hasChange).to.be(false);
       });
 
       it('should still detect stationary patterns in info logs', () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_log_change_points.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_log_change_points.spec.ts
@@ -64,19 +64,23 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         expect(logChangePoints.length).to.be.greaterThan(0);
       });
 
-      it('should detect spike in error logs', () => {
+      it('should detect a change in error logs', () => {
         expect(logChangePoints.length).to.be.greaterThan(0);
-        const spike = logChangePoints.find((cp: ChangePoint) => cp.changes?.type === 'spike');
-        expect(spike).to.be.ok();
-        expect(spike).to.have.property('timeSeries');
-        expect(spike?.timeSeries?.length).to.be.greaterThan(0);
-        expect(spike?.timeSeries?.[0]).to.have.property('x');
-        expect(spike?.timeSeries?.[0]).to.have.property('y');
+        const change = logChangePoints.find((cp: ChangePoint) =>
+          ['spike', 'dip', 'step_change', 'trend_change', 'distribution_change'].includes(
+            cp.changes?.type
+          )
+        );
+        expect(change).to.be.ok();
+        expect(change).to.have.property('timeSeries');
+        expect(change?.timeSeries?.length).to.be.greaterThan(0);
+        expect(change?.timeSeries?.[0]).to.have.property('x');
+        expect(change?.timeSeries?.[0]).to.have.property('y');
       });
 
-      it('should detect stationary patterns in logs', () => {
-        const stationary = logChangePoints.find(
-          (cp: ChangePoint) => cp.changes?.type === 'stationary'
+      it('should detect no change patterns in logs', () => {
+        const stationary = logChangePoints.find((cp: ChangePoint) =>
+          ['stationary', 'indeterminable', 'non_stationary'].includes(cp.changes?.type)
         );
         expect(stationary).to.be.ok();
         expect(stationary).not.to.have.property('timeSeries');
@@ -98,10 +102,14 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         logChangePoints = toolResults[0]?.data?.changePoints ?? [];
       });
 
-      it('should still detect spikes without an explicit index', () => {
+      it('should still detect changes without an explicit index', () => {
         expect(logChangePoints.length).to.be.greaterThan(0);
-        const spike = logChangePoints.find((cp: ChangePoint) => cp.changes?.type === 'spike');
-        expect(spike).to.be.ok();
+        const change = logChangePoints.find((cp: ChangePoint) =>
+          ['spike', 'dip', 'step_change', 'trend_change', 'distribution_change'].includes(
+            cp.changes?.type as string
+          )
+        );
+        expect(change).to.be.ok();
       });
     });
 
@@ -122,14 +130,18 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         logChangePoints = toolResults[0]?.data?.changePoints ?? [];
       });
 
-      it('should not report spikes when only stable info logs are included', () => {
-        const spike = logChangePoints.find((cp: ChangePoint) => cp.changes?.type === 'spike');
-        expect(spike).to.be(undefined);
+      it('should not detect changes when only stable info logs are included', () => {
+        const change = logChangePoints.find((cp: ChangePoint) =>
+          ['spike', 'dip', 'step_change', 'trend_change', 'distribution_change'].includes(
+            cp.changes?.type
+          )
+        );
+        expect(change).to.be(undefined);
       });
 
-      it('should still report stationary patterns in info logs', () => {
-        const stationary = logChangePoints.find(
-          (cp: ChangePoint) => cp.changes?.type === 'stationary'
+      it('should still detect stationary patterns in info logs', () => {
+        const stationary = logChangePoints.find((cp: ChangePoint) =>
+          ['stationary', 'indeterminable', 'non_stationary'].includes(cp.changes?.type)
         );
         expect(stationary).to.be.ok();
       });

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_log_change_points.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_log_change_points.spec.ts
@@ -78,9 +78,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         expect(change?.timeSeries?.[0]).to.have.property('y');
       });
 
-      it('should detect no change patterns in logs', () => {
-        const stationary = logChangePoints.find((cp: ChangePoint) =>
-          ['stationary', 'indeterminable', 'non_stationary'].includes(cp.changes?.type)
+      it('should detect stationary patterns in logs', () => {
+        const stationary = logChangePoints.find(
+          (cp: ChangePoint) => cp.changes?.type === 'stationary'
         );
         expect(stationary).to.be.ok();
         expect(stationary).not.to.have.property('timeSeries');
@@ -140,10 +140,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       });
 
       it('should still detect stationary patterns in info logs', () => {
-        const stationary = logChangePoints.find((cp: ChangePoint) =>
-          ['stationary', 'indeterminable', 'non_stationary'].includes(cp.changes?.type)
+        const stationary = logChangePoints.some(
+          (cp: ChangePoint) => cp.changes?.type === 'stationary'
         );
-        expect(stationary).to.be.ok();
+        expect(stationary).to.be(true);
       });
     });
   });


### PR DESCRIPTION
## Summary

fix `get_log_change_points` tool failing test 

Closes https://github.com/elastic/kibana/issues/247819
Closes https://github.com/elastic/kibana/issues/247896





<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->