### PR TITLE
[Agent Builder] Agent selector options behind RBAC

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/input_actions/agent_selector/agent_select_dropdown.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/input_actions/agent_selector/agent_select_dropdown.tsx
@@ -18,6 +18,7 @@ import { i18n } from '@kbn/i18n';
 import type { AgentDefinition } from '@kbn/agent-builder-common';
 import React, { useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { useUiPrivileges } from '../../../../../hooks/use_ui_privileges';
 import { useHasActiveConversation } from '../../../../../hooks/use_conversation';
 import { useNavigation } from '../../../../../hooks/use_navigation';
 import { appPaths } from '../../../../../utils/app_paths';
@@ -81,6 +82,7 @@ const AgentSelectPopoverButton: React.FC<{
 };
 
 const AgentListFooter: React.FC = () => {
+  const { manageAgents } = useUiPrivileges();
   const { createAgentBuilderUrl } = useNavigation();
   const createAgentHref = createAgentBuilderUrl(appPaths.agents.new);
   const manageAgentsHref = createAgentBuilderUrl(appPaths.agents.list);
@@ -94,6 +96,7 @@ const AgentListFooter: React.FC = () => {
             color="text"
             aria-label={manageAgentsAriaLabel}
             href={manageAgentsHref}
+            disabled={!manageAgents}
           >
             <FormattedMessage
               id="xpack.agentBuilder.conversationInput.agentSelector.manageAgents"
@@ -107,6 +110,7 @@ const AgentListFooter: React.FC = () => {
             iconType="plus"
             aria-label={createAgentAriaLabel}
             href={createAgentHref}
+            disabled={!manageAgents}
           >
             <FormattedMessage
               id="xpack.agentBuilder.conversationInput.agentSelector.createNewAgent"


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/247250

- [x] Adds RBAC check to "manage agents"
- [x] Adds RBAC check to "new agent"

<img width="283" height="358" alt="image" src="https://github.com/user-attachments/assets/c7a2e820-396b-432b-9f98-13a015e79d14" />


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->