### PR TITLE
[8.19] [APM][Discover] Fix trace links calculating date range incorrectly (#247531)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/trace_link/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/trace_link/index.tsx
@@ -10,13 +10,11 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { Redirect } from 'react-router-dom';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
-import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { FETCH_STATUS, useFetcher } from '../../../hooks/use_fetcher';
 import { getRedirectToTransactionDetailPageUrl } from './get_redirect_to_transaction_detail_page_url';
 import { getRedirectToTracePageUrl } from './get_redirect_to_trace_page_url';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useTimeRange } from '../../../hooks/use_time_range';
-import type { ApmPluginStartDeps } from '../../../plugin';
 
 const CentralizedContainer = euiStyled.div`
   height: 100%;
@@ -24,12 +22,9 @@ const CentralizedContainer = euiStyled.div`
 `;
 
 export function TraceLink() {
-  const { services } = useKibana<ApmPluginStartDeps>();
-  const { data: dataService } = services;
-  const timeRange = dataService.query.timefilter.timefilter.getTime();
   const {
     path: { traceId },
-    query: { rangeFrom = timeRange.from, rangeTo = timeRange.to, waterfallItemId },
+    query: { rangeFrom, rangeTo, waterfallItemId },
   } = useApmParams('/link-to/trace/{traceId}');
 
   const { start, end } = useTimeRange({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM][Discover] Fix trace links calculating date range incorrectly (#247531)](https://github.com/elastic/kibana/pull/247531)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miłosz Marcinkowski","email":"38698566+miloszmarcinkowski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-07T16:02:05Z","message":"[APM][Discover] Fix trace links calculating date range incorrectly (#247531)\n\nCloses #231116\n\n## Summary\n\nThe [previous\nlogic](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/apm/public/components/app/trace_link/index.tsx#L27-L29)\nin the `TraceLink` component attempted to use the date picker's selected\nvalues when redirecting. This approach is unreliable because the date\npicker selection is not persistent when a link is opened in a new tab,\ndefaulting to the last 15 minutes. These default values then override\nthe date range calculation based on the transaction's `@timestamp` from\nthe `root_transaction` API, preventing the trace from displaying\ncorrectly on the Transaction page.\n\n## Solution\n\nRemoved the date picker fallback logic from the `TraceLink` component.\nThe correct approach for preserving the date picker selection is to pass\nvalues via query parameters (`rangeFrom`/`rangeTo`). When query\nparameters are not provided, the component now correctly falls back to\ncalculating the date range from the transaction timestamp.\n\n## How Date Ranges Are Calculated in `TraceLink` component\n\n**When transaction is found, then Redirects to Transaction page:**\n1. **Query parameters (`rangeFrom`/`rangeTo`)** - Takes precedence when\nprovided. This enables passing previously selected date picker values\nvia the URL.\n2. **Transaction timestamp** - Fallback when query params are not\nprovided. Calculated from `@timestamp` returned by the\n`root_transaction` API and rounded to 5-minute intervals.\n\n**When no transaction is found, then Redirects to Traces page:**\n- Uses query parameters if provided, otherwise defaults to last 15\nminutes. The `trace.id` is preselected via `kuery` filter.\n\nFor the `root_transaction` API search, the component uses query\nparameters if provided, otherwise falls back to maximum date range to\nensure the transaction is found.\n\n> [!NOTE]\n> There is a discrepancy in date range behavior between `traceId` links\nin Discover:\n> - **Discover grid** — Opens in a new tab without query parameters, so\nthe date range is calculated from the transaction timestamp.\n> - **Traces in Discover flyout** — Opens in the same tab with query\nparameters, so the date range is preserved from the current date picker\nselection.","sha":"77e6f012623ff2135bd087bf39648906df17c90f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:all-open","v9.4.0","Team:obs-presentation"],"title":"[APM][Discover] Fix trace links calculating date range incorrectly","number":247531,"url":"https://github.com/elastic/kibana/pull/247531","mergeCommit":{"message":"[APM][Discover] Fix trace links calculating date range incorrectly (#247531)\n\nCloses #231116\n\n## Summary\n\nThe [previous\nlogic](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/apm/public/components/app/trace_link/index.tsx#L27-L29)\nin the `TraceLink` component attempted to use the date picker's selected\nvalues when redirecting. This approach is unreliable because the date\npicker selection is not persistent when a link is opened in a new tab,\ndefaulting to the last 15 minutes. These default values then override\nthe date range calculation based on the transaction's `@timestamp` from\nthe `root_transaction` API, preventing the trace from displaying\ncorrectly on the Transaction page.\n\n## Solution\n\nRemoved the date picker fallback logic from the `TraceLink` component.\nThe correct approach for preserving the date picker selection is to pass\nvalues via query parameters (`rangeFrom`/`rangeTo`). When query\nparameters are not provided, the component now correctly falls back to\ncalculating the date range from the transaction timestamp.\n\n## How Date Ranges Are Calculated in `TraceLink` component\n\n**When transaction is found, then Redirects to Transaction page:**\n1. **Query parameters (`rangeFrom`/`rangeTo`)** - Takes precedence when\nprovided. This enables passing previously selected date picker values\nvia the URL.\n2. **Transaction timestamp** - Fallback when query params are not\nprovided. Calculated from `@timestamp` returned by the\n`root_transaction` API and rounded to 5-minute intervals.\n\n**When no transaction is found, then Redirects to Traces page:**\n- Uses query parameters if provided, otherwise defaults to last 15\nminutes. The `trace.id` is preselected via `kuery` filter.\n\nFor the `root_transaction` API search, the component uses query\nparameters if provided, otherwise falls back to maximum date range to\nensure the transaction is found.\n\n> [!NOTE]\n> There is a discrepancy in date range behavior between `traceId` links\nin Discover:\n> - **Discover grid** — Opens in a new tab without query parameters, so\nthe date range is calculated from the transaction timestamp.\n> - **Traces in Discover flyout** — Opens in the same tab with query\nparameters, so the date range is preserved from the current date picker\nselection.","sha":"77e6f012623ff2135bd087bf39648906df17c90f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247531","number":247531,"mergeCommit":{"message":"[APM][Discover] Fix trace links calculating date range incorrectly (#247531)\n\nCloses #231116\n\n## Summary\n\nThe [previous\nlogic](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/apm/public/components/app/trace_link/index.tsx#L27-L29)\nin the `TraceLink` component attempted to use the date picker's selected\nvalues when redirecting. This approach is unreliable because the date\npicker selection is not persistent when a link is opened in a new tab,\ndefaulting to the last 15 minutes. These default values then override\nthe date range calculation based on the transaction's `@timestamp` from\nthe `root_transaction` API, preventing the trace from displaying\ncorrectly on the Transaction page.\n\n## Solution\n\nRemoved the date picker fallback logic from the `TraceLink` component.\nThe correct approach for preserving the date picker selection is to pass\nvalues via query parameters (`rangeFrom`/`rangeTo`). When query\nparameters are not provided, the component now correctly falls back to\ncalculating the date range from the transaction timestamp.\n\n## How Date Ranges Are Calculated in `TraceLink` component\n\n**When transaction is found, then Redirects to Transaction page:**\n1. **Query parameters (`rangeFrom`/`rangeTo`)** - Takes precedence when\nprovided. This enables passing previously selected date picker values\nvia the URL.\n2. **Transaction timestamp** - Fallback when query params are not\nprovided. Calculated from `@timestamp` returned by the\n`root_transaction` API and rounded to 5-minute intervals.\n\n**When no transaction is found, then Redirects to Traces page:**\n- Uses query parameters if provided, otherwise defaults to last 15\nminutes. The `trace.id` is preselected via `kuery` filter.\n\nFor the `root_transaction` API search, the component uses query\nparameters if provided, otherwise falls back to maximum date range to\nensure the transaction is found.\n\n> [!NOTE]\n> There is a discrepancy in date range behavior between `traceId` links\nin Discover:\n> - **Discover grid** — Opens in a new tab without query parameters, so\nthe date range is calculated from the transaction timestamp.\n> - **Traces in Discover flyout** — Opens in the same tab with query\nparameters, so the date range is preserved from the current date picker\nselection.","sha":"77e6f012623ff2135bd087bf39648906df17c90f"}},{"url":"https://github.com/elastic/kibana/pull/248117","number":248117,"branch":"9.1","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/248119","number":248119,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/248120","number":248120,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->