### PR TITLE
[Security solution] Fix API doesn't use an associated conversation's system prompt 

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.test.ts
@@ -277,7 +277,9 @@ describe('chatCompleteRoute', () => {
       },
     };
 
-    await chatCompleteRoute(mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>);
+    await chatCompleteRoute(
+      mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>
+    );
   });
 
   it('appends promptId prompt content to the conversation system prompt', async () => {
@@ -310,7 +312,9 @@ describe('chatCompleteRoute', () => {
       },
     };
 
-    await chatCompleteRoute(mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>);
+    await chatCompleteRoute(
+      mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>
+    );
   });
 
   it('passes promptId prompt content when persist=false', async () => {
@@ -344,7 +348,9 @@ describe('chatCompleteRoute', () => {
       },
     };
 
-    await chatCompleteRoute(mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>);
+    await chatCompleteRoute(
+      mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>
+    );
   });
 
   it('returns the expected error when executeCustomLlmChain fails', async () => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.test.ts
@@ -25,6 +25,8 @@ import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
 import {
   appendAssistantMessageToConversation,
   createConversationWithUserInput,
+  getSystemPromptFromPromptId,
+  getSystemPromptFromUserConversation,
   langChainExecute,
 } from '../helpers';
 import type { OnLlmResponse } from '../../lib/langchain/executors/types';
@@ -44,11 +46,15 @@ jest.mock('../helpers', () => {
     ...original,
     appendAssistantMessageToConversation: jest.fn(),
     createConversationWithUserInput: jest.fn(),
+    getSystemPromptFromPromptId: jest.fn(),
+    getSystemPromptFromUserConversation: jest.fn(),
     langChainExecute: jest.fn(),
   };
 });
 const mockAppendAssistantMessageToConversation = appendAssistantMessageToConversation as jest.Mock;
 const mockCreateConversationWithUserInput = createConversationWithUserInput as jest.Mock;
+const mockGetSystemPromptFromPromptId = getSystemPromptFromPromptId as jest.Mock;
+const mockGetSystemPromptFromUserConversation = getSystemPromptFromUserConversation as jest.Mock;
 
 const mockLangChainExecute = langChainExecute as jest.Mock;
 const mockStream = jest.fn().mockImplementation(() => new PassThrough());
