### PR TITLE
[8.19] Use `allowSingleOrDouble`, allow `snake_case` in destructured variables (#244287)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1802,30 +1802,6 @@ module.exports = {
         '@kbn/telemetry/event_generating_elements_should_be_instrumented': 'warn',
       },
     },
-    /**
-     * Allows snake_case variables in the server, because that's how we return API properties
-     */
-    {
-      files: ['x-pack/solutions/search/plugins/enterprise_search/server/**/*.{ts,tsx}'],
-      rules: {
-        '@typescript-eslint/naming-convention': [
-          'error',
-          {
-            selector: 'variable',
-            modifiers: ['destructured'],
-            format: null,
-            leadingUnderscore: 'allow',
-            trailingUnderscore: 'allow',
-          },
-          {
-            selector: 'variable',
-            format: ['camelCase', 'UPPER_CASE'],
-            leadingUnderscore: 'allow',
-            trailingUnderscore: 'allow',
-          },
-        ],
-      },
-    },
     {
       // Source files only - allow `any` in test/mock files
       files: ['x-pack/solutions/search/plugins/enterprise_search/**/*.{ts,tsx}'],

--- a/packages/kbn-eslint-config/typescript.js
+++ b/packages/kbn-eslint-config/typescript.js
@@ -5,11 +5,6 @@
 
 const eslintConfigPrettierRules = require('eslint-config-prettier').rules;
 
-// The current implementation excluded all the variables matching the regexp.
-// We should remove it as soon as multiple underscores are supported by the linter.
-// https://github.com/typescript-eslint/typescript-eslint/issues/1712
-// Due to the same reason we have to duplicate the "filter" option for "default" and other "selectors".
-const allowedNameRegexp = '^(UNSAFE_|_{1,3})|_{1,3}$';
 module.exports = {
   overrides: [
     {
@@ -79,43 +74,45 @@ module.exports = {
             {
               selector: 'default',
               format: ['camelCase', 'PascalCase', 'UPPER_CASE', 'snake_case'],
+              leadingUnderscore: 'allowSingleOrDouble',
+              trailingUnderscore: 'allowSingleOrDouble',
+            },
+            {
+              selector: 'classMethod',
               filter: {
-                regex: allowedNameRegexp,
-                match: false,
+                regex: '^UNSAFE_',
+                match: true,
               },
+              prefix: ['UNSAFE_'],
+              format: ['camelCase'],
             },
             {
               selector: 'variable',
               format: [
                 'camelCase',
-                'UPPER_CASE', // const SOMETHING = ...
-                'PascalCase', // React.FunctionComponent =
+                'UPPER_CASE', // e.g. const SOMETHING = ...
+                'PascalCase', // e.g. React.FunctionComponent =
               ],
-              filter: {
-                regex: allowedNameRegexp,
-                match: false,
-              },
+              leadingUnderscore: 'allowSingleOrDouble',
+              trailingUnderscore: 'allowSingleOrDouble',
+            },
+            {
+              selector: 'variable',
+              modifiers: ['destructured'],
+              format: [
+                'camelCase',
+                'snake_case', // e.g. properties from ES response objects
+                'UPPER_CASE', // e.g. const SOMETHING = ...
+                'PascalCase', // e.g. React.FunctionComponent =
+              ],
+              leadingUnderscore: 'allowSingleOrDouble',
+              trailingUnderscore: 'allowSingleOrDouble',
             },
             {
               selector: 'parameter',
-              format: ['camelCase', 'PascalCase'],
-              filter: {
-                regex: allowedNameRegexp,
-                match: false,
-              },
-            },
-            {
-              selector: 'memberLike',
-              format: [
-                'camelCase',
-                'PascalCase',
-                'snake_case', // keys in elasticsearch requests / responses
-                'UPPER_CASE',
-              ],
-              filter: {
-                regex: allowedNameRegexp,
-                match: false,
-              },
+              format: ['camelCase', 'PascalCase', 'snake_case'],
+              leadingUnderscore: 'allowSingleOrDouble',
+              trailingUnderscore: 'allowSingleOrDouble',
             },
             {
               selector: 'function',
@@ -123,10 +120,8 @@ module.exports = {
                 'camelCase',
                 'PascalCase', // React.FunctionComponent =
               ],
-              filter: {
-                regex: allowedNameRegexp,
-                match: false,
-              },
+              leadingUnderscore: 'allowSingleOrDouble',
+              trailingUnderscore: 'allowSingleOrDouble',
             },
             {
               selector: 'typeLike',

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_update.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/bulk_update.ts
@@ -380,7 +380,6 @@ export const performBulkUpdate = async <T>(
 
       const { _seq_no: seqNo, _primary_term: primaryTerm } = rawResponse;
 
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { [type]: attributes, references, updated_at, updated_by } = documentToSave;
 
       const {

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/internals/internal_bulk_resolve.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/internals/internal_bulk_resolve.test.ts
@@ -195,14 +195,7 @@ describe('internalBulkResolve', () => {
     return { saved_object: `mock-obj-for-${id}`, outcome: 'exactMatch' };
   }
 
-  function expectAliasMatchResult({
-    id,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    alias_purpose,
-  }: {
-    id: string;
-    alias_purpose?: string;
-  }) {
+  function expectAliasMatchResult({ id, alias_purpose }: { id: string; alias_purpose?: string }) {
     return {
       saved_object: `mock-obj-for-${id}`,
       outcome: 'aliasMatch',
@@ -213,9 +206,7 @@ describe('internalBulkResolve', () => {
 
   function expectConflictResult({
     id,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     alias_target_id,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     alias_purpose,
   }: {
     id: string;

--- a/src/core/packages/saved-objects/api-server-internal/src/lib/apis/utils/internal_utils.test.ts
+++ b/src/core/packages/saved-objects/api-server-internal/src/lib/apis/utils/internal_utils.test.ts
@@ -91,8 +91,7 @@ describe('#getSavedObjectFromSource', () => {
   registry.isNamespaceAgnostic.mockImplementation((type) => type === NAMESPACE_AGNOSTIC_TYPE);
 
   const id = 'obj-id';
-  const _seq_no = 1;
-  const _primary_term = 1;
+  const { _seq_no, _primary_term } = { _seq_no: 1, _primary_term: 1 };
   const attributes = { foo: 'bar' };
   const references = [{ type: 'ref-type', id: 'ref-id', name: 'ref-name' }];
   const migrationVersion = { foo: 'migrationVersion' };

--- a/src/core/packages/saved-objects/base-server-internal/src/serialization/serializer.ts
+++ b/src/core/packages/saved-objects/base-server-internal/src/serialization/serializer.ts
@@ -144,7 +144,6 @@ export class SavedObjectsSerializer implements ISavedObjectsSerializer {
       originId,
       attributes,
       migrationVersion,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       updated_at,
       updated_by: updatedBy,
       created_at: createdAt,

--- a/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_painless.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/console/lexer_rules/nested_painless.ts
@@ -34,7 +34,6 @@ export const buildPainlessStartRule = (painlessRoot: string = 'painless_root') =
  * tokenizer and to avoid conflicts with existing console rules, only selected rules are used.
  */
 export const buildPainlessRules = (painlessRoot: string = 'painless_root') => {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { root, comment, string_dq, string_sq } = painlessLexerRules.tokenizer;
   return {
     [painlessRoot]: [

--- a/src/platform/packages/shared/response-ops/rule_form/src/common/transformations/transform_rule.ts
+++ b/src/platform/packages/shared/response-ops/rule_form/src/common/transformations/transform_rule.ts
@@ -94,9 +94,7 @@ export const transformRule: RewriteRequestCase<Rule> = ({
 });
 
 export const transformResolvedRule: RewriteRequestCase<ResolvedRule> = ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alias_target_id,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alias_purpose,
   outcome,
   ...rest

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -138,7 +138,7 @@ export function MonacoEditor({
 
   const _subscription = useRef<monaco.IDisposable | null>(null);
 
-  const __prevent_trigger_change_event = useRef<boolean | null>(null);
+  const __preventTriggerChangeEvent = useRef<boolean | null>(null);
 
   const fixedWidth = processSize(width);
 
@@ -164,7 +164,7 @@ export function MonacoEditor({
     editorDidMount?.(editor.current!, monaco);
 
     _subscription.current = editor.current!.onDidChangeModelContent((event) => {
-      if (!__prevent_trigger_change_event.current) {
+      if (!__preventTriggerChangeEvent.current) {
         onChangeRef.current?.(editor.current!.getValue(), event);
       }
     });
@@ -220,7 +220,7 @@ export function MonacoEditor({
       }
 
       const model = editor.current.getModel();
-      __prevent_trigger_change_event.current = true;
+      __preventTriggerChangeEvent.current = true;
       editor.current.pushUndoStop();
       // pushEditOperations says it expects a cursorComputer, but doesn't seem to need one.
       model!.pushEditOperations(
@@ -235,7 +235,7 @@ export function MonacoEditor({
         undefined
       );
       editor.current.pushUndoStop();
-      __prevent_trigger_change_event.current = false;
+      __preventTriggerChangeEvent.current = false;
     }
   }, [value]);
 

--- a/src/platform/plugins/private/vis_types/timeseries/public/convert_to_lens/lib/metrics/filter_ratio_formula.ts
+++ b/src/platform/plugins/private/vis_types/timeseries/public/convert_to_lens/lib/metrics/filter_ratio_formula.ts
@@ -30,7 +30,6 @@ const constructFilterRationFormula = (
 };
 
 export const getFilterRatioFormula = (currentMetric: Metric, additionalArgs: AdditionalArgs) => {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { numerator, denominator, metric_agg, field } = currentMetric;
   let aggregation: SupportedMetric | null | undefined = SUPPORTED_METRICS.count;
   if (metric_agg) {

--- a/src/platform/plugins/private/vis_types/timeseries/public/convert_to_lens/metric/index.ts
+++ b/src/platform/plugins/private/vis_types/timeseries/public/convert_to_lens/metric/index.ts
@@ -120,7 +120,6 @@ export const convertToLens: ConvertTsvbToLensVisualization = async (
     const extendedLayer: ExtendedLayer = {
       ignoreGlobalFilters: Boolean(
         model.ignore_global_filter ||
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           visibleSeries.some(({ ignore_global_filter }) => ignore_global_filter)
       ),
       indexPatternId: indexPatternId as string,

--- a/src/platform/plugins/private/vis_types/timeseries/public/convert_to_lens/table/index.ts
+++ b/src/platform/plugins/private/vis_types/timeseries/public/convert_to_lens/table/index.ts
@@ -169,7 +169,6 @@ export const convertToLens: ConvertTsvbToLensVisualization = async (
     const extendedLayer: ExtendedLayer = {
       ignoreGlobalFilters: Boolean(
         model.ignore_global_filter ||
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           visibleSeries.some(({ ignore_global_filter }) => ignore_global_filter)
       ),
       indexPatternId: indexPatternId as string,

--- a/src/platform/plugins/private/vis_types/timeseries/public/convert_to_lens/top_n/index.ts
+++ b/src/platform/plugins/private/vis_types/timeseries/public/convert_to_lens/top_n/index.ts
@@ -89,7 +89,6 @@ export const convertToLens: ConvertTsvbToLensVisualization = async (
       extendedLayers[layerIdx] = {
         ignoreGlobalFilters: Boolean(
           model.ignore_global_filter ||
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             visibleSeries.some(({ ignore_global_filter }) => ignore_global_filter)
         ),
         indexPatternId,

--- a/src/platform/plugins/shared/console/server/services/spec_definitions_service.test.ts
+++ b/src/platform/plugins/shared/console/server/services/spec_definitions_service.test.ts
@@ -28,7 +28,6 @@ const getMockEndpoint = ({
   endpointName,
   methods,
   patterns,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   data_autocomplete_rules,
   availability,
 }: {

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.ts
@@ -355,7 +355,6 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
             : undefined;
 
           const allColumns =
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             (body.all_columns ?? body.columns)?.map(({ name, type, original_types }) => {
               const originalTypes = original_types ?? [];
               const hasConflict = type === 'unsupported' && originalTypes.length > 1;

--- a/src/platform/plugins/shared/data/common/search/search_source/fetch/get_search_params.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/fetch/get_search_params.ts
@@ -33,7 +33,7 @@ export function getSearchParamsFromRequest(
 ): ISearchRequestParams {
   const { getConfig } = dependencies;
   const searchParams = { preference: getEsPreference(getConfig) };
-  // eslint-disable-next-line @typescript-eslint/naming-convention
+
   const { track_total_hits, ...body } = searchRequest.body;
   const dataView = typeof searchRequest.index !== 'string' ? searchRequest.index : undefined;
   const index = dataView?.title ?? `${searchRequest.index}`;

--- a/src/platform/plugins/shared/data/common/search/search_source/normalize_sort_request.ts
+++ b/src/platform/plugins/shared/data/common/search/search_source/normalize_sort_request.ts
@@ -68,7 +68,6 @@ function normalize(
     defaultSortOptions = JSON.parse(defaultSortOptions) as FieldSortOptions;
   }
   // Don't include unmapped_type for _score field
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { unmapped_type, ...otherSortOptions } = defaultSortOptions;
   return {
     [sortField]: {

--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/public/update_data_view.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/public/update_data_view.ts
@@ -192,10 +192,7 @@ const updateDataViewRouteFactory =
           );
           const id = req.params.id;
 
-          const {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            refresh_fields = true,
-          } = req.body;
+          const { refresh_fields = true } = req.body;
 
           const spec = req.body[serviceKey] as DataViewSpec;
 

--- a/src/platform/plugins/shared/telemetry/server/telemetry_collection/get_local_stats.ts
+++ b/src/platform/plugins/shared/telemetry/server/telemetry_collection/get_local_stats.ts
@@ -30,7 +30,6 @@ import { getDataTelemetry, DATA_TELEMETRY_ID, DataTelemetryPayload } from './get
  * @param context The context
  */
 export function handleLocalStats<ClusterStats extends estypes.ClusterStatsResponse>(
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   { cluster_name, cluster_uuid, version }: estypes.InfoResponse,
   { _nodes, cluster_name: clusterName, ...clusterStats }: ClusterStats,
   kibana: KibanaUsageStats | undefined,

--- a/src/platform/plugins/shared/unified_search/server/autocomplete/terms_agg.ts
+++ b/src/platform/plugins/shared/unified_search/server/autocomplete/terms_agg.ts
@@ -59,7 +59,6 @@ export async function termsAggSuggestions(
 }
 
 async function getBody(
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   { timeout, terminate_after }: Record<string, any>,
   field: FieldSpec | string,
   query: string,

--- a/x-pack/platform/plugins/private/cross_cluster_replication/common/services/follower_index_serialization.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/common/services/follower_index_serialization.ts
@@ -14,7 +14,7 @@ import {
   FollowerIndexAdvancedSettings,
   FollowerIndexAdvancedSettingsToEs,
 } from '../types';
-/* eslint-disable @typescript-eslint/naming-convention */
+
 export const deserializeShard = ({
   remote_cluster,
   leader_index,
@@ -107,7 +107,7 @@ export const deserializeFollowerIndex = ({
   readPollTimeout: read_poll_timeout,
   shards: shards && shards.map(deserializeShard),
 });
-/* eslint-enable @typescript-eslint/naming-convention */
+
 export const deserializeListFollowerIndices = (
   followerIndices: FollowerIndexFromEs[]
 ): FollowerIndex[] => followerIndices.map(deserializeFollowerIndex);

--- a/x-pack/platform/plugins/private/cross_cluster_replication/server/lib/ccr_stats_serialization.ts
+++ b/x-pack/platform/plugins/private/cross_cluster_replication/server/lib/ccr_stats_serialization.ts
@@ -13,7 +13,7 @@ import {
   AutoFollowStats,
   AutoFollowStatsFromEs,
 } from '../../common/types';
-/* eslint-disable @typescript-eslint/naming-convention */
+
 export const deserializeRecentAutoFollowErrors = ({
   timestamp,
   leader_index,

--- a/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/templates/register_fetch_route.ts
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/server/routes/api/templates/register_fetch_route.ts
@@ -31,7 +31,6 @@ function filterLegacyTemplates(templates: {
   const formattedTemplates = [];
   const templateNames = Object.keys(templates);
   for (const templateName of templateNames) {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { settings, index_patterns } = templates[templateName];
     if (isReservedSystemTemplate(templateName, index_patterns)) {
       continue;

--- a/x-pack/platform/plugins/private/monitoring/server/lib/elasticsearch/convert_metric_names.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/lib/elasticsearch/convert_metric_names.ts
@@ -60,14 +60,7 @@ export function uncovertMetricNames(byDateBucketResponse: { buckets: MetricNameB
   for (const metricName of LISTING_METRICS_NAMES) {
     unconverted[metricName] = {
       buckets: byDateBucketResponse.buckets.map((bucket) => {
-        const {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          key_as_string,
-          key,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          doc_count,
-          ...rest
-        } = bucket;
+        const { key_as_string, key, doc_count, ...rest } = bucket;
         const metrics = Object.entries(rest).reduce((accum, [k, value]) => {
           if (k.startsWith(`${CONVERTED_TOKEN}${metricName}`)) {
             const name = k.split('__')[1];

--- a/x-pack/platform/plugins/private/monitoring/server/telemetry_collection/get_kibana_stats.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/telemetry_collection/get_kibana_stats.ts
@@ -103,10 +103,8 @@ export function getUsageStats(rawStats: estypes.SearchResponse<KibanaUsageStats>
       dashboard,
       visualization,
       search,
-      /* eslint-disable @typescript-eslint/naming-convention */
       index_pattern,
       graph_workspace,
-      /* eslint-enable @typescript-eslint/naming-convention */
       xpack,
       ...pluginsTop
     } = currUsage;

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/generate_request_handler.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/generate_request_handler.test.ts
@@ -109,7 +109,7 @@ describe('Handle request to generate', () => {
         jobParams: mockJobParams,
       });
 
-      const { _id, created_at: _created_at, payload, ...snapObj } = report;
+      const { _id, created_at, payload, ...snapObj } = report;
       expect(snapObj).toMatchInlineSnapshot(`
         Object {
           "_index": ".reporting-foo-index-234",
@@ -167,7 +167,7 @@ describe('Handle request to generate', () => {
         jobParams: mockJobParams,
       });
 
-      const { _id, created_at: _created_at, ...snapObj } = report;
+      const { _id, created_at, ...snapObj } = report;
       expect(snapObj.payload.version).toBe('7.14.0');
     });
   });

--- a/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/schedule_request_handler.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/common/request_handler/schedule_request_handler.test.ts
@@ -159,7 +159,7 @@ describe('Handle request to schedule', () => {
         schedule: { rrule: { freq: 1, interval: 2, tzid: 'UTC' } },
       });
 
-      const { id, created_at: _created_at, payload, ...snapObj } = report;
+      const { id, created_at, payload, ...snapObj } = report;
       expect(snapObj).toMatchInlineSnapshot(`
         Object {
           "created_by": "testymcgee",
@@ -248,7 +248,7 @@ describe('Handle request to schedule', () => {
         notification: { email: { to: ['a@b.com'] } },
       });
 
-      const { id, created_at: _created_at, payload, ...snapObj } = report;
+      const { id, created_at, payload, ...snapObj } = report;
       expect(snapObj).toMatchInlineSnapshot(`
         Object {
           "created_by": "testymcgee",
@@ -339,7 +339,7 @@ describe('Handle request to schedule', () => {
         },
       });
 
-      const { id, created_at: _created_at, payload, ...snapObj } = report;
+      const { id, created_at, payload, ...snapObj } = report;
       expect(snapObj).toMatchInlineSnapshot(`
         Object {
           "created_by": "testymcgee",

--- a/x-pack/platform/plugins/private/rollup/server/lib/format_es_error.ts
+++ b/x-pack/platform/plugins/private/rollup/server/lib/format_es_error.ts
@@ -9,7 +9,7 @@ function extractCausedByChain(
   causedBy: Record<string, any> = {},
   accumulator: string[] = []
 ): string[] {
-  const { reason, caused_by } = causedBy; // eslint-disable-line @typescript-eslint/naming-convention
+  const { reason, caused_by } = causedBy;
 
   if (reason) {
     accumulator.push(reason);
@@ -34,12 +34,7 @@ export function wrapEsError(
 ): { message: string; body?: { cause?: string[] }; statusCode: number } {
   const { statusCode, response } = err;
 
-  const {
-    error: {
-      root_cause = [], // eslint-disable-line @typescript-eslint/naming-convention
-      caused_by = undefined, // eslint-disable-line @typescript-eslint/naming-convention
-    } = {},
-  } = JSON.parse(response);
+  const { error: { root_cause = [], caused_by = undefined } = {} } = JSON.parse(response);
 
   // If no custom message if specified for the error's status code, just
   // wrap the error as a Boom error response and return it

--- a/x-pack/platform/plugins/private/snapshot_restore/server/lib/wrap_es_error.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/server/lib/wrap_es_error.ts
@@ -6,7 +6,7 @@
  */
 
 const extractCausedByChain = (causedBy: any = {}, accumulator: any[] = []): any => {
-  const { reason, caused_by } = causedBy; // eslint-disable-line @typescript-eslint/naming-convention
+  const { reason, caused_by } = causedBy;
 
   if (reason) {
     accumulator.push(reason);
@@ -29,12 +29,8 @@ const extractCausedByChain = (causedBy: any = {}, accumulator: any[] = []): any 
 export const wrapEsError = (err: any, statusCodeToMessageMap: any = {}) => {
   const { statusCode, response } = err;
 
-  const {
-    error: {
-      root_cause = [], // eslint-disable-line @typescript-eslint/naming-convention
-      caused_by = {}, // eslint-disable-line @typescript-eslint/naming-convention
-    } = {},
-  } = typeof response === 'string' ? JSON.parse(response) : response;
+  const { error: { root_cause = [], caused_by = {} } = {} } =
+    typeof response === 'string' ? JSON.parse(response) : response;
 
   // If no custom message if specified for the error's status code, just
   // wrap the error as a Boom error response, include the additional information from ES, and return it

--- a/x-pack/platform/plugins/private/transform/server/routes/utils/error_utils.ts
+++ b/x-pack/platform/plugins/private/transform/server/routes/utils/error_utils.ts
@@ -96,7 +96,7 @@ function extractCausedByChain(
   causedBy: Record<string, any> = {},
   accumulator: string[] = []
 ): string[] {
-  const { reason, caused_by } = causedBy; // eslint-disable-line @typescript-eslint/naming-convention
+  const { reason, caused_by } = causedBy;
 
   if (reason) {
     accumulator.push(reason);
@@ -121,12 +121,7 @@ export function wrapEsError(err: any, statusCodeToMessageMap: Record<string, any
     meta: { body, statusCode },
   } = err;
 
-  const {
-    error: {
-      root_cause = [], // eslint-disable-line @typescript-eslint/naming-convention
-      caused_by = {}, // eslint-disable-line @typescript-eslint/naming-convention
-    } = {},
-  } = body;
+  const { error: { root_cause = [], caused_by = {} } = {} } = body;
 
   // If no custom message if specified for the error's status code, just
   // wrap the error as a Boom error response, include the additional information from ES, and return it

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/health_indicators.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/health_indicators.ts
@@ -28,7 +28,6 @@ export async function getHealthIndicators(
     ]
       .filter(isStatusNotGreen)
       .flatMap(({ status, symptom, impacts, diagnosis }) => {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         return (diagnosis || []).map(({ cause, action, help_url }) => ({
           type: 'health_indicator',
           details: symptom,

--- a/x-pack/platform/plugins/shared/alerting/common/alert_schema/field_maps/mapping_from_field_map.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/alert_schema/field_maps/mapping_from_field_map.ts
@@ -27,12 +27,10 @@ export function mappingFromFieldMap(
   });
 
   fields.forEach((field) => {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { name, required, array, multi_fields, ...rest } = field;
     const mapped = multi_fields
       ? {
           ...rest,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           fields: multi_fields.reduce((acc, multi_field: MultiField) => {
             acc[multi_field.name] = {
               type: multi_field.type,

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_get/bulk_get_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_get/bulk_get_rules.ts
@@ -58,7 +58,6 @@ export async function bulkGetRules<Params extends RuleParams = never>(
   await pMap(
     chunk(params.ids, 100),
     async (ids) => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { saved_objects } = await bulkGetRulesSo({
         savedObjectsClient: context.unsecuredSavedObjectsClient,
         ids,

--- a/x-pack/platform/plugins/shared/alerting/server/routes/backfill/apis/find/transforms/transform_request/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/backfill/apis/find/transforms/transform_request/v1.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 import type { FindBackfillRequestQueryV1 } from '../../../../../../../common/routes/backfill/apis/find';
 import type { FindBackfillParams } from '../../../../../../application/backfill/methods/find/types';

--- a/x-pack/platform/plugins/shared/alerting/server/routes/backfill/apis/schedule/transforms/transform_request/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/backfill/apis/schedule/transforms/transform_request/v1.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 import type { ScheduleBackfillRequestBodyV1 } from '../../../../../../../common/routes/backfill/apis/schedule';
 import type { ScheduleBackfillParams } from '../../../../../../application/backfill/methods/schedule/types';

--- a/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/fill/transforms/transform_request/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/fill/transforms/transform_request/v1.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 import type { FillGapByIdQueryV1 } from '../../../../../../../common/routes/gaps/apis/fill';
 import type { FillGapByIdParams } from '../../../../../../application/rule/methods/fill_gap_by_id/types';

--- a/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/find/transforms/transform_request/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/find/transforms/transform_request/v1.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 import type { FindGapsRequestBodyV1 } from '../../../../../../../common/routes/gaps/apis/find';
 import type { FindGapsParams } from '../../../../../../lib/rule_gaps/types';

--- a/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/get_gaps_summary_by_rule_ids/transforms/transform_request/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/gaps/apis/get_gaps_summary_by_rule_ids/transforms/transform_request/v1.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 import type { GetGapsSummaryByRuleIdsParams } from '../../../../../../application/rule/methods/get_gaps_summary_by_rule_ids/types';
 import type { GetGapsSummaryByRuleIdsBodyV1 } from '../../../../../../../common/routes/gaps/apis/get_gaps_summary_by_rule_ids';

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_alerts.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_alerts.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+/* eslint-disable @typescript-eslint/naming-convention */
+
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import type { MockedLogger } from '@kbn/logging-mocks';
 import { loggerMock } from '@kbn/logging-mocks';
@@ -90,13 +92,11 @@ describe('kibana index telemetry', () => {
       count_alerts_total: 6,
       count_alerts_by_rule_type: {
         '__index-threshold': 1,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         logs__alert__document__count: 2,
         document__test__: 3,
       },
       count_ignored_fields_by_rule_type: {
         '__index-threshold': 0,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         logs__alert__document__count: 2,
         document__test__: 0,
       },

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_event_log.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_event_log.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+/* eslint-disable @typescript-eslint/naming-convention */
+
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import type { MockedLogger } from '@kbn/logging-mocks';
 import { loggerMock } from '@kbn/logging-mocks';
@@ -161,44 +163,37 @@ describe('event log telemetry', () => {
         countRuleExecutionsByType: {
           '__index-threshold': 78,
           document__test__: 42,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 28,
         },
         avgExecutionTimeByType: {
           '__index-threshold': 101,
           document__test__: 770,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 88,
         },
         avgEsSearchDurationByType: {
           '__index-threshold': 41,
           document__test__: 0,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 27,
         },
         avgTotalSearchDurationByType: {
           '__index-threshold': 44,
           document__test__: 0,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 31,
         },
         generatedActionsPercentilesByType: {
           p50: {
             '__index-threshold': 0,
             document__test__: 5,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 0,
           },
           p90: {
             '__index-threshold': 0,
             document__test__: 5,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 0,
           },
           p99: {
             '__index-threshold': 0,
             document__test__: 5,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 0,
           },
         },
@@ -206,19 +201,16 @@ describe('event log telemetry', () => {
           p50: {
             '__index-threshold': 1,
             document__test__: 5,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 0,
           },
           p90: {
             '__index-threshold': 1,
             document__test__: 5,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 0,
           },
           p99: {
             '__index-threshold': 1,
             document__test__: 5,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 0,
           },
         },
@@ -311,25 +303,21 @@ describe('event log telemetry', () => {
         countRuleExecutionsByType: {
           '__index-threshold': 78,
           document__test__: 0,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 0,
         },
         avgExecutionTimeByType: {
           '__index-threshold': 101,
           document__test__: 0,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 0,
         },
         avgEsSearchDurationByType: {
           '__index-threshold': 0,
           document__test__: 0,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 0,
         },
         avgTotalSearchDurationByType: {
           '__index-threshold': 44,
           document__test__: 0,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 0,
         },
         generatedActionsPercentilesByType: {
@@ -603,7 +591,6 @@ describe('event log telemetry', () => {
           decrypt: {
             '__index-threshold': 3,
             document__test__: 2,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 1,
           },
           execute: {
@@ -736,7 +723,6 @@ describe('event log telemetry', () => {
         countFailedExecutionsByReasonByType: {
           decrypt: {
             document__test__: 2,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 1,
           },
         },
@@ -1303,7 +1289,6 @@ describe('event log telemetry', () => {
         countRuleExecutionsByType: {
           '__index-threshold': 78,
           document__test__: 42,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 28,
         },
         countTotalFailedExecutions: 10,
@@ -1315,7 +1300,6 @@ describe('event log telemetry', () => {
           decrypt: {
             '__index-threshold': 3,
             document__test__: 2,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 1,
           },
           execute: {
@@ -1328,19 +1312,16 @@ describe('event log telemetry', () => {
         avgExecutionTimeByType: {
           '__index-threshold': 101,
           document__test__: 770,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 88,
         },
         avgEsSearchDurationByType: {
           '__index-threshold': 41,
           document__test__: 0,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 27,
         },
         avgTotalSearchDurationByType: {
           '__index-threshold': 44,
           document__test__: 0,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 31,
         },
         generatedActionsPercentiles: {
@@ -1357,19 +1338,16 @@ describe('event log telemetry', () => {
           p50: {
             '__index-threshold': 0,
             document__test__: 5,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 0,
           },
           p90: {
             '__index-threshold': 0,
             document__test__: 5,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 0,
           },
           p99: {
             '__index-threshold': 0,
             document__test__: 5,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 0,
           },
         },
@@ -1377,19 +1355,16 @@ describe('event log telemetry', () => {
           p50: {
             '__index-threshold': 1,
             document__test__: 5,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 0,
           },
           p90: {
             '__index-threshold': 1,
             document__test__: 5,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 0,
           },
           p99: {
             '__index-threshold': 1,
             document__test__: 5,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 0,
           },
         },
@@ -1537,7 +1512,6 @@ describe('event log telemetry', () => {
         countExecutionTimeoutsByType: {
           '__index-threshold': 2,
           document__test__: 1,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 1,
         },
         hasErrors: false,

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_kibana.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_kibana.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+/* eslint-disable @typescript-eslint/naming-convention */
+
 import { errors } from '@elastic/elasticsearch';
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import type { MockedLogger } from '@kbn/logging-mocks';
@@ -287,7 +289,6 @@ describe('kibana index telemetry', () => {
         count_by_type: {
           '__index-threshold': 2,
           document__test__: 1,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 1,
           '__es-query_es_query': 0,
           '__es-query_esql_query': 3,
@@ -330,14 +331,11 @@ describe('kibana index telemetry', () => {
         },
         count_rules_snoozed: 11,
         count_rules_snoozed_by_type: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           slo__rules__burnRate: 1,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           observability__rules__custom_threshold: 1,
         },
         count_rules_muted: 12,
         count_rules_muted_by_type: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           observability__rules__custom_threshold: 1,
         },
         count_rules_with_muted_alerts: 13,
@@ -553,7 +551,6 @@ describe('kibana index telemetry', () => {
         countByType: {
           '__index-threshold': 2,
           document__test__: 1,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           logs__alert__document__count: 1,
           '__es-query_es_query': 0,
           '__es-query_esql_query': 3,

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_task_manager.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_task_manager.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+/* eslint-disable @typescript-eslint/naming-convention */
+
 import { errors } from '@elastic/elasticsearch';
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import type { MockedLogger } from '@kbn/logging-mocks';
@@ -72,7 +74,6 @@ describe('task manager telemetry', () => {
             document__test__: 32,
           },
           unrecognized: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 4,
           },
         },
@@ -213,7 +214,6 @@ describe('task manager telemetry', () => {
             document__test__: 32,
           },
           unrecognized: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             logs__alert__document__count: 4,
           },
         },

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/parse_simple_rule_type_bucket.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/parse_simple_rule_type_bucket.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+/* eslint-disable @typescript-eslint/naming-convention */
+
 import { parseSimpleRuleTypeBucket } from './parse_simple_rule_type_bucket';
 
 describe('parseSimpleRuleTypeBucket', () => {
@@ -27,7 +29,6 @@ describe('parseSimpleRuleTypeBucket', () => {
     ).toEqual({
       '__index-threshold': 78,
       document__test__: 42,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       logs__alert__document__count: 28,
     });
   });
@@ -51,7 +52,6 @@ describe('parseSimpleRuleTypeBucket', () => {
     ).toEqual({
       '__index-threshold': 0,
       document__test__: 42,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       logs__alert__document__count: 28,
     });
   });

--- a/x-pack/platform/plugins/shared/cases/server/client/cases/push.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/cases/push.ts
@@ -200,7 +200,6 @@ export const push = async (
       }),
     ]);
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { username, full_name, email, profile_uid } = user;
     const pushedDate = new Date().toISOString();
     const externalServiceResponse = pushRes.data as ExternalServiceResponse;

--- a/x-pack/platform/plugins/shared/cases/server/common/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/utils.ts
@@ -215,7 +215,6 @@ type NewCommentArgs = AttachmentRequest & {
 export const transformNewComment = ({
   createdDate,
   email,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   full_name,
   username,
   profile_uid: profileUid,

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/migrations/configuration.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/migrations/configuration.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import type { SavedObjectUnsanitizedDoc, SavedObjectSanitizedDoc } from '@kbn/core/server';
 import { ConnectorTypes } from '../../../common/types/domain';
 import type { SanitizedCaseOwner } from '.';

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/migrations/user_actions/alerts.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/migrations/user_actions/alerts.ts
@@ -16,8 +16,6 @@ import { GENERATED_ALERT } from '../constants';
 import { logError } from '../utils';
 import type { UserActionVersion800 } from './types';
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 export function removeRuleInformation(
   doc: SavedObjectUnsanitizedDoc<UserActionVersion800>,
   context: SavedObjectMigrationContext

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/migrations/user_actions/connector_id.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/migrations/user_actions/connector_id.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import type * as rt from 'io-ts';
 
 import type {

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/migrations/user_actions/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/migrations/user_actions/index.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import type {
   SavedObjectUnsanitizedDoc,
   SavedObjectSanitizedDoc,

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/migrations/user_actions/payload.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/migrations/user_actions/payload.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import { isEmpty, isPlainObject, isString } from 'lodash';
 
 import type {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -236,13 +236,11 @@ export function usePackagePolicyWithRelatedData(
             revision,
             inputs,
             vars,
-            /* eslint-disable @typescript-eslint/naming-convention */
             created_by,
             created_at,
             updated_by,
             updated_at,
             secret_references,
-            /* eslint-enable @typescript-eslint/naming-convention */
             ...restOfPackagePolicy
           } = basePolicy;
 
@@ -280,7 +278,6 @@ export function usePackagePolicyWithRelatedData(
               return {
                 ...restOfInput,
                 streams: streams.map((stream: any) => {
-                  // eslint-disable-next-line @typescript-eslint/naming-convention
                   const { compiled_stream, ...restOfStream } = stream;
                   return restOfStream;
                 }),

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import type { SavedObjectsClientContract } from '@kbn/core/server';
 import { load } from 'js-yaml';
 import deepMerge from 'deepmerge';
@@ -430,7 +428,6 @@ export function transformOutputToFullPolicyOutput(
       }
     };
 
-    /* eslint-enable @typescript-eslint/naming-convention */
     kafkaData = {
       client_id,
       version,
@@ -453,7 +450,7 @@ export function transformOutputToFullPolicyOutput(
     if (!isShipperDisabled) {
       shipperDiskQueueData = buildShipperQueueData(shipper);
     }
-    /* eslint-disable @typescript-eslint/naming-convention */
+
     const {
       loadbalance,
       compression_level,
@@ -461,7 +458,6 @@ export function transformOutputToFullPolicyOutput(
       max_batch_bytes,
       mem_queue_events,
     } = shipper;
-    /* eslint-enable @typescript-eslint/naming-convention */
 
     generalShipperData = {
       loadbalance,
@@ -637,7 +633,6 @@ function getOutputIdForAgentPolicy(output: Pick<Output, 'id' | 'is_default' | 't
   return output.id;
 }
 
-/* eslint-disable @typescript-eslint/naming-convention */
 function buildShipperQueueData(shipper: ShipperOutput) {
   const {
     disk_queue_enabled,
@@ -659,4 +654,3 @@ function buildShipperQueueData(shipper: ShipperOutput) {
     },
   };
 }
-/* eslint-enable @typescript-eslint/naming-convention */

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/utils.ts
@@ -11,7 +11,6 @@ import type { AgentPolicy } from '../../../common';
 import type { AgentPolicySOAttributes } from '../../types';
 
 export const mapAgentPolicySavedObjectToAgentPolicy = ({
-  /* eslint-disable @typescript-eslint/naming-convention */
   id,
   namespaces,
   version,

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/index_pattern/install.ts
@@ -70,7 +70,6 @@ export async function removeUnusedIndexPatterns(savedObjectsClient: SavedObjects
     patternsToDelete.map((pattern) => ({ id: pattern, type: INDEX_PATTERN_SAVED_OBJECT_TYPE }))
   );
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const idsToDelete = resolvedObjects.map(({ saved_object }) => saved_object.id);
 
   return Promise.all(

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/configuration_form/configuration_form.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/configuration_form/configuration_form.tsx
@@ -91,11 +91,9 @@ export const formSerializer = (formData: GenericObject) => {
 export const formDeserializer = (formData: GenericObject) => {
   const {
     dynamic,
-    /* eslint-disable @typescript-eslint/naming-convention */
     numeric_detection,
     date_detection,
     dynamic_date_formats,
-    /* eslint-enable @typescript-eslint/naming-convention */
     _source: { enabled, mode, includes, excludes } = {} as SerializedSourceField,
     _meta,
     _routing,

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/dynamic_parameter.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/dynamic_parameter.tsx
@@ -25,7 +25,7 @@ export const dynamicSerializer = (field: Field): Field => {
 
   const dynamic =
     field.dynamic_toggle === true ? true : field.dynamic_strict === true ? 'strict' : false;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
+
   const { dynamic_toggle, dynamic_strict, ...rest } = field;
 
   return {

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/templates_form/templates_form.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/templates_form/templates_form.tsx
@@ -45,7 +45,6 @@ const formSerializer: SerializerFunc<MappingsTemplates | undefined> = (formData)
 };
 
 const formDeserializer = (formData: { [key: string]: any }) => {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { dynamic_templates } = formData;
 
   return {

--- a/x-pack/platform/plugins/shared/index_management/public/application/shared/parse_mappings.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/shared/parse_mappings.ts
@@ -29,12 +29,10 @@ export const parseMappings = (
     dynamic,
     properties,
     runtime,
-    /* eslint-disable @typescript-eslint/naming-convention */
     numeric_detection,
     date_detection,
     dynamic_date_formats,
     dynamic_templates,
-    /* eslint-enable @typescript-eslint/naming-convention */
     subobjects,
   } = mappingsDefinition;
 

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/lib.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/lib.ts
@@ -44,7 +44,7 @@ export const saveTemplate = async ({
   if (isLegacy) {
     const {
       order,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
+
       index_patterns,
       version,
       settings,

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/lib.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/lib.ts
@@ -42,15 +42,8 @@ export const saveTemplate = async ({
     : serializeTemplate(template, dataStreamOptions);
 
   if (isLegacy) {
-    const {
-      order,
-
-      index_patterns,
-      version,
-      settings,
-      mappings,
-      aliases,
-    } = serializedTemplate as LegacyTemplateSerialized;
+    const { order, index_patterns, version, settings, mappings, aliases } =
+      serializedTemplate as LegacyTemplateSerialized;
 
     return await client.asCurrentUser.indices.putTemplate({
       name: template.name,

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/create.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/create.ts
@@ -39,7 +39,6 @@ export const registerCreateRoute = ({
       const { client: clusterClient } = (await ctx.core).elasticsearch;
       const pipeline = req.body as Pipeline;
 
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { name, description, processors, version, on_failure, _meta } = pipeline;
 
       try {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/update.ts
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/server/routes/api/update.ts
@@ -38,7 +38,7 @@ export const registerUpdateRoute = ({
     async (ctx, req, res) => {
       const { client: clusterClient } = (await ctx.core).elasticsearch;
       const { name } = req.params;
-      // eslint-disable-next-line @typescript-eslint/naming-convention
+
       const { description, processors, version, on_failure, _meta } = req.body;
 
       try {

--- a/x-pack/platform/plugins/shared/integration_assistant/server/integration_builder/build_integration.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/integration_builder/build_integration.ts
@@ -150,7 +150,6 @@ function mergeAndSortFields(fields: Field[], dataStreamFields: Field[]): Field[]
   return flattenObjectsList(mergedFields);
 }
 
-/* eslint-disable @typescript-eslint/naming-convention */
 /**
  * Creates a package manifest dictionary.
  *
@@ -219,7 +218,6 @@ function createPackageManifestDict(
   }
   return data;
 }
-/* eslint-enable @typescript-eslint/naming-convention */
 
 /**
  * Render the package manifest for an integration.

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/dedupe_aggs.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/dedupe_aggs.test.ts
@@ -41,7 +41,6 @@ describe('dedupeAggs', () => {
 
     const { esAggsIdMap, aggsToIdsMap } = buildMapsFromAggBuilders(aggs);
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { sum, last_value, average } = operationDefinitionMap;
 
     const operations = [sum, last_value, average];

--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/join_sources/es_distance_source/process_distance_response.test.ts
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/join_sources/es_distance_source/process_distance_response.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+/* eslint-disable @typescript-eslint/naming-convention */
+
 import { processDistanceResponse } from './process_distance_response';
 
 test('should convert elasticsearch response into table', () => {

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/tooltip_control.test.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/tooltip_control.test.tsx
@@ -270,6 +270,7 @@ describe('TooltipControl', () => {
           id: mbLayerId,
         },
         properties: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           __kbn__feature_id__: 1,
         },
       } as unknown as MapGeoJSONFeature;

--- a/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/analysis_fields_table.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/analysis_fields_table.tsx
@@ -85,7 +85,6 @@ export const AnalysisFieldsTable: FC<{
           }
         ),
         id: 'name',
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         render: ({ name, mapping_types }: { name: string; mapping_types: string[] }) => {
           const field: FieldForStats = {
             id: name,
@@ -125,7 +124,7 @@ export const AnalysisFieldsTable: FC<{
         id: 'is_included',
         alignment: LEFT_ALIGNMENT,
         isSortable: true,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+
         render: ({ is_included }: { is_included: boolean }) => (is_included ? 'Yes' : 'No'),
       },
       {
@@ -138,7 +137,7 @@ export const AnalysisFieldsTable: FC<{
         id: 'is_required',
         alignment: LEFT_ALIGNMENT,
         isSortable: true,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+
         render: ({ is_required }: { is_required: boolean }) => (is_required ? 'Yes' : 'No'),
       },
       {

--- a/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/regression_exploration/evaluate_panel.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/regression_exploration/evaluate_panel.tsx
@@ -101,7 +101,6 @@ export const EvaluatePanel: FC<Props> = ({ jobConfig, jobStatus, searchQuery }) 
       genErrorEval.eval &&
       isRegressionEvaluateResponse(genErrorEval.eval)
     ) {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { mse, msle, huber, r_squared } = getValuesFromResponse(genErrorEval.eval);
       setGeneralizationEval({
         mse,
@@ -140,7 +139,6 @@ export const EvaluatePanel: FC<Props> = ({ jobConfig, jobStatus, searchQuery }) 
       trainingErrorEval.eval &&
       isRegressionEvaluateResponse(trainingErrorEval.eval)
     ) {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { mse, msle, huber, r_squared } = getValuesFromResponse(trainingErrorEval.eval);
       setTrainingEval({
         mse,

--- a/x-pack/platform/plugins/shared/ml/public/application/model_management/expanded_row.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/model_management/expanded_row.tsx
@@ -132,13 +132,9 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
     metadata,
     tags,
     version,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     estimated_operations,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     estimated_heap_memory_usage_bytes,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     default_field_map,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     license_level,
     pipelines,
     description,

--- a/x-pack/platform/plugins/shared/osquery/public/live_queries/index.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/live_queries/index.tsx
@@ -47,7 +47,6 @@ const LiveQueryComponent: React.FC<LiveQueryProps> = ({
   onSuccess,
   query,
   savedQueryId,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   ecs_mapping,
   queryField,
   ecsMappingField,

--- a/x-pack/platform/plugins/shared/osquery/server/handlers/action/create_action_handler.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/handlers/action/create_action_handler.ts
@@ -47,7 +47,7 @@ export const createActionHandler = async (
   const { soClient, metadata, alertData, error } = options;
   const savedObjectsClient = soClient ?? coreStartServices.savedObjects.createInternalRepository();
   const elasticsearchClient = coreStartServices.elasticsearch.client.asInternalUser;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
+
   const { agent_all, agent_ids, agent_platforms, agent_policy_ids } = params;
   const selectedAgents = await parseAgentSelection(
     internalSavedObjectsClient,

--- a/x-pack/platform/plugins/shared/osquery/server/routes/pack/create_pack_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/pack/create_pack_route.ts
@@ -70,7 +70,6 @@ export const createPackRoute = (router: IRouter, osqueryContext: OsqueryAppConte
         const packagePolicyService = osqueryContext.service.getPackagePolicyService();
         const currentUser = coreContext.security.authc.getCurrentUser()?.username;
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { name, description, queries, enabled, policy_ids, shards = {} } = request.body;
         const conflictingEntries = await savedObjectsClient.find({
           type: packSavedObjectType,

--- a/x-pack/platform/plugins/shared/osquery/server/routes/pack/update_pack_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/pack/update_pack_route.ts
@@ -77,7 +77,6 @@ export const updatePackRoute = (router: IRouter, osqueryContext: OsqueryAppConte
         const packagePolicyService = osqueryContext.service.getPackagePolicyService();
         const currentUser = coreContext.security.authc.getCurrentUser()?.username;
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { name, description, queries, enabled, policy_ids, shards = {} } = request.body;
 
         const currentPackSO = await savedObjectsClient.get<{ name: string; enabled: boolean }>(

--- a/x-pack/platform/plugins/shared/osquery/server/routes/pack/utils.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/pack/utils.ts
@@ -66,7 +66,6 @@ export const convertSOQueriesToPack = (
 ) =>
   reduce(
     queries,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     (acc, { id: queryId, ecs_mapping, query, platform, ...rest }, key) => {
       const index = queryId ? queryId : key;
       acc[index] = {
@@ -91,7 +90,6 @@ export const convertSOQueriesToPackConfig = (
 ) =>
   reduce(
     queries,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     (acc, { id: queryId, ecs_mapping, query, platform, removed, snapshot, ...rest }, key) => {
       const resultType = snapshot === false ? { removed, snapshot } : {};
       const index = queryId ? queryId : key;

--- a/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/create_saved_query_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/create_saved_query_route.ts
@@ -55,7 +55,6 @@ export const createSavedQueryRoute = (router: IRouter, osqueryContext: OsqueryAp
           snapshot,
           removed,
           timeout,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           ecs_mapping,
         } = request.body;
 

--- a/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/update_saved_query_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/update_saved_query_route.ts
@@ -67,7 +67,6 @@ export const updateSavedQueryRoute = (router: IRouter, osqueryContext: OsqueryAp
           timeout,
           snapshot,
           removed,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           ecs_mapping,
         } = request.body;
 

--- a/x-pack/platform/plugins/shared/rule_registry/server/routes/find.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/routes/find.ts
@@ -55,11 +55,9 @@ export const findAlertsByQueryRoute = (router: IRouter<RacRequestHandlerContext>
           consumers,
           index,
           query,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           search_after,
           size,
           sort,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           track_total_hits,
           _source,
         } = request.body;

--- a/x-pack/platform/plugins/shared/security/public/management/users/edit_user/user_form.tsx
+++ b/x-pack/platform/plugins/shared/security/public/management/users/edit_user/user_form.tsx
@@ -91,7 +91,6 @@ export const UserForm: FunctionComponent<UserFormProps> = ({
 
   const [form, eventHandlers] = useForm({
     onSubmit: async (values) => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { password, confirm_password, ...rest } = values;
       const user = isNewUser ? { password, ...rest } : rest;
       try {

--- a/x-pack/platform/plugins/shared/spaces/server/usage_collection/spaces_usage_collector.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/usage_collection/spaces_usage_collector.ts
@@ -103,7 +103,6 @@ async function getSpacesUsage(
   }, {});
 
   const disabledFeatures: Record<string, number> = disabledFeatureBuckets.reduce(
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     (acc, { key, doc_count }) => {
       acc[key] = doc_count;
       return acc;
@@ -111,14 +110,10 @@ async function getSpacesUsage(
     initialCounts
   );
 
-  const solutions = solutionBuckets.reduce<Record<string, number>>(
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    (acc, { key, doc_count }) => {
-      acc[key] = doc_count;
-      return acc;
-    },
-    initialSolutionCounts
-  );
+  const solutions = solutionBuckets.reduce<Record<string, number>>((acc, { key, doc_count }) => {
+    acc[key] = doc_count;
+    return acc;
+  }, initialSolutionCounts);
 
   const usesFeatureControls = Object.values(disabledFeatures).some(
     (disabledSpaceCount) => disabledSpaceCount > 0

--- a/x-pack/platform/plugins/shared/stack_alerts/common/build_sorted_events_query.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/common/build_sorted_events_query.ts
@@ -36,10 +36,8 @@ export const buildSortedEventsQuery = ({
   searchAfterSortId,
   sortOrder,
   timeField,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   track_total_hits,
   fields,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   runtime_mappings,
   _source,
 }: BuildSortedEventsQuery): ESSearchRequest => {

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/lib/fetch_es_query.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/lib/fetch_es_query.ts
@@ -59,13 +59,7 @@ export async function fetchEsQuery({
   const esClient = scopedClusterClient.asCurrentUser;
   const isGroupAgg = isGroupAggregation(params.termField);
   const isCountAgg = isCountAggregation(params.aggType);
-  const {
-    query,
-    fields,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    runtime_mappings,
-    _source,
-  } = getParsedQuery(params);
+  const { query, fields, runtime_mappings, _source } = getParsedQuery(params);
 
   const filter =
     timestamp && params.excludeHitsFromPreviousRun

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/execution_plan.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/execution_plan/execution_plan.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 import { groupBy, orderBy } from 'lodash';
 import {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/processor_metrics.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/processor_metrics.tsx
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   EuiBadge,
   EuiBadgeGroup,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   FlattenRecord,
   ProcessorDefinition,

--- a/x-pack/platform/plugins/shared/task_manager/server/monitoring/monitoring_stats_stream.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/monitoring/monitoring_stats_stream.ts
@@ -143,7 +143,6 @@ export function createMonitoringStatsStream(
 export function summarizeMonitoringStats(
   logger: Logger,
   {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     last_update,
     stats: { runtime, workload, configuration, ephemeral, utilization },
   }: MonitoringStats,

--- a/x-pack/platform/plugins/shared/task_manager/server/monitoring/task_run_statistics.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/monitoring/task_run_statistics.ts
@@ -347,12 +347,9 @@ export function summarizeTaskRunStat(
   logger: Logger,
   {
     polling: {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       last_successful_poll,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       last_polling_delay,
       duration: pollingDuration,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       claim_duration,
       result_frequency_percent_as_number: pollingResultFrequency,
       claim_conflicts: claimConflicts,
@@ -361,7 +358,6 @@ export function summarizeTaskRunStat(
       persistence: pollingPersistence,
     },
     drift,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     drift_by_type,
     load,
     execution: {

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -964,7 +964,6 @@ export class TaskStore {
   public async aggregate<TSearchRequest extends AggregationOpts>({
     aggs,
     query,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     runtime_mappings,
     size = 0,
   }: TSearchRequest): Promise<estypes.SearchResponse<ConcreteTaskInstance>> {
@@ -987,26 +986,24 @@ export class TaskStore {
 
   public async updateByQuery(
     opts: UpdateByQuerySearchOpts = {},
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     { max_docs: max_docs }: UpdateByQueryOpts = {}
   ): Promise<UpdateByQueryResult> {
     const { query } = ensureQueryOnlyReturnsTaskObjects(opts);
     try {
-      const // eslint-disable-next-line @typescript-eslint/naming-convention
-        { total, updated, version_conflicts } = await this.esClientWithoutRetries.updateByQuery(
-          {
-            index: this.index,
-            ignore_unavailable: true,
-            refresh: true,
-            conflicts: 'proceed',
-            body: {
-              ...opts,
-              max_docs,
-              query,
-            },
+      const { total, updated, version_conflicts } = await this.esClientWithoutRetries.updateByQuery(
+        {
+          index: this.index,
+          ignore_unavailable: true,
+          refresh: true,
+          conflicts: 'proceed',
+          body: {
+            ...opts,
+            max_docs,
+            query,
           },
-          { requestTimeout: this.requestTimeouts.update_by_query }
-        );
+        },
+        { requestTimeout: this.requestTimeouts.update_by_query }
+      );
 
       const conflictsCorrectedForContinuation = correctVersionConflictsForContinuation(
         updated,

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/action_connector_api/load_execution_log_aggregations.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/action_connector_api/load_execution_log_aggregations.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import type { HttpSetup } from '@kbn/core/public';
 import type { SortOrder } from '@elastic/elasticsearch/lib/api/types';
 import type {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/rule_api/common_transformations.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/rule_api/common_transformations.ts
@@ -116,9 +116,7 @@ export const transformRule: RewriteRequestCase<Rule> = ({
 });
 
 export const transformResolvedRule: RewriteRequestCase<ResolvedRule> = ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alias_target_id,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alias_purpose,
   outcome,
   ...rest

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/rule_api/load_execution_log_aggregations.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/rule_api/load_execution_log_aggregations.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import type { HttpSetup } from '@kbn/core/public';
 import type { SortOrder } from '@elastic/elasticsearch/lib/api/types';
 import type {

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/alerts.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/alerts.ts
@@ -81,7 +81,6 @@ export default function alertTests({ getService }: FtrProviderContext) {
           createdBy: user.fullName,
           updatedBy: user.fullName,
           actions: actions.map((action: any) => {
-            /* eslint-disable @typescript-eslint/naming-convention */
             const { connector_type_id, group, id, params, uuid } = action;
             return {
               actionTypeId: connector_type_id,
@@ -430,7 +429,6 @@ instanceStateValue: true
             createdBy: user.fullName,
             updatedBy: Superuser.fullName,
             actions: response2.body.actions.map((action: any) => {
-              /* eslint-disable @typescript-eslint/naming-convention */
               const { connector_type_id, group, id, params, uuid } = action;
               return {
                 actionTypeId: connector_type_id,

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group1/alerts_base.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group1/alerts_base.ts
@@ -113,7 +113,6 @@ export function alertTests({ getService }: FtrProviderContext, space: Space) {
           createdBy: null,
           updatedBy: null,
           actions: response.body.actions.map((action: any) => {
-            /* eslint-disable @typescript-eslint/naming-convention */
             const { connector_type_id, group, id, params, uuid } = action;
             return {
               actionTypeId: connector_type_id,

--- a/x-pack/platform/test/api_integration/apis/management/index_management/data_streams_index_mode.ts
+++ b/x-pack/platform/test/api_integration/apis/management/index_management/data_streams_index_mode.ts
@@ -67,7 +67,6 @@ export default function ({ getService }: FtrProviderContext) {
         },
       ];
 
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       logsdbSettings.forEach(({ enabled, prior_logs_usage, indexMode }) => {
         it(`returns ${indexMode} index mode if logsdb.enabled setting is ${enabled} and logs.prior_logs_usage is ${prior_logs_usage}`, async () => {
           await es.cluster.putSettings({

--- a/x-pack/platform/test/api_integration/apis/management/index_management/templates.ts
+++ b/x-pack/platform/test/api_integration/apis/management/index_management/templates.ts
@@ -369,7 +369,6 @@ export default function ({ getService }: FtrProviderContext) {
           },
         ];
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         logsdbSettings.forEach(({ enabled, prior_logs_usage, indexMode }) => {
           it(`returns ${indexMode} index mode if logsdb.enabled setting is ${enabled} and logs.prior_logs_usage is ${prior_logs_usage}`, async () => {
             await es.cluster.putSettings({

--- a/x-pack/platform/test/api_integration/apis/ml/data_frame_analytics/explain.ts
+++ b/x-pack/platform/test/api_integration/apis/ml/data_frame_analytics/explain.ts
@@ -100,7 +100,7 @@ export default ({ getService }: FtrProviderContext) => {
           ml.api.assertResponseStatusCode(200, status, body);
 
           expect(body).to.have.property('field_selection');
-          // eslint-disable-next-line @typescript-eslint/naming-convention
+
           const { memory_estimation, field_selection } = body;
           const fieldObject = field_selection[0];
           expect(memory_estimation).to.have.property('expected_memory_with_disk');

--- a/x-pack/platform/test/api_integration/apis/telemetry/telemetry.ts
+++ b/x-pack/platform/test/api_integration/apis/telemetry/telemetry.ts
@@ -53,11 +53,9 @@ function updateClusterUuidInLogstashStats(
   clusterUuid: string,
   payload: Array<Record<string, any>>
 ) {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   return payload.map(({ stack_stats, ...item }) => {
     const { logstash } = stack_stats;
     if (logstash) {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { cluster_stats } = logstash;
       cluster_stats.monitoringClusterUuid = clusterUuid;
     }

--- a/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/connectors/cases/cases_connector.ts
+++ b/x-pack/platform/test/cases_api_integration/security_and_spaces/tests/trial/connectors/cases/cases_connector.ts
@@ -1841,7 +1841,6 @@ const generateId = ({
 const removeServerGeneratedData = (
   theCase: Case
 ): Omit<Case, 'created_at' | 'updated_at' | 'version'> => {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { created_at, updated_at, version, ...restCase } = theCase;
 
   return restCase;

--- a/x-pack/platform/test/cases_api_integration/spaces_only/tests/trial/cases/push_case.ts
+++ b/x-pack/platform/test/cases_api_integration/spaces_only/tests/trial/cases/push_case.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
 import type http from 'http';
 import expect from '@kbn/expect';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';

--- a/x-pack/platform/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -696,7 +696,7 @@ export default function (providerContext: FtrProviderContext) {
             description: 'Test',
           })
           .expect(200);
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+
         const { id, updated_at, version, ...newPolicy } = item;
 
         expect(newPolicy).to.eql({
@@ -1205,7 +1205,7 @@ export default function (providerContext: FtrProviderContext) {
           })
           .expect(200);
         createdPolicyIds.push(updatedPolicy.id);
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+
         const { id, updated_at, version, ...newPolicy } = updatedPolicy;
 
         expect(newPolicy).to.eql({
@@ -1266,7 +1266,7 @@ export default function (providerContext: FtrProviderContext) {
           })
           .expect(200);
         createdPolicyIds.push(updatedPolicy.id);
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+
         const { id, updated_at, version, ...newPolicy } = updatedPolicy;
 
         expect(newPolicy).to.eql({
@@ -1427,7 +1427,7 @@ export default function (providerContext: FtrProviderContext) {
             force: true,
           })
           .expect(200);
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+
         const { id, updated_at, version, ...newPolicy } = updatedPolicy;
         createdPolicyIds.push(updatedPolicy.id);
 
@@ -1488,7 +1488,6 @@ export default function (providerContext: FtrProviderContext) {
           })
           .expect(200);
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { id, updated_at, version, ...newPolicy } = updatedPolicy;
 
         expect(newPolicy).to.eql({
@@ -1606,7 +1605,6 @@ export default function (providerContext: FtrProviderContext) {
           })
           .expect(200);
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { id, updated_at, version, ...newPolicy } = updatedPolicy;
 
         expect(newPolicy).to.eql({

--- a/x-pack/platform/test/fleet_api_integration/apis/data_streams/list.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/data_streams/list.ts
@@ -192,7 +192,6 @@ export default function (providerContext: FtrProviderContext) {
         expect(body.data_streams.length).to.eql(2);
 
         body.data_streams.forEach((dataStream: any) => {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           const { index, size_in_bytes, size_in_bytes_formatted, last_activity_ms, ...coreFields } =
             dataStream;
           expect(expectedStreamsByDataset[coreFields.dataset]).not.to.eql(undefined);

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/health_route.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/health_route.ts
@@ -258,7 +258,6 @@ export default function ({ getService }: FtrProviderContext) {
 
       const {
         runtime: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           value: { drift, drift_by_type, load, polling, execution },
         },
       } = (await getHealthForSampleTask()).stats;

--- a/x-pack/platform/test/task_manager_claimer_update_by_query/test_suites/task_manager/health_route.ts
+++ b/x-pack/platform/test/task_manager_claimer_update_by_query/test_suites/task_manager/health_route.ts
@@ -255,7 +255,6 @@ export default function ({ getService }: FtrProviderContext) {
 
       const {
         runtime: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           value: { drift, drift_by_type, load, polling, execution },
         },
       } = (await getHealthForSampleTask()).stats;

--- a/x-pack/solutions/observability/packages/kbn-custom-integrations/src/state_machines/custom_integrations/state_machine.ts
+++ b/x-pack/solutions/observability/packages/kbn-custom-integrations/src/state_machines/custom_integrations/state_machine.ts
@@ -52,6 +52,7 @@ export const createPureCustomIntegrationsStateMachine = (
           states: {
             initialized: {
               meta: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 _DX_warning_:
                   "These inner initialized states on the top level machine exist primarily so that 'connected' components can block the reading of the state of child machines whilst undefined on the first render cycle",
               },

--- a/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -117,7 +117,6 @@ export const tasks: TelemetryTask[] = [
         expected_metric_document_count: number;
         ratio: number;
       }> {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         let { expected_metric_document_count } = prevResult ?? {
           transaction_count: 0,
           expected_metric_document_count: 0,

--- a/x-pack/solutions/observability/plugins/apm/server/routes/fleet/sync_agent_configs_to_apm_package_policies.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/fleet/sync_agent_configs_to_apm_package_policies.ts
@@ -44,7 +44,7 @@ export async function syncAgentConfigsToApmPackagePolicies({
 
   return Promise.all(
     packagePolicies.items.map(async (item) => {
-      const { id, revision, updated_at, updated_by, ...packagePolicy } = item; // eslint-disable-line @typescript-eslint/naming-convention
+      const { id, revision, updated_at, updated_by, ...packagePolicy } = item;
       const updatedPackagePolicy = getPackagePolicyWithAgentConfigurations(
         packagePolicy,
         agentConfigurations

--- a/x-pack/solutions/observability/plugins/infra/public/observability_logs/log_stream_page/state/src/state_machine.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/observability_logs/log_stream_page/state/src/state_machine.ts
@@ -100,6 +100,7 @@ export const createPureLogStreamPageStateMachine = (initialContext: LogStreamPag
           states: {
             initializingQuery: {
               meta: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 _DX_warning_:
                   "The Query machine must be invoked and complete initialisation before the Position machine is invoked. This is due to legacy URL dependencies on the 'logPosition' key, we need to read the key before it is reset by the Position machine.",
               },
@@ -135,6 +136,7 @@ export const createPureLogStreamPageStateMachine = (initialContext: LogStreamPag
             },
             initializingPositions: {
               meta: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 _DX_warning_:
                   "The Position machine must be invoked after the Query machine has been invoked and completed initialisation. This is due to the Query machine having some legacy URL dependencies on the 'logPosition' key, we don't want the Position machine to reset the URL parameters before the Query machine has had a chance to read them.",
               },

--- a/x-pack/solutions/observability/plugins/infra/public/observability_logs/log_stream_position_state/src/state_machine.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/observability_logs/log_stream_position_state/src/state_machine.ts
@@ -37,6 +37,7 @@ export const createPureLogStreamPositionStateMachine = (initialContext: LogStrea
       states: {
         uninitialized: {
           meta: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             _DX_warning_:
               "The Position machine cannot initializeFromUrl until after the Query machine has initialized, this is due to a dual dependency on the 'logPosition' URL parameter for legacy reasons.",
           },

--- a/x-pack/solutions/observability/plugins/infra/server/lib/infra_ml/metrics_hosts_anomalies.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/infra_ml/metrics_hosts_anomalies.ts
@@ -231,7 +231,6 @@ async function fetchMetricsHostsAnomalies(
 
   const anomalies = hits.map((result) => {
     const {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       job_id,
       record_score: anomalyScore,
       typical,

--- a/x-pack/solutions/observability/plugins/infra/server/lib/infra_ml/metrics_k8s_anomalies.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/infra_ml/metrics_k8s_anomalies.ts
@@ -230,7 +230,6 @@ async function fetchMetricK8sAnomalies(
 
   const anomalies = hits.map((result) => {
     const {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       job_id,
       record_score: anomalyScore,
       typical,

--- a/x-pack/solutions/observability/plugins/infra/server/lib/log_analysis/log_entry_anomalies.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/log_analysis/log_entry_anomalies.ts
@@ -311,7 +311,6 @@ async function fetchLogEntryAnomalies(
       : undefined;
   const anomalies = hits.map((result) => {
     const {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       job_id,
       record_score: anomalyScore,
       typical,

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/test_helpers.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/test_helpers.ts
@@ -34,7 +34,6 @@ export const setupMockEsCompositeQuery = <K, C, I>(
 ): ElasticsearchClientMock => {
   const esMock = elasticsearchServiceMock.createElasticsearchClient();
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   criteria.forEach(({ after_key, bucketCriteria }) => {
     const mockResponse = {
       aggregations: {

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_monitor_availability.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_monitor_availability.ts
@@ -30,7 +30,6 @@ export interface GetMonitorAvailabilityResult {
 }
 
 export const formatBuckets = async (buckets: any[]): Promise<GetMonitorAvailabilityResult[]> =>
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   buckets.map(({ key, fields, up_sum, down_sum, ratio }: any) => ({
     ...key,
     location: key.location === null ? UNNAMED_LOCATION : (key.location as string),

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_monitor_locations.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/get_monitor_locations.ts
@@ -119,7 +119,7 @@ export const getMonitorLocations: UMElasticsearchQueryFn<
   let totalDowns = 0;
 
   const monLocs: MonitorLocation[] = [];
-  // eslint-disable-next-line @typescript-eslint/naming-convention
+
   locations.forEach(({ most_recent: mostRecent, up_history, down_history }: any) => {
     const mostRecentLocation = mostRecent.hits.hits[0]._source;
     totalUps += up_history.value;

--- a/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/test_helpers.ts
+++ b/x-pack/solutions/observability/plugins/uptime/server/legacy_uptime/lib/requests/test_helpers.ts
@@ -35,7 +35,6 @@ export const setupMockEsCompositeQuery = <K, C, I>(
 ): ElasticsearchClientMock => {
   const esMock = elasticsearchServiceMock.createElasticsearchClient();
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   criteria.forEach(({ after_key, bucketCriteria }) => {
     const mockResponse = {
       aggregations: {

--- a/x-pack/solutions/observability/plugins/ux/public/components/app/rum_dashboard/visitor_breakdown_map/__stories__/map_tooltip.stories.tsx
+++ b/x-pack/solutions/observability/plugins/ux/public/components/app/rum_dashboard/visitor_breakdown_map/__stories__/map_tooltip.stories.tsx
@@ -35,6 +35,7 @@ export const Tooltip = {
             id: 'US',
             layerId: 'e8d1d974-eed8-462f-be2c-f0004b7619b2',
             mbProperties: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               __kbn__feature_id__: 'US',
               name: 'United States',
               iso2: 'US',

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/streams/processing_simulate.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/streams/processing_simulate.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import expect from '@kbn/expect';
 import { ClientRequestParamsOf } from '@kbn/server-route-repository-utils';
 import { StreamsRouteRepository } from '@kbn/streams-plugin/server';

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/utils/fetch_unallowed_values.ts
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/utils/fetch_unallowed_values.ts
@@ -21,7 +21,6 @@ export const isBucket = (maybeBucket: unknown): maybeBucket is Bucket =>
   typeof (maybeBucket as Bucket).key === 'string' &&
   typeof (maybeBucket as Bucket).doc_count === 'number';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const getUnallowedValueCount = ({ doc_count, key }: Bucket): UnallowedValueCount => ({
   count: doc_count,
   fieldName: key,

--- a/x-pack/solutions/security/packages/index-adapter/src/field_maps/mapping_from_field_map.ts
+++ b/x-pack/solutions/security/packages/index-adapter/src/field_maps/mapping_from_field_map.ts
@@ -27,12 +27,10 @@ export function mappingFromFieldMap(
   });
 
   fields.forEach((field) => {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { name, required, array, multi_fields, ...rest } = field;
     const mapped = multi_fields
       ? {
           ...rest,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           fields: multi_fields.reduce((acc, multi_field: MultiField) => {
             acc[multi_field.name] = {
               type: multi_field.type,

--- a/x-pack/solutions/security/packages/kbn-securitysolution-list-api/src/list_api/index.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-list-api/src/list_api/index.ts
@@ -65,12 +65,9 @@ const findLists = async ({
   http,
   cursor,
   page,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   per_page,
   signal,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   sort_field,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   sort_order,
 }: ApiParams & FindListSchemaEncoded): Promise<FoundListSchema> => {
   return http.fetch(`${LIST_URL}/_find`, {
@@ -116,7 +113,6 @@ const findListsBySize = async ({
   http,
   cursor,
   page,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   per_page,
   signal,
 }: ApiParams & FindListSchemaEncoded): Promise<FoundListsBySizeSchema> => {
@@ -156,7 +152,6 @@ export { findListsBySizeWithValidation as findListsBySize };
 const importList = async ({
   file,
   http,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   list_id,
   type,
   signal,
@@ -238,7 +233,6 @@ export { deleteListWithValidation as deleteList };
 
 const exportList = async ({
   http,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   list_id,
   signal,
 }: ApiParams & ExportListItemQuerySchemaEncoded): Promise<Blob> =>

--- a/x-pack/solutions/security/packages/kbn-securitysolution-list-api/src/list_item_api/index.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-list-api/src/list_item_api/index.ts
@@ -43,14 +43,10 @@ const findListItems = async ({
   http,
   cursor,
   page,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   list_id,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   per_page,
   signal,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   sort_field,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   sort_order,
   filter,
 }: ApiParams & FindListItemSchema): Promise<FoundListItemSchema> => {
@@ -186,7 +182,6 @@ const createListItem = async ({
   http,
   signal,
   value,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   list_id,
   refresh,
 }: ApiParams & CreateListItemSchema): Promise<ListItemSchema> =>

--- a/x-pack/solutions/security/plugins/cloud_defend/public/test/fixtures/cloud_defend_integration.ts
+++ b/x-pack/solutions/security/plugins/cloud_defend/public/test/fixtures/cloud_defend_integration.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import Chance from 'chance';
 import type { CloudDefendPolicy } from '../../../common';
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerability_dashboard/vulnerability_trend_graph.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerability_dashboard/vulnerability_trend_graph.tsx
@@ -128,7 +128,6 @@ const getUniqueCloudAccountsOptions = (
 const getTrendData = (vulnTrends: VulnStatsTrend[], selectedAccount: string) => {
   if (selectedAccount === DEFAULT_ACCOUNT) {
     const cleanAllTrend = vulnTrends.map((trendTimepoint) => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const { vulnerabilities_stats_by_cloud_account, policy_template, ...allAccountsTrendData } =
         trendTimepoint;
       return allAccountsTrendData;

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/create_indices/create_indices.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/create_indices/create_indices.ts
@@ -137,7 +137,6 @@ const createLatestIndex = async (
       name: indexName,
     });
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { template, composed_of, _meta } =
       indexTemplateResponse.index_templates[0].index_template;
 

--- a/x-pack/solutions/security/plugins/lists/server/services/exception_lists/exception_list_client.mock.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/exception_lists/exception_list_client.mock.ts
@@ -150,7 +150,6 @@ export const getUpdateExceptionListItemOptionsMock = (): UpdateExceptionListItem
 export const getExceptionListSoSchemaMock = (
   overrides: Partial<ExceptionListSoSchema> = {}
 ): ExceptionListSoSchema => {
-  /* eslint-disable @typescript-eslint/naming-convention */
   const {
     comments,
     created_at,
@@ -167,7 +166,6 @@ export const getExceptionListSoSchemaMock = (
     type,
     updated_by,
   } = getExceptionListItemSchemaMock();
-  /* eslint-enable @typescript-eslint/naming-convention */
 
   const soSchema: ExceptionListSoSchema = {
     comments,

--- a/x-pack/solutions/security/plugins/lists/server/services/exception_lists/utils/index.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/exception_lists/utils/index.ts
@@ -44,7 +44,6 @@ export const transformSavedObjectToExceptionList = ({
   const {
     version: _version,
     attributes: {
-      /* eslint-disable @typescript-eslint/naming-convention */
       created_at,
       created_by,
       description,
@@ -58,7 +57,6 @@ export const transformSavedObjectToExceptionList = ({
       type,
       updated_by,
       version,
-      /* eslint-enable @typescript-eslint/naming-convention */
     },
     id,
     updated_at: updatedAt,
@@ -144,7 +142,6 @@ export const transformSavedObjectToExceptionListItem = ({
   const {
     version: _version,
     attributes: {
-      /* eslint-disable @typescript-eslint/naming-convention */
       comments,
       created_at,
       created_by,
@@ -160,7 +157,6 @@ export const transformSavedObjectToExceptionListItem = ({
       tie_breaker_id,
       type,
       updated_by,
-      /* eslint-enable @typescript-eslint/naming-convention */
     },
     id,
     updated_at: updatedAt,

--- a/x-pack/solutions/security/plugins/lists/server/services/utils/transform_elastic_to_list_item.ts
+++ b/x-pack/solutions/security/plugins/lists/server/services/utils/transform_elastic_to_list_item.ts
@@ -39,7 +39,6 @@ export const transformElasticHitsToListItem = ({
   return hits.map((hit) => {
     const { _id, _source } = hit;
     const {
-      /* eslint-disable @typescript-eslint/naming-convention */
       created_at,
       deserializer,
       serializer,
@@ -49,7 +48,6 @@ export const transformElasticHitsToListItem = ({
       list_id,
       tie_breaker_id,
       meta,
-      /* eslint-enable @typescript-eslint/naming-convention */
     } = _source!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
     // @ts-expect-error _source is optional
     const value = findSourceValue(hit._source);

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/rule_request_schema.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/rule_request_schema.test.ts
@@ -882,7 +882,6 @@ describe('rules schema', () => {
   });
 
   test('saved_id is required when type is saved_query and will not validate without it', () => {
-    /* eslint-disable @typescript-eslint/naming-convention */
     const { saved_id, ...payload } = getCreateSavedQueryRulesSchemaMock();
 
     const result = RuleCreateProps.safeParse(payload);
@@ -1010,7 +1009,6 @@ describe('rules schema', () => {
     });
 
     test('threat_index, threat_query, and threat_mapping are required when type is "threat_match" and validation fails without them', () => {
-      /* eslint-disable @typescript-eslint/naming-convention */
       const { threat_index, threat_query, threat_mapping, ...payload } =
         getCreateThreatMatchRulesSchemaMock();
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/import_rules/rule_to_import.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/import_rules/rule_to_import.test.ts
@@ -340,7 +340,6 @@ describe('RuleToImport', () => {
   });
 
   test('defaults max signals to 100', () => {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { max_signals, ...noMaxSignals } = getImportRulesSchemaMock();
     const payload: RuleToImportInput = {
       ...noMaxSignals,

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/data_generators/exceptions_list_item_generator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/data_generators/exceptions_list_item_generator.ts
@@ -39,7 +39,6 @@ export const exceptionItemToCreateExceptionItem = (
   exceptionItem: ExceptionListItemSchema
 ): CreateExceptionListItemSchemaWithNonNullProps => {
   const {
-    /* eslint-disable @typescript-eslint/naming-convention */
     description,
     entries,
     expire_time,
@@ -52,7 +51,6 @@ export const exceptionItemToCreateExceptionItem = (
     namespace_type,
     os_types,
     tags,
-    /* eslint-enable @typescript-eslint/naming-convention */
   } = exceptionItem;
 
   return {
@@ -74,7 +72,6 @@ export const exceptionItemToCreateExceptionItem = (
 const exceptionItemToUpdateExceptionItem = (
   exceptionItem: ExceptionListItemSchema
 ): UpdateExceptionListItemSchemaWithNonNullProps => {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { id, item_id, _version } = exceptionItem;
   const { list_id: _, ...updateAttributes } = exceptionItemToCreateExceptionItem(exceptionItem);
 

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/policy/get_policy_data_for_update.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/policy/get_policy_data_for_update.ts
@@ -14,7 +14,6 @@ import type { MaybeImmutable, NewPolicyData, PolicyData } from '../../types';
  * @param policy
  */
 export const getPolicyDataForUpdate = (policy: MaybeImmutable<PolicyData>): NewPolicyData => {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { id, revision, created_by, created_at, updated_by, updated_at, ...rest } =
     policy as PolicyData;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/use_update_alerts_status/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/take_action/use_update_alerts_status/index.tsx
@@ -39,7 +39,7 @@ export const useUpdateAlertsStatus = () => {
     {
       onSuccess: (data: UpdatedAlertsResponse, variables: UpdateAlertsStatusParams) => {
         const { ids, kibanaAlertWorkflowStatus } = variables;
-        const { updated, version_conflicts } = data; // eslint-disable-line @typescript-eslint/naming-convention
+        const { updated, version_conflicts } = data;
 
         const alertsCount = ids.length; // total alerts
         const allAlertsUpdated = updated === alertsCount;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/links/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/links/index.tsx
@@ -574,11 +574,9 @@ const ReputationLinkComponent: React.FC<{
       ipReputationLinksSetting
         ?.slice(0, allItemsLimit)
         .filter(
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           ({ url_template, name }) =>
             !isNil(url_template) && !isNil(name) && !isUrlInvalid(url_template)
         )
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         .map(({ name, url_template }: { name: string; url_template: string }) => ({
           name: isDefaultReputationLink(name) ? defaultNameMapping[name] : name,
           url_template: url_template.replace(`{{ip}}`, encodeURIComponent(domain)),

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/helpers.ts
@@ -265,101 +265,85 @@ export const filterRuleFieldsForType = <T extends Partial<RuleFields>>(
   | NewTermsRuleFields<T> => {
   switch (type) {
     case 'machine_learning':
-      const {
-        index,
-        queryBar,
-        threshold,
-        threatIndex,
-        threatQueryBar,
-        threatMapping,
-        eqlOptions,
-        newTermsFields,
-        historyWindowSize,
-        ...mlRuleFields
-      } = fields;
-      return mlRuleFields;
+      return omit(fields, [
+        'index',
+        'queryBar',
+        'threshold',
+        'threatIndex',
+        'threatQueryBar',
+        'threatMapping',
+        'eqlOptions',
+        'newTermsFields',
+        'historyWindowSize',
+      ]);
     case 'threshold':
-      const {
-        anomalyThreshold,
-        machineLearningJobId,
-        threatIndex: _removedThreatIndex,
-        threatQueryBar: _removedThreatQueryBar,
-        threatMapping: _removedThreatMapping,
-        eqlOptions: _eqlOptions,
-        newTermsFields: removedNewTermsFields,
-        historyWindowSize: removedHistoryWindowSize,
-        ...thresholdRuleFields
-      } = fields;
-      return thresholdRuleFields;
+      return omit(fields, [
+        'anomalyThreshold',
+        'machineLearningJobId',
+        'threatIndex',
+        'threatQueryBar',
+        'threatMapping',
+        'eqlOptions',
+        'newTermsFields',
+        'historyWindowSize',
+      ]);
     case 'threat_match':
-      const {
-        anomalyThreshold: _removedAnomalyThreshold,
-        machineLearningJobId: _removedMachineLearningJobId,
-        threshold: _removedThreshold,
-        eqlOptions: __eqlOptions,
-        newTermsFields: _removedNewTermsFields,
-        historyWindowSize: _removedHistoryWindowSize,
-        ...threatMatchRuleFields
-      } = fields;
-      return threatMatchRuleFields;
+      return omit(fields, [
+        'anomalyThreshold',
+        'machineLearningJobId',
+        'threshold',
+        'eqlOptions',
+        'newTermsFields',
+        'historyWindowSize',
+      ]);
     case 'query':
     case 'saved_query':
-      const {
-        anomalyThreshold: _a,
-        machineLearningJobId: _m,
-        threshold: _t,
-        threatIndex: __removedThreatIndex,
-        threatQueryBar: __removedThreatQueryBar,
-        threatMapping: __removedThreatMapping,
-        eqlOptions: ___eqlOptions,
-        newTermsFields: __removedNewTermsFields,
-        historyWindowSize: __removedHistoryWindowSize,
-        ...queryRuleFields
-      } = fields;
-      return queryRuleFields;
+      return omit(fields, [
+        'anomalyThreshold',
+        'machineLearningJobId',
+        'threshold',
+        'threatIndex',
+        'threatQueryBar',
+        'threatMapping',
+        'eqlOptions',
+        'newTermsFields',
+        'historyWindowSize',
+      ]);
     case 'eql':
-      const {
-        anomalyThreshold: __a,
-        machineLearningJobId: __m,
-        threshold: __t,
-        threatIndex: ___removedThreatIndex,
-        threatQueryBar: ___removedThreatQueryBar,
-        threatMapping: ___removedThreatMapping,
-        newTermsFields: ___removedNewTermsFields,
-        historyWindowSize: ___removedHistoryWindowSize,
-        ...eqlRuleFields
-      } = fields;
-      return eqlRuleFields;
-
+      return omit(fields, [
+        'anomalyThreshold',
+        'machineLearningJobId',
+        'threshold',
+        'threatIndex',
+        'threatQueryBar',
+        'threatMapping',
+        'newTermsFields',
+        'historyWindowSize',
+      ]);
     case 'new_terms':
-      const {
-        anomalyThreshold: ___a,
-        machineLearningJobId: ___m,
-        threshold: ___t,
-        threatIndex: ____removedThreatIndex,
-        threatQueryBar: ____removedThreatQueryBar,
-        threatMapping: ____removedThreatMapping,
-        eqlOptions: ____eqlOptions,
-        ...newTermsRuleFields
-      } = fields;
-      return newTermsRuleFields;
-
+      return omit(fields, [
+        'anomalyThreshold',
+        'machineLearningJobId',
+        'threshold',
+        'threatIndex',
+        'threatQueryBar',
+        'threatMapping',
+        'eqlOptions',
+      ]);
     case 'esql':
-      const {
-        anomalyThreshold: _esql_a,
-        machineLearningJobId: _esql_m,
-        threshold: _esql_t,
-        threatIndex: _esql_removedThreatIndex,
-        threatQueryBar: _esql_removedThreatQueryBar,
-        threatMapping: _esql_removedThreatMapping,
-        newTermsFields: _esql_removedNewTermsFields,
-        historyWindowSize: _esql_removedHistoryWindowSize,
-        eqlOptions: _esql__eqlOptions,
-        index: _esql_index,
-        dataViewId: _esql_dataViewId,
-        ...esqlRuleFields
-      } = fields;
-      return esqlRuleFields;
+      return omit(fields, [
+        'anomalyThreshold',
+        'machineLearningJobId',
+        'threshold',
+        'threatIndex',
+        'threatQueryBar',
+        'threatMapping',
+        'newTermsFields',
+        'historyWindowSize',
+        'eqlOptions',
+        'index',
+        'dataViewId',
+      ]);
   }
   assertUnreachable(type);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/utils/helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/utils/helpers.tsx
@@ -115,7 +115,6 @@ export const getFormattedComments = (comments: CommentsArray): EuiCommentProps[]
 export const formatExceptionItemForUpdate = (
   exceptionItem: ExceptionListItemSchema
 ): UpdateExceptionListItemSchema => {
-  /* eslint-disable @typescript-eslint/naming-convention */
   const {
     created_at,
     created_by,
@@ -123,7 +122,6 @@ export const formatExceptionItemForUpdate = (
     tie_breaker_id,
     updated_at,
     updated_by,
-    /* eslint-enable @typescript-eslint/naming-convention */
     ...fieldsToUpdate
   } = exceptionItem;
   return {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_entry_card/test_utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_entry_card/test_utils.ts
@@ -25,7 +25,6 @@ export const getTrustedAppProviderMock = (): TrustedApp =>
 
 export const getExceptionProviderMock = (): ExceptionListItemSchema => {
   // Grab the properties from the generated Trusted App that should be the same across both types
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { name, description, created_at, updated_at, updated_by, created_by, id } =
     getTrustedAppProviderMock();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_entry_card/utils/map_to_artifact_info.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_entry_card/utils/map_to_artifact_info.ts
@@ -14,7 +14,6 @@ import { isTrustedApp } from './is_trusted_app';
 export const mapToArtifactInfo = (_item: MaybeImmutable<AnyArtifact>): ArtifactInfo => {
   const item = _item as AnyArtifact;
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { name, created_by, created_at, updated_at, updated_by, description = '', entries } = item;
 
   return {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/fleet.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/fleet.ts
@@ -259,7 +259,6 @@ const waitForHasAgentPolicyChanged = (
             'elastic-api-version': API_VERSIONS.public.v1,
           },
         }).then((response) => {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           const { status, policy_revision, policy_id } = response.body.item;
 
           logger.debug('Checking policy data:', { status, policy_revision, policy_id });

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/artifacts/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/artifacts/utils.ts
@@ -14,7 +14,6 @@ import type {
 export const mapUnifiedManifestSavedObjectToUnifiedManifest = ({
   id,
   attributes: { artifactIds, policyId, semanticVersion },
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   created_at,
   version,
 }: SavedObject<InternalUnifiedManifestBaseSchema>): InternalUnifiedManifestSchema => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/calculate_rule_fields_diff.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/calculate_rule_fields_diff.ts
@@ -67,7 +67,7 @@ export const calculateRuleFieldsDiff = (
   isRuleCustomized: boolean = false
 ): RuleFieldsDiff => {
   const commonFieldsDiff = calculateCommonFieldsDiff(ruleVersions, isRuleCustomized);
-  // eslint-disable-next-line @typescript-eslint/naming-convention
+
   const { base_version, current_version, target_version } = ruleVersions;
   const hasBaseVersion = base_version !== MissingVersion;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/signals/query_signals_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/signals/query_signals_route.ts
@@ -41,7 +41,6 @@ export const querySignalsRoute = (
       async (context, request, response) => {
         const esClient = (await context.core).elasticsearch.client.asCurrentUser;
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { query, aggs, _source, fields, track_total_hits, size, runtime_mappings, sort } =
           request.body;
         const siemResponse = buildSiemResponse(response);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/rule_actions/legacy_get_rule_actions_saved_object.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/rule_actions/legacy_get_rule_actions_saved_object.ts
@@ -49,14 +49,12 @@ export const legacyGetRuleActionsSavedObject = async ({
     id: ruleAlertId,
     type: 'alert',
   };
-  const {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    saved_objects,
-  } = await savedObjectsClient.find<LegacyIRuleActionsAttributesSavedObjectAttributes>({
-    type: legacyRuleActionsSavedObjectType,
-    perPage: 1,
-    hasReference: reference,
-  });
+  const { saved_objects } =
+    await savedObjectsClient.find<LegacyIRuleActionsAttributesSavedObjectAttributes>({
+      type: legacyRuleActionsSavedObjectType,
+      perPage: 1,
+      hasReference: reference,
+    });
 
   if (!saved_objects[0]) {
     return null;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/rule_actions/legacy_utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/rule_actions/legacy_utils.ts
@@ -44,7 +44,6 @@ export const legacyGetRuleActionsFromSavedObject = (
   const existingActions = savedObject.attributes.actions ?? [];
   // We have to serialize the action from the saved object references
   const actionsWithIdReplacedFromReference = existingActions.flatMap<LegacyRuleAlertAction>(
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     ({ group, params, action_type_id, actionRef }) => {
       const found = savedObject.references?.find(
         (reference) => actionRef === reference.name && reference.type === 'action'

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_response_actions/endpoint_response_action.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_response_actions/endpoint_response_action.ts
@@ -56,7 +56,6 @@ export const endpointResponseAction = async (
       response.push(
         Promise.all(
           Object.values(getIsolateAlerts(alerts)).map(
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ({ endpoint_ids, alert_ids, parameters, error, hosts }: AlertsAction) => {
               logger.info(
                 `${logMsgPrefix} [${command}] [${endpoint_ids.length}] agent(s): ${stringify(
@@ -102,7 +101,7 @@ export const endpointResponseAction = async (
           return each(actionAlerts, (actionPerAgent) => {
             return each(
               actionPerAgent,
-              // eslint-disable-next-line @typescript-eslint/naming-convention
+
               ({ endpoint_ids, alert_ids, parameters, error, hosts }: AlertsAction) => {
                 logger.info(
                   `${logMsgPrefix} [${command}] [${endpoint_ids.length}] agent(s): ${stringify(

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/risk_score/onboarding/helpers/ingest_pipeline.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/risk_score/onboarding/helpers/ingest_pipeline.ts
@@ -20,7 +20,7 @@ export const createIngestPipeline = async ({
 }) => {
   const processors =
     typeof options.processors === 'string' ? JSON.parse(options.processors) : options.processors;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
+
   const { name, description, version, on_failure } = options;
 
   try {

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/network/tls/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/network/tls/helpers.ts
@@ -24,7 +24,6 @@ export const formatNetworkTlsEdges = (buckets: NetworkTlsBuckets[]): NetworkTlsE
         subjects: bucket.subjects.buckets.map(({ key }) => key),
         ja3: bucket.ja3.buckets.map(({ key }) => key),
         issuers: bucket.issuers.buckets.map(({ key }) => key),
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         notAfter: bucket.not_after.buckets.map(({ key_as_string }) => key_as_string),
       },
       cursor: {

--- a/x-pack/solutions/security/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/crowdstrike.ts
+++ b/x-pack/solutions/security/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/crowdstrike.ts
@@ -212,7 +212,6 @@ export default function createCrowdstrikeTests({ getService }: FtrProviderContex
             isAllowedSubAction ? 'allow' : 'deny'
           } execute of ${crowdstrikeSubAction}`, async () => {
             const {
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               body: { status, message, connector_id, statusCode, error },
             } = await executeSubAction({
               supertest: supertestWithoutAuth,

--- a/x-pack/solutions/security/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/microsoft_defender_endpoint.ts
+++ b/x-pack/solutions/security/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/microsoft_defender_endpoint.ts
@@ -225,7 +225,6 @@ export default function createMicrosoftDefenderEndpointTests({ getService }: Ftr
             isAllowedSubAction ? 'allow' : 'deny'
           } execute of ${subActionValue}`, async () => {
             const {
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               body: { status, message, connector_id, statusCode, error },
             } = await executeSubAction({
               supertest: supertestWithoutAuth,

--- a/x-pack/solutions/security/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/sentinelone.ts
+++ b/x-pack/solutions/security/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/sentinelone.ts
@@ -221,7 +221,6 @@ export default function createSentinelOneTests({ getService }: FtrProviderContex
             isAllowedSubAction ? 'allow' : 'deny'
           } execute of ${s1SubAction}`, async () => {
             const {
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               body: { status, message, connector_id, statusCode, error },
             } = await executeSubAction({
               supertest: supertestWithoutAuth,

--- a/x-pack/solutions/security/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
+++ b/x-pack/solutions/security/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
@@ -139,7 +139,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const userActions = await getCaseUserActions({ supertest, caseID: postedCase.id });
         const statusUserAction = removeServerGeneratedPropertiesFromUserAction(userActions[1]);
         const data = removeServerGeneratedPropertiesFromCase(patchedCases[0]);
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+
         const { duration, time_to_investigate, time_to_resolve, ...dataWithoutMetrics } = data;
         const { duration: resDuration, ...resWithoutDuration } = postCaseResp();
 
@@ -178,7 +178,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         const userActions = await getCaseUserActions({ supertest, caseID: postedCase.id });
         const statusUserAction = removeServerGeneratedPropertiesFromUserAction(userActions[1]);
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+
         const { time_to_investigate, time_to_resolve, ...dataWithoutMetrics } =
           removeServerGeneratedPropertiesFromCase(patchedCases[0]);
 

--- a/x-pack/solutions/security/test/cases_api_integration/security_and_spaces/tests/trial/cases/push_case.ts
+++ b/x-pack/solutions/security/test/cases_api_integration/security_and_spaces/tests/trial/cases/push_case.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import type http from 'http';
 
 import expect from '@kbn/expect';

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/create_rule_exceptions.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/create_rule_exceptions.ts
@@ -74,7 +74,6 @@ export default ({ getService }: FtrProviderContext) => {
       const defaultList = udpatedRule.exceptions_list.find((list) => list.type === 'rule_default');
 
       const itemsWithoutServerGeneratedValues = items.map(
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         ({ item_id, ...restOfItem }: ExceptionListItemSchema) =>
           removeExceptionListItemServerGeneratedProperties(restOfItem)
       );
@@ -131,7 +130,6 @@ export default ({ getService }: FtrProviderContext) => {
       const defaultList = udpatedRule.exceptions_list.find((list) => list.type === 'rule_default');
 
       const itemsWithoutServerGeneratedValues = items.map(
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         ({ item_id, ...restOfItem }: ExceptionListItemSchema) =>
           removeExceptionListItemServerGeneratedProperties(restOfItem)
       );
@@ -203,7 +201,6 @@ export default ({ getService }: FtrProviderContext) => {
         .expect(200);
 
       const itemsWithoutServerGeneratedValues = items.map(
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         ({ item_id, ...restOfItem }: ExceptionListItemSchema) =>
           removeExceptionListItemServerGeneratedProperties(restOfItem)
       );

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/exception_comments_ess.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/exception_comments_ess.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import expect from 'expect';
 
 import { EXCEPTION_LIST_ITEM_URL, EXCEPTION_LIST_URL } from '@kbn/securitysolution-list-constants';

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/exception_comments_serverless.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/exception_comments_serverless.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import expect from 'expect';
 
 import { EXCEPTION_LIST_ITEM_URL, EXCEPTION_LIST_URL } from '@kbn/securitysolution-list-constants';

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/exceptions_data_integrity.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/exceptions_data_integrity.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 import expect from 'expect';
 

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/find_rule_exception_references.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/find_rule_exception_references.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import expect from '@kbn/expect';
 
 import {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/prebuilt_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/prebuilt_rules.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import expect from 'expect';
 
 import { getCreateExceptionListMinimalSchemaMock } from '@kbn/lists-plugin/common/schemas/request/create_exception_list_schema.mock';

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/rule_exceptions_execution.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/rule_exceptions_execution.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import expect from 'expect';
 import type { CreateExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 import { LIST_URL } from '@kbn/securitysolution-list-constants';

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/indicator_match/trial_license_complete_tier/indicator_match.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/indicator_match/trial_license_complete_tier/indicator_match.ts
@@ -71,15 +71,10 @@ const createThreatMatchRule = ({
   name = 'Query with a rule id',
   index = ['auditbeat-*'],
   query = '*:*',
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   rule_id = 'rule-1',
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   threat_indicator_path = 'threat.indicator',
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   threat_query = 'source.ip: "188.166.120.93"', // narrow things down with a query to a specific source ip
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   threat_index = ['auditbeat-*'],
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   threat_mapping = [
     // We match host.name against host.name
     {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/task_based/detection_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/telemetry/trial_license_complete_tier/task_based/detection_rules.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import expect from '@kbn/expect';
 import { DETECTION_ENGINE_RULES_URL } from '@kbn/security-solution-plugin/common/constants';
 import { ELASTIC_SECURITY_RULE_ID } from '@kbn/security-solution-plugin/common';

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/exception_list_and_item/list/create_container_with_endpoint_entries.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/exception_list_and_item/list/create_container_with_endpoint_entries.ts
@@ -40,7 +40,6 @@ export const createContainerWithEndpointEntries = async (
   }
 
   // create the endpoint exception list container
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { id, list_id, namespace_type, type } = await createExceptionList(supertest, log, {
     description: 'endpoint description',
     list_id: 'endpoint_list',

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/exception_list_and_item/list/create_container_with_entries.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/exception_list_and_item/list/create_container_with_entries.ts
@@ -32,7 +32,6 @@ export const createContainerWithEntries = async (
     return [];
   }
   // Create the rule exception list container
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { id, list_id, namespace_type, type } = await createExceptionList(supertest, log, {
     description: 'some description',
     list_id: 'some-list-id',

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/rules/get_simple_rule_without_rule_id.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/utils/rules/get_simple_rule_without_rule_id.ts
@@ -13,7 +13,6 @@ import { getSimpleRule } from './get_simple_rule';
  */
 export const getSimpleRuleWithoutRuleId = (): RuleCreateProps => {
   const simpleRule = getSimpleRule();
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { rule_id, ...ruleWithoutId } = simpleRule;
   return ruleWithoutId;
 };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/lists_and_exception_lists/exception_lists_items/trial_license_complete_tier/items/update_exception_list_items.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/lists_and_exception_lists/exception_lists_items/trial_license_complete_tier/items/update_exception_list_items.ts
@@ -268,7 +268,6 @@ export default ({ getService }: FtrProviderContext) => {
           .send(getCreateExceptionListMinimalSchemaMock())
           .expect(200);
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { item_id, ...itemNoId } = getCreateExceptionListItemMinimalSchemaMock();
 
         // create a simple exception list item
@@ -339,7 +338,6 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should give a 404 if both id and list_id is null', async () => {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { item_id, ...listNoId } = getUpdateMinimalExceptionListItemSchemaMock();
 
         const { body } = await supertest

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/lists_and_exception_lists/exception_lists_items/trial_license_complete_tier/lists/update_exception_lists.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/lists_and_exception_lists/exception_lists_items/trial_license_complete_tier/lists/update_exception_lists.ts
@@ -61,7 +61,6 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should update a single exception list property of name using an auto-generated list_id', async () => {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { list_id, ...listNoId } = getCreateExceptionListMinimalSchemaMock();
 
         // create a simple exception list
@@ -164,7 +163,6 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should give a 404 if both id and list_id is null', async () => {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { list_id, ...listNoId } = getUpdateMinimalExceptionListSchemaMock();
 
         const { body } = await supertest

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/lists_and_exception_lists/utils.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/lists_and_exception_lists/utils.ts
@@ -104,7 +104,6 @@ export const createExceptionListsIndex = async (
 export const removeListServerGeneratedProperties = (
   list: Partial<ListSchema>
 ): Partial<ListSchema> => {
-  /* eslint-disable-next-line @typescript-eslint/naming-convention */
   const { created_at, updated_at, id, tie_breaker_id, _version, '@timestamp': _t, ...props } = list;
   return props;
 };
@@ -116,7 +115,6 @@ export const removeListServerGeneratedProperties = (
 export const removeListItemServerGeneratedProperties = (
   list: Partial<ListItemSchema>
 ): Partial<ListItemSchema> => {
-  /* eslint-disable-next-line @typescript-eslint/naming-convention */
   const { created_at, updated_at, id, tie_breaker_id, _version, '@timestamp': _t, ...props } = list;
   return props;
 };
@@ -128,7 +126,6 @@ export const removeListItemServerGeneratedProperties = (
 export const removeExceptionListItemServerGeneratedProperties = (
   list: Partial<ExceptionListItemSchema>
 ): Partial<ExceptionListItemSchema> => {
-  /* eslint-disable-next-line @typescript-eslint/naming-convention */
   const { created_at, updated_at, id, tie_breaker_id, _version, ...removedProperties } = list;
   return removedProperties;
 };
@@ -140,7 +137,6 @@ export const removeExceptionListItemServerGeneratedProperties = (
 export const removeExceptionListServerGeneratedProperties = (
   list: Partial<ExceptionListSchema>
 ): Partial<ExceptionListSchema> => {
-  /* eslint-disable-next-line @typescript-eslint/naming-convention */
   const { created_at, updated_at, id, tie_breaker_id, _version, ...removedProperties } = list;
   return removedProperties;
 };


### PR DESCRIPTION
## Summary

Manually backporting #244287 to `8.19`.
* First commit changes the ESLINT rules.
* Second commit runs `node scripts/eslint_all_files --no-cache --fix` and manually fixes unintended blank lines.