### PR TITLE
[Controls Anywere] Remove duplicated reference spread

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/api/transforms/in/transform_dashboard_in.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/transforms/in/transform_dashboard_in.ts
@@ -91,7 +91,6 @@ export const transformDashboardIn = (
       attributes,
       references: [
         ...tagReferences,
-        ...controlGroupReferences,
         ...panelReferences,
         ...controlGroupReferences,
         ...searchSourceReferences,


### PR DESCRIPTION
## Summary

When resolving merge conflicts with https://github.com/elastic/kibana/pull/245310 in the [Controls Anywhere PR](https://github.com/elastic/kibana/pull/245588), we accidentally ended up with control references being spread twice. This PR undoes that. 