@@ -96,6 +102,9 @@ const mockContext = {
       }),
       getAIAssistantAnonymizationFieldsDataClient: jest.fn().mockResolvedValue({
         findDocuments: jest.fn().mockResolvedValue(getFindAnonymizationFieldsResultWithSingleHit()),
+      }),
+      getAIAssistantPromptsDataClient: jest.fn().mockResolvedValue({
+        findDocuments: jest.fn().mockResolvedValue({}),
       }),
     },
     core: {
@@ -155,6 +164,8 @@ describe('chatCompleteRoute', () => {
     mockAppendAssistantMessageToConversation.mockResolvedValue(true);
     license.hasAtLeast.mockReturnValue(true);
     mockCreateConversationWithUserInput.mockResolvedValue({ id: 'something' });
+    mockGetSystemPromptFromPromptId.mockResolvedValue(undefined);
+    mockGetSystemPromptFromUserConversation.mockResolvedValue(undefined);
     mockLangChainExecute.mockImplementation(
       async ({
         connectorId,
@@ -243,6 +254,97 @@ describe('chatCompleteRoute', () => {
     };
 
     chatCompleteRoute(mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>);
+  });
+
+  it('passes the conversation system prompt to langChainExecute', async () => {
+    mockGetSystemPromptFromUserConversation.mockResolvedValue('You always talk like a pirate');
+
+    const mockRouter = {
+      versioned: {
+        post: jest.fn().mockImplementation(() => {
+          return {
+            addVersion: jest.fn().mockImplementation(async (_, handler) => {
+              await handler(mockContext, mockRequest, mockResponse);
+
+              expect(mockLangChainExecute).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  systemPrompt: 'You always talk like a pirate',
+                })
+              );
+            }),
+          };
+        }),
+      },
+    };
+
+    await chatCompleteRoute(mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>);
+  });
+
+  it('appends promptId prompt content to the conversation system prompt', async () => {
+    mockGetSystemPromptFromUserConversation.mockResolvedValue('Conversation prompt');
+    mockGetSystemPromptFromPromptId.mockResolvedValue('Request prompt');
+
+    const requestWithPromptId = {
+      ...mockRequest,
+      body: {
+        ...mockRequest.body,
+        promptId: 'test-prompt-id',
+      },
+    };
+
+    const mockRouter = {
+      versioned: {
+        post: jest.fn().mockImplementation(() => {
+          return {
+            addVersion: jest.fn().mockImplementation(async (_, handler) => {
+              await handler(mockContext, requestWithPromptId, mockResponse);
+
+              expect(mockLangChainExecute).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  systemPrompt: 'Conversation prompt\n\nRequest prompt',
+                })
+              );
+            }),
+          };
+        }),
+      },
+    };
+
+    await chatCompleteRoute(mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>);
+  });
+
+  it('passes promptId prompt content when persist=false', async () => {
+    mockGetSystemPromptFromPromptId.mockResolvedValue('Request prompt');
+
+    const requestWithPromptIdAndNoPersist = {
+      ...mockRequest,
+      body: {
+        ...mockRequest.body,
+        conversationId: undefined,
+        persist: false,
+        promptId: 'test-prompt-id',
+      },
+    };
+
+    const mockRouter = {
+      versioned: {
+        post: jest.fn().mockImplementation(() => {
+          return {
+            addVersion: jest.fn().mockImplementation(async (_, handler) => {
+              await handler(mockContext, requestWithPromptIdAndNoPersist, mockResponse);
+
+              expect(mockLangChainExecute).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  systemPrompt: 'Request prompt',
+                })
+              );
+            }),
+          };
+        }),
+      },
+    };
+
+    await chatCompleteRoute(mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>);
   });
 
   it('returns the expected error when executeCustomLlmChain fails', async () => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.ts
@@ -29,6 +29,8 @@ import {
   appendAssistantMessageToConversation,
   createConversationWithUserInput,
   getIsKnowledgeBaseInstalled,
+  getSystemPromptFromPromptId,
+  getSystemPromptFromUserConversation,
   langChainExecute,
   performChecks,
 } from '../helpers';
@@ -106,6 +108,8 @@ export const chatCompleteRoute = (
 
           const anonymizationFieldsDataClient =
             await ctx.elasticAssistant.getAIAssistantAnonymizationFieldsDataClient();
+
+          const promptsDataClient = await ctx.elasticAssistant.getAIAssistantPromptsDataClient();
 
           let messages;
           const existingConversationId = request.body.conversationId;
@@ -206,6 +210,34 @@ export const chatCompleteRoute = (
             ? existingConversationId ?? newConversation?.id
             : undefined;
 
+          const systemPromptParts: string[] = [];
+
+          if (conversationsDataClient && promptsDataClient && existingConversationId) {
+            const conversationSystemPrompt = await getSystemPromptFromUserConversation({
+              conversationsDataClient,
+              conversationId: existingConversationId,
+              promptsDataClient,
+            });
+
+            if (conversationSystemPrompt) {
+              systemPromptParts.push(conversationSystemPrompt);
+            }
+          }
+
+          if (promptsDataClient && request.body.promptId) {
+            const requestSystemPrompt = await getSystemPromptFromPromptId({
+              promptId: request.body.promptId,
+              promptsDataClient,
+            });
+
+            if (requestSystemPrompt) {
+              systemPromptParts.push(requestSystemPrompt);
+            }
+          }
+
+          const systemPrompt =
+            systemPromptParts.length > 0 ? systemPromptParts.join('\n\n') : undefined;
+
           const contentReferencesStore = newContentReferencesStore({
             disabled: contentReferencesDisabled ?? false,
           });
@@ -258,6 +290,7 @@ export const chatCompleteRoute = (
               telemetry,
               responseLanguage: request.body.responseLanguage,
               savedObjectsClient,
+              systemPrompt,
               ...(productDocsAvailable ? { llmTasks: ctx.elasticAssistant.llmTasks } : {}),
             }),
             timeout,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/helpers.ts
@@ -158,6 +158,27 @@ const extractPromptFromESResult = (result: FindResponse<EsPromptsSchema>): strin
   return undefined;
 };
 
+export interface GetSystemPromptFromPromptIdParams {
+  promptId: string;
+  promptsDataClient: AIAssistantDataClient;
+}
+
+/**
+ * Fetches a system prompt by saved object id, when a request passes `promptId`.
+ */
+export const getSystemPromptFromPromptId = async ({
+  promptId,
+  promptsDataClient,
+}: GetSystemPromptFromPromptIdParams): Promise<string | undefined> => {
+  const result = await promptsDataClient.findDocuments<EsPromptsSchema>({
+    perPage: 1,
+    page: 1,
+    filter: `_id: "${promptId}"`,
+  });
+
+  return extractPromptFromESResult(result);
+};
+
 export const getSystemPromptFromUserConversation = async ({
   conversationsDataClient,
   conversationId,
@@ -171,12 +192,11 @@ export const getSystemPromptFromUserConversation = async ({
   if (!currentSystemPromptId) {
     return undefined;
   }
-  const result = await promptsDataClient.findDocuments<EsPromptsSchema>({
-    perPage: 1,
-    page: 1,
-    filter: `_id: "${currentSystemPromptId}"`,
+
+  return getSystemPromptFromPromptId({
+    promptId: currentSystemPromptId,
+    promptsDataClient,
   });
-  return extractPromptFromESResult(result);
 };
 
 export interface AppendAssistantMessageToConversationParams {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/229386 where the public Security AI Assistant API `/api/security_ai_assistant/chat/complete` did not apply the system prompt associated with a conversation (`defaultSystemPromptId`). The public API now matches the internal connector execute route behavior by applying the conversation system prompt and appending an optional request-level `promptId`.

## Changes

- **Public chat complete uses conversation system prompt**
  - `/api/security_ai_assistant/chat/complete` now resolves the conversation's `defaultSystemPromptId` and passes the resulting prompt content into the LLM execution (`systemPrompt`).
- **`promptId` is now request-scoped and applied to the LLM**
  - When `promptId` is provided, it is resolved to prompt content and appended to the conversation system prompt (if any) for the request (mimics the current behavior in `x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts`).
  - When `persist=true` and `conversationId` is not provided, `promptId` continues to be saved as the new conversation's `defaultSystemPromptId` (existing behavior), and also affects the request.

## Reviewer: reproduce + verify with script

- **Before fix**: Step 3 (internal) should talk like a pirate, Step 4 (public) does not, Step 5 shows `promptId` request-scoped also doesn’t affect response.
- **After fix**: Step 4 should talk like a pirate, and Step 5 should also reflect the `promptId`-provided prompt (request-scoped), matching the documented append behavior.

```bash
# Base URL + creds
KBN='http://localhost:5601/kbn'
AUTH='elastic:changeme'

# Uses the same connector from your bug report (change these 2 literals if yours differ)
CONNECTOR_ID='gemini_2_5_pro'
ACTION_TYPE_ID='.gemini'

# 1) Create a “talk like a pirate” system prompt (PROMPT_ID)
PROMPT_ID="$(
  curl -sS -u "$AUTH" \
    -H 'kbn-xsrf: true' \
    -H 'Content-Type: application/json' \
    "$KBN/api/security_ai_assistant/prompts/_bulk_action" \
    --data '{"create":[{"name":"Talk like a pirate!","promptType":"system","content":"You always talk like a pirate"}]}' \
  | jq -r '.attributes.results.created[0].id'
)"
echo "PROMPT_ID=$PROMPT_ID"

# 2) Create a conversation that references the prompt (CONVERSATION_ID)
CONVERSATION_ID="$(
  curl -sS -u "$AUTH" \
    -H 'kbn-xsrf: true' \
    -H 'Content-Type: application/json' \
    "$KBN/api/security_ai_assistant/current_user/conversations" \
    --data "{\"title\":\"\",\"category\":\"assistant\",\"messages\":[],\"replacements\":{},\"apiConfig\":{\"connectorId\":\"${CONNECTOR_ID}\",\"actionTypeId\":\"${ACTION_TYPE_ID}\",\"defaultSystemPromptId\":\"${PROMPT_ID}\"}}" \
  | jq -r '.id'
)"
echo "CONVERSATION_ID=$CONVERSATION_ID"

# 3) Baseline (internal API) — should talk like a pirate
curl -sS -N -u "$AUTH" \
  -H 'kbn-xsrf: true' \
  -H 'Content-Type: application/json' \
  -H 'elastic-api-version: 1' \
  -H 'x-elastic-internal-origin: Kibana' \
  "$KBN/internal/elastic_assistant/actions/connector/${CONNECTOR_ID}/_execute" \
  --data "{\"message\":\"How many open alerts do I have?\",\"subAction\":\"invokeAI\",\"conversationId\":\"${CONVERSATION_ID}\",\"actionTypeId\":\"${ACTION_TYPE_ID}\",\"replacements\":{},\"screenContext\":{\"timeZone\":\"America/New_York\"},\"alertsIndexPattern\":\".alerts-security.alerts-default\",\"size\":100}"

# 4) Repro (public API) — bug: does NOT use conversation’s system prompt
curl -sS -N -u "$AUTH" \
  -H 'kbn-xsrf: true' \
  -H 'Content-Type: application/json' \
  "$KBN/api/security_ai_assistant/chat/complete" \
  --data "{\"persist\":true,\"isStream\":false,\"messages\":[{\"role\":\"user\",\"content\":\"How many open alerts do I have?\",\"data\":{\"user_id\":\"elastic\"},\"fields_to_anonymize\":[\"user.name\",\"source.ip\"]}],\"connectorId\":\"${CONNECTOR_ID}\",\"conversationId\":\"${CONVERSATION_ID}\"}"

# 5) Optional: show promptId on /chat/complete also doesn’t affect response (request-scoped)
curl -sS -N -u "$AUTH" \
  -H 'kbn-xsrf: true' \
  -H 'Content-Type: application/json' \
  "$KBN/api/security_ai_assistant/chat/complete" \
  --data "{\"persist\":false,\"isStream\":false,\"promptId\":\"${PROMPT_ID}\",\"messages\":[{\"role\":\"user\",\"content\":\"How many open alerts do I have?\"}],\"connectorId\":\"${CONNECTOR_ID}\"}"
```

_PR developed with Cursor + gpt-5.2_

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->