### PR TITLE
[Synthetics] Fix JavaScript template literal interpolation in browser monitors on private locations

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.test.ts
@@ -244,15 +244,194 @@ describe('replaceStringWithParams', () => {
     expect(result).toEqual({});
   });
 
-  it(`should escape template literals using unicode for private location compatibility`, () => {
+  it(`should escape template literals using $$$ for Agent and Heartbeat compatibility`, () => {
     const value = inlineSourceFormatter(
       {
         [ConfigKey.SOURCE_INLINE]: 'const a = ${b}; const c = ${d}',
       },
       ConfigKey.SOURCE_INLINE
     );
-    // Uses unicode escape \u0024 for $ to prevent Elastic Agent from interpreting as policy variables
-    expect(value).toEqual('const a = \\u0024{b}; const c = \\u0024{d}');
+    // Uses $$$ escape for both Agent AND Heartbeat:
+    // - Agent: $$${b} → $${b}
+    // - Heartbeat: $${b} → ${b}
+    // - JavaScript: ${b} → interpolates
+    expect(value).toEqual('const a = $$${b}; const c = $$${d}');
+  });
+
+  it(`should escape template literals in realistic browser monitor script`, () => {
+    const script = `var host = "https://www.elastic.co";
+step(\`Go to \${host}\`, async () => {
+  await page.goto(\`\${host}/docs\`, { timeout: 60000, waitUntil: 'domcontentloaded' });
+});`;
+
+    const value = inlineSourceFormatter(
+      {
+        [ConfigKey.SOURCE_INLINE]: script,
+      },
+      ConfigKey.SOURCE_INLINE
+    );
+
+    // Verify ${host} is escaped to $$${host} for Agent + Heartbeat processing
+    expect(value).toContain('`Go to $$${host}`');
+    expect(value).toContain('`$$${host}/docs`');
+    // Verify the variable declaration is NOT escaped (no ${} pattern)
+    expect(value).toContain('var host = "https://www.elastic.co"');
+  });
+
+  it(`should handle multiple template literal variables in URL paths`, () => {
+    const script = `const baseUrl = "https://example.com";
+const path = "/api";
+await page.goto(\`\${baseUrl}\${path}/users\`);`;
+
+    const value = inlineSourceFormatter(
+      {
+        [ConfigKey.SOURCE_INLINE]: script,
+      },
+      ConfigKey.SOURCE_INLINE
+    );
+
+    expect(value).toContain('`$$${baseUrl}$$${path}/users`');
+  });
+
+  it(`should handle template literals with expressions`, () => {
+    const script = `const id = 123;
+await page.goto(\`https://api.example.com/users/\${id}/profile\`);
+console.log(\`User ID: \${id * 2}\`);`;
+
+    const value = inlineSourceFormatter(
+      {
+        [ConfigKey.SOURCE_INLINE]: script,
+      },
+      ConfigKey.SOURCE_INLINE
+    );
+
+    expect(value).toContain('`https://api.example.com/users/$$${id}/profile`');
+    expect(value).toContain('`User ID: $$${id * 2}`');
+  });
+
+  it(`should handle nested template literals and complex expressions`, () => {
+    const script = `const config = { timeout: 5000 };
+step(\`Test with timeout \${config.timeout}ms\`, async () => {
+  await page.waitForTimeout(\${config.timeout});
+});`;
+
+    const value = inlineSourceFormatter(
+      {
+        [ConfigKey.SOURCE_INLINE]: script,
+      },
+      ConfigKey.SOURCE_INLINE
+    );
+
+    expect(value).toContain('`Test with timeout $$${config.timeout}ms`');
+  });
+
+  it(`should handle journey with params object access`, () => {
+    // This script uses params.baseUrl which is a Synthetics param
+    // The ${params.baseUrl} should be escaped for Agent/Heartbeat
+    // Then JavaScript will access the params object at runtime
+    const script = `journey('Test', ({ page, params }) => {
+  step('Go to base', async () => {
+    await page.goto(\`\${params.baseUrl}/docs\`);
+  });
+});`;
+
+    const value = inlineSourceFormatter(
+      {
+        [ConfigKey.SOURCE_INLINE]: script,
+      },
+      ConfigKey.SOURCE_INLINE
+    );
+
+    expect(value).toContain('`$$${params.baseUrl}/docs`');
+  });
+
+  it(`should handle mixed JS variables and params in same template`, () => {
+    const script = `journey('Mixed', ({ page, params }) => {
+  const path = '/api/v1';
+  step('API call', async () => {
+    await page.goto(\`\${params.baseUrl}\${path}/users\`);
+  });
+});`;
+
+    const value = inlineSourceFormatter(
+      {
+        [ConfigKey.SOURCE_INLINE]: script,
+      },
+      ConfigKey.SOURCE_INLINE
+    );
+
+    expect(value).toContain('`$$${params.baseUrl}$$${path}/users`');
+  });
+
+  it(`should not modify scripts without template literals`, () => {
+    const script = `step('Simple test', async () => {
+  await page.goto('https://example.com');
+  const text = page.locator('h1');
+  await expect(text).toBeVisible();
+});`;
+
+    const value = inlineSourceFormatter(
+      {
+        [ConfigKey.SOURCE_INLINE]: script,
+      },
+      ConfigKey.SOURCE_INLINE
+    );
+
+    // Script should remain unchanged (no ${} to escape)
+    expect(value).toEqual(script);
+  });
+
+  it(`should handle dollar signs in various contexts`, () => {
+    // Dollar signs not followed by { should remain unchanged
+    const script = `const price = '$100';
+const text = 'Hello';
+step(\`Check \${text}\`, async () => {});`;
+
+    const value = inlineSourceFormatter(
+      {
+        [ConfigKey.SOURCE_INLINE]: script,
+      },
+      ConfigKey.SOURCE_INLINE
+    );
+
+    // The template literal ${text} should be escaped
+    expect(value).toContain('`Check $$${text}`');
+    // Dollar sign not followed by { should remain unchanged
+    expect(value).toContain("const price = '$100'");
+  });
+
+  it(`should handle multi-step journey with various template patterns`, () => {
+    const script = `const baseUrl = 'https://www.elastic.co';
+const userId = 42;
+
+journey('Full test', ({ page, params }) => {
+  step(\`Navigate to \${baseUrl}\`, async () => {
+    await page.goto(\`\${baseUrl}/docs\`);
+  });
+
+  step(\`Check user \${userId}\`, async () => {
+    await page.goto(\`\${params.apiUrl}/users/\${userId}\`);
+  });
+
+  step('Static step', async () => {
+    await page.goto('https://example.com');
+  });
+});`;
+
+    const value = inlineSourceFormatter(
+      {
+        [ConfigKey.SOURCE_INLINE]: script,
+      },
+      ConfigKey.SOURCE_INLINE
+    );
+
+    // All ${} patterns should be escaped
+    expect(value).toContain('`Navigate to $$${baseUrl}`');
+    expect(value).toContain('`$$${baseUrl}/docs`');
+    expect(value).toContain('`Check user $$${userId}`');
+    expect(value).toContain('`$$${params.apiUrl}/users/$$${userId}`');
+    // Static strings should remain unchanged
+    expect(value).toContain("'https://example.com'");
   });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/formatters/formatting_utils.ts
@@ -125,10 +125,13 @@ export const formatMWs = (mws?: MaintenanceWindow[], strRes = true) => {
 };
 
 function escapeTemplateLiterals(script: string): string {
-  // Escape ${...} to prevent Elastic Agent from interpreting as policy variables.
-  // Using unicode escape \u0024 for $ - agent won't recognize as variable,
-  // but JavaScript will interpret \u0024 as $ when the script runs.
-  return script.replace(/\$\{/g, '\\u0024{');
+  // Escape ${...} for BOTH Elastic Agent AND Heartbeat variable substitution.
+  // We need double escaping: $$${var}
+  // - Agent sees: $ + $${var} → outputs $ + ${var} = $${var}
+  // - Heartbeat sees: $${var} → outputs ${var}
+  // - JavaScript sees: ${var} → interpolates correctly
+  // In JS replace(), $$$$ = $$, so $$$$${  outputs $$${
+  return script.replace(/\$\{/g, '$$$$${');
 }
 
 export const inlineSourceFormatter: FormatterFn = (fields, key) => {


### PR DESCRIPTION
## Summary

Fixes JavaScript template literal interpolation in browser monitor inline scripts running on private locations.

Related to #247284

## Problem

PR #247284 introduced unicode escaping (`\u0024{`) to prevent the Elastic Agent from interpreting `${...}` patterns as policy variables. However, this broke JavaScript template literal interpolation because `\u0024{` inside a template literal is treated as literal text, not as an expression delimiter.

**Before (broken):**
```js
var host = "https://www.elastic.co";
step(`Go to ${host}`, async () => { ... });
// Result: "Go to ${host}" - literal string, not interpolated
```
## Solution

Changed escaping from `\u0024{` to `$$${` (triple dollar). This works because both Elastic Agent and Heartbeat use `$$` as an escape sequence:

1. **Agent** sees `$$${host}` → outputs `$${host}`
2. **Heartbeat** sees `$${host}` → outputs `${host}`
3. **JavaScript** sees `${host}` → interpolates correctly

**After (fixed):**
```js 
var host = "https://www.elastic.co";
step(`Go to ${host}`, async () => { ... });
// Result: "Go to https://www.elastic.co"## Testing
```
- Added unit tests covering various template literal patterns
- Manually verified on private location with browser monitor
<img width="557" height="720" alt="image" src="https://github.com/user-attachments/assets/6a877b64-ec84-452c-89d7-8f7e65aac5bb" />

## Changes

- `formatting_utils.ts`: Changed escaping from `\u0024{` to `$$${`
- `formatting_utils.test.ts`: Updated existing test + added new test cases