### PR TITLE
[Lens] Fix api transform schema for by-ref panels

### DIFF
--- a/x-pack/platform/plugins/shared/lens/server/transforms.ts
+++ b/x-pack/platform/plugins/shared/lens/server/transforms.ts
@@ -28,17 +28,27 @@ export const getLensServerTransforms = (
   };
 };
 
-export const legacyPanelSchema = lensItemDataSchema.extends({
+const legacyPanelAttributesSchema = lensItemDataSchema.extends({
   type: schema.maybe(schema.literal('lens')), // why is this added to the panel state?
 });
 
-const lensPanelSchema = schema.object(
+const lensByValuePanelSchema = schema.object(
   {
     // TODO: add missing config properties
-    attributes: schema.oneOf([lensApiStateSchema, legacyPanelSchema]),
+    attributes: schema.oneOf([lensApiStateSchema, legacyPanelAttributesSchema]),
   },
   { unknowns: 'allow' }
 );
+
+const lensByRefPanelSchema = schema.object(
+  {
+    // TODO: add missing config properties
+    savedObjectId: schema.string(),
+  },
+  { unknowns: 'allow' }
+);
+
+const lensPanelSchema = schema.oneOf([lensByValuePanelSchema, lensByRefPanelSchema]);
 
 function getExtraServerTransformProps(
   builder: LensConfigBuilder


### PR DESCRIPTION
## Summary

Fixes issue with new api transforms where by-ref lens panels cause the dashboard transform schema validation to fail.

Fixes #247804

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.