### PR TITLE
[ResponseOps][MaintenanceWindows] Fix mw internal client by passing hidden SO type

### DIFF
--- a/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.test.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.test.ts
@@ -107,12 +107,16 @@ test('creates an internal maintenance window client', async () => {
   const factory = new MaintenanceWindowClientFactory();
   factory.initialize(maintenanceWindowClientFactoryParams);
   const request = mockRouter.createKibanaRequest();
-  const mockRepository = savedObjectsService.createInternalRepository();
+  const mockRepository = savedObjectsService.createInternalRepository([
+    MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE,
+  ]);
   savedObjectsService.createInternalRepository.mockReturnValue(mockRepository);
 
   factory.createInternal(request);
 
-  expect(savedObjectsService.createInternalRepository).toHaveBeenCalledWith();
+  expect(savedObjectsService.createInternalRepository).toHaveBeenCalledWith([
+    MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE,
+  ]);
 
   const { MaintenanceWindowClient } = jest.requireMock('./client');
 

--- a/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
+++ b/x-pack/platform/plugins/shared/maintenance_windows/server/maintenance_window_client_factory.ts
@@ -78,7 +78,9 @@ export class MaintenanceWindowClientFactory {
   }
 
   public createInternal(request: KibanaRequest) {
-    const savedObjectsInternalClient = this.savedObjectsService.createInternalRepository();
+    const savedObjectsInternalClient = this.savedObjectsService.createInternalRepository([
+      MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE,
+    ]);
     return this.createMaintenanceWindowClient(request, savedObjectsInternalClient);
   }
 }


### PR DESCRIPTION
## Summary

Internal MW client using internal repository was introduced in https://github.com/elastic/kibana/pull/247390. 
It created problems while fetching MWs using all spaces in synthetics plugin. 

This PR fixes the issue.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->