### PR TITLE
[Scout Reporter] Support `scout_<custom>` directories for test reporting

### DIFF
--- a/src/platform/packages/private/kbn-scout-reporting/src/helpers/read_manifest.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/helpers/read_manifest.test.ts
@@ -25,10 +25,16 @@ describe('read_manifest', () => {
       expect(getKibanaModulePath(configPath)).toBe(expectedPath);
     });
 
-    it(`should throw an error if 'scout' is not in the path`, () => {
+    it('should resolve the manifest path correctly for a scout_* config path', () => {
+      const configPath = '/plugins/my_plugin/test/scout_custom_config/api/playwright.config.ts';
+      const expectedPath = path.resolve('/plugins/my_plugin/kibana.jsonc');
+      expect(getKibanaModulePath(configPath)).toBe(expectedPath);
+    });
+
+    it(`should throw an error if 'scout' or 'scout_*' is not in the path`, () => {
       const configPath = '/plugins/my_plugin/tests/playwright.config.ts';
       expect(() => getKibanaModulePath(configPath)).toThrow(
-        /Invalid path: "scout" directory not found/
+        /Invalid path: "scout" or "scout_\*" directory not found/
       );
     });
   });

--- a/src/platform/packages/private/kbn-scout-reporting/src/helpers/read_manifest.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/helpers/read_manifest.ts
@@ -32,16 +32,18 @@ export interface KibanaModuleMetadata {
  * Resolves the path to the `kibana.jsonc` manifest based on the Playwright configuration file path.
  * @param configPath - Absolute path to the Playwright configuration file.
  * @returns Absolute path to the `kibana.jsonc` file.
- * @throws Error if `scout` is not found in the path.
+ * @throws Error if `scout` or `scout_*` is not found in the path.
  */
 export const getKibanaModulePath = (configPath: string): string => {
   const pathSegments = configPath.split(path.sep);
-  const testDirIndex = pathSegments.indexOf('scout');
+  const testDirIndex = pathSegments.findIndex(
+    (segment) => segment === 'scout' || segment.startsWith('scout_')
+  );
 
   if (testDirIndex === -1) {
     throw new Error(
-      `Invalid path: "scout" directory not found in ${configPath}.
-  Ensure playwright configuration file is in the plugin directory: '/plugins/<plugin-name>/test/scout/ui/<config-file>'`
+      `Invalid path: "scout" or "scout_*" directory not found in ${configPath}.
+  Ensure Playwright configuration file is in the plugin directory: '/plugins/<plugin-name>/test/{scout,scout_*}/ui/<config-file>'`
     );
   }
 

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
@@ -107,6 +107,7 @@ export class ScoutPlaywrightReporter implements Reporter {
   }
 
   private getScoutConfigCategory(configPath: string): ScoutTestRunConfigCategory {
+    // match scout or scout_* directory
     const pattern = /scout(?:_[^/]+)?\/(api|ui)\//;
     const match = configPath.match(pattern);
     if (match) {

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
@@ -107,7 +107,7 @@ export class ScoutPlaywrightReporter implements Reporter {
   }
 
   private getScoutConfigCategory(configPath: string): ScoutTestRunConfigCategory {
-    // match scout or scout_* directory
+    // Matches scout/{api|ui} or scout_<custom>/{api|ui} and captures api|ui
     const pattern = /scout(?:_[^/]+)?\/(api|ui)\//;
     const match = configPath.match(pattern);
     if (match) {

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts
@@ -107,7 +107,7 @@ export class ScoutPlaywrightReporter implements Reporter {
   }
 
   private getScoutConfigCategory(configPath: string): ScoutTestRunConfigCategory {
-    const pattern = /scout\/(api|ui)\//;
+    const pattern = /scout(?:_[^/]+)?\/(api|ui)\//;
     const match = configPath.match(pattern);
     if (match) {
       return match[1] === 'api'


### PR DESCRIPTION
This PR updates the `kbn-scout-reporting` package to support Scout test file paths located in custom `scout_<custom>` directories (e.g., `scout_uiam_local`, `scout_cspm_agentless`).

Example of a path the package now supports:

```   
x-pack/platform/plugins/shared/security/test/scout_uiam_local/api/parallel.playwright.config.ts
```

With these fixes:
* ✅ The test category is correctly parsed from the path and reported correctly
* ✅ The plugin metadata is extracted from `kibana.jsonc` for failure reports

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->