### PR TITLE
Allow EIS script to fallback to default credentials and check protocol when validating creds

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-cli/README.md
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/README.md
@@ -63,8 +63,7 @@ You can connect your local Elasticsearch to the Elastic Inference Service (EIS) 
 # Start Elasticsearch with CCM enabled
 yarn es snapshot --license trial -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
 
-# In a separate terminal, configure CCM 
-# Use --no-ssl for HTTP connections
+# In a separate terminal, configure CCM
 node scripts/eis.js
 ```
 

--- a/x-pack/platform/packages/shared/kbn-inference-cli/scripts/eis.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/scripts/eis.ts
@@ -8,23 +8,12 @@ import { run } from '@kbn/dev-cli-runner';
 import { ensureEis } from '../src/eis/ensure_eis';
 
 run(
-  ({ log, flags }) => {
-    const ssl = flags.ssl as boolean;
-    return ensureEis({ log, ssl }).catch((error) => {
+  ({ log }) => {
+    return ensureEis({ log }).catch((error) => {
       throw new Error('Failed to configure Cloud Connected Mode for EIS', { cause: error });
     });
   },
   {
     description: 'Sets up Cloud Connected Mode for Elastic Inference Service (EIS)',
-    flags: {
-      boolean: ['ssl'],
-      default: {
-        ssl: true,
-      },
-      help: `
-      --ssl               Optional. Use HTTPS/SSL for Elasticsearch connection (Default: true).
-                          Use --no-ssl for HTTP connections.
-`,
-    },
   }
 );

--- a/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
@@ -52,52 +52,93 @@ function httpRequest(
   });
 }
 
-async function getES(log: ToolingLog, ssl: boolean = true): Promise<ElasticsearchConnection> {
+async function testCredentials(
+  baseUrl: string,
+  credentials: ElasticsearchCredentials,
+  ssl: boolean,
+  log: ToolingLog
+): Promise<boolean> {
+  try {
+    const auth = Buffer.from(`${credentials.username}:${credentials.password}`).toString('base64');
+    const { statusCode } = await httpRequest(
+      baseUrl,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Basic ${auth}`,
+        },
+        rejectUnauthorized: false,
+      },
+      undefined,
+      ssl
+    );
+
+    return statusCode === 200;
+  } catch (error) {
+    if (error.code === 'EPROTO') {
+      log.info(`Protocol mismatch detected — attempting to connect with ${ssl ? 'http' : 'https'}`);
+      throw new Error('Protocol mismatch error');
+    }
+
+    throw new Error('Failed to connect to Elasticsearch', { cause: error });
+  }
+}
+
+async function getES(log: ToolingLog, ssl: boolean = true) {
   log.debug('Determining Elasticsearch connection');
 
-  const protocol = ssl ? 'https' : 'http';
-  const baseUrl = `${protocol}://localhost:9200`;
+  const localhost = 'localhost:9200';
+  const protocols = ssl ? ['https', 'http'] : ['http', 'https'];
 
-  // Check environment variables first
   const envUsername = process.env.ES_USERNAME || process.env.ELASTICSEARCH_USERNAME;
   const envPassword = process.env.ES_PASSWORD || process.env.ELASTICSEARCH_PASSWORD;
 
+  const credentialsToTry: {
+    username: string;
+    password: string;
+    type: string;
+  }[] = [];
+
   if (envUsername && envPassword) {
-    log.debug('Using credentials from environment variables');
-    return { baseUrl, credentials: { username: envUsername, password: envPassword }, ssl };
+    credentialsToTry.push({
+      username: envUsername,
+      password: envPassword,
+      type: 'environment variable',
+    });
   }
 
-  // Try default credentials
-  const credentialsToTry = [
-    { username: 'elastic', password: 'changeme' },
-    { username: 'elastic_serverless', password: 'changeme' },
-  ];
+  credentialsToTry.push(
+    { username: 'elastic', password: 'changeme', type: 'default' },
+    { username: 'elastic_serverless', password: 'changeme', type: 'default' }
+  );
 
-  for (const credentials of credentialsToTry) {
-    log.debug(`Trying credentials: ${credentials.username}`);
-    try {
-      const auth = Buffer.from(`${credentials.username}:${credentials.password}`).toString(
-        'base64'
-      );
-      const { statusCode } = await httpRequest(
-        baseUrl,
-        {
-          method: 'GET',
-          headers: {
-            Authorization: `Basic ${auth}`,
-          },
-          rejectUnauthorized: false,
-        },
-        undefined,
-        ssl
-      );
+  for (const protocol of protocols) {
+    log.info(`Setting up Cloud Connected Mode for EIS (using ${protocol})`);
+    const baseUrl = `${protocol}://${localhost}`;
 
-      if (statusCode === 200) {
-        log.debug(`Credentials ${credentials.username} authorized`);
-        return { baseUrl, credentials, ssl };
+    for (const credentials of credentialsToTry) {
+      const isSsl = protocol === 'https';
+      try {
+        log.debug(`Trying ${credentials.type} credentials: ${credentials.username}`);
+
+        const isValid = await testCredentials(baseUrl, credentials, isSsl, log);
+
+        if (isValid) {
+          log.debug(
+            `Authorized with ${credentials.type} credentials ${credentials.username} (${protocol})`
+          );
+
+          return {
+            baseUrl,
+            credentials,
+            ssl: isSsl,
+          };
+        }
+      } catch (error) {
+        if (error.message === 'Protocol mismatch error') {
+          break; // stop trying creds, move to next protocol
+        }
       }
-    } catch (error) {
-      // Continue to next credentials
     }
   }
 
@@ -135,9 +176,7 @@ async function setCcmApiKey(
 
   const maxRetries = 3;
   const retryDelayMs = 2000;
-  const ccmEndpoint = '_inference/_ccm';
-  let esUrl = `${es.baseUrl}/${ccmEndpoint}`;
-  let ssl = es.ssl;
+  const esUrl = `${es.baseUrl}/_inference/_ccm`;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
@@ -158,7 +197,7 @@ async function setCcmApiKey(
           rejectUnauthorized: false,
         },
         body,
-        ssl
+        es.ssl
       );
 
       if (statusCode >= 200 && statusCode < 300) {
@@ -168,21 +207,6 @@ async function setCcmApiKey(
 
       throw new Error(`HTTP ${statusCode}`);
     } catch (error) {
-      const handshakeFailurePatterns = [
-        'EPROTO',
-        'ERR_SSL_WRONG_VERSION_NUMBER',
-        'packet length too long',
-      ];
-      const handshakeFailure = handshakeFailurePatterns.some((p) => error.message.includes(p));
-
-      if (handshakeFailure && ssl) {
-        log.info('HTTPS handshake failed due to protocol mismatch — falling back to HTTP');
-        ssl = false;
-        esUrl = `http://localhost:9200/${ccmEndpoint}`;
-        // Retry immediately with HTTP (don't count this as a failed attempt)
-        continue;
-      }
-
       if (attempt < maxRetries) {
         log.debug(`Attempt ${attempt} failed, retrying in ${retryDelayMs}ms...`);
         await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
@@ -196,9 +220,6 @@ async function setCcmApiKey(
 }
 
 export async function ensureEis({ log, ssl = true }: { log: ToolingLog; ssl?: boolean }) {
-  const protocol = ssl ? 'https' : 'http';
-  log.info(`Setting up Cloud Connected Mode for EIS (using ${protocol})`);
-
   // Get Elasticsearch connection info
   const es = await getES(log, ssl);
 

--- a/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
@@ -76,7 +76,7 @@ async function testCredentials(
     return statusCode === 200;
   } catch (error) {
     if (error.code === 'EPROTO') {
-      log.info(`Protocol mismatch detected — attempting to connect with ${ssl ? 'http' : 'https'}`);
+      log.debug('Protocol mismatch detected — attempting to connect with HTTP');
       throw new Error('Protocol mismatch error');
     }
 
@@ -84,11 +84,11 @@ async function testCredentials(
   }
 }
 
-async function getES(log: ToolingLog, ssl: boolean = true) {
+async function getES(log: ToolingLog) {
   log.debug('Determining Elasticsearch connection');
 
   const localhost = 'localhost:9200';
-  const protocols = ssl ? ['https', 'http'] : ['http', 'https'];
+  const protocols = ['https', 'http'];
 
   const envUsername = process.env.ES_USERNAME || process.env.ELASTICSEARCH_USERNAME;
   const envPassword = process.env.ES_PASSWORD || process.env.ELASTICSEARCH_PASSWORD;
@@ -113,7 +113,6 @@ async function getES(log: ToolingLog, ssl: boolean = true) {
   );
 
   for (const protocol of protocols) {
-    log.info(`Setting up Cloud Connected Mode for EIS (using ${protocol})`);
     const baseUrl = `${protocol}://${localhost}`;
 
     for (const credentials of credentialsToTry) {
@@ -219,9 +218,10 @@ async function setCcmApiKey(
   }
 }
 
-export async function ensureEis({ log, ssl = true }: { log: ToolingLog; ssl?: boolean }) {
+export async function ensureEis({ log }: { log: ToolingLog }) {
+  log.info('Setting up Cloud Connected Mode for EIS');
   // Get Elasticsearch connection info
-  const es = await getES(log, ssl);
+  const es = await getES(log);
 
   // Get EIS API key from vault
   const apiKey = await getEisApiKey(log);


### PR DESCRIPTION
## Summary

The EIS script was checking for creds set in environment variable first and if found, using them without validating. If you'd set env vars for ECH but then went to run the script with serverless, the request in `setCcmApiKey` would fail. This PR ensures the creds fallback to the default creds if the ones set in env vars are incorrect.

This PR also checks that the correct protocol is used when validating the creds as this is the first request made to Elasticsearch.



