### PR TITLE
[9.1] [@kbn/eslint-plugin-eslint] Add scout eslint rule to forbid `esArchiv… (#248227)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2527,6 +2527,7 @@ module.exports = {
         '@kbn/eslint/scout_no_describe_configure': 'error',
         '@kbn/eslint/scout_test_file_naming': 'error',
         '@kbn/eslint/scout_require_api_client_in_api_test': 'error',
+        '@kbn/eslint/scout_no_es_archiver_in_parallel_tests': 'error',
         '@kbn/eslint/require_include_in_check_a11y': 'warn',
       },
     },

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -26,6 +26,7 @@ module.exports = {
     scout_no_describe_configure: require('./rules/scout_no_describe_configure'),
     scout_test_file_naming: require('./rules/scout_test_file_naming'),
     scout_require_api_client_in_api_test: require('./rules/scout_require_api_client_in_api_test'),
+    scout_no_es_archiver_in_parallel_tests: require('./rules/scout_no_es_archiver_in_parallel_tests'),
     require_kbn_fs: require('./rules/require_kbn_fs'),
     require_include_in_check_a11y: require('./rules/require_include_in_check_a11y'),
   },

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+
+const path = require('path');
+
+const ERROR_MSG =
+  '`esArchiver` should not be used in parallel tests. Use `globalSetupHook` in `global.setup.ts` to load archives before tests run.';
+
+const TEST_FIXTURES = new Set(['test', 'apiTest']);
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Forbid esArchiver usage in parallel tests',
+      category: 'Best Practices',
+    },
+    fixable: null,
+    schema: [],
+  },
+  create: (context) => {
+    const filename = context.getFilename();
+
+    // Only apply to files in parallel_tests directories, excluding global.setup.ts
+    if (!filename.includes('/parallel_tests/') || path.basename(filename) === 'global.setup.ts') {
+      return {};
+    }
+
+    return {
+      CallExpression(node) {
+        const { callee } = node;
+
+        // Check for test(...) or test.method(...)
+        const isFixture =
+          (callee.type === 'Identifier' && TEST_FIXTURES.has(callee.name)) ||
+          (callee.type === 'MemberExpression' &&
+            callee.object.type === 'Identifier' &&
+            TEST_FIXTURES.has(callee.object.name));
+
+        if (!isFixture) return;
+
+        // Get the callback (last argument)
+        const callback = node.arguments[node.arguments.length - 1];
+        if (!callback || !['ArrowFunctionExpression', 'FunctionExpression'].includes(callback.type))
+          return;
+
+        // Check for { esArchiver } in first param
+        const param = callback.params[0];
+        if (param?.type !== 'ObjectPattern') return;
+
+        const hasEsArchiver = param.properties.some(
+          (p) => p.type === 'Property' && p.key.type === 'Identifier' && p.key.name === 'esArchiver'
+        );
+
+        if (hasEsArchiver) {
+          context.report({ node: param, message: ERROR_MSG });
+        }
+      },
+    };
+  },
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.test.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const { RuleTester } = require('eslint');
+const rule = require('./scout_no_es_archiver_in_parallel_tests');
+const dedent = require('dedent');
+
+const ERROR_MSG =
+  '`esArchiver` should not be used in parallel tests. Use `globalSetupHook` in `global.setup.ts` to load archives before tests run.';
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2020,
+  },
+});
+
+ruleTester.run('@kbn/eslint/scout_no_es_archiver_in_parallel_tests', rule, {
+  valid: [
+    // esArchiver in global.setup.ts is allowed
+    {
+      code: dedent`
+        globalSetupHook('Ingest data', async ({ esArchiver }) => {
+          await esArchiver.loadIfNeeded('test/archive');
+        });
+      `,
+      filename: '/path/to/plugin/test/scout/ui/parallel_tests/global.setup.ts',
+    },
+    // Test without esArchiver
+    {
+      code: `test('should work', async ({ page }) => {});`,
+      filename: '/path/to/plugin/test/scout/ui/parallel_tests/my_test.spec.ts',
+    },
+    // Test outside parallel_tests directory
+    {
+      code: `test('should work', async ({ esArchiver }) => {});`,
+      filename: '/path/to/plugin/test/scout/ui/tests/my_test.spec.ts',
+    },
+  ],
+
+  invalid: [
+    // test with esArchiver
+    {
+      code: `test('should work', async ({ esArchiver }) => {});`,
+      filename: '/path/to/plugin/test/scout/ui/parallel_tests/my_test.spec.ts',
+      errors: [{ message: ERROR_MSG }],
+    },
+    // test.beforeAll with esArchiver
+    {
+      code: `test.beforeAll(async ({ esArchiver }) => {});`,
+      filename: '/path/to/plugin/test/scout/ui/parallel_tests/my_test.spec.ts',
+      errors: [{ message: ERROR_MSG }],
+    },
+    // apiTest with esArchiver
+    {
+      code: `apiTest('should call API', async ({ esArchiver }) => {});`,
+      filename: '/path/to/plugin/test/scout/api/parallel_tests/api_test.spec.ts',
+      errors: [{ message: ERROR_MSG }],
+    },
+  ],
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[@kbn/eslint-plugin-eslint] Add scout eslint rule to forbid `esArchiv… (#248227)](https://github.com/elastic/kibana/pull/248227)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stelios Mavro","email":"81311181+steliosmavro@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-08T16:42:04Z","message":"[@kbn/eslint-plugin-eslint] Add scout eslint rule to forbid `esArchiv… (#248227)\n\n## Summary\nAdds a new ESLint rule `scout_no_es_archiver_in_parallel_tests` that\nforbids `esArchiver` usage in parallel test fixtures. Instead, archives\nshould be loaded in `global.setup.ts` using `globalSetupHook` to ensure\ndata is pre-loaded before parallel tests run.\n\n## What it does\nThe rule checks for `esArchiver` destructuring in test fixture callbacks\n(`spaceTest`, `test`, `apiTest` and their methods like `beforeAll`,\n`describe`, etc.) within `parallel_tests` directories.\n\n**Invalid:**\n```ts\n// ❌ esArchiver in spaceTest callback\n// test/scout/ui/parallel_tests/my_test.spec.ts\nspaceTest('should work', async ({ esArchiver }) => {\n  await esArchiver.load('test/archive');  // Error: use globalSetupHook instead\n});\n\n// ❌ esArchiver in test.beforeAll\n// test/scout/ui/parallel_tests/my_test.spec.ts\ntest.beforeAll(async ({ esArchiver }) => {\n  await esArchiver.load('test/archive');  // Error: use globalSetupHook instead\n});\n\n// ❌ esArchiver in apiTest\n// test/scout/api/parallel_tests/api_test.spec.ts\napiTest('should call API', async ({ esArchiver }) => {\n  await esArchiver.load('test/archive');  // Error: use globalSetupHook instead\n});\n```\n\n**Valid:**\n```ts\n// ✅ esArchiver in global.setup.ts\n// test/scout/ui/parallel_tests/global.setup.ts\nglobalSetupHook('Ingest data', async ({ esArchiver }) => {\n  await esArchiver.loadIfNeeded('test/archive');  // OK: this is the right place\n});\n\n// ✅ Test without esArchiver\n// test/scout/ui/parallel_tests/my_test.spec.ts\nspaceTest('should work', async ({ page }) => {\n  await page.goto('/app');  // OK: no esArchiver usage\n});\n\n// ✅ esArchiver outside parallel_tests directory\n// test/scout/ui/tests/my_test.spec.ts\ntest('should work', async ({ esArchiver }) => {\n  await esArchiver.load('test/archive');  // OK: rule only applies to parallel_tests\n});\n```\n\n## Features\n- Detects `esArchiver` destructuring in `spaceTest`, `test`, and\n`apiTest` fixtures\n- Covers fixture methods: `describe`, `beforeAll`, `beforeEach`,\n`afterAll`, `afterEach`\n- Excludes `global.setup.ts` files where `esArchiver` is allowed\n- Only applies to files within `parallel_tests` directories\n\n## Changes\n- Added rule implementation in\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.js`\n- Added test suite in\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.test.js`\n- Registered rule in plugin index and enabled as error for Scout test\nfiles","sha":"f402cef87fb23afe35f9a1b4193ee9ed96a8cf58","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.3.0","v9.4.0"],"title":"[@kbn/eslint-plugin-eslint] Add scout eslint rule to forbid `esArchiv…","number":248227,"url":"https://github.com/elastic/kibana/pull/248227","mergeCommit":{"message":"[@kbn/eslint-plugin-eslint] Add scout eslint rule to forbid `esArchiv… (#248227)\n\n## Summary\nAdds a new ESLint rule `scout_no_es_archiver_in_parallel_tests` that\nforbids `esArchiver` usage in parallel test fixtures. Instead, archives\nshould be loaded in `global.setup.ts` using `globalSetupHook` to ensure\ndata is pre-loaded before parallel tests run.\n\n## What it does\nThe rule checks for `esArchiver` destructuring in test fixture callbacks\n(`spaceTest`, `test`, `apiTest` and their methods like `beforeAll`,\n`describe`, etc.) within `parallel_tests` directories.\n\n**Invalid:**\n```ts\n// ❌ esArchiver in spaceTest callback\n// test/scout/ui/parallel_tests/my_test.spec.ts\nspaceTest('should work', async ({ esArchiver }) => {\n  await esArchiver.load('test/archive');  // Error: use globalSetupHook instead\n});\n\n// ❌ esArchiver in test.beforeAll\n// test/scout/ui/parallel_tests/my_test.spec.ts\ntest.beforeAll(async ({ esArchiver }) => {\n  await esArchiver.load('test/archive');  // Error: use globalSetupHook instead\n});\n\n// ❌ esArchiver in apiTest\n// test/scout/api/parallel_tests/api_test.spec.ts\napiTest('should call API', async ({ esArchiver }) => {\n  await esArchiver.load('test/archive');  // Error: use globalSetupHook instead\n});\n```\n\n**Valid:**\n```ts\n// ✅ esArchiver in global.setup.ts\n// test/scout/ui/parallel_tests/global.setup.ts\nglobalSetupHook('Ingest data', async ({ esArchiver }) => {\n  await esArchiver.loadIfNeeded('test/archive');  // OK: this is the right place\n});\n\n// ✅ Test without esArchiver\n// test/scout/ui/parallel_tests/my_test.spec.ts\nspaceTest('should work', async ({ page }) => {\n  await page.goto('/app');  // OK: no esArchiver usage\n});\n\n// ✅ esArchiver outside parallel_tests directory\n// test/scout/ui/tests/my_test.spec.ts\ntest('should work', async ({ esArchiver }) => {\n  await esArchiver.load('test/archive');  // OK: rule only applies to parallel_tests\n});\n```\n\n## Features\n- Detects `esArchiver` destructuring in `spaceTest`, `test`, and\n`apiTest` fixtures\n- Covers fixture methods: `describe`, `beforeAll`, `beforeEach`,\n`afterAll`, `afterEach`\n- Excludes `global.setup.ts` files where `esArchiver` is allowed\n- Only applies to files within `parallel_tests` directories\n\n## Changes\n- Added rule implementation in\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.js`\n- Added test suite in\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.test.js`\n- Registered rule in plugin index and enabled as error for Scout test\nfiles","sha":"f402cef87fb23afe35f9a1b4193ee9ed96a8cf58"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/248322","number":248322,"state":"MERGED","mergeCommit":{"sha":"d20f5f4651eb9acd245da53fcc0663da88dc6bdb","message":"[9.3] [@kbn/eslint-plugin-eslint] Add scout eslint rule to forbid `esArchiv… (#248227) (#248322)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[@kbn/eslint-plugin-eslint] Add scout eslint rule to forbid\n`esArchiv… (#248227)](https://github.com/elastic/kibana/pull/248227)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Stelios Mavro <81311181+steliosmavro@users.noreply.github.com>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248227","number":248227,"mergeCommit":{"message":"[@kbn/eslint-plugin-eslint] Add scout eslint rule to forbid `esArchiv… (#248227)\n\n## Summary\nAdds a new ESLint rule `scout_no_es_archiver_in_parallel_tests` that\nforbids `esArchiver` usage in parallel test fixtures. Instead, archives\nshould be loaded in `global.setup.ts` using `globalSetupHook` to ensure\ndata is pre-loaded before parallel tests run.\n\n## What it does\nThe rule checks for `esArchiver` destructuring in test fixture callbacks\n(`spaceTest`, `test`, `apiTest` and their methods like `beforeAll`,\n`describe`, etc.) within `parallel_tests` directories.\n\n**Invalid:**\n```ts\n// ❌ esArchiver in spaceTest callback\n// test/scout/ui/parallel_tests/my_test.spec.ts\nspaceTest('should work', async ({ esArchiver }) => {\n  await esArchiver.load('test/archive');  // Error: use globalSetupHook instead\n});\n\n// ❌ esArchiver in test.beforeAll\n// test/scout/ui/parallel_tests/my_test.spec.ts\ntest.beforeAll(async ({ esArchiver }) => {\n  await esArchiver.load('test/archive');  // Error: use globalSetupHook instead\n});\n\n// ❌ esArchiver in apiTest\n// test/scout/api/parallel_tests/api_test.spec.ts\napiTest('should call API', async ({ esArchiver }) => {\n  await esArchiver.load('test/archive');  // Error: use globalSetupHook instead\n});\n```\n\n**Valid:**\n```ts\n// ✅ esArchiver in global.setup.ts\n// test/scout/ui/parallel_tests/global.setup.ts\nglobalSetupHook('Ingest data', async ({ esArchiver }) => {\n  await esArchiver.loadIfNeeded('test/archive');  // OK: this is the right place\n});\n\n// ✅ Test without esArchiver\n// test/scout/ui/parallel_tests/my_test.spec.ts\nspaceTest('should work', async ({ page }) => {\n  await page.goto('/app');  // OK: no esArchiver usage\n});\n\n// ✅ esArchiver outside parallel_tests directory\n// test/scout/ui/tests/my_test.spec.ts\ntest('should work', async ({ esArchiver }) => {\n  await esArchiver.load('test/archive');  // OK: rule only applies to parallel_tests\n});\n```\n\n## Features\n- Detects `esArchiver` destructuring in `spaceTest`, `test`, and\n`apiTest` fixtures\n- Covers fixture methods: `describe`, `beforeAll`, `beforeEach`,\n`afterAll`, `afterEach`\n- Excludes `global.setup.ts` files where `esArchiver` is allowed\n- Only applies to files within `parallel_tests` directories\n\n## Changes\n- Added rule implementation in\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.js`\n- Added test suite in\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_es_archiver_in_parallel_tests.test.js`\n- Registered rule in plugin index and enabled as error for Scout test\nfiles","sha":"f402cef87fb23afe35f9a1b4193ee9ed96a8cf58"}}]}] BACKPORT-->