### PR TITLE
[EDR Workflows] Fix auto refresh allowing 0 second interval on Endpoint hosts page

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
@@ -448,10 +448,13 @@ export const EndpointList = () => {
   }, [getAppUrl, searchParams]);
 
   const onRefresh = useCallback(() => {
+    if (autoRefreshInterval <= 0) {
+      return;
+    }
     dispatch({
       type: 'appRequestedEndpointList',
     });
-  }, [dispatch]);
+  }, [autoRefreshInterval, dispatch]);
 
   const onRefreshChange = useCallback<NonNullable<EuiSuperDatePickerProps['onRefreshChange']>>(
     (evt) => {


### PR DESCRIPTION
When user sets auto refresh interval to 0, the refresh is disabled. If they re-enable it while interval is still 0, we don't force a default value - instead we show the validation error and simply don't trigger any fetches. This keeps the UX clean and lets the user correct the value themselves.

https://github.com/user-attachments/assets/395bd3c5-e016-4c77-80ba-81dd35fbbf6a


https://github.com/elastic/kibana/issues/247802