### PR TITLE
[Security Solution][Attacks/Alerts][Attacks page][Table section] Hide tabs for generic attack groups

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/attack_details_container.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/attack_details_container.test.tsx
@@ -55,16 +55,6 @@ describe('AttackDetailsContainer', () => {
       expect(tabs[1]).toHaveTextContent(String(mockAttack.alertIds.length));
     });
 
-    it('renders only Alerts tab when attack is undefined', () => {
-      renderContainer({ attack: undefined });
-
-      const tabs = screen.getAllByRole('tab');
-      expect(tabs).toHaveLength(1);
-      expect(tabs[0]).toHaveTextContent('Alerts');
-      expect(screen.getByTestId('alertsTab')).toBeInTheDocument();
-      expect(screen.queryByTestId('attackSummaryTab')).not.toBeInTheDocument();
-    });
-
     it('renders the attack summary tab by default with correct props', () => {
       renderContainer({ showAnonymized: true });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/attack_details_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_details/attack_details_container.tsx
@@ -31,8 +31,8 @@ interface TabInfo {
 }
 
 interface AttackDetailsContainerProps {
-  /** The attack discovery alert document. If undefined, only the Alerts tab will be shown. */
-  attack?: AttackDiscoveryAlert;
+  /** The attack discovery alert document. */
+  attack: AttackDiscoveryAlert;
   /** Whether to show anonymized values instead of replacements */
   showAnonymized?: boolean;
   /** Filters applied from grouping */
@@ -51,11 +51,9 @@ interface AttackDetailsContainerProps {
  */
 export const AttackDetailsContainer = React.memo<AttackDetailsContainerProps>(
   ({ attack, groupingFilters, defaultFilters, isTableLoading, showAnonymized }) => {
-    const tabs = useMemo<TabInfo[]>(() => {
-      const tabsList: TabInfo[] = [];
-
-      if (attack) {
-        tabsList.push({
+    const tabs = useMemo<TabInfo[]>(
+      () => [
+        {
           id: ATTACK_SUMMARY_TAB,
           name: i18n.ATTACK_SUMMARY,
           content: (
@@ -64,31 +62,29 @@ export const AttackDetailsContainer = React.memo<AttackDetailsContainerProps>(
               <SummaryTab attack={attack} showAnonymized={showAnonymized} />
             </>
           ),
-        });
-      }
-
-      tabsList.push({
-        id: ALERTS_TAB,
-        name: i18n.ALERTS,
-        content: (
-          <>
-            <EuiSpacer size="s" />
-            <AlertsTab
-              groupingFilters={groupingFilters}
-              defaultFilters={defaultFilters}
-              isTableLoading={isTableLoading}
-            />
-          </>
-        ),
-        append: attack ? (
-          <EuiNotificationBadge size="m" color="subdued">
-            {attack.alertIds.length}
-          </EuiNotificationBadge>
-        ) : undefined,
-      });
-
-      return tabsList;
-    }, [attack, groupingFilters, defaultFilters, isTableLoading, showAnonymized]);
+        },
+        {
+          id: ALERTS_TAB,
+          name: i18n.ALERTS,
+          content: (
+            <>
+              <EuiSpacer size="s" />
+              <AlertsTab
+                groupingFilters={groupingFilters}
+                defaultFilters={defaultFilters}
+                isTableLoading={isTableLoading}
+              />
+            </>
+          ),
+          append: attack ? (
+            <EuiNotificationBadge size="m" color="subdued">
+              {attack.alertIds.length}
+            </EuiNotificationBadge>
+          ) : undefined,
+        },
+      ],
+      [attack, groupingFilters, defaultFilters, isTableLoading, showAnonymized]
+    );
 
     const firstTabId = useMemo(() => (attack ? ATTACK_SUMMARY_TAB : ALERTS_TAB), [attack]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
@@ -35,11 +35,12 @@ import { GroupedAlertsTable } from '../../alerts_table/alerts_grouping';
 import type { AlertsGroupingAggregation } from '../../alerts_table/grouping_settings/types';
 import { useGetDefaultGroupTitleRenderers } from '../../../hooks/attacks/use_get_default_group_title_renderers';
 import { useAttackGroupHandler } from '../../../hooks/attacks/use_attack_group_handler';
+import type { AssigneesIdsSelection } from '../../../../common/components/assignees/types';
 
 import { AttackDetailsContainer } from './attack_details/attack_details_container';
+import { AlertsTab } from './attack_details/alerts_tab';
 import { groupingOptions, groupingSettings } from './grouping_configs';
 import * as i18n from './translations';
-import type { AssigneesIdsSelection } from '../../../../common/components/assignees/types';
 
 export const TABLE_SECTION_TEST_ID = 'attacks-page-table-section';
 export const EXPAND_ATTACK_BUTTON_TEST_ID = 'expand-attack-button';
@@ -156,6 +157,16 @@ export const TableSection = React.memo(
         // attack is undefined for the generic group marked as `-` which means this is the group of alerts that do not belong to any attack.
         const attack =
           selectedGroup && fieldBucket ? getAttack(selectedGroup, fieldBucket) : undefined;
+
+        if (!attack) {
+          return (
+            <AlertsTab
+              groupingFilters={groupingFilters}
+              defaultFilters={defaultFilters}
+              isTableLoading={isLoading}
+            />
+          );
+        }
 
         return (
           <AttackDetailsContainer


### PR DESCRIPTION
## Summary

This change updates the UI to avoid showing tabs for the generic `-` attack groups (where no specific attack is identified). Instead, only the alerts table is displayed directly.

As a consequence of this change, the `AttackDetailsContainer` component has been refactored to require the `attack` prop. Previously, the component handled logic for when `attack` was `undefined` (showing only the Alerts tab). This responsibility has been shifted to the parent component, which now renders `AlertsTab` directly when no attack is present, and conditionally renders `AttackDetailsContainer` only when a valid attack is available.

## Feature Flag

> [!NOTE]
> The feature is hidden behind the feature flag (in `kibana.dev.yml`):

```
feature_flags.overrides:
  securitySolution.attacksAlertsAlignment: true
```
