### PR TITLE
[9.1][Fleet] increase maxSize in responses (#248215)

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -15802,7 +15802,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 1000,
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             "signed": {
@@ -16235,7 +16235,7 @@
                   "properties": {
                     "dataPreview": {
                       "items": {},
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "items": {
@@ -16538,7 +16538,7 @@
                                     ],
                                     "type": "object"
                                   },
-                                  "maxItems": 1000,
+                                  "maxItems": 10000,
                                   "type": "array"
                                 }
                               },
@@ -16550,7 +16550,7 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 1000,
+                            "maxItems": 10000,
                             "type": "array"
                           },
                           "default_api_key": {
@@ -16664,7 +16664,7 @@
                             "items": {
                               "type": "string"
                             },
-                            "maxItems": 1000,
+                            "maxItems": 10000,
                             "type": "array"
                           },
                           "policy_id": {
@@ -16733,7 +16733,7 @@
                             "items": {
                               "type": "string"
                             },
-                            "maxItems": 1000,
+                            "maxItems": 10000,
                             "nullable": true,
                             "type": "array"
                           },
@@ -16950,7 +16950,7 @@
                       "items": {
                         "type": "string"
                       },
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -17185,7 +17185,7 @@
                         ],
                         "type": "object"
                       },
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -17386,7 +17386,7 @@
                       "items": {
                         "type": "string"
                       },
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -18663,7 +18663,7 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 1000,
+                                "maxItems": 10000,
                                 "type": "array"
                               }
                             },
@@ -18675,7 +18675,7 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 1000,
+                          "maxItems": 10000,
                           "type": "array"
                         },
                         "default_api_key": {
@@ -18789,7 +18789,7 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 1000,
+                          "maxItems": 10000,
                           "type": "array"
                         },
                         "policy_id": {
@@ -18858,7 +18858,7 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 1000,
+                          "maxItems": 10000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -19151,7 +19151,7 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 1000,
+                                "maxItems": 10000,
                                 "type": "array"
                               }
                             },
@@ -19163,7 +19163,7 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 1000,
+                          "maxItems": 10000,
                           "type": "array"
                         },
                         "default_api_key": {
@@ -19277,7 +19277,7 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 1000,
+                          "maxItems": 10000,
                           "type": "array"
                         },
                         "policy_id": {
@@ -19346,7 +19346,7 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 1000,
+                          "maxItems": 10000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -20109,7 +20109,7 @@
                         ],
                         "type": "object"
                       },
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -21110,7 +21110,7 @@
                         ],
                         "type": "object"
                       },
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -21882,7 +21882,7 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 1000,
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               "installed_kibana": {
@@ -21926,7 +21926,7 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 1000,
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               "installed_kibana_space_id": {
@@ -22148,7 +22148,7 @@
                         ],
                         "type": "object"
                       },
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -22559,7 +22559,7 @@
                                         }
                                       ]
                                     },
-                                    "maxItems": 1000,
+                                    "maxItems": 10000,
                                     "type": "array"
                                   },
                                   "error": {},
@@ -23234,7 +23234,7 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 1000,
+                            "maxItems": 10000,
                             "type": "array"
                           },
                           "description": {
@@ -24047,7 +24047,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 1000,
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             "installed_kibana": {
@@ -24091,7 +24091,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 1000,
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             "installed_kibana_space_id": {
@@ -24997,7 +24997,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 1000,
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             "installed_kibana": {
@@ -25041,7 +25041,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 1000,
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             "installed_kibana_space_id": {

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -15887,7 +15887,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 1000,
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             "signed": {
@@ -16320,7 +16320,7 @@
                   "properties": {
                     "dataPreview": {
                       "items": {},
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     },
                     "items": {
@@ -16623,7 +16623,7 @@
                                     ],
                                     "type": "object"
                                   },
-                                  "maxItems": 1000,
+                                  "maxItems": 10000,
                                   "type": "array"
                                 }
                               },
@@ -16635,7 +16635,7 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 1000,
+                            "maxItems": 10000,
                             "type": "array"
                           },
                           "default_api_key": {
@@ -16749,7 +16749,7 @@
                             "items": {
                               "type": "string"
                             },
-                            "maxItems": 1000,
+                            "maxItems": 10000,
                             "type": "array"
                           },
                           "policy_id": {
@@ -16818,7 +16818,7 @@
                             "items": {
                               "type": "string"
                             },
-                            "maxItems": 1000,
+                            "maxItems": 10000,
                             "nullable": true,
                             "type": "array"
                           },
@@ -17035,7 +17035,7 @@
                       "items": {
                         "type": "string"
                       },
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -17270,7 +17270,7 @@
                         ],
                         "type": "object"
                       },
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -17471,7 +17471,7 @@
                       "items": {
                         "type": "string"
                       },
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -18748,7 +18748,7 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 1000,
+                                "maxItems": 10000,
                                 "type": "array"
                               }
                             },
