### PR TITLE
[9.2] Allow excluding indices on logs status check in observability onboarding (#245324)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/agent.ts
@@ -67,3 +67,10 @@ export const PRIVILEGED_AGENT_KUERY = `not ${AGENTS_PREFIX}.local_metadata.elast
 
 // Kuery to find fips agents
 export const FIPS_AGENT_KUERY = `${AGENTS_PREFIX}.local_metadata.elastic.agent.fips: true`;
+
+export const AGENT_STATUS_CHANGE_DATA_STREAM = {
+  type: 'logs',
+  dataset: 'elastic_agent.status_change',
+  namespace: 'default',
+};
+export const AGENT_STATUS_CHANGE_DATA_STREAM_NAME = `${AGENT_STATUS_CHANGE_DATA_STREAM.type}-${AGENT_STATUS_CHANGE_DATA_STREAM.dataset}-${AGENT_STATUS_CHANGE_DATA_STREAM.namespace}`;

--- a/x-pack/platform/plugins/shared/fleet/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/index.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { AGENT_STATUS_CHANGE_DATA_STREAM_NAME } from './agent';
+
 export { INTEGRATIONS_PLUGIN_ID, PLUGIN_ID } from './plugin';
 export {
   INGEST_SAVED_OBJECT_INDEX,
@@ -65,3 +67,5 @@ export const REQUEST_DIAGNOSTICS_TIMEOUT_MS = 3 * 60 * 60 * 1000; // 3 hours;
 export * from './mappings';
 
 export const AUTO_UPGRADE_DEFAULT_RETRIES = ['30m', '1h', '2h', '4h', '8h', '16h', '24h'];
+
+export const FLEET_LOG_INDICES = [AGENT_STATUS_CHANGE_DATA_STREAM_NAME];

--- a/x-pack/platform/plugins/shared/fleet/common/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/index.ts
@@ -65,6 +65,7 @@ export {
   FLEET_ENROLLMENT_API_PREFIX,
   API_VERSIONS,
   APP_API_ROUTES,
+  FLEET_LOG_INDICES,
 } from './constants';
 export {
   // Route services

--- a/x-pack/platform/plugins/shared/fleet/cypress/e2e/agents/agent_list.cy.ts
+++ b/x-pack/platform/plugins/shared/fleet/cypress/e2e/agents/agent_list.cy.ts
@@ -208,11 +208,11 @@ describe('View agents list', () => {
   describe('Agent status filter', () => {
     const clearFilters = () => {
       cy.getBySel(FLEET_AGENT_LIST_PAGE.STATUS_FILTER).click();
-      cy.get('li').contains('Healthy').click();
-      cy.get('li').contains('Unhealthy').click();
-      cy.get('li').contains('Updating').click();
-      cy.get('li').contains('Offline').click();
-      cy.get('li').contains('Orphaned').click();
+      cy.get('li').contains('Healthy').click({ force: true });
+      cy.get('li').contains('Unhealthy').click({ force: true });
+      cy.get('li').contains('Updating').click({ force: true });
+      cy.get('li').contains('Offline').click({ force: true });
+      cy.get('li').contains('Orphaned').click({ force: true });
       cy.getBySel(FLEET_AGENT_LIST_PAGE.STATUS_FILTER).click();
       cy.wait('@getAgents');
     };
@@ -221,7 +221,7 @@ describe('View agents list', () => {
       clearFilters();
       cy.getBySel(FLEET_AGENT_LIST_PAGE.STATUS_FILTER).click();
 
-      cy.get('li').contains('Healthy').click();
+      cy.get('li').contains('Healthy').click({ force: true });
       cy.wait('@getAgents');
 
       assertTableContainsNAgents(18);
@@ -233,7 +233,7 @@ describe('View agents list', () => {
       clearFilters();
       cy.getBySel(FLEET_AGENT_LIST_PAGE.STATUS_FILTER).click();
 
-      cy.get('li').contains('Unhealthy').click();
+      cy.get('li').contains('Unhealthy').click({ force: true });
       cy.wait('@getAgents');
 
       assertTableContainsNAgents(1);
@@ -246,7 +246,7 @@ describe('View agents list', () => {
 
       cy.getBySel(FLEET_AGENT_LIST_PAGE.STATUS_FILTER).click();
 
-      cy.get('li').contains('Inactive').click();
+      cy.get('li').contains('Inactive').click({ force: true });
 
       cy.getBySel(FLEET_AGENT_LIST_PAGE.TABLE).contains('No agents found');
     });
@@ -257,8 +257,8 @@ describe('View agents list', () => {
 
       cy.getBySel(FLEET_AGENT_LIST_PAGE.STATUS_FILTER).click();
 
-      cy.get('li').contains('Healthy').click();
-      cy.get('li').contains('Unhealthy').click();
+      cy.get('li').contains('Healthy').click({ force: true });
+      cy.get('li').contains('Unhealthy').click({ force: true });
       cy.wait('@getAgents');
 
       assertTableContainsNAgents(18);

--- a/x-pack/platform/plugins/shared/fleet/cypress/e2e/agents/agent_list.cy.ts
+++ b/x-pack/platform/plugins/shared/fleet/cypress/e2e/agents/agent_list.cy.ts
@@ -4,16 +4,14 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import type { CreateAgentPolicyRequest } from '@kbn/fleet-plugin/common/types';
+import { API_VERSIONS } from '@kbn/fleet-plugin/common/constants';
 
 import { FLEET_AGENT_LIST_PAGE } from '../../screens/fleet';
-
 import { createAgentDoc } from '../../tasks/agents';
 import { setupFleetServer } from '../../tasks/fleet_server';
 import { deleteAgentDocs, cleanupAgentPolicies } from '../../tasks/cleanup';
-import type { CreateAgentPolicyRequest } from '@kbn/fleet-plugin/common/types';
 import { setUISettings } from '../../tasks/ui_settings';
-
-import { API_VERSIONS } from '@kbn/fleet-plugin/common/constants';
 import { request } from '../../tasks/common';
 import { login } from '../../tasks/login';
 

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/agent_status_change_task.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/agent_status_change_task.ts
@@ -20,6 +20,10 @@ import { getDeleteTaskRunResult } from '@kbn/task-manager-plugin/server/task';
 import type { LoggerFactory, SavedObjectsClientContract } from '@kbn/core/server';
 import { errors, type estypes } from '@elastic/elasticsearch';
 
+import {
+  AGENT_STATUS_CHANGE_DATA_STREAM,
+  AGENT_STATUS_CHANGE_DATA_STREAM_NAME,
+} from '../../common/constants/agent';
 import { agentPolicyService, appContextService } from '../services';
 import { bulkUpdateAgents, fetchAllAgentsByKuery } from '../services/agents';
 import type { Agent } from '../types';
@@ -33,12 +37,6 @@ const SCOPE = ['fleet'];
 const DEFAULT_INTERVAL = '1m';
 const TIMEOUT = '1m';
 const AGENTS_BATCHSIZE = 10000;
-const AGENT_STATUS_CHANGE_DATA_STREAM = {
-  type: 'logs',
-  dataset: 'elastic_agent.status_change',
-  namespace: 'default',
-};
-const AGENT_STATUS_CHANGE_DATA_STREAM_NAME = `${AGENT_STATUS_CHANGE_DATA_STREAM.type}-${AGENT_STATUS_CHANGE_DATA_STREAM.dataset}-${AGENT_STATUS_CHANGE_DATA_STREAM.namespace}`;
 
 export const HAS_CHANGED_RUNTIME_FIELD: estypes.SearchRequest['runtime_mappings'] = {
   hasChanged: {

--- a/x-pack/platform/plugins/shared/logs_data_access/public/services/log_data_service/log_data_service.ts
+++ b/x-pack/platform/plugins/shared/logs_data_access/public/services/log_data_service/log_data_service.ts
@@ -15,14 +15,17 @@ export function createLogDataService(
 ): LogDataService {
   const { logSourcesService, deps } = params;
 
-  async function getStatus() {
+  async function getStatus(opts?: { excludeIndices?: string[] }) {
+    const excludeLogSourcesIndex = (opts?.excludeIndices ?? [])
+      .map((index) => `-${index}`)
+      .join(',');
     const logSourcesIndex = await logSourcesService.getFlattenedLogSources();
     const status = await lastValueFrom(
       deps.search.search({
         params: {
           ignore_unavailable: true,
           allow_no_indices: true,
-          index: logSourcesIndex,
+          index: [logSourcesIndex, excludeLogSourcesIndex].join(','),
           size: 0,
           terminate_after: 1,
           track_total_hits: 1,

--- a/x-pack/platform/plugins/shared/logs_data_access/public/services/log_data_service/types.ts
+++ b/x-pack/platform/plugins/shared/logs_data_access/public/services/log_data_service/types.ts
@@ -8,5 +8,7 @@
 export type LogDataStatus = 'available' | 'empty' | 'missing' | 'unknown';
 
 export interface LogDataService {
-  getStatus(): Promise<{ status: LogDataStatus; hasData: boolean }>;
+  getStatus(opts?: {
+    excludeIndices?: string[];
+  }): Promise<{ status: LogDataStatus; hasData: boolean }>;
 }

--- a/x-pack/solutions/observability/plugins/observability/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability/kibana.jsonc
@@ -65,6 +65,7 @@
       "cases",
       "data",
       "discover",
+      "fleet",
       "logsShared",
       "kibanaReact",
       "kibanaUtils",

--- a/x-pack/solutions/observability/plugins/observability/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability/moon.yml
@@ -140,6 +140,7 @@ dependsOn:
   - '@kbn/core-elasticsearch-server-utils'
   - '@kbn/core-http-browser-mocks'
   - '@kbn/react-query'
+  - '@kbn/fleet-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/observability/plugins/observability/public/pages/landing/landing.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/landing/landing.tsx
@@ -8,6 +8,7 @@ import React, { useEffect } from 'react';
 import { LOGS_LOCATOR_ID } from '@kbn/logs-shared-plugin/common';
 import { OBSERVABILITY_ONBOARDING_LOCATOR } from '@kbn/deeplinks-observability';
 import type { SharePublicStart } from '@kbn/share-plugin/public/plugin';
+import { FLEET_LOG_INDICES } from '@kbn/fleet-plugin/common';
 import { OBSERVABILITY_COMPLETE_LANDING_PAGE_FEATURE } from '../../../common';
 import { useHasData } from '../../hooks/use_has_data';
 import { useKibana } from '../../utils/kibana_react';
@@ -15,7 +16,6 @@ import { APM_APP_LOCATOR_ID } from '../../components/alert_sources/get_apm_app_u
 
 export function LandingPage() {
   const { pricing } = useKibana().services;
-
   const hasCompleteLandingPage = pricing.isFeatureAvailable(
     OBSERVABILITY_COMPLETE_LANDING_PAGE_FEATURE.id
   );
@@ -34,7 +34,9 @@ function ObservabilityCompleteLandingPage() {
   useEffect(() => {
     async function redirectToLanding() {
       if (isAllRequestsComplete) {
-        const { hasData: hasLogsData } = await logsDataAccess.services.logDataService.getStatus();
+        const { hasData: hasLogsData } = await logsDataAccess.services.logDataService.getStatus({
+          excludeIndices: FLEET_LOG_INDICES,
+        });
         const hasApmData = hasDataMap.apm?.hasData;
 
         const locators = getLocators(share);
@@ -60,7 +62,9 @@ function ObservabilityLogsEssentialsLandingPage() {
 
   useEffect(() => {
     async function redirectToLanding() {
-      const { hasData: hasLogsData } = await logsDataAccess.services.logDataService.getStatus();
+      const { hasData: hasLogsData } = await logsDataAccess.services.logDataService.getStatus({
+        excludeIndices: FLEET_LOG_INDICES,
+      });
 
       const locators = getLocators(share);
 

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/generators.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/fixtures/generators.ts
@@ -14,7 +14,8 @@ const TEST_END_TIME = '2024-01-01T01:00:00.000Z';
  * Generate synthetic logs data for testing
  */
 export async function generateLogsData(
-  logsSynthtraceEsClient: SynthtraceFixture['logsSynthtraceEsClient']
+  logsSynthtraceEsClient: SynthtraceFixture['logsSynthtraceEsClient'],
+  opts?: { dataset?: string }
 ) {
   const logsData = timerange(TEST_START_TIME, TEST_END_TIME)
     .interval('1m')
@@ -24,7 +25,7 @@ export async function generateLogsData(
         .create()
         .message('Test log message')
         .timestamp(timestamp)
-        .dataset('synth.test')
+        .dataset(opts?.dataset ?? 'synth.test')
         .namespace('default')
         .logLevel(Math.random() > 0.5 ? 'info' : 'warn')
         .defaults({

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/landing.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/landing.spec.ts
@@ -101,4 +101,24 @@ test.describe('Observability Landing Page', { tag: ['@ess', '@svlOblt'] }, () =>
     // Wait for redirect and verify we're on onboarding page
     await expect(page).toHaveURL(/\/app\/observabilityOnboarding/, { timeout: 10000 });
   });
+
+  test('redirects to onboarding when log data that should be ignored exists', async ({
+    page,
+    pageObjects,
+    logsSynthtraceEsClient,
+  }) => {
+    // Generate Fleet Agent status change log data which should be ignored
+    await generateLogsData({
+      from: new Date(TEST_START_DATE).getTime(),
+      to: new Date(TEST_END_DATE).getTime(),
+      client: logsSynthtraceEsClient,
+      opts: { dataset: 'elastic_agent.status_change' },
+    });
+
+    // Navigate to observability landing page with no data
+    await pageObjects.observabilityNavigation.gotoLanding();
+
+    // Wait for redirect and verify we're on onboarding page
+    await expect(page).toHaveURL(/\/app\/observabilityOnboarding/, { timeout: 10000 });
+  });
 });

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/landing.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/tests/landing.spec.ts
@@ -108,12 +108,7 @@ test.describe('Observability Landing Page', { tag: ['@ess', '@svlOblt'] }, () =>
     logsSynthtraceEsClient,
   }) => {
     // Generate Fleet Agent status change log data which should be ignored
-    await generateLogsData({
-      from: new Date(TEST_START_DATE).getTime(),
-      to: new Date(TEST_END_DATE).getTime(),
-      client: logsSynthtraceEsClient,
-      opts: { dataset: 'elastic_agent.status_change' },
-    });
+    await generateLogsData(logsSynthtraceEsClient, { dataset: 'elastic_agent.status_change' });
 
     // Navigate to observability landing page with no data
     await pageObjects.observabilityNavigation.gotoLanding();

--- a/x-pack/solutions/observability/plugins/observability/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability/tsconfig.json
@@ -135,6 +135,7 @@
     "@kbn/core-elasticsearch-server-utils",
     "@kbn/core-http-browser-mocks",
     "@kbn/react-query",
+    "@kbn/fleet-plugin"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Allow excluding indices on logs status check in observability onboarding (#245324)](https://github.com/elastic/kibana/pull/245324)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Michel Losier","email":"michel.losier@elastic.co"},"sourceCommit":{"committedDate":"2026-01-07T16:35:24Z","message":"Allow excluding indices on logs status check in observability onboarding (#245324)\n\nResolves: https://github.com/elastic/kibana/issues/245163\n\n* Updates `LogDataService.getStatus` to receive an option to exclude\nindices from the status check\n* Has Observability LandingPage component provide FLEET_LOG_INDICES to\nexclude from this check\n* Right now that constant just contains the agent_status_change index\nwhich is written to when the fleet server agent comes up.\n\nThis helps resolve the issue of having the landing page redirect to the\nlogging view when this log data is present.","sha":"baafff9adb5a7790618c0bb0fe3b80e4c744ac9c","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","ci:cloud-deploy","backport:version","v9.3.0","v9.4.0","Team:obs-ux-management","v9.2.4"],"title":"Allow excluding indices on logs status check in observability onboarding","number":245324,"url":"https://github.com/elastic/kibana/pull/245324","mergeCommit":{"message":"Allow excluding indices on logs status check in observability onboarding (#245324)\n\nResolves: https://github.com/elastic/kibana/issues/245163\n\n* Updates `LogDataService.getStatus` to receive an option to exclude\nindices from the status check\n* Has Observability LandingPage component provide FLEET_LOG_INDICES to\nexclude from this check\n* Right now that constant just contains the agent_status_change index\nwhich is written to when the fleet server agent comes up.\n\nThis helps resolve the issue of having the landing page redirect to the\nlogging view when this log data is present.","sha":"baafff9adb5a7790618c0bb0fe3b80e4c744ac9c"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/245324","number":245324,"mergeCommit":{"message":"Allow excluding indices on logs status check in observability onboarding (#245324)\n\nResolves: https://github.com/elastic/kibana/issues/245163\n\n* Updates `LogDataService.getStatus` to receive an option to exclude\nindices from the status check\n* Has Observability LandingPage component provide FLEET_LOG_INDICES to\nexclude from this check\n* Right now that constant just contains the agent_status_change index\nwhich is written to when the fleet server agent comes up.\n\nThis helps resolve the issue of having the landing page redirect to the\nlogging view when this log data is present.","sha":"baafff9adb5a7790618c0bb0fe3b80e4c744ac9c"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->