### PR TITLE
[Flaky test] Observability alerts pagination - Previous page button is disabled

### DIFF
--- a/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/alerts/pagination.ts
+++ b/x-pack/solutions/observability/test/observability_functional/apps/observability/pages/alerts/pagination.ts
@@ -116,9 +116,12 @@ export default ({ getService }: FtrProviderContext) => {
         });
 
         it('Previous page button is disabled', async () => {
-          const prevButtonDisabledValue =
-            await observability.alerts.pagination.getPrevButtonDisabledValue();
-          expect(prevButtonDisabledValue).to.be('true');
+          await observability.alerts.common.alertDataHasLoaded();
+          await retry.try(async () => {
+            const prevButtonDisabledValue =
+              await observability.alerts.pagination.getPrevButtonDisabledValue();
+            expect(prevButtonDisabledValue).to.be('true');
+          });
         });
 
         it('Goes to nth page', async () => {


### PR DESCRIPTION
It closes https://github.com/elastic/kibana/issues/233241.

### Summary

Fixes intermittent test failure in `pagination.ts` where the test `'Previous page button is disabled'` would sometimes fail with:

`Error: expected null to equal 'true'
`
### Problem

The test was checking the `disabled` attribute of the previous page button without waiting for the alert data to finish loading.

### Solution

- Added `alertDataHasLoaded()` to wait for the alerts table to finish loading before checking the button state
- Wrapped the assertion in `retry.try()` to handle any remaining timing edge cases

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2"]} ONMERGE-->