### PR TITLE
[Discover] Remove the flaky test to unskip the suite

### DIFF
--- a/src/platform/test/functional/apps/discover/tabs/_new_tab.ts
+++ b/src/platform/test/functional/apps/discover/tabs/_new_tab.ts
@@ -11,18 +11,14 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const { discover, unifiedTabs, timePicker } = getPageObjects([
-    'discover',
-    'unifiedTabs',
-    'timePicker',
-  ]);
+  const { discover, unifiedTabs } = getPageObjects(['discover', 'unifiedTabs']);
   const filterBar = getService('filterBar');
   const queryBar = getService('queryBar');
   const dataViews = getService('dataViews');
   const esql = getService('esql');
   const testSubjects = getService('testSubjects');
 
-  describe('new tab', function () {
+  describe('opening a new tab', function () {
     it('should create a new tab in classic mode', async () => {
       // tab 0 - with the default data view
 
@@ -90,32 +86,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await unifiedTabs.createNewTab();
       await discover.waitUntilTabIsLoaded();
       expect(await esql.getEsqlEditorQuery()).to.be(defaultQuery);
-    });
-
-    it('should be able to complete all quickly opened tabs', async () => {
-      await discover.selectTextBaseLang();
-      await discover.waitUntilTabIsLoaded();
-      const updatedQuery = 'FROM *';
-      await esql.setEsqlEditorQuery(updatedQuery);
-      await esql.submitEsqlEditorQuery();
-      await discover.waitUntilTabIsLoaded();
-      const fromTime = 'Jan 10, 2000 @ 00:00:00.000';
-      const toTime = 'Dec 10, 2025 @ 00:00:00.000';
-      await timePicker.setAbsoluteRange(fromTime, toTime);
-      await discover.waitUntilTabIsLoaded();
-
-      const tabCount = 7;
-
-      for (let i = 0; i < tabCount; i++) {
-        await testSubjects.click('unifiedTabs_tabsBar_newTabBtn');
-      }
-
-      await discover.waitUntilTabIsLoaded();
-
-      for (let i = tabCount - 1; i > 0; i--) {
-        await unifiedTabs.selectTab(i);
-        await discover.waitUntilTabIsLoaded();
-      }
     });
   });
 }


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/247926

## Summary

This PR removes the flaky test to unskip the suite and run the others. The test will be restored when it will come to addressing https://github.com/elastic/kibana/issues/246406



<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->