### PR TITLE
[9.3] [Streams] Show index mode and ilm retention form simulated template in confirm details section (#246828)

### DIFF
--- a/x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared/src/services/index.ts
+++ b/x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared/src/services/index.ts
@@ -5,8 +5,4 @@
  * 2.0.
  */
 
-export const ILM_LOCATOR_ID = 'ILM_LOCATOR_ID';
-export type * from './src/policies';
-export type * from './src/locator';
-export type * from './src/types';
-export type * from './src/services';
+export type { PublicApiServiceSetup } from './public_api_service';

--- a/x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared/src/services/public_api_service.ts
+++ b/x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared/src/services/public_api_service.ts
@@ -5,8 +5,11 @@
  * 2.0.
  */
 
-export const ILM_LOCATOR_ID = 'ILM_LOCATOR_ID';
-export type * from './src/policies';
-export type * from './src/locator';
-export type * from './src/types';
-export type * from './src/services';
+import type { PolicyFromES } from '../policies';
+
+export interface PublicApiServiceSetup {
+  /**
+   * Fetches all ILM policies available in Index Lifecycle Management.
+   */
+  getPolicies(options?: { signal?: AbortSignal }): Promise<PolicyFromES[]>;
+}

--- a/x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared/src/types.ts
+++ b/x-pack/platform/packages/shared/index-lifecycle-management/index_lifecycle_management_common_shared/src/types.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-export const ILM_LOCATOR_ID = 'ILM_LOCATOR_ID';
-export type * from './src/policies';
-export type * from './src/locator';
-export type * from './src/types';
-export type * from './src/services';
+import type { PublicApiServiceSetup } from './services';
+
+export interface IndexLifecycleManagementPluginStart {
+  apiService: PublicApiServiceSetup;
+}

--- a/x-pack/platform/packages/shared/index-management/index_management_shared_types/src/services/public_api_service.ts
+++ b/x-pack/platform/packages/shared/index-management/index_management_shared_types/src/services/public_api_service.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import type { EnrichPolicyType } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  EnrichPolicyType,
+  IndicesSimulateTemplateResponse,
+} from '@elastic/elasticsearch/lib/api/types';
 import type { SendRequestResponse } from '../types';
 import type { GetIndexTemplatesResponse } from '../index_templates';
 
@@ -18,6 +21,8 @@ export interface SerializedEnrichPolicy {
   query?: Record<string, any>;
 }
 
+export type SimulateIndexTemplateResponse = IndicesSimulateTemplateResponse;
+
 export interface PublicApiServiceSetup {
   getAllEnrichPolicies(): Promise<SendRequestResponse<SerializedEnrichPolicy[]>>;
   /**
@@ -25,4 +30,13 @@ export interface PublicApiServiceSetup {
    * `GET /api/index_management/index_templates` endpoint.
    */
   getIndexTemplates(options?: { signal?: AbortSignal }): Promise<GetIndexTemplatesResponse>;
+  /**
+   * Simulates an index template by name using the
+   * `POST /api/index_management/index_templates/simulate/{templateName}` endpoint.
+   * Returns the resolved template configuration that would be applied to matching indices.
+   */
+  simulateIndexTemplate(options: {
+    templateName: string;
+    signal?: AbortSignal;
+  }): Promise<SimulateIndexTemplateResponse>;
 }

--- a/x-pack/platform/packages/shared/kbn-classic-stream-flyout/README.md
+++ b/x-pack/platform/packages/shared/kbn-classic-stream-flyout/README.md
@@ -1,15 +1,13 @@
 # @kbn/classic-stream-flyout
 
-> ⚠️ **Work in Progress**: This package is currently under development.
-
 A reusable React component package that provides a multi-step flyout interface for creating classic streams in Kibana.
 
 ## Overview
 
 The Create Classic Stream Flyout is a wizard-based interface that guides users through:
 
-- Selecting an index template for the classic stream
-- Naming and confirming the classic stream configuration
+1. **Selecting an index template** - Browse, search, and select from available index templates. Selecting a template automatically advances to the next step. Navigating back clears the selection.
+2. **Naming and confirming** - Configure the stream name by filling in wildcard portions of the selected index pattern and review template details including index mode, ILM policy phases, and data retention
 
 ## Installation
 
