### PR TITLE
[Security solution] Remove agent builder from Serverless Essentials

### DIFF
--- a/config/serverless.security.complete.yml
+++ b/config/serverless.security.complete.yml
@@ -6,6 +6,10 @@ xpack.cloud.serverless.product_tier: complete
 xpack.features.overrides:
   ### Workflows Management should be moved from Analytics category to the Security one.
   workflowsManagement.category: "security"
+  ### Agent Builder feature is available in this tier; move it from Analytics category to Security.
+  agentBuilder:
+    category: "security"
+    order: 1101
 
 # Elastic Managed LLMs
 xpack.actions.preconfigured:

--- a/config/serverless.security.essentials.yml
+++ b/config/serverless.security.essentials.yml
@@ -7,3 +7,5 @@ xpack.cloud.serverless.product_tier: essentials
 workflowsManagement.enabled: false
 workflowsExecutionEngine.enabled: false
 
+### Agent Builder should not be enabled in this tier
+xpack.agentBuilder.enabled: false

--- a/config/serverless.security.search_ai_lake.yml
+++ b/config/serverless.security.search_ai_lake.yml
@@ -25,6 +25,10 @@ xpack.features.overrides:
   securitySolutionTimeline.hidden: true
   securitySolutionNotes.hidden: true
   securitySolutionSiemMigrations.hidden: true
+  ### Agent Builder feature is available in this tier; move it from Analytics category to Security.
+  agentBuilder:
+    category: 'security'
+    order: 1101
 
   ## Fine-tune the security solution essentials feature privileges. These feature privilege overrides are set individually for each project type. Also, refer to `serverless.yml` for the project-agnostic overrides.
   siemV5:

--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -20,10 +20,6 @@ xpack.features.overrides:
   visualize_v2.hidden: true
   maps.hidden: true
   maps_v2.hidden: true
