### PR TITLE
[@kbn/eslint-plugin-eslint] Add scout eslint rule to forbid `esArchiv…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2716,6 +2716,7 @@ module.exports = {
         '@kbn/eslint/scout_test_file_naming': 'error',
         '@kbn/eslint/scout_require_api_client_in_api_test': 'error',
         '@kbn/eslint/scout_require_global_setup_hook_in_parallel_tests': 'error',
+        '@kbn/eslint/scout_no_es_archiver_in_parallel_tests': 'error',
         '@kbn/eslint/require_include_in_check_a11y': 'warn',
       },
     },

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -28,6 +28,7 @@ module.exports = {
     scout_test_file_naming: require('./rules/scout_test_file_naming'),
     scout_require_api_client_in_api_test: require('./rules/scout_require_api_client_in_api_test'),
     scout_require_global_setup_hook_in_parallel_tests: require('./rules/scout_require_global_setup_hook_in_parallel_tests'),
+    scout_no_es_archiver_in_parallel_tests: require('./rules/scout_no_es_archiver_in_parallel_tests'),
     require_kbn_fs: require('./rules/require_kbn_fs'),
     require_include_in_check_a11y: require('./rules/require_include_in_check_a11y'),
   },

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.js
@@ -14,7 +14,7 @@ const path = require('path');
 const ERROR_MSG =
   '`esArchiver` should not be used in parallel tests. Use `globalSetupHook` in `global.setup.ts` to load archives before tests run.';
 
-const TEST_FIXTURES = new Set(['spaceTest', 'test', 'apiTest']);
+const TEST_FIXTURES = new Set(['test', 'apiTest']);
 
 /** @type {Rule} */
 module.exports = {

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+
+const path = require('path');
+
+const ERROR_MSG =
+  '`esArchiver` should not be used in parallel tests. Use `globalSetupHook` in `global.setup.ts` to load archives before tests run.';
+
+const TEST_FIXTURES = new Set(['spaceTest', 'test', 'apiTest']);
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Forbid esArchiver usage in parallel tests',
+      category: 'Best Practices',
+    },
+    fixable: null,
+    schema: [],
+  },
+  create: (context) => {
+    const filename = context.getFilename();
+
+    // Only apply to files in parallel_tests directories, excluding global.setup.ts
+    if (!filename.includes('/parallel_tests/') || path.basename(filename) === 'global.setup.ts') {
+      return {};
+    }
+
+    return {
+      CallExpression(node) {
+        const { callee } = node;
+
+        // Check for test(...) or test.method(...)
+        const isFixture =
+          (callee.type === 'Identifier' && TEST_FIXTURES.has(callee.name)) ||
+          (callee.type === 'MemberExpression' &&
+            callee.object.type === 'Identifier' &&
+            TEST_FIXTURES.has(callee.object.name));
+
+        if (!isFixture) return;
+
+        // Get the callback (last argument)
+        const callback = node.arguments[node.arguments.length - 1];
+        if (!callback || !['ArrowFunctionExpression', 'FunctionExpression'].includes(callback.type))
+          return;
+
+        // Check for { esArchiver } in first param
+        const param = callback.params[0];
+        if (param?.type !== 'ObjectPattern') return;
+
+        const hasEsArchiver = param.properties.some(
+          (p) => p.type === 'Property' && p.key.type === 'Identifier' && p.key.name === 'esArchiver'
+        );
+
+        if (hasEsArchiver) {
+          context.report({ node: param, message: ERROR_MSG });
+        }
+      },
+    };
+  },
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.test.js
@@ -35,7 +35,7 @@ ruleTester.run('@kbn/eslint/scout_no_es_archiver_in_parallel_tests', rule, {
     },
     // Test without esArchiver
     {
-      code: `spaceTest('should work', async ({ page }) => {});`,
+      code: `test('should work', async ({ page }) => {});`,
       filename: '/path/to/plugin/test/scout/ui/parallel_tests/my_test.spec.ts',
     },
     // Test outside parallel_tests directory
@@ -46,9 +46,9 @@ ruleTester.run('@kbn/eslint/scout_no_es_archiver_in_parallel_tests', rule, {
   ],
 
   invalid: [
-    // spaceTest with esArchiver
+    // test with esArchiver
     {
-      code: `spaceTest('should work', async ({ esArchiver }) => {});`,
+      code: `test('should work', async ({ esArchiver }) => {});`,
       filename: '/path/to/plugin/test/scout/ui/parallel_tests/my_test.spec.ts',
       errors: [{ message: ERROR_MSG }],
     },

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.test.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const { RuleTester } = require('eslint');
+const rule = require('./scout_no_es_archiver_in_parallel_tests');
+const dedent = require('dedent');
+
+const ERROR_MSG =
+  '`esArchiver` should not be used in parallel tests. Use `globalSetupHook` in `global.setup.ts` to load archives before tests run.';
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2020,
+  },
+});
+
+ruleTester.run('@kbn/eslint/scout_no_es_archiver_in_parallel_tests', rule, {
+  valid: [
+    // esArchiver in global.setup.ts is allowed
+    {
+      code: dedent`
+        globalSetupHook('Ingest data', async ({ esArchiver }) => {
+          await esArchiver.loadIfNeeded('test/archive');
+        });
+      `,
+      filename: '/path/to/plugin/test/scout/ui/parallel_tests/global.setup.ts',
+    },
+    // Test without esArchiver
+    {
+      code: `spaceTest('should work', async ({ page }) => {});`,
+      filename: '/path/to/plugin/test/scout/ui/parallel_tests/my_test.spec.ts',
+    },
+    // Test outside parallel_tests directory
+    {
+      code: `test('should work', async ({ esArchiver }) => {});`,
+      filename: '/path/to/plugin/test/scout/ui/tests/my_test.spec.ts',
+    },
+  ],
+
+  invalid: [
+    // spaceTest with esArchiver
+    {
+      code: `spaceTest('should work', async ({ esArchiver }) => {});`,
+      filename: '/path/to/plugin/test/scout/ui/parallel_tests/my_test.spec.ts',
+      errors: [{ message: ERROR_MSG }],
+    },
+    // test.beforeAll with esArchiver
+    {
+      code: `test.beforeAll(async ({ esArchiver }) => {});`,
+      filename: '/path/to/plugin/test/scout/ui/parallel_tests/my_test.spec.ts',
+      errors: [{ message: ERROR_MSG }],
+    },
+    // apiTest with esArchiver
+    {
+      code: `apiTest('should call API', async ({ esArchiver }) => {});`,
+      filename: '/path/to/plugin/test/scout/api/parallel_tests/api_test.spec.ts',
+      errors: [{ message: ERROR_MSG }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
Adds a new ESLint rule `scout_no_es_archiver_in_parallel_tests` that forbids `esArchiver` usage in parallel test fixtures. Instead, archives should be loaded in `global.setup.ts` using `globalSetupHook` to ensure data is pre-loaded before parallel tests run.

## What it does
The rule checks for `esArchiver` destructuring in test fixture callbacks (`spaceTest`, `test`, `apiTest` and their methods like `beforeAll`, `describe`, etc.) within `parallel_tests` directories.

**Invalid:**
```ts
// ❌ esArchiver in spaceTest callback
// test/scout/ui/parallel_tests/my_test.spec.ts
spaceTest('should work', async ({ esArchiver }) => {
  await esArchiver.load('test/archive');  // Error: use globalSetupHook instead
});

