### PR TITLE
[Cases] Update total event in ES document when attaching an event

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/client/attachments/delete.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/attachments/delete.ts
@@ -203,6 +203,7 @@ const updateCaseAttachmentStats = async ({
 
   const totalComments = attachmentStats.get(caseId)?.userComments ?? 0;
   const totalAlerts = attachmentStats.get(caseId)?.alerts ?? 0;
+  const totalEvents = attachmentStats.get(caseId)?.events ?? 0;
 
   await caseService.patchCase({
     originalCase,
@@ -212,6 +213,7 @@ const updateCaseAttachmentStats = async ({
       updated_by: user,
       total_comments: totalComments,
       total_alerts: totalAlerts,
+      total_events: totalEvents,
     },
     refresh: false,
   });

--- a/x-pack/platform/plugins/shared/cases/server/common/types/case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/types/case.ts
@@ -69,6 +69,7 @@ export type CaseTransformedAttributes = CaseAttributes;
 export type CaseTransformedAttributesWithAttachmentStats = CaseAttributes & {
   total_comments: number;
   total_alerts: number;
+  total_events: number;
 };
 
 export const CaseTransformedAttributesRt = CaseAttributesRt;
@@ -83,10 +84,15 @@ export const getPartialCaseTransformedAttributesRt = (): Type<
 
   return exact(
     /**
-     * We add the `total_comments` and `total_alerts` properties to allow the
+     * We add the `total_comments`, `total_alerts`, and `total_events` properties to allow the
      * attachments stats to be updated.
      */
-    partial({ ...caseTransformedAttributesProps, total_comments: number, total_alerts: number })
+    partial({
+      ...caseTransformedAttributesProps,
+      total_comments: number,
+      total_alerts: number,
+      total_events: number,
+    })
   );
 };
 

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/index.test.ts
@@ -1427,7 +1427,9 @@ describe('CasesService', () => {
 
         expect(res).toMatchInlineSnapshot(`
           Object {
-            "attributes": Object {},
+            "attributes": Object {
+              "total_events": -1,
+            },
           }
         `);
       });


### PR DESCRIPTION
## Summary

Ref: https://github.com/elastic/kibana/issues/245916

How to test:
- Create a case and attach some alerts and events
- Go to Discover, create a data view called Cases, with pattern `.kibana_alerting_cases*`
- Verify the stats are populated correctly

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->