### PR TITLE
[Security solution] Persist agent builder attachment label

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/use_attack_discovery_attachment/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/use_attack_discovery_attachment/index.test.tsx
@@ -67,7 +67,7 @@ describe('useAttackDiscoveryAttachment', () => {
       attachmentType: SecurityAgentBuilderAttachments.alert,
       attachmentData: {
         alert: '',
-        attachmentLabel: undefined,
+        attachmentLabel: 'Attack discovery',
       },
       attachmentPrompt: expect.any(String),
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/use_attack_discovery_attachment/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/use_attack_discovery_attachment/index.tsx
@@ -12,9 +12,17 @@ import {
   getAttackDiscoveryMarkdown,
   type Replacements,
 } from '@kbn/elastic-assistant-common';
+import { i18n } from '@kbn/i18n';
 import { SecurityAgentBuilderAttachments } from '../../../../../common/constants';
 import { ATTACK_DISCOVERY_ATTACHMENT_PROMPT } from '../../../../agent_builder/components/prompts';
 import { useAgentBuilderAttachment } from '../../../../agent_builder/hooks/use_agent_builder_attachment';
+
+const DEFAULT_ATTACK_DISCOVERY_ATTACHMENT_LABEL = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.agentBuilder.attachmentLabel',
+  {
+    defaultMessage: 'Attack discovery',
+  }
+);
 
 export const useAttackDiscoveryAttachment = (
   attackDiscovery?: AttackDiscovery | AttackDiscoveryAlert,
@@ -30,7 +38,7 @@ export const useAttackDiscoveryAttachment = (
               replacements,
             })
           : '',
-        attachmentLabel: attackDiscovery?.title,
+        attachmentLabel: attackDiscovery?.title ?? DEFAULT_ATTACK_DISCOVERY_ATTACHMENT_LABEL,
       },
       attachmentPrompt: ATTACK_DISCOVERY_ATTACHMENT_PROMPT,
     }),

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/alert.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/alert.test.ts
@@ -23,7 +23,7 @@ describe('createAlertAttachmentType', () => {
 
   describe('validate', () => {
     it('returns valid when alert data is valid', async () => {
-      const input = { alert: 'test alert data' };
+      const input = { alert: 'test alert data', attachmentLabel: 'Security Alert' };
 
       const result = await attachmentType.validate(input);
 
@@ -61,7 +61,7 @@ describe('createAlertAttachmentType', () => {
       const attachment: Attachment<string, unknown> = {
         id: 'test-id',
         type: SecurityAgentBuilderAttachments.alert,
-        data: { alert: 'test alert content' },
+        data: { alert: 'test alert content', attachmentLabel: 'Security Alert' },
       };
 
       const formatted = await attachmentType.format(attachment, formatContext);
@@ -75,7 +75,7 @@ describe('createAlertAttachmentType', () => {
       const attachment: Attachment<string, unknown> = {
         id: 'test-id',
         type: SecurityAgentBuilderAttachments.alert,
-        data: { invalid: 'data' },
+        data: { invalid: 'data', attachmentLabel: 'Security Alert' },
       };
 
       expect(() => attachmentType.format(attachment, formatContext)).toThrow(

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/alert.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/alert.ts
@@ -16,8 +16,9 @@ import {
   SECURITY_LABS_SEARCH_TOOL_ID,
   SECURITY_ALERTS_TOOL_ID,
 } from '../tools';
+import { securityAttachmentDataSchema } from './security_attachment_data_schema';
 
-export const alertAttachmentDataSchema = z.object({
+export const alertAttachmentDataSchema = securityAttachmentDataSchema.extend({
   alert: z.string(),
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.test.ts
@@ -17,7 +17,7 @@ describe('createEntityAttachmentType', () => {
 
   describe('validate', () => {
     it('returns valid when entity data is valid with host identifierType', async () => {
-      const input = { identifierType: 'host', identifier: 'hostname-1' };
+      const input = { identifierType: 'host', identifier: 'hostname-1', attachmentLabel: 'Risk Entity' };
 
       const result = await attachmentType.validate(input);
 
@@ -28,7 +28,7 @@ describe('createEntityAttachmentType', () => {
     });
 
     it('returns valid when entity data is valid with user identifierType', async () => {
-      const input = { identifierType: 'user', identifier: 'username-1' };
+      const input = { identifierType: 'user', identifier: 'username-1', attachmentLabel: 'Risk Entity' };
 
       const result = await attachmentType.validate(input);
 
@@ -39,7 +39,7 @@ describe('createEntityAttachmentType', () => {
     });
 
     it('returns valid when entity data is valid with service identifierType', async () => {
-      const input = { identifierType: 'service', identifier: 'service-1' };
+      const input = { identifierType: 'service', identifier: 'service-1', attachmentLabel: 'Risk Entity' };
 
       const result = await attachmentType.validate(input);
 
@@ -50,7 +50,7 @@ describe('createEntityAttachmentType', () => {
     });
 
     it('returns valid when entity data is valid with generic identifierType', async () => {
-      const input = { identifierType: 'generic', identifier: 'generic-1' };
+      const input = { identifierType: 'generic', identifier: 'generic-1', attachmentLabel: 'Risk Entity' };
 
       const result = await attachmentType.validate(input);
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.test.ts
@@ -17,7 +17,11 @@ describe('createEntityAttachmentType', () => {
 
   describe('validate', () => {
     it('returns valid when entity data is valid with host identifierType', async () => {
-      const input = { identifierType: 'host', identifier: 'hostname-1', attachmentLabel: 'Risk Entity' };
+      const input = {
+        identifierType: 'host',
+        identifier: 'hostname-1',
+        attachmentLabel: 'Risk Entity',
+      };
 
       const result = await attachmentType.validate(input);
 
@@ -28,7 +32,11 @@ describe('createEntityAttachmentType', () => {
     });
 
     it('returns valid when entity data is valid with user identifierType', async () => {
-      const input = { identifierType: 'user', identifier: 'username-1', attachmentLabel: 'Risk Entity' };
+      const input = {
+        identifierType: 'user',
+        identifier: 'username-1',
+        attachmentLabel: 'Risk Entity',
+      };
 
       const result = await attachmentType.validate(input);
 
@@ -39,7 +47,11 @@ describe('createEntityAttachmentType', () => {
     });
 
     it('returns valid when entity data is valid with service identifierType', async () => {
-      const input = { identifierType: 'service', identifier: 'service-1', attachmentLabel: 'Risk Entity' };
+      const input = {
+        identifierType: 'service',
+        identifier: 'service-1',
+        attachmentLabel: 'Risk Entity',
+      };
 
       const result = await attachmentType.validate(input);
 
@@ -50,7 +62,11 @@ describe('createEntityAttachmentType', () => {
     });
 
     it('returns valid when entity data is valid with generic identifierType', async () => {
-      const input = { identifierType: 'generic', identifier: 'generic-1', attachmentLabel: 'Risk Entity' };
+      const input = {
+        identifierType: 'generic',
+        identifier: 'generic-1',
+        attachmentLabel: 'Risk Entity',
+      };
 
       const result = await attachmentType.validate(input);
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.ts
@@ -9,7 +9,9 @@ import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachm
 import type { Attachment } from '@kbn/agent-builder-common/attachments';
 import { SecurityAgentBuilderAttachments } from '../../../common/constants';
 import { SECURITY_ENTITY_RISK_SCORE_TOOL_ID } from '../tools';
-const riskEntityAttachmentDataSchema = z.object({
+import { securityAttachmentDataSchema } from './security_attachment_data_schema';
+
+const riskEntityAttachmentDataSchema = securityAttachmentDataSchema.extend({
   identifierType: z.enum(['host', 'user', 'service', 'generic']),
   identifier: z.string().min(1),
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/rule.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/rule.ts
@@ -10,8 +10,9 @@ import type { Attachment } from '@kbn/agent-builder-common/attachments';
 import { platformCoreTools } from '@kbn/agent-builder-common';
 import { z } from '@kbn/zod';
 import { SecurityAgentBuilderAttachments } from '../../../common/constants';
+import { securityAttachmentDataSchema } from './security_attachment_data_schema';
 
-export const ruleAttachmentDataSchema = z.object({
+export const ruleAttachmentDataSchema = securityAttachmentDataSchema.extend({
   text: z.string(),
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/security_attachment_data_schema.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/security_attachment_data_schema.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+
+/**
+ * Base schema for all Security Solution agent-builder attachments.
+ *
+ * Each attachment can override its UI label by providing an `attachmentLabel`.
+ */
+export const securityAttachmentDataSchema = z.object({
+  attachmentLabel: z.string(),
+});
+
+export type SecurityAttachmentData = z.infer<typeof securityAttachmentDataSchema>;
+

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/security_attachment_data_schema.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/security_attachment_data_schema.ts
@@ -10,11 +10,9 @@ import { z } from '@kbn/zod';
 /**
  * Base schema for all Security Solution agent-builder attachments.
  *
- * Each attachment can override its UI label by providing an `attachmentLabel`.
+ * Each attachment can override its UI label by providing an `attachmentLabel`,
+ * which must be included in the schema in order for the attachment validate method to persist the label
  */
 export const securityAttachmentDataSchema = z.object({
   attachmentLabel: z.string(),
 });
-
-export type SecurityAttachmentData = z.infer<typeof securityAttachmentDataSchema>;
-


### PR DESCRIPTION
**Summary**
- Ensure Security Solution agent-builder attachments persist a stable `attachmentLabel` in conversations by standardizing it across attachment schemas.

**Why**
- The attachment `validate` method is where `attachmentLabel` is persisted. By requiring the property in each security attachment's schema, we ensure the labels are persisted
- Previously, `attachmentLabel` wasn’t consistently required/persisted, so after the response stream completed the label could **revert to the default**.

**What changed**
- Added a shared `securityAttachmentDataSchema` with required `attachmentLabel: z.string()`.
- Updated security attachment schemas (`alert`, `rule`, `entity`) to extend the shared schema.
- Updated server attachment tests to include `attachmentLabel`.
- Ensured Attack Discovery always sends a string `attachmentLabel` (defaulting when title is missing) and updated its test.

**Manual testing / repro**
- Start Kibana and opt in to Agent Builder
- Open **Security → Alerts** and open an alert flyout.
- Click **Add to chat** and then send the message to create a conversation with an alert attachment.
- Observe the attachment label in the conversation during streaming, then wait for the response stream to complete.
- **Before**: attachment label could revert to the default label after streaming completes.
- **After**: attachment label remains the expected custom label (e.g. rule name / entity name / attack discovery title) after streaming completes.

### Before
<img width="1463" height="839" alt="Screenshot 2026-01-08 at 9 35 02 AM" src="https://github.com/user-attachments/assets/708fec5e-8ca9-4a2b-b8f7-77f9b7429065" />

### After
<img width="1463" height="839" alt="Screenshot 2026-01-08 at 9 33 19 AM" src="https://github.com/user-attachments/assets/996b8583-6f4c-42b9-a26d-45b00aeb8c9e" />


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->