### PR TITLE
[DOCS][8.19.7][Release notes]: Turning flapping off prevents alerts to be generated when alert delay is set to more than 1

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -194,7 +194,12 @@ Machine Learning::
 [[release-notes-8.19.7]]
 == {kib} 8.19.7
 
-The 8.19.7 release includes the following enhancements and fixes.
+The 8.19.7 release includes the following known issues, enhancements, and fixes.
+
+[float]
+[[known-issues-8.19.7]]
+=== Known issues
+include::CHANGELOG.asciidoc[tag=known-issue-3610]
 
 [float]
 [[enhancement-v8.19.7]]


### PR DESCRIPTION
Addresses [this ask](https://github.com/elastic/docs-content/issues/3610#issuecomment-3720587838) to document the alert flapping bug as a known issue in the 8.19.7 Kibana release notes. 

Preview - https://kibana_bk_248197.docs-preview.app.elstc.co/guide/en/kibana/8.19/release-notes-8.19.7.html