@@ -18760,7 +18760,7 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 1000,
+                          "maxItems": 10000,
                           "type": "array"
                         },
                         "default_api_key": {
@@ -18874,7 +18874,7 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 1000,
+                          "maxItems": 10000,
                           "type": "array"
                         },
                         "policy_id": {
@@ -18943,7 +18943,7 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 1000,
+                          "maxItems": 10000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -19236,7 +19236,7 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 1000,
+                                "maxItems": 10000,
                                 "type": "array"
                               }
                             },
@@ -19248,7 +19248,7 @@
                             ],
                             "type": "object"
                           },
-                          "maxItems": 1000,
+                          "maxItems": 10000,
                           "type": "array"
                         },
                         "default_api_key": {
@@ -19362,7 +19362,7 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 1000,
+                          "maxItems": 10000,
                           "type": "array"
                         },
                         "policy_id": {
@@ -19431,7 +19431,7 @@
                           "items": {
                             "type": "string"
                           },
-                          "maxItems": 1000,
+                          "maxItems": 10000,
                           "nullable": true,
                           "type": "array"
                         },
@@ -20194,7 +20194,7 @@
                         ],
                         "type": "object"
                       },
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -21195,7 +21195,7 @@
                         ],
                         "type": "object"
                       },
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -21968,7 +21968,7 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 1000,
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               "installed_kibana": {
@@ -22012,7 +22012,7 @@
                                   ],
                                   "type": "object"
                                 },
-                                "maxItems": 1000,
+                                "maxItems": 10000,
                                 "type": "array"
                               },
                               "installed_kibana_space_id": {
@@ -22234,7 +22234,7 @@
                         ],
                         "type": "object"
                       },
-                      "maxItems": 1000,
+                      "maxItems": 10000,
                       "type": "array"
                     }
                   },
@@ -22645,7 +22645,7 @@
                                         }
                                       ]
                                     },
-                                    "maxItems": 1000,
+                                    "maxItems": 10000,
                                     "type": "array"
                                   },
                                   "error": {},
@@ -23320,7 +23320,7 @@
                               ],
                               "type": "object"
                             },
