### PR TITLE
[Agent Builder] test flyout - submit button is hidden by bottom bar

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/create_tool.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/create_tool.tsx
@@ -13,7 +13,7 @@ import { ToolFormMode } from './form/tool_form';
 
 export const TOOL_SOURCE_QUERY_PARAM = 'source_id';
 export const TOOL_TYPE_QUERY_PARAM = 'tool_type';
-export const OPEN_TEST_FLYOUT_QUERY_PARAM = 'open_test_flyout';
+export const TEST_TOOL_ID_QUERY_PARAM = 'test_tool_id';
 
 export const CreateTool: React.FC = () => {
   const [searchParams] = useSearchParams();

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/execute/test_tools.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/execute/test_tools.tsx
@@ -7,7 +7,6 @@
 
 import {
   EuiButton,
-  EuiButtonEmpty,
   EuiCodeBlock,
   EuiFieldNumber,
   EuiFieldText,
@@ -15,7 +14,6 @@ import {
   EuiFlexItem,
   EuiFlyout,
   EuiFlyoutBody,
-  EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiForm,
   EuiFormRow,
@@ -37,7 +35,6 @@ import type { ExecuteToolResponse } from '../../../../../common/http_api/tools';
 import { useAgentBuilderServices } from '../../../hooks/use_agent_builder_service';
 import { useExecuteTool } from '../../../hooks/tools/use_execute_tools';
 import { useTool } from '../../../hooks/tools/use_tools';
-import { ToolFormMode } from '../form/tool_form';
 import { labels } from '../../../utils/i18n';
 
 const flyoutStyles = css`
@@ -216,10 +213,9 @@ const renderFormField = ({
 export interface ToolTestFlyoutProps {
   toolId: string;
   onClose: () => void;
-  formMode?: ToolFormMode;
 }
 
-export const ToolTestFlyout: React.FC<ToolTestFlyoutProps> = ({ toolId, onClose, formMode }) => {
+export const ToolTestFlyout: React.FC<ToolTestFlyoutProps> = ({ toolId, onClose }) => {
   const isSmallScreen = useIsWithinBreakpoints(['xs', 's', 'm']);
   const { docLinksService } = useAgentBuilderServices();
   const [response, setResponse] = useState<string>('{}');
@@ -363,17 +359,6 @@ export const ToolTestFlyout: React.FC<ToolTestFlyoutProps> = ({ toolId, onClose,
           </FormProvider>
         )}
       </EuiFlyoutBody>
-      {formMode === ToolFormMode.Edit && (
-        <EuiFlyoutFooter>
-          <EuiButtonEmpty
-            aria-label={labels.tools.testTool.backToEditToolButton}
-            iconType="sortLeft"
-            onClick={onClose}
-          >
-            {labels.tools.testTool.backToEditToolButton}
-          </EuiButtonEmpty>
-        </EuiFlyoutFooter>
-      )}
     </EuiFlyout>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/tool.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/tool.tsx
@@ -49,7 +49,7 @@ import {
   getUpdatePayloadFromData,
   getToolTypeDefaultValues,
 } from './form/registry/tools_form_registry';
-import { OPEN_TEST_FLYOUT_QUERY_PARAM, TOOL_TYPE_QUERY_PARAM } from './create_tool';
+import { TOOL_TYPE_QUERY_PARAM, TEST_TOOL_ID_QUERY_PARAM } from './create_tool';
 import { ToolTestFlyout } from './execute/test_tools';
 import { ToolEditContextMenu } from './form/components/tool_edit_context_menu';
 import { ToolForm, ToolFormMode } from './form/tool_form';
@@ -99,10 +99,6 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
     },
     [navigateToAgentBuilderUrl]
   );
-  const [openTestFlyoutParam, setOpenTestFlyoutParam] = useQueryState<boolean>(
-    OPEN_TEST_FLYOUT_QUERY_PARAM,
-    { defaultValue: false }
-  );
   const [urlToolType, setUrlToolType] = useQueryState<ToolType>(TOOL_TYPE_QUERY_PARAM);
 
   const initialToolType = useMemo(() => {
@@ -132,14 +128,6 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
 
   const currentToolId = useWatch({ name: 'toolId', control });
   const toolType = useWatch({ name: 'type', control });
-
-  // Handle opening test tool flyout on navigation
-  useEffect(() => {
-    if (openTestFlyoutParam && currentToolId && !showTestFlyout) {
-      openTestFlyout();
-      setOpenTestFlyoutParam(false);
-    }
-  }, [openTestFlyoutParam, currentToolId, showTestFlyout, setOpenTestFlyoutParam, openTestFlyout]);
 
   const handleCancel = useCallback(() => {
     setIsCancelling(true);
@@ -187,8 +175,8 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
         buttonId: BUTTON_IDS.SAVE_AND_TEST,
       });
       if (mode === ToolFormMode.Create && response) {
-        deferNavigateToAgentBuilderUrl(appPaths.tools.details({ toolId: response.id }), {
-          [OPEN_TEST_FLYOUT_QUERY_PARAM]: 'true',
+        deferNavigateToAgentBuilderUrl(appPaths.tools.list, {
+          [TEST_TOOL_ID_QUERY_PARAM]: response.id,
         });
       } else {
         handleTestTool();

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/tool.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/tools/tool.tsx
@@ -50,12 +50,11 @@ import {
   getToolTypeDefaultValues,
 } from './form/registry/tools_form_registry';
 import { TOOL_TYPE_QUERY_PARAM, TEST_TOOL_ID_QUERY_PARAM } from './create_tool';
-import { ToolTestFlyout } from './execute/test_tools';
 import { ToolEditContextMenu } from './form/components/tool_edit_context_menu';
 import { ToolForm, ToolFormMode } from './form/tool_form';
 import type { ToolFormData } from './form/types/tool_form_types';
-import { useFlyoutState } from '../../hooks/use_flyout_state';
 import { useAgentBuilderServices } from '../../hooks/use_agent_builder_service';
+import { useToolsActions } from '../../context/tools_provider';
 
 const BUTTON_IDS = {
   SAVE: 'save',
@@ -112,12 +111,8 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
   const { control, reset, formState, handleSubmit, getValues } = form;
   const { errors, isDirty, isSubmitSuccessful } = formState;
   const [isCancelling, setIsCancelling] = useState(false);
-  const {
-    isOpen: showTestFlyout,
-    openFlyout: openTestFlyout,
-    closeFlyout: closeTestFlyout,
-  } = useFlyoutState(false);
   const [submittingButtonId, setSubmittingButtonId] = useState<string | undefined>();
+  const { testTool } = useToolsActions();
   const { services } = useKibana();
   const {
     application: { navigateToUrl },
@@ -165,8 +160,10 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
   );
 
   const handleTestTool = useCallback(() => {
-    openTestFlyout();
-  }, [openTestFlyout]);
+    if (currentToolId) {
+      testTool(currentToolId);
+    }
+  }, [currentToolId, testTool]);
 
   const handleSaveAndTest = useCallback(
     async (data: ToolFormData) => {
@@ -418,15 +415,6 @@ export const Tool: React.FC<ToolProps> = ({ mode, tool, isLoading, isSubmitting,
           </KibanaPageTemplate.BottomBar>
         </KibanaPageTemplate>
       </FormProvider>
-      {showTestFlyout && currentToolId && (
-        <ToolTestFlyout
-          toolId={currentToolId}
-          formMode={mode}
-          onClose={() => {
-            closeTestFlyout();
-          }}
-        />
-      )}
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/tools_provider.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/tools_provider.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { createContext, useCallback, useContext } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { EuiConfirmModal, EuiText, useGeneratedHtmlId } from '@elastic/eui';
 import type { ToolType } from '@kbn/agent-builder-common';
 import { appPaths } from '../utils/app_paths';
@@ -13,10 +13,12 @@ import { useNavigation } from '../hooks/use_navigation';
 import { useDeleteTool, useDeleteTools } from '../hooks/tools/use_delete_tools';
 import { labels } from '../utils/i18n';
 import {
-  OPEN_TEST_FLYOUT_QUERY_PARAM,
   TOOL_SOURCE_QUERY_PARAM,
   TOOL_TYPE_QUERY_PARAM,
+  TEST_TOOL_ID_QUERY_PARAM,
 } from '../components/tools/create_tool';
+import { ToolTestFlyout } from '../components/tools/execute/test_tools';
+import { useQueryState } from '../hooks/use_query_state';
 
 export interface ToolsActionsContextType {
   createTool: (toolType: ToolType) => void;
@@ -68,14 +70,24 @@ export const ToolsProvider = ({ children }: { children: React.ReactNode }) => {
     [navigateToAgentBuilderUrl]
   );
 
-  const testTool = useCallback(
-    (toolId: string) => {
-      navigateToAgentBuilderUrl(appPaths.tools.details({ toolId }), {
-        [OPEN_TEST_FLYOUT_QUERY_PARAM]: 'true',
-      });
-    },
-    [navigateToAgentBuilderUrl]
-  );
+  const [testToolId, setTestToolId] = useState<string | null>(null);
+  const [testToolIdParam, setTestToolIdParam] = useQueryState<string>(TEST_TOOL_ID_QUERY_PARAM);
+
+  // Handle opening test flyout from query param (one-time trigger, then clear param)
+  useEffect(() => {
+    if (testToolIdParam && !testToolId) {
+      setTestToolId(testToolIdParam);
+      setTestToolIdParam(null);
+    }
+  }, [testToolIdParam, testToolId, setTestToolIdParam]);
+
+  const testTool = useCallback((toolId: string) => {
+    setTestToolId(toolId);
+  }, []);
+
+  const closeTestFlyout = useCallback(() => {
+    setTestToolId(null);
+  }, []);
 
   const getEditToolUrl = useCallback(
     (toolId: string) => {
@@ -182,6 +194,7 @@ export const ToolsProvider = ({ children }: { children: React.ReactNode }) => {
           <EuiText>{labels.tools.bulkDeleteEsqlToolsConfirmationText}</EuiText>
         </EuiConfirmModal>
       )}
+      {testToolId && <ToolTestFlyout toolId={testToolId} onClose={closeTestFlyout} />}
     </ToolsActionsContext.Provider>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/pages/tool_create.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/pages/tool_create.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { CreateTool } from '../components/tools/create_tool';
+import { ToolsProvider } from '../context/tools_provider';
 import { useBreadcrumb } from '../hooks/use_breadcrumbs';
 import { appPaths } from '../utils/app_paths';
 import { labels } from '../utils/i18n';
@@ -22,5 +23,9 @@ export const AgentBuilderToolCreatePage = () => {
       path: appPaths.tools.new,
     },
   ]);
-  return <CreateTool />;
+  return (
+    <ToolsProvider>
+      <CreateTool />
+    </ToolsProvider>
+  );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
@@ -302,15 +302,6 @@ export const labels = {
         defaultMessage: "You can't recover deleted data.",
       }
     ),
-    testTool: {
-      backToEditToolButton: i18n.translate(
-        'xpack.agentBuilder.tools.testTool.backToEditToolButton',
-        {
-          defaultMessage: 'Back to edit tool',
-        }
-      ),
-    },
-
     // Bulk import MCP tools
     bulkImportMcp: {
       title: i18n.translate('xpack.agentBuilder.tools.bulkImportMcp.title', {


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/12315

**Problem solved**: Portal ordering issue when navigating to open the flyout (flyout portal created before bottom bar portal → bottom bar appeared on top of flyout).

**Solution**: Made the test flyout self-contained and managed at the ToolsProvider level with a single source of truth:
- ToolsProvider owns the flyout state and renders ToolTestFlyout
- Removed local flyout state from tool.tsx - all pages now use testTool(id) from the provider
- From list page → testTool(id) opens flyout directly (no navigation, no portal issues)
- From edit page → testTool(id) opens flyout (same mechanism)
- After creating tool → navigate to list page with ?test_tool_id=xxx → provider opens flyout and clears param
- Removed redundant "Back to edit tool" footer (close button in header is sufficient)

✅ One source of truth - flyout state lives only in ToolsProvider
✅ Avoids portal ordering entirely - flyout is always created within the same provider context
✅ Flyout is truly self-contained - fetches its own tool data via useTool({ toolId })
✅ Consistent behavior whether opening from list context menu, edit page, or after creating


https://github.com/user-attachments/assets/db908688-b3ba-4d5f-bc88-36c2adba2ecf




<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->