### PR TITLE
[SharedUX] Add feedback and tours to core notifications

### DIFF
--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -45,7 +45,7 @@ Change the settings that apply only to a specific {{product.kibana}} space.
 
 ### General [kibana-general-settings]
 
-$$$hideAnnouncements$$$`hideAnnouncements` {applies_to}`stack: deprecated 9.4` {applies_to}`serverless: unavailable`
+$$$hideAnnouncements$$$`hideAnnouncements` {applies_to}`stack: ga 9.0-9.3, deprecated 9.4+` {applies_to}`serverless: unavailable`
 :   Stops showing messages and tours that highlight new features. `false` by default.
 
 $$$dateformat$$$`dateFormat` {applies_to}`stack: ga` {applies_to}`serverless: unavailable`

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -45,7 +45,7 @@ Change the settings that apply only to a specific {{product.kibana}} space.
 
 ### General [kibana-general-settings]
 
-$$$hideAnnouncements$$$`hideAnnouncements` {applies_to}`stack: ga` {applies_to}`serverless: unavailable`
+$$$hideAnnouncements$$$`hideAnnouncements` {applies_to}`stack: deprecated 9.4` {applies_to}`serverless: unavailable`
 :   Stops showing messages and tours that highlight new features. `false` by default.
 
 $$$dateformat$$$`dateFormat` {applies_to}`stack: ga` {applies_to}`serverless: unavailable`
@@ -647,6 +647,11 @@ Change the settings that apply to all of {{product.kibana}}.
 2. Click **Global Settings**.
 3. Scroll or search for the setting.
 4. Make your change, then click **Save changes**.
+
+### General [kibana-general-global-settings]
+
+$$$hideAnnouncements$$$`hideAnnouncements` {applies_to}`stack: ga` {applies_to}`serverless: unavailable`
+:   Stops showing messages and tours that highlight new features. `false` by default.
 
 
 ### Custom branding [kibana-custom-branding-settings]

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -650,7 +650,7 @@ Change the settings that apply to all of {{product.kibana}}.
 
 ### General [kibana-general-global-settings]
 
-$$$hideAnnouncements$$$`hideAnnouncements` {applies_to}`stack: ga` {applies_to}`serverless: unavailable`
+$$$hideAnnouncements-global$$$`hideAnnouncements` {applies_to}`stack: ga 9.4+` {applies_to}`serverless: unavailable`
 :   Stops showing messages and tours that highlight new features. `false` by default.
 
 

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -46,7 +46,11 @@ Change the settings that apply only to a specific {{product.kibana}} space.
 ### General [kibana-general-settings]
 
 $$$hideAnnouncements$$$`hideAnnouncements` {applies_to}`stack: ga 9.0-9.3, deprecated 9.4+` {applies_to}`serverless: unavailable`
