### PR TITLE
[Cases] Fix incremental id search

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/containers/use_get_cases.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_get_cases.test.tsx
@@ -165,7 +165,7 @@ describe('useGetCases', () => {
       filterOptions: {
         ...DEFAULT_FILTER_OPTIONS,
         search: '123',
-        searchFields: ['incremental_id.text'],
+        searchFields: ['cases.incremental_id.text'],
         owner: ['securitySolution'],
       },
       queryParams: DEFAULT_QUERY_PARAMS,

--- a/x-pack/platform/plugins/shared/cases/public/containers/utils.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/utils.test.ts
@@ -268,11 +268,11 @@ describe('utils', () => {
 
     it('returns the correct overrides for an incremental id search', () => {
       expect(getIncrementalIdSearchOverrides('#123')).toEqual({
-        searchFields: ['incremental_id.text'],
+        searchFields: ['cases.incremental_id.text'],
         search: '123',
       });
       expect(getIncrementalIdSearchOverrides('   #123   ')).toEqual({
-        searchFields: ['incremental_id.text'],
+        searchFields: ['cases.incremental_id.text'],
         search: '123',
       });
     });

--- a/x-pack/platform/plugins/shared/cases/public/containers/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/utils.ts
@@ -246,7 +246,7 @@ export const getIncrementalIdSearchOverrides = (search: string) => {
     // search only in `incremental_id` since types with `title`
     // and `description` don't overlap
     overrides = {
-      searchFields: ['incremental_id.text'],
+      searchFields: ['cases.incremental_id.text'],
       search: trimmedSearch,
     };
   }


### PR DESCRIPTION
## Summary

Ref: https://github.com/elastic/kibana/issues/246506

This PR fixes a bug where the incremental id field was not properly updated to match new search field pattern.

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->