### PR TITLE
[9.2] [ML] Data Visualizer map view fix on small screen sizes (#247615)

### DIFF
--- a/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/stats_table/data_visualizer_stats_table.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/common/components/stats_table/data_visualizer_stats_table.tsx
@@ -389,6 +389,7 @@ const UnmemoizedDataVisualizerTable = <T extends DataVisualizerTableItem>({
 
   const $panelWidthS = `calc(max(20%, 225px))`;
   const $panelWidthM = `calc(max(30%, 300px))`;
+  const $panelWidthL = `calc(max(35%, 400px))`;
 
   const dvTableCss = css({
     thead: {
@@ -400,6 +401,16 @@ const UnmemoizedDataVisualizerTable = <T extends DataVisualizerTableItem>({
     },
     '.euiTableRow > .euiTableRowCell': {
       borderTop: 0,
+    },
+    '& .dvMap__wrapper': {
+      minWidth: '100px',
+      height: '240px',
+      [useEuiMinBreakpoint('s')]: {
+        minWidth: $panelWidthM,
+      },
+      [useEuiMinBreakpoint('m')]: {
+        minWidth: $panelWidthL,
+      },
     },
     [useEuiMinBreakpoint('s')]: {
       '& .columnHeader__title': {
@@ -457,10 +468,6 @@ const UnmemoizedDataVisualizerTable = <T extends DataVisualizerTableItem>({
       '& .dvPanel__wrapper:last-child': {
         margin: `${euiTheme.size.xs} 0 ${euiTheme.size.m} 0`,
       },
-
-      '& .dvMap__wrapper': {
-        height: '240px',
-      },
       '& .dvText__wrapper': {
         minWidth: $panelWidthS,
       },
@@ -502,6 +509,11 @@ const UnmemoizedDataVisualizerTable = <T extends DataVisualizerTableItem>({
             data-test-subj={`dataVisualizerTable-${loading ? 'loading' : 'loaded'}`}
             rowProps={(item) => ({
               'data-test-subj': `dataVisualizerRow row-${item.fieldName}`,
+            })}
+            tableCaption={i18n.translate('xpack.dataVisualizer.dataGrid.tableCaption', {
+              defaultMessage:
+                'Field statistics table showing {count, plural, one {# field} other {# fields}} with their types, document counts, distinct values, and value distributions.',
+              values: { count: items.length },
             })}
           />
         </div>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[ML] Data Visualizer map view fix on small screen sizes (#247615)](https://github.com/elastic/kibana/pull/247615)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Krasocki","email":"104936644+KodeRad@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-05T12:03:32Z","message":"[ML] Data Visualizer map view fix on small screen sizes (#247615)\n\n## Summary\n\nThis PR:\n\n- Fixes the issue where the map was was not visible on small screen\nwidths\n- Adds table caption for a11y reasons\n\nScreenshots:\n\n\nhttps://github.com/user-attachments/assets/784a281f-3e35-4a19-8466-27e361b9ad9c\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nFixes https://github.com/elastic/kibana/issues/242007","sha":"006909c8e7f71e14dbe06eea8ca80e904932ad35","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","Team:ML","backport:all-open","v9.3.0","v9.4.0"],"title":"[ML] Data Visualizer: fixes display of map view for small screen sizes","number":247615,"url":"https://github.com/elastic/kibana/pull/247615","mergeCommit":{"message":"[ML] Data Visualizer map view fix on small screen sizes (#247615)\n\n## Summary\n\nThis PR:\n\n- Fixes the issue where the map was was not visible on small screen\nwidths\n- Adds table caption for a11y reasons\n\nScreenshots:\n\n\nhttps://github.com/user-attachments/assets/784a281f-3e35-4a19-8466-27e361b9ad9c\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nFixes https://github.com/elastic/kibana/issues/242007","sha":"006909c8e7f71e14dbe06eea8ca80e904932ad35"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/247809","number":247809,"state":"MERGED","mergeCommit":{"sha":"2077ebb39251488b9b1ffa9e70e913821ece080e","message":"[9.3] [ML] Data Visualizer map view fix on small screen sizes (#247615) (#247809)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[ML] Data Visualizer map view fix on small screen sizes\n(#247615)](https://github.com/elastic/kibana/pull/247615)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Konrad Krasocki <104936644+KodeRad@users.noreply.github.com>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247615","number":247615,"mergeCommit":{"message":"[ML] Data Visualizer map view fix on small screen sizes (#247615)\n\n## Summary\n\nThis PR:\n\n- Fixes the issue where the map was was not visible on small screen\nwidths\n- Adds table caption for a11y reasons\n\nScreenshots:\n\n\nhttps://github.com/user-attachments/assets/784a281f-3e35-4a19-8466-27e361b9ad9c\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nFixes https://github.com/elastic/kibana/issues/242007","sha":"006909c8e7f71e14dbe06eea8ca80e904932ad35"}}]}] BACKPORT-->