### PR TITLE
[Agent Builder] Polish - Adjust reasoning truncation to word-break: break-all

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_thinking/round_thinking_title.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_thinking/round_thinking_title.tsx
@@ -14,12 +14,12 @@ import { RoundIcon } from './round_icon';
 import { lineClampStyles } from '../../../../../common.styles';
 
 const clampTextStyles = css`
-  word-break: break-word;
+  word-break: break-all;
   ${lineClampStyles(1)}
 `;
 
 const defaultThinkingLabel = i18n.translate('xpack.agentBuilder.conversation.thinking.label', {
-  defaultMessage: 'Thinking...',
+  defaultMessage: 'Thinking…',
 });
 const thinkingCompletedLabel = i18n.translate(
   'xpack.agentBuilder.conversation.thinking.completedReasoning',


### PR DESCRIPTION
## Summary

Fixes issue where the whitespace between the reasoning text and the toggle button was too large when the text had been truncated. Fixed by truncating between any two characters with `word-break: break-all` instead of only at word boundaries. 

### Before
<img width="857" height="193" alt="image" src="https://github.com/user-attachments/assets/6754c373-cbfd-4d56-ac3b-d9ae512eef5e" />

### After
<img width="809" height="65" alt="image" src="https://github.com/user-attachments/assets/32e6d0da-6282-43c0-be57-cfc5da2335d7" />

### Additional changes
Swaps `...` for UTF ellipsis character


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->