### PR TITLE
[Search] Replace semantic query with match in semantic search examples

### DIFF
--- a/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/semantic_tutorial.ts
+++ b/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/semantic_tutorial.ts
@@ -57,9 +57,8 @@ POST /_bulk?pretty
 GET kibana_sample_data_semantic/_search
 {
   "query": {
-    "semantic": {
-      "field": "text",
-      "query": "Which park is most popular?"
+    "match": {
+      "text": "Which park is most popular?"
     }
   }
 }
@@ -81,9 +80,8 @@ GET kibana_sample_data_semantic/_search
     "bool": {
       "must": [
         {
-          "semantic": {
-            "field": "text",
-            "query": "Which park has the most wildlife?"
+          "match": {
+            "text": "Which park has the most wildlife?"
           }
         }
       ],
@@ -116,9 +114,8 @@ GET kibana_sample_data_semantic/_search
 {
   "min_score": 15.0,
   "query": {
-    "semantic": {
-      "field": "text",
-      "query": "Which park is best for hiking?"
+    "match": {
+      "text": "Which park is best for hiking?"
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR updates the Semantic Search card to remove examples that use the semantic query type and replaces them with equivalent match query examples, as this is recommended for new projects.

## Testing

Navigate to the getting started page and select the `Intro to semantic search` tutorial to run it in the console. Go through all of the steps and confirm that the tutorial works as expected.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->