-  ### agent builder feature is moved from Analytics category to the Security one the bottom
-  agentBuilder:
-    category: "security"
-    order: 1101
   ### Machine Learning feature is moved from Analytics category to the Security one as the last item.
   ml:
     category: "security"

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
@@ -39,119 +39,120 @@ export const createNavigationTree = async (
     | Record<string, { show?: boolean }>
     | undefined;
   const canAccessAgentBuilder =
-    chatExperience === AIChatExperience.Agent && agentBuilderCapabilities?.agentBuilder?.show === true;
+    chatExperience === AIChatExperience.Agent &&
+    agentBuilderCapabilities?.agentBuilder?.show === true;
 
   return {
     body: [
-    {
-      id: 'security_solution_home',
-      link: securityLink(SecurityPageName.landing),
-      title: SOLUTION_NAME,
-      icon: 'logoSecurity',
-      renderAs: 'home',
-    },
-    {
-      link: 'discover',
-      icon: 'discoverApp',
-    },
-    defaultNavigationTree.dashboards(),
-    defaultNavigationTree.rules(),
-    services.featureFlags.getBooleanValue(ATTACKS_ALERTS_ALIGNMENT_ENABLED, false)
-      ? defaultNavigationTree.alertDetections()
-      : {
-          id: SecurityPageName.alerts,
-          icon: 'warning',
-          link: securityLink(SecurityPageName.alerts),
-        },
-    {
-      // TODO: update icon from EUI
-      icon: LazyIconWorkflow,
-      link: 'workflows',
-      badgeType: 'techPreview' as const,
-    },
-    ...(canAccessAgentBuilder
-      ? [
-          {
-            // TODO: update icon to 'robot' once it's available in EUI
-            icon: LazyIconAgentBuilder,
-            link: 'agent_builder' as AppDeepLinkId,
+      {
+        id: 'security_solution_home',
+        link: securityLink(SecurityPageName.landing),
+        title: SOLUTION_NAME,
+        icon: 'logoSecurity',
+        renderAs: 'home',
+      },
+      {
+        link: 'discover',
+        icon: 'discoverApp',
+      },
+      defaultNavigationTree.dashboards(),
+      defaultNavigationTree.rules(),
+      services.featureFlags.getBooleanValue(ATTACKS_ALERTS_ALIGNMENT_ENABLED, false)
+        ? defaultNavigationTree.alertDetections()
+        : {
+            id: SecurityPageName.alerts,
+            icon: 'warning',
+            link: securityLink(SecurityPageName.alerts),
           },
-        ]
-      : []),
-    {
-      id: SecurityPageName.attackDiscovery,
-      icon: 'bolt',
-      link: securityLink(SecurityPageName.attackDiscovery),
-    },
-    {
-      id: SecurityPageName.cloudSecurityPostureFindings,
-      // TODO change this to the `bullseye` EUI icon when available
-      icon: LazyIconFindings,
-      link: securityLink(SecurityPageName.cloudSecurityPostureFindings),
-    },
-    defaultNavigationTree.cases(),
-    defaultNavigationTree.entityAnalytics(),
-    defaultNavigationTree.explore(),
-    defaultNavigationTree.investigations(),
-    {
-      id: SecurityPageName.threatIntelligence,
-      // TODO change this to the `compute` EUI icon when available
-      icon: LazyIconIntelligence,
-      link: securityLink(SecurityPageName.threatIntelligence),
-    },
-    {
-      id: SecurityPageName.assetInventory,
-      icon: 'editorChecklist',
-      link: securityLink(SecurityPageName.assetInventory),
-    },
-    defaultNavigationTree.assets(services),
-    defaultNavigationTree.ml(),
-  ],
-  footer: [
-    {
-      id: SecurityGroupName.launchpad,
-      title: i18nStrings.launchPad.title,
-      renderAs: 'panelOpener',
-      icon: 'launch',
-      children: [
-        {
-          children: [
+      {
+        // TODO: update icon from EUI
+        icon: LazyIconWorkflow,
+        link: 'workflows',
+        badgeType: 'techPreview' as const,
+      },
+      ...(canAccessAgentBuilder
+        ? [
             {
-              id: SecurityPageName.landing,
-              link: securityLink(SecurityPageName.landing),
+              // TODO: update icon to 'robot' once it's available in EUI
+              icon: LazyIconAgentBuilder,
+              link: 'agent_builder' as AppDeepLinkId,
             },
-            {
-              id: SecurityPageName.siemReadiness,
-              link: securityLink(SecurityPageName.siemReadiness),
-            },
-            {
-              // value report
-              id: SecurityPageName.aiValue,
-              link: securityLink(SecurityPageName.aiValue),
-            },
-          ],
-        },
-        {
-          title: i18nStrings.launchPad.migrations.title,
-          children: [
-            {
-              id: SecurityPageName.siemMigrationsRules,
-              link: securityLink(SecurityPageName.siemMigrationsRules),
-            },
-            {
-              id: SecurityPageName.siemMigrationsDashboards,
-              link: securityLink(SecurityPageName.siemMigrationsDashboards),
-            },
-          ],
-        },
-      ],
-    },
-    {
-      link: 'dev_tools',
-      title: i18nStrings.devTools,
-      icon: 'editorCodeBlock',
-    },
-    createManagementFooterItemsTree(chatExperience),
-  ],
+          ]
+        : []),
+      {
+        id: SecurityPageName.attackDiscovery,
+        icon: 'bolt',
+        link: securityLink(SecurityPageName.attackDiscovery),
+      },
+      {
+        id: SecurityPageName.cloudSecurityPostureFindings,
+        // TODO change this to the `bullseye` EUI icon when available
+        icon: LazyIconFindings,
+        link: securityLink(SecurityPageName.cloudSecurityPostureFindings),
+      },
+      defaultNavigationTree.cases(),
+      defaultNavigationTree.entityAnalytics(),
+      defaultNavigationTree.explore(),
+      defaultNavigationTree.investigations(),
+      {
+        id: SecurityPageName.threatIntelligence,
+        // TODO change this to the `compute` EUI icon when available
+        icon: LazyIconIntelligence,
+        link: securityLink(SecurityPageName.threatIntelligence),
+      },
+      {
+        id: SecurityPageName.assetInventory,
+        icon: 'editorChecklist',
+        link: securityLink(SecurityPageName.assetInventory),
+      },
+      defaultNavigationTree.assets(services),
+      defaultNavigationTree.ml(),
+    ],
+    footer: [
+      {
+        id: SecurityGroupName.launchpad,
+        title: i18nStrings.launchPad.title,
+        renderAs: 'panelOpener',
+        icon: 'launch',
+        children: [
+          {
+            children: [
+              {
+                id: SecurityPageName.landing,
+                link: securityLink(SecurityPageName.landing),
+              },
+              {
+                id: SecurityPageName.siemReadiness,
+                link: securityLink(SecurityPageName.siemReadiness),
+              },
+              {
+                // value report
+                id: SecurityPageName.aiValue,
+                link: securityLink(SecurityPageName.aiValue),
+              },
+            ],
+          },
+          {
+            title: i18nStrings.launchPad.migrations.title,
+            children: [
+              {
+                id: SecurityPageName.siemMigrationsRules,
+                link: securityLink(SecurityPageName.siemMigrationsRules),
+              },
+              {
+                id: SecurityPageName.siemMigrationsDashboards,
+                link: securityLink(SecurityPageName.siemMigrationsDashboards),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        link: 'dev_tools',
+        title: i18nStrings.devTools,
+        icon: 'editorCodeBlock',
+      },
+      createManagementFooterItemsTree(chatExperience),
+    ],
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
@@ -33,126 +33,116 @@ const SOLUTION_NAME = i18n.translate(
 export const createNavigationTree = async (
   services: Services,
   chatExperience: AIChatExperience = AIChatExperience.Classic
-): Promise<NavigationTreeDefinition> => {
-  // `agentBuilder` capability key matches `AGENTBUILDER_FEATURE_ID` ('agentBuilder')
-  const agentBuilderCapabilities = services.application.capabilities as
-    | Record<string, { show?: boolean }>
-    | undefined;
-  const canAccessAgentBuilder =
-    chatExperience === AIChatExperience.Agent &&
-    agentBuilderCapabilities?.agentBuilder?.show === true;
-
-  return {
-    body: [
-      {
-        id: 'security_solution_home',
-        link: securityLink(SecurityPageName.landing),
-        title: SOLUTION_NAME,
-        icon: 'logoSecurity',
-        renderAs: 'home',
-      },
-      {
-        link: 'discover',
-        icon: 'discoverApp',
-      },
-      defaultNavigationTree.dashboards(),
-      defaultNavigationTree.rules(),
-      services.featureFlags.getBooleanValue(ATTACKS_ALERTS_ALIGNMENT_ENABLED, false)
-        ? defaultNavigationTree.alertDetections()
-        : {
-            id: SecurityPageName.alerts,
-            icon: 'warning',
-            link: securityLink(SecurityPageName.alerts),
+): Promise<NavigationTreeDefinition> => ({
+  body: [
+    {
+      id: 'security_solution_home',
+      link: securityLink(SecurityPageName.landing),
+      title: SOLUTION_NAME,
+      icon: 'logoSecurity',
+      renderAs: 'home',
+    },
+    {
+      link: 'discover',
+      icon: 'discoverApp',
+    },
+    defaultNavigationTree.dashboards(),
+    defaultNavigationTree.rules(),
+    services.featureFlags.getBooleanValue(ATTACKS_ALERTS_ALIGNMENT_ENABLED, false)
+      ? defaultNavigationTree.alertDetections()
+      : {
+          id: SecurityPageName.alerts,
+          icon: 'warning',
+          link: securityLink(SecurityPageName.alerts),
+        },
+    {
+      // TODO: update icon from EUI
+      icon: LazyIconWorkflow,
+      link: 'workflows',
+      badgeType: 'techPreview' as const,
+    },
+    ...(chatExperience === AIChatExperience.Agent
+      ? [
+          {
+            // TODO: update icon to 'robot' once it's available in EUI
+            icon: LazyIconAgentBuilder,
+            link: 'agent_builder' as AppDeepLinkId,
           },
-      {
-        // TODO: update icon from EUI
-        icon: LazyIconWorkflow,
-        link: 'workflows',
-        badgeType: 'techPreview' as const,
-      },
-      ...(canAccessAgentBuilder
-        ? [
+        ]
+      : []),
+    {
+      id: SecurityPageName.attackDiscovery,
+      icon: 'bolt',
+      link: securityLink(SecurityPageName.attackDiscovery),
+    },
+    {
+      id: SecurityPageName.cloudSecurityPostureFindings,
+      // TODO change this to the `bullseye` EUI icon when available
+      icon: LazyIconFindings,
+      link: securityLink(SecurityPageName.cloudSecurityPostureFindings),
+    },
+    defaultNavigationTree.cases(),
+    defaultNavigationTree.entityAnalytics(),
+    defaultNavigationTree.explore(),
+    defaultNavigationTree.investigations(),
+    {
+      id: SecurityPageName.threatIntelligence,
+      // TODO change this to the `compute` EUI icon when available
+      icon: LazyIconIntelligence,
+      link: securityLink(SecurityPageName.threatIntelligence),
+    },
+    {
+      id: SecurityPageName.assetInventory,
+      icon: 'editorChecklist',
+      link: securityLink(SecurityPageName.assetInventory),
+    },
+    defaultNavigationTree.assets(services),
+    defaultNavigationTree.ml(),
+  ],
+  footer: [
+    {
+      id: SecurityGroupName.launchpad,
+      title: i18nStrings.launchPad.title,
+      renderAs: 'panelOpener',
+      icon: 'launch',
+      children: [
+        {
+          children: [
             {
-              // TODO: update icon to 'robot' once it's available in EUI
-              icon: LazyIconAgentBuilder,
-              link: 'agent_builder' as AppDeepLinkId,
+              id: SecurityPageName.landing,
+              link: securityLink(SecurityPageName.landing),
             },
-          ]
-        : []),
-      {
-        id: SecurityPageName.attackDiscovery,
-        icon: 'bolt',
-        link: securityLink(SecurityPageName.attackDiscovery),
-      },
-      {
-        id: SecurityPageName.cloudSecurityPostureFindings,
-        // TODO change this to the `bullseye` EUI icon when available
-        icon: LazyIconFindings,
-        link: securityLink(SecurityPageName.cloudSecurityPostureFindings),
-      },
-      defaultNavigationTree.cases(),
-      defaultNavigationTree.entityAnalytics(),
-      defaultNavigationTree.explore(),
-      defaultNavigationTree.investigations(),
-      {
-        id: SecurityPageName.threatIntelligence,
-        // TODO change this to the `compute` EUI icon when available
-        icon: LazyIconIntelligence,
-        link: securityLink(SecurityPageName.threatIntelligence),
-      },
-      {
-        id: SecurityPageName.assetInventory,
-        icon: 'editorChecklist',
-        link: securityLink(SecurityPageName.assetInventory),
-      },
-      defaultNavigationTree.assets(services),
-      defaultNavigationTree.ml(),
-    ],
-    footer: [
-      {
-        id: SecurityGroupName.launchpad,
-        title: i18nStrings.launchPad.title,
-        renderAs: 'panelOpener',
-        icon: 'launch',
-        children: [
-          {
-            children: [
-              {
-                id: SecurityPageName.landing,
-                link: securityLink(SecurityPageName.landing),
-              },
-              {
-                id: SecurityPageName.siemReadiness,
-                link: securityLink(SecurityPageName.siemReadiness),
-              },
-              {
-                // value report
-                id: SecurityPageName.aiValue,
-                link: securityLink(SecurityPageName.aiValue),
-              },
-            ],
-          },
-          {
-            title: i18nStrings.launchPad.migrations.title,
-            children: [
-              {
-                id: SecurityPageName.siemMigrationsRules,
-                link: securityLink(SecurityPageName.siemMigrationsRules),
-              },
-              {
-                id: SecurityPageName.siemMigrationsDashboards,
-                link: securityLink(SecurityPageName.siemMigrationsDashboards),
-              },
-            ],
-          },
-        ],
-      },
-      {
-        link: 'dev_tools',
-        title: i18nStrings.devTools,
-        icon: 'editorCodeBlock',
-      },
-      createManagementFooterItemsTree(chatExperience),
-    ],
-  };
-};
+            {
+              id: SecurityPageName.siemReadiness,
+              link: securityLink(SecurityPageName.siemReadiness),
+            },
+            {
+              // value report
+              id: SecurityPageName.aiValue,
+              link: securityLink(SecurityPageName.aiValue),
+            },
+          ],
+        },
+        {
+          title: i18nStrings.launchPad.migrations.title,
+          children: [
+            {
+              id: SecurityPageName.siemMigrationsRules,
+              link: securityLink(SecurityPageName.siemMigrationsRules),
+            },
+            {
+              id: SecurityPageName.siemMigrationsDashboards,
+              link: securityLink(SecurityPageName.siemMigrationsDashboards),
+            },
+          ],
+        },
+      ],
+    },
+    {
+      link: 'dev_tools',
+      title: i18nStrings.devTools,
+      icon: 'editorCodeBlock',
+    },
+    createManagementFooterItemsTree(chatExperience),
+  ],
+});

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
@@ -33,8 +33,16 @@ const SOLUTION_NAME = i18n.translate(
 export const createNavigationTree = async (
   services: Services,
   chatExperience: AIChatExperience = AIChatExperience.Classic
-): Promise<NavigationTreeDefinition> => ({
-  body: [
+): Promise<NavigationTreeDefinition> => {
+  // `agentBuilder` capability key matches `AGENTBUILDER_FEATURE_ID` ('agentBuilder')
+  const agentBuilderCapabilities = services.application.capabilities as
+    | Record<string, { show?: boolean }>
+    | undefined;
+  const canAccessAgentBuilder =
+    chatExperience === AIChatExperience.Agent && agentBuilderCapabilities?.agentBuilder?.show === true;
+
+  return {
+    body: [
     {
       id: 'security_solution_home',
       link: securityLink(SecurityPageName.landing),
@@ -61,7 +69,7 @@ export const createNavigationTree = async (
       link: 'workflows',
       badgeType: 'techPreview' as const,
     },
-    ...(chatExperience === AIChatExperience.Agent
+    ...(canAccessAgentBuilder
       ? [
           {
             // TODO: update icon to 'robot' once it's available in EUI
@@ -145,4 +153,5 @@ export const createNavigationTree = async (
     },
     createManagementFooterItemsTree(chatExperience),
   ],
-});
+  };
+};


### PR DESCRIPTION
## Summary

Agent builder should not be available in Serverless Security Essentials product tier. The agent builder setting was added to `config/serverless.security.yml`, meaning agent builder could show in Essentials. I've moved the setting to only be in `complete` and `search_ai_lake` tiers and removed it from the `essentials` tier.

## To reproduce

1. Start serverless with security complete or search ai lake.
2. Opt-in to the Agent builder chat experience
3. Start serverless with security essentials
4. Note agent is now hidden in essentials tier

## Before (Agent shows in Essentials)
<img width="1347" height="766" alt="Screenshot 2026-01-07 at 2 09 15 PM" src="https://github.com/user-attachments/assets/5d4ee718-ffed-49ac-b283-db4adc9991a0" />

## After (Agent hidden in Essentials)
<img width="1348" height="759" alt="good" src="https://github.com/user-attachments/assets/e4986c1c-a194-495a-8515-51e5740e4506" />
