### PR TITLE
[8.19] [Security Solution] Change alert suppression icon (#247964)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/alert_suppression_label.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/alert_suppression_label.tsx
@@ -31,9 +31,8 @@ export const AlertSuppressionLabel = ({ label, ruleType }: AlertSuppressionLabel
       {alertSuppressionUpsellingMessage && (
         <EuiToolTip position="top" content={alertSuppressionUpsellingMessage}>
           <EuiIcon
-            type={'warning'}
+            type={'lock'}
             size="l"
-            color="#BD271E"
             style={{ marginLeft: '8px' }}
             data-test-subj="alertSuppressionInsufficientLicensingIcon"
           />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Change alert suppression icon (#247964)](https://github.com/elastic/kibana/pull/247964)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nikita Indik","email":"nikita.indik@elastic.co"},"sourceCommit":{"committedDate":"2026-01-09T11:38:15Z","message":"[Security Solution] Change alert suppression icon (#247964)\n\n**Resolves: https://github.com/elastic/kibana/issues/247884**\n\n## Summary\n\nThis PR changes the icon that is shown when alert suppression is not\navailable because of insufficient license.\n\nThis previous \"warning\" icon looks confusing and misleading, as if\nsomething is broken and needed to be fixed. We are updating the icon to\nthe one that aligns more with the designs for upgrade call-outs.\n\n**Before**\n<img width=\"672\" height=\"126\" alt=\"Screenshot 2026-01-08 at 21 50 56\"\nsrc=\"https://github.com/user-attachments/assets/cd5182e4-ca61-4698-99f3-adfc556ef36a\"\n/>\n\n**After** \n<img width=\"672\" height=\"126\" alt=\"Screenshot 2026-01-08 at 21 51 30\"\nsrc=\"https://github.com/user-attachments/assets/221e124c-8ee4-4c80-abdd-581393268183\"\n/>","sha":"22408ea2358ac47d53e58b84749db2597c066047","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Rule Details","backport:version","v9.3.0","v9.4.0","v9.2.4","v9.1.10","v8.19.10"],"title":"[Security Solution] Change alert suppression icon","number":247964,"url":"https://github.com/elastic/kibana/pull/247964","mergeCommit":{"message":"[Security Solution] Change alert suppression icon (#247964)\n\n**Resolves: https://github.com/elastic/kibana/issues/247884**\n\n## Summary\n\nThis PR changes the icon that is shown when alert suppression is not\navailable because of insufficient license.\n\nThis previous \"warning\" icon looks confusing and misleading, as if\nsomething is broken and needed to be fixed. We are updating the icon to\nthe one that aligns more with the designs for upgrade call-outs.\n\n**Before**\n<img width=\"672\" height=\"126\" alt=\"Screenshot 2026-01-08 at 21 50 56\"\nsrc=\"https://github.com/user-attachments/assets/cd5182e4-ca61-4698-99f3-adfc556ef36a\"\n/>\n\n**After** \n<img width=\"672\" height=\"126\" alt=\"Screenshot 2026-01-08 at 21 51 30\"\nsrc=\"https://github.com/user-attachments/assets/221e124c-8ee4-4c80-abdd-581393268183\"\n/>","sha":"22408ea2358ac47d53e58b84749db2597c066047"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/248430","number":248430,"state":"MERGED","mergeCommit":{"sha":"946eb12fa4b351666607f2a97256501020d63bbf","message":"[9.3] [Security Solution] Change alert suppression icon (#247964) (#248430)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Security Solution] Change alert suppression icon\n(#247964)](https://github.com/elastic/kibana/pull/247964)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nikita Indik <nikita.indik@elastic.co>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247964","number":247964,"mergeCommit":{"message":"[Security Solution] Change alert suppression icon (#247964)\n\n**Resolves: https://github.com/elastic/kibana/issues/247884**\n\n## Summary\n\nThis PR changes the icon that is shown when alert suppression is not\navailable because of insufficient license.\n\nThis previous \"warning\" icon looks confusing and misleading, as if\nsomething is broken and needed to be fixed. We are updating the icon to\nthe one that aligns more with the designs for upgrade call-outs.\n\n**Before**\n<img width=\"672\" height=\"126\" alt=\"Screenshot 2026-01-08 at 21 50 56\"\nsrc=\"https://github.com/user-attachments/assets/cd5182e4-ca61-4698-99f3-adfc556ef36a\"\n/>\n\n**After** \n<img width=\"672\" height=\"126\" alt=\"Screenshot 2026-01-08 at 21 51 30\"\nsrc=\"https://github.com/user-attachments/assets/221e124c-8ee4-4c80-abdd-581393268183\"\n/>","sha":"22408ea2358ac47d53e58b84749db2597c066047"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/248429","number":248429,"state":"MERGED","mergeCommit":{"sha":"ccb3e50f89bf63537f3ef4fc8ad6022778102369","message":"[9.2] [Security Solution] Change alert suppression icon (#247964) (#248429)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Security Solution] Change alert suppression icon\n(#247964)](https://github.com/elastic/kibana/pull/247964)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nikita Indik <nikita.indik@elastic.co>"}},{"branch":"9.1","label":"v9.1.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/248428","number":248428,"state":"MERGED","mergeCommit":{"sha":"e006717481b45375f3f90f02012b6f8e9639f3d0","message":"[9.1] [Security Solution] Change alert suppression icon (#247964) (#248428)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.1`:\n- [[Security Solution] Change alert suppression icon\n(#247964)](https://github.com/elastic/kibana/pull/247964)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Nikita Indik <nikita.indik@elastic.co>"}},{"branch":"8.19","label":"v8.19.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->