@@ -19,7 +17,254 @@ This package is part of the Kibana monorepo and is available as a shared browser
 import { CreateClassicStreamFlyout } from '@kbn/classic-stream-flyout';
 ```
 
+## Usage
+
+### Basic Usage
+
+```typescript
+import React, { useState } from 'react';
+import { CreateClassicStreamFlyout } from '@kbn/classic-stream-flyout';
+import type { TemplateListItem } from '@kbn/index-management-shared-types';
+
+const MyComponent = () => {
+  const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+  const [templates, setTemplates] = useState<TemplateListItem[]>([]);
+
+  const handleCreate = async (streamName: string) => {
+    // Handle the stream creation
+    await createClassicStream(streamName);
+    setIsFlyoutVisible(false);
+  };
+
+  const handleClose = () => {
+    setIsFlyoutVisible(false);
+  };
+
+  return (
+    <>
+      <button onClick={() => setIsFlyoutVisible(true)}>Create Classic Stream</button>
+
+      {isFlyoutVisible && (
+        <CreateClassicStreamFlyout
+          onClose={handleClose}
+          onCreate={handleCreate}
+          onCreateTemplate={() => {
+            /* Navigate to template creation */
+          }}
+          templates={templates}
+          onRetryLoadTemplates={() => {
+            /* Retry loading templates */
+          }}
+        />
+      )}
+    </>
+  );
+};
+```
+
+### With Custom Validation
+
+```typescript
+<CreateClassicStreamFlyout
+  onClose={handleClose}
+  onCreate={handleCreate}
+  onCreateTemplate={handleCreateTemplate}
+  templates={templates}
+  onRetryLoadTemplates={handleRetry}
+  onValidate={async (streamName, template, signal) => {
+    // Check for duplicate stream names or higher priority template conflicts
+    const isDuplicate = await checkDuplicate(streamName, signal);
+    if (isDuplicate) {
+      return { errorType: 'duplicate' };
+    }
+
+    const conflict = await checkTemplatePriority(streamName, template, signal);
+    if (conflict) {
+      return {
+        errorType: 'higherPriority',
+        conflictingIndexPattern: conflict.pattern,
+      };
+    }
+
+    return { errorType: null };
+  }}
+/>
+```
+
+### With Simulated Template and ILM Policy Details
+
+The flyout can display detailed template information by fetching simulated template data (to show resolved index mode and ILM policy) and ILM policy details (to show lifecycle phases):
+
+```typescript
+<CreateClassicStreamFlyout
+  onClose={handleClose}
+  onCreate={handleCreate}
+  onCreateTemplate={handleCreateTemplate}
+  templates={templates}
+  onRetryLoadTemplates={handleRetry}
+  getSimulatedTemplate={async (templateName, signal) => {
+    // Fetch simulated template to get resolved index mode and ILM policy name
+    return await simulateTemplate(templateName, signal);
+  }}
+  getIlmPolicy={async (policyName, signal) => {
+    // Fetch ILM policy details for phase display
+    return await fetchIlmPolicy(policyName, signal);
+  }}
+/>
+```
+
+### With Error State
+
+```typescript
+<CreateClassicStreamFlyout
+  onClose={handleClose}
+  onCreate={handleCreate}
+  onCreateTemplate={handleCreateTemplate}
+  templates={templates}
+  hasErrorLoadingTemplates={true}
+  onRetryLoadTemplates={handleRetry}
+/>
+```
+
+## API Reference
+
+### CreateClassicStreamFlyout Props
+
+| Prop                       | Type                                    | Required | Description                                                                            |
+| -------------------------- | --------------------------------------- | -------- | -------------------------------------------------------------------------------------- |
+| `onClose`                  | `() => void`                            | ✓        | Callback when the flyout is closed                                                     |
+| `onCreate`                 | `(streamName: string) => Promise<void>` | ✓        | Callback when the stream is created with the final stream name                         |
+| `onCreateTemplate`         | `() => void`                            | ✓        | Callback to navigate to create template flow (shown when no templates exist)           |
+| `templates`                | `TemplateListItem[]`                    | ✓        | Available index templates to select from                                               |
+| `isLoadingTemplates`       | `boolean`                               | ✗        | Whether templates are currently being loaded (defaults to `false`)                     |
+| `onRetryLoadTemplates`     | `() => void`                            | ✓        | Callback to retry loading templates after an error                                     |
+| `hasErrorLoadingTemplates` | `boolean`                               | ✗        | Whether there was an error loading templates (defaults to `false`)                     |
+| `onValidate`               | `StreamNameValidator`                   | ✗        | Async callback to validate the stream name for duplicates and priority conflicts       |
+| `getSimulatedTemplate`     | `SimulatedTemplateFetcher`              | ✗        | Async callback to fetch simulated template data for resolved index mode and ILM policy |
+| `getIlmPolicy`             | `IlmPolicyFetcher`                      | ✗        | Async callback to fetch ILM policy details by name for phase display                   |
+
+### StreamNameValidator
+
+```typescript
+type StreamNameValidator = (
+  streamName: string,
+  selectedTemplate: IndexTemplate,
+  signal?: AbortSignal
+) => Promise<{
+  errorType: 'duplicate' | 'higherPriority' | null;
+  conflictingIndexPattern?: string;
+}>;
+```
+
+### SimulatedTemplateFetcher
+
+```typescript
+type SimulatedTemplateFetcher = (
+  templateName: string,
+  signal?: AbortSignal
+) => Promise<SimulateIndexTemplateResponse | null>;
+```
+
+This fetcher calls the index management API to get the resolved template configuration, which includes:
+
+- **Index mode**: The effective index mode (`standard`, `logsdb`, `time_series`, `lookup`)
+- **ILM policy name**: The resolved ILM policy name from composed templates
+
+### IlmPolicyFetcher
+
+```typescript
+type IlmPolicyFetcher = (policyName: string, signal?: AbortSignal) => Promise<PolicyFromES | null>;
+```
+
+### ValidationErrorType
+
+| Error Type         | Description                                                               |
+| ------------------ | ------------------------------------------------------------------------- |
+| `'empty'`          | Stream name has unfilled wildcards or is empty                            |
+| `'invalidFormat'`  | Stream name contains invalid characters or format                         |
+| `'duplicate'`      | Stream name already exists (from `onValidate`)                            |
+| `'higherPriority'` | Stream name conflicts with a higher priority template (from `onValidate`) |
+| `null`             | No error, validation passed                                               |
+
+## Stream Name Format Rules
+
+Stream names follow Elasticsearch data stream naming rules:
+
+**Cannot include:**
+
+- `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`, `#`, `:`, or space characters
+
+**Cannot start with:**
+
+- `-`, `_`, `+`, or `.ds-`
+
+**Cannot be:**
+
+- `.` or `..`
+
+## Technical Details
+
+### Validation Modes
+
+The flyout implements a validation state machine with three modes:
+
+| Mode       | Description                                  | Behavior                                                  |
+| ---------- | -------------------------------------------- | --------------------------------------------------------- |
+| **IDLE**   | Initial state, no active validation          | Typing does not trigger validation                        |
+| **CREATE** | User clicked Create button                   | Validation in progress, typing aborts and returns to IDLE |
+| **LIVE**   | Has validation error, validates on keystroke | Debounced validation on every change (300ms default)      |
+
+### Template Details Display
+
+When `getSimulatedTemplate` is provided, the confirmation step displays:
+
+1. **Index Mode**: Resolved from the simulated template (`standard`, `logsdb`, `time_series`, or `lookup`)
+2. **Retention**: Either from the ILM policy (via `getIlmPolicy`) or from the template's data stream lifecycle
+3. **ILM Policy Phases**: Detailed phase information (hot, warm, cold, frozen, delete) when an ILM policy is configured
+
+If the simulated template fetch fails, a warning message is displayed and only basic template information is shown.
+
+### Race Condition Handling
+
+The validation and data fetching systems use AbortController to handle race conditions:
+
+- **Create validation**: Aborted when user types during validation
+- **Debounced validation**: Previous call aborted when new input arrives
+- **Template change**: All pending validations and fetches are aborted
+- **Simulated template fetch**: Aborted when navigating back or switching templates
+- **ILM policy fetch**: Aborted when template changes or component unmounts
+- **Component unmount**: All pending operations cleaned up
+
+## Features
+
+- **Two-Step Wizard**: Guides users through template selection and stream naming with auto-advance on selection
+- **Template Search**: Searchable list of available index templates
+- **Simulated Template Data**: Fetches resolved template configuration for accurate display
+- **Index Mode Display**: Shows the effective index mode from composed templates
+- **ILM Policy Display**: Shows ILM policy information with phase details
+- **Data Retention Display**: Shows lifecycle data retention for templates without ILM
+- **Managed Template Indicator**: Visual indicator for managed templates
+- **Multiple Index Pattern Support**: Dropdown selector when template has multiple patterns
+- **Dynamic Wildcard Inputs**: Generates input fields based on wildcards in index pattern
+- **Comprehensive Validation**: Empty check, format validation, and custom async validation
+- **Debounced Live Validation**: Validates on keystroke after first error (300ms debounce)
+- **Race Condition Safety**: AbortController-based cancellation for async operations
+- **Form State Management**: Reducer-based state with discriminated union types
+- **Internationalization**: Full i18n support with formatted messages
+- **Accessibility**: ARIA-compliant flyout with proper labeling
+- **Type Safety**: Full TypeScript support with comprehensive type definitions
+- **Storybook Integration**: Includes Storybook stories for component development
+
 ## Development
+
+### Testing
+
+The package includes comprehensive test coverage:
+
+```bash
+# Run tests
+yarn jest --config x-pack/platform/packages/shared/kbn-classic-stream-flyout/jest.config.js
+```
 
 ### Storybook
 
@@ -27,12 +272,4 @@ View and develop the component in Storybook:
 
 ```bash
 yarn storybook classic_stream_flyout
-```
-
-### Testing
-
-Run tests for the package:
-
-```bash
-yarn jest --config x-pack/platform/packages/shared/kbn-classic-stream-flyout/jest.config.js
 ```

--- a/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/components/create_classic_stream_flyout/create_classic_stream_flyout.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/components/create_classic_stream_flyout/create_classic_stream_flyout.test.tsx
@@ -80,16 +80,13 @@ const renderFlyout = (props = {}) => {
 };
 
 // Helper to select a template and navigate to second step
