### PR TITLE
[9.3] [Agent Builder] test tool flyout: add support for array/object params (#248213)

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/execute/test_tools.test.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/execute/test_tools.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { parseFormData } from './test_tools';
+
+describe('parseFormData', () => {
+  const mockParameters = [
+    { name: 'settings', type: 'object' },
+    { name: 'tags', type: 'array' },
+    { name: 'description', type: 'string' },
+  ];
+
+  it('successfully parses valid JSON strings for object/array types', () => {
+    const rawData = {
+      settings: '{"color": "blue", "retry": true}',
+      tags: '["urgent", "review"]',
+      description: 'Standard text',
+    };
+
+    const result = parseFormData(rawData, mockParameters);
+
+    expect(result.settings).toEqual({ color: 'blue', retry: true });
+    expect(result.tags).toEqual(['urgent', 'review']);
+    expect(result.description).toBe('Standard text');
+  });
+
+  it('falls back to the raw string if JSON is malformed', () => {
+    const rawData = {
+      settings: '{"unclosed_brace": true', // Missing '}'
+    };
+
+    const result = parseFormData(rawData, mockParameters);
+
+    // Should return the original string instead of throwing an error
+    expect(result.settings).toBe('{"unclosed_brace": true');
+  });
+
+  it('excludes empty strings and whitespace-only values', () => {
+    const rawData = {
+      settings: '   ',
+      tags: '',
+      description: 'valid value',
+    };
+
+    const result = parseFormData(rawData, mockParameters);
+
+    expect(result).not.toHaveProperty('settings');
+    expect(result).not.toHaveProperty('tags');
+    expect(result.description).toBe('valid value');
+  });
+
+  it('handles fields that are not present in the parameters list', () => {
+    const rawData = {
+      unknownField: '{"key": "value"}',
+    };
+
+    const result = parseFormData(rawData, mockParameters);
+
+    // It should just pass through unchanged because the type isn't confirmed
+    expect(result.unknownField).toBe('{"key": "value"}');
+  });
+
+  it('passes through non-string values unchanged', () => {
+    const rawData = {
+      settings: { alreadyParsed: true },
+      tags: ['already', 'an', 'array'],
+      description: 123,
+    };
+
+    const result = parseFormData(rawData, mockParameters);
+
+    expect(result.settings).toEqual({ alreadyParsed: true });
+    expect(result.tags).toEqual(['already', 'an', 'array']);
+    expect(result.description).toBe(123);
+  });
+
+  it('handles empty form data', () => {
+    const result = parseFormData({}, mockParameters);
+    expect(result).toEqual({});
+  });
+
+  it('handles empty parameters list', () => {
+    const rawData = {
+      settings: '{"key": "value"}',
+      description: 'text',
+    };
+
+    const result = parseFormData(rawData, []);
+
+    // Without parameter type info, values pass through as-is
+    expect(result.settings).toBe('{"key": "value"}');
+    expect(result.description).toBe('text');
+  });
+});

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/execute/test_tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/execute/test_tools.tsx
@@ -256,7 +256,6 @@ export interface ToolTestFlyoutProps {
 
 export const ToolTestFlyout: React.FC<ToolTestFlyoutProps> = ({ toolId, onClose, formMode }) => {
   const isSmallScreen = useIsWithinBreakpoints(['xs', 's', 'm']);
-  const { docLinksService } = useAgentBuilderServices();
   const [response, setResponse] = useState<string>('{}');
   // Re-mount new responses, needed for virtualized EuiCodeBlock
   // https://github.com/elastic/eui/issues/9034

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/execute/test_tools.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/execute/test_tools.tsx
@@ -69,9 +69,11 @@ const i18nMessages = {
       defaultMessage: 'Enter {label}',
       values: { label },
     }),
-  title: i18n.translate('xpack.onechat.tools.testFlyout.title', {
-    defaultMessage: 'Test Tool',
-  }),
+  title: (toolName: string) =>
+    i18n.translate('xpack.onechat.tools.testFlyout.title', {
+      defaultMessage: 'Test tool: {toolName}',
+      values: { toolName },
+    }),
   inputsTitle: i18n.translate('xpack.onechat.tools.testTool.inputsTitle', {
     defaultMessage: 'Inputs',
   }),
@@ -139,6 +141,39 @@ const getParameters = (tool?: ToolDefinitionWithSchema): Array<ToolParameter> =>
       optional: !requiredParams.has(paramName),
     };
   });
