### PR TITLE
[9.1] [Synthetics] Add global params sync internal API !! (#239284)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
@@ -24,6 +24,8 @@ export enum SYNTHETICS_API_URLS {
   SYNTHETICS_PROJECT_APIKEY = '/internal/synthetics/service/api_key',
   SYNTHETICS_HAS_INTEGRATION_MONITORS = '/internal/synthetics/fleet/has_integration_monitors',
   PRIVATE_LOCATIONS_CLEANUP = `/internal/synthetics/private_locations/_cleanup`,
+  SYNC_GLOBAL_PARAMS = `/internal/synthetics/sync_global_params`,
+  SYNC_GLOBAL_PARAMS_SETTINGS = `/internal/synthetics/sync_global_params/_settings`,
 
   PINGS = '/internal/synthetics/pings',
   MONITOR_STATUS_HEATMAP = '/internal/synthetics/ping_heatmap',

--- a/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/plugin.ts
@@ -93,9 +93,9 @@ export class Plugin implements PluginType {
 
     this.syncPrivateLocationMonitorsTask = new SyncPrivateLocationMonitorsTask(
       this.server,
-      plugins.taskManager,
       this.syntheticsMonitorClient
     );
+    this.syncPrivateLocationMonitorsTask.registerTaskDefinition(plugins.taskManager);
 
     return {};
   }

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { syncParamsSettingsParamsRoute } from './settings/params/sync_global_params_settings';
+import { syncParamsSyntheticsParamsRoute } from './settings/params/sync_global_params';
 import { cleanupPrivateLocationRoute } from './settings/private_locations/cleanup_private_locations';
 import { getSyntheticsTriggerTaskRun } from './tasks/trigger_task_run';
 import { syntheticsInspectStatusRuleRoute } from './rules/inspect_status_rule';
@@ -108,6 +110,8 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   syntheticsInspectTLSRuleRoute,
   getSyntheticsTriggerTaskRun,
   cleanupPrivateLocationRoute,
+  syncParamsSyntheticsParamsRoute,
+  syncParamsSettingsParamsRoute,
 ];
 
 export const syntheticsAppPublicRestApiRoutes: SyntheticsRestApiRouteFactory[] = [

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/sync_global_params.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/sync_global_params.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SyncPrivateLocationMonitorsTask } from '../../../tasks/sync_private_locations_monitors_task';
+import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { getPrivateLocations } from '../../../synthetics_service/get_private_locations';
+import type { SyntheticsRestApiRouteFactory } from '../../types';
+
+export const syncParamsSyntheticsParamsRoute: SyntheticsRestApiRouteFactory = () => ({
+  method: 'PUT',
+  path: SYNTHETICS_API_URLS.SYNC_GLOBAL_PARAMS,
+  validate: {},
+  options: {
+    // 5 minutes
+    timeout: {
+      payload: 1000 * 60 * 5,
+    },
+  },
+  writeAccess: true,
+  handler: async ({ syntheticsMonitorClient, server }): Promise<any> => {
+    const soClient = server.coreStart.savedObjects.createInternalRepository();
+
+    const allPrivateLocations = await getPrivateLocations(soClient);
+
+    const syncTask = new SyncPrivateLocationMonitorsTask(server, syntheticsMonitorClient);
+    if (allPrivateLocations.length > 0) {
+      await syncTask.syncGlobalParams({
+        allPrivateLocations,
+        soClient,
+      });
+    }
+
+    return { success: true };
+  },
+});

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/sync_global_params_settings.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/settings/params/sync_global_params_settings.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { disableSyncPrivateLocationTask } from '../../../tasks/sync_private_locations_monitors_task';
+import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import type { SyntheticsRestApiRouteFactory } from '../../types';
+
+export const syncParamsSettingsParamsRoute: SyntheticsRestApiRouteFactory = () => ({
+  method: 'PUT',
+  path: SYNTHETICS_API_URLS.SYNC_GLOBAL_PARAMS_SETTINGS,
+  validate: {
+    body: schema.object({
+      enable: schema.boolean(),
+    }),
+  },
+  writeAccess: true,
+  handler: async ({ server, request }): Promise<any> => {
+    const { enable } = request.body as { enable: boolean };
+    await disableSyncPrivateLocationTask({ server, disableAutoSync: !enable });
+    return { success: true };
+  },
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Synthetics] Add global params sync internal API !! (#239284)](https://github.com/elastic/kibana/pull/239284)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2025-12-09T08:45:43Z","message":"[Synthetics] Add global params sync internal API !! (#239284)\n\n## Summary\n\nThese two endpoints are added to provide bit more control around the\nsync task functionality, they are currently not being used in UI.\n\nFollowing two endpoints have been added to be used internally !!\n\n`/internal/synthetics/sync_global_params`\n\nThis will trigger syncing of global params to private locations. \n\n\n```\n`PUT /internal/synthetics/sync_global_params/_settings`\n{\n\tenable: false\n}\n```\n\nThis can be used to disable/enable the task which performs auto syncing\nof global params to private locations.\n\n---------\n\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>\nCo-authored-by: Justin Kambic <jk@elastic.co>","sha":"d40cdc43feac6995a0036c0b80d59584fea874be","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:feature","Team:actionable-obs","backport:version","author:obs-ux-management","v8.19.6","Team:obs-ux-management","v9.2.3","v8.19.9","v9.1.10"],"title":"[Synthetics] Add global params sync internal API !!","number":239284,"url":"https://github.com/elastic/kibana/pull/239284","mergeCommit":{"message":"[Synthetics] Add global params sync internal API !! (#239284)\n\n## Summary\n\nThese two endpoints are added to provide bit more control around the\nsync task functionality, they are currently not being used in UI.\n\nFollowing two endpoints have been added to be used internally !!\n\n`/internal/synthetics/sync_global_params`\n\nThis will trigger syncing of global params to private locations. \n\n\n```\n`PUT /internal/synthetics/sync_global_params/_settings`\n{\n\tenable: false\n}\n```\n\nThis can be used to disable/enable the task which performs auto syncing\nof global params to private locations.\n\n---------\n\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>\nCo-authored-by: Justin Kambic <jk@elastic.co>","sha":"d40cdc43feac6995a0036c0b80d59584fea874be"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/245601","number":245601,"state":"MERGED","mergeCommit":{"sha":"1215ac8b2928aa103db3c6f2b59ec69c04fdbffc","message":"[8.19] [Synthetics] Add global params sync internal API !! (#239284) (#245601)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Synthetics] Add global params sync internal API !!\n(#239284)](https://github.com/elastic/kibana/pull/239284)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>"}},{"branch":"9.2","label":"v9.2.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/245599","number":245599,"state":"MERGED","mergeCommit":{"sha":"e8fe3ec5d822d21fcba9082d51d26af87076f071","message":"[9.2] [Synthetics] Add global params sync internal API !! (#239284) (#245599)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Synthetics] Add global params sync internal API !!\n(#239284)](https://github.com/elastic/kibana/pull/239284)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>\nCo-authored-by: Justin Kambic <jk@elastic.co>"}},{"branch":"9.1","label":"v9.1.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->