+// Selecting a template automatically navigates to the next step
 const selectTemplateAndGoToStep2 = (
   getByTestId: (id: string) => HTMLElement,
   templateName: string
 ) => {
-  // Click on a template option
   const templateOption = getByTestId(`template-option-${templateName}`);
   fireEvent.click(templateOption);
-
-  // Navigate to second step
-  fireEvent.click(getByTestId('nextButton'));
 };
 
 describe('CreateClassicStreamFlyout', () => {
@@ -116,11 +113,8 @@ describe('CreateClassicStreamFlyout', () => {
   });
 
   describe('navigation', () => {
-    it('navigates to second step when clicking Next button with selected template', () => {
+    it('auto-advances to second step when selecting a template', () => {
       const { getByTestId, queryByTestId } = renderFlyout();
-
-      // Select a template first
-      fireEvent.click(getByTestId('template-option-template-1'));
 
       // Check that the first step content is rendered
       expect(getByTestId('selectTemplateStep')).toBeInTheDocument();
@@ -128,12 +122,11 @@ describe('CreateClassicStreamFlyout', () => {
 
       // Verify that correct buttons are visible
       expect(getByTestId('cancelButton')).toBeInTheDocument();
-      expect(getByTestId('nextButton')).toBeInTheDocument();
       expect(queryByTestId('backButton')).not.toBeInTheDocument();
       expect(queryByTestId('createButton')).not.toBeInTheDocument();
 
-      // Click Next button
-      fireEvent.click(getByTestId('nextButton'));
+      // Select a template
+      fireEvent.click(getByTestId('template-option-template-1'));
 
       // Verify that the second step content is rendered
       expect(queryByTestId('selectTemplateStep')).not.toBeInTheDocument();
@@ -143,13 +136,12 @@ describe('CreateClassicStreamFlyout', () => {
       expect(getByTestId('backButton')).toBeInTheDocument();
       expect(getByTestId('createButton')).toBeInTheDocument();
       expect(queryByTestId('cancelButton')).not.toBeInTheDocument();
-      expect(queryByTestId('nextButton')).not.toBeInTheDocument();
     });
 
-    it('navigates back to first step when clicking Back button', () => {
+    it('navigates back to first step when clicking Back button and clears template selection', () => {
       const { getByTestId, queryByTestId } = renderFlyout();
 
-      // Select template and navigate to second step
+      // Select template
       selectTemplateAndGoToStep2(getByTestId, 'template-1');
 
       // Verify that the second step content is rendered
@@ -160,7 +152,6 @@ describe('CreateClassicStreamFlyout', () => {
       expect(getByTestId('backButton')).toBeInTheDocument();
       expect(getByTestId('createButton')).toBeInTheDocument();
       expect(queryByTestId('cancelButton')).not.toBeInTheDocument();
-      expect(queryByTestId('nextButton')).not.toBeInTheDocument();
 
       // Navigate back
       fireEvent.click(getByTestId('backButton'));
@@ -171,9 +162,12 @@ describe('CreateClassicStreamFlyout', () => {
 
       // Verify that correct buttons are visible
       expect(getByTestId('cancelButton')).toBeInTheDocument();
-      expect(getByTestId('nextButton')).toBeInTheDocument();
       expect(queryByTestId('backButton')).not.toBeInTheDocument();
       expect(queryByTestId('createButton')).not.toBeInTheDocument();
+
+      // Verify that template selection was cleared (step 2 is disabled)
+      const nextStep = getByTestId('createClassicStreamStep-nameAndConfirm');
+      expect(nextStep).toBeDisabled();
     });
   });
 
@@ -238,8 +232,6 @@ describe('CreateClassicStreamFlyout', () => {
       // Select template
       fireEvent.click(getByTestId('template-option-template-1'));
 
-      // Navigate forward
-      fireEvent.click(getByTestId('nextButton'));
       expect(onCreate).not.toHaveBeenCalled();
       expect(onClose).not.toHaveBeenCalled();
 
@@ -313,46 +305,11 @@ describe('CreateClassicStreamFlyout', () => {
       });
     });
     describe('template selection', () => {
-      it('disables next step and Next button when no template is selected', () => {
+      it('disables next step in horizontal steps when no template is selected', () => {
         const { getByTestId } = renderFlyout();
 
         const nextStep = getByTestId('createClassicStreamStep-nameAndConfirm');
         expect(nextStep).toBeDisabled();
-
-        const nextButton = getByTestId('nextButton');
-        expect(nextButton).toBeDisabled();
-      });
-
-      it('enables next step and Next button when a template is selected', () => {
-        const { getByTestId } = renderFlyout();
-
-        // Select a template
-        fireEvent.click(getByTestId('template-option-template-1'));
-
-        const nextStep = getByTestId('createClassicStreamStep-nameAndConfirm');
-        expect(nextStep).toBeEnabled();
-
-        const nextButton = getByTestId('nextButton');
-        expect(nextButton).toBeEnabled();
-      });
-
-      it('displays ILM badge for templates with ILM policy', () => {
-        const { getAllByText, getByText } = renderFlyout();
-
-        // template-1 has ilmPolicy: { name: '30d' }, template-2 has ilmPolicy: { name: '90d' }
-        // Both should display ILM badge
-        const ilmBadges = getAllByText('ILM');
-        expect(ilmBadges.length).toBeGreaterThanOrEqual(2);
-        expect(getByText('90d')).toBeInTheDocument();
-      });
-
-      it('displays lifecycle data retention for templates without ILM policy', () => {
-        const { getByTestId } = renderFlyout();
-
-        // template-3 has lifecycle: { enabled: true, value: 30, unit: 'd' } but no ILM
-        // Should display the retention period in the template option
-        const templateOption = getByTestId('template-option-template-3');
-        expect(templateOption).toBeInTheDocument();
       });
 
       it('renders all template options including managed templates', () => {
@@ -367,8 +324,26 @@ describe('CreateClassicStreamFlyout', () => {
   });
 
   describe('name and confirm step', () => {
-    it('renders the name and confirm step with template details', () => {
-      const { getByTestId, getByText } = renderFlyout();
+    // Helper to create a mock simulated template response
+    const createMockSimulatedTemplate = (overrides: Record<string, unknown> = {}) => ({
+      template: {
+        settings: {
+          index: {
+            mode: 'standard',
+            lifecycle: { name: '30d' },
+            ...((overrides.settings as Record<string, unknown>)?.index || {}),
+          },
+        },
+        ...overrides,
+      },
+    });
+
+    it('renders the name and confirm step with template details', async () => {
+      const mockGetSimulatedTemplate = jest.fn().mockResolvedValue(createMockSimulatedTemplate());
+
+      const { getByTestId, getByText } = renderFlyout({
+        getSimulatedTemplate: mockGetSimulatedTemplate,
+      });
 
       // Select template and navigate to second step
       selectTemplateAndGoToStep2(getByTestId, 'template-1');
@@ -382,8 +357,12 @@ describe('CreateClassicStreamFlyout', () => {
 
       // Check template details are displayed
       expect(getByTestId('templateDetails')).toBeInTheDocument();
-      expect(getByText('Index mode')).toBeInTheDocument();
-      expect(getByText('Standard')).toBeInTheDocument();
+
+      // Wait for simulated template to load
+      await waitFor(() => {
+        expect(getByText('Index mode')).toBeInTheDocument();
+        expect(getByText('Standard')).toBeInTheDocument();
+      });
       expect(getByText('Component templates')).toBeInTheDocument();
     });
 
@@ -429,14 +408,28 @@ describe('CreateClassicStreamFlyout', () => {
       expect(getByText('logs@settings')).toBeInTheDocument();
     });
 
-    it('displays correct index mode for different templates', () => {
-      const { getByTestId, getByText } = renderFlyout();
+    it('displays correct index mode for different templates', async () => {
+      const mockGetSimulatedTemplate = jest.fn().mockResolvedValue({
+        template: {
+          settings: {
+            index: {
+              mode: 'logsdb',
+            },
+          },
+        },
+      });
+
+      const { getByTestId, getByText } = renderFlyout({
+        getSimulatedTemplate: mockGetSimulatedTemplate,
+      });
 
       // Select template-2 and navigate to second step
       selectTemplateAndGoToStep2(getByTestId, 'template-2');
 
-      // template-2 has indexMode: 'logsdb'
-      expect(getByText('LogsDB')).toBeInTheDocument();
+      // Wait for simulated template to load
+      await waitFor(() => {
+        expect(getByText('LogsDB')).toBeInTheDocument();
+      });
     });
 
     it('displays version when available', () => {
@@ -512,9 +505,6 @@ describe('CreateClassicStreamFlyout', () => {
 
         // Select a different template
         fireEvent.click(getByTestId('template-option-template-2'));
-
-        // Navigate to second step again
-        fireEvent.click(getByTestId('nextButton'));
 
         // The input should be reset (empty)
         const newInput = getByTestId('streamNameInput-wildcard-0');
@@ -733,7 +723,6 @@ describe('CreateClassicStreamFlyout', () => {
         // Go back and change template
         fireEvent.click(getByTestId('backButton'));
         fireEvent.click(getByTestId('template-option-template-2'));
-        fireEvent.click(getByTestId('nextButton'));
 
         // Validation error should be cleared (stream name reset is tested in existing test above)
         await waitFor(() => {
@@ -894,102 +883,21 @@ describe('CreateClassicStreamFlyout', () => {
     });
   });
 
-  describe('showDataRetention prop', () => {
-    describe('select template step', () => {
-      it('hides ILM badge and policy name when showDataRetention is false', () => {
-        const { queryAllByText, queryByText, getByTestId } = renderFlyout({
-          showDataRetention: false,
-        });
-
-        // template-1 and template-2 have ILM policies, but badges should be hidden
-        expect(queryAllByText('ILM')).toHaveLength(0);
-
-        // ILM policy names should also be hidden
-        expect(queryByText('30d')).not.toBeInTheDocument();
-        expect(queryByText('90d')).not.toBeInTheDocument();
-
-        // Template options should still be visible
-        expect(getByTestId('template-option-template-1')).toBeInTheDocument();
-        expect(getByTestId('template-option-template-2')).toBeInTheDocument();
-      });
-
-      it('hides data retention text when showDataRetention is false', () => {
-        const { queryByText } = renderFlyout({ showDataRetention: false });
-
-        // template-3 has lifecycle: { enabled: true, value: 30, unit: 'd' } - retention text should be hidden
-        // ILM policy names should also be hidden
-        expect(queryByText('30d')).not.toBeInTheDocument();
-        expect(queryByText('90d')).not.toBeInTheDocument();
-      });
-
-      it('shows ILM badge when showDataRetention is true (default)', () => {
-        const { getAllByText } = renderFlyout();
-
-        // template-1 and template-2 have ILM policies - badges should be visible
-        const ilmBadges = getAllByText('ILM');
-        expect(ilmBadges.length).toBeGreaterThanOrEqual(2);
-      });
-    });
-
-    describe('name and confirm step', () => {
-      it('hides retention section when showDataRetention is false', () => {
-        const { getByTestId, queryByText } = renderFlyout({ showDataRetention: false });
-
-        // Select template with ILM policy and navigate to second step
-        selectTemplateAndGoToStep2(getByTestId, 'template-1');
-
-        // Retention should be hidden
-        expect(queryByText('Retention')).not.toBeInTheDocument();
-        expect(queryByText('30d')).not.toBeInTheDocument();
-        expect(queryByText('ILM')).not.toBeInTheDocument();
-
-        // Other template details should still be visible
-        expect(queryByText('Index mode')).toBeInTheDocument();
-        expect(queryByText('Component templates')).toBeInTheDocument();
-      });
-
-      it('does not call getIlmPolicy when showDataRetention is false', () => {
-        const mockGetIlmPolicy = jest.fn().mockResolvedValue(null);
-        const { getByTestId } = renderFlyout({
-          showDataRetention: false,
-          getIlmPolicy: mockGetIlmPolicy,
-        });
-
-        // Select template with ILM policy and navigate to second step
-        selectTemplateAndGoToStep2(getByTestId, 'template-1');
-
-        // Verify we're on the second step
-        expect(getByTestId('nameAndConfirmStep')).toBeInTheDocument();
-
-        // getIlmPolicy should not be called
-        expect(mockGetIlmPolicy).not.toHaveBeenCalled();
-      });
-
-      it('shows retention section and calls getIlmPolicy when showDataRetention is true', async () => {
-        const mockGetIlmPolicy = jest.fn().mockResolvedValue(null);
-        const { getByTestId, getByText } = renderFlyout({
-          showDataRetention: true,
-          getIlmPolicy: mockGetIlmPolicy,
-        });
-
-        // Select template with ILM policy and navigate to second step
-        selectTemplateAndGoToStep2(getByTestId, 'template-1');
-
-        // Retention should be visible
-        expect(getByText('Retention')).toBeInTheDocument();
-
-        // getIlmPolicy should be called
-        await waitFor(() => {
-          expect(mockGetIlmPolicy).toHaveBeenCalledWith('30d', expect.any(AbortSignal));
-        });
-      });
-    });
-  });
-
   describe('ILM policy fetching integration', () => {
     // Note: Basic ILM policy fetching, loading states, error handling, and abort signal tests
     // are covered in confirm_template_details_section.test.tsx.
     // These tests focus on navigation-specific integration behavior.
+
+    const createMockSimulatedTemplateWithIlm = (ilmPolicyName: string) => ({
+      template: {
+        settings: {
+          index: {
+            mode: 'standard',
+            lifecycle: { name: ilmPolicyName },
+          },
+        },
+      },
+    });
 
     it('should abort ILM policy fetch when going back to template selection', async () => {
       let capturedSignal: AbortSignal | undefined;
@@ -999,8 +907,14 @@ describe('CreateClassicStreamFlyout', () => {
           setTimeout(() => resolve(null), 10000);
         });
       });
+      const mockGetSimulatedTemplate = jest
+        .fn()
+        .mockResolvedValue(createMockSimulatedTemplateWithIlm('30d'));
 
-      const { getByTestId } = renderFlyout({ getIlmPolicy: mockGetIlmPolicy });
+      const { getByTestId } = renderFlyout({
+        getIlmPolicy: mockGetIlmPolicy,
+        getSimulatedTemplate: mockGetSimulatedTemplate,
+      });
 
       // Select template with ILM policy and navigate to second step
       selectTemplateAndGoToStep2(getByTestId, 'template-1');
@@ -1021,21 +935,27 @@ describe('CreateClassicStreamFlyout', () => {
     it('should abort previous ILM policy fetch when switching templates via navigation', async () => {
       let firstSignal: AbortSignal | undefined;
       let secondSignal: AbortSignal | undefined;
-      let callCount = 0;
+      let ilmCallCount = 0;
 
       const mockGetIlmPolicy = jest.fn().mockImplementation((policyName, signal) => {
-        callCount++;
-        if (callCount === 1) {
+        ilmCallCount++;
+        if (ilmCallCount === 1) {
           firstSignal = signal;
-        } else if (callCount === 2) {
+        } else if (ilmCallCount === 2) {
           secondSignal = signal;
         }
         return new Promise((resolve) => {
           setTimeout(() => resolve(null), 10000);
         });
       });
+      const mockGetSimulatedTemplate = jest
+        .fn()
+        .mockResolvedValue(createMockSimulatedTemplateWithIlm('30d'));
 
-      const { getByTestId } = renderFlyout({ getIlmPolicy: mockGetIlmPolicy });
+      const { getByTestId } = renderFlyout({
+        getIlmPolicy: mockGetIlmPolicy,
+        getSimulatedTemplate: mockGetSimulatedTemplate,
+      });
 
       // Select template-1 and navigate to second step
       selectTemplateAndGoToStep2(getByTestId, 'template-1');
@@ -1048,12 +968,207 @@ describe('CreateClassicStreamFlyout', () => {
       // Go back and select template-2
       fireEvent.click(getByTestId('backButton'));
       fireEvent.click(getByTestId('template-option-template-2'));
-      fireEvent.click(getByTestId('nextButton'));
 
       await waitFor(() => {
         expect(mockGetIlmPolicy).toHaveBeenCalledTimes(2);
         expect(firstSignal?.aborted).toBe(true);
         expect(secondSignal).toBeDefined();
+      });
+    });
+  });
+
+  describe('Simulated template fetching integration', () => {
+    // Tests for getSimulatedTemplate integration behavior.
+
+    const createMockSimulatedTemplate = (mode: string = 'standard', ilmPolicyName?: string) => ({
+      template: {
+        settings: {
+          index: {
+            mode,
+            ...(ilmPolicyName ? { lifecycle: { name: ilmPolicyName } } : {}),
+          },
+        },
+      },
+    });
+
+    it('calls getSimulatedTemplate when navigating to second step', async () => {
+      const mockGetSimulatedTemplate = jest.fn().mockResolvedValue(createMockSimulatedTemplate());
+
+      const { getByTestId } = renderFlyout({
+        getSimulatedTemplate: mockGetSimulatedTemplate,
+      });
+
+      // Select template and navigate to second step
+      selectTemplateAndGoToStep2(getByTestId, 'template-1');
+
+      await waitFor(() => {
+        expect(mockGetSimulatedTemplate).toHaveBeenCalledWith(
+          'template-1',
+          expect.any(AbortSignal)
+        );
+      });
+    });
+
+    it('displays index mode from simulated template', async () => {
+      const mockGetSimulatedTemplate = jest
+        .fn()
+        .mockResolvedValue(createMockSimulatedTemplate('logsdb'));
+
+      const { getByTestId, getByText } = renderFlyout({
+        getSimulatedTemplate: mockGetSimulatedTemplate,
+      });
+
+      // Select template and navigate to second step
+      selectTemplateAndGoToStep2(getByTestId, 'template-1');
+
+      await waitFor(() => {
+        expect(getByText('Index mode')).toBeInTheDocument();
+        expect(getByText('LogsDB')).toBeInTheDocument();
+      });
+    });
+
+    it('displays retention from simulated template when ILM policy is present', async () => {
+      const mockGetSimulatedTemplate = jest
+        .fn()
+        .mockResolvedValue(createMockSimulatedTemplate('standard', 'my-ilm-policy'));
+      const mockGetIlmPolicy = jest.fn().mockResolvedValue(null);
+
+      const { getByTestId, getByText } = renderFlyout({
+        getSimulatedTemplate: mockGetSimulatedTemplate,
+        getIlmPolicy: mockGetIlmPolicy,
+      });
+
+      // Select template and navigate to second step
+      selectTemplateAndGoToStep2(getByTestId, 'template-1');
+
+      await waitFor(() => {
+        expect(getByText('Retention')).toBeInTheDocument();
+        expect(getByText('my-ilm-policy')).toBeInTheDocument();
+      });
+
+      // Verify getIlmPolicy is called with the policy name from simulated template
+      await waitFor(() => {
+        expect(mockGetIlmPolicy).toHaveBeenCalledWith('my-ilm-policy', expect.any(AbortSignal));
+      });
+    });
+
+    it('should abort simulated template fetch when going back to template selection', async () => {
+      let capturedSignal: AbortSignal | undefined;
+      const mockGetSimulatedTemplate = jest.fn().mockImplementation((templateName, signal) => {
+        capturedSignal = signal;
+        return new Promise((resolve) => {
+          setTimeout(() => resolve(createMockSimulatedTemplate()), 10000);
+        });
+      });
+
+      const { getByTestId } = renderFlyout({
+        getSimulatedTemplate: mockGetSimulatedTemplate,
+      });
+
+      // Select template and navigate to second step
+      selectTemplateAndGoToStep2(getByTestId, 'template-1');
+
+      await waitFor(() => {
+        expect(mockGetSimulatedTemplate).toHaveBeenCalled();
+        expect(capturedSignal).toBeDefined();
+      });
+
+      // Go back - should abort the fetch
+      fireEvent.click(getByTestId('backButton'));
+
+      await waitFor(() => {
+        expect(capturedSignal?.aborted).toBe(true);
+      });
+    });
+
+    it('should abort previous simulated template fetch when switching templates', async () => {
+      let firstSignal: AbortSignal | undefined;
+      let secondSignal: AbortSignal | undefined;
+      let callCount = 0;
+
+      const mockGetSimulatedTemplate = jest.fn().mockImplementation((templateName, signal) => {
+        callCount++;
+        if (callCount === 1) {
+          firstSignal = signal;
+        } else if (callCount === 2) {
+          secondSignal = signal;
+        }
+        return new Promise((resolve) => {
+          setTimeout(() => resolve(createMockSimulatedTemplate()), 10000);
+        });
+      });
+
+      const { getByTestId } = renderFlyout({
+        getSimulatedTemplate: mockGetSimulatedTemplate,
+      });
+
+      // Select template-1 and navigate to second step
+      selectTemplateAndGoToStep2(getByTestId, 'template-1');
+
+      await waitFor(() => {
+        expect(mockGetSimulatedTemplate).toHaveBeenCalledTimes(1);
+        expect(firstSignal).toBeDefined();
+      });
+
+      // Go back and select template-2
+      fireEvent.click(getByTestId('backButton'));
+      fireEvent.click(getByTestId('template-option-template-2'));
+
+      await waitFor(() => {
+        expect(mockGetSimulatedTemplate).toHaveBeenCalledTimes(2);
+        expect(firstSignal?.aborted).toBe(true);
+        expect(secondSignal).toBeDefined();
+      });
+    });
+
+    it('shows error message when simulated template fetch fails', async () => {
+      const mockGetSimulatedTemplate = jest.fn().mockRejectedValue(new Error('Network error'));
+
+      const { getByTestId, getByText, queryByText } = renderFlyout({
+        getSimulatedTemplate: mockGetSimulatedTemplate,
+      });
+
+      // Select template and navigate to second step
+      selectTemplateAndGoToStep2(getByTestId, 'template-1');
+
+      await waitFor(() => {
+        expect(
+          getByText(/There was an error while loading index mode and data retention info/i)
+        ).toBeInTheDocument();
+      });
+
+      // Index mode should not be shown when simulated template fails
+      expect(queryByText('Index mode')).not.toBeInTheDocument();
+    });
+
+    it('does not show index mode or retention when getSimulatedTemplate is not provided', () => {
+      const { getByTestId, queryByText } = renderFlyout();
+
+      // Select template and navigate to second step
+      selectTemplateAndGoToStep2(getByTestId, 'template-1');
+
+      // Index mode and retention require simulated template
+      expect(queryByText('Index mode')).not.toBeInTheDocument();
+    });
+
+    it('falls back to template lifecycle when simulated template has no ILM policy', async () => {
+      // Simulated template with no ILM policy
+      const mockGetSimulatedTemplate = jest
+        .fn()
+        .mockResolvedValue(createMockSimulatedTemplate('standard'));
+
+      const { getByTestId, getByText } = renderFlyout({
+        getSimulatedTemplate: mockGetSimulatedTemplate,
+        // Use template-3 which has lifecycle: { enabled: true, value: 30, unit: 'd' }
+      });
+
+      // Select template-3 with data retention and navigate to second step
+      selectTemplateAndGoToStep2(getByTestId, 'template-3');
+
+      await waitFor(() => {
+        // Should show the fallback data retention from template
+        expect(getByText('Retention')).toBeInTheDocument();
+        expect(getByText('30d')).toBeInTheDocument();
       });
     });
   });

--- a/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/components/create_classic_stream_flyout/steps/name_and_confirm/name_and_confirm_step.tsx
+++ b/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/components/create_classic_stream_flyout/steps/name_and_confirm/name_and_confirm_step.tsx
@@ -20,7 +20,7 @@ export const NameAndConfirmStep = ({
   validationError = null,
   conflictingIndexPattern,
   getIlmPolicy,
-  showDataRetention = true,
+  getSimulatedTemplate,
 }: NameAndConfirmStepProps) => {
   const indexPatterns = template.indexPatterns ?? [];
 
@@ -42,7 +42,7 @@ export const NameAndConfirmStep = ({
         <ConfirmTemplateDetailsSection
           template={template}
           getIlmPolicy={getIlmPolicy}
-          showDataRetention={showDataRetention}
+          getSimulatedTemplate={getSimulatedTemplate}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/components/create_classic_stream_flyout/steps/name_and_confirm/types.ts
+++ b/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/components/create_classic_stream_flyout/steps/name_and_confirm/types.ts
@@ -6,7 +6,11 @@
  */
 import type { TemplateListItem as IndexTemplate } from '@kbn/index-management-shared-types';
 
-import type { IlmPolicyFetcher, ValidationErrorType } from '../../../../utils';
+import type {
+  IlmPolicyFetcher,
+  SimulatedTemplateFetcher,
+  ValidationErrorType,
+} from '../../../../utils';
 
 export interface NameAndConfirmBaseProps {
   selectedIndexPattern: string;
@@ -20,7 +24,7 @@ export interface NameAndConfirmBaseProps {
 export interface NameAndConfirmStepProps extends NameAndConfirmBaseProps {
   template: IndexTemplate;
   getIlmPolicy?: IlmPolicyFetcher;
-  showDataRetention?: boolean;
+  getSimulatedTemplate?: SimulatedTemplateFetcher;
 }
 
 export interface NameStreamSectionProps extends NameAndConfirmBaseProps {

--- a/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/utils/ilm_utils.ts
+++ b/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/utils/ilm_utils.ts
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import type { PolicyFromES, Phases } from '@kbn/index-lifecycle-management-common-shared';
+import type { SimulateIndexTemplateResponse } from '@kbn/index-management-shared-types';
 
 /**
  * Phase description for UI display
@@ -31,6 +32,14 @@ export type IlmPolicyFetcher = (
   policyName: string,
   signal?: AbortSignal
 ) => Promise<PolicyFromES | null>;
+
+/**
+ * Async function to fetch simulated template data by template name.
+ */
+export type SimulatedTemplateFetcher = (
+  templateName: string,
+  signal?: AbortSignal
+) => Promise<SimulateIndexTemplateResponse | null>;
 
 /**
  * Phase indicator colors for ILM phases

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/index.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/index.ts
@@ -13,3 +13,5 @@ import { IndexLifecycleManagementPlugin } from './plugin';
 export const plugin = (initializerContext: PluginInitializerContext) => {
   return new IndexLifecycleManagementPlugin(initializerContext);
 };
+
+export type { IndexLifecycleManagementPluginStart } from './types';

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/plugin.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/plugin.tsx
@@ -14,20 +14,31 @@ import { init as initUiMetric } from './application/services/ui_metric';
 import { init as initNotification } from './application/services/notification';
 import { BreadcrumbService } from './application/services/breadcrumbs';
 import { addAllExtensions } from './extend_index_management';
-import type { ClientConfigType, SetupDependencies, StartDependencies } from './types';
+import type {
+  ClientConfigType,
+  IndexLifecycleManagementPluginStart,
+  SetupDependencies,
+  StartDependencies,
+} from './types';
 import { IlmLocatorDefinition } from './locator';
+import { PublicApiService } from './services';
 
 export class IndexLifecycleManagementPlugin
-  implements Plugin<void, void, SetupDependencies, StartDependencies>
+  implements
+    Plugin<void, IndexLifecycleManagementPluginStart, SetupDependencies, StartDependencies>
 {
   constructor(private readonly initializerContext: PluginInitializerContext) {}
 
   private breadcrumbService = new BreadcrumbService();
+  private apiService?: PublicApiService;
 
   public setup(coreSetup: CoreSetup<StartDependencies>, plugins: SetupDependencies) {
     const {
       ui: { enabled: isIndexLifecycleManagementUiEnabled },
     } = this.initializerContext.config.get<ClientConfigType>();
+
+    // Initialize apiService regardless of UI enabled state, as it's used by other plugins
+    this.apiService = new PublicApiService(coreSetup.http);
 
     if (isIndexLifecycleManagementUiEnabled) {
       const {
@@ -114,7 +125,11 @@ export class IndexLifecycleManagementPlugin
     }
   }
 
-  public start() {}
+  public start(): IndexLifecycleManagementPluginStart {
+    return {
+      apiService: this.apiService!,
+    };
+  }
 
   public stop() {}
 }

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/services/index.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/services/index.ts
@@ -5,8 +5,4 @@
  * 2.0.
  */
 
-export const ILM_LOCATOR_ID = 'ILM_LOCATOR_ID';
-export type * from './src/policies';
-export type * from './src/locator';
-export type * from './src/types';
-export type * from './src/services';
+export { PublicApiService } from './public_api_service';

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/services/public_api_service.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/services/public_api_service.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { HttpSetup } from '@kbn/core-http-browser';
+import type { PolicyFromES } from '@kbn/index-lifecycle-management-common-shared';
+import { API_BASE_PATH } from '../../common/constants';
+
+/**
+ * Index Lifecycle Management public API service
+ */
+export class PublicApiService {
+  private http: HttpSetup;
+
+  /**
+   * constructor
+   * @param http http dependency
+   */
+  constructor(http: HttpSetup) {
+    this.http = http;
+  }
+
+  /**
+   * Fetches all ILM policies available in Index Lifecycle Management.
+   */
+  getPolicies(options?: { signal?: AbortSignal }) {
+    return this.http.get<PolicyFromES[]>(`${API_BASE_PATH}/policies`, {
+      signal: options?.signal,
+    });
+  }
+}

--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/types.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/types.ts
@@ -19,6 +19,8 @@ import type { ILicense } from '@kbn/licensing-types';
 
 import type { BreadcrumbService } from './application/services/breadcrumbs';
 
+export type { IndexLifecycleManagementPluginStart } from '@kbn/index-lifecycle-management-common-shared';
+
 export interface SetupDependencies {
   usageCollection?: UsageCollectionSetup;
   management: ManagementSetup;

--- a/x-pack/platform/plugins/shared/index_management/public/services/public_api_service.mock.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/services/public_api_service.mock.ts
@@ -12,6 +12,7 @@ export type PublicApiServiceSetupMock = jest.Mocked<PublicApiServiceSetup>;
 const createServiceMock = (): PublicApiServiceSetupMock => ({
   getAllEnrichPolicies: jest.fn(),
   getIndexTemplates: jest.fn(),
+  simulateIndexTemplate: jest.fn(),
 });
 
 export const publicApiServiceMock = {

--- a/x-pack/platform/plugins/shared/index_management/public/services/public_api_service.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/services/public_api_service.ts
@@ -6,7 +6,10 @@
  */
 
 import type { HttpSetup } from '@kbn/core-http-browser';
-import type { GetIndexTemplatesResponse } from '@kbn/index-management-shared-types';
+import type {
+  GetIndexTemplatesResponse,
+  SimulateIndexTemplateResponse,
+} from '@kbn/index-management-shared-types';
 import { API_BASE_PATH, INTERNAL_API_BASE_PATH } from '../../common';
 import { sendRequest } from '../shared_imports';
 
@@ -41,5 +44,18 @@ export class PublicApiService {
     return this.http.get<GetIndexTemplatesResponse>(`${API_BASE_PATH}/index_templates`, {
       signal: options?.signal,
     });
+  }
+
+  /**
+   * Simulates an index template by name.
+   * Returns the resolved template configuration that would be applied to matching indices.
+   */
+  simulateIndexTemplate(options: { templateName: string; signal?: AbortSignal }) {
+    return this.http.post<SimulateIndexTemplateResponse>(
+      `${API_BASE_PATH}/index_templates/simulate/${encodeURIComponent(options.templateName)}`,
+      {
+        signal: options.signal,
+      }
+    );
   }
 }

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/register_simulate_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/register_simulate_route.ts
@@ -48,7 +48,33 @@ export function registerSimulateRoute({ router, lib: { handleEsError } }: RouteD
           };
 
       try {
-        const templatePreview = await client.asCurrentUser.indices.simulateTemplate(params);
+        const templatePromise = client.asCurrentUser.indices.getIndexTemplate({
+          name: templateName!,
+        });
+        const templatePreviewPromise = client.asCurrentUser.indices.simulateTemplate(params);
+        const settingsPromise = client.asInternalUser.cluster.getSettings({
+          include_defaults: true,
+        });
+
+        const [templateContent, templatePreview, { persistent, defaults }] = await Promise.all([
+          templatePromise,
+          templatePreviewPromise,
+          settingsPromise,
+        ]);
+
+        const isLogsPattern = !!templateContent.index_templates.find((t) =>
+          // @ts-expect-error I think there are some incorrect types from the es client package
+          t.index_template.index_patterns?.some((pattern) => pattern === 'logs-*-*')
+        );
+
+        const isLogsdbEnabled =
+          (persistent?.cluster?.logsdb?.enabled ?? defaults?.cluster?.logsdb?.enabled) === 'true';
+
+        templatePreview.template.settings.index = templatePreview.template.settings.index || {};
+
+        templatePreview.template.settings.index.mode =
+          templatePreview.template.settings.index.mode ||
+          (isLogsdbEnabled && isLogsPattern ? 'logsdb' : 'standard');
 
         return response.ok({ body: templatePreview });
       } catch (error) {

--- a/x-pack/platform/plugins/shared/streams/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/public/plugin.ts
@@ -19,6 +19,7 @@ import { map, catchError } from 'rxjs';
 import { once } from 'lodash';
 import type { StreamsPublicConfig } from '../common/config';
 import type {
+  ClassicStreamsStatus,
   StreamsNavigationStatus,
   StreamsPluginClass,
   StreamsPluginSetup,
@@ -62,7 +63,17 @@ export class Plugin implements StreamsPluginClass {
           });
         } catch (error) {
           this.logger.error(error);
-          return UNKNOWN_STATUS;
+          return UNKNOWN_WIRED_STATUS;
+        }
+      },
+      getClassicStatus: async () => {
+        try {
+          return await this.repositoryClient.fetch('GET /internal/streams/_classic_status', {
+            signal: new AbortController().signal,
+          });
+        } catch (error) {
+          this.logger.error(error);
+          return UNKNOWN_CLASSIC_STATUS;
         }
       },
       enableWiredMode: async (signal: AbortSignal) => {
@@ -82,7 +93,8 @@ export class Plugin implements StreamsPluginClass {
   stop() {}
 }
 
-const UNKNOWN_STATUS: WiredStreamsStatus = { enabled: 'unknown', can_manage: false };
+const UNKNOWN_WIRED_STATUS: WiredStreamsStatus = { enabled: 'unknown', can_manage: false };
+const UNKNOWN_CLASSIC_STATUS: ClassicStreamsStatus = { can_manage: false };
 
 const createStreamsNavigationStatusObservable = once(
   (

--- a/x-pack/platform/plugins/shared/streams/public/types.ts
+++ b/x-pack/platform/plugins/shared/streams/public/types.ts
@@ -22,6 +22,10 @@ export interface WiredStreamsStatus {
   can_manage: boolean;
 }
 
+export interface ClassicStreamsStatus {
+  can_manage: boolean;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StreamsPluginSetup {}
 
@@ -29,6 +33,7 @@ export interface StreamsPluginStart {
   streamsRepositoryClient: StreamsRepositoryClient;
   navigationStatus$: Observable<StreamsNavigationStatus>;
   getWiredStatus: () => Promise<WiredStreamsStatus>;
+  getClassicStatus: () => Promise<ClassicStreamsStatus>;
   enableWiredMode: (signal: AbortSignal) => Promise<EnableStreamsResponse>;
   disableWiredMode: (signal: AbortSignal) => Promise<DisableStreamsResponse>;
   config$: Observable<StreamsPublicConfig>;

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/management/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/management/route.ts
@@ -102,8 +102,32 @@ export const getStreamsStatusRoute = createServerRoute({
   },
 });
 
+export const getClassicStreamsStatusRoute = createServerRoute({
+  endpoint: 'GET /internal/streams/_classic_status',
+  options: {
+    access: 'internal',
+  },
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.read],
+    },
+  },
+  handler: async ({ request, getScopedClients }): Promise<{ can_manage: boolean }> => {
+    const { scopedClusterClient } = await getScopedClients({ request });
+
+    const REQUIRED_MANAGE_PRIVILEGES = ['manage_index_templates'];
+
+    const privileges = await scopedClusterClient.asCurrentUser.security.hasPrivileges({
+      cluster: REQUIRED_MANAGE_PRIVILEGES,
+    });
+
+    return { can_manage: privileges.cluster.manage_index_templates === true };
+  },
+});
+
 export const managementRoutes = {
   ...forkStreamsRoute,
   ...resyncStreamsRoute,
   ...getStreamsStatusRoute,
+  ...getClassicStreamsStatusRoute,
 };

--- a/x-pack/platform/plugins/shared/streams_app/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/streams_app/kibana.jsonc
@@ -29,7 +29,7 @@
       "unifiedDocViewer",
       "dashboard",
     ],
-    "optionalPlugins": ["cloud", "spaces"],
+    "optionalPlugins": ["cloud", "spaces", "indexLifecycleManagement"],
     "requiredBundles": [
       "discover",
       "kibanaReact",

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiFlexGroup,
@@ -23,8 +23,6 @@ import { isEmpty } from 'lodash';
 import type { OverlayRef } from '@kbn/core/public';
 import { usePerformanceContext } from '@kbn/ebt-tools';
 import { Streams } from '@kbn/streams-schema';
-import { isEmpty } from 'lodash';
-import React, { useEffect, useMemo, useState } from 'react';
 import { useKibana } from '../../hooks/use_kibana';
 import { useStreamsAppFetch } from '../../hooks/use_streams_app_fetch';
 import { StreamsTreeTable } from './tree_table';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.test.tsx
@@ -37,12 +37,14 @@ describe('StreamsSettingsFlyout', () => {
   const mockRefreshStreams = jest.fn();
   const mockAddError = jest.fn();
   const mockTrackWiredStreamsStatusChanged = jest.fn();
+  const mockGetClassicStatus = jest.fn();
 
   const defaultKibanaMock = {
     dependencies: {
       start: {
         streams: {
           getWiredStatus: mockGetWiredStatus,
+          getClassicStatus: mockGetClassicStatus,
           enableWiredMode: mockEnableWiredMode,
           disableWiredMode: mockDisableWiredMode,
         },

--- a/x-pack/platform/plugins/shared/streams_app/public/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/types.ts
@@ -17,6 +17,7 @@ import type {
 } from '@kbn/discover-shared-plugin/public';
 import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import type { IndexManagementPluginStart } from '@kbn/index-management-shared-types';
+import type { IndexLifecycleManagementPluginStart } from '@kbn/index-lifecycle-management-common-shared';
 import type { IngestPipelinesPluginStart } from '@kbn/ingest-pipelines-plugin/public';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { NavigationPublicStart } from '@kbn/navigation-plugin/public/types';
@@ -57,6 +58,7 @@ export interface StreamsAppStartDependencies {
   discoverShared: DiscoverSharedPublicStart;
   fieldFormats: FieldFormatsStart;
   fieldsMetadata: FieldsMetadataPublicStart;
+  indexLifecycleManagement?: IndexLifecycleManagementPluginStart;
   indexManagement: IndexManagementPluginStart;
   ingestPipelines: IngestPipelinesPluginStart;
   licensing: LicensingPluginStart;

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/classic_stream_creation.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/classic_stream_creation.spec.ts
@@ -113,8 +113,6 @@ test.describe('Streams list view - classic stream creation', { tag: ['@ess', '@s
       // Step 1: Select template
       await selectClassicStreamTemplate(flyout, templateName);
 
-      await flyout.getByTestId('nextButton').click();
-
       // Step 2: Name and confirm (fill the single wildcard part)
       const wildcardInput = flyout.getByTestId('streamNameInput-wildcard-0');
       await expect(wildcardInput).toBeVisible();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Streams] Show index mode and ilm retention form simulated template in confirm details section (#246828)](https://github.com/elastic/kibana/pull/246828)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Damian Polewski","email":"125268832+damian-polewski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-06T22:37:40Z","message":"[Streams] Show index mode and ilm retention form simulated template in confirm details section (#246828)\n\n## Summary\n\nCloses #246447 \n\nChanges:\n\n- Adds `indexLifecycleManagement.apiService` to allow fetching ILM\nPolicies by using `getPolicies()`,\n- Extends `indexManagement.apiService` to allow simulating template by\nusing `simulateTemplate()`,\n- Changes the source of index mode and ILM retention from selected\ntemplate to simulated template to get the final data that will be\napplied,\n- Removes `showDataRetention` prop from `CreateClassicStreamFlyout`,\n- Changes the navigation to auto-advance to second step when user\nselects the template (it gets deselected when user goes back),\n- Adjusts the create classic stream button size to `s`,\n- Updates package `README.md` file,\n- Adds `getClassicStatus()` check to enable the button only when use has\nsufficient privileges.\n\n### How to test\n\n1. Navigate to Streams\n2. Click `Create classic stream` button\n<img width=\"1919\" height=\"960\" alt=\"Screenshot 2025-12-19 at 08 54 21\"\nsrc=\"https://github.com/user-attachments/assets/a9935c0a-9764-4a68-a0a5-4336d962fda5\"\n/>\n3. Select some template\n<img width=\"1914\" height=\"960\" alt=\"Screenshot 2025-12-19 at 13 35 21\"\nsrc=\"https://github.com/user-attachments/assets/fe801472-6595-4a8a-b462-7e21e734c39a\"\n/>\n4. Name the stream and confirm\n<img width=\"1914\" height=\"960\" alt=\"Screenshot 2025-12-19 at 13 35 42\"\nsrc=\"https://github.com/user-attachments/assets/d54ca936-5537-4273-adbe-57112647db01\"\n/>\n5. After creation you will be navigated to the classic stream page\n<img width=\"1914\" height=\"960\" alt=\"Screenshot 2025-12-19 at 08 58 06\"\nsrc=\"https://github.com/user-attachments/assets/46f159ba-c855-413a-927b-d5a1fe7609ea\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Matthew Kime <matt@mattki.me>","sha":"013b6bdfcca87cd601c8d1100bc6654c05a2fb8a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport missing","backport:version","Feature:Streams","v9.3.0","v9.4.0"],"title":"[Streams] Show index mode and ilm retention form simulated template in confirm details section","number":246828,"url":"https://github.com/elastic/kibana/pull/246828","mergeCommit":{"message":"[Streams] Show index mode and ilm retention form simulated template in confirm details section (#246828)\n\n## Summary\n\nCloses #246447 \n\nChanges:\n\n- Adds `indexLifecycleManagement.apiService` to allow fetching ILM\nPolicies by using `getPolicies()`,\n- Extends `indexManagement.apiService` to allow simulating template by\nusing `simulateTemplate()`,\n- Changes the source of index mode and ILM retention from selected\ntemplate to simulated template to get the final data that will be\napplied,\n- Removes `showDataRetention` prop from `CreateClassicStreamFlyout`,\n- Changes the navigation to auto-advance to second step when user\nselects the template (it gets deselected when user goes back),\n- Adjusts the create classic stream button size to `s`,\n- Updates package `README.md` file,\n- Adds `getClassicStatus()` check to enable the button only when use has\nsufficient privileges.\n\n### How to test\n\n1. Navigate to Streams\n2. Click `Create classic stream` button\n<img width=\"1919\" height=\"960\" alt=\"Screenshot 2025-12-19 at 08 54 21\"\nsrc=\"https://github.com/user-attachments/assets/a9935c0a-9764-4a68-a0a5-4336d962fda5\"\n/>\n3. Select some template\n<img width=\"1914\" height=\"960\" alt=\"Screenshot 2025-12-19 at 13 35 21\"\nsrc=\"https://github.com/user-attachments/assets/fe801472-6595-4a8a-b462-7e21e734c39a\"\n/>\n4. Name the stream and confirm\n<img width=\"1914\" height=\"960\" alt=\"Screenshot 2025-12-19 at 13 35 42\"\nsrc=\"https://github.com/user-attachments/assets/d54ca936-5537-4273-adbe-57112647db01\"\n/>\n5. After creation you will be navigated to the classic stream page\n<img width=\"1914\" height=\"960\" alt=\"Screenshot 2025-12-19 at 08 58 06\"\nsrc=\"https://github.com/user-attachments/assets/46f159ba-c855-413a-927b-d5a1fe7609ea\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Matthew Kime <matt@mattki.me>","sha":"013b6bdfcca87cd601c8d1100bc6654c05a2fb8a"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246828","number":246828,"mergeCommit":{"message":"[Streams] Show index mode and ilm retention form simulated template in confirm details section (#246828)\n\n## Summary\n\nCloses #246447 \n\nChanges:\n\n- Adds `indexLifecycleManagement.apiService` to allow fetching ILM\nPolicies by using `getPolicies()`,\n- Extends `indexManagement.apiService` to allow simulating template by\nusing `simulateTemplate()`,\n- Changes the source of index mode and ILM retention from selected\ntemplate to simulated template to get the final data that will be\napplied,\n- Removes `showDataRetention` prop from `CreateClassicStreamFlyout`,\n- Changes the navigation to auto-advance to second step when user\nselects the template (it gets deselected when user goes back),\n- Adjusts the create classic stream button size to `s`,\n- Updates package `README.md` file,\n- Adds `getClassicStatus()` check to enable the button only when use has\nsufficient privileges.\n\n### How to test\n\n1. Navigate to Streams\n2. Click `Create classic stream` button\n<img width=\"1919\" height=\"960\" alt=\"Screenshot 2025-12-19 at 08 54 21\"\nsrc=\"https://github.com/user-attachments/assets/a9935c0a-9764-4a68-a0a5-4336d962fda5\"\n/>\n3. Select some template\n<img width=\"1914\" height=\"960\" alt=\"Screenshot 2025-12-19 at 13 35 21\"\nsrc=\"https://github.com/user-attachments/assets/fe801472-6595-4a8a-b462-7e21e734c39a\"\n/>\n4. Name the stream and confirm\n<img width=\"1914\" height=\"960\" alt=\"Screenshot 2025-12-19 at 13 35 42\"\nsrc=\"https://github.com/user-attachments/assets/d54ca936-5537-4273-adbe-57112647db01\"\n/>\n5. After creation you will be navigated to the classic stream page\n<img width=\"1914\" height=\"960\" alt=\"Screenshot 2025-12-19 at 08 58 06\"\nsrc=\"https://github.com/user-attachments/assets/46f159ba-c855-413a-927b-d5a1fe7609ea\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Matthew Kime <matt@mattki.me>","sha":"013b6bdfcca87cd601c8d1100bc6654c05a2fb8a"}}]}] BACKPORT-->