### PR TITLE
[Onboarding] Use correct service selector for OTel Kubernetes e2e test

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
@@ -28,7 +28,6 @@ test.beforeEach(async ({ page }) => {
  */
 const INSTRUMENTED_APP_CONTAINER_NAMESPACE = 'java';
 const INSTRUMENTED_APP_NAME = 'java-app';
-const isServerless = process.env.CLUSTER_ENVIRONMENT === 'serverless';
 
 test('Otel Kubernetes', async ({ page, onboardingHomePage, otelKubernetesFlowPage }) => {
   assertEnv(process.env.ARTIFACTS_FOLDER, 'ARTIFACTS_FOLDER is not defined.');
@@ -97,9 +96,7 @@ test('Otel Kubernetes', async ({ page, onboardingHomePage, otelKubernetesFlowPag
       await otelKubernetesFlowPage.openServiceInventoryInNewTab()
     );
 
-    const serviceTestId = isServerless
-      ? 'serviceLink_java'
-      : 'serviceLink_opentelemetry/java/elastic';
+    const serviceTestId = 'serviceLink_opentelemetry/java/elastic';
 
     await apmServiceInventoryPage.page.getByTestId(serviceTestId).click();
     await apmServiceInventoryPage.assertTransactionExists();


### PR DESCRIPTION
## Summary 📚 

Fixes flaky Kubernetes OTel e2e test for serverless by correcting the service link selector.

### Problem

The Kubernetes OTel onboarding e2e test has started failing intermittently for a while now, with timeouts when trying to click on the Java service in the APM Service Inventory.

### What Likely Caused the Failure

The flakiness started appearing after version bump the kube-stack Helm chart from `0.10.5` to `0.12.4`. This update included:

- OpenTelemetry Operator upgrade from `0.97.1` to `0.99.0`
- EDOT Java agent upgrade from `1.0.0` to `1.6.0`


### Root Cause 

The test was using different selectors for serverless vs stateful environments:

```
const serviceTestId = isServerless
  ? 'serviceLink_java' // 
  : 'serviceLink_opentelemetry/java/elastic'; 
```

**The issue:** The `serviceLink_java` selector matched **`opbeans-java`** (a background demo service using the native APM Java agent), not the **`java-app`** service that we deploy and instrument via EDOT as part of the onboarding flow.

The `java-app` service uses EDOT (Elastic Distribution of OpenTelemetry) Java auto-instrumentation, which reports `agent.name` as `opentelemetry/java/elastic` - the same in both serverless and stateful environments.

### Fix 
```typescript
const serviceTestId = 'serviceLink_opentelemetry/java/elastic';
```

## Testing 🧪 

To verify the fix, I added debug logging to capture all `serviceLink_*` test IDs present on the APM Service Inventory page. This confirmed which services were available and their corresponding agent names:
https://github.com/elastic/ensemble/actions/runs/20816375777
You can check last 4 runs and the artifact. 

Latest run : https://github.com/elastic/ensemble/actions/runs/20849921266