### PR TITLE
[kbn/synthtrace] speed up data ingestion

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/global.setup.ts
@@ -21,6 +21,7 @@ globalSetupHook(
   'Ingest data to Elasticsearch',
   { tag: ['@ess', '@svlOblt'] },
   async ({ apmSynthtraceEsClient, apiServices, log, config, esClient }) => {
+    const startTime = Date.now();
     if (!config.isCloud) {
       await apiServices.fleet.internal.setup();
       log.info('Fleet infrastructure setup completed');
@@ -83,5 +84,6 @@ globalSetupHook(
       await esClient.ml.deleteJob({ job_id: job.job_id, force: true });
       log.info(`Deleted job: ${job.job_id}`);
     }
+    log.info(`APM data ingestion took ${Date.now() - startTime} ms`);
   }
 );


### PR DESCRIPTION
## Summary

Experimenting to speed up data ingestion with synthtrace.

Tests against MKI Oblt project (QA env) using Scout APM hook with multiple synthrace calls:

https://github.com/elastic/kibana/blob/16ef87746eb9757088f111cc31c1f67cb6a2af11/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/global.setup.ts#L35-L69

```
node scripts/scout run-tests --serverless=oblt --testTarget=cloud --config x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel.playwright.config.ts --debug
```

| Attempt | Before | After |
--- | --- | ---
| run 1 | 98398 | 57241 |
| run 2 | 95685 | 56398 |
| run 3 | 113251 | 59065 |