### PR TITLE
[Security Solution][Attacks] Wire-in assignee filter into attack's query

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/content.tsx
@@ -157,7 +157,12 @@ export const AttacksPageContent = React.memo(({ dataView }: AttacksPageContentPr
           <EuiSpacer size="l" />
         </Display>
 
-        <TableSection dataView={dataView} statusFilter={statusFilter} pageFilters={pageFilters} />
+        <TableSection
+          dataView={dataView}
+          statusFilter={statusFilter}
+          pageFilters={pageFilters}
+          assignees={assignees}
+        />
 
         {showFlyout && <SchedulesFlyout onClose={onClose} />}
       </SecuritySolutionPageWrapper>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.test.tsx
@@ -38,6 +38,13 @@ const mockUseGetDefaultGroupTitleRenderers = useGetDefaultGroupTitleRenderers as
 const mockUseAttackGroupHandler = useAttackGroupHandler as jest.Mock;
 const mockGroupedAlertsTable = GroupedAlertsTable as unknown as jest.Mock;
 
+const defaultProps: Parameters<typeof TableSection>[0] = {
+  assignees: [],
+  pageFilters: [],
+  statusFilter: [],
+  dataView,
+};
+
 describe('<TableSection />', () => {
   beforeEach(() => {
     mockUseGetDefaultGroupTitleRenderers.mockReturnValue({
@@ -71,7 +78,7 @@ describe('<TableSection />', () => {
   it('should render correctly', async () => {
     const { getByTestId } = render(
       <TestProviders>
-        <TableSection statusFilter={[]} pageFilters={[]} dataView={dataView} />
+        <TableSection {...defaultProps} />
       </TestProviders>
     );
 
@@ -89,7 +96,7 @@ describe('<TableSection />', () => {
 
     render(
       <TestProviders>
-        <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+        <TableSection {...defaultProps} />
       </TestProviders>
     );
 
@@ -105,7 +112,7 @@ describe('<TableSection />', () => {
   it('should pass groupingOptions and groupingSettings to GroupedAlertsTable', async () => {
     render(
       <TestProviders>
-        <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+        <TableSection {...defaultProps} />
       </TestProviders>
     );
 
@@ -129,7 +136,7 @@ describe('<TableSection />', () => {
 
     render(
       <TestProviders>
-        <TableSection pageFilters={[]} statusFilter={[]} dataView={dataView} />
+        <TableSection {...defaultProps} />
       </TestProviders>
     );
 
@@ -170,7 +177,7 @@ describe('<TableSection />', () => {
 
     render(
       <TestProviders>
-        <TableSection pageFilters={[]} statusFilter={[]} dataView={dataView} />
+        <TableSection {...defaultProps} />
       </TestProviders>
     );
 
@@ -211,7 +218,7 @@ describe('<TableSection />', () => {
 
     render(
       <TestProviders>
-        <TableSection statusFilter={[]} pageFilters={[]} dataView={dataView} />
+        <TableSection {...defaultProps} />
       </TestProviders>
     );
 
@@ -233,7 +240,7 @@ describe('<TableSection />', () => {
 
     render(
       <TestProviders>
-        <TableSection statusFilter={[]} pageFilters={[]} dataView={dataView} />
+        <TableSection {...defaultProps} />
       </TestProviders>
     );
 
@@ -258,7 +265,7 @@ describe('<TableSection />', () => {
     it('should render the show anonymized switch', async () => {
       const { getByTestId } = render(
         <TestProviders>
-          <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+          <TableSection {...defaultProps} />
         </TestProviders>
       );
 
@@ -270,7 +277,7 @@ describe('<TableSection />', () => {
     it('should render the switch as unchecked by default', async () => {
       const { getByTestId } = render(
         <TestProviders>
-          <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+          <TableSection {...defaultProps} />
         </TestProviders>
       );
 
@@ -285,7 +292,7 @@ describe('<TableSection />', () => {
     it('should toggle the switch state when clicked', async () => {
       const { getByTestId } = render(
         <TestProviders>
-          <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+          <TableSection {...defaultProps} />
         </TestProviders>
       );
 
@@ -312,7 +319,7 @@ describe('<TableSection />', () => {
     it('should pass the switch in additionalToolbarControls to GroupedAlertsTable', async () => {
       render(
         <TestProviders>
-          <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+          <TableSection {...defaultProps} />
         </TestProviders>
       );
 
@@ -330,7 +337,7 @@ describe('<TableSection />', () => {
     it('should pass showAnonymized=false to useGetDefaultGroupTitleRenderers by default', async () => {
       render(
         <TestProviders>
-          <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+          <TableSection {...defaultProps} />
         </TestProviders>
       );
 
@@ -346,7 +353,7 @@ describe('<TableSection />', () => {
     it('should pass showAnonymized=true to useGetDefaultGroupTitleRenderers when switch is toggled on', async () => {
       const { getByTestId } = render(
         <TestProviders>
-          <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+          <TableSection {...defaultProps} />
         </TestProviders>
       );
 
@@ -378,7 +385,7 @@ describe('<TableSection />', () => {
     it('should update showAnonymized back to false when switch is toggled off', async () => {
       const { getByTestId } = render(
         <TestProviders>
-          <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+          <TableSection {...defaultProps} />
         </TestProviders>
       );
 
@@ -418,7 +425,7 @@ describe('<TableSection />', () => {
     it('should pass all grouping settings including enforcedGroups', async () => {
       render(
         <TestProviders>
-          <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+          <TableSection {...defaultProps} />
         </TestProviders>
       );
 
@@ -439,7 +446,7 @@ describe('<TableSection />', () => {
     it('should return an empty array for null group buckets', async () => {
       render(
         <TestProviders>
-          <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+          <TableSection {...defaultProps} />
         </TestProviders>
       );
 
@@ -464,7 +471,7 @@ describe('<TableSection />', () => {
     it('should return an expand button for non-null grouping buckets', async () => {
       render(
         <TestProviders>
-          <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+          <TableSection {...defaultProps} />
         </TestProviders>
       );
 
@@ -491,7 +498,7 @@ describe('<TableSection />', () => {
     it('should return an empty array for non-grouping buckets', async () => {
       render(
         <TestProviders>
-          <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+          <TableSection {...defaultProps} />
         </TestProviders>
       );
 
@@ -517,7 +524,7 @@ describe('<TableSection />', () => {
 
       render(
         <TestProviders>
-          <TableSection dataView={dataView} statusFilter={[]} pageFilters={[]} />
+          <TableSection {...defaultProps} />
         </TestProviders>
       );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
@@ -26,6 +26,7 @@ import { inputsSelectors } from '../../../../common/store/inputs';
 import { useUserData } from '../../user_info';
 import { useListsConfig } from '../../../containers/detection_engine/lists/use_lists_config';
 import {
+  buildAlertAssigneesFilter,
   buildShowBuildingBlockFilter,
   buildThreatMatchFilter,
 } from '../../alerts_table/default_config';
@@ -38,6 +39,7 @@ import { useAttackGroupHandler } from '../../../hooks/attacks/use_attack_group_h
 import { AttackDetailsContainer } from './attack_details/attack_details_container';
 import { groupingOptions, groupingSettings } from './grouping_configs';
 import * as i18n from './translations';
+import type { AssigneesIdsSelection } from '../../../../common/components/assignees/types';
 
 export const TABLE_SECTION_TEST_ID = 'attacks-page-table-section';
 export const EXPAND_ATTACK_BUTTON_TEST_ID = 'expand-attack-button';
@@ -57,13 +59,18 @@ export interface TableSectionProps {
    * The page filters retrieved from the FiltersSection component to filter the table
    */
   pageFilters: Filter[] | undefined;
+
+  /**
+   * The list of assignees to add to the others filters
+   */
+  assignees: AssigneesIdsSelection[];
 }
 
 /**
  * Renders the alerts table with grouping functionality in the attacks page.
  */
 export const TableSection = React.memo(
-  ({ dataView, statusFilter, pageFilters }: TableSectionProps) => {
+  ({ dataView, statusFilter, pageFilters, assignees }: TableSectionProps) => {
     const getGlobalFiltersQuerySelector = useMemo(
       () => inputsSelectors.globalFiltersQuerySelector(),
       []
@@ -130,8 +137,9 @@ export const TableSection = React.memo(
         ...buildShowBuildingBlockFilter(showBuildingBlockAlerts),
         ...buildThreatMatchFilter(showOnlyThreatIndicatorAlerts),
         ...(pageFilters ?? []),
+        ...buildAlertAssigneesFilter(assignees),
       ],
-      [showBuildingBlockAlerts, showOnlyThreatIndicatorAlerts, pageFilters]
+      [showBuildingBlockAlerts, showOnlyThreatIndicatorAlerts, pageFilters, assignees]
     );
 
     const isLoading = useMemo(


### PR DESCRIPTION
## Summary

Up until this point the assignee filter in the new attacks page was just for show, it wasn't really doing anything.
In this PR, we connect it to the page in order to actually filter the results.


https://github.com/user-attachments/assets/efbc80e2-267b-4acb-80e9-a177aa87da12

