### PR TITLE
test(serverless): stabilize Index Details privilege-gated actions

### DIFF
--- a/x-pack/platform/test/functional/page_objects/index_management_page.ts
+++ b/x-pack/platform/test/functional/page_objects/index_management_page.ts
@@ -193,15 +193,15 @@ export function IndexManagementPageProvider({ getService, getPageObjects }: FtrP
       },
       async expectEditSettingsToBeEnabled() {
         await testSubjects.existOrFail('indexDetailsSettingsEditModeSwitch', { timeout: 2000 });
-        const isEditSettingsButtonDisabled = await testSubjects.isEnabled(
-          'indexDetailsSettingsEditModeSwitch'
-        );
-        expect(isEditSettingsButtonDisabled).to.be(true);
+        await retry.waitFor('edit settings switch to be enabled', async () => {
+          return (await testSubjects.isEnabled('indexDetailsSettingsEditModeSwitch')) === true;
+        });
       },
       async expectIndexDetailsMappingsAddFieldToBeEnabled() {
         await testSubjects.existOrFail('indexDetailsMappingsAddField');
-        const isMappingsFieldEnabled = await testSubjects.isEnabled('indexDetailsMappingsAddField');
-        expect(isMappingsFieldEnabled).to.be(true);
+        await retry.waitFor('mappings add field button to be enabled', async () => {
+          return (await testSubjects.isEnabled('indexDetailsMappingsAddField')) === true;
+        });
       },
       async expectTabsExists() {
         await testSubjects.existOrFail('indexDetailsTab-mappings', { timeout: 2000 });

--- a/x-pack/platform/test/serverless/functional/test_suites/management/index_management/index_detail.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/management/index_management/index_detail.ts
@@ -33,7 +33,10 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     });
     describe('can view index details', function () {
       it('index with no documents', async () => {
-        await pageObjects.indexManagement.indexDetailsPage.openIndexDetailsPage(0);
+        // Open the details page for the index created in this suite rather than relying on
+        // the first row in the indices table (which can vary depending on existing indices).
+        await pageObjects.indexManagement.manageIndex(testIndexName);
+        await pageObjects.indexManagement.changeManageIndexTab('showOverviewIndexMenuButton');
         await pageObjects.indexManagement.indexDetailsPage.expectIndexDetailsPageIsLoaded();
         await pageObjects.indexManagement.indexDetailsPage.expectTabsExists();
       });


### PR DESCRIPTION
Closes #248558
Closes #248555

## Summary

This fixes a serverless functional test failure in Index Management > Index Details where the test asserted that the **Mappings > Add field** action is enabled.

### What was happening

The **Add field** button is privilege-gated in Index Management. Kibana requests index privileges via:

- `GET /api/index_management/start_privileges/{indexName}` → returns `canManageIndex`

The UI disables the Add field button unless it has confirmed `canManageIndex === true`.

**This is why the original assertion failed (`expected false to equal true`):** the test asserted the button is enabled, but the UI had it disabled at assertion time.

We also verified from a failure screenshot that the Index Details page was already showing a test-created index (e.g. `index-ftr-test-*`) while the Add field button was still disabled. This supports a timing race around privilege resolution (not just selecting the wrong index).

Separately, the test previously opened Index Details by table position (`openIndexDetailsPage(0)`). That is inherently non-deterministic because the indices table can contain multiple indices during Common Group runs, so row 0 is not guaranteed to be the index created by this suite.

### What this PR changes

- Make the test navigation deterministic (don’t open index details by row position).
- Make the assertion resilient to the async privilege check by waiting for the privilege-gated controls to become enabled before asserting.

## Why this started failing

Two recent changes make the flake more visible / easier to hit:

- #247920 (commit `e11935a5e0b20`): introduced `start_privileges/{indexName}` and wired the UI enablement for updating mappings to `canManageIndex` (index `manage`).
- #197869 (commit `a6dfa6b6f6168`): started privilege-gating index actions (including add field) in the index details UI.

## Test plan

- `node scripts/functional_tests --config x-pack/platform/test/serverless/functional/configs/security/config.group1.ts --grep "Index Details"`
- `node scripts/functional_tests --config x-pack/platform/test/serverless/functional/configs/observability/config.group1.ts --grep "Index Details"`

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->