### PR TITLE
[ES|QL] Refetches controls options when the timerange changes

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_manager.test.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_manager.test.tsx
@@ -260,5 +260,42 @@ describe('initializeESQLControlManager', () => {
 
       expect(setDataLoadingMock).not.toHaveBeenCalled();
     });
+
+    test('should refetch values when the timeRange changes', async () => {
+      const initialState = {
+        selectedOptions: [],
+        variableName: 'variable1',
+        variableType: ESQLVariableType.VALUES,
+        esqlQuery: 'FROM foo | WHERE @timestamp >= ?start AND @timestamp <= ?end | STATS BY column',
+        controlType: EsqlControlType.VALUES_FROM_QUERY,
+        singleSelect: true,
+        title: 'My variable',
+      } as ESQLControlState;
+
+      const setDataLoadingMock = jest.fn();
+      initializeESQLControlManager(uuid, dashboardApi, initialState, setDataLoadingMock);
+
+      setDataLoadingMock.mockClear();
+      // Initial fetch with timeRange
+      mockFetch$.next({
+        timeRange: { from: '2024-01-01', to: '2024-01-31' },
+        esqlVariables: [],
+      });
+
+      await waitFor(() => {
+        expect(setDataLoadingMock).toHaveBeenCalledWith(false);
+      });
+
+      // Change the timeRange (query and variables stay the same)
+      setDataLoadingMock.mockClear();
+      mockFetch$.next({
+        timeRange: { from: '2024-02-01', to: '2024-02-28' },
+        esqlVariables: [],
+      });
+
+      await waitFor(() => {
+        expect(setDataLoadingMock).toHaveBeenCalledWith(true);
+      });
+    });
   });
 });

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_manager.ts
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_manager.ts
@@ -33,6 +33,7 @@ import {
 } from '@kbn/presentation-publishing';
 import { hasStartEndParams } from '@kbn/esql-utils';
 
+import type { TimeRange } from '@kbn/es-query';
 import type { OptionsListSuggestions } from '../../../common/options_list';
 import { dataService } from '../../services/kibana_services';
 import { initializeTemporayStateManager } from '../data_controls/options_list_control/temporay_state_manager';
@@ -136,6 +137,7 @@ export function initializeESQLControlManager(
   // For Values From Query controls, update values on dashboard load/reload
   // or when dependencies change in case of chaining controls
   let previousESQLVariables: ESQLControlVariable[] = [];
+  let previousTimeRange: TimeRange | undefined;
   let hasInitialFetch = false;
   const fetchSubscription = fetch$({ uuid, parentApi })
     .pipe(
@@ -153,12 +155,17 @@ export function initializeESQLControlManager(
           (variable) => variable.key !== currentVariableName
         );
 
+        // Check if timeRange has changed
+        const timeRangeChanged = !deepEqual(previousTimeRange, timeRange);
+
         const shouldFetch =
           !hasInitialFetch ||
+          timeRangeChanged ||
           haveVariablesValuesChanged(externalVariables, previousESQLVariables, variablesInQuery);
 
         if (shouldFetch) {
           previousESQLVariables = [...externalVariables];
+          previousTimeRange = timeRange ? { ...timeRange } : undefined;
           hasInitialFetch = true;
         }
 
@@ -288,6 +295,7 @@ export function initializeESQLControlManager(
       title$.next(lastSaved?.title);
       temporaryStateManager.api.setInvalidSelections(new Set());
       previousESQLVariables = [];
+      previousTimeRange = undefined;
       hasInitialFetch = false;
     },
     getLatestState: () => {


### PR DESCRIPTION
## Summary

This PR is fixing the following bug:

- Create an ES|QL control that uses the time variables (e.g. `FROM kibana_sample_data_logs |  WHERE @timestamp <=?_tend and @timestamp >?_tstart  STATS BY extension.keyword `)
- Change the timepicker
- See that the options are not been updated (in main)

In this PR the options are being updated if the ES|QL query of the control is associated with the time picker

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios