### PR TITLE
[8.19] [Synthetics] Only update relevant monitors where maintenance windows exists (#246088)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
@@ -11,7 +11,7 @@ import type {
 } from '@kbn/core-saved-objects-api-server';
 import type { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
 import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
-import type { MaintenanceWindow } from '@kbn/alerting-plugin/common';
+import type { MaintenanceWindow } from '@kbn/alerting-plugin/server/application/maintenance_window/types';
 import {
   legacyMonitorAttributes,
   syntheticsMonitorAttributes,

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
@@ -11,6 +11,12 @@ import type {
 } from '@kbn/core-saved-objects-api-server';
 import type { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
 import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
+import type { MaintenanceWindow } from '@kbn/maintenance-windows-plugin/server/application/types';
+import {
+  legacyMonitorAttributes,
+  syntheticsMonitorAttributes,
+  syntheticsMonitorSOTypes,
+} from '../../common/types/saved_objects';
 import { normalizeSecrets } from '../synthetics_service/utils';
 import type { PrivateLocationAttributes } from '../runtime_types/private_locations';
 import type {
@@ -18,6 +24,7 @@ import type {
   MonitorFields,
   SyntheticsMonitorWithSecretsAttributes,
 } from '../../common/runtime_types';
+import { ConfigKey } from '../../common/runtime_types';
 import { MonitorConfigRepository } from '../services/monitor_config_repository';
 import type { SyntheticsMonitorClient } from '../synthetics_service/synthetics_monitor/synthetics_monitor_client';
 import type { SyntheticsServerSetup } from '../types';
@@ -26,13 +33,144 @@ import {
   mixParamsWithGlobalParams,
 } from '../synthetics_service/formatters/public_formatters/format_configs';
 
+interface SyncConfig {
+  config: HeartbeatConfig;
+  globalParams: Record<string, string>;
+}
+
 export class DeployPrivateLocationMonitors {
   constructor(
     public serverSetup: SyntheticsServerSetup,
     public syntheticsMonitorClient: SyntheticsMonitorClient
   ) {}
 
-  async syncPackagePolicies({
+  async syncPackagePoliciesForMws({
+    allPrivateLocations,
+    updatedMWs,
+    missingMWIds,
+    soClient,
+    maintenanceWindows,
+  }: {
+    maintenanceWindows: MaintenanceWindow[];
+    updatedMWs?: MaintenanceWindow[];
+    missingMWIds?: string[];
+    soClient: SavedObjectsClientContract;
+    allPrivateLocations: PrivateLocationAttributes[];
+  }) {
+    if (allPrivateLocations.length === 0) {
+      this.debugLog('No private locations found, skipping sync of private location monitors');
+      return;
+    }
+    const { syntheticsService } = this.syntheticsMonitorClient;
+
+    const paramsBySpace = await syntheticsService.getSyntheticsParams({
+      spaceId: ALL_SPACES_ID,
+    });
+
+    // config can have multiple mws, so we need to track which configs have been updated to avoid duplicate processing
+    const listOfUpdatedConfigs: Array<string> = [];
+
+    return this.serverSetup.fleet.runWithCache(async () => {
+      const commonProps = {
+        listOfUpdatedConfigs,
+        allPrivateLocations,
+        maintenanceWindows,
+        soClient,
+        paramsBySpace,
+      };
+      for (const mw of updatedMWs || []) {
+        await this.updateMonitorsForMw({
+          ...commonProps,
+          mwId: mw.id,
+        });
+      }
+
+      for (const mwId of missingMWIds || []) {
+        await this.updateMonitorsForMw({
+          ...commonProps,
+          mwId,
+          isMissingMw: true,
+        });
+      }
+    });
+  }
+
+  async updateMonitorsForMw({
+    listOfUpdatedConfigs,
+    allPrivateLocations,
+    mwId,
+    maintenanceWindows,
+    soClient,
+    paramsBySpace,
+    isMissingMw = false,
+  }: {
+    mwId: string;
+    maintenanceWindows: MaintenanceWindow[];
+    missingMWIds?: string[];
+    soClient: SavedObjectsClientContract;
+    allPrivateLocations: PrivateLocationAttributes[];
+    paramsBySpace: Record<string, Record<string, string>>;
+    listOfUpdatedConfigs: Array<string>;
+    isMissingMw?: boolean;
+  }) {
+    const {
+      pluginsStart: { encryptedSavedObjects },
+    } = this.serverSetup;
+    const encryptedClient = encryptedSavedObjects.getClient();
+
+    const finder =
+      await encryptedClient.createPointInTimeFinderDecryptedAsInternalUser<SyntheticsMonitorWithSecretsAttributes>(
+        {
+          type: syntheticsMonitorSOTypes,
+          perPage: 500,
+          namespaces: ['*'],
+          // TODO: Exclude public monitors
+          filter: `${syntheticsMonitorAttributes}.${ConfigKey.MAINTENANCE_WINDOWS}: "${mwId}" or ${legacyMonitorAttributes}.${ConfigKey.MAINTENANCE_WINDOWS}: "${mwId}"`,
+        }
+      );
+
+    for await (const result of finder.find()) {
+      const monitors = result.saved_objects.filter((monitor) => {
+        // Avoid processing the same config multiple times, updating it once will update all mws on it
+        if (listOfUpdatedConfigs.includes(monitor.id)) {
+          this.debugLog(
+            `Skipping monitor id: ${monitor.id} as it has already been processed for another maintenance window`
+          );
+          return false;
+        }
+        listOfUpdatedConfigs.push(monitor.id);
+        return true;
+      });
+      this.debugLog(`Processing mw id: ${mwId}, monitors count: ${monitors?.length ?? 0}`);
+
+      const { configsBySpaces, monitorSpaceIds } = this.mixParamsWithMonitors(
+        monitors,
+        paramsBySpace
+      );
+
+      await this.deployEditMonitors({
+        allPrivateLocations,
+        configsBySpaces,
+        monitorSpaceIds,
+        paramsBySpace,
+        maintenanceWindows,
+      });
+
+      if (isMissingMw) {
+        await this.removeMwsFromMonitorConfigs({
+          mwId,
+          monitors,
+          soClient,
+        });
+      }
+    }
+
+    finder.close().catch(() => {});
+
+    this.debugLog(`Syncing package policies for updated maintenance window id: ${mwId}`);
+  }
+
+  async syncAllPackagePolicies({
     allPrivateLocations,
     encryptedSavedObjects,
     soClient,
@@ -48,8 +186,6 @@ export class DeployPrivateLocationMonitors {
       return;
     }
 
-    const { privateLocationAPI } = this.syntheticsMonitorClient;
-
     const { configsBySpaces, paramsBySpace, monitorSpaceIds, maintenanceWindows } =
       await this.getAllMonitorConfigs({
         encryptedSavedObjects,
@@ -63,39 +199,61 @@ export class DeployPrivateLocationMonitors {
           ', '
         )}`
       );
-      for (const spaceId of monitorSpaceIds) {
-        const privateConfigs: Array<{
-          config: HeartbeatConfig;
-          globalParams: Record<string, string>;
-        }> = [];
-        const monitors = configsBySpaces[spaceId];
-        this.debugLog(`Processing spaceId: ${spaceId}, monitors count: ${monitors?.length ?? 0}`);
-        if (!monitors) {
-          continue;
-        }
-        for (const monitor of monitors) {
-          const { privateLocations } = this.parseLocations(monitor);
+      await this.deployEditMonitors({
+        allPrivateLocations,
+        configsBySpaces,
+        monitorSpaceIds,
+        paramsBySpace,
+        maintenanceWindows,
+      });
+      this.debugLog('Completed sync of private location monitors');
+    });
+  }
 
-          if (privateLocations.length > 0) {
-            privateConfigs.push({ config: monitor, globalParams: paramsBySpace[spaceId] });
-          }
-        }
-        if (privateConfigs.length > 0) {
-          this.debugLog(
-            `Syncing private configs for spaceId: ${spaceId}, privateConfigs count: ${privateConfigs.length}`
-          );
+  async deployEditMonitors({
+    allPrivateLocations,
+    configsBySpaces,
+    monitorSpaceIds,
+    paramsBySpace,
+    maintenanceWindows,
+  }: {
+    allPrivateLocations: PrivateLocationAttributes[];
+    configsBySpaces: Record<string, HeartbeatConfig[]>;
+    monitorSpaceIds: Set<string>;
+    paramsBySpace: Record<string, Record<string, string>>;
+    maintenanceWindows: MaintenanceWindow[];
+  }) {
+    const { privateLocationAPI } = this.syntheticsMonitorClient;
 
-          await privateLocationAPI.editMonitors(
-            privateConfigs,
-            allPrivateLocations,
-            spaceId,
-            maintenanceWindows
-          );
-        } else {
-          this.debugLog(`No privateConfigs to sync for spaceId: ${spaceId}`);
+    for (const spaceId of monitorSpaceIds) {
+      const privateConfigs: Array<SyncConfig> = [];
+      const monitors = configsBySpaces[spaceId];
+      this.debugLog(`Processing spaceId: ${spaceId}, monitors count: ${monitors?.length ?? 0}`);
+      if (!monitors) {
+        continue;
+      }
+      for (const monitor of monitors) {
+        const { privateLocations } = this.parseLocations(monitor);
+
+        if (privateLocations.length > 0) {
+          privateConfigs.push({ config: monitor, globalParams: paramsBySpace[spaceId] });
         }
       }
-    });
+      if (privateConfigs.length > 0) {
+        this.debugLog(
+          `Syncing private configs for spaceId: ${spaceId}, privateConfigs count: ${privateConfigs.length}`
+        );
+
+        await privateLocationAPI.editMonitors(
+          privateConfigs,
+          allPrivateLocations,
+          spaceId,
+          maintenanceWindows
+        );
+      } else {
+        this.debugLog(`No privateConfigs to sync for spaceId: ${spaceId}`);
+      }
+    }
   }
 
   async getAllMonitorConfigs({
@@ -181,5 +339,36 @@ export class DeployPrivateLocationMonitors {
 
   debugLog = (message: string) => {
     this.serverSetup.logger.debug(`[DeployPrivateLocationMonitors] ${message}`);
+  };
+
+  removeMwsFromMonitorConfigs = async ({
+    mwId,
+    monitors,
+    soClient,
+  }: {
+    mwId: string;
+    monitors: Array<SavedObjectsFindResult<SyntheticsMonitorWithSecretsAttributes>>;
+    soClient: SavedObjectsClientContract;
+  }) => {
+    this.debugLog(
+      `Removing maintenance window id: ${mwId} from monitors count: ${monitors?.length ?? 0}`
+    );
+    const toUpdateMonitors = monitors.map((monitor) => {
+      const existingMws = monitor.attributes[ConfigKey.MAINTENANCE_WINDOWS] || [];
+      const updatedMws = existingMws.filter((id) => id !== mwId);
+      return {
+        id: monitor.id,
+        type: monitor.type,
+        attributes: {
+          [ConfigKey.MAINTENANCE_WINDOWS]: updatedMws,
+        },
+        namespace: monitor.namespaces?.[0],
+      };
+    });
+
+    const result = await soClient.bulkUpdate(toUpdateMonitors);
+    this.debugLog(
+      `Removed maintenance window id: ${mwId} from monitors, updated monitors count: ${result.saved_objects.length}`
+    );
   };
 }

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/deploy_private_location_monitors.ts
@@ -11,7 +11,7 @@ import type {
 } from '@kbn/core-saved-objects-api-server';
 import type { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
 import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
-import type { MaintenanceWindow } from '@kbn/maintenance-windows-plugin/server/application/types';
+import type { MaintenanceWindow } from '@kbn/alerting-plugin/common';
 import {
   legacyMonitorAttributes,
   syntheticsMonitorAttributes,

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_global_params_task.ts
@@ -80,7 +80,7 @@ export class SyncGlobalParamsPrivateLocationsTask {
 
         const allPrivateLocations = await getPrivateLocations(soClient, ALL_SPACES_ID);
         if (allPrivateLocations.length > 0) {
-          await this.deployPackagePolicies.syncPackagePolicies({
+          await this.deployPackagePolicies.syncAllPackagePolicies({
             allPrivateLocations,
             soClient,
             encryptedSavedObjects,

--- a/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/tasks/sync_private_locations_monitors_task.test.ts
@@ -130,7 +130,9 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const taskInstance = getMockTaskInstance();
       jest.spyOn(task, 'hasMWsChanged').mockResolvedValue({
         hasMWsChanged: false,
-      });
+      } as any);
+      // fetchMonitorMwsIds is used in the implementation now
+      jest.spyOn(task, 'fetchMonitorMwsIds').mockResolvedValue(['mw-1']);
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
         {
           id: 'pl-1',
@@ -152,7 +154,6 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         disableAutoSync: false,
         hasAlreadyDoneCleanup: false,
         lastStartedAt: expect.anything(),
-        lastTotalMWs: 1,
         maxCleanUpRetries: 2,
       });
     });
@@ -161,7 +162,10 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       const taskInstance = getMockTaskInstance();
       jest.spyOn(task, 'hasMWsChanged').mockResolvedValue({
         hasMWsChanged: true,
-      });
+        updatedMWs: [],
+        missingMWIds: [],
+      } as any);
+      jest.spyOn(task, 'fetchMonitorMwsIds').mockResolvedValue(['mw-1']);
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
         {
           id: 'pl-1',
@@ -170,54 +174,42 @@ describe('SyncPrivateLocationMonitorsTask', () => {
           agentPolicyId: 'policy-1',
         },
       ]);
-      jest.spyOn(task.deployPackagePolicies, 'syncPackagePolicies').mockResolvedValue(undefined);
+      jest
+        .spyOn(task.deployPackagePolicies, 'syncPackagePoliciesForMws')
+        .mockResolvedValue(undefined);
 
       const result = await task.runTask({ taskInstance });
-      expect(mockLogger.debug).toHaveBeenNthCalledWith(
-        2,
-        '[PrivateLocationCleanUpTask] Starting cleanup of duplicated package policies'
-      );
 
-      expect(mockLogger.debug).toHaveBeenNthCalledWith(
-        3,
-        '[SyncPrivateLocationMonitorsTask] Syncing private location monitors because data has changed'
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Syncing private location monitors because data has changed')
       );
-      expect(mockLogger.debug).toHaveBeenNthCalledWith(
-        4,
-        '[SyncPrivateLocationMonitorsTask] Sync of private location monitors succeeded'
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Sync of private location monitors succeeded')
       );
-      expect(task.deployPackagePolicies.syncPackagePolicies).toHaveBeenCalled();
+      expect(task.deployPackagePolicies.syncPackagePoliciesForMws).toHaveBeenCalled();
       expect(result.error).toBeUndefined();
       expect(result.state).toEqual({
         disableAutoSync: false,
-        lastTotalMWs: 1,
         maxCleanUpRetries: 2,
         hasAlreadyDoneCleanup: false,
         lastStartedAt: expect.anything(),
       });
     });
 
-    it('should not sync if data changed but no private locations exist', async () => {
-      const taskInstance = getMockTaskInstance();
-      jest.spyOn(task, 'hasMWsChanged').mockResolvedValue({
-        hasMWsChanged: true,
-      });
-      jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([]);
-      jest.spyOn(task.deployPackagePolicies, 'syncPackagePolicies');
-
-      await task.runTask({ taskInstance });
-
-      expect(getPrivateLocationsModule.getPrivateLocations).toHaveBeenCalled();
-      expect(task.deployPackagePolicies.syncPackagePolicies).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenLastCalledWith(
-        '[SyncPrivateLocationMonitorsTask] Sync of private location monitors succeeded'
-      );
-    });
-
     it('should handle errors during the run', async () => {
       const taskInstance = getMockTaskInstance();
       const error = new Error('Sync failed');
+      // fetchMonitorMwsIds is called before hasMWsChanged in runTask
+      jest.spyOn(task, 'fetchMonitorMwsIds').mockResolvedValue(['mw-1']);
       jest.spyOn(task, 'hasMWsChanged').mockRejectedValue(error);
+      jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
+        {
+          id: 'pl-1',
+          label: 'Private Location 1',
+          isServiceManaged: false,
+          agentPolicyId: 'policy-1',
+        },
+      ]);
 
       const result = await task.runTask({ taskInstance });
 
@@ -228,7 +220,6 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(result.state).toEqual({
         disableAutoSync: false,
         lastStartedAt: expect.anything(),
-        lastTotalMWs: 1,
         hasAlreadyDoneCleanup: false,
         maxCleanUpRetries: 2,
       });
@@ -243,7 +234,8 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       };
       jest.spyOn(task, 'hasMWsChanged').mockResolvedValue({
         hasMWsChanged: false,
-      });
+      } as any);
+      jest.spyOn(task, 'fetchMonitorMwsIds').mockResolvedValue(['mw-1']);
       jest.spyOn(getPrivateLocationsModule, 'getPrivateLocations').mockResolvedValue([
         {
           id: 'pl-1',
@@ -269,6 +261,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         taskState: { lastTotalMWs: 1 } as any,
         soClient: mockSoClient as any,
         lastStartedAt: new Date().toISOString(),
+        monitorMwsIds: ['mw-1'],
       });
 
       expect(res.hasMWsChanged).toBe(true);
@@ -285,6 +278,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         taskState: taskState as any,
         soClient: mockSoClient as any,
         lastStartedAt: new Date().toISOString(),
+        monitorMwsIds: ['mw-1'],
       });
 
       expect(res.hasMWsChanged).toBe(false);
@@ -293,43 +287,53 @@ describe('SyncPrivateLocationMonitorsTask', () => {
 
   describe('hasMWsChanged', () => {
     it('returns true if updated MWs are found', async () => {
-      mockSoClient.find
-        .mockResolvedValueOnce({ total: 1 } as any) // updated
-        .mockResolvedValueOnce({ total: 5 } as any); // total
+      // mock maintenance window client to return an updated MW
+      mockSyntheticsMonitorClient.syntheticsService.getMaintenanceWindows = jest
+        .fn()
+        .mockReturnValue([{ id: 'mw-1', updatedAt: '2024-01-02T00:00:00.000Z' }]);
+
       const { hasMWsChanged } = await task.hasMWsChanged({
         soClient: mockSoClient as any,
-        lastStartedAt: '...',
+        lastStartedAt: '2024-01-01T00:00:00.000Z',
         taskState: {
           lastTotalMWs: 5,
         } as any,
+        monitorMwsIds: ['mw-1'],
       });
       expect(hasMWsChanged).toBe(true);
     });
 
-    it('returns true if total number of MWs changed', async () => {
-      mockSoClient.find
-        .mockResolvedValueOnce({ total: 0 } as any) // updated
-        .mockResolvedValueOnce({ total: 6 } as any); // total
+    it('returns true if total number of MWs changed (missing ids)', async () => {
+      //  returns no maintenance windows -> missing ids detected
+      mockSyntheticsMonitorClient.syntheticsService.getMaintenanceWindows = jest
+        .fn()
+        .mockReturnValue([]);
+
       const { hasMWsChanged } = await task.hasMWsChanged({
         soClient: mockSoClient as any,
         lastStartedAt: '...',
         taskState: {
           lastTotalMWs: 5,
         } as any,
+        monitorMwsIds: ['missing-mw'],
       });
       expect(hasMWsChanged).toBe(true);
     });
 
     it('returns false if no changes are detected', async () => {
-      mockSoClient.find
-        .mockResolvedValueOnce({ total: 0 } as any) // updated
-        .mockResolvedValueOnce({ total: 5 } as any); // total
+      // bulkGet returns MWs updated before lastStartedAt and all ids present
+
+      mockSyntheticsMonitorClient.syntheticsService.getMaintenanceWindows = jest
+        .fn()
+        .mockReturnValue([{ id: 'mw-1', updatedAt: '2023-01-01T00:00:00.000Z' }]);
+
       const { hasMWsChanged } = await task.hasMWsChanged({
         soClient: mockSoClient as any,
-        lastStartedAt: '...',
+        lastStartedAt: '2023-02-01T00:00:00.000Z',
         taskState: {
           lastTotalMWs: 5,
         } as any,
+        monitorMwsIds: ['mw-1'],
       });
       expect(hasMWsChanged).toBe(false);
     });
@@ -353,7 +357,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         .spyOn(task, 'parseLocations')
         .mockReturnValue({ privateLocations: ['pl-1'], publicLocations: [] } as any);
 
-      await task.deployPackagePolicies.syncPackagePolicies({
+      await task.deployPackagePolicies.syncAllPackagePolicies({
         allPrivateLocations: mockAllPrivateLocations as any,
         soClient: mockSoClient as any,
         spaceIdToSync: 'space1',
@@ -384,7 +388,7 @@ describe('SyncPrivateLocationMonitorsTask', () => {
         .spyOn(task, 'parseLocations')
         .mockReturnValue({ privateLocations: [], publicLocations: [] } as any);
 
-      await task.deployPackagePolicies.syncPackagePolicies({
+      await task.deployPackagePolicies.syncAllPackagePolicies({
         allPrivateLocations: [],
         soClient: mockSoClient as any,
         encryptedSavedObjects: mockEncryptedSoClient as any,
@@ -531,6 +535,36 @@ describe('SyncPrivateLocationMonitorsTask', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         '[PrivateLocationCleanUpTask] Skipping cleanup of duplicated package policies as max retries have been reached'
       );
+    });
+  });
+
+  // Replace old monitorsHaveMaintenanceWindows tests with fetchMonitorMwsIds tests
+  describe('fetchMonitorMwsIds', () => {
+    it('returns the combined unique ids from monitor and legacy aggregations', async () => {
+      mockSoClient.find.mockResolvedValue({
+        aggregations: {
+          monitorMws: { buckets: [{ key: 'a' }, { key: 'b' }] },
+          legacyMonitorsMws: { buckets: [{ key: 'b' }, { key: 'c' }] },
+        },
+      } as any);
+
+      const res = await task.fetchMonitorMwsIds(mockSoClient as any);
+      expect(res).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+      expect(mockSoClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: expect.anything(),
+          perPage: 0,
+          namespaces: [expect.any(String)],
+          aggs: expect.any(Object),
+        })
+      );
+    });
+
+    it('returns empty array when aggregations are missing', async () => {
+      mockSoClient.find.mockResolvedValue({} as any);
+
+      const res = await task.fetchMonitorMwsIds(mockSoClient as any);
+      expect(res).toEqual([]);
     });
   });
 });

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/index.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/index.ts
@@ -27,5 +27,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./add_edit_params'));
     loadTestFile(require.resolve('./private_location_apis'));
     loadTestFile(require.resolve('./list_monitors'));
+    loadTestFile(require.resolve('./sync_maintenance_windows'));
   });
 }

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/sample_data/test_policy.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/sample_data/test_policy.ts
@@ -7,7 +7,7 @@
 import expect from 'expect';
 import { omit, sortBy } from 'lodash';
 import type { PackagePolicy, PackagePolicyConfigRecord } from '@kbn/fleet-plugin/common';
-import type { MaintenanceWindow } from '@kbn/alerting-plugin/common';
+import type { MaintenanceWindow } from '@kbn/alerting-plugin/server/application/maintenance_window/types';
 import { INSTALLED_VERSION } from '../services/private_location_test_service';
 import { commonVars } from './test_project_monitor_policy';
 

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/sample_data/test_policy.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/sample_data/test_policy.ts
@@ -6,7 +6,8 @@
  */
 import expect from 'expect';
 import { omit, sortBy } from 'lodash';
-import { PackagePolicy, PackagePolicyConfigRecord } from '@kbn/fleet-plugin/common';
+import type { PackagePolicy, PackagePolicyConfigRecord } from '@kbn/fleet-plugin/common';
+import type { MaintenanceWindow } from '@kbn/alerting-plugin/common';
 import { INSTALLED_VERSION } from '../services/private_location_test_service';
 import { commonVars } from './test_project_monitor_policy';
 
@@ -22,6 +23,7 @@ interface PolicyProps {
   params?: Record<string, any>;
   isBrowser?: boolean;
   spaceId?: string;
+  mws?: MaintenanceWindow[];
 }
 
 export const getTestSyntheticsPolicy = (props: PolicyProps): PackagePolicy => {
@@ -133,6 +135,7 @@ export const getHttpInput = ({
   isBrowser,
   spaceId,
   namespace,
+  mws,
   name = 'check if title is present-Test private location 0',
 }: PolicyProps) => {
   const enabled = !isBrowser;
@@ -172,7 +175,9 @@ export const getHttpInput = ({
     location_id: { value: 'fleet_managed', type: 'text' },
     location_name: { value: 'Fleet managed', type: 'text' },
     max_attempts: { type: 'integer', value: 2 },
-    maintenance_windows: { type: 'yaml' },
+    maintenance_windows: {
+      type: 'yaml',
+    },
     id: { type: 'text' },
     origin: { type: 'text' },
     ipv4: { type: 'bool', value: true },
@@ -249,7 +254,7 @@ export const getHttpInput = ({
       value: JSON.stringify(location.name) ?? '"Test private location 0"',
       type: 'text',
     },
-    ...commonVars,
+    ...commonVars(mws),
     id: { value: JSON.stringify(id), type: 'text' },
     origin: { value: projectId ? 'project' : 'ui', type: 'text' },
     ipv4: { type: 'bool', value: true },

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/sample_data/test_project_monitor_policy.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/sample_data/test_project_monitor_policy.ts
@@ -6,19 +6,21 @@
  */
 
 import { type PackagePolicy } from '@kbn/fleet-plugin/common';
+import type { MaintenanceWindow } from '@kbn/maintenance-windows-plugin/server/application/types';
+import { formatMWs } from '@kbn/synthetics-plugin/server/synthetics_service/formatters/formatting_utils';
 import { INSTALLED_VERSION } from '../services/private_location_test_service';
 import { getDataStream } from './test_policy';
 
-export const commonVars = {
+export const commonVars = (mws?: MaintenanceWindow[]) => ({
   max_attempts: {
     type: 'integer',
     value: 2,
   },
   maintenance_windows: {
     type: 'yaml',
-    value: [],
+    value: mws ? formatMWs(mws) : [],
   },
-};
+});
 
 export const getTestProjectSyntheticsPolicyLightweight = (
   {
@@ -30,6 +32,7 @@ export const getTestProjectSyntheticsPolicyLightweight = (
     projectId = 'test-suite',
     locationName = 'Fleet Managed',
     namespace,
+    mws,
   }: {
     name?: string;
     inputs: Record<string, { value: string | boolean; type: string }>;
@@ -39,6 +42,7 @@ export const getTestProjectSyntheticsPolicyLightweight = (
     locationId: string;
     locationName?: string;
     namespace?: string;
+    mws?: MaintenanceWindow[];
   } = {
     name: 'My Monitor 3',
     inputs: {},
@@ -138,7 +142,7 @@ export const getTestProjectSyntheticsPolicyLightweight = (
               type: 'integer',
               value: '0',
             },
-            ...commonVars,
+            ...commonVars(mws),
             mode: {
               type: 'text',
               value: 'any',
@@ -334,7 +338,7 @@ export const getTestProjectSyntheticsPolicyLightweight = (
             'ssl.supported_protocols': { type: 'yaml' },
             location_id: { value: 'fleet_managed', type: 'text' },
             location_name: { value: 'Fleet managed', type: 'text' },
-            ...commonVars,
+            ...commonVars(mws),
             id: { type: 'text' },
             origin: { type: 'text' },
             ipv4: { type: 'bool', value: true },
@@ -369,7 +373,7 @@ export const getTestProjectSyntheticsPolicyLightweight = (
             tags: { type: 'yaml' },
             location_id: { value: 'fleet_managed', type: 'text' },
             location_name: { value: 'Fleet managed', type: 'text' },
-            ...commonVars,
+            ...commonVars(mws),
             id: { type: 'text' },
             origin: { type: 'text' },
             ipv4: { type: 'bool', value: true },
@@ -438,7 +442,7 @@ export const getTestProjectSyntheticsPolicyLightweight = (
             'source.zip_url.proxy_url': { type: 'text' },
             location_id: { value: 'fleet_managed', type: 'text' },
             location_name: { value: 'Fleet managed', type: 'text' },
-            ...commonVars,
+            ...commonVars(mws),
             id: { type: 'text' },
             origin: { type: 'text' },
             ...inputs,
@@ -523,6 +527,7 @@ export const getTestProjectSyntheticsPolicy = (
     locationId,
     locationName = 'Fleet Managed',
     namespace,
+    mws,
   }: {
     name?: string;
     inputs: Record<string, { value: string | boolean; type: string }>;
@@ -532,6 +537,7 @@ export const getTestProjectSyntheticsPolicy = (
     locationName?: string;
     locationId: string;
     namespace?: string;
+    mws?: MaintenanceWindow[];
   } = {
     name: 'check if title is present-Test private location 0',
     inputs: {},
@@ -596,7 +602,7 @@ export const getTestProjectSyntheticsPolicy = (
             'ssl.supported_protocols': { type: 'yaml' },
             location_id: { value: 'fleet_managed', type: 'text' },
             location_name: { value: 'Fleet managed', type: 'text' },
-            ...commonVars,
+            ...commonVars(mws),
             id: { type: 'text' },
             origin: { type: 'text' },
             ipv4: { type: 'bool', value: true },
@@ -639,7 +645,7 @@ export const getTestProjectSyntheticsPolicy = (
             'ssl.verification_mode': { type: 'text' },
             'ssl.supported_protocols': { type: 'yaml' },
             location_name: { value: 'Fleet managed', type: 'text' },
-            ...commonVars,
+            ...commonVars(mws),
             id: { type: 'text' },
             origin: { type: 'text' },
             ipv4: { type: 'bool', value: true },
@@ -743,7 +749,7 @@ export const getTestProjectSyntheticsPolicy = (
             'source.zip_url.ssl.supported_protocols': { type: 'yaml' },
             'source.zip_url.proxy_url': { type: 'text' },
             location_name: { value: 'Test private location 0', type: 'text' },
-            ...commonVars,
+            ...commonVars(mws),
             location_id: { value: 'fleet_managed', type: 'text' },
             id: { value: id, type: 'text' },
             origin: { value: 'project', type: 'text' },

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/sample_data/test_project_monitor_policy.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/sample_data/test_project_monitor_policy.ts
@@ -6,7 +6,7 @@
  */
 
 import { type PackagePolicy } from '@kbn/fleet-plugin/common';
-import type { MaintenanceWindow } from '@kbn/alerting-plugin/common';
+import type { MaintenanceWindow } from '@kbn/alerting-plugin/server/application/maintenance_window/types';
 import { formatMWs } from '@kbn/synthetics-plugin/server/synthetics_service/formatters/formatting_utils';
 import { INSTALLED_VERSION } from '../services/private_location_test_service';
 import { getDataStream } from './test_policy';

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/sample_data/test_project_monitor_policy.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/sample_data/test_project_monitor_policy.ts
@@ -6,7 +6,7 @@
  */
 
 import { type PackagePolicy } from '@kbn/fleet-plugin/common';
-import type { MaintenanceWindow } from '@kbn/maintenance-windows-plugin/server/application/types';
+import type { MaintenanceWindow } from '@kbn/alerting-plugin/common';
 import { formatMWs } from '@kbn/synthetics-plugin/server/synthetics_service/formatters/formatting_utils';
 import { INSTALLED_VERSION } from '../services/private_location_test_service';
 import { getDataStream } from './test_policy';

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/services/synthetics_monitor_test_service.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/services/synthetics_monitor_test_service.ts
@@ -155,4 +155,25 @@ export class SyntheticsMonitorTestService {
     expect(deleteResponse.status).to.eql(statusCode);
     return deleteResponse;
   }
+
+  async createMaintenanceWindow() {
+    const response = await this.supertest
+      .post(`/internal/alerting/rules/maintenance_window`)
+      .set('kbn-xsrf', 'foo')
+      .send({
+        title: 'test-maintenance-window',
+        duration: 60 * 60 * 1000, // 1 hr
+        r_rule: {
+          dtstart: new Date().toISOString(),
+          tzid: 'UTC',
+          freq: 0,
+          count: 1,
+        },
+        category_ids: ['management'],
+      });
+
+    expect(response.status).to.equal(200);
+
+    return response.body;
+  }
 }

--- a/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_maintenance_windows.ts
+++ b/x-pack/solutions/observability/test/api_integration/apis/synthetics/sync_maintenance_windows.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type {
+  HTTPFields,
+  PrivateLocation,
+  ServiceLocation,
+} from '@kbn/synthetics-plugin/common/runtime_types';
+import { ConfigKey, LocationStatus } from '@kbn/synthetics-plugin/common/runtime_types';
+import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
+import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import expect from '@kbn/expect';
+import { syntheticsParamType } from '@kbn/synthetics-plugin/common/types/saved_objects';
+import { SyntheticsMonitorTestService } from './services/synthetics_monitor_test_service';
+import type { FtrProviderContext } from '../../ftr_provider_context';
+import { getFixtureJson } from './helper/get_fixture_json';
+import { PrivateLocationTestService } from './services/private_location_test_service';
+import { comparePolicies, getTestSyntheticsPolicy } from './sample_data/test_policy';
+import { omitMonitorKeys } from './add_monitor';
+
+export const LOCAL_LOCATION = {
+  id: 'dev',
+  label: 'Dev Service',
+  geo: {
+    lat: 0,
+    lon: 0,
+  },
+  isServiceManaged: true,
+};
+
+export default function ({ getService }: FtrProviderContext) {
+  describe('SyncMaintenanceWindows', function () {
+    this.tags('skipCloud');
+    const supertestAPI = getService('supertest');
+    const kServer = getService('kibanaServer');
+
+    let testFleetPolicyID: string;
+    let loc: any;
+    let _browserMonitorJson: HTTPFields;
+    let browserMonitorJson: HTTPFields;
+
+    let mwObject: any;
+
+    let newBrowserMonitorId: string;
+
+    const testPrivateLocations = new PrivateLocationTestService(getService);
+    const monitorTestService = new SyntheticsMonitorTestService(getService);
+
+    const params: Record<string, string> = {};
+
+    before(async () => {
+      await kServer.savedObjects.cleanStandardList();
+      await testPrivateLocations.installSyntheticsPackage();
+
+      _browserMonitorJson = getFixtureJson('browser_monitor');
+      await kServer.savedObjects.clean({ types: [syntheticsParamType] });
+    });
+
+    beforeEach(() => {
+      browserMonitorJson = _browserMonitorJson;
+    });
+
+    it('adds a test maintenance windows', async () => {
+      mwObject = await monitorTestService.createMaintenanceWindow();
+      mwObject.rRule = mwObject.r_rule;
+    });
+    it('adds a test param', async () => {
+      const apiResponse = await supertestAPI
+        .post(SYNTHETICS_API_URLS.PARAMS)
+        .set('kbn-xsrf', 'true')
+        .send({ key: 'test', value: 'http://proxy.com' });
+
+      expect(apiResponse.status).eql(200);
+    });
+
+    it('create test private location', async () => {
+      loc = await testPrivateLocations.createPrivateLocation();
+      testFleetPolicyID = loc.agentPolicyId;
+      const apiResponse = await supertestAPI.get(SYNTHETICS_API_URLS.SERVICE_LOCATIONS);
+      const testLocations: Array<PrivateLocation | ServiceLocation> = [
+        {
+          id: 'dev',
+          label: 'Dev Service',
+          geo: { lat: 0, lon: 0 },
+          url: 'mockDevUrl',
+          isServiceManaged: true,
+          status: LocationStatus.EXPERIMENTAL,
+          isInvalid: false,
+        },
+        {
+          id: 'dev2',
+          label: 'Dev Service 2',
+          geo: { lat: 0, lon: 0 },
+          url: 'mockDevUrl',
+          isServiceManaged: true,
+          status: LocationStatus.EXPERIMENTAL,
+          isInvalid: false,
+        },
+        {
+          id: loc.id,
+          isInvalid: false,
+          isServiceManaged: false,
+          label: 'Test private location 0',
+          geo: {
+            lat: 0,
+            lon: 0,
+          },
+          agentPolicyId: testFleetPolicyID,
+          spaces: ['*'],
+        },
+      ];
+      expect(apiResponse.body.locations).eql(testLocations);
+    });
+
+    it('adds a monitor in private location', async () => {
+      const newMonitor = browserMonitorJson;
+
+      const pvtLoc = {
+        id: loc.id,
+        agentPolicyId: testFleetPolicyID,
+        label: 'Test private location 0',
+        isServiceManaged: false,
+        geo: {
+          lat: 0,
+          lon: 0,
+        },
+      };
+
+      newMonitor.locations.push(pvtLoc);
+      newMonitor.maintenance_windows = [mwObject.id];
+
+      const apiResponse = await monitorTestService.createMonitor({ monitor: newMonitor });
+
+      expect(apiResponse.body).eql(
+        omitMonitorKeys({
+          ...newMonitor,
+          [ConfigKey.MONITOR_QUERY_ID]: apiResponse.body.id,
+          [ConfigKey.CONFIG_ID]: apiResponse.body.id,
+          locations: [LOCAL_LOCATION, pvtLoc],
+          spaces: ['default'],
+        })
+      );
+      newBrowserMonitorId = apiResponse.rawBody.id;
+    });
+
+    it('verify integration for previously added monitor', async () => {
+      const packagePolicy = await testPrivateLocations.getPackagePolicy({
+        monitorId: newBrowserMonitorId,
+        locId: loc.id,
+      });
+
+      expect(packagePolicy?.policy_id).eql(testFleetPolicyID);
+
+      comparePolicies(
+        packagePolicy,
+        getTestSyntheticsPolicy({
+          name: browserMonitorJson.name,
+          id: newBrowserMonitorId,
+          isBrowser: true,
+          location: { id: testFleetPolicyID },
+          mws: [mwObject],
+        })
+      );
+    });
+
+    it('added mw to  previously added integration', async () => {
+      const apiResponse = await supertestAPI.get(
+        '/api/fleet/package_policies?page=1&perPage=2000&kuery=ingest-package-policies.package.name%3A%20synthetics'
+      );
+
+      const packagePolicy = apiResponse.body.items.find(
+        (pkgPolicy: PackagePolicy) =>
+          pkgPolicy.id === newBrowserMonitorId + '-' + loc.id + '-default'
+      );
+
+      expect(packagePolicy.policy_id).eql(testFleetPolicyID);
+
+      comparePolicies(
+        packagePolicy,
+        getTestSyntheticsPolicy({
+          name: browserMonitorJson.name,
+          id: newBrowserMonitorId,
+          params,
+          isBrowser: true,
+          location: { id: testFleetPolicyID },
+          mws: [mwObject],
+        })
+      );
+    });
+  });
+}

--- a/x-pack/solutions/observability/test/moon.yml
+++ b/x-pack/solutions/observability/test/moon.yml
@@ -96,6 +96,7 @@ dependsOn:
   - '@kbn/logs-explorer-plugin'
   - '@kbn/observability-logs-explorer-plugin'
   - '@kbn/security-plugin-types-common'
+  - '@kbn/maintenance-windows-plugin'
 tags:
   - test-helper
   - package

--- a/x-pack/solutions/observability/test/moon.yml
+++ b/x-pack/solutions/observability/test/moon.yml
@@ -96,7 +96,6 @@ dependsOn:
   - '@kbn/logs-explorer-plugin'
   - '@kbn/observability-logs-explorer-plugin'
   - '@kbn/security-plugin-types-common'
-  - '@kbn/maintenance-windows-plugin'
 tags:
   - test-helper
   - package


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Only update relevant monitors where maintenance windows exists (#246088)](https://github.com/elastic/kibana/pull/246088)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2026-01-07T19:29:51Z","message":"[Synthetics] Only update relevant monitors where maintenance windows exists (#246088)\n\n## Release note\n\nOnly update Synthetics package policies that use maintenance windows\nwhen maintenance windows are updated or deleted. Prevents extra\nSynthetics package policies from being updated when maintenance windows\nare updated or deleted, even if the monitor itself does not use\nmaintenance windows.\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/245866\n\nThe task will only update relevant monitors where mws exists, following\nqueries have been updated\n\n\nUsing these aggs to determine value count and short circuit the code if\nno value exists in the task\n\nusing this it will first fetch list of Mws Ids\n\n```\n      type: syntheticsMonitorSOTypes,\n      perPage: 0,\n      namespaces: [ALL_SPACES_ID],\n      fields: [],\n      aggs: {\n        monitorMws: {\n          terms: { field: `${syntheticsMonitorAttributes}.maintenance_windows`, size: 1000 },\n        },\n        legacyMonitorsMws: {\n          terms: { field: `${legacyMonitorAttributes}.maintenance_windows`, size: 1000 },\n        },\n      },\n```\n\nin a following up call, it check out of these using\n`maintenanceWindowClient.bulkGet` which mws have been since updated or\nmissing.\n\nWhen it has list of missing and updated mws, it loops through them and\nfetch relevant monitors\n\n\nFor the updated mws , it update the monitors and for missing mws, it\nremoved them also from monitor config.\n\n### Testing\n\nenable logging \n\n```\nlogging.loggers:\n - name: plugins.synthetics\n   level: debug\n   appenders: [console]\n```\n\nchange task interval from 60m to 1m \n\nand add following line \n`    await taskManager.removeIfExists(PRIVATE_LOCATIONS_SYNC_TASK_ID);\n`\n\nabove this line in code base\n\n`     await taskManager.ensureScheduled({\n`\n\ndefine and set maintenance windows and test both use -cases\n\nand look for following log lines\n\n`    this.debugLog(`Found ${count} monitors with maintenance windows`);\n`\n\n\n\n---------\n\nCo-authored-by: Christos Nasikas <xristosnasikas@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>","sha":"24922bac0379d15baf94a7eb7faf9000719737ba","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.3.0","v9.4.0","author:actionable-obs","Team:obs-ux-management","v9.2.4","v8.19.10"],"title":"[Synthetics] Only update relevant monitors where maintenance windows exists","number":246088,"url":"https://github.com/elastic/kibana/pull/246088","mergeCommit":{"message":"[Synthetics] Only update relevant monitors where maintenance windows exists (#246088)\n\n## Release note\n\nOnly update Synthetics package policies that use maintenance windows\nwhen maintenance windows are updated or deleted. Prevents extra\nSynthetics package policies from being updated when maintenance windows\nare updated or deleted, even if the monitor itself does not use\nmaintenance windows.\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/245866\n\nThe task will only update relevant monitors where mws exists, following\nqueries have been updated\n\n\nUsing these aggs to determine value count and short circuit the code if\nno value exists in the task\n\nusing this it will first fetch list of Mws Ids\n\n```\n      type: syntheticsMonitorSOTypes,\n      perPage: 0,\n      namespaces: [ALL_SPACES_ID],\n      fields: [],\n      aggs: {\n        monitorMws: {\n          terms: { field: `${syntheticsMonitorAttributes}.maintenance_windows`, size: 1000 },\n        },\n        legacyMonitorsMws: {\n          terms: { field: `${legacyMonitorAttributes}.maintenance_windows`, size: 1000 },\n        },\n      },\n```\n\nin a following up call, it check out of these using\n`maintenanceWindowClient.bulkGet` which mws have been since updated or\nmissing.\n\nWhen it has list of missing and updated mws, it loops through them and\nfetch relevant monitors\n\n\nFor the updated mws , it update the monitors and for missing mws, it\nremoved them also from monitor config.\n\n### Testing\n\nenable logging \n\n```\nlogging.loggers:\n - name: plugins.synthetics\n   level: debug\n   appenders: [console]\n```\n\nchange task interval from 60m to 1m \n\nand add following line \n`    await taskManager.removeIfExists(PRIVATE_LOCATIONS_SYNC_TASK_ID);\n`\n\nabove this line in code base\n\n`     await taskManager.ensureScheduled({\n`\n\ndefine and set maintenance windows and test both use -cases\n\nand look for following log lines\n\n`    this.debugLog(`Found ${count} monitors with maintenance windows`);\n`\n\n\n\n---------\n\nCo-authored-by: Christos Nasikas <xristosnasikas@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>","sha":"24922bac0379d15baf94a7eb7faf9000719737ba"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","8.19"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/248177","number":248177,"state":"OPEN"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246088","number":246088,"mergeCommit":{"message":"[Synthetics] Only update relevant monitors where maintenance windows exists (#246088)\n\n## Release note\n\nOnly update Synthetics package policies that use maintenance windows\nwhen maintenance windows are updated or deleted. Prevents extra\nSynthetics package policies from being updated when maintenance windows\nare updated or deleted, even if the monitor itself does not use\nmaintenance windows.\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/245866\n\nThe task will only update relevant monitors where mws exists, following\nqueries have been updated\n\n\nUsing these aggs to determine value count and short circuit the code if\nno value exists in the task\n\nusing this it will first fetch list of Mws Ids\n\n```\n      type: syntheticsMonitorSOTypes,\n      perPage: 0,\n      namespaces: [ALL_SPACES_ID],\n      fields: [],\n      aggs: {\n        monitorMws: {\n          terms: { field: `${syntheticsMonitorAttributes}.maintenance_windows`, size: 1000 },\n        },\n        legacyMonitorsMws: {\n          terms: { field: `${legacyMonitorAttributes}.maintenance_windows`, size: 1000 },\n        },\n      },\n```\n\nin a following up call, it check out of these using\n`maintenanceWindowClient.bulkGet` which mws have been since updated or\nmissing.\n\nWhen it has list of missing and updated mws, it loops through them and\nfetch relevant monitors\n\n\nFor the updated mws , it update the monitors and for missing mws, it\nremoved them also from monitor config.\n\n### Testing\n\nenable logging \n\n```\nlogging.loggers:\n - name: plugins.synthetics\n   level: debug\n   appenders: [console]\n```\n\nchange task interval from 60m to 1m \n\nand add following line \n`    await taskManager.removeIfExists(PRIVATE_LOCATIONS_SYNC_TASK_ID);\n`\n\nabove this line in code base\n\n`     await taskManager.ensureScheduled({\n`\n\ndefine and set maintenance windows and test both use -cases\n\nand look for following log lines\n\n`    this.debugLog(`Found ${count} monitors with maintenance windows`);\n`\n\n\n\n---------\n\nCo-authored-by: Christos Nasikas <xristosnasikas@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>","sha":"24922bac0379d15baf94a7eb7faf9000719737ba"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->