-                            "maxItems": 1000,
+                            "maxItems": 10000,
                             "type": "array"
                           },
                           "description": {
@@ -24134,7 +24134,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 1000,
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             "installed_kibana": {
@@ -24178,7 +24178,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 1000,
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             "installed_kibana_space_id": {
@@ -25085,7 +25085,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 1000,
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             "installed_kibana": {
@@ -25129,7 +25129,7 @@
                                 ],
                                 "type": "object"
                               },
-                              "maxItems": 1000,
+                              "maxItems": 10000,
                               "type": "array"
                             },
                             "installed_kibana_space_id": {

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -20115,7 +20115,7 @@ paths:
                                   type: string
                               required:
                                 - id
-                            maxItems: 1000
+                            maxItems: 10000
                             type: array
                           signed:
                             additionalProperties: false
@@ -20580,7 +20580,7 @@ paths:
                 properties:
                   dataPreview:
                     items: {}
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                   items:
                     items:
@@ -20790,14 +20790,14 @@ paths:
                                     - type
                                     - status
                                     - message
-                                maxItems: 1000
+                                maxItems: 10000
                                 type: array
                             required:
                               - id
                               - type
                               - status
                               - message
-                          maxItems: 1000
+                          maxItems: 10000
                           type: array
                         default_api_key:
                           type: string
@@ -20877,7 +20877,7 @@ paths:
                         packages:
                           items:
                             type: string
-                          maxItems: 1000
+                          maxItems: 10000
                           type: array
                         policy_id:
                           type: string
@@ -20930,7 +20930,7 @@ paths:
                         upgrade_attempts:
                           items:
                             type: string
-                          maxItems: 1000
+                          maxItems: 10000
                           nullable: true
                           type: array
                         upgrade_details:
@@ -21082,7 +21082,7 @@ paths:
                   items:
                     items:
                       type: string
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -21262,14 +21262,14 @@ paths:
                                   - type
                                   - status
                                   - message
-                              maxItems: 1000
+                              maxItems: 10000
                               type: array
                           required:
                             - id
                             - type
                             - status
                             - message
-                        maxItems: 1000
+                        maxItems: 10000
                         type: array
                       default_api_key:
                         type: string
@@ -21349,7 +21349,7 @@ paths:
                       packages:
                         items:
                           type: string
-                        maxItems: 1000
+                        maxItems: 10000
                         type: array
                       policy_id:
                         type: string
@@ -21402,7 +21402,7 @@ paths:
                       upgrade_attempts:
                         items:
                           type: string
-                        maxItems: 1000
+                        maxItems: 10000
                         nullable: true
                         type: array
                       upgrade_details:
@@ -21614,14 +21614,14 @@ paths:
                                   - type
                                   - status
                                   - message
-                              maxItems: 1000
+                              maxItems: 10000
                               type: array
                           required:
                             - id
                             - type
                             - status
                             - message
-                        maxItems: 1000
+                        maxItems: 10000
                         type: array
                       default_api_key:
                         type: string
@@ -21701,7 +21701,7 @@ paths:
                       packages:
                         items:
                           type: string
-                        maxItems: 1000
+                        maxItems: 10000
                         type: array
                       policy_id:
                         type: string
@@ -21754,7 +21754,7 @@ paths:
                       upgrade_attempts:
                         items:
                           type: string
-                        maxItems: 1000
+                        maxItems: 10000
                         nullable: true
                         type: array
                       upgrade_details:
@@ -22268,7 +22268,7 @@ paths:
                         - createTime
                         - status
                         - actionId
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -22435,7 +22435,7 @@ paths:
                         - nbAgentsActioned
                         - status
                         - creationTime
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -22570,7 +22570,7 @@ paths:
                   items:
                     items:
                       type: string
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -23906,7 +23906,7 @@ paths:
                         - id
                         - title
                         - count
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -24434,7 +24434,7 @@ paths:
                                 required:
                                   - id
                                   - type
-                              maxItems: 1000
+                              maxItems: 10000
                               type: array
                             installed_kibana:
                               items:
@@ -24465,7 +24465,7 @@ paths:
                                 required:
                                   - id
                                   - type
-                              maxItems: 1000
+                              maxItems: 10000
                               type: array
                             installed_kibana_space_id:
                               type: string
@@ -24613,7 +24613,7 @@ paths:
                         - version
                         - title
                         - id
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -24890,7 +24890,7 @@ paths:
                                         required:
                                           - id
                                           - type
-                                  maxItems: 1000
+                                  maxItems: 10000
                                   type: array
                                 error: {}
                                 installSource:
@@ -25630,7 +25630,7 @@ paths:
                               required:
                                 - id
                                 - type
-                            maxItems: 1000
+                            maxItems: 10000
                             type: array
                           installed_kibana:
                             items:
@@ -25661,7 +25661,7 @@ paths:
                               required:
                                 - id
                                 - type
-                            maxItems: 1000
+                            maxItems: 10000
                             type: array
                           installed_kibana_space_id:
                             type: string
@@ -26279,7 +26279,7 @@ paths:
                               required:
                                 - id
                                 - type
-                            maxItems: 1000
+                            maxItems: 10000
                             type: array
                           installed_kibana:
                             items:
@@ -26310,7 +26310,7 @@ paths:
                               required:
                                 - id
                                 - type
-                            maxItems: 1000
+                            maxItems: 10000
                             type: array
                           installed_kibana_space_id:
                             type: string
@@ -26967,7 +26967,7 @@ paths:
                             required:
                               - name
                               - title
-                          maxItems: 1000
+                          maxItems: 10000
                           type: array
                         description:
                           type: string

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -22290,7 +22290,7 @@ paths:
                                   type: string
                               required:
                                 - id
-                            maxItems: 1000
+                            maxItems: 10000
                             type: array
                           signed:
                             additionalProperties: false
@@ -22755,7 +22755,7 @@ paths:
                 properties:
                   dataPreview:
                     items: {}
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                   items:
                     items:
@@ -22965,14 +22965,14 @@ paths:
                                     - type
                                     - status
                                     - message
-                                maxItems: 1000
+                                maxItems: 10000
                                 type: array
                             required:
                               - id
                               - type
                               - status
                               - message
-                          maxItems: 1000
+                          maxItems: 10000
                           type: array
                         default_api_key:
                           type: string
@@ -23052,7 +23052,7 @@ paths:
                         packages:
                           items:
                             type: string
-                          maxItems: 1000
+                          maxItems: 10000
                           type: array
                         policy_id:
                           type: string
@@ -23105,7 +23105,7 @@ paths:
                         upgrade_attempts:
                           items:
                             type: string
-                          maxItems: 1000
+                          maxItems: 10000
                           nullable: true
                           type: array
                         upgrade_details:
@@ -23257,7 +23257,7 @@ paths:
                   items:
                     items:
                       type: string
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -23437,14 +23437,14 @@ paths:
                                   - type
                                   - status
                                   - message
-                              maxItems: 1000
+                              maxItems: 10000
                               type: array
                           required:
                             - id
                             - type
                             - status
                             - message
-                        maxItems: 1000
+                        maxItems: 10000
                         type: array
                       default_api_key:
                         type: string
@@ -23524,7 +23524,7 @@ paths:
                       packages:
                         items:
                           type: string
-                        maxItems: 1000
+                        maxItems: 10000
                         type: array
                       policy_id:
                         type: string
@@ -23577,7 +23577,7 @@ paths:
                       upgrade_attempts:
                         items:
                           type: string
-                        maxItems: 1000
+                        maxItems: 10000
                         nullable: true
                         type: array
                       upgrade_details:
@@ -23789,14 +23789,14 @@ paths:
                                   - type
                                   - status
                                   - message
-                              maxItems: 1000
+                              maxItems: 10000
                               type: array
                           required:
                             - id
                             - type
                             - status
                             - message
-                        maxItems: 1000
+                        maxItems: 10000
                         type: array
                       default_api_key:
                         type: string
@@ -23876,7 +23876,7 @@ paths:
                       packages:
                         items:
                           type: string
-                        maxItems: 1000
+                        maxItems: 10000
                         type: array
                       policy_id:
                         type: string
@@ -23929,7 +23929,7 @@ paths:
                       upgrade_attempts:
                         items:
                           type: string
-                        maxItems: 1000
+                        maxItems: 10000
                         nullable: true
                         type: array
                       upgrade_details:
@@ -24443,7 +24443,7 @@ paths:
                         - createTime
                         - status
                         - actionId
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -24610,7 +24610,7 @@ paths:
                         - nbAgentsActioned
                         - status
                         - creationTime
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -24745,7 +24745,7 @@ paths:
                   items:
                     items:
                       type: string
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -26081,7 +26081,7 @@ paths:
                         - id
                         - title
                         - count
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -26608,7 +26608,7 @@ paths:
                                 required:
                                   - id
                                   - type
-                              maxItems: 1000
+                              maxItems: 10000
                               type: array
                             installed_kibana:
                               items:
@@ -26639,7 +26639,7 @@ paths:
                                 required:
                                   - id
                                   - type
-                              maxItems: 1000
+                              maxItems: 10000
                               type: array
                             installed_kibana_space_id:
                               type: string
@@ -26787,7 +26787,7 @@ paths:
                         - version
                         - title
                         - id
-                    maxItems: 1000
+                    maxItems: 10000
                     type: array
                 required:
                   - items
@@ -27064,7 +27064,7 @@ paths:
                                         required:
                                           - id
                                           - type
-                                  maxItems: 1000
+                                  maxItems: 10000
                                   type: array
                                 error: {}
                                 installSource:
@@ -27803,7 +27803,7 @@ paths:
                               required:
                                 - id
                                 - type
-                            maxItems: 1000
+                            maxItems: 10000
                             type: array
                           installed_kibana:
                             items:
@@ -27834,7 +27834,7 @@ paths:
                               required:
                                 - id
                                 - type
-                            maxItems: 1000
+                            maxItems: 10000
                             type: array
                           installed_kibana_space_id:
                             type: string
@@ -28451,7 +28451,7 @@ paths:
                               required:
                                 - id
                                 - type
-                            maxItems: 1000
+                            maxItems: 10000
                             type: array
                           installed_kibana:
                             items:
@@ -28482,7 +28482,7 @@ paths:
                               required:
                                 - id
                                 - type
-                            maxItems: 1000
+                            maxItems: 10000
                             type: array
                           installed_kibana_space_id:
                             type: string
@@ -29139,7 +29139,7 @@ paths:
                             required:
                               - name
                               - title
-                          maxItems: 1000
+                          maxItems: 10000
                           type: array
                         description:
                           type: string

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/agent_policy.ts
@@ -516,7 +516,7 @@ export const FullAgentPolicyResponseSchema = schema.object({
       schema.object({
         id: schema.string(),
       }),
-      { maxSize: 1000 }
+      { maxSize: 10000 }
     )
   ),
   signed: schema.maybe(

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/agent.ts
@@ -186,7 +186,7 @@ export const AgentResponseSchema = schema.object({
     )
   ),
   status: schema.maybe(AgentStatusSchema),
-  packages: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+  packages: schema.arrayOf(schema.string(), { maxSize: 10000 }),
   sort: schema.maybe(schema.arrayOf(schema.any(), { maxSize: 10 })), // ES can return many different types for `sort` array values, including unsafe numbers
   metrics: schema.maybe(
     schema.object({
@@ -228,7 +228,7 @@ export const AgentResponseSchema = schema.object({
     ])
   ),
   upgrade_attempts: schema.maybe(
-    schema.oneOf([schema.literal(null), schema.arrayOf(schema.string(), { maxSize: 1000 })])
+    schema.oneOf([schema.literal(null), schema.arrayOf(schema.string(), { maxSize: 10000 })])
   ),
   access_api_key_id: schema.maybe(schema.string()),
   default_api_key: schema.maybe(schema.string()),
@@ -265,11 +265,11 @@ export const AgentResponseSchema = schema.object({
               message: schema.string(),
               payload: schema.maybe(schema.recordOf(schema.string(), schema.any())),
             }),
-            { maxSize: 1000 }
+            { maxSize: 10000 }
           )
         ),
       }),
-      { maxSize: 1000 }
+      { maxSize: 10000 }
     )
   ),
   agent: schema.maybe(
@@ -354,7 +354,7 @@ export const PostRetrieveAgentsByActionsRequestSchema = {
 };
 
 export const PostRetrieveAgentsByActionsResponseSchema = schema.object({
-  items: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+  items: schema.arrayOf(schema.string(), { maxSize: 10000 }),
 });
 
 export const PostAgentUnenrollRequestSchema = {
@@ -513,7 +513,7 @@ export const ListAgentUploadsResponseSchema = schema.object({
       actionId: schema.string(),
       error: schema.maybe(schema.string()),
     }),
-    { maxSize: 1000 }
+    { maxSize: 10000 }
   ),
 });
 
