### PR TITLE
[Lens][Data Table] Only apply background color for colorMode: cell

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/cell_value.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/cell_value.test.tsx
@@ -372,5 +372,39 @@ describe('datatable cell renderer', () => {
       const linkColor = '#1750BA';
       expect(screen.getByRole('button')).toHaveStyle(`color: ${linkColor}`);
     });
+
+    it('should not adjust link color when colorMode is none', () => {
+      const backgroundColor = '#FF0000'; // A distinct background color
+      const isDarkMode = false;
+      const columnConfigNonCellColorMode: DatatableArgs = {
+        ...columnConfig,
+        columns: [
+          {
+            ...columnConfig.columns[0],
+            colorMode: 'none',
+          },
+        ],
+      };
+      renderThemedCellRenderer(columnConfigNonCellColorMode, isDarkMode, backgroundColor);
+      const linkColor = '#1750BA'; // Default EuiLink color for light mode
+      expect(screen.getByRole('button')).toHaveStyle(`color: ${linkColor}`);
+    });
+
+    it('should not adjust link color when colorMode is text', () => {
+      const backgroundColor = '#FF0000'; // A distinct background color
+      const isDarkMode = false;
+      const columnConfigNonCellColorMode: DatatableArgs = {
+        ...columnConfig,
+        columns: [
+          {
+            ...columnConfig.columns[0],
+            colorMode: 'text',
+          },
+        ],
+      };
+      renderThemedCellRenderer(columnConfigNonCellColorMode, isDarkMode, backgroundColor);
+      const linkColor = '#1750BA'; // Default EuiLink color for light mode
+      expect(screen.getByRole('button')).toHaveStyle(`color: ${linkColor}`);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/cell_value.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/cell_value.tsx
@@ -80,12 +80,14 @@ export const createGridCell = (
       const backgroundColor = getCellColor(columnId, palette, colorMapping)(rawValue);
       const linkColor = euiTheme.colors.link;
 
-      const adjustedLinkColor = backgroundColor
-        ? makeHighContrastColor(
-            isDarkMode ? euiTheme.colors.highlight : linkColor, // preferred foreground color
-            4.5 // WCAG AA contrast ratio (default in EUI)
-          )(backgroundColor)
-        : linkColor;
+      // Only adjust the color for colorMode: cell
+      const adjustedLinkColor =
+        colorMode === 'cell' && backgroundColor
+          ? makeHighContrastColor(
+              isDarkMode ? euiTheme.colors.highlight : linkColor, // preferred foreground color
+              4.5 // WCAG AA contrast ratio (default in EUI)
+            )(backgroundColor)
+          : linkColor;
 
       return (
         <div


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/issues/242181

## Summary

This PR ensures to only apply the color contrast when colorMode is "cell" and ignores this change for "none" or "text" colorMode.

|Before|After|
|---|---|
|<img width="1505" height="817" alt="image" src="https://github.com/user-attachments/assets/b511bf97-9595-4621-b3b0-42d208386be3" />|<img width="1511" height="819" alt="image" src="https://github.com/user-attachments/assets/9274242b-084a-46d7-bd7a-5d547624ba66" />|

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->