### PR TITLE
[9.1] [Lens][Data Table] Fix 'Direct Filter On Click' link color in dark mode (#247721)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/cell_value.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/cell_value.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { EuiThemeProvider } from '@elastic/eui';
 import { DataContext } from './table_basic';
 import { createGridCell } from './cell_value';
 import { getTransposeId } from '@kbn/transpose-utils';
@@ -290,6 +291,86 @@ describe('datatable cell renderer', () => {
       renderCellComponent(columnConfig, {});
 
       expect(setCellProps).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('one click filter with background color', () => {
+    const handleFilterClick = jest.fn();
+
+    const renderThemedCellRenderer = (
+      columnConfig: DatatableArgs,
+      isDarkMode: boolean,
+      backgroundColor: string | null
+    ) => {
+      innerCellColorFnMock.mockReturnValue(backgroundColor);
+      const CellRendererWithColor = createGridCell(
+        {
+          a: { convert: (x) => `formatted ${x}` } as FieldFormat,
+        },
+        columnConfig,
+        DataContext,
+        isDarkMode,
+        cellColorFnMock
+      );
+
+      render(
+        <EuiThemeProvider colorMode={isDarkMode ? 'dark' : 'light'}>
+          <CellRendererWithColor
+            rowIndex={0}
+            colIndex={0}
+            columnId="a"
+            setCellProps={setCellProps}
+            isExpandable={false}
+            isDetails={false}
+            isExpanded={false}
+          />
+        </EuiThemeProvider>,
+        {
+          wrapper: DataContextProviderWrapper({
+            handleFilterClick,
+            table,
+          }),
+        }
+      );
+    };
+
+    const columnConfig: DatatableArgs = {
+      title: 'myData',
+      columns: [
+        {
+          columnId: 'a',
+          type: 'lens_datatable_column',
+          oneClickFilter: true,
+          colorMode: 'cell',
+        },
+      ],
+      sortingColumnId: '',
+      sortingDirection: 'none',
+    };
+
+    it('should adjust link color for dark background in light mode', () => {
+      const backgroundColor = '#000000';
+      const expectedColor = '#4b78c9';
+      const isDarkMode = false;
+      renderThemedCellRenderer(columnConfig, isDarkMode, backgroundColor);
+
+      expect(screen.getByRole('button')).toHaveStyle(`color: ${expectedColor}`);
+    });
+
+    it('should adjust link color for light background in dark mode', () => {
+      const backgroundColor = '#FFFFFF';
+      const expectedColor = '#1750BA';
+      const isDarkMode = true;
+      renderThemedCellRenderer(columnConfig, isDarkMode, backgroundColor);
+
+      expect(screen.getByRole('button')).toHaveStyle(`color: ${expectedColor}`);
+    });
+
+    it('should not adjust link color when there is no background color', () => {
+      const isDarkMode = false;
+      renderThemedCellRenderer(columnConfig, isDarkMode, null);
+      const linkColor = '#1750BA';
+      expect(screen.getByRole('button')).toHaveStyle(`color: ${linkColor}`);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/cell_value.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/cell_value.tsx
@@ -6,7 +6,8 @@
  */
 
 import React, { useContext, useEffect } from 'react';
-import { EuiDataGridCellValueElementProps, EuiLink } from '@elastic/eui';
+import type { EuiDataGridCellValueElementProps } from '@elastic/eui';
+import { EuiLink, makeHighContrastColor, useEuiTheme } from '@elastic/eui';
 import classNames from 'classnames';
 import { PaletteOutput } from '@kbn/coloring';
 import { CustomPaletteState } from '@kbn/charts-plugin/common';
@@ -34,6 +35,7 @@ export const createGridCell = (
     const formatter = formatters[columnId];
     const rawValue: RawValue = table?.rows[rowIndex]?.[columnId];
     const colIndex = columnConfig.columns.findIndex(({ columnId: id }) => id === columnId);
+    const { euiTheme } = useEuiTheme();
     const {
       oneClickFilter,
       colorMode = 'none',
@@ -74,6 +76,16 @@ export const createGridCell = (
     }, [rawValue, columnId, setCellProps, colorMode, palette, colorMapping, isExpanded]);
 
     if (filterOnClick) {
+      const backgroundColor = getCellColor(columnId, palette, colorMapping)(rawValue);
+      const linkColor = euiTheme.colors.link;
+
+      const adjustedLinkColor = backgroundColor
+        ? makeHighContrastColor(
+            isDarkMode ? euiTheme.colors.highlight : linkColor, // preferred foreground color
+            4.5 // WCAG AA contrast ratio (default in EUI)
+          )(backgroundColor)
+        : linkColor;
+
       return (
         <div
           data-test-subj="lnsTableCellContent"
@@ -83,6 +95,7 @@ export const createGridCell = (
           })}
         >
           <EuiLink
+            style={{ color: adjustedLinkColor }}
             onClick={() => {
               handleFilterClick?.(columnId, rawValue, colIndex, rowIndex);
             }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Lens][Data Table] Fix 'Direct Filter On Click' link color in dark mode (#247721)](https://github.com/elastic/kibana/pull/247721)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2026-01-07T09:01:35Z","message":"[Lens][Data Table] Fix 'Direct Filter On Click' link color in dark mode (#247721)\n\nFixes https://github.com/elastic/kibana/issues/242181\n\n## Summary\n\nThis PR adjust the link text color when 'Direct Filter On Click' is\nenabled to have mode contrast with the background, using\n`makeHighContrastColor` with `euiTheme.colors.link` in light mode and\n`euiTheme.colors.highlight` in dark mode.\n\n|Color palette|Before|After|\n|---|---|---|\n|Elastic classic|<img width=\"792\" height=\"459\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/dd53dea6-ddf5-4a60-85e1-cd0dec5192d7\"\n/>|<img width=\"801\" height=\"466\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/68a9e6fe-6a2e-4f4b-82f7-322bcc72decd\"\n/>|\n|Kibana 4.0|<img width=\"792\" height=\"456\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/813cf8a0-959b-452e-a847-06f7fddde774\"\n/>|<img width=\"791\" height=\"458\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5ca137a0-8c5c-42e4-83a1-7ae3ff91dc21\"\n/>|\n|Elastic|<img width=\"793\" height=\"457\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/bb558474-de9b-4eb0-8d7c-cdbb9895f82f\"\n/>|<img width=\"793\" height=\"457\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/97189120-7050-4bea-a182-555666c65399\"\n/>|\n|Kibana 7.0|<img width=\"792\" height=\"460\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/49aae99f-119f-4978-8849-a3d83e833e1b\"\n/>|<img width=\"795\" height=\"455\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c7d70935-b97a-41b1-82db-01a58b6ad5c9\"\n/>|\n\n\n\nhttps://github.com/user-attachments/assets/cf2e1c5a-1c93-490e-ba3b-f59a9379c82c\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"11291ce6a213264487cd1b86f50ee67b7cdc9dd7","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:all-open","v9.3.0","v9.4.0","v9.2.4"],"title":"[Lens][Data Table] Fix link's color contrast","number":247721,"url":"https://github.com/elastic/kibana/pull/247721","mergeCommit":{"message":"[Lens][Data Table] Fix 'Direct Filter On Click' link color in dark mode (#247721)\n\nFixes https://github.com/elastic/kibana/issues/242181\n\n## Summary\n\nThis PR adjust the link text color when 'Direct Filter On Click' is\nenabled to have mode contrast with the background, using\n`makeHighContrastColor` with `euiTheme.colors.link` in light mode and\n`euiTheme.colors.highlight` in dark mode.\n\n|Color palette|Before|After|\n|---|---|---|\n|Elastic classic|<img width=\"792\" height=\"459\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/dd53dea6-ddf5-4a60-85e1-cd0dec5192d7\"\n/>|<img width=\"801\" height=\"466\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/68a9e6fe-6a2e-4f4b-82f7-322bcc72decd\"\n/>|\n|Kibana 4.0|<img width=\"792\" height=\"456\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/813cf8a0-959b-452e-a847-06f7fddde774\"\n/>|<img width=\"791\" height=\"458\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5ca137a0-8c5c-42e4-83a1-7ae3ff91dc21\"\n/>|\n|Elastic|<img width=\"793\" height=\"457\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/bb558474-de9b-4eb0-8d7c-cdbb9895f82f\"\n/>|<img width=\"793\" height=\"457\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/97189120-7050-4bea-a182-555666c65399\"\n/>|\n|Kibana 7.0|<img width=\"792\" height=\"460\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/49aae99f-119f-4978-8849-a3d83e833e1b\"\n/>|<img width=\"795\" height=\"455\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c7d70935-b97a-41b1-82db-01a58b6ad5c9\"\n/>|\n\n\n\nhttps://github.com/user-attachments/assets/cf2e1c5a-1c93-490e-ba3b-f59a9379c82c\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"11291ce6a213264487cd1b86f50ee67b7cdc9dd7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/248112","number":248112,"state":"MERGED","mergeCommit":{"sha":"8c5c95af3de416cb098bab7d56f5c1e14b92c9c8","message":"[9.3] [Lens][Data Table] Fix 'Direct Filter On Click' link color in dark mode (#247721) (#248112)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Lens][Data Table] Fix 'Direct Filter On Click' link color in dark\nmode (#247721)](https://github.com/elastic/kibana/pull/247721)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maryam Saeidi <maryam.saeidi@elastic.co>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247721","number":247721,"mergeCommit":{"message":"[Lens][Data Table] Fix 'Direct Filter On Click' link color in dark mode (#247721)\n\nFixes https://github.com/elastic/kibana/issues/242181\n\n## Summary\n\nThis PR adjust the link text color when 'Direct Filter On Click' is\nenabled to have mode contrast with the background, using\n`makeHighContrastColor` with `euiTheme.colors.link` in light mode and\n`euiTheme.colors.highlight` in dark mode.\n\n|Color palette|Before|After|\n|---|---|---|\n|Elastic classic|<img width=\"792\" height=\"459\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/dd53dea6-ddf5-4a60-85e1-cd0dec5192d7\"\n/>|<img width=\"801\" height=\"466\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/68a9e6fe-6a2e-4f4b-82f7-322bcc72decd\"\n/>|\n|Kibana 4.0|<img width=\"792\" height=\"456\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/813cf8a0-959b-452e-a847-06f7fddde774\"\n/>|<img width=\"791\" height=\"458\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5ca137a0-8c5c-42e4-83a1-7ae3ff91dc21\"\n/>|\n|Elastic|<img width=\"793\" height=\"457\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/bb558474-de9b-4eb0-8d7c-cdbb9895f82f\"\n/>|<img width=\"793\" height=\"457\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/97189120-7050-4bea-a182-555666c65399\"\n/>|\n|Kibana 7.0|<img width=\"792\" height=\"460\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/49aae99f-119f-4978-8849-a3d83e833e1b\"\n/>|<img width=\"795\" height=\"455\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c7d70935-b97a-41b1-82db-01a58b6ad5c9\"\n/>|\n\n\n\nhttps://github.com/user-attachments/assets/cf2e1c5a-1c93-490e-ba3b-f59a9379c82c\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"11291ce6a213264487cd1b86f50ee67b7cdc9dd7"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/248111","number":248111,"state":"MERGED","mergeCommit":{"sha":"b84daf4b7c6fc3cab0f5d2b460239d01ed66739f","message":"[9.2] [Lens][Data Table] Fix 'Direct Filter On Click' link color in dark mode (#247721) (#248111)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Lens][Data Table] Fix 'Direct Filter On Click' link color in dark\nmode (#247721)](https://github.com/elastic/kibana/pull/247721)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Maryam Saeidi <maryam.saeidi@elastic.co>"}}]}] BACKPORT-->