### PR TITLE
[PoC] [Discover] Doc viewer restorable state

### DIFF
--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer_tab.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer_tab.tsx
@@ -7,16 +7,20 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { KibanaSectionErrorBoundary } from '@kbn/shared-ux-error-boundary';
-import type { DocViewRenderProps } from '../../types';
+import type { DocViewComponent, DocViewRenderProps } from '../../types';
+import type { DocViewerProps } from './doc_viewer';
 
-interface Props {
+interface Props
+  extends Pick<DocViewerProps, 'initialDocViewState' | 'onInitialDocViewStateChange'> {
   id: string;
   renderProps: DocViewRenderProps;
   title: string;
-  component: React.ComponentType<DocViewRenderProps>;
+  component: DocViewComponent;
 }
+
+type ExtractState<T> = T extends DocViewComponent<infer S> ? S : never;
 
 /**
  * Renders the tab content of a doc view.
@@ -24,11 +28,29 @@ interface Props {
  * Error Boundaries.
  */
 export const DocViewerTab = (props: Props) => {
-  const { component: Component, renderProps, title } = props;
+  const {
+    id,
+    component: Component,
+    renderProps,
+    title,
+    initialDocViewState,
+    onInitialDocViewStateChange,
+  } = props;
+
+  const onInitialStateChange = useCallback(
+    (initialState: ExtractState<typeof Component>) => {
+      onInitialDocViewStateChange?.({ ...initialDocViewState, [id]: initialState });
+    },
+    [id, initialDocViewState, onInitialDocViewStateChange]
+  );
 
   return (
     <KibanaSectionErrorBoundary sectionName={title}>
-      <Component {...renderProps} />
+      <Component
+        initialState={initialDocViewState?.[id] as ExtractState<typeof Component>}
+        onInitialStateChange={onInitialStateChange}
+        {...renderProps}
+      />
     </KibanaSectionErrorBoundary>
   );
 };

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/types.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/types.ts
@@ -10,6 +10,7 @@
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { AggregateQuery, Query } from '@kbn/es-query';
 import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils/types';
+import type { RestorableStateProviderProps } from '@kbn/restorable-state';
 import type { DocViewsRegistry } from './doc_views_registry';
 
 export interface FieldMapping {
@@ -44,17 +45,19 @@ export interface DocViewRenderProps {
   onRemoveColumn?: (columnName: string) => void;
   docViewsRegistry?: DocViewsRegistry | ((prevRegistry: DocViewsRegistry) => DocViewsRegistry);
   decreaseAvailableHeightBy?: number;
-  initialTabId?: string;
 }
 
-export type DocViewerComponent = React.FC<DocViewRenderProps>;
+export type DocViewComponentProps<TState extends object = any> = DocViewRenderProps &
+  RestorableStateProviderProps<TState>;
 
-export interface DocView {
+export type DocViewComponent<TState extends object = any> = React.FC<DocViewComponentProps<TState>>;
+
+export interface DocView<TState extends object = any> {
   id: string;
   order: number;
   title: string;
-  component: DocViewerComponent;
+  component: DocViewComponent<TState>;
   enabled?: boolean;
 }
 
-export type DocViewFactory = () => DocView;
+export type DocViewFactory<TState extends object = any> = () => DocView<TState>;

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/types.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/types.ts
@@ -11,5 +11,5 @@ export type {
   DocView,
   DocViewFilterFn,
   DocViewRenderProps,
-  DocViewerComponent,
+  DocViewComponent,
 } from './services/types';

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/types.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/types.ts
@@ -8,4 +8,4 @@
  */
 
 export type { ElasticRequestState } from '.';
-export type { DocViewFilterFn, DocViewRenderProps, DocView, DocViewerComponent } from './src/types';
+export type { DocViewFilterFn, DocViewRenderProps, DocView, DocViewComponent } from './src/types';

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -52,6 +52,7 @@ import type { DiscoverGridSettings } from '@kbn/saved-search-plugin/common';
 import { useQuerySubscriber } from '@kbn/unified-field-list';
 import type { DocViewerApi } from '@kbn/unified-doc-viewer';
 import useLatest from 'react-use/lib/useLatest';
+import useUnmount from 'react-use/lib/useUnmount';
 import { DiscoverGrid } from '../../../../components/discover_grid';
 import { getDefaultRowsPerPage } from '../../../../../common/constants';
 import { useAppStateSelector } from '../../state_management/redux';
@@ -315,6 +316,21 @@ function DiscoverDocumentsComponent({
     [dispatch, stateContainer.actions.updateESQLQuery]
   );
 
+  const docViewerUiState = useCurrentTabSelector((state) => state.uiState.docViewer);
+  const setDocViewerUiState = useCurrentTabAction(internalStateActions.setDocViewerUiState);
+  const onInitialDocViewStateChange = useCallback(
+    (docViews: Record<string, unknown>) => {
+      dispatch(setDocViewerUiState({ docViewerUiState: { ...docViewerUiState, docViews } }));
+    },
+    [dispatch, docViewerUiState, setDocViewerUiState]
+  );
+
+  const [selectedDocViewerTabId, setSelectedDocViewerTabId] = useState<string>();
+
+  useUnmount(() => {
+    setExpandedDoc(expandedDoc, { initialTabId: selectedDocViewerTabId });
+  });
+
   const renderDocumentView = useCallback(
     (
       hit: DataTableRecord,
@@ -339,6 +355,9 @@ function DiscoverDocumentsComponent({
         initialTabId={initialDocViewerTabId}
         docViewerRef={docViewerRef}
         docViewerExtensionActions={docViewerExtensionActions}
+        initialDocViewState={docViewerUiState.docViews}
+        onInitialDocViewStateChange={onInitialDocViewStateChange}
+        onUpdateSelectedTabId={setSelectedDocViewerTabId}
       />
     ),
     [
@@ -351,6 +370,8 @@ function DiscoverDocumentsComponent({
       query,
       initialDocViewerTabId,
       docViewerExtensionActions,
+      docViewerUiState.docViews,
+      onInitialDocViewStateChange,
     ]
   );
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -149,8 +149,8 @@ function DiscoverDocumentsComponent({
       state.density,
     ];
   });
-  const expandedDoc = useInternalStateSelector((state) => state.expandedDoc);
-  const initialDocViewerTabId = useInternalStateSelector((state) => state.initialDocViewerTabId);
+  const expandedDoc = useCurrentTabSelector((state) => state.expandedDoc);
+  const initialDocViewerTabId = useCurrentTabSelector((state) => state.initialDocViewerTabId);
   const isEsqlMode = useIsEsqlMode();
   const documentState = useDataState(documents$);
   const isDataLoading =
@@ -216,10 +216,11 @@ function DiscoverDocumentsComponent({
   );
 
   const docViewerRef = useRef<DocViewerApi>(null);
+  const setExpandedDocAction = useCurrentTabAction(internalStateActions.setExpandedDoc);
   const setExpandedDoc = useCallback(
     (doc: DataTableRecord | undefined, options?: { initialTabId?: string }) => {
       dispatch(
-        internalStateActions.setExpandedDoc({
+        setExpandedDocAction({
           expandedDoc: doc,
           initialDocViewerTabId: options?.initialTabId,
         })
@@ -228,7 +229,7 @@ function DiscoverDocumentsComponent({
         docViewerRef.current?.setSelectedTabId(options.initialTabId);
       }
     },
-    [dispatch]
+    [dispatch, setExpandedDocAction]
   );
 
   const latestGrid = useLatest(grid);

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -288,8 +288,6 @@ export const updateTabs: InternalStateThunkActionCreator<
         searchSessionManager.removeSearchSessionIdFromURL({ replace: true });
         services.data.search.session.reset();
       }
-
-      dispatch(internalStateSlice.actions.discardFlyoutsOnTabChange());
     }
 
     dispatch(

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -22,6 +22,7 @@ import type { DiscoverAppState, TabState } from '../types';
 import { selectAllTabs, selectRecentlyClosedTabs, selectTab } from '../selectors';
 import {
   internalStateSlice,
+  discardFlyoutsOnTabChange,
   type TabActionPayload,
   type InternalStateThunkActionCreator,
 } from '../internal_state';
@@ -288,6 +289,8 @@ export const updateTabs: InternalStateThunkActionCreator<
         searchSessionManager.removeSearchSessionIdFromURL({ replace: true });
         services.data.search.session.reset();
       }
+
+      dispatch(discardFlyoutsOnTabChange());
     }
 
     dispatch(

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
@@ -33,5 +33,6 @@ export const DEFAULT_TAB_STATE: Omit<TabState, keyof TabItem> = {
     breakdownField: false,
     hideChart: false,
   },
-  uiState: {},
+  expandedDoc: undefined,
+  uiState: { docViewer: { docViews: {} } },
 };

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -170,6 +170,10 @@ export const internalStateSlice = createSlice({
       }>
     ) => {
       withTab(state, action.payload, (tab) => {
+        if (tab.expandedDoc?.id !== action.payload.expandedDoc?.id) {
+          tab.uiState.docViewer.docViews = {};
+        }
+
         tab.expandedDoc = action.payload.expandedDoc;
         tab.initialDocViewerTabId = action.payload.initialDocViewerTabId;
       });
@@ -269,6 +273,7 @@ export const internalStateSlice = createSlice({
         tab.overriddenVisContextAfterInvalidation = undefined;
         tab.expandedDoc = undefined;
         tab.initialDocViewerTabId = undefined;
+        tab.uiState.docViewer.docViews = {};
       }),
 
     setESQLEditorUiState: (
@@ -340,6 +345,14 @@ export const internalStateSlice = createSlice({
     ) =>
       withTab(state, action.payload, (tab) => {
         tab.uiState.metricsGrid = action.payload.metricsGridState;
+      }),
+
+    setDocViewerUiState: (
+      state,
+      action: TabAction<{ docViewerUiState: TabState['uiState']['docViewer'] }>
+    ) =>
+      withTab(state, action.payload, (tab) => {
+        tab.uiState.docViewer = action.payload.docViewerUiState;
       }),
   },
   extraReducers: (builder) => {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -23,6 +23,7 @@ import {
   createAction,
   isAnyOf,
 } from '@reduxjs/toolkit';
+import { dismissFlyouts, DiscoverFlyouts } from '@kbn/discover-utils';
 import type { IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { DiscoverSession } from '@kbn/saved-search-plugin/common';
@@ -391,6 +392,8 @@ export const syncLocallyPersistedTabState = createAction<TabActionPayload>(
   'internalState/syncLocallyPersistedTabState'
 );
 
+export const discardFlyoutsOnTabChange = createAction('internalState/discardFlyoutsOnTabChange');
+
 type InternalStateListenerEffect<
   TActionCreator extends PayloadActionCreator<TPayload>,
   TPayload = TActionCreator extends PayloadActionCreator<infer T> ? T : never
@@ -445,6 +448,13 @@ const createMiddleware = (options: InternalStateDependencies) => {
       MIDDLEWARE_THROTTLE_MS,
       MIDDLEWARE_THROTTLE_OPTIONS
     ),
+  });
+
+  startListening({
+    actionCreator: discardFlyoutsOnTabChange,
+    effect: () => {
+      dismissFlyouts([DiscoverFlyouts.lensEdit, DiscoverFlyouts.metricInsights]);
+    },
   });
 
   startListening({

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/tabs.ts
@@ -33,9 +33,3 @@ export const selectIsTabsBarHidden = createSelector(
   (state: DiscoverInternalState) => state.tabsBarVisibility,
   (tabsBarVisibility) => tabsBarVisibility === TabsBarVisibility.hidden
 );
-
-export const selectExpandedDoc = (state: DiscoverInternalState, tabId: string) =>
-  state.tabs.byId[tabId]?.expandedDoc;
-
-export const selectInitialDocViewerTabId = (state: DiscoverInternalState, tabId: string) =>
-  state.tabs.byId[tabId]?.initialDocViewerTabId;

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/selectors/tabs.ts
@@ -33,3 +33,9 @@ export const selectIsTabsBarHidden = createSelector(
   (state: DiscoverInternalState) => state.tabsBarVisibility,
   (tabsBarVisibility) => tabsBarVisibility === TabsBarVisibility.hidden
 );
+
+export const selectExpandedDoc = (state: DiscoverInternalState, tabId: string) =>
+  state.tabs.byId[tabId]?.expandedDoc;
+
+export const selectInitialDocViewerTabId = (state: DiscoverInternalState, tabId: string) =>
+  state.tabs.byId[tabId]?.initialDocViewerTabId;

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -166,6 +166,8 @@ export interface TabState extends TabItem {
     searchDraft?: Partial<UnifiedSearchDraft>;
     metricsGrid?: Partial<UnifiedMetricsGridRestorableState>;
   };
+  expandedDoc: DataTableRecord | undefined;
+  initialDocViewerTabId?: string;
 }
 
 export interface RecentlyClosedTabState extends TabState {
@@ -185,8 +187,6 @@ export interface DiscoverInternalState {
   hasUnsavedChanges: boolean;
   savedDataViews: DataViewListItem[];
   defaultProfileAdHocDataViewIds: string[];
-  expandedDoc: DataTableRecord | undefined;
-  initialDocViewerTabId?: string;
   isESQLToDataViewTransitionModalVisible: boolean;
   tabsBarVisibility: TabsBarVisibility;
   tabs: {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -165,6 +165,7 @@ export interface TabState extends TabItem {
     layout?: Partial<DiscoverLayoutRestorableState>;
     searchDraft?: Partial<UnifiedSearchDraft>;
     metricsGrid?: Partial<UnifiedMetricsGridRestorableState>;
+    docViewer: { docViews: Record<string, unknown> };
   };
   expandedDoc: DataTableRecord | undefined;
   initialDocViewerTabId?: string;

--- a/src/platform/plugins/shared/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
@@ -26,7 +26,11 @@ import { useProfileAccessor } from '../../context_awareness';
 
 export const FLYOUT_WIDTH_KEY = 'discover:flyoutWidth';
 
-export interface DiscoverGridFlyoutProps {
+export interface DiscoverGridFlyoutProps
+  extends Pick<
+    DocViewerProps,
+    'initialDocViewState' | 'onInitialDocViewStateChange' | 'onUpdateSelectedTabId'
+  > {
   savedSearchId?: string;
   filters?: Filter[];
   query?: Query | AggregateQuery;
@@ -65,6 +69,9 @@ export function DiscoverGridFlyout({
   onRemoveColumn,
   onAddColumn,
   setExpandedDoc,
+  initialDocViewState,
+  onInitialDocViewStateChange,
+  onUpdateSelectedTabId,
 }: DiscoverGridFlyoutProps) {
   const services = useDiscoverServices();
   const flyoutCustomization = useDiscoverCustomization('flyout');
@@ -127,6 +134,9 @@ export function DiscoverGridFlyout({
       setExpandedDoc={setExpandedDoc}
       initialTabId={initialTabId}
       docViewerRef={docViewerRef}
+      initialDocViewState={initialDocViewState}
+      onInitialDocViewStateChange={onInitialDocViewStateChange}
+      onUpdateSelectedTabId={onUpdateSelectedTabId}
     />
   );
 }

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/alert_event_overview.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/alert_event_overview.tsx
@@ -10,7 +10,7 @@
 import React, { useMemo, useState } from 'react';
 import type { FC, PropsWithChildren } from 'react';
 import { fieldConstants, getFieldValue } from '@kbn/discover-utils';
-import type { DocViewerComponent } from '@kbn/unified-doc-viewer/types';
+import type { DocViewComponent } from '@kbn/unified-doc-viewer/types';
 import {
   EuiTitle,
   EuiSpacer,
@@ -60,7 +60,7 @@ export const ExpandableSection: FC<PropsWithChildren<{ title: string }>> = ({
   );
 };
 
-export const AlertEventOverview: DocViewerComponent = ({ hit }) => {
+export const AlertEventOverview: DocViewComponent = ({ hit }) => {
   const {
     application: { getUrlForApp },
     fieldsMetadata,

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer/doc_viewer.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer/doc_viewer.tsx
@@ -8,13 +8,12 @@
  */
 
 import React, { forwardRef, useMemo } from 'react';
-import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
-import type { DocViewerApi } from '@kbn/unified-doc-viewer';
+import type { DocViewerApi, DocViewerProps } from '@kbn/unified-doc-viewer';
 import { DocViewer } from '@kbn/unified-doc-viewer';
 
 import { getUnifiedDocViewerServices } from '../../plugin';
 
-export const UnifiedDocViewer = forwardRef<DocViewerApi, DocViewRenderProps>(
+export const UnifiedDocViewer = forwardRef<DocViewerApi, Omit<DocViewerProps, 'docViews'>>(
   ({ docViewsRegistry, ...props }, ref) => {
     const { unifiedDocViewer } = getUnifiedDocViewerServices();
 

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
@@ -35,7 +35,11 @@ import type { DocViewerProps } from '@kbn/unified-doc-viewer';
 import { UnifiedDocViewer } from '../lazy_doc_viewer';
 import { useFlyoutA11y } from './use_flyout_a11y';
 
-export interface UnifiedDocViewerFlyoutProps {
+export interface UnifiedDocViewerFlyoutProps
+  extends Pick<
+    DocViewerProps,
+    'initialDocViewState' | 'onInitialDocViewStateChange' | 'onUpdateSelectedTabId'
+  > {
   docViewerRef?: DocViewerProps['ref'];
   'data-test-subj'?: string;
   flyoutTitle?: string;
@@ -100,6 +104,9 @@ export function UnifiedDocViewerFlyout({
   onAddColumn,
   setExpandedDoc,
   initialTabId,
+  initialDocViewState,
+  onInitialDocViewStateChange,
+  onUpdateSelectedTabId,
 }: UnifiedDocViewerFlyoutProps) {
   const { euiTheme } = useEuiTheme();
   const isXlScreen = useIsWithinMinBreakpoint('xl');
@@ -213,6 +220,9 @@ export function UnifiedDocViewerFlyout({
         docViewsRegistry={docViewsRegistry}
         decreaseAvailableHeightBy={euiTheme.base}
         initialTabId={initialTabId}
+        initialDocViewState={initialDocViewState}
+        onInitialDocViewStateChange={onInitialDocViewStateChange}
+        onUpdateSelectedTabId={onUpdateSelectedTabId}
       />
     ),
     [
@@ -229,6 +239,9 @@ export function UnifiedDocViewerFlyout({
       docViewsRegistry,
       euiTheme.base,
       initialTabId,
+      initialDocViewState,
+      onInitialDocViewStateChange,
+      onUpdateSelectedTabId,
     ]
   );
 

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/lazy_doc_viewer.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/lazy_doc_viewer.tsx
@@ -9,11 +9,10 @@
 
 import React from 'react';
 import { withSuspense } from '@kbn/shared-ux-utility';
-import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/src/services/types';
 import { EuiDelayRender, EuiSkeletonText } from '@elastic/eui';
 
 const LazyUnifiedDocViewer = React.lazy(() => import('./doc_viewer'));
-export const UnifiedDocViewer = withSuspense<DocViewRenderProps>(
+export const UnifiedDocViewer = withSuspense(
   LazyUnifiedDocViewer,
   <EuiDelayRender delay={300}>
     <EuiSkeletonText />

--- a/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import type { CoreSetup, Plugin } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import { DocViewsRegistry } from '@kbn/unified-doc-viewer';
-import { EuiDelayRender, EuiSkeletonText } from '@elastic/eui';
+import { EuiButton, EuiDelayRender, EuiSkeletonText, EuiSpacer } from '@elastic/eui';
 import { createGetterSetter, Storage } from '@kbn/kibana-utils-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
@@ -20,6 +20,7 @@ import { dynamic } from '@kbn/shared-ux-utility';
 import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { DiscoverSharedPublicStart } from '@kbn/discover-shared-plugin/public';
+import { createRestorableStateProvider } from '@kbn/restorable-state';
 import type { UnifiedDocViewerServices } from './types';
 
 export const [getUnifiedDocViewerServices, setUnifiedDocViewerServices] =
@@ -88,6 +89,34 @@ export class UnifiedDocViewerPublicPlugin
           />
         );
       },
+    });
+
+    interface TestDocViewRestorableState {
+      count: number;
+    }
+
+    const { withRestorableState, useRestorableState } =
+      createRestorableStateProvider<TestDocViewRestorableState>();
+
+    const Test = withRestorableState(() => {
+      const [count, setCount] = useRestorableState('count', 0);
+      return (
+        <>
+          <EuiSpacer size="s" />
+          <div>Count: {count}</div>
+          <EuiSpacer size="s" />
+          <EuiButton color="text" size="s" onClick={() => setCount(count + 1)}>
+            Increment
+          </EuiButton>
+        </>
+      );
+    });
+
+    this.docViewsRegistry.add({
+      id: 'test',
+      title: 'Test',
+      order: 30,
+      component: Test,
     });
 
     return {


### PR DESCRIPTION
## Summary

PoC.

Related to #248564.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.