### PR TITLE
[Automatic Migrations] Prevents blank or whitespace-only migration names

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/components/migration_name_step/migration_name_input.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/components/migration_name_step/migration_name_input.test.tsx
@@ -56,6 +56,17 @@ describe('MigrationNameInput', () => {
     expect(mockSetMigrationName).toHaveBeenCalledWith('New Name');
   });
 
+  it('does not accept empty string as migration name', () => {
+    render(<MigrationNameInput {...defaultProps} />);
+    const input = screen.getByDisplayValue('Default Name');
+
+    fireEvent.change(input, { target: { value: '       ' } });
+    fireEvent.blur(input);
+
+    expect(mockSetMigrationName).toHaveBeenCalledWith('');
+    expect(screen.getByText(i18n.MIGRATION_NAME_INPUT_ERROR)).toBeInTheDocument();
+  });
+
   it('shows error when empty name is submitted', () => {
     render(<MigrationNameInput {...defaultProps} />);
     const input = screen.getByDisplayValue('Default Name');

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/components/migration_name_step/migration_name_input.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/common/components/migration_name_step/migration_name_input.tsx
@@ -23,10 +23,10 @@ export const MigrationNameInput = React.memo<MigrationNameInputProps>(
     }, []);
 
     const handleNameSave = useCallback(() => {
-      setMigrationName(name);
+      setMigrationName(name.trim());
     }, [name, setMigrationName]);
 
-    const isInvalid = name.length === 0;
+    const isInvalid = name.trim().length === 0;
     const errors = useMemo(() => {
       if (isInvalid) {
         return [i18n.MIGRATION_NAME_INPUT_ERROR];


### PR DESCRIPTION
## Summary


https://github.com/elastic/kibana/issues/247352


https://github.com/user-attachments/assets/bd4bfe15-1925-486e-8a42-da1eebba5210


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->