### PR TITLE
Support initial `modelVersion` in `Check Saved Objects` CI step

### DIFF
--- a/docs/extend/saved-objects.md
+++ b/docs/extend/saved-objects.md
@@ -297,11 +297,22 @@ const myType: SavedObjectsType = {
 };
 ```
 
-### Defining model versions for existing Saved Objects
+### Transitioning legacy Saved Objects
 
-If you are updating a legacy Saved Object type that lacks an existing model version, you must establish a baseline by creating an initial version, which defines the current, existing shape of the Saved Object.
+If you are updating a legacy Saved Object (SO) type that lacks a model version, you must first establish a baseline. This requires a two-step PR process to ensure that Serverless environments can be safely rolled back in an emergency.
 
-While the example below shows the minimal configuration for an initial version, we recommend defining `create` and `forwardCompatibility` schemas that closely match your Saved Object's structure. Doing so ensures you benefit from full **Saved Objects Repository (SOR)** validation during both creation and retrieval.
+#### The Initial Version PR
+
+The first PR must define the **current, existing shape** of the Saved Object.
+
+- No Mapping Changes: The initial version must not alter any existing mappings; it should only introduce the required schemas.
+- Deployment Requirement: This PR must be merged and released in Serverless before you submit a second PR with your desired changes.
+
+#### Schema definition
+
+While you can use a minimal configuration for the initial version, we recommend defining `create` and `forwardCompatibility` schemas that closely reflect your SO’s current structure. This enables full **Saved Objects Repository (SOR)** validation for both creation and retrieval.
+
+#### Minimal configuration example
 
 ```ts
 const myType: SavedObjectsType = {

--- a/docs/extend/saved-objects.md
+++ b/docs/extend/saved-objects.md
@@ -297,6 +297,33 @@ const myType: SavedObjectsType = {
 };
 ```
 
+### Defining model versions for existing Saved Objects
+
+If you are updating a legacy Saved Object type that lacks an existing model version, you must establish a baseline by creating an initial version, which defines the current, existing shape of the Saved Object.
+
+While the example below shows the minimal configuration for an initial version, we recommend defining `create` and `forwardCompatibility` schemas that closely match your Saved Object's structure. Doing so ensures you benefit from full **Saved Objects Repository (SOR)** validation during both creation and retrieval.
+
+```ts
+const myType: SavedObjectsType = {
+  ...
+  modelVersions: {
+    1: {
+      changes: [],
+      schemas: {
+        create: schema.object({}, { unknowns: 'allow' }),
+        forwardCompatibility: (attrs) => _.pick([
+          'knownField1',
+          'knownField2',
+          ...
+          'knownFieldN',
+        ]),
+      },
+    },
+  ...
+```
+
+If your Saved Object type was defining `schemas:` along with the legacy `migrations:`, you can simply use the latest schema for the initial version.
+
 ## Structure of a model version [_structure_of_a_model_version]
 
 [Model versions](https://github.com/elastic/kibana/blob/master/src/core/packages/saved-objects/server/src/model_version/model_version.ts#L12-L20) are not just functions as the previous migrations were, but structured objects describing how the version behaves and what changed since the last one.

--- a/packages/kbn-check-saved-objects-cli/src/commands/run_check_saved_objects_cli.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/run_check_saved_objects_cli.ts
@@ -169,6 +169,11 @@ export function runCheckSavedObjectsCli() {
           { fallbackRenderer: 'simple', exitOnError: false }
         ).run(context);
       }
+      if (exitCode) {
+        log.warning(
+          'Validation Failed. Please refer to our troubleshooting guide for more information: https://www.elastic.co/docs/extend/kibana/saved-objects#troubleshooting'
+        );
+      }
       process.exit(exitCode);
     },
     {

--- a/packages/kbn-check-saved-objects-cli/src/commands/tasks/check_documents.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/tasks/check_documents.ts
@@ -35,7 +35,7 @@ export function checkDocuments({
         const messages = [
           `❌ A document of type '${type}' did NOT match any of the fixtures`,
           ...documents.map((fixture, index) => [
-            `document 🆚 fixtures['${version}'][${index}] (${relativePath})`,
+            `document 🆚 fixtures['${version}'][${index}] (${relativePath})\n`,
             diff(fixture, attributes),
           ]),
         ];

--- a/packages/kbn-check-saved-objects-cli/src/commands/tasks/create_baseline.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/tasks/create_baseline.ts
@@ -49,9 +49,9 @@ export const createBaseline: Task = async (ctx, task) => {
         // convert the fixtures into SavedObjectsBulkCreateObject[]
         const allDocs = Object.entries(ctx.fixtures.previous).flatMap(
           ([type, { version, documents }]) => {
-            // This is a special case for when a type has no migrations yet, we do not send the typeMigrationVersion field
-            // because this type has not been migrated under the model version system yet.
-            if (version === '10.0.0') {
+            // When a type has no migrations nor modelVersions
+            // we should not send the typeMigrationVersion field
+            if (version === '0.0.0') {
               version = undefined as unknown as string;
             }
 

--- a/packages/kbn-check-saved-objects-cli/src/commands/tasks/create_baseline.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/tasks/create_baseline.ts
@@ -30,11 +30,14 @@ export const createBaseline: Task = async (ctx, task) => {
   const subtasks: ListrTask<TaskContext>[] = [
     {
       title: `Delete pre-existing '${defaultKibanaIndex}' index`,
-      task: async () =>
+      task: async () => {
+        // TODO the delete operation does not seem to delete the system index
+        // this causes issues when running multiple times with the --server and --client flags
         await client.indices.delete({
           index: defaultKibanaIndex,
           ignore_unavailable: true,
-        }),
+        });
+      },
     },
     {
       title: `Create '${defaultKibanaIndex}' index with previous version mappings`,

--- a/packages/kbn-check-saved-objects-cli/src/commands/tasks/test_rollback.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/tasks/test_rollback.ts
@@ -26,13 +26,13 @@ export const testRollback: Task = async (ctx, task) => {
 
   const subtasks: ListrTask<TaskContext>[] = [
     {
-      title: `Run rollback migration on updated types: '${ctx.updatedTypes
+      title: `Run rollback migration on rollback-testable types: '${updatedTypes
         .map(({ name }) => name)
         .join(', ')}'`,
       task: async () => await performRollback(),
     },
     {
-      title: `Ensure SO API-retrieved SOs match previous version fixtures`,
+      title: `Ensure API-retrieved SOs match previous version fixtures`,
       task: checkDocuments({
         repository: savedObjectsRepository,
         types: previousVersionTypes,

--- a/packages/kbn-check-saved-objects-cli/src/commands/tasks/test_rollback.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/tasks/test_rollback.ts
@@ -26,7 +26,7 @@ export const testRollback: Task = async (ctx, task) => {
 
   const subtasks: ListrTask<TaskContext>[] = [
     {
-      title: `Run rollback migration on rollback-testable types: '${updatedTypes
+      title: `Run rollback migration on updated types: '${updatedTypes
         .map(({ name }) => name)
         .join(', ')}'`,
       task: async () => await performRollback(),

--- a/packages/kbn-check-saved-objects-cli/src/commands/test/baseline_mappings.json
+++ b/packages/kbn-check-saved-objects-cli/src/commands/test/baseline_mappings.json
@@ -1,4 +1,26 @@
 {
+  "old-type-no-migrations": {
+    "dynamic": false,
+    "properties": {
+      "aTextAttribute": {
+        "type": "text"
+      },
+      "aBooleanAttribute": {
+        "type": "boolean"
+      }
+    }
+  },
+  "old-type-with-migrations": {
+    "dynamic": false,
+    "properties": {
+      "aTextAttribute": {
+        "type": "text"
+      },
+      "textLength": {
+        "type": "integer"
+      }
+    }
+  },
   "person-so-type": {
     "dynamic": false,
     "properties": {

--- a/packages/kbn-check-saved-objects-cli/src/commands/test/baseline_snapshot.json
+++ b/packages/kbn-check-saved-objects-cli/src/commands/test/baseline_snapshot.json
@@ -7,6 +7,34 @@
     "pullRequestUrl": null
   },
   "typeDefinitions": {
+    "old-type-no-migrations": {
+      "name": "old-type-no-migrations",
+      "migrationVersions": [],
+      "hash": "4631898d09a686928fabbbe1ad0b7f2b22c44b565443408ab5d20b4dcae64e35",
+      "modelVersions": [],
+      "schemaVersions": [],
+      "mappings": {
+        "dynamic": false,
+        "properties.aTextAttribute.type": "text",
+        "properties.aBooleanAttribute.type": "boolean"
+      }
+    },
+    "old-type-with-migrations": {
+      "name": "old-type-with-migrations",
+      "migrationVersions": [
+        "8.7.0"
+      ],
+      "hash": "a7916755843d9ed712ccefb6888ebcbdd2f2f3628e058bfd174454aef644437a",
+      "modelVersions": [],
+      "schemaVersions": [
+        "8.7.0"
+      ],
+      "mappings": {
+        "dynamic": false,
+        "properties.aTextAttribute.type": "text",
+        "properties.aBooleanAttribute.type": "boolean"
+      }
+    },
     "person-so-type": {
       "name": "person-so-type",
       "migrationVersions": [],

--- a/packages/kbn-check-saved-objects-cli/src/commands/test/index.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/test/index.ts
@@ -9,6 +9,6 @@
 
 import { resolve } from 'path';
 
-export { TEST_TYPES } from './test_types';
+export { TEST_TYPES } from './types';
 export { getTestSnapshots } from './snapshots';
 export const BASELINE_MAPPINGS_TEST = resolve(__dirname, './baseline_mappings.json');

--- a/packages/kbn-check-saved-objects-cli/src/commands/test/snapshots.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/test/snapshots.ts
@@ -32,6 +32,8 @@ export const getTestSnapshots: Task = async (ctx, task) => {
       title: `Take snapshot of current SO type definitions`,
       task: async () => {
         ctx.to = await takeSnapshot(ctx.registeredTypes!);
+        // console.log('SNAPSHOT', JSON.stringify(ctx.to, null, 2));
+        // throw new Error('STOP');
       },
     },
   ];

--- a/packages/kbn-check-saved-objects-cli/src/commands/test/snapshots.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/test/snapshots.ts
@@ -32,8 +32,6 @@ export const getTestSnapshots: Task = async (ctx, task) => {
       title: `Take snapshot of current SO type definitions`,
       task: async () => {
         ctx.to = await takeSnapshot(ctx.registeredTypes!);
-        // console.log('SNAPSHOT', JSON.stringify(ctx.to, null, 2));
-        // throw new Error('STOP');
       },
     },
   ];

--- a/packages/kbn-check-saved-objects-cli/src/commands/test/types/index.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/test/types/index.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
+import { defaultKibanaIndex } from '@kbn/migrator-test-kit';
+import { OLD_TYPE_NO_MIGRATIONS } from './no_migrations';
+import { OLD_TYPE_WITH_MIGRATIONS } from './migrations';
+import { PERSON_SO_TYPE } from './person';
+
+function createSavedObjectType<T>(properties: Partial<SavedObjectsType<T>>): SavedObjectsType<T> {
+  return {
+    name: 'unnamed',
+    indexPattern: defaultKibanaIndex,
+    hidden: false,
+    namespaceType: 'agnostic',
+    mappings: {
+      dynamic: false,
+      properties: {
+        foo: { type: 'keyword' },
+        bar: { type: 'boolean' },
+      },
+    },
+    ...properties,
+  };
+}
+
+export const TEST_TYPES: SavedObjectsType<any>[] = [
+  OLD_TYPE_NO_MIGRATIONS,
+  OLD_TYPE_WITH_MIGRATIONS,
+  PERSON_SO_TYPE,
+].map((partial) => createSavedObjectType(partial));

--- a/packages/kbn-check-saved-objects-cli/src/commands/test/types/migrations.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/test/types/migrations.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
+
+const initialSchema = schema.object({
+  aTextAttribute: schema.string(),
+  textLength: schema.number(),
+  anIntegerAttribute: schema.number(),
+});
+
+export const OLD_TYPE_WITH_MIGRATIONS: Partial<SavedObjectsType> = {
+  name: 'old-type-with-migrations',
+  mappings: {
+    dynamic: false,
+    properties: {
+      aTextAttribute: { type: 'text' },
+      aBooleanAttribute: { type: 'boolean' },
+      anIntegerAttribute: { type: 'integer' },
+    },
+  },
+  migrations: {
+    '8.7.0': (doc) => ({
+      ...doc,
+      attributes: { ...doc.attributes, textLength: doc.attributes.aTextAttribute.length },
+    }),
+  },
+  modelVersions: {
+    1: {
+      changes: [],
+      schemas: {
+        create: initialSchema,
+        forwardCompatibility: initialSchema.extends({}, { unknowns: 'ignore' }),
+      },
+    },
+  },
+};

--- a/packages/kbn-check-saved-objects-cli/src/commands/test/types/no_migrations.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/test/types/no_migrations.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
+
+const v1 = schema.object({
+  aTextAttribute: schema.string(),
+  aBooleanAttribute: schema.boolean(),
+  anIntegerAttribute: schema.number(),
+});
+
+export const OLD_TYPE_NO_MIGRATIONS: Partial<SavedObjectsType> = {
+  name: 'old-type-no-migrations',
+  mappings: {
+    dynamic: false,
+    properties: {
+      aTextAttribute: { type: 'text' },
+      aBooleanAttribute: { type: 'boolean' },
+      anIntegerAttribute: { type: 'integer' },
+    },
+  },
+  modelVersions: {
+    1: {
+      changes: [],
+      schemas: {
+        create: v1,
+        forwardCompatibility: v1.extends({}, { unknowns: 'ignore' }),
+      },
+    },
+  },
+};

--- a/packages/kbn-check-saved-objects-cli/src/commands/test/types/person.ts
+++ b/packages/kbn-check-saved-objects-cli/src/commands/test/types/person.ts
@@ -34,7 +34,7 @@ const fullNameBackfill: SavedObjectModelDataBackfillFn<PersonV1, PersonV2> = (do
   };
 };
 
-const PERSON_SO_TYPE = createSavedObjectType({
+export const PERSON_SO_TYPE: Partial<SavedObjectsType> = {
   name: 'person-so-type',
   mappings: {
     dynamic: false,
@@ -79,22 +79,4 @@ const PERSON_SO_TYPE = createSavedObjectType({
       },
     },
   },
-});
-
-function createSavedObjectType<T>(properties: Partial<SavedObjectsType<T>>): SavedObjectsType<T> {
-  return {
-    name: 'unnamed',
-    hidden: false,
-    namespaceType: 'agnostic',
-    mappings: {
-      dynamic: false,
-      properties: {
-        foo: { type: 'keyword' },
-        bar: { type: 'boolean' },
-      },
-    },
-    ...properties,
-  };
-}
-
-export const TEST_TYPES: SavedObjectsType<any>[] = [PERSON_SO_TYPE];
+};

--- a/packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/old-type-no-migrations/10.1.0.json
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/old-type-no-migrations/10.1.0.json
@@ -1,0 +1,14 @@
+{
+  "0.0.0": [
+    {
+      "aTextAttribute": "Hello world!",
+      "aBooleanAttribute": "false"
+    }
+  ],
+  "10.1.0": [
+    {
+      "aTextAttribute": "Hello world!",
+      "aBooleanAttribute": "false"
+    }
+  ]
+}

--- a/packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/old-type-with-migrations/10.1.0.json
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/__fixtures__/old-type-with-migrations/10.1.0.json
@@ -1,0 +1,14 @@
+{
+  "8.7.0": [
+    {
+      "aTextAttribute": "Hello world!",
+      "textLength": 12
+    }
+  ],
+  "10.1.0": [
+    {
+      "aTextAttribute": "Hello world!",
+      "textLength": 12
+    }
+  ]
+}

--- a/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/create_fixture_file.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/fixtures/create_fixture_file.ts
@@ -31,10 +31,13 @@ export async function createFixtureFile({
   await jsonToFile(path, {
     [previous]: [
       {
-        TODO: `Please create one or more test objects with properties that reflect real '${type}' objects`,
+        TODO: `Please create one or more sample objects with properties that reflect real '${type}' objects`,
         NOTE: `That each modelVersion has a corresponding fixture file, which defines the previous and current versions.`,
+        NOTE2: `These fixtures define the before and after state, and are used for both upgrade and rollback testing.`,
         HINT: `You can use the template below and create sample objects for ${previous} and ${current} versions.`,
         HINT2: `Alternatively, you can copy the contents from older fixture files (if they exist) and adapt them accordingly.`,
+        IMPORTANT: `The current version fixtures (below) are defining how objects from the previous version fixtures (this array) would look like AFTER upgrading.`,
+        IMPORTANT2: `They are NOT defining random sample objects with properties that are valid for the current model version.`,
       },
     ],
     [current]: [typeTemplate],

--- a/packages/kbn-check-saved-objects-cli/src/migrations/versions.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/versions.test.ts
@@ -37,20 +37,13 @@ describe('getVersions', () => {
   it('includes migrationVersions and generated model versions and reverses newest-to-oldest', () => {
     const typeSnapshot = makeTypeSnapshot(['7.10.0', '8.0.0'], 2); // modelVersions -> 10.1.0, 10.2.0
 
-    expect(getVersions(typeSnapshot)).toEqual([
-      '10.2.0',
-      '10.1.0',
-      '10.0.0',
-      '8.0.0',
-      '7.10.0',
-      '0.0.0',
-    ]);
+    expect(getVersions(typeSnapshot)).toEqual(['10.2.0', '10.1.0', '8.0.0', '7.10.0', '0.0.0']);
   });
 
   it('handles single migrationVersion and single modelVersion', () => {
     const typeSnapshot = makeTypeSnapshot(['1.0.0'], 1); // -> 10.1.0
 
-    expect(getVersions(typeSnapshot)).toEqual(['10.1.0', '10.0.0', '1.0.0', '0.0.0']);
+    expect(getVersions(typeSnapshot)).toEqual(['10.1.0', '1.0.0', '0.0.0']);
   });
 
   it('preserves duplicates from migrationVersions and includes model versions accordingly', () => {
@@ -60,7 +53,6 @@ describe('getVersions', () => {
       '10.3.0',
       '10.2.0',
       '10.1.0',
-      '10.0.0',
       '2.0.0',
       '2.0.0',
       '0.0.0',

--- a/packages/kbn-check-saved-objects-cli/src/migrations/versions.ts
+++ b/packages/kbn-check-saved-objects-cli/src/migrations/versions.ts
@@ -22,7 +22,6 @@ export function getVersions(
   return [
     '0.0.0',
     ...typeSnapshot.migrationVersions,
-    ...(typeSnapshot.modelVersions.length ? ['10.0.0'] : []),
     ...typeSnapshot.modelVersions.map(({ version }) => `10.${version}.0`),
   ].reverse() as string[];
 }

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/mocks/changes_in_initial_version.json
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/mocks/changes_in_initial_version.json
@@ -1,0 +1,35 @@
+{
+  "meta": {
+    "timestamp": 1756914281687,
+    "date": "2025-09-03T15:44:41.687Z",
+    "kibanaCommitHash": "20b1ec4d471768b45fab2c61f781bbc5ce776452",
+    "buildUrl": "https://buildkite.com/elastic/kibana-on-merge/builds/76489",
+    "pullRequestUrl": "https://github.com/elastic/kibana/pulls/233325"
+  },
+  "typeDefinitions": {
+    "usage-counter": {
+      "name": "usage-counter",
+      "hidden": false,
+      "namespaceType": "agnostic",
+      "mappings": {
+        "properties": {
+          "name": {
+            "type": "keyword"
+          }
+        }
+      },
+      "migrationVersions": [],
+      "modelVersions": [
+        {
+          "version": "1",
+          "schemas": {
+            "create": true,
+            "forwardCompatibility": true
+          },
+          "changeTypes": ["mappings_addition"],
+          "modelVersionHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        }
+      ]
+    }
+  }
+}

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes.test.ts
@@ -96,4 +96,13 @@ describe('validateChangesExistingType', () => {
       `❌ The 'task' SO type has changes in the mappings, but is missing a modelVersion that defines these changes.`
     );
   });
+
+  it('should throw if the initial model version defines mapping changes', () => {
+    const from = loadSnapshot('baseline.json');
+    const to = loadSnapshot('changes_in_initial_version.json');
+
+    expect(() => validateChangesWrapper({ from, to, name: 'usage-counter' })).toThrowError(
+      `❌ The new model version '1' for SO type 'usage-counter' is defining mappings' changes. For backwards-compatibility reasons, the initial model version can only include schema definitions.`
+    );
+  });
 });

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes.test.ts
@@ -66,7 +66,7 @@ describe('validateChangesExistingType', () => {
     const from = loadSnapshot('baseline.json');
     const to = loadSnapshot('two_new_model_versions.json');
     expect(() => validateChangesWrapper({ from, to, name: 'task' })).toThrowError(
-      `❌ The SO type 'task' is defining two (or more) new model versions. Please refer to our troubleshooting guide: https://www.elastic.co/docs/extend/kibana/saved-objects#troubleshooting`
+      `❌ The SO type 'task' is defining two (or more) new model versions.`
     );
   });
 

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes.ts
@@ -39,9 +39,7 @@ export function validateChangesExistingType({ from, to }: ValidateChangesExistin
 
   // check that current changes don't define more than 1 new modelVersion
   if (to.modelVersions.length - from.modelVersions.length > 1) {
-    throw new Error(
-      `❌ The SO type '${name}' is defining two (or more) new model versions. Please refer to our troubleshooting guide: https://www.elastic.co/docs/extend/kibana/saved-objects#troubleshooting`
-    );
+    throw new Error(`❌ The SO type '${name}' is defining two (or more) new model versions.`);
   }
 
   // check that existing model versions have not been mutated

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes.ts
@@ -130,6 +130,13 @@ function validateLastModelVersion(name: string, mvs: ModelVersionSummary[]) {
       `❌ The new model version '${mv.version}' for SO type '${name}' is missing the 'create' schema definition.`
     );
   }
+  if (mvs.length === 1 && mv.changeTypes.length) {
+    // Do NOT allow changes in the first (initial) modelVersion, only schema additions.
+    // This guarantees rollback safety towards previous versions.
+    throw new Error(
+      `❌ The new model version '${mv.version}' for SO type '${name}' is defining mappings' changes. For backwards-compatibility reasons, the initial model version can only include schema definitions.`
+    );
+  }
 }
 
 function getMutatedModelVersions(

--- a/src/core/packages/saved-objects/migration-server-internal/src/document_migrator/document_migrator.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/document_migrator/document_migrator.test.ts
@@ -317,7 +317,7 @@ describe('DocumentMigrator', () => {
           typeMigrationVersion: '10.2.0',
         })
       ).toThrow(
-        /Document "smelly" belongs to a more recent version of Kibana \[10\.2\.0\] when the last known version is \[undefined\]/i
+        /Document "smelly" of type 'dog' belongs to a more recent version of Kibana \[10\.2\.0\] when the last known version is \[0\.0\.0\]/i
       );
     });
 

--- a/src/core/packages/saved-objects/migration-server-internal/src/document_migrator/pipelines/upgrade_pipeline.test.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/document_migrator/pipelines/upgrade_pipeline.test.ts
@@ -199,7 +199,7 @@ describe('DocumentMigratorPipeline', () => {
       });
 
       expect(() => pipeline.run()).toThrowErrorMatchingInlineSnapshot(
-        `"Document \\"foo-1\\" belongs to a more recent version of Kibana [8.9.0] when the last known version is [8.8.0]."`
+        `"Document \\"foo-1\\" of type 'foo' belongs to a more recent version of Kibana [8.9.0] when the last known version is [8.8.0]."`
       );
     });
 

--- a/src/core/packages/saved-objects/migration-server-internal/src/document_migrator/pipelines/upgrade_pipeline.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/document_migrator/pipelines/upgrade_pipeline.ts
@@ -127,13 +127,19 @@ export class DocumentUpgradePipeline implements MigrationPipeline {
   private assertCompatibility() {
     const { id, type, typeMigrationVersion: currentVersion } = this.document;
     const latestVersion = maxVersion(
+      '0.0.0',
       this.migrations[type]?.latestVersion.migrate,
       this.migrations[type]?.latestVersion.convert
     );
 
-    if (isGreater(currentVersion, latestVersion)) {
+    if (
+      // a SO type with no migrations: and only a single modelVersion: is, by definition,
+      // compatible, as we only allow schema definitions in the initial modelVersion.
+      (currentVersion !== '10.1.0' || latestVersion !== '0.0.0') &&
+      isGreater(currentVersion, latestVersion)
+    ) {
       throw Boom.badData(
-        `Document "${id}" belongs to a more recent version of Kibana [${currentVersion}] when the last known version is [${latestVersion}].`,
+        `Document "${id}" of type '${type}' belongs to a more recent version of Kibana [${currentVersion}] when the last known version is [${latestVersion}].`,
         this.document
       );
     }

--- a/src/core/packages/saved-objects/migration-server-internal/src/document_migrator/pipelines/utils.ts
+++ b/src/core/packages/saved-objects/migration-server-internal/src/document_migrator/pipelines/utils.ts
@@ -66,7 +66,9 @@ export const assertValidCoreVersion = ({
   }
 };
 
-export function maxVersion(a?: string, b?: string) {
+export function maxVersion(a?: string, ...otherVersions: string[]): string | undefined {
+  const b = otherVersions.length ? maxVersion(...otherVersions) : undefined;
+
   if (!a) {
     return b;
   }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/248231

The PR updates the `Check Saved Objects` CI step logic to support the definition of the first (initial) modelVersion `"1"`, by doing the following 2 things:

* Not allowing mappings changes in the initial model version `10.1.0`.
* Updating the document migrator logic to consider `10.1.0` compatible with `0.0.0`. Without this change, the CI check fails irremediably whenever we are introducing the first update (first _modelVersion_) for a given SO type. When stumbling upon such object after a rollback, the SOR APIs will not know how to handle it, and fail with an error of the form:

```
ERROR Error: Document "1281cd3a-293a-4415-ad71-64e8f79e8086" belongs to a more recent version of Kibana [10.1.0] when the last known version is [0.0.0].
```