@@ -658,7 +658,7 @@ export const GetAgentDataResponseSchema = schema.object({
     ),
     { maxSize: 10000 }
   ),
-  dataPreview: schema.arrayOf(schema.any(), { maxSize: 1000 }),
+  dataPreview: schema.arrayOf(schema.any(), { maxSize: 10000 }),
 });
 
 export const GetActionStatusRequestSchema = {
@@ -789,10 +789,10 @@ export const GetActionStatusResponseSchema = schema.object({
         })
       ),
     }),
-    { maxSize: 1000 }
+    { maxSize: 10000 }
   ),
 });
 
 export const GetAvailableAgentVersionsResponseSchema = schema.object({
-  items: schema.arrayOf(schema.string(), { maxSize: 1000 }),
+  items: schema.arrayOf(schema.string(), { maxSize: 10000 }),
 });

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
@@ -25,7 +25,7 @@ const CategorySummaryItemSchema = schema.object({
 });
 
 export const GetCategoriesResponseSchema = schema.object({
-  items: schema.arrayOf(CategorySummaryItemSchema, { maxSize: 1000 }),
+  items: schema.arrayOf(CategorySummaryItemSchema, { maxSize: 10000 }),
 });
 
 export const GetPackagesRequestSchema = {
@@ -80,11 +80,11 @@ export const InstallationInfoSchema = schema.object({
   created_at: schema.maybe(schema.string()),
   updated_at: schema.maybe(schema.string()),
   namespaces: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 100 })),
