### PR TITLE
[9.3] [Fleet] Fix reusable integration multiplespace validation (#236428)

### DIFF
--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/helpers.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/helpers.ts
@@ -48,6 +48,7 @@ export async function cleanFleetIndices(esClient: Client) {
           q: '*',
           ignore_unavailable: true,
           refresh: true,
+          conflicts: 'proceed'
         }),
       { retries: DELETE_RETRIES }
     ),
@@ -58,6 +59,7 @@ export async function cleanFleetIndices(esClient: Client) {
           q: '*',
           ignore_unavailable: true,
           refresh: true,
+          conflicts: 'proceed'
         }),
       { retries: DELETE_RETRIES }
     ),
@@ -68,6 +70,7 @@ export async function cleanFleetIndices(esClient: Client) {
           q: '*',
           ignore_unavailable: true,
           refresh: true,
+          conflicts: 'proceed'
         }),
       { retries: DELETE_RETRIES }
     ),
@@ -82,6 +85,7 @@ export async function cleanFleetAgents(esClient: Client) {
         q: '*',
         ignore_unavailable: true,
         refresh: true,
+        conflicts: 'proceed'
       }),
     { retries: DELETE_RETRIES }
   );
@@ -95,6 +99,7 @@ export async function cleanFleetAgentPolicies(esClient: Client) {
         q: '*',
         refresh: true,
         ignore_unavailable: true,
+        conflicts: 'proceed'
       }),
     { retries: DELETE_RETRIES }
   );
@@ -110,6 +115,7 @@ export async function cleanFleetActionIndices(esClient: Client) {
             q: '*',
             ignore_unavailable: true,
             refresh: true,
+            conflicts: 'proceed'
           }),
         { retries: DELETE_RETRIES }
       ),
@@ -120,6 +126,7 @@ export async function cleanFleetActionIndices(esClient: Client) {
               index: AGENT_ACTIONS_RESULTS_INDEX,
               q: '*',
               refresh: true,
+              conflicts: 'proceed'
             },
             ES_INDEX_OPTIONS
           ),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Fleet] Fix reusable integration multiplespace validation (#236428)](https://github.com/elastic/kibana/pull/236428)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2025-09-25T20:18:20Z","message":"[Fleet] Fix reusable integration multiplespace validation (#236428)","sha":"dbcae6c2fc4836d8205b26ba890ce437687f0089","branchLabelMapping":{"^v9.2.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.2.0","v9.3.0","v9.1.7","v9.4.0","v9.1.10"],"title":"[Fleet] Fix reusable integration multiplespace validation","number":236428,"url":"https://github.com/elastic/kibana/pull/236428","mergeCommit":{"message":"[Fleet] Fix reusable integration multiplespace validation (#236428)","sha":"dbcae6c2fc4836d8205b26ba890ce437687f0089"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.2.0","branchLabelMappingKey":"^v9.2.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/236428","number":236428,"mergeCommit":{"message":"[Fleet] Fix reusable integration multiplespace validation (#236428)","sha":"dbcae6c2fc4836d8205b26ba890ce437687f0089"}},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->