### PR TITLE
[Docs] Specify 9.3 availability for relevant connectors

### DIFF
--- a/docs/reference/connectors-kibana/abuseipdb-action-type.md
+++ b/docs/reference/connectors-kibana/abuseipdb-action-type.md
@@ -3,7 +3,7 @@ navigation_title: "AbuseIPDB"
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/abuseipdb-action-type.html
 applies_to:
-  stack: preview
+  stack: preview 9.3
   serverless: preview
 ---
 

--- a/docs/reference/connectors-kibana/alienvault-otx-action-type.md
+++ b/docs/reference/connectors-kibana/alienvault-otx-action-type.md
@@ -3,7 +3,7 @@ navigation_title: "AlienVault OTX"
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/alienvault-otx-action-type.html
 applies_to:
-  stack: preview
+  stack: preview 9.3
   serverless: preview
 ---
 

--- a/docs/reference/connectors-kibana/brave-search-action-type.md
+++ b/docs/reference/connectors-kibana/brave-search-action-type.md
@@ -3,7 +3,7 @@ navigation_title: "Brave Search"
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/brave-search-action-type.html
 applies_to:
-  stack: preview
+  stack: preview 9.3
   serverless: preview
 ---
 

--- a/docs/reference/connectors-kibana/greynoise-action-type.md
+++ b/docs/reference/connectors-kibana/greynoise-action-type.md
@@ -3,7 +3,7 @@ navigation_title: "GreyNoise"
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/greynoise-action-type.html
 applies_to:
-  stack: preview
+  stack: preview 9.3
   serverless: preview
 ---
 

--- a/docs/reference/connectors-kibana/notion-action-type.md
+++ b/docs/reference/connectors-kibana/notion-action-type.md
@@ -3,7 +3,7 @@ navigation_title: "Notion"
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/notion-action-type.html
 applies_to:
-  stack: preview
+  stack: preview 9.3
   serverless: preview
 ---
 

--- a/docs/reference/connectors-kibana/shodan-action-type.md
+++ b/docs/reference/connectors-kibana/shodan-action-type.md
@@ -3,7 +3,7 @@ navigation_title: "Shodan"
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/shodan-action-type.html
 applies_to:
-  stack: preview
+  stack: preview 9.3
   serverless: preview
 ---
 

--- a/docs/reference/connectors-kibana/urlvoid-action-type.md
+++ b/docs/reference/connectors-kibana/urlvoid-action-type.md
@@ -3,7 +3,7 @@ navigation_title: "URLVoid"
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/urlvoid-action-type.html
 applies_to:
-  stack: preview
+  stack: preview 9.3
   serverless: preview
 ---
 

--- a/docs/reference/connectors-kibana/virustotal-action-type.md
+++ b/docs/reference/connectors-kibana/virustotal-action-type.md
@@ -3,7 +3,7 @@ navigation_title: "VirusTotal"
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/virustotal-action-type.html
 applies_to:
-  stack: preview
+  stack: preview 9.3
   serverless: preview
 ---
 


### PR DESCRIPTION
This PR specifies the correct availability information for relevant connectors recently added

Spotted through this internal Slack discussion: https://elastic.slack.com/archives/C6E3MTCD7/p1767800497658729