### PR TITLE
[9.1] [ci] update baseline-browser-mapping through a resolutions field (#248610)

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "**/@types/node": "22.19.1",
     "**/@types/prop-types": "15.7.5",
     "**/@typescript-eslint/utils": "8.46.3",
+    "**/baseline-browser-mapping": "2.9.14",
     "**/chokidar": "^3.5.3",
     "**/d3-scale/**/d3-color": "npm:@elastic/kibana-d3-color@2.0.1",
     "**/globule/minimatch": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15685,10 +15685,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-baseline-browser-mapping@^2.8.25:
-  version "2.8.26"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.26.tgz#2c7e2f840f0ae4d83782bdfe795229a43dfc3e59"
-  integrity sha512-73lC1ugzwoaWCLJ1LvOgrR5xsMLTqSKIEoMHVtL9E/HNk0PXtTM76ZIm84856/SF7Nv8mPZxKoBsgpm0tR1u1Q==
+baseline-browser-mapping@2.9.14, baseline-browser-mapping@^2.8.25:
+  version "2.9.14"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz#3b6af0bc032445bca04de58caa9a87cfe921cbb3"
+  integrity sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==
 
 basic-auth-parser@0.0.2-1:
   version "0.0.2-1"
@@ -16538,7 +16538,7 @@ cheerio@^1.0.0-rc.12, cheerio@^1.0.0-rc.3:
     parse5 "^7.0.0"
     parse5-htmlparser2-tree-adapter "^7.0.0"
 
-chokidar@^2.1.2, chokidar@^2.1.8, chokidar@^3.3.1, chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.5.1, chokidar@^3.5.3, chokidar@^3.6.0:
+chokidar@3.5.3, chokidar@^2.1.2, chokidar@^2.1.8, chokidar@^3.3.1, chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.5.1, chokidar@^3.5.3, chokidar@^3.6.0:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16538,7 +16538,7 @@ cheerio@^1.0.0-rc.12, cheerio@^1.0.0-rc.3:
     parse5 "^7.0.0"
     parse5-htmlparser2-tree-adapter "^7.0.0"
 
-chokidar@3.5.3, chokidar@^2.1.2, chokidar@^2.1.8, chokidar@^3.3.1, chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.5.1, chokidar@^3.5.3, chokidar@^3.6.0:
+chokidar@^2.1.2, chokidar@^2.1.8, chokidar@^3.3.1, chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.5.1, chokidar@^3.5.3, chokidar@^3.6.0:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ci] update baseline-browser-mapping through a resolutions field (#248610)](https://github.com/elastic/kibana/pull/248610)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-01-12T12:19:09Z","message":"[ci] update baseline-browser-mapping through a resolutions field (#248610)\n\n## Summary\nUpdates browser-baseline-mapping as it's causing warnings in the install\nprocess, and some sensitive tests are failing due to that.\n\nFixes: https://github.com/elastic/kibana/issues/89079","sha":"6dacc2afcff47d7c6417618142bfbf291a2d23c9","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open","v9.4.0"],"title":"[ci] update baseline-browser-mapping through a resolutions field","number":248610,"url":"https://github.com/elastic/kibana/pull/248610","mergeCommit":{"message":"[ci] update baseline-browser-mapping through a resolutions field (#248610)\n\n## Summary\nUpdates browser-baseline-mapping as it's causing warnings in the install\nprocess, and some sensitive tests are failing due to that.\n\nFixes: https://github.com/elastic/kibana/issues/89079","sha":"6dacc2afcff47d7c6417618142bfbf291a2d23c9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248610","number":248610,"mergeCommit":{"message":"[ci] update baseline-browser-mapping through a resolutions field (#248610)\n\n## Summary\nUpdates browser-baseline-mapping as it's causing warnings in the install\nprocess, and some sensitive tests are failing due to that.\n\nFixes: https://github.com/elastic/kibana/issues/89079","sha":"6dacc2afcff47d7c6417618142bfbf291a2d23c9"}}]}] BACKPORT-->