-:   Stops showing messages and tours that highlight new features. `false` by default.
+:   Stops showing messages and tours that highlight new features. `false` by default. 
+    :::{note}
+    :applies_to: stack: ga 9.4+
+    If this setting is set to `false` but the `hideAnnouncements` setting located in the **Global Settings** tab is set to `true`, then messages and tours that highlight new features won't show for the current space.
+    :::
 
 $$$dateformat$$$`dateFormat` {applies_to}`stack: ga` {applies_to}`serverless: unavailable`
 :   The format to use for displaying [pretty formatted dates](https://momentjs.com/docs/#/displaying/format/).

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -14,6 +14,7 @@ import {
   BehaviorSubject,
   combineLatest,
   filter,
+  from,
   map,
   merge,
   mergeMap,
@@ -436,6 +437,10 @@ export class ChromeService {
     const activeDataTestSubj$ = projectNavigation.getActiveDataTestSubj$();
     const feedbackUrlParams$ = projectNavigation.getFeedbackUrlParams$();
 
+    const isFeedbackEnabled = from(
+      getNotifications().then((notifications) => notifications.feedback.isEnabled())
+    );
+
     const navProps: NavigationProps = {
       basePath: http.basePath,
       application,
@@ -451,6 +456,7 @@ export class ChromeService {
       isFeedbackBtnVisible$: this.isFeedbackBtnVisible$,
       feedbackUrlParams$,
       onToggleCollapsed: setIsSideNavCollapsed,
+      isFeedbackEnabled$: isFeedbackEnabled,
     };
 
     const getProjectHeader = ({

--- a/src/core/packages/chrome/browser-internal/src/ui/project/sidenav/navigation/navigation.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/project/sidenav/navigation/navigation.tsx
@@ -44,10 +44,11 @@ export interface ChromeNavigationProps {
 
   // other state that might be needed later
   recentlyAccessed$: Observable<ChromeRecentlyAccessedHistoryItem[]>;
-  isFeedbackBtnVisible$: Observable<boolean>;
   loadingCount$: Observable<number>;
   dataTestSubj$?: Observable<string | undefined>;
 
+  isFeedbackBtnVisible$: Observable<boolean>;
+  isFeedbackEnabled$: Observable<boolean>;
   feedbackUrlParams$: Observable<URLSearchParams | undefined>;
 
   // collapse toggle callback
@@ -58,6 +59,7 @@ export const Navigation = (props: ChromeNavigationProps) => {
   const state = useNavigationItems(props);
   const dataTestSubj = useObservable(props.dataTestSubj$ ?? EMPTY, undefined);
   const feedbackUrlParams = useObservable(props.feedbackUrlParams$ ?? EMPTY, undefined);
+  const isFeedbackEnabled = useObservable(props.isFeedbackEnabled$ ?? EMPTY, true);
 
   if (!state) {
     return null;
@@ -72,6 +74,7 @@ export const Navigation = (props: ChromeNavigationProps) => {
         logo={logoItem}
         sidePanelFooter={
           <NavigationFeedbackSnippet
+            isEnabled={isFeedbackEnabled}
             solutionId={solutionId}
             feedbackUrlParams={feedbackUrlParams}
           />

--- a/src/core/packages/chrome/browser-internal/src/ui/project/sidenav/navigation/navigation_feedback_snippet.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/project/sidenav/navigation/navigation_feedback_snippet.tsx
@@ -13,10 +13,10 @@ import type { SolutionId } from '@kbn/core-chrome-browser';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
-
 export interface NavigationFeedbackSnippetProps {
   solutionId: SolutionId;
   feedbackUrlParams: URLSearchParams | undefined;
+  isEnabled: boolean;
 }
 
 const feedbackSnippetId = 'sideNavigationFeedback';
@@ -58,22 +58,25 @@ const getSurveyFeedbackURL = (
 export const NavigationFeedbackSnippet = ({
   solutionId,
   feedbackUrlParams,
+  isEnabled,
 }: NavigationFeedbackSnippetProps) => {
   const feedbackSurveyUrl = getSurveyFeedbackURL(solutionId, feedbackUrlParams);
   const { euiTheme } = useEuiTheme();
 
   return (
-    <div
-      css={css`
-        border-top: ${euiTheme.border.width.thin} solid ${euiTheme.colors.borderBaseSubdued};
-      `}
-    >
-      <FeedbackSnippet
-        feedbackButtonMessage={feedbackButtonMessage}
-        feedbackSnippetId={feedbackSnippetId}
-        promptViewMessage={promptViewMessage}
-        surveyUrl={feedbackSurveyUrl}
-      />
-    </div>
+    isEnabled && (
+      <div
+        css={css`
+          border-top: ${euiTheme.border.width.thin} solid ${euiTheme.colors.borderBaseSubdued};
+        `}
+      >
+        <FeedbackSnippet
+          feedbackButtonMessage={feedbackButtonMessage}
+          feedbackSnippetId={feedbackSnippetId}
+          promptViewMessage={promptViewMessage}
+          surveyUrl={feedbackSurveyUrl}
+        />
+      </div>
+    )
   );
 };

--- a/src/core/packages/notifications/browser-internal/src/feedback/feedback_service.test.ts
+++ b/src/core/packages/notifications/browser-internal/src/feedback/feedback_service.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { FeedbackService } from './feedback_service';
+import { settingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
+
+describe('FeedbackService', () => {
+  describe('#start()', () => {
+    it('returns a FeedbackStart contract', () => {
+      const service = new FeedbackService();
+      const mockSettings = settingsServiceMock.createStartContract();
+
+      const feedbackStart = service.start({ settings: mockSettings });
+
+      expect(feedbackStart).toBeDefined();
+      expect(feedbackStart.isEnabled).toBeDefined();
+    });
+  });
+
+  describe('isEnabled()', () => {
+    it.each`
+      settingValue | expectedResult
+      ${false}     | ${true}
+      ${true}      | ${false}
+      ${undefined} | ${true}
+    `(
+      'returns $expectedResult when hideFeedback is $settingValue',
+      ({ settingValue, expectedResult }) => {
+        const service = new FeedbackService();
+        const mockSettings = settingsServiceMock.createStartContract();
+        mockSettings.globalClient.get.mockReturnValue(settingValue);
+
+        const feedbackStart = service.start({ settings: mockSettings });
+
+        expect(feedbackStart.isEnabled()).toBe(expectedResult);
+        expect(mockSettings.globalClient.get).toHaveBeenCalledWith('hideFeedback', false);
+      }
+    );
+  });
+});

--- a/src/core/packages/notifications/browser-internal/src/feedback/feedback_service.ts
+++ b/src/core/packages/notifications/browser-internal/src/feedback/feedback_service.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SettingsStart } from '@kbn/core-ui-settings-browser';
+import type { FeedbackStart } from '@kbn/core-notifications-browser';
+
+export interface StartDeps {
+  settings: SettingsStart;
+}
+
+export class FeedbackService {
+  private settings?: SettingsStart;
+
+  public start({ settings }: StartDeps): FeedbackStart {
+    this.settings = settings;
+
+    return {
+      isEnabled: () => {
+        return !this.settings?.globalClient.get<boolean>('hideFeedback', false);
+      },
+    };
+  }
+}

--- a/src/core/packages/notifications/browser-internal/src/feedback/feedback_service.ts
+++ b/src/core/packages/notifications/browser-internal/src/feedback/feedback_service.ts
@@ -10,7 +10,7 @@
 import type { SettingsStart } from '@kbn/core-ui-settings-browser';
 import type { FeedbackStart } from '@kbn/core-notifications-browser';
 
-export interface StartDeps {
+interface StartDeps {
   settings: SettingsStart;
 }
 

--- a/src/core/packages/notifications/browser-internal/src/feedback/index.ts
+++ b/src/core/packages/notifications/browser-internal/src/feedback/index.ts
@@ -7,22 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  ErrorToastOptions,
-  ToastOptions,
-  Toast,
-  ToastInput,
-  IToasts,
-  ToastInputFields,
-  NotificationCoordinator,
-  NotificationCoordinatorState,
-  NotificationCoordinatorPublicApi,
-} from './src/types';
-export type {
-  ToastsSetup,
-  ToastsStart,
-  NotificationsSetup,
-  NotificationsStart,
-} from './src/contracts';
-export type { FeedbackStart } from './src/feedback_types';
-export type { ToursStart } from './src/tours_types';
+export { FeedbackService } from './feedback_service';

--- a/src/core/packages/notifications/browser-internal/src/tours/index.ts
+++ b/src/core/packages/notifications/browser-internal/src/tours/index.ts
@@ -7,22 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  ErrorToastOptions,
-  ToastOptions,
-  Toast,
-  ToastInput,
-  IToasts,
-  ToastInputFields,
-  NotificationCoordinator,
-  NotificationCoordinatorState,
-  NotificationCoordinatorPublicApi,
-} from './src/types';
-export type {
-  ToastsSetup,
-  ToastsStart,
-  NotificationsSetup,
-  NotificationsStart,
-} from './src/contracts';
-export type { FeedbackStart } from './src/feedback_types';
-export type { ToursStart } from './src/tours_types';
+export { ToursService } from './tours_service';

--- a/src/core/packages/notifications/browser-internal/src/tours/tours_service.test.ts
+++ b/src/core/packages/notifications/browser-internal/src/tours/tours_service.test.ts
@@ -19,11 +19,11 @@ describe('ToursService', () => {
       const toursStart = service.start({ settings: mockSettings });
 
       expect(toursStart).toBeDefined();
-      expect(toursStart.areEnabled).toBeDefined();
+      expect(toursStart.isEnabled).toBeDefined();
     });
   });
 
-  describe('areEnabled()', () => {
+  describe('isEnabled()', () => {
     it.each`
       globalSetting | namespaceSetting | expectedResult | description
       ${false}      | ${false}         | ${true}        | ${'both settings are false'}
@@ -41,7 +41,7 @@ describe('ToursService', () => {
 
         const toursStart = service.start({ settings: mockSettings });
 
-        expect(toursStart.areEnabled()).toBe(expectedResult);
+        expect(toursStart.isEnabled()).toBe(expectedResult);
         expect(mockSettings.globalClient.get).toHaveBeenCalledWith('hideAnnouncements', false);
         expect(mockSettings.client.get).toHaveBeenCalledWith('hideAnnouncements', false);
       }

--- a/src/core/packages/notifications/browser-internal/src/tours/tours_service.test.ts
+++ b/src/core/packages/notifications/browser-internal/src/tours/tours_service.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ToursService } from './tours_service';
+import { settingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
+
+describe('ToursService', () => {
+  describe('#start()', () => {
+    it('returns a ToursStart contract', () => {
+      const service = new ToursService();
+      const mockSettings = settingsServiceMock.createStartContract();
+
+      const toursStart = service.start({ settings: mockSettings });
+
+      expect(toursStart).toBeDefined();
+      expect(toursStart.areEnabled).toBeDefined();
+    });
+  });
+
+  describe('areEnabled()', () => {
+    it.each`
+      globalSetting | namespaceSetting | expectedResult | description
+      ${false}      | ${false}         | ${true}        | ${'both settings are false'}
+      ${false}      | ${true}          | ${false}       | ${'namespace setting is true'}
+      ${undefined}  | ${undefined}     | ${true}        | ${'both settings are undefined'}
+    `(
+      'returns $expectedResult when $description',
+      ({ globalSetting, namespaceSetting, expectedResult }) => {
+        const service = new ToursService();
+        const mockSettings = settingsServiceMock.createStartContract();
+        mockSettings.globalClient.get.mockReturnValue(globalSetting);
+        mockSettings.client.get.mockReturnValue(namespaceSetting);
+
+        const toursStart = service.start({ settings: mockSettings });
+
+        expect(toursStart.areEnabled()).toBe(expectedResult);
+        expect(mockSettings.globalClient.get).toHaveBeenCalledWith('hideAnnouncements', false);
+        expect(mockSettings.client.get).toHaveBeenCalledWith('hideAnnouncements', false);
+      }
+    );
+
+    it('returns false and short-circuits when global setting is true', () => {
+      const service = new ToursService();
+      const mockSettings = settingsServiceMock.createStartContract();
+      mockSettings.globalClient.get.mockReturnValue(true);
+
+      const toursStart = service.start({ settings: mockSettings });
+
+      expect(toursStart.areEnabled()).toBe(false);
+      expect(mockSettings.globalClient.get).toHaveBeenCalledWith('hideAnnouncements', false);
+      expect(mockSettings.client.get).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/core/packages/notifications/browser-internal/src/tours/tours_service.test.ts
+++ b/src/core/packages/notifications/browser-internal/src/tours/tours_service.test.ts
@@ -28,6 +28,8 @@ describe('ToursService', () => {
       globalSetting | namespaceSetting | expectedResult | description
       ${false}      | ${false}         | ${true}        | ${'both settings are false'}
       ${false}      | ${true}          | ${false}       | ${'namespace setting is true'}
+      ${true}       | ${false}         | ${false}       | ${'global setting is true'}
+      ${true}       | ${true}          | ${false}       | ${'both settings are true'}
       ${undefined}  | ${undefined}     | ${true}        | ${'both settings are undefined'}
     `(
       'returns $expectedResult when $description',
@@ -44,17 +46,5 @@ describe('ToursService', () => {
         expect(mockSettings.client.get).toHaveBeenCalledWith('hideAnnouncements', false);
       }
     );
-
-    it('returns false and short-circuits when global setting is true', () => {
-      const service = new ToursService();
-      const mockSettings = settingsServiceMock.createStartContract();
-      mockSettings.globalClient.get.mockReturnValue(true);
-
-      const toursStart = service.start({ settings: mockSettings });
-
-      expect(toursStart.areEnabled()).toBe(false);
-      expect(mockSettings.globalClient.get).toHaveBeenCalledWith('hideAnnouncements', false);
-      expect(mockSettings.client.get).not.toHaveBeenCalled();
-    });
   });
 });

--- a/src/core/packages/notifications/browser-internal/src/tours/tours_service.ts
+++ b/src/core/packages/notifications/browser-internal/src/tours/tours_service.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SettingsStart } from '@kbn/core-ui-settings-browser';
+import type { ToursStart } from '@kbn/core-notifications-browser';
+
+export interface StartDeps {
+  settings: SettingsStart;
+}
+
+export class ToursService {
+  private settings?: SettingsStart;
+
+  public start({ settings }: StartDeps): ToursStart {
+    this.settings = settings;
+
+    return {
+      areEnabled: () => {
+        return (
+          !this.settings?.globalClient.get<boolean>('hideAnnouncements', false) &&
+          !this.settings?.client.get<boolean>('hideAnnouncements', false)
+        );
+      },
+    };
+  }
+}

--- a/src/core/packages/notifications/browser-internal/src/tours/tours_service.ts
+++ b/src/core/packages/notifications/browser-internal/src/tours/tours_service.ts
@@ -10,7 +10,7 @@
 import type { SettingsStart } from '@kbn/core-ui-settings-browser';
 import type { ToursStart } from '@kbn/core-notifications-browser';
 
-export interface StartDeps {
+interface StartDeps {
   settings: SettingsStart;
 }
 

--- a/src/core/packages/notifications/browser-internal/src/tours/tours_service.ts
+++ b/src/core/packages/notifications/browser-internal/src/tours/tours_service.ts
@@ -22,10 +22,15 @@ export class ToursService {
 
     return {
       areEnabled: () => {
-        return (
-          !this.settings?.globalClient.get<boolean>('hideAnnouncements', false) &&
-          !this.settings?.client.get<boolean>('hideAnnouncements', false)
+        const isEnabledGlobally = !this.settings?.globalClient.get<boolean>(
+          'hideAnnouncements',
+          false
         );
+        const isEnabledInNamespace = !this.settings?.client.get<boolean>(
+          'hideAnnouncements',
+          false
+        );
+        return isEnabledGlobally && isEnabledInNamespace;
       },
     };
   }

--- a/src/core/packages/notifications/browser-internal/src/tours/tours_service.ts
+++ b/src/core/packages/notifications/browser-internal/src/tours/tours_service.ts
@@ -21,7 +21,7 @@ export class ToursService {
     this.settings = settings;
 
     return {
-      areEnabled: () => {
+      isEnabled: () => {
         const isEnabledGlobally = !this.settings?.globalClient.get<boolean>(
           'hideAnnouncements',
           false

--- a/src/core/packages/notifications/browser-mocks/src/feedback_service.mock.ts
+++ b/src/core/packages/notifications/browser-mocks/src/feedback_service.mock.ts
@@ -7,22 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  ErrorToastOptions,
-  ToastOptions,
-  Toast,
-  ToastInput,
-  IToasts,
-  ToastInputFields,
-  NotificationCoordinator,
-  NotificationCoordinatorState,
-  NotificationCoordinatorPublicApi,
-} from './src/types';
-export type {
-  ToastsSetup,
-  ToastsStart,
-  NotificationsSetup,
-  NotificationsStart,
-} from './src/contracts';
-export type { FeedbackStart } from './src/feedback_types';
-export type { ToursStart } from './src/tours_types';
+import type { FeedbackStart } from '@kbn/core-notifications-browser';
+
+const createStartContract = (): jest.Mocked<FeedbackStart> => {
+  return {
+    isEnabled: jest.fn().mockReturnValue(true),
+  };
+};
+
+export const feedbackServiceMock = {
+  createStartContract,
+};

--- a/src/core/packages/notifications/browser-mocks/src/notifications_service.mock.ts
+++ b/src/core/packages/notifications/browser-mocks/src/notifications_service.mock.ts
@@ -10,6 +10,8 @@
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
 import type { NotificationsSetup, NotificationsStart } from '@kbn/core-notifications-browser';
 import { toastsServiceMock } from './toasts_service.mock';
+import { feedbackServiceMock } from './feedback_service.mock';
+import { toursServiceMock } from './tours_service.mock';
 import { createNotificationCoordinatorMock } from './notification_coordinator.mock';
 
 import { lazyObject } from '@kbn/lazy-object';
@@ -28,6 +30,8 @@ const createStartContractMock = () => {
     // we have to suppress type errors until decide how to mock es6 class
     toasts: toastsServiceMock.createStartContract(),
     showErrorDialog: jest.fn(),
+    feedback: feedbackServiceMock.createStartContract(),
+    tours: toursServiceMock.createStartContract(),
   });
   return startContract;
 };

--- a/src/core/packages/notifications/browser-mocks/src/tours_service.mock.ts
+++ b/src/core/packages/notifications/browser-mocks/src/tours_service.mock.ts
@@ -11,7 +11,7 @@ import type { ToursStart } from '@kbn/core-notifications-browser';
 
 const createStartContract = (): jest.Mocked<ToursStart> => {
   return {
-    areEnabled: jest.fn().mockReturnValue(true),
+    isEnabled: jest.fn().mockReturnValue(true),
   };
 };
 

--- a/src/core/packages/notifications/browser-mocks/src/tours_service.mock.ts
+++ b/src/core/packages/notifications/browser-mocks/src/tours_service.mock.ts
@@ -7,22 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  ErrorToastOptions,
-  ToastOptions,
-  Toast,
-  ToastInput,
-  IToasts,
-  ToastInputFields,
-  NotificationCoordinator,
-  NotificationCoordinatorState,
-  NotificationCoordinatorPublicApi,
-} from './src/types';
-export type {
-  ToastsSetup,
-  ToastsStart,
-  NotificationsSetup,
-  NotificationsStart,
-} from './src/contracts';
-export type { FeedbackStart } from './src/feedback_types';
-export type { ToursStart } from './src/tours_types';
+import type { ToursStart } from '@kbn/core-notifications-browser';
+
+const createStartContract = (): jest.Mocked<ToursStart> => {
+  return {
+    areEnabled: jest.fn().mockReturnValue(true),
+  };
+};
+
+export const toursServiceMock = {
+  createStartContract,
+};

--- a/src/core/packages/notifications/browser/src/contracts.ts
+++ b/src/core/packages/notifications/browser/src/contracts.ts
@@ -8,6 +8,8 @@
  */
 
 import type { IToasts, NotificationCoordinator } from './types';
+import type { FeedbackStart } from './feedback_types';
+import type { ToursStart } from './tours_types';
 
 /**
  * {@link IToasts}
@@ -36,4 +38,15 @@ export interface NotificationsStart {
   /** {@link ToastsStart} */
   toasts: ToastsStart;
   showErrorDialog: (options: { title: string; error: Error }) => void;
+  /**
+   * Controls visibility of feedback elements
+   * @public
+   */
+  feedback: FeedbackStart;
+
+  /**
+   * Controls visibility of guided tours
+   * @public
+   */
+  tours: ToursStart;
 }

--- a/src/core/packages/notifications/browser/src/feedback_types.ts
+++ b/src/core/packages/notifications/browser/src/feedback_types.ts
@@ -7,6 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+/**
+ * Exposes public API of the Feedback service during the start phase.
+ * @public
+ */
 export interface FeedbackStart {
   /**
    * Returns whether feedback elements are allowed to be shown.

--- a/src/core/packages/notifications/browser/src/feedback_types.ts
+++ b/src/core/packages/notifications/browser/src/feedback_types.ts
@@ -7,22 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  ErrorToastOptions,
-  ToastOptions,
-  Toast,
-  ToastInput,
-  IToasts,
-  ToastInputFields,
-  NotificationCoordinator,
-  NotificationCoordinatorState,
-  NotificationCoordinatorPublicApi,
-} from './src/types';
-export type {
-  ToastsSetup,
-  ToastsStart,
-  NotificationsSetup,
-  NotificationsStart,
-} from './src/contracts';
-export type { FeedbackStart } from './src/feedback_types';
-export type { ToursStart } from './src/tours_types';
+export interface FeedbackStart {
+  /**
+   * Returns whether feedback elements are allowed to be shown.
+   */
+  isEnabled(): boolean;
+}

--- a/src/core/packages/notifications/browser/src/tours_types.ts
+++ b/src/core/packages/notifications/browser/src/tours_types.ts
@@ -15,5 +15,5 @@ export interface ToursStart {
   /**
    * Returns whether guided tours are allowed to be shown.
    */
-  areEnabled(): boolean;
+  isEnabled(): boolean;
 }

--- a/src/core/packages/notifications/browser/src/tours_types.ts
+++ b/src/core/packages/notifications/browser/src/tours_types.ts
@@ -7,22 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  ErrorToastOptions,
-  ToastOptions,
-  Toast,
-  ToastInput,
-  IToasts,
-  ToastInputFields,
-  NotificationCoordinator,
-  NotificationCoordinatorState,
-  NotificationCoordinatorPublicApi,
-} from './src/types';
-export type {
-  ToastsSetup,
-  ToastsStart,
-  NotificationsSetup,
-  NotificationsStart,
-} from './src/contracts';
-export type { FeedbackStart } from './src/feedback_types';
-export type { ToursStart } from './src/tours_types';
+export interface ToursStart {
+  /**
+   * Returns whether guided tours are allowed to be shown.
+   */
+  areEnabled(): boolean;
+}

--- a/src/core/packages/notifications/browser/src/tours_types.ts
+++ b/src/core/packages/notifications/browser/src/tours_types.ts
@@ -7,6 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+/**
+ * Exposes public API of the Tours service during the start phase.
+ * @public
+ */
 export interface ToursStart {
   /**
    * Returns whether guided tours are allowed to be shown.

--- a/src/core/packages/root/browser-internal/src/core_system.test.ts
+++ b/src/core/packages/root/browser-internal/src/core_system.test.ts
@@ -481,6 +481,7 @@ describe('#start()', () => {
       targetDomElement: expect.any(HTMLElement),
       analytics: expect.any(Object),
       rendering: expect.any(Object),
+      settings: expect.any(Object),
     });
   });
 

--- a/src/core/packages/root/browser-internal/src/core_system.ts
+++ b/src/core/packages/root/browser-internal/src/core_system.ts
@@ -397,6 +397,7 @@ export class CoreSystem {
         overlays,
         targetDomElement: notificationsTargetDomElement,
         rendering,
+        settings,
       });
 
       resolveNotifications!(notifications);

--- a/src/core/packages/ui-settings/browser-mocks/src/settings_service.mock.ts
+++ b/src/core/packages/ui-settings/browser-mocks/src/settings_service.mock.ts
@@ -18,14 +18,17 @@ const createSetupContractMock = () => {
   });
 };
 
+const createStartContractMock = createSetupContractMock;
+
 const createMock = () => {
   const mocked = serviceContractMock();
   mocked.setup.mockReturnValue(createSetupContractMock());
+  mocked.start.mockReturnValue(createStartContractMock());
   return mocked;
 };
 
 export const settingsServiceMock = {
   create: createMock,
   createSetupContract: createSetupContractMock,
-  createStartContract: createSetupContractMock,
+  createStartContract: createStartContractMock,
 };

--- a/src/core/packages/ui-settings/server-internal/src/settings/announcements.test.ts
+++ b/src/core/packages/ui-settings/server-internal/src/settings/announcements.test.ts
@@ -8,7 +8,7 @@
  */
 
 import type { UiSettingsParams } from '@kbn/core-ui-settings-common';
-import { getAnnouncementsSettings } from './announcements';
+import { getAnnouncementsSettings, getGlobalAnnouncementsSettings } from './announcements';
 
 describe('announcements settings', () => {
   const state = getAnnouncementsSettings();
@@ -28,6 +28,47 @@ describe('announcements settings', () => {
       expect(() => validate(12)).toThrowErrorMatchingInlineSnapshot(
         `"expected value of type [boolean] but got [number]"`
       );
+    });
+  });
+});
+
+describe('global announcements settings', () => {
+  const state = getGlobalAnnouncementsSettings();
+
+  const getValidationFn = (setting: UiSettingsParams) => (value: any) =>
+    setting.schema.validate(value);
+
+  describe('hideAnnouncements', () => {
+    const validate = getValidationFn(state.hideAnnouncements);
+
+    it('should only accept boolean values', () => {
+      expect(() => validate(true)).not.toThrow();
+      expect(() => validate(false)).not.toThrow();
+      expect(() => validate('foo')).toThrowErrorMatchingInlineSnapshot(
+        `"expected value of type [boolean] but got [string]"`
+      );
+      expect(() => validate(12)).toThrowErrorMatchingInlineSnapshot(
+        `"expected value of type [boolean] but got [number]"`
+      );
+    });
+  });
+
+  describe('hideFeedback', () => {
+    const validate = getValidationFn(state.hideFeedback);
+
+    it('should only accept boolean values', () => {
+      expect(() => validate(true)).not.toThrow();
+      expect(() => validate(false)).not.toThrow();
+      expect(() => validate('foo')).toThrowErrorMatchingInlineSnapshot(
+        `"expected value of type [boolean] but got [string]"`
+      );
+      expect(() => validate(12)).toThrowErrorMatchingInlineSnapshot(
+        `"expected value of type [boolean] but got [number]"`
+      );
+    });
+
+    it('should be readonly', () => {
+      expect(state.hideFeedback.readonly).toBe(true);
     });
   });
 });

--- a/src/core/packages/ui-settings/server-internal/src/settings/announcements.ts
+++ b/src/core/packages/ui-settings/server-internal/src/settings/announcements.ts
@@ -21,7 +21,42 @@ export const getAnnouncementsSettings = (): Record<string, UiSettingsParams> => 
       description: i18n.translate('core.ui_settings.params.hideAnnouncementsText', {
         defaultMessage: 'Stop showing messages and tours that highlight new features.',
       }),
+      deprecation: {
+        message: i18n.translate('core.ui_settings.params.hideAnnouncementsDeprecation', {
+          defaultMessage:
+            'This setting is deprecated and will be removed in Kibana 10.0. Use the global setting "Hide announcements" instead.',
+        }),
+        docLinksKey: 'uiSettings',
+      },
       schema: schema.boolean(),
+    },
+  };
+};
+
+export const getGlobalAnnouncementsSettings = (): Record<string, UiSettingsParams> => {
+  return {
+    hideAnnouncements: {
+      name: i18n.translate('core.ui_settings.params.hideAnnouncementsGlobal', {
+        defaultMessage: 'Hide announcements',
+      }),
+      value: false,
+      description: i18n.translate('core.ui_settings.params.hideAnnouncementsGlobalText', {
+        defaultMessage: 'Stop showing messages and tours that highlight new features.',
+      }),
+      schema: schema.boolean(),
+      scope: 'global',
+    },
+    hideFeedback: {
+      name: i18n.translate('core.ui_settings.params.hideFeedback', {
+        defaultMessage: 'Hide feedback',
+      }),
+      value: false,
+      description: i18n.translate('core.ui_settings.params.hideFeedbackText', {
+        defaultMessage: 'Stop showing elements requesting user feedback.',
+      }),
+      schema: schema.boolean(),
+      scope: 'global',
+      readonly: true,
     },
   };
 };

--- a/src/core/packages/ui-settings/server-internal/src/settings/index.ts
+++ b/src/core/packages/ui-settings/server-internal/src/settings/index.ts
@@ -14,7 +14,7 @@ import { getMiscUiSettings } from './misc';
 import { getNotificationsSettings } from './notifications';
 import { getThemeSettings } from './theme';
 import { getStateSettings } from './state';
-import { getAnnouncementsSettings } from './announcements';
+import { getAnnouncementsSettings, getGlobalAnnouncementsSettings } from './announcements';
 
 export interface GetCoreSettingsOptions {
   isDist: boolean;
@@ -33,5 +33,11 @@ export const getCoreSettings = (
     ...getNotificationsSettings(),
     ...getThemeSettings(options),
     ...getStateSettings(),
+  };
+};
+
+export const getGlobalCoreSettings = (): Record<string, UiSettingsParams> => {
+  return {
+    ...getGlobalAnnouncementsSettings(),
   };
 };

--- a/src/core/packages/ui-settings/server-internal/src/ui_settings_config.ts
+++ b/src/core/packages/ui-settings/server-internal/src/ui_settings_config.ts
@@ -26,6 +26,7 @@ export const defaultThemeSchema = schema.oneOf([
 
 const configSchema = schema.object({
   overrides: schema.object({}, { unknowns: 'allow' }),
+  globalOverrides: schema.object({}, { unknowns: 'allow' }),
   publicApiEnabled: offeringBasedSchema({ serverless: schema.boolean({ defaultValue: false }) }),
   experimental: schema.maybe(
     schema.object({

--- a/src/core/packages/ui-settings/server-internal/src/ui_settings_service.test.mock.ts
+++ b/src/core/packages/ui-settings/server-internal/src/ui_settings_service.test.mock.ts
@@ -23,6 +23,8 @@ jest.doMock('./clients/ui_settings_defaults_client', () => ({
 }));
 
 export const getCoreSettingsMock = jest.fn();
+export const getCoreGlobalSettingsMock = jest.fn();
 jest.doMock('./settings', () => ({
   getCoreSettings: getCoreSettingsMock,
+  getGlobalCoreSettings: getCoreGlobalSettingsMock,
 }));

--- a/src/core/packages/ui-settings/server-internal/src/ui_settings_service.test.ts
+++ b/src/core/packages/ui-settings/server-internal/src/ui_settings_service.test.ts
@@ -17,6 +17,7 @@ import {
   MockUiSettingsGlobalClientConstructor,
   MockUiSettingsDefaultsClientConstructor,
   getCoreSettingsMock,
+  getCoreGlobalSettingsMock,
 } from './ui_settings_service.test.mock';
 import type { SetupDeps } from './ui_settings_service';
 import { UiSettingsService } from './ui_settings_service';
@@ -46,7 +47,9 @@ describe('uiSettings', () => {
 
   beforeEach(() => {
     const coreContext = mockCoreContext.create();
-    coreContext.configService.atPath.mockReturnValue(new BehaviorSubject({ overrides }));
+    coreContext.configService.atPath.mockReturnValue(
+      new BehaviorSubject({ overrides, globalOverrides: {} })
+    );
     const httpSetup = httpServiceMock.createInternalSetupContract();
     const savedObjectsSetup = savedObjectsServiceMock.createInternalSetupContract();
     setupDeps = { http: httpSetup, savedObjects: savedObjectsSetup };
@@ -58,6 +61,7 @@ describe('uiSettings', () => {
     MockUiSettingsClientConstructor.mockClear();
     MockUiSettingsGlobalClientConstructor.mockClear();
     getCoreSettingsMock.mockClear();
+    getCoreGlobalSettingsMock.mockClear();
   });
 
   describe('#preboot', () => {
@@ -197,6 +201,7 @@ describe('uiSettings', () => {
             overrides: {
               custom: 42,
             },
+            globalOverrides: {},
           })
         );
         const customizedService = new UiSettingsService(coreContext);
@@ -220,6 +225,7 @@ describe('uiSettings', () => {
             overrides: {
               custom: 42,
             },
+            globalOverrides: {},
           })
         );
         const customizedService = new UiSettingsService(coreContext);

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -47,7 +47,12 @@ export type {
   PublicUiSettingsParams,
 } from '@kbn/core-ui-settings-browser';
 export type { Capabilities } from '@kbn/core-capabilities-common';
-export type { NotificationsSetup, NotificationsStart } from '@kbn/core-notifications-browser';
+export type {
+  NotificationsSetup,
+  NotificationsStart,
+  FeedbackStart,
+  ToursStart,
+} from '@kbn/core-notifications-browser';
 export type {
   ChromeBadge,
   ChromeBreadcrumb,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/core_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/core_fixtures.ts
@@ -253,9 +253,6 @@ export const coreWorkerFixtures = base.extend<{}, CoreWorkerFixtures>({
         return { cookieValue, cookieHeader };
       };
 
-      // Hide the announcements (including the sidenav tour) in the default space
-      await kbnClient.uiSettings.update({ hideAnnouncements: true });
-
       await use({
         session,
         customRoleName,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/core_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/core_fixtures.ts
@@ -253,6 +253,10 @@ export const coreWorkerFixtures = base.extend<{}, CoreWorkerFixtures>({
         return { cookieValue, cookieHeader };
       };
 
+      // TODO: rely on global setting before https://github.com/elastic/kibana/issues/248983
+      // Hide announcements (e.g. tours) in the default space
+      await kbnClient.uiSettings.update({ hideAnnouncements: true });
+
       await use({
         session,
         customRoleName,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/scout_space/parallel.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/scout_space/parallel.ts
@@ -126,14 +126,6 @@ export const scoutSpaceParallelFixture = coreWorkerFixtures.extend<
         setDefaultTime,
       };
 
-      /**
-       * To hide the sidenav tour we need to enable 'hideAnnouncements' setting
-       * It should hide both space tour and sidenav tour.
-       * Currently it can be set only per space, so we set it right after new space is created.
-       * TODO: update if setting becomes global https://github.com/elastic/kibana/issues/234771
-       */
-      await kbnClient.uiSettings.update({ hideAnnouncements: true }, { space: spaceId });
-
       log.serviceMessage('scoutSpace', `New Kibana space '${spaceId}' created`);
       await use({ savedObjects, uiSettings, id: spaceId });
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/scout_space/parallel.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/scout_space/parallel.ts
@@ -126,6 +126,10 @@ export const scoutSpaceParallelFixture = coreWorkerFixtures.extend<
         setDefaultTime,
       };
 
+      // TODO: rely on global setting before https://github.com/elastic/kibana/issues/248983
+      // Hide announcements (e.g. tours) in the current space
+      await kbnClient.uiSettings.update({ hideAnnouncements: true }, { space: spaceId });
+
       log.serviceMessage('scoutSpace', `New Kibana space '${spaceId}' created`);
       await use({ savedObjects, uiSettings, id: spaceId });
 

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/default/serverless/serverless.base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/default/serverless/serverless.base.config.ts
@@ -192,6 +192,8 @@ export const defaultConfig: ScoutServerConfig = {
           hosts: ['https://localhost:9200'],
         },
       ])}`,
+      // Disable tours globally for all tests
+      '--uiSettings.globalOverrides.hideAnnouncements=true',
     ],
   },
 };

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/default/serverless/serverless.base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/default/serverless/serverless.base.config.ts
@@ -192,8 +192,6 @@ export const defaultConfig: ScoutServerConfig = {
           hosts: ['https://localhost:9200'],
         },
       ])}`,
-      // Disable tours globally for all tests
-      '--uiSettings.globalOverrides.hideAnnouncements=true',
     ],
   },
 };

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/default/stateful/base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/default/stateful/base.config.ts
@@ -221,8 +221,6 @@ export const defaultConfig: ScoutServerConfig = {
       `--server.publicBaseUrl=${kbnUrl}`,
       // Allow dynamic config overrides in tests
       `--coreApp.allowDynamicConfigOverrides=true`,
-      // Disable tours globally for all tests
-      '--uiSettings.globalOverrides.hideAnnouncements=true',
     ],
   },
 };

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/default/stateful/base.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/default/stateful/base.config.ts
@@ -221,6 +221,8 @@ export const defaultConfig: ScoutServerConfig = {
       `--server.publicBaseUrl=${kbnUrl}`,
       // Allow dynamic config overrides in tests
       `--coreApp.allowDynamicConfigOverrides=true`,
+      // Disable tours globally for all tests
+      '--uiSettings.globalOverrides.hideAnnouncements=true',
     ],
   },
 };

--- a/src/platform/test/functional/apps/discover/group1/_date_nanos_mixed.ts
+++ b/src/platform/test/functional/apps/discover/group1/_date_nanos_mixed.ts
@@ -31,7 +31,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       );
       await kibanaServer.uiSettings.replace({
         defaultIndex: 'timestamp-*',
-        hideAnnouncements: true, // should be enough vertical space to render rows
       });
       await browser.setWindowSize(1200, 900);
       await security.testUser.setRoles(['kibana_admin', 'kibana_date_nanos_mixed']);

--- a/src/platform/test/functional/apps/discover/group10/_lens_vis.ts
+++ b/src/platform/test/functional/apps/discover/group10/_lens_vis.ts
@@ -28,7 +28,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const security = getService('security');
   const defaultSettings = {
     defaultIndex: 'logstash-*',
-    hideAnnouncements: true,
   };
 
   const defaultTimespan =

--- a/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_field_tokens.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid2/_data_grid_field_tokens.ts
@@ -29,7 +29,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const security = getService('security');
   const defaultSettings = {
     defaultIndex: 'logstash-*',
-    hideAnnouncements: true,
   };
 
   async function findFirstColumnTokens() {

--- a/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_pagination.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_pagination.ts
@@ -106,7 +106,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         ...defaultSettings,
         'discover:sampleSize': 12,
         'discover:sampleRowsPerPage': 6,
-        hideAnnouncements: true,
       });
 
       // first render is based on settings value
@@ -158,7 +157,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await kibanaServer.uiSettings.update({
         ...defaultSettings,
         'discover:sampleRowsPerPage': rowsPerPage,
-        hideAnnouncements: true,
       });
 
       await common.navigateToApp('discover');

--- a/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_row_selection.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_row_selection.ts
@@ -31,7 +31,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const defaultSettings = {
     defaultIndex: 'logstash-*',
     'discover:sampleRowsPerPage': PAGE_SIZE,
-    hideAnnouncements: true,
   };
 
   describe('discover data grid row selection', function describeIndexTests() {

--- a/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_sample_size.ts
+++ b/src/platform/test/functional/apps/discover/group2_data_grid3/_data_grid_sample_size.ts
@@ -39,7 +39,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'discover:sampleSize': DEFAULT_SAMPLE_SIZE,
     'discover:rowHeightOption': 0, // single line
     'discover:sampleRowsPerPage': DEFAULT_ROWS_PER_PAGE,
-    hideAnnouncements: true,
   };
 
   describe('discover data grid sample size', function describeIndexTests() {

--- a/src/platform/test/functional/apps/discover/group3/_default_columns.ts
+++ b/src/platform/test/functional/apps/discover/group3/_default_columns.ts
@@ -25,7 +25,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const defaultSettings = {
     defaultIndex: 'logstash-*',
     defaultColumns: ['message', 'extension', 'DestCountry'],
-    hideAnnouncements: true,
   };
 
   describe('discover default columns', function () {

--- a/src/platform/test/functional/apps/discover/group5/_url_state.ts
+++ b/src/platform/test/functional/apps/discover/group5/_url_state.ts
@@ -32,7 +32,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   const defaultSettings = {
     defaultIndex: 'logstash-*',
-    hideAnnouncements: true,
   };
 
   describe('discover URL state', () => {

--- a/src/platform/test/functional/apps/discover/group6/_time_field_column.ts
+++ b/src/platform/test/functional/apps/discover/group6/_time_field_column.ts
@@ -36,7 +36,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const security = getService('security');
   const defaultSettings = {
     defaultIndex: 'logstash-*',
-    hideAnnouncements: true,
   };
 
   describe('discover time field column', function () {

--- a/src/platform/test/functional/apps/discover/group6/_unsaved_changes_badge.ts
+++ b/src/platform/test/functional/apps/discover/group6/_unsaved_changes_badge.ts
@@ -32,7 +32,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const security = getService('security');
   const defaultSettings = {
     defaultIndex: 'logstash-*',
-    hideAnnouncements: true,
   };
 
   describe('discover unsaved changes badge', function describeIndexTests() {

--- a/src/platform/test/functional/apps/discover/group6/_unsaved_changes_modal.ts
+++ b/src/platform/test/functional/apps/discover/group6/_unsaved_changes_modal.ts
@@ -24,7 +24,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const security = getService('security');
   const defaultSettings = {
     defaultIndex: 'logstash-*',
-    hideAnnouncements: true,
   };
 
   describe('discover unsaved changes modal', function describeIndexTests() {

--- a/src/platform/test/functional/apps/discover/group9/_doc_viewer.ts
+++ b/src/platform/test/functional/apps/discover/group9/_doc_viewer.ts
@@ -41,7 +41,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       );
       await kibanaServer.uiSettings.replace({
         defaultIndex: 'logstash-*',
-        hideAnnouncements: true,
       });
       await timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await common.navigateToApp('discover');

--- a/src/platform/test/functional/apps/discover/group9/_panels_toggle.ts
+++ b/src/platform/test/functional/apps/discover/group9/_panels_toggle.ts
@@ -26,7 +26,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const security = getService('security');
   const defaultSettings = {
     defaultIndex: 'logstash-*',
-    hideAnnouncements: true,
   };
 
   describe('discover panels toggle', function () {

--- a/src/platform/test/functional/config.base.js
+++ b/src/platform/test/functional/config.base.js
@@ -42,6 +42,8 @@ export default async function ({ readConfigFile }) {
 
         // disable fleet task that writes to metrics.fleet_server.* data streams, impacting functional tests
         `--xpack.task_manager.unsafe.exclude_task_types=${JSON.stringify(['Fleet-Metrics-Task'])}`,
+        // disable tours globally for all tests
+        '--uiSettings.globalOverrides.hideAnnouncements=true',
       ],
     },
 

--- a/x-pack/platform/plugins/shared/fleet/.storybook/context/notifications.ts
+++ b/x-pack/platform/plugins/shared/fleet/.storybook/context/notifications.ts
@@ -27,6 +27,12 @@ const notifications: NotificationsStart = {
     get$: () => of([]),
   },
   showErrorDialog: () => {},
+  feedback: {
+    isEnabled: () => true,
+  },
+  tours: {
+    areEnabled: () => true,
+  },
 };
 
 export const getNotifications = () => notifications;

--- a/x-pack/platform/plugins/shared/fleet/.storybook/context/notifications.ts
+++ b/x-pack/platform/plugins/shared/fleet/.storybook/context/notifications.ts
@@ -31,7 +31,7 @@ const notifications: NotificationsStart = {
     isEnabled: () => true,
   },
   tours: {
-    areEnabled: () => true,
+    isEnabled: () => true,
   },
 };
 

--- a/x-pack/platform/plugins/shared/fleet/cypress/e2e/agents/agent_list.cy.ts
+++ b/x-pack/platform/plugins/shared/fleet/cypress/e2e/agents/agent_list.cy.ts
@@ -12,7 +12,6 @@ import { FLEET_AGENT_LIST_PAGE } from '../../screens/fleet';
 import { createAgentDoc } from '../../tasks/agents';
 import { setupFleetServer } from '../../tasks/fleet_server';
 import { deleteAgentDocs, cleanupAgentPolicies } from '../../tasks/cleanup';
-import { setUISettings } from '../../tasks/ui_settings';
 
 import { request } from '../../tasks/common';
 import { login } from '../../tasks/login';
@@ -98,7 +97,6 @@ describe('View agents list', () => {
     deleteAgentDocs(true);
     cleanupAgentPolicies();
     setupFleetServer();
-    setUISettings('hideAnnouncements', true);
 
     cy.getKibanaVersion().then((version) => {
       docs = createAgentDocs(version);

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_dismissable_tour.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_dismissable_tour.test.ts
@@ -41,8 +41,8 @@ describe('useDismissableTour', () => {
     expect(storageValue.active).toEqual(false);
   });
 
-  it('should not display the tour if hideAnnouncements:true', () => {
-    jest.mocked(startServices.uiSettings.get).mockReturnValue(true);
+  it('should not display the tour if tours are disabled', () => {
+    jest.mocked(startServices.notifications.tours.areEnabled).mockReturnValue(false);
     const res = renderHook(() => useDismissableTour('GRANULAR_PRIVILEGES'));
 
     expect(res.result.current.isHidden).toBe(true);

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_dismissable_tour.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_dismissable_tour.test.ts
@@ -42,7 +42,7 @@ describe('useDismissableTour', () => {
   });
 
   it('should not display the tour if tours are disabled', () => {
-    jest.mocked(startServices.notifications.tours.areEnabled).mockReturnValue(false);
+    jest.mocked(startServices.notifications.tours.isEnabled).mockReturnValue(false);
     const res = renderHook(() => useDismissableTour('GRANULAR_PRIVILEGES'));
 
     expect(res.result.current.isHidden).toBe(true);

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_dismissable_tour.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_dismissable_tour.ts
@@ -19,11 +19,11 @@ import { useTourManager } from './use_tour_manager';
  * @param enabled - Additional condition that must be true for the tour to show
  */
 export function useDismissableTour(tourKey: TourKey, enabled: boolean = true) {
-  const { storage, uiSettings } = useStartServices();
+  const { storage, notifications } = useStartServices();
   const { activeTour, setActiveTour } = useTourManager();
 
   const defaultValue =
-    uiSettings.get('hideAnnouncements', false) ||
+    !notifications.tours.areEnabled() ||
     (storage.get(TOUR_STORAGE_KEYS[tourKey]) as TourConfig | undefined)?.active === false;
 
   const [isHidden, setIsHidden] = React.useState(defaultValue);

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_dismissable_tour.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_dismissable_tour.ts
@@ -23,7 +23,7 @@ export function useDismissableTour(tourKey: TourKey, enabled: boolean = true) {
   const { activeTour, setActiveTour } = useTourManager();
 
   const defaultValue =
-    !notifications.tours.areEnabled() ||
+    !notifications.tours.isEnabled() ||
     (storage.get(TOUR_STORAGE_KEYS[tourKey]) as TourConfig | undefined)?.active === false;
 
   const [isHidden, setIsHidden] = React.useState(defaultValue);

--- a/x-pack/platform/plugins/shared/security/public/authentication/login/__snapshots__/login_page.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/__snapshots__/login_page.test.tsx.snap
@@ -185,6 +185,9 @@ exports[`LoginPage enabled form state renders as expected 1`] = `
   loginAssistanceMessage=""
   notifications={
     Object {
+      "feedback": Object {
+        "isEnabled": [MockFunction],
+      },
       "showErrorDialog": [MockFunction],
       "toasts": Object {
         "add": [MockFunction],
@@ -195,6 +198,9 @@ exports[`LoginPage enabled form state renders as expected 1`] = `
         "addWarning": [MockFunction],
         "get$": [MockFunction],
         "remove": [MockFunction],
+      },
+      "tours": Object {
+        "areEnabled": [MockFunction],
       },
     }
   }
@@ -224,6 +230,9 @@ exports[`LoginPage enabled form state renders as expected when loginAssistanceMe
   loginAssistanceMessage="This is an *important* message"
   notifications={
     Object {
+      "feedback": Object {
+        "isEnabled": [MockFunction],
+      },
       "showErrorDialog": [MockFunction],
       "toasts": Object {
         "add": [MockFunction],
@@ -234,6 +243,9 @@ exports[`LoginPage enabled form state renders as expected when loginAssistanceMe
         "addWarning": [MockFunction],
         "get$": [MockFunction],
         "remove": [MockFunction],
+      },
+      "tours": Object {
+        "areEnabled": [MockFunction],
       },
     }
   }
@@ -264,6 +276,9 @@ exports[`LoginPage enabled form state renders as expected when loginHelp is set 
   loginHelp="**some-help**"
   notifications={
     Object {
+      "feedback": Object {
+        "isEnabled": [MockFunction],
+      },
       "showErrorDialog": [MockFunction],
       "toasts": Object {
         "add": [MockFunction],
@@ -274,6 +289,9 @@ exports[`LoginPage enabled form state renders as expected when loginHelp is set 
         "addWarning": [MockFunction],
         "get$": [MockFunction],
         "remove": [MockFunction],
+      },
+      "tours": Object {
+        "areEnabled": [MockFunction],
       },
     }
   }

--- a/x-pack/platform/plugins/shared/security/public/authentication/login/__snapshots__/login_page.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/__snapshots__/login_page.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`LoginPage enabled form state renders as expected 1`] = `
         "remove": [MockFunction],
       },
       "tours": Object {
-        "areEnabled": [MockFunction],
+        "isEnabled": [MockFunction],
       },
     }
   }
@@ -245,7 +245,7 @@ exports[`LoginPage enabled form state renders as expected when loginAssistanceMe
         "remove": [MockFunction],
       },
       "tours": Object {
-        "areEnabled": [MockFunction],
+        "isEnabled": [MockFunction],
       },
     }
   }
@@ -291,7 +291,7 @@ exports[`LoginPage enabled form state renders as expected when loginHelp is set 
         "remove": [MockFunction],
       },
       "tours": Object {
-        "areEnabled": [MockFunction],
+        "isEnabled": [MockFunction],
       },
     }
   }

--- a/x-pack/platform/plugins/shared/security/public/authentication/login/components/login_form/__snapshots__/login_form.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/components/login_form/__snapshots__/login_form.test.tsx.snap
@@ -2573,7 +2573,7 @@ exports[`LoginForm renders as expected 1`] = `
                     "remove": [MockFunction],
                   },
                   "tours": Object {
-                    "areEnabled": [MockFunction],
+                    "isEnabled": [MockFunction],
                   },
                 }
               }

--- a/x-pack/platform/plugins/shared/security/public/authentication/login/components/login_form/__snapshots__/login_form.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/security/public/authentication/login/components/login_form/__snapshots__/login_form.test.tsx.snap
@@ -2558,6 +2558,9 @@ exports[`LoginForm renders as expected 1`] = `
               loginAssistanceMessage=""
               notifications={
                 Object {
+                  "feedback": Object {
+                    "isEnabled": [MockFunction],
+                  },
                   "showErrorDialog": [MockFunction],
                   "toasts": Object {
                     "add": [MockFunction],
@@ -2568,6 +2571,9 @@ exports[`LoginForm renders as expected 1`] = `
                     "addWarning": [MockFunction],
                     "get$": [MockFunction],
                     "remove": [MockFunction],
+                  },
+                  "tours": Object {
+                    "areEnabled": [MockFunction],
                   },
                 }
               }

--- a/x-pack/platform/plugins/shared/security/public/management/role_mappings/role_mappings_management_app.test.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/role_mappings/role_mappings_management_app.test.tsx
@@ -90,7 +90,7 @@ describe('roleMappingsManagementApp', () => {
     expect(docTitle.reset).not.toHaveBeenCalled();
     expect(container).toMatchInlineSnapshot(`
       <div>
-        Role Mappings Page: {"notifications":{"toasts":{}},"rolesAPIClient":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"roleMappingsAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"securityFeaturesAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"docLinks":{},"history":{"action":"PUSH","length":1,"location":{"pathname":"/","search":"","hash":""}},"readOnly":false}
+        Role Mappings Page: {"notifications":{"toasts":{},"feedback":{},"tours":{}},"rolesAPIClient":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"roleMappingsAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"securityFeaturesAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"docLinks":{},"history":{"action":"PUSH","length":1,"location":{"pathname":"/","search":"","hash":""}},"readOnly":false}
       </div>
     `);
 
@@ -112,7 +112,7 @@ describe('roleMappingsManagementApp', () => {
     expect(docTitle.reset).not.toHaveBeenCalled();
     expect(container).toMatchInlineSnapshot(`
       <div>
-        Role Mappings Page: {"notifications":{"toasts":{}},"rolesAPIClient":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"roleMappingsAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"securityFeaturesAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"docLinks":{},"history":{"action":"PUSH","length":1,"location":{"pathname":"/","search":"","hash":""}},"readOnly":true}
+        Role Mappings Page: {"notifications":{"toasts":{},"feedback":{},"tours":{}},"rolesAPIClient":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"roleMappingsAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"securityFeaturesAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"docLinks":{},"history":{"action":"PUSH","length":1,"location":{"pathname":"/","search":"","hash":""}},"readOnly":true}
       </div>
     `);
 
@@ -137,7 +137,7 @@ describe('roleMappingsManagementApp', () => {
     expect(docTitle.reset).not.toHaveBeenCalled();
     expect(container).toMatchInlineSnapshot(`
       <div>
-        Role Mapping Edit Page: {"action":"edit","roleMappingsAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"securityFeaturesAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"rolesAPIClient":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"notifications":{"toasts":{}},"docLinks":{},"history":{"action":"PUSH","length":1,"location":{"pathname":"/edit","search":"","hash":""}},"readOnly":false}
+        Role Mapping Edit Page: {"action":"edit","roleMappingsAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"securityFeaturesAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"rolesAPIClient":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"notifications":{"toasts":{},"feedback":{},"tours":{}},"docLinks":{},"history":{"action":"PUSH","length":1,"location":{"pathname":"/edit","search":"","hash":""}},"readOnly":false}
       </div>
     `);
 
@@ -167,7 +167,7 @@ describe('roleMappingsManagementApp', () => {
     expect(docTitle.reset).not.toHaveBeenCalled();
     expect(container).toMatchInlineSnapshot(`
       <div>
-        Role Mapping Edit Page: {"action":"edit","name":"role@mapping","roleMappingsAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"securityFeaturesAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"rolesAPIClient":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"notifications":{"toasts":{}},"docLinks":{},"history":{"action":"PUSH","length":1,"location":{"pathname":"/edit/role@mapping","search":"","hash":""}},"readOnly":false}
+        Role Mapping Edit Page: {"action":"edit","name":"role@mapping","roleMappingsAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"securityFeaturesAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"rolesAPIClient":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"notifications":{"toasts":{},"feedback":{},"tours":{}},"docLinks":{},"history":{"action":"PUSH","length":1,"location":{"pathname":"/edit/role@mapping","search":"","hash":""}},"readOnly":false}
       </div>
     `);
 
@@ -198,7 +198,7 @@ describe('roleMappingsManagementApp', () => {
     expect(docTitle.reset).not.toHaveBeenCalled();
     expect(container).toMatchInlineSnapshot(`
       <div>
-        Role Mapping Edit Page: {"action":"edit","name":"role@mapping","roleMappingsAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"securityFeaturesAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"rolesAPIClient":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"notifications":{"toasts":{}},"docLinks":{},"history":{"action":"PUSH","length":1,"location":{"pathname":"/edit/role@mapping","search":"","hash":""}},"readOnly":true}
+        Role Mapping Edit Page: {"action":"edit","name":"role@mapping","roleMappingsAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"securityFeaturesAPI":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"rolesAPIClient":{"http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}}},"notifications":{"toasts":{},"feedback":{},"tours":{}},"docLinks":{},"history":{"action":"PUSH","length":1,"location":{"pathname":"/edit/role@mapping","search":"","hash":""}},"readOnly":true}
       </div>
     `);
 

--- a/x-pack/platform/plugins/shared/spaces/public/management/spaces_management_app.test.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/management/spaces_management_app.test.tsx
@@ -129,7 +129,7 @@ describe('spacesManagementApp', () => {
           class="css-qvyf25-redirectAppLinksStyles"
           data-test-subj="kbnRedirectAppLink"
         >
-          Spaces Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"notifications":{"toasts":{}},"spacesManager":{"onActiveSpaceChange$":{}},"serverBasePath":"","history":{"action":"PUSH","length":1,"location":{"pathname":"/","search":"","hash":""}},"maxSpaces":1000,"allowSolutionVisibility":true,"isServerless":false}
+          Spaces Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"notifications":{"toasts":{},"feedback":{},"tours":{}},"spacesManager":{"onActiveSpaceChange$":{}},"serverBasePath":"","history":{"action":"PUSH","length":1,"location":{"pathname":"/","search":"","hash":""}},"maxSpaces":1000,"allowSolutionVisibility":true,"isServerless":false}
         </div>
       </div>
     `);
@@ -156,7 +156,7 @@ describe('spacesManagementApp', () => {
           class="css-qvyf25-redirectAppLinksStyles"
           data-test-subj="kbnRedirectAppLink"
         >
-          Spaces Create Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"notifications":{"toasts":{}},"spacesManager":{"onActiveSpaceChange$":{}},"history":{"action":"PUSH","length":1,"location":{"pathname":"/create","search":"","hash":""}},"allowFeatureVisibility":true,"allowSolutionVisibility":true,"eventTracker":{"analytics":{}}}
+          Spaces Create Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"notifications":{"toasts":{},"feedback":{},"tours":{}},"spacesManager":{"onActiveSpaceChange$":{}},"history":{"action":"PUSH","length":1,"location":{"pathname":"/create","search":"","hash":""}},"allowFeatureVisibility":true,"allowSolutionVisibility":true,"eventTracker":{"analytics":{}}}
         </div>
       </div>
     `);
@@ -189,7 +189,7 @@ describe('spacesManagementApp', () => {
           class="css-qvyf25-redirectAppLinksStyles"
           data-test-subj="kbnRedirectAppLink"
         >
-          Spaces Edit Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"serverBasePath":"","http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}},"overlays":{"banners":{}},"notifications":{"toasts":{}},"userProfile":{},"theme":{"theme$":{}},"i18n":{},"logger":{"context":[]},"spacesManager":{"onActiveSpaceChange$":{}},"spaceId":"some-space","history":{"action":"PUSH","length":1,"location":{"pathname":"/edit/some-space","search":"","hash":""}},"allowFeatureVisibility":true,"allowSolutionVisibility":true,"enableSecurityLink":"https://www.elastic.co/docs/deploy-manage/security/set-up-minimal-security#_enable_es_security_features"}
+          Spaces Edit Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"serverBasePath":"","http":{"basePath":{"basePath":"","serverBasePath":"","assetsHrefBase":""},"anonymousPaths":{},"externalUrl":{},"staticAssets":{}},"overlays":{"banners":{}},"notifications":{"toasts":{},"feedback":{},"tours":{}},"userProfile":{},"theme":{"theme$":{}},"i18n":{},"logger":{"context":[]},"spacesManager":{"onActiveSpaceChange$":{}},"spaceId":"some-space","history":{"action":"PUSH","length":1,"location":{"pathname":"/edit/some-space","search":"","hash":""}},"allowFeatureVisibility":true,"allowSolutionVisibility":true,"enableSecurityLink":"https://www.elastic.co/docs/deploy-manage/security/set-up-minimal-security#_enable_es_security_features"}
         </div>
       </div>
     `);

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/.storybook/decorator.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/.storybook/decorator.tsx
@@ -50,6 +50,12 @@ const notifications: NotificationsStart = {
     get$: () => of([]),
   },
   showErrorDialog: () => {},
+  feedback: {
+    isEnabled: () => true,
+  },
+  tours: {
+    areEnabled: () => true,
+  },
 };
 
 const userProfile = { getUserProfile$: () => of(null) };

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/.storybook/decorator.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/.storybook/decorator.tsx
@@ -54,7 +54,7 @@ const notifications: NotificationsStart = {
     isEnabled: () => true,
   },
   tours: {
-    areEnabled: () => true,
+    isEnabled: () => true,
   },
 };
 

--- a/x-pack/platform/test/api_integration/services/ml/test_resources.ts
+++ b/x-pack/platform/test/api_integration/services/ml/test_resources.ts
@@ -46,14 +46,6 @@ export function MachineLearningTestResourcesProvider(
       await kibanaServer.uiSettings.unset('dateFormat:tz');
     },
 
-    async disableKibanaAnnouncements() {
-      await kibanaServer.uiSettings.update({ hideAnnouncements: true });
-    },
-
-    async resetKibanaAnnouncements() {
-      await kibanaServer.uiSettings.unset('hideAnnouncements');
-    },
-
     async savedObjectExistsById(
       id: string,
       objectType: SavedObjectType,

--- a/x-pack/platform/test/functional/apps/lens/group4/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group4/index.ts
@@ -58,7 +58,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.uiSettings.update({
         defaultIndex: indexPatternString,
         'dateFormat:tz': 'UTC',
-        hideAnnouncements: true,
       });
       await kibanaServer.importExport.load(fixtureDirs.lensBasic);
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);

--- a/x-pack/platform/test/functional/apps/lens/group4/tsdb.ts
+++ b/x-pack/platform/test/functional/apps/lens/group4/tsdb.ts
@@ -57,7 +57,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'dateFormat:tz': 'UTC',
         defaultIndex: '0ae0bc7a-e4ca-405c-ab67-f2b5913f2a51',
         'timepicker:timeDefaults': `{ "from": "${fromTime}", "to": "${toTime}" }`,
-        hideAnnouncements: true,
       });
     });
 

--- a/x-pack/platform/test/functional/apps/lens/group7/esql.ts
+++ b/x-pack/platform/test/functional/apps/lens/group7/esql.ts
@@ -29,7 +29,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   const defaultSettings = {
     defaultIndex: 'logstash-*',
-    hideAnnouncements: true,
   };
 
   describe('lens ES|QL tests', () => {

--- a/x-pack/platform/test/functional/apps/lens/group7/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/group7/index.ts
@@ -58,7 +58,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
       await kibanaServer.uiSettings.update({
         defaultIndex: indexPatternString,
         'dateFormat:tz': 'UTC',
-        hideAnnouncements: true,
       });
       await kibanaServer.importExport.load(fixtureDirs.lensBasic);
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);

--- a/x-pack/platform/test/functional/apps/lens/group7/logsdb.ts
+++ b/x-pack/platform/test/functional/apps/lens/group7/logsdb.ts
@@ -61,7 +61,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'dateFormat:tz': 'UTC',
         defaultIndex: '0ae0bc7a-e4ca-405c-ab67-f2b5913f2a51',
         'timepicker:timeDefaults': `{ "from": "${fromTime}", "to": "${toTime}" }`,
-        hideAnnouncements: true,
       });
     });
 

--- a/x-pack/platform/test/functional/config.base.ts
+++ b/x-pack/platform/test/functional/config.base.ts
@@ -52,6 +52,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--server.restrictInternalApis=false',
         // disable fleet task that writes to metrics.fleet_server.* data streams, impacting functional tests
         `--xpack.task_manager.unsafe.exclude_task_types=${JSON.stringify(['Fleet-Metrics-Task'])}`,
+        // disable tours globally for all tests
+        '--uiSettings.globalOverrides.hideAnnouncements=true',
       ],
     },
     uiSettings: {

--- a/x-pack/platform/test/functional/services/ml/test_resources.ts
+++ b/x-pack/platform/test/functional/services/ml/test_resources.ts
@@ -47,14 +47,6 @@ export function MachineLearningTestResourcesProvider(
       await kibanaServer.uiSettings.unset('dateFormat:tz');
     },
 
-    async disableKibanaAnnouncements() {
-      await kibanaServer.uiSettings.update({ hideAnnouncements: true });
-    },
-
-    async resetKibanaAnnouncements() {
-      await kibanaServer.uiSettings.unset('hideAnnouncements');
-    },
-
     async savedObjectExistsById(
       id: string,
       objectType: SavedObjectType,

--- a/x-pack/platform/test/screenshot_creation/apps/ml_docs/index.ts
+++ b/x-pack/platform/test/screenshot_creation/apps/ml_docs/index.ts
@@ -23,7 +23,6 @@ export default function ({ getPageObject, getService, loadTestFile }: FtrProvide
     before(async () => {
       await sampleData.testResources.installAllKibanaSampleData();
       await ml.testResources.setKibanaTimeZoneToUTC();
-      await ml.testResources.disableKibanaAnnouncements();
       await browser.setWindowSize(1920, 1080);
     });
 
@@ -31,7 +30,6 @@ export default function ({ getPageObject, getService, loadTestFile }: FtrProvide
       await securityPage.forceLogout();
       await sampleData.testResources.removeAllKibanaSampleData();
       await ml.testResources.resetKibanaTimeZone();
-      await ml.testResources.resetKibanaAnnouncements();
     });
 
     loadTestFile(require.resolve('./anomaly_detection'));

--- a/x-pack/platform/test/screenshot_creation/apps/response_ops_docs/index.ts
+++ b/x-pack/platform/test/screenshot_creation/apps/response_ops_docs/index.ts
@@ -24,7 +24,6 @@ export default function ({ getPageObject, getService, loadTestFile }: FtrProvide
     before(async () => {
       await sampleData.testResources.installAllKibanaSampleData();
       await ml.testResources.setKibanaTimeZoneToUTC();
-      await ml.testResources.disableKibanaAnnouncements();
       await browser.setWindowSize(1920, 1080);
       await securityPage.login(
         esTestConfig.getUrlParts().username,
@@ -36,7 +35,6 @@ export default function ({ getPageObject, getService, loadTestFile }: FtrProvide
       await securityPage.forceLogout();
       await sampleData.testResources.removeAllKibanaSampleData();
       await ml.testResources.resetKibanaTimeZone();
-      await ml.testResources.resetKibanaAnnouncements();
     });
 
     loadTestFile(require.resolve('./stack_alerting'));

--- a/x-pack/platform/test/screenshot_creation/apps/transform_docs/index.ts
+++ b/x-pack/platform/test/screenshot_creation/apps/transform_docs/index.ts
@@ -17,7 +17,6 @@ export default function ({ getPageObject, getService, loadTestFile }: FtrProvide
 
     before(async () => {
       await ml.testResources.setKibanaTimeZoneToUTC();
-      await ml.testResources.disableKibanaAnnouncements();
       await browser.setWindowSize(1920, 1080);
       await securityPage.login(
         esTestConfig.getUrlParts().username,
@@ -28,7 +27,6 @@ export default function ({ getPageObject, getService, loadTestFile }: FtrProvide
     after(async () => {
       await securityPage.forceLogout();
       await ml.testResources.resetKibanaTimeZone();
-      await ml.testResources.resetKibanaAnnouncements();
     });
 
     loadTestFile(require.resolve('./transform_alerts'));

--- a/x-pack/platform/test/serverless/functional/config.base.ts
+++ b/x-pack/platform/test/serverless/functional/config.base.ts
@@ -39,6 +39,8 @@ export function createTestConfig<
           ...svlSharedConfig.get('kbnTestServer.serverArgs'),
           `--serverless=${options.serverlessProject}`,
           ...(options.kbnServerArgs ?? []),
+          // Disable tours globally for all tests
+          '--uiSettings.globalOverrides.hideAnnouncements=true',
         ],
       },
       testFiles: options.testFiles,

--- a/x-pack/platform/test/serverless/functional/test_suites/discover/group6/_unsaved_changes_badge.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/group6/_unsaved_changes_badge.ts
@@ -29,7 +29,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const security = getService('security');
   const defaultSettings = {
     defaultIndex: 'logstash-*',
-    hideAnnouncements: true,
   };
 
   describe('discover unsaved changes badge', function describeIndexTests() {

--- a/x-pack/platform/test/serverless/functional/test_suites/visualizations/group5/tsdb.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/visualizations/group5/tsdb.ts
@@ -63,7 +63,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'dateFormat:tz': 'UTC',
         defaultIndex: '0ae0bc7a-e4ca-405c-ab67-f2b5913f2a51',
         'timepicker:timeDefaults': `{ "from": "${fromTime}", "to": "${toTime}" }`,
-        hideAnnouncements: true,
       });
     });
 

--- a/x-pack/platform/test/serverless/functional/test_suites/visualizations/group6/logsdb.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/visualizations/group6/logsdb.ts
@@ -65,7 +65,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'dateFormat:tz': 'UTC',
         defaultIndex: '0ae0bc7a-e4ca-405c-ab67-f2b5913f2a51',
         'timepicker:timeDefaults': `{ "from": "${fromTime}", "to": "${toTime}" }`,
-        hideAnnouncements: true,
       });
     });
 

--- a/x-pack/solutions/observability/test/screenshot_creation/apps/response_ops_docs/index.ts
+++ b/x-pack/solutions/observability/test/screenshot_creation/apps/response_ops_docs/index.ts
@@ -24,7 +24,6 @@ export default function ({ getPageObject, getService, loadTestFile }: FtrProvide
     before(async () => {
       await sampleData.testResources.installAllKibanaSampleData();
       await ml.testResources.setKibanaTimeZoneToUTC();
-      await ml.testResources.disableKibanaAnnouncements();
       await browser.setWindowSize(1920, 1080);
       await securityPage.login(
         esTestConfig.getUrlParts().username,
@@ -36,7 +35,6 @@ export default function ({ getPageObject, getService, loadTestFile }: FtrProvide
       await securityPage.forceLogout();
       await sampleData.testResources.removeAllKibanaSampleData();
       await ml.testResources.resetKibanaTimeZone();
-      await ml.testResources.resetKibanaAnnouncements();
     });
 
     loadTestFile(require.resolve('./observability_alerting'));

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs/index.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs/index.ts
@@ -16,13 +16,11 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
     before(async () => {
       await ml.testResources.setKibanaTimeZoneToUTC();
-      await ml.testResources.disableKibanaAnnouncements();
       await browser.setWindowSize(1920, 1080);
     });
 
     after(async () => {
       await ml.testResources.resetKibanaTimeZone();
-      await ml.testResources.resetKibanaAnnouncements();
     });
 
     loadTestFile(require.resolve('./cases'));

--- a/x-pack/solutions/search/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs/index.ts
+++ b/x-pack/solutions/search/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs/index.ts
@@ -25,7 +25,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
         svlCommonApi.getInternalRequestHeader()
       );
       await ml.testResources.setKibanaTimeZoneToUTC();
-      await ml.testResources.disableKibanaAnnouncements();
       await browser.setWindowSize(1920, 1080);
     });
 
@@ -34,7 +33,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
         svlCommonApi.getInternalRequestHeader()
       );
       await ml.testResources.resetKibanaTimeZone();
-      await ml.testResources.resetKibanaAnnouncements();
     });
 
     loadTestFile(require.resolve('./stack_connectors'));

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/feature_tour/rules_feature_tour.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/feature_tour/rules_feature_tour.tsx
@@ -76,12 +76,12 @@ export const RuleFeatureTour: FC = () => {
     storage.set(TOUR_STORAGE_KEY, { isTourActive, currentTourStep });
   }, [tourState, storage]);
 
-  const areToursEnabled = notifications.tours.areEnabled();
+  const isTourEnabled = notifications.tours.isEnabled();
   const isTourAnchorMounted = useIsElementMounted(CREATE_NEW_RULE_TOUR_ANCHOR);
   const canEditRules = useUserPrivileges().rulesPrivileges.edit;
   // Display the tour only if the user has permissions to create/edit rules,
   // otherwise they could not follow the tour steps
-  const shouldShowRuleUpgradeTour = areToursEnabled && isTourAnchorMounted && canEditRules;
+  const shouldShowRuleUpgradeTour = isTourEnabled && isTourAnchorMounted && canEditRules;
 
   const enhancedSteps = useMemo(
     () =>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/feature_tour/rules_feature_tour.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/feature_tour/rules_feature_tour.tsx
@@ -59,7 +59,7 @@ const stepsConfig: EuiStatelessTourStep[] = [
 ];
 
 export const RuleFeatureTour: FC = () => {
-  const { storage } = useKibana().services;
+  const { storage, notifications } = useKibana().services;
 
   const restoredState = useMemo<EuiTourState>(
     () => ({
@@ -76,11 +76,12 @@ export const RuleFeatureTour: FC = () => {
     storage.set(TOUR_STORAGE_KEY, { isTourActive, currentTourStep });
   }, [tourState, storage]);
 
+  const areToursEnabled = notifications.tours.areEnabled();
   const isTourAnchorMounted = useIsElementMounted(CREATE_NEW_RULE_TOUR_ANCHOR);
   const canEditRules = useUserPrivileges().rulesPrivileges.edit;
   // Display the tour only if the user has permissions to create/edit rules,
   // otherwise they could not follow the tour steps
-  const shouldShowRuleUpgradeTour = isTourAnchorMounted && canEditRules;
+  const shouldShowRuleUpgradeTour = areToursEnabled && isTourAnchorMounted && canEditRules;
 
   const enhancedSteps = useMemo(
     () =>

--- a/x-pack/solutions/security/test/screenshot_creation/apps/response_ops_docs/index.ts
+++ b/x-pack/solutions/security/test/screenshot_creation/apps/response_ops_docs/index.ts
@@ -24,7 +24,6 @@ export default function ({ getPageObject, getService, loadTestFile }: FtrProvide
     before(async () => {
       await sampleData.testResources.installAllKibanaSampleData();
       await ml.testResources.setKibanaTimeZoneToUTC();
-      await ml.testResources.disableKibanaAnnouncements();
       await browser.setWindowSize(1920, 1080);
       await securityPage.login(
         esTestConfig.getUrlParts().username,
@@ -36,7 +35,6 @@ export default function ({ getPageObject, getService, loadTestFile }: FtrProvide
       await securityPage.forceLogout();
       await sampleData.testResources.removeAllKibanaSampleData();
       await ml.testResources.resetKibanaTimeZone();
-      await ml.testResources.resetKibanaAnnouncements();
     });
 
     loadTestFile(require.resolve('./security_cases'));

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs/index.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs/index.ts
@@ -16,13 +16,11 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
     before(async () => {
       await ml.testResources.setKibanaTimeZoneToUTC();
-      await ml.testResources.disableKibanaAnnouncements();
       await browser.setWindowSize(1920, 1080);
     });
 
     after(async () => {
       await ml.testResources.resetKibanaTimeZone();
-      await ml.testResources.resetKibanaAnnouncements();
     });
 
     loadTestFile(require.resolve('./cases'));


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/234771

One-pager with some more context and considered approaches [here](https://docs.google.com/document/d/1BjiXyuyoIA1HzD1rm5fnSBVyEpoekgKC5_oiOY0qlH0/edit?tab=t.0#heading=h.zffn43idadhe). 

## Summary

- Created 2 new **globally scoped** UI settings: `hideAnnouncements` and `hideFeedback`.
- Marked already existing **space-scoped** setting `hideAnnouncements` as deprecated to avoid redundancy ([deprecation GH issue](https://github.com/elastic/kibana/issues/248983)).
- Added globally scoped settings overrides support due to `hideFeedback` being readonly and to accommodate this [ER](https://github.com/elastic/enhancements/issues/26978).
- Added to `core.notifications` `tours` and `feedback` services reading advanced settings and returning a boolean `isEnabled` flag when tours/feedback components are allowed to be rendered based on above mentioned new settings. 
- Called this new services for:
  1. Side Nav Feedback Snippet
  2. Fleet tours (migrated from space-scoped one)
  3. Security Rules tour
 
## Testing

- Removed all space-scoped references to `hideAnnouncements` from tests
- Added globally scoped one to tests `base.config` files. 
- Manually tested the above-mentioned use cases:
  1. `NavigationFeedbackSnippet`: to test, override the setting via `kibana.dev.yml` with `uiSettings.globalOverrides.hideFeedback: true`. You should see the side nav feedback snippet disappearing. 
  2. Fleet tours: test toggling either the deprecated space setting or the global one on the Advanced Settings UI and verify tours being rendered or not (e.g. visit `Fleet/Agents` and you should see one prompting on `Agent policies`)
  3. Security Rules tour: same as above, test toggling either the deprecated space setting or the global one. See demo:
 
https://github.com/user-attachments/assets/b62fc2cd-8d74-447e-b743-c970f6b30164

## Future PRs

- Will add the new settings to Cloud allowlist
- Will add the `notifications.tours.areEnabled()` and the `notifications.feedback.isEnabled()` check to other elements

