### PR TITLE
Make Inference team the EIS script codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -962,7 +962,7 @@ x-pack/platform/packages/shared/kbn-event-stacktrace @elastic/obs-presentation-t
 x-pack/platform/packages/shared/kbn-failure-store-modal @elastic/kibana-management
 x-pack/platform/packages/shared/kbn-fs @elastic/kibana-security
 x-pack/platform/packages/shared/kbn-grok-heuristics @elastic/obs-onboarding-team
-x-pack/platform/packages/shared/kbn-inference-cli @elastic/appex-ai-infra
+x-pack/platform/packages/shared/kbn-inference-cli @elastic/appex-ai-infra @elastic/search-inference-team
 x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-inference-prompt-utils @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-inference-tracing @elastic/appex-ai-infra
@@ -1265,6 +1265,10 @@ x-pack/solutions/workplaceai/test @elastic/workchat-eng
 /x-pack/solutions/observability/test/api_integration/apis/metrics_ui @elastic/obs-presentation-team
 x-pack/platform/test/serverless/api_integration/test_suites/platform_security @elastic/kibana-security
 /src/platform/test/functional/apps/management @elastic/kibana-management
+
+# Utility Scripts
+x-pack/platform/packages/shared/kbn-inference-cli/scripts/eis.ts @elastic/search-inference-team
+x-pack/platform/packages/shared/kbn-inference-cli/src/eis @elastic/search-inference-team
 
 # Data Discovery
 /x-pack/platform/test/api_integration/services/data_view_api.ts @elastic/kibana-data-discovery

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -962,7 +962,7 @@ x-pack/platform/packages/shared/kbn-event-stacktrace @elastic/obs-presentation-t
 x-pack/platform/packages/shared/kbn-failure-store-modal @elastic/kibana-management
 x-pack/platform/packages/shared/kbn-fs @elastic/kibana-security
 x-pack/platform/packages/shared/kbn-grok-heuristics @elastic/obs-onboarding-team
-x-pack/platform/packages/shared/kbn-inference-cli @elastic/appex-ai-infra @elastic/search-inference-team
+x-pack/platform/packages/shared/kbn-inference-cli @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-inference-prompt-utils @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-inference-tracing @elastic/appex-ai-infra

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -962,7 +962,7 @@ x-pack/platform/packages/shared/kbn-event-stacktrace @elastic/obs-presentation-t
 x-pack/platform/packages/shared/kbn-failure-store-modal @elastic/kibana-management
 x-pack/platform/packages/shared/kbn-fs @elastic/kibana-security
 x-pack/platform/packages/shared/kbn-grok-heuristics @elastic/obs-onboarding-team
-x-pack/platform/packages/shared/kbn-inference-cli @elastic/appex-ai-infra
+x-pack/platform/packages/shared/kbn-inference-cli @elastic/appex-ai-infra @elastic/search-inference-team
 x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-inference-prompt-utils @elastic/appex-ai-infra
 x-pack/platform/packages/shared/kbn-inference-tracing @elastic/appex-ai-infra

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1266,10 +1266,6 @@ x-pack/solutions/workplaceai/test @elastic/workchat-eng
 x-pack/platform/test/serverless/api_integration/test_suites/platform_security @elastic/kibana-security
 /src/platform/test/functional/apps/management @elastic/kibana-management
 
-# Utility Scripts
-x-pack/platform/packages/shared/kbn-inference-cli/scripts/eis.ts @elastic/search-inference-team
-x-pack/platform/packages/shared/kbn-inference-cli/src/eis @elastic/search-inference-team
-
 # Data Discovery
 /x-pack/platform/test/api_integration/services/data_view_api.ts @elastic/kibana-data-discovery
 /src/platform/test/functional/page_objects/unified_field_list.ts @elastic/kibana-data-discovery

--- a/x-pack/platform/packages/shared/kbn-inference-cli/kibana.jsonc
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/kibana.jsonc
@@ -1,7 +1,10 @@
 {
   "type": "shared-common",
   "id": "@kbn/inference-cli",
-  "owner": "@elastic/appex-ai-infra",
+  "owner": [
+    "@elastic/appex-ai-infra",
+    "@elastic/search-inference-team"
+  ],
   "group": "platform",
   "visibility": "shared",
   "devOnly": true


### PR DESCRIPTION
Another attempt after automation removed the actual change in https://github.com/elastic/kibana/pull/247946.

## Summary

With https://github.com/elastic/kibana/pull/247413, we've significantly simplified the EIS local dev setup, and its now in a place where the Search Inference Team should be able to own its maintenance, or at least be notified of any change requests. This PR makes them codeowners of the `script/eis.js` code