### PR TITLE
[ES|QL] Suggest operators after cast

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/position.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/position.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { isColumn, isFunctionExpression, isLiteral } from '../../../../../ast/is';
+import { isColumn, isFunctionExpression, isInlineCast, isLiteral } from '../../../../../ast/is';
 import { within } from '../../../../../ast/location';
 import type { ESQLSingleAstItem, ESQLFunction } from '../../../../../types';
 import type { ESQLColumnData } from '../../../../registry/types';
@@ -63,6 +63,10 @@ export function getPosition(
     if (!endsWithColumnName) {
       return 'after_complete';
     }
+  }
+
+  if (isInlineCast(expressionRoot) && !expressionRoot.incomplete) {
+    return 'after_complete';
   }
 
   // Function expression (operators or variadic functions like CONCAT)

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/__tests__/autocomplete.inline_cast.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/__tests__/autocomplete.inline_cast.test.ts
@@ -51,7 +51,7 @@ describe('Inline Cast Autocomplete Suggestions', () => {
 
   it('suggests operators after inline cast', async () => {
     const { assertSuggestions } = await setup('^');
-    await assertSuggestions('FROM index_a | WHERE false::boolean ^', [
+    await assertSuggestions('FROM index_a | WHERE "false"::boolean ^', [
       '| ',
       ...getFunctionSignaturesByReturnType(
         Location.WHERE,

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/__tests__/autocomplete.inline_cast.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/__tests__/autocomplete.inline_cast.test.ts
@@ -17,7 +17,8 @@
  */
 
 import { getCastingTypesSuggestions } from '../../../commands/definitions/utils/autocomplete/expressions/positions/after_cast';
-import { fields, setup } from './helpers';
+import { fields, getFunctionSignaturesByReturnType, setup } from './helpers';
+import { Location } from '../../../commands/registry/types';
 
 const fieldsToTest = fields.filter(
   (field) => field.name !== 'any#Char$Field' && field.type !== 'unsupported'
@@ -46,5 +47,21 @@ describe('Inline Cast Autocomplete Suggestions', () => {
       'FROM index_a | WHERE abs(false::^)',
       getCastingTypesSuggestions('boolean')
     );
+  });
+
+  it('suggests operators after inline cast', async () => {
+    const { assertSuggestions } = await setup('^');
+    await assertSuggestions('FROM index_a | WHERE false::boolean ^', [
+      '| ',
+      ...getFunctionSignaturesByReturnType(
+        Location.WHERE,
+        'any',
+        {
+          operators: true,
+          skipAssign: true,
+        },
+        ['boolean']
+      ),
+    ]);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/pull/247626#discussion_r2663882268
## Summary
Wrong suggestions were presented after doing a cast, now we suggest the correct operators.

<img width="1001" height="430" alt="image" src="https://github.com/user-attachments/assets/c2889af1-6db7-44d3-b07a-653034061397" />




