### PR TITLE
[8.19] Add Scout events reporter integration (#245528)

### DIFF
--- a/.buildkite/scripts/steps/functional/apm_cypress.sh
+++ b/.buildkite/scripts/steps/functional/apm_cypress.sh
@@ -13,4 +13,9 @@ echo "--- APM Cypress Tests"
 cd "$XPACK_DIR/solutions/observability/plugins/apm/ftr_e2e"
 
 set +e
-yarn cypress:run; status=$?; yarn junit:merge || :; exit $status
+yarn cypress:run; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/asset_inventory.sh
+++ b/.buildkite/scripts/steps/functional/asset_inventory.sh
@@ -4,15 +4,16 @@ set -euo pipefail
 
 source .buildkite/scripts/steps/functional/common.sh
 
-export JOB=kibana-security-solution-chrome
+export JOB=kibana-asset-inventory-cypress
 export KIBANA_INSTALL_DIR=${KIBANA_BUILD_LOCATION}
 
-echo "--- Response Ops Cypress Tests on Security Solution"
+echo "--- Asset Inventory Workflows Cypress tests"
 
 cd x-pack/solutions/security/test/security_solution_cypress
 
 set +e
-yarn cypress:run:respops:ess; status=$?; yarn junit:merge || :
+
+yarn cypress:asset_inventory:run:ess; status=$?; yarn junit:merge || :
 
 # Scout reporter
 upload_scout_cypress_events "Cypress tests"

--- a/.buildkite/scripts/steps/functional/asset_inventory_serverless.sh
+++ b/.buildkite/scripts/steps/functional/asset_inventory_serverless.sh
@@ -4,15 +4,16 @@ set -euo pipefail
 
 source .buildkite/scripts/steps/functional/common.sh
 
-export JOB=kibana-security-solution-chrome
+export JOB=kibana-asset-inventory-serverless-cypress
 export KIBANA_INSTALL_DIR=${KIBANA_BUILD_LOCATION}
 
-echo "--- Response Ops Cypress Tests on Security Solution"
+echo "--- Asset Inventory Workflows Cypress tests on Serverless"
 
 cd x-pack/solutions/security/test/security_solution_cypress
 
 set +e
-yarn cypress:run:respops:ess; status=$?; yarn junit:merge || :
+
+yarn cypress:asset_inventory:run:serverless; status=$?; yarn junit:merge || :
 
 # Scout reporter
 upload_scout_cypress_events "Cypress tests"

--- a/.buildkite/scripts/steps/functional/cloud_security_posture.sh
+++ b/.buildkite/scripts/steps/functional/cloud_security_posture.sh
@@ -13,4 +13,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 
 set +e
 
-yarn cypress:cloud_security_posture:run:ess; status=$?; yarn junit:merge || :; exit $status
+yarn cypress:cloud_security_posture:run:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/cloud_security_posture_serverless.sh
+++ b/.buildkite/scripts/steps/functional/cloud_security_posture_serverless.sh
@@ -13,4 +13,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 
 set +e
 
-yarn cypress:cloud_security_posture:run:serverless; status=$?; yarn junit:merge || :; exit $status
+yarn cypress:cloud_security_posture:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/common.sh
+++ b/.buildkite/scripts/steps/functional/common.sh
@@ -12,3 +12,34 @@ source .buildkite/scripts/common/util.sh
 
 is_test_execution_step
 
+# Upload Scout reporter events after Cypress test execution
+upload_scout_cypress_events() {
+  local test_name="${1:-Cypress tests}"
+
+  if [[ "${SCOUT_REPORTER_ENABLED:-}" =~ ^(1|true)$ ]]; then
+    # Save current directory and navigate to Kibana root
+    local current_dir=$(pwd)
+    cd "${KIBANA_DIR:-$(git rev-parse --show-toplevel)}"
+
+    # Check if reports exist before uploading
+    if compgen -G '.scout/reports/*' > /dev/null; then
+      echo "--- Upload Scout reporter events to AppEx QA's team cluster for $test_name"
+      node scripts/scout upload-events --dontFailOnError
+
+      # Clean up only Cypress event reports to avoid double ingestion
+      # Only remove scout-cypress-* directories, preserving other test reports and failure reports
+      if compgen -G '.scout/reports/scout-cypress-*' > /dev/null; then
+       echo "🧹 Cleaning up Scout Cypress event reports"
+       rm -rf .scout/reports/scout-cypress-*
+      fi
+    else
+      echo "❌ No Scout reports found for $test_name"
+    fi
+
+    # Return to original directory
+    cd "$current_dir"
+  else
+    echo "SCOUT_REPORTER_ENABLED=$SCOUT_REPORTER_ENABLED, skipping event upload."
+  fi
+}
+

--- a/.buildkite/scripts/steps/functional/defend_workflows.sh
+++ b/.buildkite/scripts/steps/functional/defend_workflows.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/plugins/security_solution
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci defend-workflows-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:dw:run; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:dw:run; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/defend_workflows_serverless.sh
+++ b/.buildkite/scripts/steps/functional/defend_workflows_serverless.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/plugins/security_solution
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci defend-workflows-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:dw:serverless:run; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:dw:serverless:run; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/fleet_cypress.sh
+++ b/.buildkite/scripts/steps/functional/fleet_cypress.sh
@@ -12,4 +12,14 @@ echo "--- Fleet Cypress tests (Chrome)"
 cd x-pack/platform/plugins/shared/fleet
 
 set +e
-yarn cypress:run:reporter; status=$?; yarn cypress_space_awareness:run:reporter; space_status=$?; yarn junit:merge || :; [ "$status" -ne 0 ] && exit $status || [ "$space_status" -ne 0 ] && exit $space_status || exit 0
+yarn cypress:run:reporter; status=$?; yarn cypress_space_awareness:run:reporter; space_status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Fleet Cypress tests"
+
+# Exit with appropriate status
+if [ "$status" -ne 0 ]; then
+  exit $status
+elif [ "$space_status" -ne 0 ]; then
+  exit $space_status
+fi

--- a/.buildkite/scripts/steps/functional/osquery_cypress.sh
+++ b/.buildkite/scripts/steps/functional/osquery_cypress.sh
@@ -13,4 +13,9 @@ echo "--- Osquery Cypress tests"
 cd x-pack/platform/plugins/shared/osquery
 
 set +e
-yarn cypress:run; status=$?; yarn junit:merge || :; exit $status
+yarn cypress:run; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/response_ops_cases.sh
+++ b/.buildkite/scripts/steps/functional/response_ops_cases.sh
@@ -12,4 +12,9 @@ echo "--- Response Ops Cases Cypress Tests on Security Solution"
 cd x-pack/solutions/security/test/security_solution_cypress
 
 set +e
-yarn cypress:run:cases:ess; status=$?; yarn junit:merge || :; exit $status
+yarn cypress:run:cases:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_ai4dsoc.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_ai4dsoc.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:ai4dsoc:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:ai4dsoc:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:ai_assistant:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:ai_assistant:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_automatic_import.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_automatic_import.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:automatic_import:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:automatic_import:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:detection_engine:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:detection_engine:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:detection_engine:exceptions:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:detection_engine:exceptions:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:entity_analytics:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:entity_analytics:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_explore.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_explore.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:explore:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:explore:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_investigations.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_investigations.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:investigations:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:investigations:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_osquery.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_osquery.sh
@@ -13,4 +13,9 @@ echo "--- Security Osquery Serverless Cypress"
 cd x-pack/platform/plugins/shared/osquery
 
 set +e
-yarn cypress:serverless:run; status=$?; yarn junit:merge || :; exit $status
+yarn cypress:serverless:run; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_rule_management.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_rule_management.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:customization:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:customization:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:installation:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:installation:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:management:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:management:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:upgrade:run:serverless; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:upgrade:run:serverless; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:ai_assistant:run:ess; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:ai_assistant:run:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "AI Assistant Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_detection_engine.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_detection_engine.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:detection_engine:run:ess; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:detection_engine:run:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Detection Engine Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:detection_engine:exceptions:run:ess; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:detection_engine:exceptions:run:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:entity_analytics:run:ess; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:entity_analytics:run:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_explore.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_explore.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:explore:run:ess; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:explore:run:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Explore Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_investigations.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_investigations.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:investigations:run:ess; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:investigations:run:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Investigations Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_rule_management.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_rule_management.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:run:ess; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:run:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Rule Management Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:customization:run:ess; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:customization:run:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:installation:run:ess; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:installation:run:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:management:run:ess; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:management:run:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
@@ -14,4 +14,9 @@ cd x-pack/solutions/security/test/security_solution_cypress
 set +e
 BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
 
-BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:upgrade:run:ess; status=$?; yarn junit:merge || :; exit $status
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:rule_management:prebuilt_rules:upgrade:run:ess; status=$?; yarn junit:merge || :
+
+# Scout reporter
+upload_scout_cypress_events "Cypress tests"
+
+exit $status

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/event.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/event.ts
@@ -43,7 +43,7 @@ export interface ScoutReportEventInfo {
  */
 export interface ScoutReporterInfo {
   name: string;
-  type: 'jest' | 'ftr' | 'playwright';
+  type: 'jest' | 'ftr' | 'playwright' | 'cypress';
 }
 
 /**

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/event.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/event.ts
@@ -71,6 +71,12 @@ export interface ScoutTestRunInfo {
   };
   status?: string;
   duration?: number;
+  tests?: {
+    passes?: number;
+    pending?: number;
+    failures?: number;
+    total?: number;
+  };
 }
 
 /**

--- a/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/event.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/reporting/report/events/event.ts
@@ -122,4 +122,7 @@ export interface ScoutReportEvent {
   test_run: ScoutTestRunInfo;
   suite?: ScoutSuiteInfo;
   test?: ScoutTestInfo;
+  process?: {
+    uptime?: number;
+  };
 }

--- a/src/platform/packages/shared/kbn-cypress-config/index.ts
+++ b/src/platform/packages/shared/kbn-cypress-config/index.ts
@@ -11,13 +11,123 @@ import { v4 as uuid } from 'uuid';
 import { defineConfig } from 'cypress';
 import wp from '@cypress/webpack-preprocessor';
 import { NodeLibsBrowserPlugin } from '@kbn/node-libs-browser-webpack-plugin';
+import {
+  SCOUT_REPORT_OUTPUT_ROOT,
+  SCOUT_REPORTER_ENABLED,
+  ScoutTestRunConfigCategory,
+} from '@kbn/scout-info';
+import { REPO_ROOT } from '@kbn/repo-info';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { camelCase } from 'lodash';
+import fs from 'fs';
+
+export const SCOUT_CYPRESS_REPORTER_PATH = path.join(
+  REPO_ROOT,
+  'src/platform/packages/shared/kbn-cypress-config/src/reporting/scout_events'
+);
+
+function getProjectRoot(): string {
+  const projectRootIndex = process.argv.findIndex((arg) => arg === '--projectRoot');
+  if (projectRootIndex !== -1) {
+    return process.argv[projectRootIndex + 1];
+  }
+  return '';
+}
+
+function getCategoryFromPath(configPath: string): ScoutTestRunConfigCategory {
+  // Check for API integration tests
+  if (configPath.includes('api_integration') || configPath.includes('/api/')) {
+    return ScoutTestRunConfigCategory.API_TEST;
+  }
+
+  // Check for unit tests
+  if (
+    configPath.includes('unit') ||
+    configPath.includes('.test.') ||
+    configPath.includes('.spec.')
+  ) {
+    return ScoutTestRunConfigCategory.UNIT_TEST;
+  }
+
+  // Default to UI_TEST for Cypress
+  return ScoutTestRunConfigCategory.UI_TEST;
+}
+
+function getReportingOptionOverrides(options?: Cypress.ConfigOptions): Record<string, any> {
+  if (!SCOUT_REPORTER_ENABLED) {
+    // Scout reporter not enabled, no reporting settings to override
+    return {};
+  }
+
+  const reporter: string | undefined = options?.reporter;
+  // if reporter is not defined then config runs locally and logs results to console
+  if (reporter === undefined || !reporter.endsWith('cypress-multi-reporters')) {
+    return {};
+  }
+
+  // this is the list of reporters that should be enabled through the multi-reporter plugin
+  let enabledReporters: string[] = [];
+  let reporterOptions: Record<string, any> = options?.reporterOptions ?? {};
+
+  if (reporterOptions.configFile) {
+    // Check if config file exists in current directory
+    if (fs.existsSync(path.join(process.cwd(), reporterOptions.configFile))) {
+      reporterOptions = JSON.parse(
+        readFileSync(path.join(process.cwd(), reporterOptions.configFile), 'utf8')
+      );
+    } else {
+      // Else get the project root and read the config file from there
+      reporterOptions = JSON.parse(
+        readFileSync(path.join(getProjectRoot(), reporterOptions.configFile), 'utf8')
+      );
+    }
+  }
+
+  if (reporterOptions.reporterEnabled) {
+    enabledReporters = reporterOptions.reporterEnabled.split(',').map((r: string) => r.trim());
+  }
+
+  if (SCOUT_REPORTER_ENABLED) {
+    enabledReporters.push(SCOUT_CYPRESS_REPORTER_PATH);
+
+    reporterOptions[`${camelCase(SCOUT_CYPRESS_REPORTER_PATH)}ReporterOptions`] = {
+      name: 'cypress',
+      outputPath: SCOUT_REPORT_OUTPUT_ROOT,
+      config: {
+        // The config properties will be set later in setupNodeEvents where config.configFile is available.
+      },
+    };
+  }
+
+  // Make sure all the correct reporters are enabled
+  reporterOptions.reporterEnabled = enabledReporters.join(', ');
+
+  return { reporter, reporterOptions };
+}
 
 export function defineCypressConfig(options?: Cypress.ConfigOptions<any>) {
   return defineConfig({
     ...options,
+    ...getReportingOptionOverrides(options),
     e2e: {
       ...options?.e2e,
       setupNodeEvents(on, config) {
+        // Update Scout reporter options with actual config file path
+        // This runs once per config file, so each config gets its own correct path
+        if (SCOUT_REPORTER_ENABLED && config.configFile) {
+          const reporterOptionsKey = `${camelCase(SCOUT_CYPRESS_REPORTER_PATH)}ReporterOptions`;
+
+          // Update the reporter options in the config object
+          // This ensures each config file gets the correct path
+          if (config.reporterOptions && config.reporterOptions[reporterOptionsKey]) {
+            config.reporterOptions[reporterOptionsKey].config.path = config.configFile;
+            config.reporterOptions[reporterOptionsKey].config.category = getCategoryFromPath(
+              config.configFile
+            );
+          }
+        }
+
         on('file:preprocessor', (file) => {
           const id = uuid();
           // Fix an issue with running Cypress parallel
@@ -61,6 +171,9 @@ export function defineCypressConfig(options?: Cypress.ConfigOptions<any>) {
 
           return config;
         }
+
+        // Return the modified config so Cypress uses the updated reporter options
+        return config;
       },
     },
   });

--- a/src/platform/packages/shared/kbn-cypress-config/moon.yml
+++ b/src/platform/packages/shared/kbn-cypress-config/moon.yml
@@ -19,6 +19,11 @@ project:
     sourceRoot: src/platform/packages/shared/kbn-cypress-config
 dependsOn:
   - '@kbn/node-libs-browser-webpack-plugin'
+  - '@kbn/scout-info'
+  - '@kbn/repo-info'
+  - '@kbn/tooling-log'
+  - '@kbn/scout-reporting'
+  - '@kbn/code-owners'
 tags:
   - shared-common
   - package

--- a/src/platform/packages/shared/kbn-cypress-config/src/reporting/scout_events/index.js
+++ b/src/platform/packages/shared/kbn-cypress-config/src/reporting/scout_events/index.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+require('@kbn/babel-register').install();
+module.exports = require('./reporter').ScoutCypressReporter;

--- a/src/platform/packages/shared/kbn-cypress-config/src/reporting/scout_events/reporter.ts
+++ b/src/platform/packages/shared/kbn-cypress-config/src/reporting/scout_events/reporter.ts
@@ -1,0 +1,293 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import path from 'node:path';
+import { ToolingLog } from '@kbn/tooling-log';
+import type { ScoutTestRunConfigCategory } from '@kbn/scout-info';
+import { SCOUT_REPORT_OUTPUT_ROOT, SCOUT_TARGET_MODE, SCOUT_TARGET_TYPE } from '@kbn/scout-info';
+import { REPO_ROOT } from '@kbn/repo-info';
+import type { ScoutFileInfo } from '@kbn/scout-reporting';
+import {
+  datasources,
+  ScoutEventsReport,
+  ScoutReportEventAction,
+  type ScoutTestRunInfo,
+  generateTestRunId,
+  computeTestID,
+} from '@kbn/scout-reporting';
+import {
+  type CodeOwnersEntry,
+  type CodeOwnerArea,
+  getOwningTeamsForPath,
+  getCodeOwnersEntries,
+  findAreaForCodeOwner,
+} from '@kbn/code-owners';
+
+/**
+ * Configuration options for the Scout Cypress reporter
+ */
+export interface ScoutCypressReporterOptions {
+  name?: string;
+  outputPath?: string;
+  config?: {
+    path: string;
+    category: ScoutTestRunConfigCategory;
+  };
+}
+
+/**
+ * Scout Cypress reporter
+ */
+export class ScoutCypressReporter {
+  readonly log: ToolingLog;
+  readonly name: string;
+  readonly runId: string;
+  private report: ScoutEventsReport;
+  private readonly baseTestRunInfo: ScoutTestRunInfo;
+  private readonly codeOwnersEntries: CodeOwnersEntry[];
+  private readonly reporterOptions: ScoutCypressReporterOptions;
+
+  constructor(
+    private runner: Mocha.Runner,
+    options: {
+      reporterOptions?: ScoutCypressReporterOptions;
+    }
+  ) {
+    this.log = new ToolingLog({
+      level: 'info',
+      writeTo: process.stdout,
+    });
+
+    this.reporterOptions = options.reporterOptions || {};
+    this.name = this.reporterOptions.name || 'cypress';
+    this.runId = generateTestRunId();
+    this.log.info(`Scout test run ID: ${this.runId}`);
+
+    this.report = new ScoutEventsReport(this.log);
+    this.codeOwnersEntries = getCodeOwnersEntries();
+    const configPath = this.reporterOptions.config?.path || undefined;
+    const category = this.reporterOptions.config?.category || undefined;
+
+    this.baseTestRunInfo = {
+      id: this.runId,
+      target: {
+        type: SCOUT_TARGET_TYPE,
+        mode: SCOUT_TARGET_MODE,
+      },
+      config: {
+        file: configPath
+          ? this.getScoutFileInfoForPath(path.relative(REPO_ROOT, configPath))
+          : undefined,
+        category,
+      },
+    };
+
+    // Register event listeners
+    for (const [eventName, listener] of Object.entries({
+      start: this.onRunStart,
+      end: this.onRunEnd,
+      test: this.onTestStart,
+      'test end': this.onTestEnd,
+    })) {
+      runner.on(eventName, listener);
+    }
+  }
+
+  private getFileOwners(filePath: string): string[] {
+    return getOwningTeamsForPath(filePath, this.codeOwnersEntries);
+  }
+
+  private getOwnerAreas(owners: string[]): CodeOwnerArea[] {
+    return owners
+      .map((owner) => findAreaForCodeOwner(owner))
+      .filter((area) => area !== undefined) as CodeOwnerArea[];
+  }
+
+  private getScoutFileInfoForPath(filePath: string): ScoutFileInfo {
+    const fileOwners = this.getFileOwners(filePath);
+
+    return {
+      path: filePath,
+      owner: fileOwners,
+      area: this.getOwnerAreas(fileOwners),
+    };
+  }
+
+  /**
+   * Recursively find the file path by traversing up the parent chain
+   * This is required as test.file can be undefined in some Cypress tests
+   */
+  private getTestFile(test: Mocha.Test): string | undefined {
+    // Try test.file first
+    if (test.file) {
+      return test.file;
+    }
+
+    // Try parent suite
+    if (test.parent) {
+      return this.getSuiteFile(test.parent);
+    }
+
+    // Last resort: check the root suite from the runner
+    if (this.runner.suite?.file) {
+      return this.runner.suite.file;
+    }
+
+    return undefined;
+  }
+
+  private getSuiteFile(suite: Mocha.Suite): string | undefined {
+    // Try suite.file first
+    if (suite.file) {
+      return suite.file;
+    }
+
+    // Try parent suite recursively
+    if (suite.parent) {
+      return this.getSuiteFile(suite.parent);
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Root path of this reporter's output
+   */
+  public get reportRootPath(): string {
+    const outputPath = this.reporterOptions.outputPath || SCOUT_REPORT_OUTPUT_ROOT;
+    return path.join(outputPath, `scout-cypress-${this.runId}`);
+  }
+
+  onRunStart = () => {
+    /**
+     * Root suite execution began (all files have been parsed and hooks/tests are ready for execution)
+     */
+    this.report.logEvent({
+      ...datasources.environmentMetadata,
+      reporter: {
+        name: this.name,
+        type: 'cypress',
+      },
+      test_run: this.baseTestRunInfo,
+      event: {
+        action: ScoutReportEventAction.RUN_BEGIN,
+      },
+    });
+  };
+
+  onTestStart = (test: Mocha.Test) => {
+    /**
+     * Test execution started
+     */
+    const testFile = this.getTestFile(test);
+    const relativeTestFile = testFile ? path.relative(REPO_ROOT, testFile) : 'unknown';
+
+    this.report.logEvent({
+      ...datasources.environmentMetadata,
+      reporter: {
+        name: this.name,
+        type: 'cypress',
+      },
+      test_run: this.baseTestRunInfo,
+      suite: {
+        title: test.parent?.fullTitle() || 'unknown',
+        type: test.parent?.root ? 'root' : 'suite',
+      },
+      test: {
+        id: computeTestID(relativeTestFile, test.fullTitle()),
+        title: test.title,
+        tags: [],
+        file: testFile ? this.getScoutFileInfoForPath(relativeTestFile) : undefined,
+      },
+      event: {
+        action: ScoutReportEventAction.TEST_BEGIN,
+      },
+    });
+  };
+
+  onTestEnd = (test: Mocha.Test) => {
+    /**
+     * Test execution ended
+     */
+    const testFile = this.getTestFile(test);
+    const relativeTestFile = testFile ? path.relative(REPO_ROOT, testFile) : 'unknown';
+
+    this.report.logEvent({
+      ...datasources.environmentMetadata,
+      reporter: {
+        name: this.name,
+        type: 'cypress',
+      },
+      test_run: this.baseTestRunInfo,
+      suite: {
+        title: test.parent?.fullTitle() || 'unknown',
+        type: test.parent?.root ? 'root' : 'suite',
+      },
+      test: {
+        id: computeTestID(relativeTestFile, test.fullTitle()),
+        title: test.title,
+        tags: [],
+        status: test.isPending() ? 'skipped' : test.isPassed() ? 'passed' : 'failed',
+        duration: test.duration,
+        file: testFile ? this.getScoutFileInfoForPath(relativeTestFile) : undefined,
+      },
+      event: {
+        action: ScoutReportEventAction.TEST_END,
+        error: {
+          message: test.err?.message,
+          stack_trace: test.err?.stack,
+        },
+      },
+    });
+  };
+
+  onRunEnd = () => {
+    /**
+     * Root suite execution has ended
+     */
+    const passes = this.runner.stats?.passes ?? 0;
+    const failures = this.runner.stats?.failures ?? 0;
+    const pending = this.runner.stats?.pending ?? 0;
+
+    this.report.logEvent({
+      ...datasources.environmentMetadata,
+      reporter: {
+        name: this.name,
+        type: 'cypress',
+      },
+      test_run: {
+        ...this.baseTestRunInfo,
+        status: this.runner.stats?.failures === 0 ? 'passed' : 'failed',
+        duration: this.runner.stats?.duration || 0,
+        tests: {
+          passes,
+          failures,
+          pending,
+          total: passes + failures + pending,
+        },
+      },
+      event: {
+        action: ScoutReportEventAction.RUN_END,
+      },
+      process: {
+        uptime: Math.floor(process.uptime() * 1000),
+      },
+    });
+
+    // Save & conclude the report
+    try {
+      this.report.save(this.reportRootPath);
+    } catch (e) {
+      // Log the error but don't propagate it
+      this.log.error(e);
+    } finally {
+      this.report.conclude();
+    }
+  };
+}

--- a/src/platform/packages/shared/kbn-cypress-config/tsconfig.json
+++ b/src/platform/packages/shared/kbn-cypress-config/tsconfig.json
@@ -15,5 +15,10 @@
   ],
   "kbn_references": [
     "@kbn/node-libs-browser-webpack-plugin",
+    "@kbn/scout-info",
+    "@kbn/repo-info",
+    "@kbn/tooling-log",
+    "@kbn/scout-reporting",
+    "@kbn/code-owners",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add Scout events reporter integration (#245528)](https://github.com/elastic/kibana/pull/245528)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Charis Kalpakis","email":"39087493+fake-haris@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-06T09:48:30Z","message":"Add Scout events reporter integration (#245528)\n\n## Summary\n\nAdds Scout events reporter integration to the kbn-cypress-config\npackage, enabling automatic test run tracking and reporting for Cypress\ntests when Scout reporting is enabled.\n\n### Changes \n\n- **Scout reporter integration**\n([index.ts](src/platform/packages/shared/kbn-cypress-config/index.ts))\n- Added `getReportingOptionOverrides()` to inject Scout reporter into\nCypress multi-reporter configuration\n- Auto-detects test category (API, Unit, or UI) based on config file\npath\n- Parses existing reporter configuration and appends Scout reporter when\n`SCOUT_REPORTER_ENABLED` is true\n  - Extracts config file path and project root from CLI arguments\n\n- **Custom Cypress reporter**\n([reporter.ts](src/platform/packages/shared/kbn-cypress-config/src/reporting/scout_events/reporter.ts))\n- Implements `ScoutCypressReporter` class that hooks into Mocha's test\nlifecycle\n  - Captures test run events (start, end, test begin, test end)\n  - Integrates with code owners to track team ownership for test files\n- Generates structured Scout events with environment metadata, test\nstatus, and duration\n\n---------\n\nCo-authored-by: David Olaru <dolaru@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"2300d2da736b498c700fafa169eacfa935e589a2","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:QA","release_note:skip","ci:all-cypress-suites","backport:all-open","v9.3.0","v9.4.0","v9.2.4","v9.1.10"],"title":"Add Scout events reporter integration","number":245528,"url":"https://github.com/elastic/kibana/pull/245528","mergeCommit":{"message":"Add Scout events reporter integration (#245528)\n\n## Summary\n\nAdds Scout events reporter integration to the kbn-cypress-config\npackage, enabling automatic test run tracking and reporting for Cypress\ntests when Scout reporting is enabled.\n\n### Changes \n\n- **Scout reporter integration**\n([index.ts](src/platform/packages/shared/kbn-cypress-config/index.ts))\n- Added `getReportingOptionOverrides()` to inject Scout reporter into\nCypress multi-reporter configuration\n- Auto-detects test category (API, Unit, or UI) based on config file\npath\n- Parses existing reporter configuration and appends Scout reporter when\n`SCOUT_REPORTER_ENABLED` is true\n  - Extracts config file path and project root from CLI arguments\n\n- **Custom Cypress reporter**\n([reporter.ts](src/platform/packages/shared/kbn-cypress-config/src/reporting/scout_events/reporter.ts))\n- Implements `ScoutCypressReporter` class that hooks into Mocha's test\nlifecycle\n  - Captures test run events (start, end, test begin, test end)\n  - Integrates with code owners to track team ownership for test files\n- Generates structured Scout events with environment metadata, test\nstatus, and duration\n\n---------\n\nCo-authored-by: David Olaru <dolaru@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"2300d2da736b498c700fafa169eacfa935e589a2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247916","number":247916,"state":"MERGED","mergeCommit":{"sha":"66a4ff2fbea0cc960c8799f45844a19f5546d8ec","message":"[9.3] Add Scout events reporter integration (#245528) (#247916)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [Add Scout events reporter integration\n(#245528)](https://github.com/elastic/kibana/pull/245528)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Charis Kalpakis <39087493+fake-haris@users.noreply.github.com>\nCo-authored-by: David Olaru <dolaru@elastic.co>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245528","number":245528,"mergeCommit":{"message":"Add Scout events reporter integration (#245528)\n\n## Summary\n\nAdds Scout events reporter integration to the kbn-cypress-config\npackage, enabling automatic test run tracking and reporting for Cypress\ntests when Scout reporting is enabled.\n\n### Changes \n\n- **Scout reporter integration**\n([index.ts](src/platform/packages/shared/kbn-cypress-config/index.ts))\n- Added `getReportingOptionOverrides()` to inject Scout reporter into\nCypress multi-reporter configuration\n- Auto-detects test category (API, Unit, or UI) based on config file\npath\n- Parses existing reporter configuration and appends Scout reporter when\n`SCOUT_REPORTER_ENABLED` is true\n  - Extracts config file path and project root from CLI arguments\n\n- **Custom Cypress reporter**\n([reporter.ts](src/platform/packages/shared/kbn-cypress-config/src/reporting/scout_events/reporter.ts))\n- Implements `ScoutCypressReporter` class that hooks into Mocha's test\nlifecycle\n  - Captures test run events (start, end, test begin, test end)\n  - Integrates with code owners to track team ownership for test files\n- Generates structured Scout events with environment metadata, test\nstatus, and duration\n\n---------\n\nCo-authored-by: David Olaru <dolaru@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"2300d2da736b498c700fafa169eacfa935e589a2"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247915","number":247915,"state":"MERGED","mergeCommit":{"sha":"0058a2f52982532e46a40adc3288e7cd341f243e","message":"[9.2] Add Scout events reporter integration (#245528) (#247915)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [Add Scout events reporter integration\n(#245528)](https://github.com/elastic/kibana/pull/245528)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Charis Kalpakis <39087493+fake-haris@users.noreply.github.com>\nCo-authored-by: David Olaru <dolaru@elastic.co>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>"}},{"branch":"9.1","label":"v9.1.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247914","number":247914,"state":"MERGED","mergeCommit":{"sha":"6399a0c12f85a9a9a8dce12bb6cac07fc2da72e5","message":"[9.1] Add Scout events reporter integration (#245528) (#247914)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [Add Scout events reporter integration\n(#245528)](https://github.com/elastic/kibana/pull/245528)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Charis Kalpakis <39087493+fake-haris@users.noreply.github.com>\nCo-authored-by: David Olaru <dolaru@elastic.co>\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>"}}]}] BACKPORT-->