// ❌ esArchiver in test.beforeAll
// test/scout/ui/parallel_tests/my_test.spec.ts
test.beforeAll(async ({ esArchiver }) => {
  await esArchiver.load('test/archive');  // Error: use globalSetupHook instead
});

// ❌ esArchiver in apiTest
// test/scout/api/parallel_tests/api_test.spec.ts
apiTest('should call API', async ({ esArchiver }) => {
  await esArchiver.load('test/archive');  // Error: use globalSetupHook instead
});
```

**Valid:**
```ts
// ✅ esArchiver in global.setup.ts
// test/scout/ui/parallel_tests/global.setup.ts
globalSetupHook('Ingest data', async ({ esArchiver }) => {
  await esArchiver.loadIfNeeded('test/archive');  // OK: this is the right place
});

// ✅ Test without esArchiver
// test/scout/ui/parallel_tests/my_test.spec.ts
spaceTest('should work', async ({ page }) => {
  await page.goto('/app');  // OK: no esArchiver usage
});

// ✅ esArchiver outside parallel_tests directory
// test/scout/ui/tests/my_test.spec.ts
test('should work', async ({ esArchiver }) => {
  await esArchiver.load('test/archive');  // OK: rule only applies to parallel_tests
});
```

## Features
- Detects `esArchiver` destructuring in `spaceTest`, `test`, and `apiTest` fixtures
- Covers fixture methods: `describe`, `beforeAll`, `beforeEach`, `afterAll`, `afterEach`
- Excludes `global.setup.ts` files where `esArchiver` is allowed
- Only applies to files within `parallel_tests` directories

## Changes
- Added rule implementation in `packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.js`
- Added test suite in `packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.test.js`
- Registered rule in plugin index and enabled as error for Scout test files


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->