### PR TITLE
[Agent Builder] rename workflow step to `ai.agent`

### DIFF
--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
@@ -25,7 +25,7 @@
  */
 export const APPROVED_STEP_DEFINITIONS: Array<{ id: string; handlerHash: string }> = [
   {
-    id: 'agentBuilder.runAgent',
+    id: 'ai.agent',
     handlerHash: '5900dff8945512df13e3e082cec3750deddb8ca43675bde01e452b263c2f2d9d',
   },
   {

--- a/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
@@ -11,7 +11,7 @@ import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
 /**
  * Step type ID for the agentBuilder run agent step.
  */
-export const RunAgentStepTypeId = 'agentBuilder.runAgent';
+export const RunAgentStepTypeId = 'ai.agent';
 
 /**
  * Input schema for the run agent step.


### PR DESCRIPTION
## Summary

Because naming is hard. Rename the "run agent" workflow step's id from `agentBuilder.runAgent` to `ai.agent`

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->