### PR TITLE
[Bug] Fix missing agents count

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/basic_metric_badges.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/basic_metric_badges.tsx
@@ -111,7 +111,7 @@ export const BasicMetricBadges = () => {
       metric: [
         agents !== undefined && agents !== null
           ? i18n.translate('xpack.searchHomepage.metricPanel.basic.agentBuilder.agents', {
-              defaultMessage: '{agents} agents',
+              defaultMessage: '{agents, plural, one {# agent} other {# agents}}',
               values: {
                 agents,
               },
@@ -119,7 +119,7 @@ export const BasicMetricBadges = () => {
           : undefined,
         tools !== undefined && tools !== null
           ? i18n.translate('xpack.searchHomepage.metricPanel.basic.agentBuilder.tools', {
-              defaultMessage: '{tools} tools',
+              defaultMessage: '{tools, plural, one {# tool} other {# tools}}',
               values: {
                 tools,
               },

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.test.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { useKibana } from '../use_kibana';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAgentCount } from './use_agent_count';
+
+jest.mock('../use_kibana');
+const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
+const mockToolsService = {
+  list: jest.fn().mockReturnValue(Promise.resolve([])),
+};
+const mockAgentsService = {
+  list: jest.fn().mockReturnValue(Promise.resolve([])),
+};
+const mockAgentBuilderService = {
+  tools: mockToolsService,
+  agents: mockAgentsService,
+};
+
+const queryClient = new QueryClient();
+const wrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('useAgentCount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient.clear();
+
+    // look for better typecasting
+    mockUseKibana.mockReturnValue({
+      services: {
+        agentBuilder: mockAgentBuilderService,
+      } as any,
+    } as any);
+  });
+
+  it('should fetch the agent count', async () => {
+    mockAgentsService.list.mockReturnValue(
+      Promise.resolve([
+        {
+          agent: 'fake-agent',
+        },
+        {
+          agent: 'fake-agent2',
+        },
+      ])
+    );
+    const { result } = renderHook(() => useAgentCount(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+    await waitFor(() => expect(result.current.isError).toBeFalsy());
+    await waitFor(() => expect(result.current.agents).toBe(2));
+  });
+
+  it('should fetch the tools count', async () => {
+    mockToolsService.list.mockReturnValue(
+      Promise.resolve([{ tool: 'fake-tool' }, { tool: 'fake-tool2' }])
+    );
+    const { result } = renderHook(() => useAgentCount());
+
+    await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+    await waitFor(() => expect(result.current.isError).toBeFalsy());
+    await waitFor(() => expect(result.current.tools).toBe(2));
+  });
+
+  it('should set isError when failed', async () => {
+    mockAgentsService.list.mockReturnValue(Promise.reject(new Error()));
+    const { result } = renderHook(() => useAgentCount());
+    await waitFor(() => expect(result.current.isError).toBeTruthy());
+  });
+});

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.test.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.test.tsx
@@ -65,16 +65,10 @@ describe('useAgentCount', () => {
     mockToolsService.list.mockReturnValue(
       Promise.resolve([{ tool: 'fake-tool' }, { tool: 'fake-tool2' }])
     );
-    const { result } = renderHook(() => useAgentCount());
+    const { result } = renderHook(() => useAgentCount(), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBeFalsy());
     await waitFor(() => expect(result.current.isError).toBeFalsy());
     await waitFor(() => expect(result.current.tools).toBe(2));
-  });
-
-  it('should set isError when failed', async () => {
-    mockAgentsService.list.mockReturnValue(Promise.reject(new Error()));
-    const { result } = renderHook(() => useAgentCount());
-    await waitFor(() => expect(result.current.isError).toBeTruthy());
   });
 });

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/api/use_agent_count.ts
@@ -12,6 +12,7 @@ export const useAgentCount = () => {
   const {
     services: { agentBuilder },
   } = useKibana();
+  const [agentCount, setAgentCount] = useState<number>(0);
   const [toolCount, setToolCount] = useState<number>(0);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isError, setIsError] = useState<boolean>(false);
@@ -28,7 +29,16 @@ export const useAgentCount = () => {
       .finally(() => {
         setIsLoading(false);
       });
+    agentBuilder?.agents
+      .list()
+      .then((agents) => {
+        setAgentCount(agents.length);
+      })
+      .catch(setIsError)
+      .finally(() => {
+        setIsLoading(false);
+      });
   }, [agentBuilder]);
 
-  return { tools: toolCount, agents: 0, isLoading, isError };
+  return { tools: toolCount, agents: agentCount, isLoading, isError };
 };


### PR DESCRIPTION
## Summary

Adds missing update for agents count on homepage
<img width="1239" height="258" alt="Screenshot 2026-01-12 at 14 38 46" src="https://github.com/user-attachments/assets/852d94c6-80f6-45bc-b6a1-32df647d9cfa" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release Note

Fixed an issue with agents count not updating in homepage




<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->