### PR TITLE
[SigEvents Discovery] Decouple search bar from StreamsTreeTable

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/streams_tree/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/streams_tree/tree_table.tsx
@@ -20,6 +20,7 @@ import {
   EuiInMemoryTable,
   EuiLink,
   EuiLoadingSpinner,
+  EuiSearchBar,
   EuiTourStep,
   useEuiTheme,
 } from '@elastic/eui';
@@ -247,130 +248,140 @@ export function StreamsTreeTable({
   };
 
   return (
-    <EuiInMemoryTable<TableRow>
-      selection={selection}
-      loading={loading}
-      data-test-subj="streamsTable"
-      columns={[
-        {
-          field: 'nameSortKey',
-          name: nameColumnHeader,
-          sortable: (row: TableRow) => row.rootNameSortKey,
-          dataType: 'string',
-          render: (_: unknown, item: TableRow) => {
-            // Only show expand/collapse if tree mode is active and has children
-            const treeMode = shouldComposeTree(sortField);
-            const hasChildren = !!item.children && item.children.length > 0;
-            const isCollapsed = collapsed.has(item.stream.name);
-            return (
-              <EuiFlexGroup
-                alignItems="center"
-                gutterSize="s"
-                responsive={false}
-                className={css`
-                  margin-left: ${item.level * parseInt(euiTheme.size.xl, 10)}px;
-                `}
-              >
-                {treeMode && item.children && hasChildren && (
-                  <EuiFlexItem grow={false}>
-                    <EuiIcon
-                      type={isCollapsed ? 'arrowRight' : 'arrowDown'}
-                      color="text"
-                      size="m"
-                      data-test-subj={`${isCollapsed ? 'expand' : 'collapse'}Button-${
-                        item.stream.name
-                      }`}
-                      aria-label={i18n.translate(
-                        isCollapsed
-                          ? 'xpack.streams.streamsTreeTable.collapsedNodeAriaLabel'
-                          : 'xpack.streams.streamsTreeTable.expandedNodeAriaLabel',
-                        {
-                          defaultMessage: isCollapsed
-                            ? 'Collapsed node with {childCount} children'
-                            : 'Expanded node with {childCount} children',
-                          values: { childCount: item.children.length },
-                        }
-                      )}
-                      onClick={(e: React.MouseEvent) => {
-                        handleToggleCollapse(item.stream.name);
-                      }}
-                      tabIndex={0}
-                      role="button"
-                      onKeyDown={(e: React.KeyboardEvent) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          handleToggleCollapse(item.stream.name);
-                        }
-                      }}
-                      style={{ cursor: 'pointer' }}
-                    />
-                  </EuiFlexItem>
-                )}
-                {treeMode && !hasChildren && (
-                  <EuiFlexItem grow={false}>
-                    <EuiIcon type="empty" color="text" size="m" aria-hidden="true" />
-                  </EuiFlexItem>
-                )}
-                <EuiFlexItem grow={false}>
-                  <EuiLink
-                    data-test-subj={`streamsNameLink-${item.stream.name}`}
-                    href={router.link('/{key}', { path: { key: item.stream.name } })}
-                  >
-                    <EuiHighlight search={searchQuery?.text ?? ''}>{item.stream.name}</EuiHighlight>
-                  </EuiLink>
-                </EuiFlexItem>
-                {false && (
-                  <EuiFlexItem grow={false}>
-                    <EuiLoadingSpinner size="m" />
-                  </EuiFlexItem>
-                )}
-              </EuiFlexGroup>
-            );
-          },
-        },
-        {
-          field: 'definition',
-          name: 'Actions',
-          width: '60px',
-          align: 'left',
-          sortable: false,
-          dataType: 'string',
-          render: (_: unknown, item: TableRow) => {
-            return (
-              <EuiButtonIcon
-                iconType="securitySignalDetected"
-                aria-label={RUN_STREAM_DISCOVERY_BUTTON_LABEL}
-              />
-            );
-          },
-        },
-      ]}
-      itemId="nameSortKey"
-      items={items}
-      sorting={sorting}
-      noItemsMessage={NO_STREAMS_MESSAGE}
-      onTableChange={handleTableChange}
-      pagination={{
-        initialPageSize: 25,
-        pageSizeOptions: [25, 50, 100],
-        pageIndex: pagination.pageIndex,
-        pageSize: pagination.pageSize,
-      }}
-      executeQueryOptions={{ enabled: false }}
-      search={{
-        query: searchQuery,
-        onChange: handleQueryChange,
-        box: {
-          incremental: true,
-          'aria-label': STREAMS_TABLE_SEARCH_ARIA_LABEL,
-        },
-        toolsRight: (
-          <div className={datePickerStyle}>
+    <EuiFlexGroup direction="column" gutterSize="m">
+      <EuiFlexItem grow={false}>
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem>
+            <EuiSearchBar
+              query={searchQuery}
+              onChange={handleQueryChange}
+              box={{
+                incremental: true,
+                'aria-label': STREAMS_TABLE_SEARCH_ARIA_LABEL,
+              }}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false} className={datePickerStyle}>
             <StreamsAppSearchBar showDatePicker />
-          </div>
-        ),
-      }}
-      tableCaption={STREAMS_TABLE_CAPTION_ARIA_LABEL}
-    />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+
+      <EuiFlexItem>
+        <EuiInMemoryTable<TableRow>
+          selection={selection}
+          loading={loading}
+          data-test-subj="streamsTable"
+          columns={[
+            {
+              field: 'nameSortKey',
+              name: nameColumnHeader,
+              sortable: (row: TableRow) => row.rootNameSortKey,
+              dataType: 'string',
+              render: (_: unknown, item: TableRow) => {
+                // Only show expand/collapse if tree mode is active and has children
+                const treeMode = shouldComposeTree(sortField);
+                const hasChildren = !!item.children && item.children.length > 0;
+                const isCollapsed = collapsed.has(item.stream.name);
+                return (
+                  <EuiFlexGroup
+                    alignItems="center"
+                    gutterSize="s"
+                    responsive={false}
+                    className={css`
+                      margin-left: ${item.level * parseInt(euiTheme.size.xl, 10)}px;
+                    `}
+                  >
+                    {treeMode && item.children && hasChildren && (
+                      <EuiFlexItem grow={false}>
+                        <EuiIcon
+                          type={isCollapsed ? 'arrowRight' : 'arrowDown'}
+                          color="text"
+                          size="m"
+                          data-test-subj={`${isCollapsed ? 'expand' : 'collapse'}Button-${
+                            item.stream.name
+                          }`}
+                          aria-label={i18n.translate(
+                            isCollapsed
+                              ? 'xpack.streams.streamsTreeTable.collapsedNodeAriaLabel'
+                              : 'xpack.streams.streamsTreeTable.expandedNodeAriaLabel',
+                            {
+                              defaultMessage: isCollapsed
+                                ? 'Collapsed node with {childCount} children'
+                                : 'Expanded node with {childCount} children',
+                              values: { childCount: item.children.length },
+                            }
+                          )}
+                          onClick={(e: React.MouseEvent) => {
+                            handleToggleCollapse(item.stream.name);
+                          }}
+                          tabIndex={0}
+                          role="button"
+                          onKeyDown={(e: React.KeyboardEvent) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              handleToggleCollapse(item.stream.name);
+                            }
+                          }}
+                          style={{ cursor: 'pointer' }}
+                        />
+                      </EuiFlexItem>
+                    )}
+                    {treeMode && !hasChildren && (
+                      <EuiFlexItem grow={false}>
+                        <EuiIcon type="empty" color="text" size="m" aria-hidden="true" />
+                      </EuiFlexItem>
+                    )}
+                    <EuiFlexItem grow={false}>
+                      <EuiLink
+                        data-test-subj={`streamsNameLink-${item.stream.name}`}
+                        href={router.link('/{key}', { path: { key: item.stream.name } })}
+                      >
+                        <EuiHighlight search={searchQuery?.text ?? ''}>
+                          {item.stream.name}
+                        </EuiHighlight>
+                      </EuiLink>
+                    </EuiFlexItem>
+                    {false && (
+                      <EuiFlexItem grow={false}>
+                        <EuiLoadingSpinner size="m" />
+                      </EuiFlexItem>
+                    )}
+                  </EuiFlexGroup>
+                );
+              },
+            },
+            {
+              field: 'definition',
+              name: 'Actions',
+              width: '60px',
+              align: 'left',
+              sortable: false,
+              dataType: 'string',
+              render: (_: unknown, item: TableRow) => {
+                return (
+                  <EuiButtonIcon
+                    iconType="securitySignalDetected"
+                    aria-label={RUN_STREAM_DISCOVERY_BUTTON_LABEL}
+                  />
+                );
+              },
+            },
+          ]}
+          itemId="nameSortKey"
+          items={items}
+          sorting={sorting}
+          noItemsMessage={NO_STREAMS_MESSAGE}
+          onTableChange={handleTableChange}
+          pagination={{
+            initialPageSize: 25,
+            pageSizeOptions: [25, 50, 100],
+            pageIndex: pagination.pageIndex,
+            pageSize: pagination.pageSize,
+          }}
+          tableCaption={STREAMS_TABLE_CAPTION_ARIA_LABEL}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 }


### PR DESCRIPTION
It closes https://github.com/elastic/streams-program/issues/720.

## Summary

Refactors the `StreamsTreeTable` component to extract the search controls from `EuiInMemoryTable`, enabling future insertion of additional UI elements (such as a histogram chart) between the search bar and the table.