### PR TITLE
[Streams][StreamLang] Add support for arrays with single values to conditionToPainless

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/filter_conditions.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/filter_conditions.spec.ts
@@ -969,4 +969,64 @@ apiTest.describe('Cross-compatibility - Filter Conditions', { tag: ['@ess', '@sv
       })
     );
   });
+
+  apiTest(
+    'should handle single-element arrays in filter conditions',
+    async ({ testBed, esql }) => {
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'set',
+            to: 'attributes.matched',
+            value: 'yes',
+            where: {
+              field: 'attributes.tag',
+              eq: 'important',
+            },
+          } as SetProcessor,
+        ],
+      };
+
+      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { query } = transpileEsql(streamlangDSL);
+
+      const mappingDoc = { attributes: { tag: 'null', matched: 'null' } };
+      const docs = [
+        { attributes: { tag: ['important'] } }, // single-element array - should match
+        { attributes: { tag: 'important' } }, // regular string - should match
+        { attributes: { tag: ['other'] } }, // single-element array - should NOT match
+        { attributes: { tag: 'other' } }, // regular string - should NOT match
+      ];
+
+      await testBed.ingest('ingest-single-array', docs, processors);
+      const ingestResult = await testBed.getDocsOrdered('ingest-single-array');
+
+      await testBed.ingest('esql-single-array', [mappingDoc, ...docs]);
+      const esqlResult = await esql.queryOnIndex('esql-single-array', query);
+
+      // Single-element array ['important'] should match like 'important'
+      expect(ingestResult[0].attributes).toStrictEqual(
+        expect.objectContaining({ matched: 'yes' })
+      );
+      expect(ingestResult[1].attributes).toStrictEqual(
+        expect.objectContaining({ matched: 'yes' })
+      );
+      expect(ingestResult[2].attributes).not.toHaveProperty('matched');
+      expect(ingestResult[3].attributes).not.toHaveProperty('matched');
+
+      // ES|QL should produce the same results
+      expect(esqlResult.documentsOrdered[1]).toStrictEqual(
+        expect.objectContaining({ 'attributes.matched': 'yes' })
+      );
+      expect(esqlResult.documentsOrdered[2]).toStrictEqual(
+        expect.objectContaining({ 'attributes.matched': 'yes' })
+      );
+      expect(esqlResult.documentsOrdered[3]).toStrictEqual(
+        expect.objectContaining({ 'attributes.matched': null })
+      );
+      expect(esqlResult.documentsOrdered[4]).toStrictEqual(
+        expect.objectContaining({ 'attributes.matched': null })
+      );
+    }
+  );
 });

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/conditions/condition_to_painless.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/conditions/condition_to_painless.test.ts
@@ -325,7 +325,10 @@ describe('conditionToPainless', () => {
     expect(conditionToPainless(condition)).toMatchInlineSnapshot(`
       "
         try {
+        
         def val_log = $('log', null); if (val_log instanceof List && val_log.size() == 1) { val_log = val_log[0]; }
+        
+        
         if (val_log !== null) {
           return true;
         }
@@ -352,8 +355,11 @@ describe('conditionToPainless', () => {
     expect(conditionToPainless(condition)).toMatchInlineSnapshot(`
       "
         try {
+        
         def val_log_logger_name = $('log.logger.name', null); if (val_log_logger_name instanceof List && val_log_logger_name.size() == 1) { val_log_logger_name = val_log_logger_name[0]; }
         def val_log_level = $('log.level', null); if (val_log_level instanceof List && val_log_level.size() == 1) { val_log_level = val_log_level[0]; }
+        
+        
         if ((val_log_logger_name !== null && ((val_log_logger_name instanceof Number && val_log_logger_name.toString() == \\"nginx_proxy\\") || val_log_logger_name == \\"nginx_proxy\\")) && ((val_log_level !== null && ((val_log_level instanceof Number && val_log_level.toString() == \\"error\\") || val_log_level == \\"error\\")) || (val_log_level !== null && ((val_log_level instanceof Number && val_log_level.toString() == \\"ERROR\\") || val_log_level == \\"ERROR\\")))) {
           return true;
         }

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/conditions/condition_to_painless.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/conditions/condition_to_painless.test.ts
@@ -91,6 +91,31 @@ const operatorConditionAndResults = [
 ];
 
 describe('conditionToPainless', () => {
+  describe('single-element array unwrapping', () => {
+    test('should unwrap single-element arrays before comparison', () => {
+      const condition = { field: 'foo', eq: 'bar' };
+      const result = conditionToPainless(condition);
+
+      // Should contain List instanceof check and size check
+      expect(result).toContain('instanceof List');
+      expect(result).toContain('.size() == 1');
+    });
+
+    test('should handle multiple fields with array unwrapping', () => {
+      const condition = {
+        and: [
+          { field: 'foo', eq: 'bar' },
+          { field: 'baz', eq: 'qux' },
+        ],
+      };
+      const result = conditionToPainless(condition);
+
+      // Should contain List checks for both fields
+      expect(result).toContain('instanceof List');
+      expect(result).toContain('.size() == 1');
+    });
+  });
+
   describe('conditionToStatement', () => {
     describe('operators', () => {
       operatorConditionAndResults.forEach((setup) => {
@@ -300,7 +325,8 @@ describe('conditionToPainless', () => {
     expect(conditionToPainless(condition)).toMatchInlineSnapshot(`
       "
         try {
-        if ($('log', null) !== null) {
+        def val_log = $('log', null); if (val_log instanceof List && val_log.size() == 1) { val_log = val_log[0]; }
+        if (val_log !== null) {
           return true;
         }
         return false;
@@ -326,7 +352,9 @@ describe('conditionToPainless', () => {
     expect(conditionToPainless(condition)).toMatchInlineSnapshot(`
       "
         try {
-        if (($('log.logger.name', null) !== null && (($('log.logger.name', null) instanceof Number && $('log.logger.name', null).toString() == \\"nginx_proxy\\") || $('log.logger.name', null) == \\"nginx_proxy\\")) && (($('log.level', null) !== null && (($('log.level', null) instanceof Number && $('log.level', null).toString() == \\"error\\") || $('log.level', null) == \\"error\\")) || ($('log.level', null) !== null && (($('log.level', null) instanceof Number && $('log.level', null).toString() == \\"ERROR\\") || $('log.level', null) == \\"ERROR\\")))) {
+        def val_log_logger_name = $('log.logger.name', null); if (val_log_logger_name instanceof List && val_log_logger_name.size() == 1) { val_log_logger_name = val_log_logger_name[0]; }
+        def val_log_level = $('log.level', null); if (val_log_level instanceof List && val_log_level.size() == 1) { val_log_level = val_log_level[0]; }
+        if ((val_log_logger_name !== null && ((val_log_logger_name instanceof Number && val_log_logger_name.toString() == \\"nginx_proxy\\") || val_log_logger_name == \\"nginx_proxy\\")) && ((val_log_level !== null && ((val_log_level instanceof Number && val_log_level.toString() == \\"error\\") || val_log_level == \\"error\\")) || (val_log_level !== null && ((val_log_level instanceof Number && val_log_level.toString() == \\"ERROR\\") || val_log_level == \\"ERROR\\")))) {
           return true;
         }
         return false;

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/__snapshots__/transpiler.test.ts.snap
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/__snapshots__/transpiler.test.ts.snap
@@ -25,7 +25,10 @@ Object {
         "field": "foo",
         "if": "
   try {
+  
   def val_attributes_status = $('attributes.status', null); if (val_attributes_status instanceof List && val_attributes_status.size() == 1) { val_attributes_status = val_attributes_status[0]; }
+  
+  
   if ((val_attributes_status !== null && ((val_attributes_status instanceof Number && val_attributes_status.toString() == \\"active\\") || val_attributes_status == \\"active\\"))) {
     return true;
   }
@@ -76,7 +79,10 @@ Object {
         "field": "attributes.not_flag",
         "if": "
   try {
+  
   def val_attributes_status = $('attributes.status', null); if (val_attributes_status instanceof List && val_attributes_status.size() == 1) { val_attributes_status = val_attributes_status[0]; }
+  
+  
   if (!((val_attributes_status !== null && ((val_attributes_status instanceof Number && val_attributes_status.toString() == \\"active\\") || val_attributes_status == \\"active\\")))) {
     return true;
   }
@@ -93,8 +99,11 @@ Object {
         "field": "attributes.not_nested",
         "if": "
   try {
+  
   def val_attributes_a = $('attributes.a', null); if (val_attributes_a instanceof List && val_attributes_a.size() == 1) { val_attributes_a = val_attributes_a[0]; }
   def val_attributes_b = $('attributes.b', null); if (val_attributes_b instanceof List && val_attributes_b.size() == 1) { val_attributes_b = val_attributes_b[0]; }
+  
+  
   if (!(((val_attributes_a !== null && ((val_attributes_a instanceof Number && val_attributes_a.toString() == \\"1\\") || val_attributes_a == 1)) || (val_attributes_b !== null && ((val_attributes_b instanceof Number && val_attributes_b.toString() == \\"2\\") || val_attributes_b == 2))))) {
     return true;
   }
@@ -118,10 +127,13 @@ Object {
         "field": "attributes.boolean_true_test",
         "if": "
   try {
+  
   def val_attributes_is_active = $('attributes.is_active', null); if (val_attributes_is_active instanceof List && val_attributes_is_active.size() == 1) { val_attributes_is_active = val_attributes_is_active[0]; }
   def val_attributes_is_active_str = $('attributes.is_active_str', null); if (val_attributes_is_active_str instanceof List && val_attributes_is_active_str.size() == 1) { val_attributes_is_active_str = val_attributes_is_active_str[0]; }
   def val_attributes_is_inactive = $('attributes.is_inactive', null); if (val_attributes_is_inactive instanceof List && val_attributes_is_inactive.size() == 1) { val_attributes_is_inactive = val_attributes_is_inactive[0]; }
   def val_attributes_is_inactive_str = $('attributes.is_inactive_str', null); if (val_attributes_is_inactive_str instanceof List && val_attributes_is_inactive_str.size() == 1) { val_attributes_is_inactive_str = val_attributes_is_inactive_str[0]; }
+  
+  
   if ((val_attributes_is_active !== null && ((val_attributes_is_active instanceof Number && val_attributes_is_active.toString() == \\"true\\") || val_attributes_is_active == true)) && (val_attributes_is_active_str !== null && ((val_attributes_is_active_str instanceof Number && val_attributes_is_active_str.toString() == \\"true\\") || val_attributes_is_active_str == \\"true\\")) && (val_attributes_is_inactive !== null && ((val_attributes_is_inactive instanceof Number && val_attributes_is_inactive.toString() != \\"true\\") || val_attributes_is_inactive != true)) && (val_attributes_is_inactive_str !== null && ((val_attributes_is_inactive_str instanceof Number && val_attributes_is_inactive_str.toString() != \\"true\\") || val_attributes_is_inactive_str != \\"true\\"))) {
     return true;
   }
@@ -138,10 +150,13 @@ Object {
         "field": "attributes.boolean_false_test",
         "if": "
   try {
+  
   def val_attributes_is_disabled = $('attributes.is_disabled', null); if (val_attributes_is_disabled instanceof List && val_attributes_is_disabled.size() == 1) { val_attributes_is_disabled = val_attributes_is_disabled[0]; }
   def val_attributes_is_disabled_str = $('attributes.is_disabled_str', null); if (val_attributes_is_disabled_str instanceof List && val_attributes_is_disabled_str.size() == 1) { val_attributes_is_disabled_str = val_attributes_is_disabled_str[0]; }
   def val_attributes_is_enabled = $('attributes.is_enabled', null); if (val_attributes_is_enabled instanceof List && val_attributes_is_enabled.size() == 1) { val_attributes_is_enabled = val_attributes_is_enabled[0]; }
   def val_attributes_is_enabled_str = $('attributes.is_enabled_str', null); if (val_attributes_is_enabled_str instanceof List && val_attributes_is_enabled_str.size() == 1) { val_attributes_is_enabled_str = val_attributes_is_enabled_str[0]; }
+  
+  
   if ((val_attributes_is_disabled !== null && ((val_attributes_is_disabled instanceof Number && val_attributes_is_disabled.toString() == \\"false\\") || val_attributes_is_disabled == false)) && (val_attributes_is_disabled_str !== null && ((val_attributes_is_disabled_str instanceof Number && val_attributes_is_disabled_str.toString() == \\"false\\") || val_attributes_is_disabled_str == \\"false\\")) && (val_attributes_is_enabled !== null && ((val_attributes_is_enabled instanceof Number && val_attributes_is_enabled.toString() != \\"false\\") || val_attributes_is_enabled != false)) && (val_attributes_is_enabled_str !== null && ((val_attributes_is_enabled_str instanceof Number && val_attributes_is_enabled_str.toString() != \\"false\\") || val_attributes_is_enabled_str != \\"false\\"))) {
     return true;
   }
@@ -158,10 +173,13 @@ Object {
         "field": "attributes.numeric_450_test",
         "if": "
   try {
+  
   def val_attributes_status_code = $('attributes.status_code', null); if (val_attributes_status_code instanceof List && val_attributes_status_code.size() == 1) { val_attributes_status_code = val_attributes_status_code[0]; }
   def val_attributes_status_code_str = $('attributes.status_code_str', null); if (val_attributes_status_code_str instanceof List && val_attributes_status_code_str.size() == 1) { val_attributes_status_code_str = val_attributes_status_code_str[0]; }
   def val_attributes_other_code = $('attributes.other_code', null); if (val_attributes_other_code instanceof List && val_attributes_other_code.size() == 1) { val_attributes_other_code = val_attributes_other_code[0]; }
   def val_attributes_other_code_str = $('attributes.other_code_str', null); if (val_attributes_other_code_str instanceof List && val_attributes_other_code_str.size() == 1) { val_attributes_other_code_str = val_attributes_other_code_str[0]; }
+  
+  
   if ((val_attributes_status_code !== null && ((val_attributes_status_code instanceof Number && val_attributes_status_code.toString() == \\"450\\") || val_attributes_status_code == 450)) && (val_attributes_status_code_str !== null && ((val_attributes_status_code_str instanceof Number && val_attributes_status_code_str.toString() == \\"450\\") || val_attributes_status_code_str == \\"450\\")) && (val_attributes_other_code !== null && ((val_attributes_other_code instanceof Number && val_attributes_other_code.toString() != \\"450\\") || val_attributes_other_code != 450)) && (val_attributes_other_code_str !== null && ((val_attributes_other_code_str instanceof Number && val_attributes_other_code_str.toString() != \\"450\\") || val_attributes_other_code_str != \\"450\\"))) {
     return true;
   }
@@ -178,11 +196,14 @@ Object {
         "field": "attributes.mixed_coercion_test",
         "if": "
   try {
+  
   def val_attributes_response_time = $('attributes.response_time', null); if (val_attributes_response_time instanceof List && val_attributes_response_time.size() == 1) { val_attributes_response_time = val_attributes_response_time[0]; }
   def val_attributes_response_time_str = $('attributes.response_time_str', null); if (val_attributes_response_time_str instanceof List && val_attributes_response_time_str.size() == 1) { val_attributes_response_time_str = val_attributes_response_time_str[0]; }
   def val_attributes_port = $('attributes.port', null); if (val_attributes_port instanceof List && val_attributes_port.size() == 1) { val_attributes_port = val_attributes_port[0]; }
   def val_attributes_is_enabled = $('attributes.is_enabled', null); if (val_attributes_is_enabled instanceof List && val_attributes_is_enabled.size() == 1) { val_attributes_is_enabled = val_attributes_is_enabled[0]; }
   def val_attributes_count_str = $('attributes.count_str', null); if (val_attributes_count_str instanceof List && val_attributes_count_str.size() == 1) { val_attributes_count_str = val_attributes_count_str[0]; }
+  
+  
   if ((val_attributes_response_time !== null && ((val_attributes_response_time instanceof String && Float.parseFloat(val_attributes_response_time) > 100) || val_attributes_response_time > 100)) && (val_attributes_response_time_str !== null && ((val_attributes_response_time_str instanceof String && Float.parseFloat(val_attributes_response_time_str) > 100) || val_attributes_response_time_str > 100)) && (val_attributes_port !== null && ((val_attributes_port instanceof Number && val_attributes_port >= 8000 && val_attributes_port <= 9000) || (val_attributes_port instanceof String && Float.parseFloat(val_attributes_port) >= 8000 && Float.parseFloat(val_attributes_port) <= 9000))) && (val_attributes_is_enabled !== null && ((val_attributes_is_enabled instanceof Number && val_attributes_is_enabled.toString() == \\"true\\") || val_attributes_is_enabled == true)) && (val_attributes_count_str !== null && ((val_attributes_count_str instanceof Number && val_attributes_count_str.toString() == \\"42\\") || val_attributes_count_str == \\"42\\"))) {
     return true;
   }
@@ -205,7 +226,10 @@ Object {
       "drop": Object {
         "if": "
   try {
+  
   def val_https_status_code = $('https.status_code', null); if (val_https_status_code instanceof List && val_https_status_code.size() == 1) { val_https_status_code = val_https_status_code[0]; }
+  
+  
   if ((val_https_status_code !== null && ((val_https_status_code instanceof Number && val_https_status_code.toString() == \\"200\\") || val_https_status_code == 200))) {
     return true;
   }
@@ -221,7 +245,10 @@ Object {
         "field": "http.status_code",
         "if": "
   try {
+  
   def val_http_error = $('http.error', null); if (val_http_error instanceof List && val_http_error.size() == 1) { val_http_error = val_http_error[0]; }
+  
+  
   if ((val_http_error !== null && ((val_http_error instanceof Number && val_http_error.toString() == \\"404\\") || val_http_error == 404))) {
     return true;
   }
@@ -239,7 +266,10 @@ Object {
         "field": "message",
         "if": "
   try {
+  
   def val_log_level = $('log_level', null); if (val_log_level instanceof List && val_log_level.size() == 1) { val_log_level = val_log_level[0]; }
+  
+  
   if ((val_log_level !== null && ((val_log_level instanceof Number && val_log_level.toString() == \\"ERROR\\") || val_log_level == \\"ERROR\\"))) {
     return true;
   }
@@ -318,7 +348,10 @@ Object {
         "field": "attributes.flag",
         "if": "
   try {
+  
   def val_attributes_status = $('attributes.status', null); if (val_attributes_status instanceof List && val_attributes_status.size() == 1) { val_attributes_status = val_attributes_status[0]; }
+  
+  
   if ((val_attributes_status !== null && ((val_attributes_status instanceof Number && val_attributes_status.toString() == \\"active\\") || val_attributes_status == \\"active\\"))) {
     return true;
   }
@@ -335,7 +368,10 @@ Object {
         "field": "attributes.prod_flag",
         "if": "
   try {
+  
   def val_attributes_env = $('attributes.env', null); if (val_attributes_env instanceof List && val_attributes_env.size() == 1) { val_attributes_env = val_attributes_env[0]; }
+  
+  
   if ((val_attributes_env !== null && ((val_attributes_env instanceof Number && val_attributes_env.toString() == \\"prod\\") || val_attributes_env == \\"prod\\"))) {
     return true;
   }
@@ -352,8 +388,11 @@ Object {
         "field": "attributes.prod_flag",
         "if": "
   try {
+  
   def val_attributes_a = $('attributes.a', null); if (val_attributes_a instanceof List && val_attributes_a.size() == 1) { val_attributes_a = val_attributes_a[0]; }
   def val_attributes_b = $('attributes.b', null); if (val_attributes_b instanceof List && val_attributes_b.size() == 1) { val_attributes_b = val_attributes_b[0]; }
+  
+  
   if ((val_attributes_a !== null && ((val_attributes_a instanceof Number && val_attributes_a.toString() == \\"1\\") || val_attributes_a == 1)) || (val_attributes_b !== null && ((val_attributes_b instanceof Number && val_attributes_b.toString() == \\"2\\") || val_attributes_b == 2))) {
     return true;
   }
@@ -370,9 +409,12 @@ Object {
         "field": "attributes.department_flag",
         "if": "
   try {
+  
   def val_attributes_a = $('attributes.a', null); if (val_attributes_a instanceof List && val_attributes_a.size() == 1) { val_attributes_a = val_attributes_a[0]; }
   def val_attributes_b = $('attributes.b', null); if (val_attributes_b instanceof List && val_attributes_b.size() == 1) { val_attributes_b = val_attributes_b[0]; }
   def val_attributes_department = $('attributes.department', null); if (val_attributes_department instanceof List && val_attributes_department.size() == 1) { val_attributes_department = val_attributes_department[0]; }
+  
+  
   if (((val_attributes_a !== null && ((val_attributes_a instanceof Number && val_attributes_a.toString() == \\"1\\") || val_attributes_a == 1)) || (val_attributes_b !== null && ((val_attributes_b instanceof Number && val_attributes_b.toString() == \\"2\\") || val_attributes_b == 2))) && (val_attributes_department !== null && ((val_attributes_department instanceof Number && val_attributes_department.toString() == \\"legal\\") || val_attributes_department == \\"legal\\"))) {
     return true;
   }
@@ -389,8 +431,11 @@ Object {
         "field": "attributes.test",
         "if": "
   try {
+  
   def val_attributes_status = $('attributes.status', null); if (val_attributes_status instanceof List && val_attributes_status.size() == 1) { val_attributes_status = val_attributes_status[0]; }
   def val_attributes_read_only = $('attributes.read_only', null); if (val_attributes_read_only instanceof List && val_attributes_read_only.size() == 1) { val_attributes_read_only = val_attributes_read_only[0]; }
+  
+  
   if ((val_attributes_status !== null && ((val_attributes_status instanceof Number && val_attributes_status.toString() == \\"active\\") || val_attributes_status == \\"active\\")) || ((val_attributes_status !== null && ((val_attributes_status instanceof Number && val_attributes_status.toString() == \\"inactive\\") || val_attributes_status == \\"inactive\\")) && (val_attributes_read_only !== null && ((val_attributes_read_only instanceof Number && val_attributes_read_only.toString() == \\"false\\") || val_attributes_read_only == false)))) {
     return true;
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/__snapshots__/transpiler.test.ts.snap
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/__snapshots__/transpiler.test.ts.snap
@@ -25,7 +25,8 @@ Object {
         "field": "foo",
         "if": "
   try {
-  if (($('attributes.status', null) !== null && (($('attributes.status', null) instanceof Number && $('attributes.status', null).toString() == \\"active\\") || $('attributes.status', null) == \\"active\\"))) {
+  def val_attributes_status = $('attributes.status', null); if (val_attributes_status instanceof List && val_attributes_status.size() == 1) { val_attributes_status = val_attributes_status[0]; }
+  if ((val_attributes_status !== null && ((val_attributes_status instanceof Number && val_attributes_status.toString() == \\"active\\") || val_attributes_status == \\"active\\"))) {
     return true;
   }
   return false;
@@ -75,7 +76,8 @@ Object {
         "field": "attributes.not_flag",
         "if": "
   try {
-  if (!(($('attributes.status', null) !== null && (($('attributes.status', null) instanceof Number && $('attributes.status', null).toString() == \\"active\\") || $('attributes.status', null) == \\"active\\")))) {
+  def val_attributes_status = $('attributes.status', null); if (val_attributes_status instanceof List && val_attributes_status.size() == 1) { val_attributes_status = val_attributes_status[0]; }
+  if (!((val_attributes_status !== null && ((val_attributes_status instanceof Number && val_attributes_status.toString() == \\"active\\") || val_attributes_status == \\"active\\")))) {
     return true;
   }
   return false;
@@ -91,7 +93,9 @@ Object {
         "field": "attributes.not_nested",
         "if": "
   try {
-  if (!((($('attributes.a', null) !== null && (($('attributes.a', null) instanceof Number && $('attributes.a', null).toString() == \\"1\\") || $('attributes.a', null) == 1)) || ($('attributes.b', null) !== null && (($('attributes.b', null) instanceof Number && $('attributes.b', null).toString() == \\"2\\") || $('attributes.b', null) == 2))))) {
+  def val_attributes_a = $('attributes.a', null); if (val_attributes_a instanceof List && val_attributes_a.size() == 1) { val_attributes_a = val_attributes_a[0]; }
+  def val_attributes_b = $('attributes.b', null); if (val_attributes_b instanceof List && val_attributes_b.size() == 1) { val_attributes_b = val_attributes_b[0]; }
+  if (!(((val_attributes_a !== null && ((val_attributes_a instanceof Number && val_attributes_a.toString() == \\"1\\") || val_attributes_a == 1)) || (val_attributes_b !== null && ((val_attributes_b instanceof Number && val_attributes_b.toString() == \\"2\\") || val_attributes_b == 2))))) {
     return true;
   }
   return false;
@@ -114,7 +118,11 @@ Object {
         "field": "attributes.boolean_true_test",
         "if": "
   try {
-  if (($('attributes.is_active', null) !== null && (($('attributes.is_active', null) instanceof Number && $('attributes.is_active', null).toString() == \\"true\\") || $('attributes.is_active', null) == true)) && ($('attributes.is_active_str', null) !== null && (($('attributes.is_active_str', null) instanceof Number && $('attributes.is_active_str', null).toString() == \\"true\\") || $('attributes.is_active_str', null) == \\"true\\")) && ($('attributes.is_inactive', null) !== null && (($('attributes.is_inactive', null) instanceof Number && $('attributes.is_inactive', null).toString() != \\"true\\") || $('attributes.is_inactive', null) != true)) && ($('attributes.is_inactive_str', null) !== null && (($('attributes.is_inactive_str', null) instanceof Number && $('attributes.is_inactive_str', null).toString() != \\"true\\") || $('attributes.is_inactive_str', null) != \\"true\\"))) {
+  def val_attributes_is_active = $('attributes.is_active', null); if (val_attributes_is_active instanceof List && val_attributes_is_active.size() == 1) { val_attributes_is_active = val_attributes_is_active[0]; }
+  def val_attributes_is_active_str = $('attributes.is_active_str', null); if (val_attributes_is_active_str instanceof List && val_attributes_is_active_str.size() == 1) { val_attributes_is_active_str = val_attributes_is_active_str[0]; }
+  def val_attributes_is_inactive = $('attributes.is_inactive', null); if (val_attributes_is_inactive instanceof List && val_attributes_is_inactive.size() == 1) { val_attributes_is_inactive = val_attributes_is_inactive[0]; }
+  def val_attributes_is_inactive_str = $('attributes.is_inactive_str', null); if (val_attributes_is_inactive_str instanceof List && val_attributes_is_inactive_str.size() == 1) { val_attributes_is_inactive_str = val_attributes_is_inactive_str[0]; }
+  if ((val_attributes_is_active !== null && ((val_attributes_is_active instanceof Number && val_attributes_is_active.toString() == \\"true\\") || val_attributes_is_active == true)) && (val_attributes_is_active_str !== null && ((val_attributes_is_active_str instanceof Number && val_attributes_is_active_str.toString() == \\"true\\") || val_attributes_is_active_str == \\"true\\")) && (val_attributes_is_inactive !== null && ((val_attributes_is_inactive instanceof Number && val_attributes_is_inactive.toString() != \\"true\\") || val_attributes_is_inactive != true)) && (val_attributes_is_inactive_str !== null && ((val_attributes_is_inactive_str instanceof Number && val_attributes_is_inactive_str.toString() != \\"true\\") || val_attributes_is_inactive_str != \\"true\\"))) {
     return true;
   }
   return false;
@@ -130,7 +138,11 @@ Object {
         "field": "attributes.boolean_false_test",
         "if": "
   try {
-  if (($('attributes.is_disabled', null) !== null && (($('attributes.is_disabled', null) instanceof Number && $('attributes.is_disabled', null).toString() == \\"false\\") || $('attributes.is_disabled', null) == false)) && ($('attributes.is_disabled_str', null) !== null && (($('attributes.is_disabled_str', null) instanceof Number && $('attributes.is_disabled_str', null).toString() == \\"false\\") || $('attributes.is_disabled_str', null) == \\"false\\")) && ($('attributes.is_enabled', null) !== null && (($('attributes.is_enabled', null) instanceof Number && $('attributes.is_enabled', null).toString() != \\"false\\") || $('attributes.is_enabled', null) != false)) && ($('attributes.is_enabled_str', null) !== null && (($('attributes.is_enabled_str', null) instanceof Number && $('attributes.is_enabled_str', null).toString() != \\"false\\") || $('attributes.is_enabled_str', null) != \\"false\\"))) {
+  def val_attributes_is_disabled = $('attributes.is_disabled', null); if (val_attributes_is_disabled instanceof List && val_attributes_is_disabled.size() == 1) { val_attributes_is_disabled = val_attributes_is_disabled[0]; }
+  def val_attributes_is_disabled_str = $('attributes.is_disabled_str', null); if (val_attributes_is_disabled_str instanceof List && val_attributes_is_disabled_str.size() == 1) { val_attributes_is_disabled_str = val_attributes_is_disabled_str[0]; }
+  def val_attributes_is_enabled = $('attributes.is_enabled', null); if (val_attributes_is_enabled instanceof List && val_attributes_is_enabled.size() == 1) { val_attributes_is_enabled = val_attributes_is_enabled[0]; }
+  def val_attributes_is_enabled_str = $('attributes.is_enabled_str', null); if (val_attributes_is_enabled_str instanceof List && val_attributes_is_enabled_str.size() == 1) { val_attributes_is_enabled_str = val_attributes_is_enabled_str[0]; }
+  if ((val_attributes_is_disabled !== null && ((val_attributes_is_disabled instanceof Number && val_attributes_is_disabled.toString() == \\"false\\") || val_attributes_is_disabled == false)) && (val_attributes_is_disabled_str !== null && ((val_attributes_is_disabled_str instanceof Number && val_attributes_is_disabled_str.toString() == \\"false\\") || val_attributes_is_disabled_str == \\"false\\")) && (val_attributes_is_enabled !== null && ((val_attributes_is_enabled instanceof Number && val_attributes_is_enabled.toString() != \\"false\\") || val_attributes_is_enabled != false)) && (val_attributes_is_enabled_str !== null && ((val_attributes_is_enabled_str instanceof Number && val_attributes_is_enabled_str.toString() != \\"false\\") || val_attributes_is_enabled_str != \\"false\\"))) {
     return true;
   }
   return false;
@@ -146,7 +158,11 @@ Object {
         "field": "attributes.numeric_450_test",
         "if": "
   try {
-  if (($('attributes.status_code', null) !== null && (($('attributes.status_code', null) instanceof Number && $('attributes.status_code', null).toString() == \\"450\\") || $('attributes.status_code', null) == 450)) && ($('attributes.status_code_str', null) !== null && (($('attributes.status_code_str', null) instanceof Number && $('attributes.status_code_str', null).toString() == \\"450\\") || $('attributes.status_code_str', null) == \\"450\\")) && ($('attributes.other_code', null) !== null && (($('attributes.other_code', null) instanceof Number && $('attributes.other_code', null).toString() != \\"450\\") || $('attributes.other_code', null) != 450)) && ($('attributes.other_code_str', null) !== null && (($('attributes.other_code_str', null) instanceof Number && $('attributes.other_code_str', null).toString() != \\"450\\") || $('attributes.other_code_str', null) != \\"450\\"))) {
+  def val_attributes_status_code = $('attributes.status_code', null); if (val_attributes_status_code instanceof List && val_attributes_status_code.size() == 1) { val_attributes_status_code = val_attributes_status_code[0]; }
+  def val_attributes_status_code_str = $('attributes.status_code_str', null); if (val_attributes_status_code_str instanceof List && val_attributes_status_code_str.size() == 1) { val_attributes_status_code_str = val_attributes_status_code_str[0]; }
+  def val_attributes_other_code = $('attributes.other_code', null); if (val_attributes_other_code instanceof List && val_attributes_other_code.size() == 1) { val_attributes_other_code = val_attributes_other_code[0]; }
+  def val_attributes_other_code_str = $('attributes.other_code_str', null); if (val_attributes_other_code_str instanceof List && val_attributes_other_code_str.size() == 1) { val_attributes_other_code_str = val_attributes_other_code_str[0]; }
+  if ((val_attributes_status_code !== null && ((val_attributes_status_code instanceof Number && val_attributes_status_code.toString() == \\"450\\") || val_attributes_status_code == 450)) && (val_attributes_status_code_str !== null && ((val_attributes_status_code_str instanceof Number && val_attributes_status_code_str.toString() == \\"450\\") || val_attributes_status_code_str == \\"450\\")) && (val_attributes_other_code !== null && ((val_attributes_other_code instanceof Number && val_attributes_other_code.toString() != \\"450\\") || val_attributes_other_code != 450)) && (val_attributes_other_code_str !== null && ((val_attributes_other_code_str instanceof Number && val_attributes_other_code_str.toString() != \\"450\\") || val_attributes_other_code_str != \\"450\\"))) {
     return true;
   }
   return false;
@@ -162,7 +178,12 @@ Object {
         "field": "attributes.mixed_coercion_test",
         "if": "
   try {
-  if (($('attributes.response_time', null) !== null && (($('attributes.response_time', null) instanceof String && Float.parseFloat($('attributes.response_time', null)) > 100) || $('attributes.response_time', null) > 100)) && ($('attributes.response_time_str', null) !== null && (($('attributes.response_time_str', null) instanceof String && Float.parseFloat($('attributes.response_time_str', null)) > 100) || $('attributes.response_time_str', null) > 100)) && ($('attributes.port', null) !== null && (($('attributes.port', null) instanceof Number && $('attributes.port', null) >= 8000 && $('attributes.port', null) <= 9000) || ($('attributes.port', null) instanceof String && Float.parseFloat($('attributes.port', null)) >= 8000 && Float.parseFloat($('attributes.port', null)) <= 9000))) && ($('attributes.is_enabled', null) !== null && (($('attributes.is_enabled', null) instanceof Number && $('attributes.is_enabled', null).toString() == \\"true\\") || $('attributes.is_enabled', null) == true)) && ($('attributes.count_str', null) !== null && (($('attributes.count_str', null) instanceof Number && $('attributes.count_str', null).toString() == \\"42\\") || $('attributes.count_str', null) == \\"42\\"))) {
+  def val_attributes_response_time = $('attributes.response_time', null); if (val_attributes_response_time instanceof List && val_attributes_response_time.size() == 1) { val_attributes_response_time = val_attributes_response_time[0]; }
+  def val_attributes_response_time_str = $('attributes.response_time_str', null); if (val_attributes_response_time_str instanceof List && val_attributes_response_time_str.size() == 1) { val_attributes_response_time_str = val_attributes_response_time_str[0]; }
+  def val_attributes_port = $('attributes.port', null); if (val_attributes_port instanceof List && val_attributes_port.size() == 1) { val_attributes_port = val_attributes_port[0]; }
+  def val_attributes_is_enabled = $('attributes.is_enabled', null); if (val_attributes_is_enabled instanceof List && val_attributes_is_enabled.size() == 1) { val_attributes_is_enabled = val_attributes_is_enabled[0]; }
+  def val_attributes_count_str = $('attributes.count_str', null); if (val_attributes_count_str instanceof List && val_attributes_count_str.size() == 1) { val_attributes_count_str = val_attributes_count_str[0]; }
+  if ((val_attributes_response_time !== null && ((val_attributes_response_time instanceof String && Float.parseFloat(val_attributes_response_time) > 100) || val_attributes_response_time > 100)) && (val_attributes_response_time_str !== null && ((val_attributes_response_time_str instanceof String && Float.parseFloat(val_attributes_response_time_str) > 100) || val_attributes_response_time_str > 100)) && (val_attributes_port !== null && ((val_attributes_port instanceof Number && val_attributes_port >= 8000 && val_attributes_port <= 9000) || (val_attributes_port instanceof String && Float.parseFloat(val_attributes_port) >= 8000 && Float.parseFloat(val_attributes_port) <= 9000))) && (val_attributes_is_enabled !== null && ((val_attributes_is_enabled instanceof Number && val_attributes_is_enabled.toString() == \\"true\\") || val_attributes_is_enabled == true)) && (val_attributes_count_str !== null && ((val_attributes_count_str instanceof Number && val_attributes_count_str.toString() == \\"42\\") || val_attributes_count_str == \\"42\\"))) {
     return true;
   }
   return false;
@@ -184,7 +205,8 @@ Object {
       "drop": Object {
         "if": "
   try {
-  if (($('https.status_code', null) !== null && (($('https.status_code', null) instanceof Number && $('https.status_code', null).toString() == \\"200\\") || $('https.status_code', null) == 200))) {
+  def val_https_status_code = $('https.status_code', null); if (val_https_status_code instanceof List && val_https_status_code.size() == 1) { val_https_status_code = val_https_status_code[0]; }
+  if ((val_https_status_code !== null && ((val_https_status_code instanceof Number && val_https_status_code.toString() == \\"200\\") || val_https_status_code == 200))) {
     return true;
   }
   return false;
@@ -199,7 +221,8 @@ Object {
         "field": "http.status_code",
         "if": "
   try {
-  if (($('http.error', null) !== null && (($('http.error', null) instanceof Number && $('http.error', null).toString() == \\"404\\") || $('http.error', null) == 404))) {
+  def val_http_error = $('http.error', null); if (val_http_error instanceof List && val_http_error.size() == 1) { val_http_error = val_http_error[0]; }
+  if ((val_http_error !== null && ((val_http_error instanceof Number && val_http_error.toString() == \\"404\\") || val_http_error == 404))) {
     return true;
   }
   return false;
@@ -216,7 +239,8 @@ Object {
         "field": "message",
         "if": "
   try {
-  if (($('log_level', null) !== null && (($('log_level', null) instanceof Number && $('log_level', null).toString() == \\"ERROR\\") || $('log_level', null) == \\"ERROR\\"))) {
+  def val_log_level = $('log_level', null); if (val_log_level instanceof List && val_log_level.size() == 1) { val_log_level = val_log_level[0]; }
+  if ((val_log_level !== null && ((val_log_level instanceof Number && val_log_level.toString() == \\"ERROR\\") || val_log_level == \\"ERROR\\"))) {
     return true;
   }
   return false;
@@ -294,7 +318,8 @@ Object {
         "field": "attributes.flag",
         "if": "
   try {
-  if (($('attributes.status', null) !== null && (($('attributes.status', null) instanceof Number && $('attributes.status', null).toString() == \\"active\\") || $('attributes.status', null) == \\"active\\"))) {
+  def val_attributes_status = $('attributes.status', null); if (val_attributes_status instanceof List && val_attributes_status.size() == 1) { val_attributes_status = val_attributes_status[0]; }
+  if ((val_attributes_status !== null && ((val_attributes_status instanceof Number && val_attributes_status.toString() == \\"active\\") || val_attributes_status == \\"active\\"))) {
     return true;
   }
   return false;
@@ -310,7 +335,8 @@ Object {
         "field": "attributes.prod_flag",
         "if": "
   try {
-  if (($('attributes.env', null) !== null && (($('attributes.env', null) instanceof Number && $('attributes.env', null).toString() == \\"prod\\") || $('attributes.env', null) == \\"prod\\"))) {
+  def val_attributes_env = $('attributes.env', null); if (val_attributes_env instanceof List && val_attributes_env.size() == 1) { val_attributes_env = val_attributes_env[0]; }
+  if ((val_attributes_env !== null && ((val_attributes_env instanceof Number && val_attributes_env.toString() == \\"prod\\") || val_attributes_env == \\"prod\\"))) {
     return true;
   }
   return false;
@@ -326,7 +352,9 @@ Object {
         "field": "attributes.prod_flag",
         "if": "
   try {
-  if (($('attributes.a', null) !== null && (($('attributes.a', null) instanceof Number && $('attributes.a', null).toString() == \\"1\\") || $('attributes.a', null) == 1)) || ($('attributes.b', null) !== null && (($('attributes.b', null) instanceof Number && $('attributes.b', null).toString() == \\"2\\") || $('attributes.b', null) == 2))) {
+  def val_attributes_a = $('attributes.a', null); if (val_attributes_a instanceof List && val_attributes_a.size() == 1) { val_attributes_a = val_attributes_a[0]; }
+  def val_attributes_b = $('attributes.b', null); if (val_attributes_b instanceof List && val_attributes_b.size() == 1) { val_attributes_b = val_attributes_b[0]; }
+  if ((val_attributes_a !== null && ((val_attributes_a instanceof Number && val_attributes_a.toString() == \\"1\\") || val_attributes_a == 1)) || (val_attributes_b !== null && ((val_attributes_b instanceof Number && val_attributes_b.toString() == \\"2\\") || val_attributes_b == 2))) {
     return true;
   }
   return false;
@@ -342,7 +370,10 @@ Object {
         "field": "attributes.department_flag",
         "if": "
   try {
-  if ((($('attributes.a', null) !== null && (($('attributes.a', null) instanceof Number && $('attributes.a', null).toString() == \\"1\\") || $('attributes.a', null) == 1)) || ($('attributes.b', null) !== null && (($('attributes.b', null) instanceof Number && $('attributes.b', null).toString() == \\"2\\") || $('attributes.b', null) == 2))) && ($('attributes.department', null) !== null && (($('attributes.department', null) instanceof Number && $('attributes.department', null).toString() == \\"legal\\") || $('attributes.department', null) == \\"legal\\"))) {
+  def val_attributes_a = $('attributes.a', null); if (val_attributes_a instanceof List && val_attributes_a.size() == 1) { val_attributes_a = val_attributes_a[0]; }
+  def val_attributes_b = $('attributes.b', null); if (val_attributes_b instanceof List && val_attributes_b.size() == 1) { val_attributes_b = val_attributes_b[0]; }
+  def val_attributes_department = $('attributes.department', null); if (val_attributes_department instanceof List && val_attributes_department.size() == 1) { val_attributes_department = val_attributes_department[0]; }
+  if (((val_attributes_a !== null && ((val_attributes_a instanceof Number && val_attributes_a.toString() == \\"1\\") || val_attributes_a == 1)) || (val_attributes_b !== null && ((val_attributes_b instanceof Number && val_attributes_b.toString() == \\"2\\") || val_attributes_b == 2))) && (val_attributes_department !== null && ((val_attributes_department instanceof Number && val_attributes_department.toString() == \\"legal\\") || val_attributes_department == \\"legal\\"))) {
     return true;
   }
   return false;
@@ -358,7 +389,9 @@ Object {
         "field": "attributes.test",
         "if": "
   try {
-  if (($('attributes.status', null) !== null && (($('attributes.status', null) instanceof Number && $('attributes.status', null).toString() == \\"active\\") || $('attributes.status', null) == \\"active\\")) || (($('attributes.status', null) !== null && (($('attributes.status', null) instanceof Number && $('attributes.status', null).toString() == \\"inactive\\") || $('attributes.status', null) == \\"inactive\\")) && ($('attributes.read_only', null) !== null && (($('attributes.read_only', null) instanceof Number && $('attributes.read_only', null).toString() == \\"false\\") || $('attributes.read_only', null) == false)))) {
+  def val_attributes_status = $('attributes.status', null); if (val_attributes_status instanceof List && val_attributes_status.size() == 1) { val_attributes_status = val_attributes_status[0]; }
+  def val_attributes_read_only = $('attributes.read_only', null); if (val_attributes_read_only instanceof List && val_attributes_read_only.size() == 1) { val_attributes_read_only = val_attributes_read_only[0]; }
+  if ((val_attributes_status !== null && ((val_attributes_status instanceof Number && val_attributes_status.toString() == \\"active\\") || val_attributes_status == \\"active\\")) || ((val_attributes_status !== null && ((val_attributes_status instanceof Number && val_attributes_status.toString() == \\"inactive\\") || val_attributes_status == \\"inactive\\")) && (val_attributes_read_only !== null && ((val_attributes_read_only instanceof Number && val_attributes_read_only.toString() == \\"false\\") || val_attributes_read_only == false)))) {
     return true;
   }
   return false;

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/migration_on_read.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/migration_on_read.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect/expect';
+import expect from '@kbn/expect';
 import type { Streams } from '@kbn/streams-schema';
 import {
   OBSERVABILITY_STREAMS_ENABLE_ATTACHMENTS,

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/migration_on_read.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/migration_on_read.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
+import expect from '@kbn/expect/expect';
 import type { Streams } from '@kbn/streams-schema';
 import {
   OBSERVABILITY_STREAMS_ENABLE_ATTACHMENTS,
@@ -58,7 +58,7 @@ const migratedProcessing = {
         {
           set: {
             field: 'message',
-            if: "\n  try {\n  if (($('message', null) !== null && (($('message', null) instanceof Number && $('message', null).toString() == \"oldValue\") || $('message', null) == \"oldValue\"))) {\n    return true;\n  }\n  return false;\n} catch (Exception e) {\n  return false;\n}\n",
+            if: '\n  try {\n  \n  def val_message = $(\'message\', null); if (val_message instanceof List && val_message.size() == 1) { val_message = val_message[0]; }\n  \n  \n  if ((val_message !== null && ((val_message instanceof Number && val_message.toString() == "oldValue") || val_message == "oldValue"))) {\n    return true;\n  }\n  return false;\n} catch (Exception e) {\n  return false;\n}\n',
             value: 'newValue',
           },
         },


### PR DESCRIPTION
Resolves https://github.com/elastic/streams-program/issues/618

## Summary

This expands `conditionToPainless` to handle fields containing single-element arrays. When a field value is a List with exactly one element, it gets unwrapped so comparisons work the same as with scalar values.

## Details

The generated Painless now includes variable declarations with unwrapping logic:

```
def val_foo = $('foo', null);> if (val_foo instanceof List && val_foo.size() == 1) { val_foo = val_foo[0]; }>
```

To implement this efficiently, we:

1. Extract all unique field names from the condition tree before generating the statement
2. Generate a variable declaration block with the List unwrapping logic for each field
3. Use variable references throughout the condition instead of repeated inline $() accessors

This approach avoids duplicating the unwrapping logic for each field reference in the generated script.

## Question for reviewers

- Should this be backported?