### PR TITLE
Fix flaky test runner serverless flag for Search solution

### DIFF
--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -74,7 +74,7 @@ function getScoutServerRunFlags(configPath: string): string[] {
   } else if (groupType === 'security') {
     flags.push('--serverless=security');
   } else if (groupType === 'search') {
-    flags.push('--serverless=search');
+    flags.push('--serverless=es');
   } else {
     throw new Error(`Unknown solution type: ${groupType}.`);
   }


### PR DESCRIPTION
## Summary

The flaky test runner was using '--serverless=search' for the Search solution, but 'search' is not a [valid serverless option](https://github.com/elastic/kibana/blob/e586a3927b42e5a13c3710e2162b6dba03cfb77c/src/platform/packages/shared/kbn-scout/src/servers/flags.ts#L34). The valid options are: es, oblt, oblt-logs-essentials, security, security-essentials, security-ease.

Changed '--serverless=search' to '--serverless=es' for the Search solution to match the valid CLI options defined in kbn-scout.

This change resolves similar errors found in https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10391/steps/canvas?jid=019ba419-e514-4657-bcbb-30650621ba0b

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



