### PR TITLE
[Agent Builder ]Add tech preview label mcp tool 

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/bulk_import/bulk_import_mcp_tools.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/bulk_import/bulk_import_mcp_tools.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback, useState } from 'react';
 import {
+  EuiBetaBadge,
   EuiButton,
   EuiButtonEmpty,
   EuiFlexGroup,
@@ -15,6 +16,7 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { EuiButtonProps, UseEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { defer } from 'lodash';
@@ -36,6 +38,19 @@ const headerStyles = ({ euiTheme }: UseEuiTheme) => css`
   background-color: ${euiTheme.colors.backgroundBasePlain};
   border-block-end: none;
 `;
+
+const TECH_PREVIEW_LABEL = i18n.translate(
+  'xpack.agentBuilder.tools.bulkImportMcp.techPreviewBadgeLabel',
+  { defaultMessage: 'Technical preview' }
+);
+
+const TECH_PREVIEW_DESCRIPTION = i18n.translate(
+  'xpack.agentBuilder.tools.bulkImportMcp.techPreviewBadgeDescription',
+  {
+    defaultMessage:
+      'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
+  }
+);
 
 const bottomBarStyles = ({ euiTheme }: UseEuiTheme) => css`
   z-index: ${euiTheme.levels.header};
@@ -151,7 +166,18 @@ export const BulkImportMcpTools: React.FC = () => {
     <FormProvider {...form}>
       <KibanaPageTemplate data-test-subj="agentBuilderBulkImportMcpToolsPage">
         <KibanaPageTemplate.Header
-          pageTitle={labels.tools.bulkImportMcp.title}
+          pageTitle={
+            <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+              <EuiFlexItem grow={false}>{labels.tools.bulkImportMcp.title}</EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiBetaBadge
+                  label={TECH_PREVIEW_LABEL}
+                  tooltipContent={TECH_PREVIEW_DESCRIPTION}
+                  size="m"
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          }
           description={labels.tools.bulkImportMcp.description}
           rightSideItems={[
             renderImportToolsButton({ size: 'm', testSubj: 'bulkImportMcpToolsImportButton' }),

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/type.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/type.tsx
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import { EuiFormRow, EuiSelect } from '@elastic/eui';
+import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSuperSelect } from '@elastic/eui';
+import { ToolType } from '@kbn/agent-builder-common';
+import { i18n } from '@kbn/i18n';
 import React, { useMemo } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useAgentBuilderServices } from '../../../../hooks/use_agent_builder_service';
@@ -15,6 +17,10 @@ import { useToolTypes } from '../../../../hooks/tools/use_tool_type_info';
 import type { ToolFormData } from '../types/tool_form_types';
 import { getToolTypeConfig, getEditableToolTypes } from '../registry/tools_form_registry';
 import { ToolFormMode } from '../tool_form';
+
+const TECH_PREVIEW_LABEL = i18n.translate('xpack.agentBuilder.tools.techPreviewBadgeLabel', {
+  defaultMessage: 'Tech preview',
+});
 
 export interface TypeProps {
   mode: ToolFormMode;
@@ -44,7 +50,20 @@ export const TypeSection = ({ mode }: TypeProps) => {
 
       editableTypes = editableTypes.filter((t) => serverEnabledEditableTypes.includes(t.value));
     }
-    return editableTypes;
+    return editableTypes.map((t) => ({
+      value: t.value,
+      inputDisplay: t.text,
+      dropdownDisplay: (
+        <EuiFlexGroup gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>{t.text}</EuiFlexItem>
+          {t.value === ToolType.mcp && (
+            <EuiFlexItem grow={false}>
+              <EuiBetaBadge iconType="flask" label={TECH_PREVIEW_LABEL} size="s" />
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      ),
+    }));
   }, [serverToolTypes, toolTypesLoading]);
 
   return (
@@ -61,13 +80,14 @@ export const TypeSection = ({ mode }: TypeProps) => {
         <Controller
           control={control}
           name="type"
-          render={({ field: { ref, ...field } }) => (
-            <EuiSelect
+          render={({ field: { value, onChange } }) => (
+            <EuiSuperSelect
               data-test-subj="agentBuilderToolTypeSelect"
               options={editableToolTypes}
-              {...field}
-              inputRef={ref}
+              valueOfSelected={value}
+              onChange={onChange}
               disabled={mode === ToolFormMode.Edit}
+              fullWidth
             />
           )}
         />

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/type.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/form/sections/type.tsx
@@ -53,6 +53,7 @@ export const TypeSection = ({ mode }: TypeProps) => {
     return editableTypes.map((t) => ({
       value: t.value,
       inputDisplay: t.text,
+      'data-test-subj': `agentBuilderToolTypeOption-${t.value}`,
       dropdownDisplay: (
         <EuiFlexGroup gutterSize="s" responsive={false}>
           <EuiFlexItem grow={false}>{t.text}</EuiFlexItem>

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/mcp/mcp.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/mcp/mcp.tsx
@@ -16,6 +16,7 @@ export const getConnectorType = (): MCPConnector => {
   return {
     id: CONNECTOR_ID,
     actionTypeTitle: CONNECTOR_NAME,
+    isExperimental: true,
     iconClass: lazy(() => import('./logo')),
     selectMessage: i18n.translate('xpack.stackConnectors.components.mcp.selectMessageText', {
       defaultMessage: 'Connect to an MCP (Model Context Protocol) server.',

--- a/x-pack/platform/test/functional/page_objects/agent_builder_page.ts
+++ b/x-pack/platform/test/functional/page_objects/agent_builder_page.ts
@@ -338,7 +338,9 @@ export class AgentBuilderPageObject extends FtrService {
   }
 
   async selectToolType(type: Exclude<ToolType, ToolType.builtin>) {
-    await this.testSubjects.selectValue('agentBuilderToolTypeSelect', type);
+    // EuiSuperSelect requires clicking the button to open the dropdown, then clicking the option
+    await this.testSubjects.click('agentBuilderToolTypeSelect');
+    await this.testSubjects.click(`agentBuilderToolTypeOption-${type}`);
   }
 
   async setToolDescription(description: string) {


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/12247

- [x] In the "Type" field, having a small tech preview badge next to "MCP"
- [x] In this flyout, having a tech preview badge (probably the full text one) next to the title is the play
- [x] Full tech preview badge next to the title on Bulk Import Page

**MCP Tool Type dropdown (now a super select to allow for the badge)**
<img width="1136" height="424" alt="image" src="https://github.com/user-attachments/assets/92c3cd72-b856-4b9b-8129-1ace6a78a58b" />

**MCP Connector Flyout**
<img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/645a6d10-9135-412c-8f92-0b44af686271" />


**Bulk Import tools title with badge**
<img width="1728" height="1001" alt="image" src="https://github.com/user-attachments/assets/777f1368-f925-418b-9e43-beefd294211d" />




<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->