### PR TITLE
Skip serverless Discover histogram tests for MKI

### DIFF
--- a/x-pack/platform/test/serverless/functional/test_suites/discover/group1/_discover_histogram.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/group1/_discover_histogram.ts
@@ -33,6 +33,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const queryBar = getService('queryBar');
 
   describe('discover histogram', function describeIndexTests() {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/248077
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       await esArchiver.loadIfNeeded(
         'src/platform/test/functional/fixtures/es_archiver/logstash_functional'


### PR DESCRIPTION
## Summary

This PR skips the serverless Discover histogram tests for MKI runs.
Details in the failure/flakiness in #248077.