### PR TITLE
[Docs] Add logSources missing advanced setting to 8.19 docs

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -400,6 +400,9 @@ value is 10000.
 [[observability-advanced-settings]]
 ==== Observability
 
+[[observability-log-sources]]`observability:logSources`::
+Sources to use for logs data. If the data of these indices is not logs data, you can experience degraded functionality. Changes to this setting can potentially impact the sources queried in Log Threshold rules. `logs-*-*, logs-*, filebeat-*` by default.
+
 [horizontal]
 [[apm-enable-service-overview]]`apm:enableServiceOverview`::
 When enabled, displays the *Overview* tab for services in *APM*.


### PR DESCRIPTION
This PR adds a missing logSources setting to the advanced settings docs

Rel: https://github.com/elastic/docs-content/issues/3487#issuecomment-3738403448
Rel: https://github.com/elastic/sdh-apm/issues/1937

@jennypavlova For context, this will update the 8.19 docs page for these settings: https://www.elastic.co/guide/en/kibana/8.19/advanced-options.html#observability-advanced-settings. 

And not https://www.elastic.co/docs/reference/kibana/advanced-settings#observability-advanced-settings which are the v9 docs


Please advise if this setting should also be added to previous versions.