### PR TITLE
[CodeEditor] Fix Monaco error after back navigation in dark mode

### DIFF
--- a/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
@@ -569,6 +569,10 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
 
       editorWillUnmount?.();
 
+      // Clear the stored editor reference before it gets disposed, to avoid downstream
+      // effects/hooks attempting to call into a disposed editor instance.
+      setEditor(null);
+
       const model = editor.getModel();
       model?.dispose();
     },


### PR DESCRIPTION
Closes #247611

## Summary
- This change aims to prevent Monaco widget customization code from calling into editor contributions after the editor has been disposed during SPA back/forward navigation.
- When the timing lines up, Monaco can throw (e.g. `AbstractContextKeyService has been disposed`) and the management settings editor field can trip its error boundary.

## What I think is happening (high-level)
- `EditorWidgetsCustomizations` accesses Monaco contributions (suggest controller + parameter hints) via `editor.getContribution(...)`.
- If navigation disposes the editor between render and effect flush, `getContribution(...)` can throw from Monaco internals.
- Separately, `monaco.editor.onDidChangeMarkers(...)` is a global subscription; if it outlives the component/editor it can also run while the editor is already disposed.

## Changes (and why)
- Guard `EditorWidgetsCustomizations` with an `isEditorUsable(...)` check (model exists + not disposed, editor DOM node exists + still connected).
  - This keeps the logic conservative without relying on an editor-level `isDisposed()` API (Monaco exposes `isDisposed()` on the model).
- Wrap `editor.getContribution(...)` reads in `try/catch`.
  - The intent is to treat a mid-flight disposal as a no-op rather than letting an exception bubble into the React tree.
- Dispose the `monaco.editor.onDidChangeMarkers(...)` subscription on unmount (and before re-registering) and clear stale editor refs.
  - This aims to avoid global marker callbacks running after editor disposal.
- Clear the stored editor state in `CodeEditor` during `editorWillUnmount`.
  - This is meant to reduce the chance of downstream hooks/effects running against a disposed editor instance.

## Why it tends to show up more in dark mode (soft hypothesis)
This seems to be more reproducible in dark mode because the theme layer can introduce extra updates around navigation:
- Kibana/EUI theme changes cause `euiTheme` changes, and the Monaco wrapper reacts to those changes by defining themes.
- With more theme-related updates in-flight, it looks like the window where an effect runs right as the editor is being torn down becomes easier to hit.

## Fix demo

https://github.com/user-attachments/assets/74954343-f5c2-4305-872b-f7593d942049

## Test plan
- Enable dark mode.
- Go to Advanced Settings and focus any Monaco-backed setting (e.g. Scaled date format / Query string options).
- Navigate away and use browser back to return.
- Confirm the editor renders and the console does not show `AbstractContextKeyService has been disposed`.

## Related (directly touching the relevant code paths)
- [Monaco] Decouple rendering for monaco widgets (#246170)
- a11y improvements for kbn code editor (#228407)

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->