### PR TITLE
[9.3] [Obs AI] Hide AI Insight component when there are no connectors (#248542)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/ai_insight/ai_insight.tsx
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/ai_insight/ai_insight.tsx
@@ -24,6 +24,7 @@ import { AIChatExperience } from '@kbn/ai-assistant-common';
 import { AI_CHAT_EXPERIENCE_TYPE } from '@kbn/management-settings-ids';
 import { useKibana } from '../../hooks/use_kibana';
 import { useLicense } from '../../hooks/use_license';
+import { useGenAIConnectors } from '../../hooks/use_genai_connectors';
 import { StartConversationButton } from './start_conversation_button';
 import { AiInsightErrorBanner } from './ai_insight_error_banner';
 
@@ -62,6 +63,8 @@ export function AiInsight({ title, fetchInsight, buildAttachments }: AiInsightPr
   const [chatExperience] = useUiSetting$<AIChatExperience>(AI_CHAT_EXPERIENCE_TYPE);
   const isAgentChatExperienceEnabled = chatExperience === AIChatExperience.Agent;
 
+  const { hasConnectors } = useGenAIConnectors();
+
   const hasEnterpriseLicense = license?.hasAtLeast('enterprise');
   const hasAgentBuilderAccess = application?.capabilities.agentBuilder?.show === true;
 
@@ -90,6 +93,7 @@ export function AiInsight({ title, fetchInsight, buildAttachments }: AiInsightPr
 
   if (
     !onechat ||
+    !hasConnectors ||
     !isAgentChatExperienceEnabled ||
     !hasAgentBuilderAccess ||
     !hasEnterpriseLicense

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/hooks/use_genai_connectors.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/hooks/use_genai_connectors.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import type { InferenceConnector } from '@kbn/inference-common';
+import { InferenceConnectorType } from '@kbn/inference-common';
+import { useGenAIConnectors } from './use_genai_connectors';
+import { useKibana } from './use_kibana';
+
+jest.mock('./use_kibana');
+
+const mockUseKibana = useKibana as jest.Mock;
+const mockGetConnectors = jest.fn();
+
+const mockConnectors: InferenceConnector[] = [
+  {
+    connectorId: 'connector-1',
+    name: 'OpenAI Connector',
+    type: InferenceConnectorType.OpenAI,
+    config: {},
+    capabilities: {},
+  },
+  {
+    connectorId: 'connector-2',
+    name: 'Bedrock Connector',
+    type: InferenceConnectorType.Bedrock,
+    config: {},
+    capabilities: {},
+  },
+];
+
+describe('useGenAIConnectors', () => {
+  beforeEach(() => {
+    mockGetConnectors.mockReset();
+    mockUseKibana.mockReturnValue({
+      services: {
+        inference: {
+          getConnectors: mockGetConnectors,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch connectors and set hasConnectors to true when connectors exist', async () => {
+    mockGetConnectors.mockResolvedValue(mockConnectors);
+    const { result, unmount } = renderHook(() => useGenAIConnectors());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.connectors).toEqual(mockConnectors);
+    expect(result.current.hasConnectors).toBe(true);
+
+    unmount();
+  });
+
+  it('should set hasConnectors to false when no connectors exist', async () => {
+    mockGetConnectors.mockResolvedValue([]);
+    const { result, unmount } = renderHook(() => useGenAIConnectors());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.connectors).toEqual([]);
+    expect(result.current.hasConnectors).toBe(false);
+
+    unmount();
+  });
+
+  it('should handle API errors', async () => {
+    mockGetConnectors.mockRejectedValue(new Error('API failed'));
+    const { result, unmount } = renderHook(() => useGenAIConnectors());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.connectors).toEqual([]);
+    expect(result.current.hasConnectors).toBe(false);
+
+    unmount();
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/hooks/use_genai_connectors.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/hooks/use_genai_connectors.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import useAsync from 'react-use/lib/useAsync';
+import type { InferenceConnector } from '@kbn/inference-common';
+import { useKibana } from './use_kibana';
+
+export interface UseGenAIConnectorsResult {
+  connectors: InferenceConnector[];
+  hasConnectors: boolean;
+  loading: boolean;
+}
+
+/**
+ * Hook to fetch available GenAI connectors.
+ */
+export function useGenAIConnectors(): UseGenAIConnectorsResult {
+  const {
+    services: { inference },
+  } = useKibana();
+
+  const { value: connectors = [], loading } = useAsync(async () => {
+    if (!inference) {
+      return [];
+    }
+    return inference.getConnectors();
+  }, [inference]);
+
+  return {
+    connectors,
+    hasConnectors: connectors.length > 0,
+    loading,
+  };
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/types.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/types.ts
@@ -7,6 +7,7 @@
 import type { ComponentType } from 'react';
 import type { OnechatPluginStart } from '@kbn/onechat-plugin/public';
 import type { DiscoverSharedPublicStart } from '@kbn/discover-shared-plugin/public';
+import type { InferencePublicStart } from '@kbn/inference-plugin/public';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { AlertAiInsightProps, ErrorSampleAiInsightProps } from './components/insights';
 
@@ -24,5 +25,6 @@ export interface ObservabilityAgentBuilderPluginSetupDependencies {}
 export interface ObservabilityAgentBuilderPluginStartDependencies {
   discoverShared: DiscoverSharedPublicStart;
   onechat: OnechatPluginStart;
+  inference: InferencePublicStart;
   licensing: LicensingPluginStart;
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Obs AI] Hide AI Insight component when there are no connectors (#248542)](https://github.com/elastic/kibana/pull/248542)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2026-01-09T23:05:01Z","message":"[Obs AI] Hide AI Insight component when there are no connectors (#248542)\n\nCloses https://github.com/elastic/obs-ai-team/issues/461\n\n## Summary\n\nThe AI Insight component was being shown when there are no connectors,\nresulting in an error when the component is clicked to fetch AI\nInsights.\n\nThis PR fixes it by hiding the component, when there are no connectors\nset up.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"e586a3927b42e5a13c3710e2162b6dba03cfb77c","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.3.0","Team:obs-ai","v9.4.0"],"title":"[Obs AI] Hide AI Insight component when there are no connectors","number":248542,"url":"https://github.com/elastic/kibana/pull/248542","mergeCommit":{"message":"[Obs AI] Hide AI Insight component when there are no connectors (#248542)\n\nCloses https://github.com/elastic/obs-ai-team/issues/461\n\n## Summary\n\nThe AI Insight component was being shown when there are no connectors,\nresulting in an error when the component is clicked to fetch AI\nInsights.\n\nThis PR fixes it by hiding the component, when there are no connectors\nset up.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"e586a3927b42e5a13c3710e2162b6dba03cfb77c"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248542","number":248542,"mergeCommit":{"message":"[Obs AI] Hide AI Insight component when there are no connectors (#248542)\n\nCloses https://github.com/elastic/obs-ai-team/issues/461\n\n## Summary\n\nThe AI Insight component was being shown when there are no connectors,\nresulting in an error when the component is clicked to fetch AI\nInsights.\n\nThis PR fixes it by hiding the component, when there are no connectors\nset up.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"e586a3927b42e5a13c3710e2162b6dba03cfb77c"}}]}] BACKPORT-->