+};
+
+export const parseFormData = (
+  formData: Record<string, any>,
+  parameters: Array<{ name: string; type: string }>
+): Record<string, any> => {
+  const parsedFormData: Record<string, any> = {};
+
+  for (const [key, value] of Object.entries(formData)) {
+    // Skip empty string values
+    if (typeof value === 'string' && value.trim() === '') {
+      continue;
+    }
+
+    const param = parameters.find((p) => p.name === key);
+    if (
+      param &&
+      (param.type === 'object' || param.type === 'array') &&
+      typeof value === 'string' &&
+      value.trim() !== ''
+    ) {
+      try {
+        parsedFormData[key] = JSON.parse(value);
+      } catch {
+        // If parsing fails, use the original string value
+        parsedFormData[key] = value;
+      }
+    } else {
+      parsedFormData[key] = value;
+    }
+  }
+
+  return parsedFormData;
 };
 
 const renderFormField = ({
@@ -221,6 +256,7 @@ export interface ToolTestFlyoutProps {
 
 export const ToolTestFlyout: React.FC<ToolTestFlyoutProps> = ({ toolId, onClose, formMode }) => {
   const isSmallScreen = useIsWithinBreakpoints(['xs', 's', 'm']);
+  const { docLinksService } = useAgentBuilderServices();
   const [response, setResponse] = useState<string>('{}');
   // Re-mount new responses, needed for virtualized EuiCodeBlock
   // https://github.com/elastic/eui/issues/9034
@@ -252,9 +288,12 @@ export const ToolTestFlyout: React.FC<ToolTestFlyoutProps> = ({ toolId, onClose,
   });
 
   const onSubmit = async (formData: Record<string, any>) => {
+    const parameters = getParameters(tool);
+    const parsedFormData = parseFormData(formData, parameters);
+
     await executeTool({
       toolId: tool!.id,
-      toolParams: formData,
+      toolParams: parsedFormData,
     });
   };
 
@@ -266,7 +305,7 @@ export const ToolTestFlyout: React.FC<ToolTestFlyoutProps> = ({ toolId, onClose,
         <EuiFlexGroup direction="column" gutterSize="s">
           <EuiFlexItem>
             <EuiTitle size="m">
-              <h2 id="flyoutTitle">{i18nMessages.title}</h2>
+              <h2 id="flyoutTitle">{i18nMessages.title(tool.id)}</h2>
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem>
@@ -300,7 +339,7 @@ export const ToolTestFlyout: React.FC<ToolTestFlyoutProps> = ({ toolId, onClose,
                 <EuiForm component="form" onSubmit={handleSubmit(onSubmit)}>
                   <EuiFlexGroup direction="column" gutterSize="none">
                     {getParameters(tool).map((parameter) => {
-                      const { name, label, description, optional } = parameter;
+                      const { name, label, description, type, optional } = parameter;
                       return (
                         <EuiFormRow
                           key={name}
@@ -312,7 +351,12 @@ export const ToolTestFlyout: React.FC<ToolTestFlyoutProps> = ({ toolId, onClose,
                               </EuiText>
                             )
                           }
-                          helpText={description}
+                          helpText={
+                            <>
+                              <code>{type}</code>
+                              {description && ` - ${description}`}
+                            </>
+                          }
                           isInvalid={!!errors[name]}
                           error={errors[name]?.message as string}
                           fullWidth


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Agent Builder] test tool flyout: add support for array/object params (#248213)](https://github.com/elastic/kibana/pull/248213)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pierre Gayvallet","email":"pierre.gayvallet@elastic.co"},"sourceCommit":{"committedDate":"2026-01-08T10:23:10Z","message":"[Agent Builder] test tool flyout: add support for array/object params (#248213)\n\n## Summary\n\nAdd support for array / object parameter in the test flyout by\nJSON-parsing those parameter types before sending them to the server\ninstead of sending them as string.\n\nAlso display the type of each parameter, and display the tool's name in\nthe flyout title.\n\nAlso fix https://github.com/elastic/kibana/pull/248213","sha":"d8651e2d8820c9a6823e9cb9e75d016f4933f5d5","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport:version","v9.3.0","v9.4.0"],"title":"[Agent Builder] test tool flyout: add support for array/object params","number":248213,"url":"https://github.com/elastic/kibana/pull/248213","mergeCommit":{"message":"[Agent Builder] test tool flyout: add support for array/object params (#248213)\n\n## Summary\n\nAdd support for array / object parameter in the test flyout by\nJSON-parsing those parameter types before sending them to the server\ninstead of sending them as string.\n\nAlso display the type of each parameter, and display the tool's name in\nthe flyout title.\n\nAlso fix https://github.com/elastic/kibana/pull/248213","sha":"d8651e2d8820c9a6823e9cb9e75d016f4933f5d5"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248213","number":248213,"mergeCommit":{"message":"[Agent Builder] test tool flyout: add support for array/object params (#248213)\n\n## Summary\n\nAdd support for array / object parameter in the test flyout by\nJSON-parsing those parameter types before sending them to the server\ninstead of sending them as string.\n\nAlso display the type of each parameter, and display the tool's name in\nthe flyout title.\n\nAlso fix https://github.com/elastic/kibana/pull/248213","sha":"d8651e2d8820c9a6823e9cb9e75d016f4933f5d5"}}]}] BACKPORT-->