### PR TITLE
[AI Infra] Fix Security Labs install not working

### DIFF
--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/service.mock.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/service.mock.ts
@@ -18,6 +18,12 @@ const createInstallClientMock = (): InstallClientMock => {
     setUninstalled: jest.fn(),
     setUninstallationStarted: jest.fn(),
     getPreviouslyInstalledInferenceIds: jest.fn().mockResolvedValue([]),
+    getPreviouslyInstalledSecurityLabsInferenceIds: jest.fn().mockResolvedValue([]),
+    getSecurityLabsInstallationStatus: jest.fn(),
+    setSecurityLabsInstallationStarted: jest.fn(),
+    setSecurityLabsInstallationSuccessful: jest.fn(),
+    setSecurityLabsInstallationFailed: jest.fn(),
+    setSecurityLabsUninstalled: jest.fn(),
   } as unknown as InstallClientMock;
 };
 

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.test.mocks.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.test.mocks.ts
@@ -7,6 +7,7 @@
 
 export const validateArtifactArchiveMock = jest.fn();
 export const fetchArtifactVersionsMock = jest.fn();
+export const fetchSecurityLabsVersionsMock = jest.fn();
 export const createIndexMock = jest.fn();
 export const populateIndexMock = jest.fn();
 
@@ -16,6 +17,7 @@ jest.doMock('./steps', () => {
     ...actual,
     validateArtifactArchive: validateArtifactArchiveMock,
     fetchArtifactVersions: fetchArtifactVersionsMock,
+    fetchSecurityLabsVersions: fetchSecurityLabsVersionsMock,
     createIndex: createIndexMock,
     populateIndex: populateIndexMock,
   };

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/package_installer.ts
@@ -356,9 +356,9 @@ export class PackageInstaller {
       const artifactPath = `${this.artifactsFolder}/${artifactFileName}`;
 
       this.log.debug(`Downloading Security Labs from [${artifactUrl}] to [${artifactPath}]`);
-      await downloadToDisk(artifactUrl, artifactPath);
+      const downloadedFullPath = await downloadToDisk(artifactUrl, artifactPath);
 
-      zipArchive = await openZipArchive(artifactPath);
+      zipArchive = await openZipArchive(downloadedFullPath);
       validateArtifactArchive(zipArchive);
 
       const [manifest, mappings] = await Promise.all([


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/247549 

Security Labs (`installSecurityLabs`) would download to `artifactPath` but then open the zip using `artifactPath`, not the returned safe path. That worked "by accident" as long as the downloader wrote to exactly that path; once `downloadToDisk()` started writing to a safe location under `data/`, the Security Labs install started failing.

#### Root cause

`downloadToDisk()` was updated to use `@kbn/fs safe-path` handling (dce7e81c354da638d562b41bd166c90b3bd255a8). That change makes writes land under Kibana’s `data/` dir (like `.../data/ai-kb-artifacts/...`), which is safer — but it exposed the bug where Security Labs didn’t use the returned full path.

#### Fix details
Security Labs now opens the zip using the downloadToDisk() return value (the same pattern the main product docs path already used), so it opens the file where it was actually written, and corresponding tests to catch this have been added.




### Checklist

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->