### PR TITLE
[Cloud Security] Cloud connector switch in usage flyout

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/test_subjects.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/common/test_subjects.ts
@@ -98,4 +98,18 @@ export const CLOUD_CONNECTOR_POLICIES_FLYOUT_TEST_SUBJECTS = {
   POLICY_LINK: 'cloudConnectorPolicyLink',
   EMPTY_STATE: 'cloudConnectorPoliciesEmptyState',
   ERROR_STATE: 'cloudConnectorPoliciesErrorState',
+  POLICY_ACTIONS_BUTTON: 'policyActionsButton',
+  SWITCH_CONNECTOR_MENU_ITEM: 'switchConnectorMenuItem',
+  VIEW_POLICY_MENU_ITEM: 'viewPolicyMenuItem',
+};
+
+export const SWITCH_CONNECTOR_MODAL_TEST_SUBJECTS = {
+  MODAL: 'switchConnectorModal',
+  TITLE: 'switchConnectorModalTitle',
+  POLICY_NAME: 'switchConnectorModalPolicyName',
+  CURRENT_CONNECTOR_NAME: 'switchConnectorModalCurrentConnectorName',
+  WARNING_CALLOUT: 'switchConnectorModalWarningCallout',
+  NO_CONNECTORS_CALLOUT: 'switchConnectorModalNoConnectorsCallout',
+  CANCEL_BUTTON: 'switchConnectorModalCancelButton',
+  SWITCH_BUTTON: 'switchConnectorModalSwitchButton',
 };

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/aws_credentials_form/aws_credentials_form_agentless.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/aws_credentials_form/aws_credentials_form_agentless.tsx
@@ -54,6 +54,7 @@ import { CloudConnectorSetup } from '../cloud_connector/cloud_connector_setup';
 
 interface AwsAgentlessFormProps {
   cloud: CloudSetup;
+  packagePolicyId?: string;
   input: NewPackagePolicyInput;
   newPolicy: NewPackagePolicy;
   packageInfo: PackageInfo;
@@ -131,6 +132,7 @@ const getCloudFormationConfig = (
 // TODO: Extract cloud connector logic into separate component
 export const AwsCredentialsFormAgentless = ({
   cloud,
+  packagePolicyId,
   input,
   newPolicy,
   packageInfo,
@@ -339,6 +341,7 @@ export const AwsCredentialsFormAgentless = ({
       {awsCredentialsType === AWS_CREDENTIALS_TYPE.CLOUD_CONNECTORS && (
         <CloudConnectorSetup
           templateName={templateName}
+          packagePolicyId={packagePolicyId}
           input={input}
           newPolicy={newPolicy}
           packageInfo={packageInfo}

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/azure_credentials_form/azure_credentials_form_agentless.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/azure_credentials_form/azure_credentials_form_agentless.tsx
@@ -39,6 +39,7 @@ import { AzureCredentialTypeSelector } from './azure_credential_type_selector';
 import { CloudConnectorSetup } from '../cloud_connector/cloud_connector_setup';
 
 interface AzureCredentialsFormProps {
+  packagePolicyId?: string;
   newPolicy: NewPackagePolicy;
   input: NewPackagePolicyInput;
   updatePolicy: UpdatePolicy;
@@ -65,6 +66,7 @@ const getCloudConnectorCredentialOptions = (
 };
 
 export const AzureCredentialsFormAgentless = ({
+  packagePolicyId,
   input,
   newPolicy,
   updatePolicy,
@@ -147,6 +149,7 @@ export const AzureCredentialsFormAgentless = ({
       )}
       {azureCredentialsType === 'cloud_connectors' && isAzureCloudConnectorEnabled ? (
         <CloudConnectorSetup
+          packagePolicyId={packagePolicyId}
           input={input}
           newPolicy={newPolicy}
           packageInfo={packageInfo}

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/aws_cloud_connector/aws_reusable_connector_form.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/aws_cloud_connector/aws_reusable_connector_form.tsx
@@ -17,7 +17,8 @@ export const AWSReusableConnectorForm: React.FC<{
   isEditPage: boolean;
   credentials: AwsCloudConnectorCredentials;
   setCredentials: (credentials: AwsCloudConnectorCredentials) => void;
-}> = ({ credentials, setCredentials, isEditPage, cloudConnectorId }) => {
+  packagePolicyId?: string;
+}> = ({ credentials, setCredentials, isEditPage, cloudConnectorId, packagePolicyId }) => {
   return (
     <>
       <EuiSpacer size="m" />
@@ -33,6 +34,7 @@ export const AWSReusableConnectorForm: React.FC<{
         cloudConnectorId={cloudConnectorId}
         credentials={credentials}
         setCredentials={setCredentials}
+        packagePolicyId={packagePolicyId}
       />
       <EuiSpacer size="m" />
     </>

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/azure_cloud_connector/azure_reusable_connector_form.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/azure_cloud_connector/azure_reusable_connector_form.test.tsx
@@ -230,4 +230,39 @@ describe('AzureReusableConnectorForm', () => {
       });
     });
   });
+
+  describe('packagePolicyId prop', () => {
+    it('renders form correctly with packagePolicyId', () => {
+      renderWithIntl(<AzureReusableConnectorForm {...defaultProps} packagePolicyId="policy-123" />);
+
+      // Verify form elements render correctly
+      expect(screen.getByText(/To streamline your Azure integration process/i)).toBeInTheDocument();
+      expect(screen.getByTestId(AZURE_CLOUD_CONNECTOR_SUPER_SELECT_TEST_SUBJ)).toBeInTheDocument();
+    });
+
+    it('renders form correctly without packagePolicyId', () => {
+      renderWithIntl(<AzureReusableConnectorForm {...defaultProps} />);
+
+      // Verify form elements render correctly without the prop
+      expect(screen.getByText(/To streamline your Azure integration process/i)).toBeInTheDocument();
+      expect(screen.getByTestId(AZURE_CLOUD_CONNECTOR_SUPER_SELECT_TEST_SUBJ)).toBeInTheDocument();
+    });
+
+    it('allows connector selection with packagePolicyId', async () => {
+      renderWithIntl(<AzureReusableConnectorForm {...defaultProps} packagePolicyId="policy-123" />);
+
+      const comboBox = screen.getByTestId(AZURE_CLOUD_CONNECTOR_SUPER_SELECT_TEST_SUBJ);
+      await userEvent.click(comboBox);
+
+      const connectorOption = await screen.findByText('Azure Connector 1');
+      await userEvent.click(connectorOption);
+
+      expect(mockSetCredentials).toHaveBeenCalledWith({
+        tenantId: 'tenant-123',
+        clientId: 'client-456',
+        azure_credentials_cloud_connector_id: 'azure-cc-789',
+        cloudConnectorId: 'connector-1',
+      });
+    });
+  });
 });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/azure_cloud_connector/azure_reusable_connector_form.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/azure_cloud_connector/azure_reusable_connector_form.tsx
@@ -17,7 +17,8 @@ export const AzureReusableConnectorForm: React.FC<{
   isEditPage: boolean;
   credentials: AzureCloudConnectorCredentials;
   setCredentials: (credentials: AzureCloudConnectorCredentials) => void;
-}> = ({ credentials, setCredentials, isEditPage, cloudConnectorId }) => {
+  packagePolicyId?: string;
+}> = ({ credentials, setCredentials, isEditPage, cloudConnectorId, packagePolicyId }) => {
   return (
     <>
       <EuiSpacer size="m" />
@@ -33,6 +34,7 @@ export const AzureReusableConnectorForm: React.FC<{
         cloudConnectorId={cloudConnectorId}
         credentials={credentials}
         setCredentials={setCredentials}
+        packagePolicyId={packagePolicyId}
       />
       <EuiSpacer size="m" />
     </>

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_policies_flyout/index.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_policies_flyout/index.tsx
@@ -281,7 +281,9 @@ export const CloudConnectorPoliciesFlyout: React.FC<CloudConnectorPoliciesFlyout
                 closePopover();
                 handleOpenSwitchModal(item);
               }}
-              data-test-subj="switchConnectorMenuItem"
+              data-test-subj={
+                CLOUD_CONNECTOR_POLICIES_FLYOUT_TEST_SUBJECTS.SWITCH_CONNECTOR_MENU_ITEM
+              }
             >
               {i18n.translate(
                 'securitySolutionPackages.cloudSecurityPosture.cloudConnectorPoliciesFlyout.switchConnectorAction',
@@ -297,7 +299,7 @@ export const CloudConnectorPoliciesFlyout: React.FC<CloudConnectorPoliciesFlyout
                 closePopover();
                 handleNavigateToPolicy(item.id);
               }}
-              data-test-subj="viewPolicyMenuItem"
+              data-test-subj={CLOUD_CONNECTOR_POLICIES_FLYOUT_TEST_SUBJECTS.VIEW_POLICY_MENU_ITEM}
             >
               {i18n.translate(
                 'securitySolutionPackages.cloudSecurityPosture.cloudConnectorPoliciesFlyout.viewPolicyAction',
@@ -322,7 +324,9 @@ export const CloudConnectorPoliciesFlyout: React.FC<CloudConnectorPoliciesFlyout
                       defaultMessage: 'Actions',
                     }
                   )}
-                  data-test-subj="policyActionsButton"
+                  data-test-subj={
+                    CLOUD_CONNECTOR_POLICIES_FLYOUT_TEST_SUBJECTS.POLICY_ACTIONS_BUTTON
+                  }
                 />
               }
               isOpen={isOpen}

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_policies_flyout/switch_connector_modal.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_policies_flyout/switch_connector_modal.test.tsx
@@ -1,0 +1,234 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { SwitchConnectorModal } from './switch_connector_modal';
+import { useGetCloudConnectors } from '../hooks/use_get_cloud_connectors';
+import { useUpdatePackagePolicyCloudConnector } from '../hooks/use_update_package_policy';
+import { SINGLE_ACCOUNT, ORGANIZATION_ACCOUNT } from '@kbn/fleet-plugin/common/constants';
+import type { AccountType } from '@kbn/fleet-plugin/common/types';
+import type { CloudConnectorCredentials } from '../types';
+
+// Mock the hooks
+jest.mock('../hooks/use_get_cloud_connectors');
+jest.mock('../hooks/use_update_package_policy');
+jest.mock('../form/cloud_connector_selector', () => ({
+  CloudConnectorSelector: ({
+    setCredentials,
+  }: {
+    setCredentials: (credentials: CloudConnectorCredentials) => void;
+  }) => (
+    <div data-test-subj="cloud-connector-selector">
+      <button
+        type="button"
+        onClick={() =>
+          setCredentials({
+            cloudConnectorId: 'new-connector-id',
+          })
+        }
+      >
+        {'Select Connector'}
+      </button>
+    </div>
+  ),
+}));
+
+const mockUseGetCloudConnectors = useGetCloudConnectors as jest.MockedFunction<
+  typeof useGetCloudConnectors
+>;
+const mockUseUpdatePackagePolicyCloudConnector =
+  useUpdatePackagePolicyCloudConnector as jest.MockedFunction<
+    typeof useUpdatePackagePolicyCloudConnector
+  >;
+
+describe('SwitchConnectorModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnSuccess = jest.fn();
+  const mockMutate = jest.fn();
+
+  const defaultProps = {
+    packagePolicyId: 'policy-123',
+    packagePolicyName: 'Test Policy',
+    currentCloudConnectorId: 'current-connector-id',
+    currentCloudConnectorName: 'Current Connector',
+    provider: 'aws' as const,
+    accountType: SINGLE_ACCOUNT as AccountType,
+    onClose: mockOnClose,
+    onSuccess: mockOnSuccess,
+  };
+
+  const mockConnectors = [
+    {
+      id: 'current-connector-id',
+      name: 'Current Connector',
+      cloudProvider: 'aws',
+      accountType: SINGLE_ACCOUNT,
+      vars: {},
+      packagePolicyCount: 1,
+      created_at: '2023-01-01',
+      updated_at: '2023-01-01',
+    },
+    {
+      id: 'new-connector-id',
+      name: 'New Connector',
+      cloudProvider: 'aws',
+      accountType: SINGLE_ACCOUNT,
+      vars: {},
+      packagePolicyCount: 0,
+      created_at: '2023-01-02',
+      updated_at: '2023-01-02',
+    },
+    {
+      id: 'different-account-type',
+      name: 'Different Account Type',
+      cloudProvider: 'aws',
+      accountType: ORGANIZATION_ACCOUNT,
+      vars: {},
+      packagePolicyCount: 0,
+      created_at: '2023-01-03',
+      updated_at: '2023-01-03',
+    },
+  ];
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseGetCloudConnectors.mockReturnValue({
+      data: mockConnectors,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useGetCloudConnectors>);
+    mockUseUpdatePackagePolicyCloudConnector.mockReturnValue({
+      mutate: mockMutate,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useUpdatePackagePolicyCloudConnector>);
+  });
+
+  it('renders modal with correct title and current connector info', () => {
+    render(<SwitchConnectorModal {...defaultProps} />, { wrapper });
+
+    expect(screen.getByText('Switch Cloud Connector')).toBeInTheDocument();
+    expect(screen.getByText('Test Policy')).toBeInTheDocument();
+    expect(screen.getByText('Current Connector')).toBeInTheDocument();
+  });
+
+  it('filters connectors by provider and account type, excluding current connector', () => {
+    render(<SwitchConnectorModal {...defaultProps} />, { wrapper });
+
+    // Should render the CloudConnectorSelector with filtered connectors
+    expect(screen.getByTestId('cloud-connector-selector')).toBeInTheDocument();
+  });
+
+  it('disables switch button when no connector is selected', () => {
+    render(<SwitchConnectorModal {...defaultProps} />, { wrapper });
+
+    const switchButton = screen.getByText('Switch Connector');
+    expect(switchButton).toBeDisabled();
+  });
+
+  it('enables switch button when a connector is selected', async () => {
+    const user = userEvent.setup();
+    render(<SwitchConnectorModal {...defaultProps} />, { wrapper });
+
+    const selectButton = screen.getByText('Select Connector');
+    await user.click(selectButton);
+
+    await waitFor(() => {
+      const switchButton = screen.getByText('Switch Connector');
+      expect(switchButton).not.toBeDisabled();
+    });
+  });
+
+  it('calls update mutation with correct parameters when switching', async () => {
+    const user = userEvent.setup();
+    render(<SwitchConnectorModal {...defaultProps} />, { wrapper });
+
+    // Select a connector
+    const selectButton = screen.getByText('Select Connector');
+    await user.click(selectButton);
+
+    // Click switch button
+    const switchButton = screen.getByText('Switch Connector');
+    await user.click(switchButton);
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      packagePolicyId: 'policy-123',
+      cloudConnectorId: 'new-connector-id',
+    });
+  });
+
+  it('shows warning callout about switching impact', () => {
+    render(<SwitchConnectorModal {...defaultProps} />, { wrapper });
+
+    expect(screen.getByText('Switching cloud connectors')).toBeInTheDocument();
+    expect(
+      screen.getByText(/This will change the cloud credentials used by this integration/)
+    ).toBeInTheDocument();
+  });
+
+  it('shows error message when no compatible connectors are available', () => {
+    mockUseGetCloudConnectors.mockReturnValue({
+      data: [mockConnectors[0]], // Only current connector
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useGetCloudConnectors>);
+
+    render(<SwitchConnectorModal {...defaultProps} />, { wrapper });
+
+    expect(screen.getByText('No compatible connectors available')).toBeInTheDocument();
+    expect(screen.getByText(/There are no other cloud connectors/)).toBeInTheDocument();
+  });
+
+  it('disables switch button when no compatible connectors exist', () => {
+    mockUseGetCloudConnectors.mockReturnValue({
+      data: [mockConnectors[0]],
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useGetCloudConnectors>);
+
+    render(<SwitchConnectorModal {...defaultProps} />, { wrapper });
+
+    const switchButton = screen.getByText('Switch Connector');
+    expect(switchButton).toBeDisabled();
+  });
+
+  it('shows loading state during update', () => {
+    mockUseUpdatePackagePolicyCloudConnector.mockReturnValue({
+      mutate: mockMutate,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useUpdatePackagePolicyCloudConnector>);
+
+    render(<SwitchConnectorModal {...defaultProps} />, { wrapper });
+
+    const switchButton = screen.getByText('Switch Connector');
+    expect(switchButton.closest('button')).toHaveAttribute('disabled');
+  });
+
+  it('calls onClose when cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<SwitchConnectorModal {...defaultProps} />, { wrapper });
+
+    const cancelButton = screen.getByText('Cancel');
+    await user.click(cancelButton);
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_policies_flyout/switch_connector_modal.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_policies_flyout/switch_connector_modal.tsx
@@ -205,10 +205,6 @@ export const SwitchConnectorModal: React.FC<SwitchConnectorModalProps> = ({
               <FormattedMessage
                 id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.noConnectorsMessage"
                 defaultMessage="There are no other cloud connectors with the same provider and account type."
-                values={{
-                  provider: provider.toUpperCase(),
-                  accountType: accountType || 'undefined',
-                }}
               />
             </p>
           </EuiCallOut>

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_policies_flyout/switch_connector_modal.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_policies_flyout/switch_connector_modal.tsx
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState, useMemo, useCallback } from 'react';
+import {
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiSpacer,
+  EuiText,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { AccountType } from '@kbn/fleet-plugin/common/types';
+import type { CloudProviders, CloudConnectorCredentials } from '../types';
+import { useGetCloudConnectors } from '../hooks/use_get_cloud_connectors';
+import { CloudConnectorSelector } from '../form/cloud_connector_selector';
+import { useUpdatePackagePolicyCloudConnector } from '../hooks/use_update_package_policy';
+import { AccountBadge } from '../components/account_badge';
+
+interface SwitchConnectorModalProps {
+  packagePolicyId: string;
+  packagePolicyName: string;
+  currentCloudConnectorId: string;
+  currentCloudConnectorName: string;
+  provider: CloudProviders;
+  accountType?: AccountType;
+  onClose: () => void;
+  onSuccess: (newCloudConnectorId: string) => void;
+}
+
+export const SwitchConnectorModal: React.FC<SwitchConnectorModalProps> = ({
+  packagePolicyId,
+  packagePolicyName,
+  currentCloudConnectorId,
+  currentCloudConnectorName,
+  provider,
+  accountType,
+  onClose,
+  onSuccess,
+}) => {
+  const modalTitleId = useGeneratedHtmlId();
+  const [selectedCredentials, setSelectedCredentials] = useState<CloudConnectorCredentials>({
+    cloudConnectorId: undefined,
+  });
+
+  const { data: allCloudConnectors = [] } = useGetCloudConnectors(provider);
+
+  const { mutate: updatePackagePolicy, isLoading } = useUpdatePackagePolicyCloudConnector(
+    () => {
+      // Pass the newly selected connector ID to the success callback
+      if (selectedCredentials.cloudConnectorId) {
+        onSuccess(selectedCredentials.cloudConnectorId);
+      }
+      onClose();
+    },
+    () => {
+      // Error handling is done by the hook
+    }
+  );
+
+  // Filter connectors by provider and account type, excluding current connector
+  const compatibleConnectors = useMemo(() => {
+    return allCloudConnectors.filter(
+      (connector) =>
+        connector.cloudProvider === provider &&
+        connector.accountType === accountType &&
+        connector.id !== currentCloudConnectorId
+    );
+  }, [allCloudConnectors, provider, accountType, currentCloudConnectorId]);
+
+  const hasCompatibleConnectors = compatibleConnectors.length > 0;
+  const canSwitch = selectedCredentials.cloudConnectorId !== undefined;
+
+  const handleSwitch = useCallback(() => {
+    if (selectedCredentials.cloudConnectorId) {
+      updatePackagePolicy({
+        packagePolicyId,
+        cloudConnectorId: selectedCredentials.cloudConnectorId,
+      });
+    }
+  }, [packagePolicyId, selectedCredentials.cloudConnectorId, updatePackagePolicy]);
+
+  return (
+    <EuiModal onClose={onClose} style={{ maxWidth: 600 }} aria-labelledby={modalTitleId}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle id={modalTitleId}>
+          <FormattedMessage
+            id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.title"
+            defaultMessage="Switch Cloud Connector"
+          />
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        <EuiText size="s">
+          <p>
+            <FormattedMessage
+              id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.policyName"
+              defaultMessage="Integration: {policyName}"
+              values={{ policyName: <strong>{packagePolicyName}</strong> }}
+            />
+          </p>
+        </EuiText>
+
+        <EuiSpacer size="m" />
+
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiText size="s">
+              <strong>
+                <FormattedMessage
+                  id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.currentConnector"
+                  defaultMessage="Current:"
+                />
+              </strong>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText size="s">{currentCloudConnectorName}</EuiText>
+          </EuiFlexItem>
+          {accountType && (
+            <EuiFlexItem grow={false}>
+              <AccountBadge accountType={accountType} variant="default" />
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+
+        <EuiSpacer size="m" />
+
+        <EuiCallOut
+          title={i18n.translate(
+            'securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.warningTitle',
+            {
+              defaultMessage: 'Switching cloud connectors',
+            }
+          )}
+          color="warning"
+          iconType="warning"
+          size="s"
+        >
+          <p>
+            <FormattedMessage
+              id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.warningMessage"
+              defaultMessage="This will change the cloud credentials used by this integration. Make sure the new connector has access to the same resources."
+            />
+          </p>
+        </EuiCallOut>
+
+        <EuiSpacer size="m" />
+
+        {hasCompatibleConnectors ? (
+          <>
+            <CloudConnectorSelector
+              provider={provider}
+              cloudConnectorId={selectedCredentials.cloudConnectorId}
+              credentials={selectedCredentials}
+              setCredentials={setSelectedCredentials}
+            />
+          </>
+        ) : (
+          <EuiCallOut
+            announceOnMount={false}
+            title={i18n.translate(
+              'securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.noConnectorsTitle',
+              {
+                defaultMessage: 'No compatible connectors available',
+              }
+            )}
+            color="danger"
+            iconType="error"
+          >
+            <p>
+              <FormattedMessage
+                id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.noConnectorsMessage"
+                defaultMessage="There are no other cloud connectors with the same provider and account type."
+                values={{
+                  provider: provider.toUpperCase(),
+                  accountType: accountType || 'undefined',
+                }}
+              />
+            </p>
+          </EuiCallOut>
+        )}
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiButtonEmpty onClick={onClose} disabled={isLoading}>
+          <FormattedMessage
+            id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.cancelButton"
+            defaultMessage="Cancel"
+          />
+        </EuiButtonEmpty>
+        <EuiButton
+          onClick={handleSwitch}
+          fill
+          disabled={!canSwitch || isLoading || !hasCompatibleConnectors}
+          isLoading={isLoading}
+        >
+          <FormattedMessage
+            id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.switchButton"
+            defaultMessage="Switch Connector"
+          />
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_policies_flyout/switch_connector_modal.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_policies_flyout/switch_connector_modal.tsx
@@ -23,6 +23,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { SWITCH_CONNECTOR_MODAL_TEST_SUBJECTS } from '@kbn/cloud-security-posture-common/test_subjects';
 import type { AccountType } from '@kbn/fleet-plugin/common/types';
 import type { CloudProviders, CloudConnectorCredentials } from '../types';
 import { useGetCloudConnectors } from '../hooks/use_get_cloud_connectors';
@@ -94,9 +95,17 @@ export const SwitchConnectorModal: React.FC<SwitchConnectorModalProps> = ({
   }, [packagePolicyId, selectedCredentials.cloudConnectorId, updatePackagePolicy]);
 
   return (
-    <EuiModal onClose={onClose} style={{ maxWidth: 600 }} aria-labelledby={modalTitleId}>
+    <EuiModal
+      onClose={onClose}
+      style={{ maxWidth: 600 }}
+      aria-labelledby={modalTitleId}
+      data-test-subj={SWITCH_CONNECTOR_MODAL_TEST_SUBJECTS.MODAL}
+    >
       <EuiModalHeader>
-        <EuiModalHeaderTitle id={modalTitleId}>
+        <EuiModalHeaderTitle
+          id={modalTitleId}
+          data-test-subj={SWITCH_CONNECTOR_MODAL_TEST_SUBJECTS.TITLE}
+        >
           <FormattedMessage
             id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.title"
             defaultMessage="Switch Cloud Connector"
@@ -105,31 +114,39 @@ export const SwitchConnectorModal: React.FC<SwitchConnectorModalProps> = ({
       </EuiModalHeader>
 
       <EuiModalBody>
-        <EuiText size="s">
-          <p>
-            <FormattedMessage
-              id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.policyName"
-              defaultMessage="Integration: {policyName}"
-              values={{ policyName: <strong>{packagePolicyName}</strong> }}
-            />
-          </p>
-        </EuiText>
-
-        <EuiSpacer size="m" />
-
+        <EuiFlexGroup gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <strong>
+              <FormattedMessage
+                id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.policyName"
+                defaultMessage="Integration:"
+              />
+            </strong>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText size="s" data-test-subj={SWITCH_CONNECTOR_MODAL_TEST_SUBJECTS.POLICY_NAME}>
+              {packagePolicyName}
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiText size="s">
               <strong>
                 <FormattedMessage
                   id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.currentConnector"
-                  defaultMessage="Current:"
+                  defaultMessage="Current Cloud Connector:"
                 />
               </strong>
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiText size="s">{currentCloudConnectorName}</EuiText>
+            <EuiText
+              size="s"
+              data-test-subj={SWITCH_CONNECTOR_MODAL_TEST_SUBJECTS.CURRENT_CONNECTOR_NAME}
+            >
+              {currentCloudConnectorName}
+            </EuiText>
           </EuiFlexItem>
           {accountType && (
             <EuiFlexItem grow={false}>
@@ -150,6 +167,7 @@ export const SwitchConnectorModal: React.FC<SwitchConnectorModalProps> = ({
           color="warning"
           iconType="warning"
           size="s"
+          data-test-subj={SWITCH_CONNECTOR_MODAL_TEST_SUBJECTS.WARNING_CALLOUT}
         >
           <p>
             <FormattedMessage
@@ -181,6 +199,7 @@ export const SwitchConnectorModal: React.FC<SwitchConnectorModalProps> = ({
             )}
             color="danger"
             iconType="error"
+            data-test-subj={SWITCH_CONNECTOR_MODAL_TEST_SUBJECTS.NO_CONNECTORS_CALLOUT}
           >
             <p>
               <FormattedMessage
@@ -197,7 +216,11 @@ export const SwitchConnectorModal: React.FC<SwitchConnectorModalProps> = ({
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty onClick={onClose} disabled={isLoading}>
+        <EuiButtonEmpty
+          onClick={onClose}
+          disabled={isLoading}
+          data-test-subj={SWITCH_CONNECTOR_MODAL_TEST_SUBJECTS.CANCEL_BUTTON}
+        >
           <FormattedMessage
             id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.cancelButton"
             defaultMessage="Cancel"
@@ -208,6 +231,7 @@ export const SwitchConnectorModal: React.FC<SwitchConnectorModalProps> = ({
           fill
           disabled={!canSwitch || isLoading || !hasCompatibleConnectors}
           isLoading={isLoading}
+          data-test-subj={SWITCH_CONNECTOR_MODAL_TEST_SUBJECTS.SWITCH_BUTTON}
         >
           <FormattedMessage
             id="securitySolutionPackages.cloudSecurityPosture.switchConnectorModal.switchButton"

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_setup.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/cloud_connector_setup.tsx
@@ -26,6 +26,7 @@ import type { UpdatePolicy } from '../types';
 import { TABS, CLOUD_FORMATION_EXTERNAL_DOC_URL } from './constants';
 import { isCloudConnectorReusableEnabled } from './utils';
 export interface CloudConnectorSetupProps {
+  packagePolicyId?: string;
   input: NewPackagePolicyInput;
   newPolicy: NewPackagePolicy;
   packageInfo: PackageInfo;
@@ -38,6 +39,7 @@ export interface CloudConnectorSetupProps {
 }
 
 export const CloudConnectorSetup: React.FC<CloudConnectorSetupProps> = ({
+  packagePolicyId,
   input,
   newPolicy,
   packageInfo,
@@ -147,6 +149,7 @@ export const CloudConnectorSetup: React.FC<CloudConnectorSetupProps> = ({
       content: (
         <ReusableCloudConnectorForm
           isEditPage={isEditPage}
+          packagePolicyId={packagePolicyId}
           newPolicy={newPolicy}
           cloudProvider={cloudProvider}
           credentials={existingConnectionCredentials}

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/form/cloud_connector_selector.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/form/cloud_connector_selector.tsx
@@ -36,6 +36,7 @@ interface CloudConnectorSelectorProps {
   cloudConnectorId: string | undefined;
   credentials: CloudConnectorCredentials;
   setCredentials: (credentials: CloudConnectorCredentials) => void;
+  packagePolicyId?: string;
 }
 
 export const CloudConnectorSelector = ({
@@ -43,6 +44,7 @@ export const CloudConnectorSelector = ({
   cloudConnectorId,
   credentials,
   setCredentials,
+  packagePolicyId,
 }: CloudConnectorSelectorProps) => {
   const { data: cloudConnectors = [] } = useGetCloudConnectors(provider);
   const [flyoutConnectorId, setFlyoutConnectorId] = useState<string | null>(null);
@@ -192,6 +194,25 @@ export const CloudConnectorSelector = ({
     [cloudConnectors, provider, setCredentials]
   );
 
+  // Handle when a policy's connector is switched from within the flyout
+  const handlePolicyCloudConnectorSwitched = useCallback(
+    (switchedPackagePolicyId: string, newCloudConnectorId: string) => {
+      // Only update if the switched policy is the one currently being edited
+      if (!packagePolicyId || switchedPackagePolicyId !== packagePolicyId) {
+        return;
+      }
+
+      // Check if the new connector is already in our loaded list
+      const connectorExists = cloudConnectors.some((c) => c.id === newCloudConnectorId);
+
+      if (connectorExists) {
+        // Reuse the existing handleChange logic
+        handleChange(newCloudConnectorId);
+      }
+    },
+    [packagePolicyId, cloudConnectors, handleChange]
+  );
+
   const testSubj =
     provider === 'aws'
       ? AWS_CLOUD_CONNECTOR_SUPER_SELECT_TEST_SUBJ
@@ -225,6 +246,7 @@ export const CloudConnectorSelector = ({
           accountType={flyoutConnector.accountType}
           provider={provider}
           onClose={handleCloseFlyout}
+          onPolicyCloudConnectorSwitched={handlePolicyCloudConnectorSwitched}
         />
       )}
     </>

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/form/reusable_cloud_connector_form.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/form/reusable_cloud_connector_form.tsx
@@ -15,10 +15,11 @@ import { AWS_PROVIDER, AZURE_PROVIDER } from '../constants';
 export const ReusableCloudConnectorForm: React.FC<{
   credentials: CloudConnectorCredentials;
   setCredentials: (credentials: CloudConnectorCredentials) => void;
+  packagePolicyId?: string;
   newPolicy: NewPackagePolicy;
   cloudProvider?: CloudProvider;
   isEditPage: boolean;
-}> = ({ credentials, setCredentials, cloudProvider, newPolicy, isEditPage }) => {
+}> = ({ credentials, setCredentials, cloudProvider, packagePolicyId, newPolicy, isEditPage }) => {
   const provider = cloudProvider || AWS_PROVIDER;
 
   switch (provider) {
@@ -29,6 +30,7 @@ export const ReusableCloudConnectorForm: React.FC<{
           credentials={credentials}
           cloudConnectorId={newPolicy.cloud_connector_id || undefined}
           setCredentials={setCredentials}
+          packagePolicyId={packagePolicyId}
         />
       );
     case AZURE_PROVIDER:
@@ -38,6 +40,7 @@ export const ReusableCloudConnectorForm: React.FC<{
           credentials={credentials}
           cloudConnectorId={newPolicy.cloud_connector_id || undefined}
           setCredentials={setCredentials}
+          packagePolicyId={packagePolicyId}
         />
       );
     case 'gcp':

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/hooks/use_update_package_policy.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_connector/hooks/use_update_package_policy.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMutation, useQueryClient } from '@kbn/react-query';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { i18n } from '@kbn/i18n';
+import type {
+  UpdatePackagePolicy,
+  GetOnePackagePolicyResponse,
+  UpdatePackagePolicyResponse,
+} from '@kbn/fleet-plugin/common';
+import type { CloudConnector } from '@kbn/fleet-plugin/common/types';
+import { packagePolicyRouteService, API_VERSIONS } from '@kbn/fleet-plugin/common';
+import { CLOUD_CONNECTOR_API_ROUTES } from '@kbn/fleet-plugin/public';
+import type { PackagePolicyConfigRecord } from '@kbn/fleet-plugin/public/types';
+import {
+  updateInputVarsWithCredentials,
+  isAwsCloudConnectorVars,
+  isAzureCloudConnectorVars,
+} from '../utils';
+import type { CloudConnectorCredentials } from '../types';
+
+interface UpdatePackagePolicyCloudConnectorParams {
+  packagePolicyId: string;
+  cloudConnectorId: string;
+}
+
+// Helper to convert cloud connector vars to credentials format
+const convertCloudConnectorVarsToCredentials = (
+  cloudConnector: CloudConnector
+): CloudConnectorCredentials => {
+  if (isAwsCloudConnectorVars(cloudConnector.vars, cloudConnector.cloudProvider)) {
+    return {
+      roleArn: cloudConnector.vars.role_arn?.value,
+      externalId: cloudConnector.vars.external_id?.value?.id, // Secret reference ID
+      cloudConnectorId: cloudConnector.id,
+    };
+  } else if (isAzureCloudConnectorVars(cloudConnector.vars, cloudConnector.cloudProvider)) {
+    return {
+      tenantId: cloudConnector.vars.tenant_id?.value?.id, // Secret reference ID
+      clientId: cloudConnector.vars.client_id?.value?.id, // Secret reference ID
+      azure_credentials_cloud_connector_id:
+        cloudConnector.vars.azure_credentials_cloud_connector_id?.value,
+      cloudConnectorId: cloudConnector.id,
+    };
+  }
+
+  return { cloudConnectorId: cloudConnector.id };
+};
+
+export const useUpdatePackagePolicyCloudConnector = (
+  onSuccess?: () => void,
+  onError?: (error: Error) => void
+) => {
+  const { notifications, http } = useKibana().services;
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    async ({ packagePolicyId, cloudConnectorId }: UpdatePackagePolicyCloudConnectorParams) => {
+      if (!http) {
+        throw new Error('HTTP service is not available');
+      }
+
+      const cloudConnectorResponse = await http.get<{ item: CloudConnector }>(
+        CLOUD_CONNECTOR_API_ROUTES.INFO_PATTERN.replace('{cloudConnectorId}', cloudConnectorId)
+      );
+      const cloudConnector = cloudConnectorResponse.item;
+
+      // TODO: use sendGetOnePackagePolicy when this is moved to Fleet plugin
+      const packagePolicyResponse = await http.get<GetOnePackagePolicyResponse>(
+        packagePolicyRouteService.getInfoPath(packagePolicyId),
+        {
+          version: API_VERSIONS.public.v1,
+        }
+      );
+      if (!packagePolicyResponse || !packagePolicyResponse.item) {
+        throw new Error('Package policy not found');
+      }
+      const currentPolicy = packagePolicyResponse.item;
+
+      const credentials = convertCloudConnectorVarsToCredentials(cloudConnector);
+
+      const currentInput = currentPolicy.inputs?.find((input) => input.enabled);
+      if (!currentInput?.streams?.[0]?.vars) {
+        throw new Error('Unable to find input variables in package policy');
+      }
+
+      const updatedInputVars = updateInputVarsWithCredentials(
+        currentInput.streams[0].vars as PackagePolicyConfigRecord,
+        credentials
+      );
+
+      const updatedInputs = currentPolicy.inputs.map((input) => {
+        if (input.enabled && input.streams?.[0]) {
+          return {
+            ...input,
+            streams: input.streams.map((stream, idx) =>
+              idx === 0 ? { ...stream, vars: updatedInputVars } : stream
+            ),
+          };
+        }
+        return input;
+      });
+
+      const body: Partial<UpdatePackagePolicy> = {
+        cloud_connector_id: cloudConnectorId,
+        inputs: updatedInputs,
+      };
+
+      // TODO: use sendUpdatePackagePolicy when this is moved to Fleet plugin
+      const result = await http.put<UpdatePackagePolicyResponse>(
+        packagePolicyRouteService.getUpdatePath(packagePolicyId),
+        {
+          version: API_VERSIONS.public.v1,
+          body: JSON.stringify(body),
+        }
+      );
+
+      return result;
+    },
+    {
+      onSuccess: () => {
+        // Invalidate relevant queries to refresh the UI
+        queryClient.invalidateQueries(['cloud-connector-usage']);
+        queryClient.invalidateQueries(['get-cloud-connectors']);
+
+        notifications?.toasts.addSuccess({
+          title: i18n.translate(
+            'securitySolutionPackages.cloudSecurityPosture.switchCloudConnector.successTitle',
+            {
+              defaultMessage: 'Cloud connector switched successfully',
+            }
+          ),
+        });
+
+        if (onSuccess) {
+          onSuccess();
+        }
+      },
+      onError: (error: Error) => {
+        notifications?.toasts.addError(error, {
+          title: i18n.translate(
+            'securitySolutionPackages.cloudSecurityPosture.switchCloudConnector.errorTitle',
+            {
+              defaultMessage: 'Failed to switch cloud connector',
+            }
+          ),
+        });
+
+        if (onError) {
+          onError(error);
+        }
+      },
+    }
+  );
+};

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_setup.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/cloud_setup.tsx
@@ -58,6 +58,7 @@ type CloudSetupProps = CloudIntegrationSetupProps & {
 
 interface CloudIntegrationSetupProps {
   cloud: ICloudSetup;
+  packagePolicyId?: string;
   defaultSetupTechnology?: SetupTechnology;
   handleSetupTechnologyChange?: (setupTechnology: SetupTechnology) => void;
   isAgentlessEnabled?: boolean;
@@ -74,6 +75,7 @@ const CloudIntegrationSetup = memo<CloudIntegrationSetupProps>(
   // eslint-disable-next-line complexity
   ({
     cloud,
+    packagePolicyId,
     defaultSetupTechnology,
     handleSetupTechnologyChange,
     isAgentlessEnabled,
@@ -278,6 +280,7 @@ const CloudIntegrationSetup = memo<CloudIntegrationSetupProps>(
         {selectedProvider === AWS_PROVIDER && setupTechnology === SetupTechnology.AGENTLESS && (
           <AwsCredentialsFormAgentless
             cloud={cloud}
+            packagePolicyId={packagePolicyId}
             input={input}
             newPolicy={newPolicy}
             packageInfo={packageInfo}
@@ -323,6 +326,7 @@ const CloudIntegrationSetup = memo<CloudIntegrationSetupProps>(
 
         {selectedProvider === AZURE_PROVIDER && setupTechnology === SetupTechnology.AGENTLESS && (
           <AzureCredentialsFormAgentless
+            packagePolicyId={packagePolicyId}
             input={input}
             newPolicy={newPolicy}
             packageInfo={packageInfo}
@@ -356,6 +360,7 @@ export const CloudSetup = memo<CloudSetupProps>(
   ({
     configuration,
     cloud,
+    packagePolicyId,
     defaultSetupTechnology,
     handleSetupTechnologyChange,
     isAgentlessEnabled,
@@ -377,6 +382,7 @@ export const CloudSetup = memo<CloudSetupProps>(
       >
         <CloudIntegrationSetup
           cloud={cloud}
+          packagePolicyId={packagePolicyId}
           defaultSetupTechnology={defaultSetupTechnology}
           handleSetupTechnologyChange={handleSetupTechnologyChange}
           isAgentlessEnabled={isAgentlessEnabled}

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -70,7 +70,10 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
     defaultSetupTechnology,
     integrationToEnable,
     setIntegrationToEnable,
+    ...rest
   }) => {
+    const policy = 'policy' in rest ? rest.policy : undefined;
+    const packagePolicyId = policy?.id;
     const CLOUD_CONNECTOR_PACKAGE_VERSION_ENABLED_AWS = '2.0.0-preview01';
     const CLOUD_CONNECTOR_PACKAGE_VERSION_ENABLED_AZURE = '3.1.0-preview02';
     const CLOUD_CREDENTIALS_PACKAGE_VERSION = '1.11.0-preview13';
@@ -214,6 +217,7 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
         {input.policy_template === CSPM_POLICY_TEMPLATE && (
           <CloudSetup
             configuration={CLOUD_SETUP_MAPPING}
+            packagePolicyId={packagePolicyId}
             newPolicy={newPolicy}
             updatePolicy={updatePolicy}
             packageInfo={packageInfo}


### PR DESCRIPTION
## Summary

This pull request introduces new UI capabilities for managing cloud connector policies, primarily by adding action menus and modal dialogs for policy operations. 

The main focus is on enabling users to switch cloud connectors associated with policies and view policy details, with corresponding updates to component props, test subjects, and test coverage. These changes improve the flexibility and user experience of the cloud connector management interface.

<img width="1034" height="508" alt="Screenshot 2026-01-07 at 2 00 58 PM" src="https://github.com/user-attachments/assets/63994a98-ac98-4528-892d-b091658eb11a" />
<img width="1920" height="1080" alt="Screenshot 2026-01-07 at 2 06 58 PM (3)" src="https://github.com/user-attachments/assets/b75ca205-2a34-48b2-98e2-0aeedda0a8f8" />
<img width="1335" height="646" alt="Screenshot 2026-01-07 at 2 07 50 PM" src="https://github.com/user-attachments/assets/ab0f5b3c-64c2-4b6e-b0f4-3bb956237bf7" />




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks
Low - None