-  installed_kibana: schema.arrayOf(KibanaAssetReferenceSchema, { maxSize: 1000 }),
+  installed_kibana: schema.arrayOf(KibanaAssetReferenceSchema, { maxSize: 10000 }),
   additional_spaces_installed_kibana: schema.maybe(
     schema.recordOf(schema.string(), schema.arrayOf(KibanaAssetReferenceSchema, { maxSize: 100 }))
   ),
-  installed_es: schema.arrayOf(EsAssetReferenceSchema, { maxSize: 1000 }),
+  installed_es: schema.arrayOf(EsAssetReferenceSchema, { maxSize: 10000 }),
   name: schema.string(),
   version: schema.string(),
   install_status: schema.oneOf([
@@ -223,7 +223,7 @@ export const PackageListItemSchema = PackageInfoSchema.extends({
 });
 
 export const GetPackagesResponseSchema = schema.object({
-  items: schema.arrayOf(PackageListItemSchema, { maxSize: 1000 }),
+  items: schema.arrayOf(PackageListItemSchema, { maxSize: 10000 }),
 });
 
 export const InstalledPackageSchema = schema.object({
@@ -238,7 +238,7 @@ export const InstalledPackageSchema = schema.object({
       name: schema.string(),
       title: schema.string(),
     }),
-    { maxSize: 1000 }
+    { maxSize: 10000 }
   ),
 });
 
@@ -368,7 +368,7 @@ export const BulkInstallPackagesResponseItemSchema = schema.oneOf([
     name: schema.string(),
     version: schema.string(),
     result: schema.object({
-      assets: schema.maybe(schema.arrayOf(AssetReferenceSchema, { maxSize: 1000 })),
+      assets: schema.maybe(schema.arrayOf(AssetReferenceSchema, { maxSize: 10000 })),
       status: schema.maybe(
         schema.oneOf([schema.literal('installed'), schema.literal('already_installed')])
       ),

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/settings.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/settings.ts
@@ -132,7 +132,7 @@ export const GetEnrollmentSettingsResponseSchema = schema.object({
         has_fleet_server: schema.maybe(schema.boolean()),
         fleet_server_host_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
         download_source_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
-        space_ids: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 1000 })),
+        space_ids: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10000 })),
         data_output_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
       }),
       { maxSize: 10000 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Fleet] increase maxSize in responses (#248215)](https://github.com/elastic/kibana/pull/248215)