### PR TITLE
[9.3] [Agent Builder] rename workflow step to `ai.agent` (#248297)

### DIFF
--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
@@ -26,7 +26,7 @@
 export const APPROVED_STEP_DEFINITIONS: Array<{ id: string; handlerHash: string }> = [
   {
     id: 'ai.agent',
-    handlerHash: '5900dff8945512df13e3e082cec3750deddb8ca43675bde01e452b263c2f2d9d',
+    handlerHash: '4f61ed4415041b7423c43fb4a2ef0d19032360092cef14b99587c2003ba7667e',
   },
   {
     id: 'ai.prompt',

--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
@@ -25,11 +25,11 @@
  */
 export const APPROVED_STEP_DEFINITIONS: Array<{ id: string; handlerHash: string }> = [
   {
-    id: 'ai.prompt',
-    handlerHash: 'fa1e9cfa78ed6c6cbebabe3533286b88ff9b3715dfb1b64b3d460251f72f9838',
+    id: 'ai.agent',
+    handlerHash: '5900dff8945512df13e3e082cec3750deddb8ca43675bde01e452b263c2f2d9d',
   },
   {
-    id: 'onechat.runAgent',
-    handlerHash: '4f61ed4415041b7423c43fb4a2ef0d19032360092cef14b99587c2003ba7667e',
+    id: 'ai.prompt',
+    handlerHash: 'fa1e9cfa78ed6c6cbebabe3533286b88ff9b3715dfb1b64b3d460251f72f9838',
   },
 ];

--- a/x-pack/platform/plugins/shared/onechat/common/step_types/run_agent_step.ts
+++ b/x-pack/platform/plugins/shared/onechat/common/step_types/run_agent_step.ts
@@ -11,7 +11,7 @@ import type { CommonStepDefinition } from '@kbn/workflows-extensions/common';
 /**
  * Step type ID for the onechat run agent step.
  */
-export const RunAgentStepTypeId = 'onechat.runAgent';
+export const RunAgentStepTypeId = 'ai.agent';
 
 /**
  * Input schema for the run agent step.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Agent Builder] rename workflow step to `ai.agent` (#248297)](https://github.com/elastic/kibana/pull/248297)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pierre Gayvallet","email":"pierre.gayvallet@elastic.co"},"sourceCommit":{"committedDate":"2026-01-09T07:57:22Z","message":"[Agent Builder] rename workflow step to `ai.agent` (#248297)\n\n## Summary\n\nBecause naming is hard. Rename the \"run agent\" workflow step's id from\n`agentBuilder.runAgent` to `ai.agent`","sha":"d7811b569372999054d9c04bc4d0fc0cf3fb9499","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.3.0","v9.4.0"],"title":"[Agent Builder] rename workflow step to `ai.agent`","number":248297,"url":"https://github.com/elastic/kibana/pull/248297","mergeCommit":{"message":"[Agent Builder] rename workflow step to `ai.agent` (#248297)\n\n## Summary\n\nBecause naming is hard. Rename the \"run agent\" workflow step's id from\n`agentBuilder.runAgent` to `ai.agent`","sha":"d7811b569372999054d9c04bc4d0fc0cf3fb9499"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248297","number":248297,"mergeCommit":{"message":"[Agent Builder] rename workflow step to `ai.agent` (#248297)\n\n## Summary\n\nBecause naming is hard. Rename the \"run agent\" workflow step's id from\n`agentBuilder.runAgent` to `ai.agent`","sha":"d7811b569372999054d9c04bc4d0fc0cf3fb9499"}}]}] BACKPORT-->