### PR TITLE
[Search] Fix: Only run ML saved object check if saving semantic text mapping

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -197,8 +197,8 @@ export const DetailsPageMappingsContent: FunctionComponent<{
       let inferenceToModelIdMap = state.inferenceToModelIdMap;
       setIsUpdatingMappings(true);
       try {
-        await ml?.mlApi?.savedObjects.syncSavedObjects();
         if (isSemanticTextEnabled && hasMLPermissions && hasSemanticText && !forceSaveMappings) {
+          await ml?.mlApi?.savedObjects.syncSavedObjects();
           inferenceToModelIdMap = await fetchInferenceToModelIdMap();
         }
         const fields = hasSemanticText ? getStateWithCopyToFields(state).fields : state.fields;


### PR DESCRIPTION
## Summary

When running Elasticsearch with a Basic license, attempting to update index mappings could fail even when adding non-ML field types. This happened because, during mapping updates, we unconditionally made a synchronous call to fetch the latest ML data from Saved Objects. That call requires a Platinum license and therefore fails under a Basic license.

This change guards the sync call behind explicit checks for both ML and semantic text permissions (which require a Platinum license), and only executes it when a semantic_text field is being saved. This prevents mapping updates from failing on lower license tiers while preserving the existing behavior for semantic text fields.

## Testing

To test this PR you will need to confirm that you can save mappings with both a basic and trial license. You will also need to run EIS locally with a trial license:

### Basic license
1. Run Elasticsearch with a basic license: `yarn es snapshot`
2. Create an index
3. Confirm you can add a field and successfully save the mapping

### Trial license
1. Run Elasticsearch with a trial license: `yarn es snapshot --license trial`
2. Run EIS locally. You can find the instructions in the [EIS script README](https://github.com/elastic/kibana/blob/main/x-pack/platform/packages/shared/kbn-inference-cli/README.md).
3. Create an index
3. Confirm you can add a `semantic_text` field and successfully save the mapping

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release note
Fixes an issue when running Elasticsearch with a Basic license, where users might encounter errors when updating index mappings, even when adding non-ML field types. This issue has been resolved so that mapping updates now work as expected, while advanced semantic text features continue to require the appropriate license.






<!--ONMERGE {"backportTargets":["9.1","9.2","9.3"]} ONMERGE-->