### PR TITLE
[Cases] Encode search term in cases page

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/utils/all_cases_url_state_serializer.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/utils/all_cases_url_state_serializer.test.ts
@@ -126,4 +126,23 @@ describe('allCasesUrlStateSerializer', () => {
       }
     `);
   });
+
+  it('encodes the search term', () => {
+    expect(
+      allCasesUrlStateSerializer({
+        filterOptions: { ...DEFAULT_FILTER_OPTIONS, search: '#123' },
+        queryParams: DEFAULT_QUERY_PARAMS,
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "from": "now-30d",
+        "page": 1,
+        "perPage": 10,
+        "search": "%23123",
+        "sortField": "createdAt",
+        "sortOrder": "desc",
+        "to": "now",
+      }
+    `);
+  });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/utils/all_cases_url_state_serializer.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/utils/all_cases_url_state_serializer.ts
@@ -41,6 +41,7 @@ export const allCasesUrlStateSerializer = (state: AllCasesTableState): AllCasesU
       assignee === null ? NO_ASSIGNEES_FILTERING_KEYWORD : assignee
     ),
     customFields: customFieldsAsQueryParams,
+    search: encodeURIComponent(state.filterOptions.search ?? ''),
   };
 
   // filters empty values


### PR DESCRIPTION
## Summary

Ref: https://github.com/elastic/kibana/issues/237767

This PR adds encoding to search term to prevent decoding errors for a terms like `%123`.


### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->