### PR TITLE
[Fleet] Disable buttons on settings page when another operation is in progress

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/reinstall_button.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/reinstall_button.tsx
@@ -23,8 +23,14 @@ export function ReinstallButton(props: ReinstallationButtonProps) {
   const installPackage = useInstallPackage();
   const getPackageInstallStatus = useGetPackageInstallStatus();
   const { status: installationStatus } = getPackageInstallStatus(name);
-
   const isReinstalling = installationStatus === InstallStatus.reinstalling;
+
+  const isStatusInProgress = [
+    InstallStatus.installing,
+    InstallStatus.rollingBack,
+    InstallStatus.uninstalling,
+  ].includes(installationStatus);
+
   const isUploadedPackage = installSource === 'upload';
 
   const handleClickReinstall = useCallback(() => {
@@ -33,10 +39,11 @@ export function ReinstallButton(props: ReinstallationButtonProps) {
 
   const reinstallButton = (
     <EuiButton
+      data-test-subj="reinstallButton"
       iconType="refresh"
       isLoading={isReinstalling}
       onClick={handleClickReinstall}
-      disabled={isUploadedPackage || isCustomPackage}
+      disabled={isUploadedPackage || isCustomPackage || isStatusInProgress}
     >
       {isReinstalling ? (
         <FormattedMessage

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/rollback_button.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/settings/rollback_button.tsx
@@ -33,6 +33,18 @@ export function RollbackButton({ packageInfo, isCustomPackage }: RollbackButtonP
   const isRollbackTTLExpired = !!packageInfo.installationInfo?.is_rollback_ttl_expired;
   const isUploadedPackage = packageInfo.installationInfo?.install_source === 'upload';
   const isRegistryPackage = packageInfo.installationInfo?.install_source === 'registry';
+
+  const {
+    actions: { bulkRollbackIntegrationsWithConfirmModal },
+  } = useInstalledIntegrationsActions();
+  const rollbackPackage = useRollbackPackage();
+  const getPackageInstallStatus = useGetPackageInstallStatus();
+  const { status: installationStatus } = getPackageInstallStatus(packageInfo.name);
+  const isRollingBack = installationStatus === InstallStatus.rollingBack;
+  const isReinstalling = installationStatus === InstallStatus.reinstalling;
+  const isUninstalling = installationStatus === InstallStatus.uninstalling;
+  const isInstalling = installationStatus === InstallStatus.installing;
+
   const isDisabled =
     !canRollbackPackages ||
     !hasPreviousVersion ||
@@ -41,14 +53,10 @@ export function RollbackButton({ packageInfo, isCustomPackage }: RollbackButtonP
     isCustomPackage ||
     !licenseService.isEnterprise() ||
     isRollbackTTLExpired ||
-    !isAvailable;
-  const {
-    actions: { bulkRollbackIntegrationsWithConfirmModal },
-  } = useInstalledIntegrationsActions();
-  const rollbackPackage = useRollbackPackage();
-  const getPackageInstallStatus = useGetPackageInstallStatus();
-  const { status: installationStatus } = getPackageInstallStatus(packageInfo.name);
-  const isRollingBack = installationStatus === InstallStatus.rollingBack;
+    !isAvailable ||
+    isReinstalling ||
+    isUninstalling ||
+    isInstalling;
 
   const openRollbackModal = useCallback(async () => {
     await rollbackPackage(packageInfo, bulkRollbackIntegrationsWithConfirmModal);


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/245338


## Summary

Disable buttons on settings page when another operation is in progress

### Testing
- Upgrade an integration and its policies
- Navigate to Details page > Settings
- Rollback integration
- The reinstall button is now disabled while rolling back

<img width="1706" height="987" alt="Screenshot 2026-01-09 at 11 35 12" src="https://github.com/user-attachments/assets/92fddfe4-df6c-4ae6-a078-7b1ce8370237" />

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->