### PR TITLE
Fix discover search CCS cancel functional test

### DIFF
--- a/src/platform/test/functional/apps/discover/ccs_compatibility/_cancel_results.ts
+++ b/src/platform/test/functional/apps/discover/ccs_compatibility/_cancel_results.ts
@@ -73,7 +73,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
                 "name": "*:*",
                 "error_type": "exception",
                 "message": "'Watch out!'",
-                "stall_time_seconds": 5
+                "stall_time_seconds": 30
               }
             ]
           }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/246775.

In looking at the failures, it looks like we don't get the partial results indicators because the search request completes before we hit the cancel button.

This PR increases the delay so we should realistically never cancel before the search request is complete.