### PR TITLE
storage adapter for langgraph checkpointer

### DIFF
--- a/src/platform/packages/shared/kbn-storage-adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/index.ts
@@ -17,6 +17,8 @@ import type {
   IndexResponse,
   Result,
   SearchRequest,
+  UpdateRequest,
+  UpdateResponse,
 } from '@elastic/elasticsearch/lib/api/types';
 import type { InferSearchResponseOf } from '@kbn/es-types';
 import type { StorageFieldTypeOf, StorageMappingProperty } from './types';
@@ -91,6 +93,13 @@ export type StorageClientIndexRequest<TDocument = unknown> = Omit<
 
 export type StorageClientIndexResponse = IndexResponse;
 
+export type StorageClientUpdateRequest<TDocument = unknown> = Omit<
+  UpdateRequest<Partial<TDocument>, Partial<TDocument>>,
+  'index'
+>;
+
+export type StorageClientUpdateResponse = UpdateResponse;
+
 export type StorageClientGetRequest = Omit<GetRequest & SearchRequest, 'index'>;
 export type StorageClientGetResponse<TDocument extends { _id?: string }> = GetResponse<TDocument>;
 
@@ -115,6 +124,10 @@ export type StorageClientIndex<TDocumentType = never> = (
   request: StorageClientIndexRequest<TDocumentType>
 ) => Promise<StorageClientIndexResponse>;
 
+export type StorageClientUpdate<TDocumentType = never> = (
+  request: StorageClientUpdateRequest<TDocumentType>
+) => Promise<StorageClientUpdateResponse>;
+
 export type StorageClientDelete = (
   request: StorageClientDeleteRequest
 ) => Promise<StorageClientDeleteResponse>;
@@ -131,6 +144,7 @@ export interface InternalIStorageClient<TDocumentType extends { _id?: string } =
   search: StorageClientSearch<TDocumentType>;
   bulk: StorageClientBulk<TDocumentType>;
   index: StorageClientIndex<TDocumentType>;
+  update: StorageClientUpdate<TDocumentType>;
   delete: StorageClientDelete;
   clean: StorageClientClean;
   get: StorageClientGet<TDocumentType>;

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
@@ -37,6 +37,8 @@ import type {
   StorageClientSearchResponse,
   StorageClientClean,
   StorageClientCleanResponse,
+  StorageClientUpdate,
+  StorageClientUpdateResponse,
   InternalIStorageClient,
 } from '../..';
 import { getSchemaVersion } from '../get_schema_version';
@@ -350,6 +352,75 @@ export class StorageIndexAdapter<
     });
   };
 
+  private update: StorageClientUpdate<TApplicationType> = async ({
+    id,
+    refresh = 'wait_for',
+    ...request
+  }): Promise<StorageClientUpdateResponse> => {
+    this.logger.debug(`Updating document with id ${id}`);
+
+    // First, find which index the document is in
+    const searchResponse = await this.search({
+      track_total_hits: false,
+      size: 1,
+      query: {
+        bool: {
+          filter: [
+            {
+              term: {
+                _id: id,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const document = searchResponse.hits.hits[0];
+    const isUpsert = request.doc_as_upsert === true || request.upsert !== undefined;
+
+    // If document doesn't exist and upsert is not enabled, throw 404
+    if (!document && !isUpsert) {
+      throw new errors.ResponseError({
+        meta: {
+          aborted: false,
+          attempts: 1,
+          connection: null,
+          context: null,
+          name: 'resource_not_found_exception',
+          request: {} as unknown as DiagnosticResult['meta']['request'],
+        },
+        warnings: [],
+        body: 'resource_not_found_exception',
+        statusCode: 404,
+      });
+    }
+
+    // Use the document's index if it exists, otherwise use the write target for upserts
+    const targetIndex = document?._index ?? this.getWriteTarget();
+
+    const attemptUpdate = async () => {
+      return wrapEsCall(
+        this.esClient.update({
+          ...request,
+          id,
+          refresh,
+          index: targetIndex,
+          require_alias: !document, // Only require alias for upserts
+        })
+      );
+    };
+
+    // For upserts to a new index, validate components first
+    const updateResponse = !document
+      ? await this.validateComponentsBeforeWriting(attemptUpdate)
+      : await attemptUpdate();
+
+    this.logger.debug(() => `Updated document ${id} in ${updateResponse._index}`);
+
+    return updateResponse;
+  };
+
   private bulk: StorageClientBulk<TApplicationType> = ({
     operations,
     refresh = 'wait_for',
@@ -559,6 +630,7 @@ export class StorageIndexAdapter<
       delete: this.delete,
       clean: this.clean,
       index: this.index,
+      update: this.update,
       search: this.search,
       get: this.get,
       existsIndex: this.existsIndex,

--- a/src/platform/packages/shared/kbn-storage-adapter/types.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/types.ts
@@ -23,6 +23,7 @@ type StorageMappingPropertyType = AllMappingPropertyType &
     | 'float'
     | 'double'
     | 'long'
+    | 'binary'
     | 'object'
   );
 
@@ -72,6 +73,7 @@ const types = {
   date: createFactory('date', { format: 'strict_date_optional_time' }),
   byte: createFactory('byte'),
   float: createFactory('float'),
+  binary: createFactory('binary'),
   object: createFactory('object'),
 } satisfies {
   [TKey in StorageMappingPropertyType]: MappingPropertyFactory<TKey, any>;
@@ -91,6 +93,7 @@ type PrimitiveOf<TProperty extends StorageMappingProperty> = {
   long: number;
   byte: number;
   float: number;
+  binary: string;
   object: TProperty extends { properties: Record<string, StorageMappingProperty> }
     ? {
         [key in keyof TProperty['properties']]?: StorageFieldTypeOf<TProperty['properties'][key]>;

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/index.ts
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { ElasticSearchSaver } from './server/elastic-search-checkpoint-saver';
+export type { ElasticSearchSaverParams } from './server/elastic-search-checkpoint-saver';
+
+export {
+  createCheckpointerClient,
+  CheckpointerServiceImpl,
+  createCheckpointsStorage,
+  createCheckpointWritesStorage,
+  getCheckpointsIndexName,
+  getCheckpointWritesIndexName,
+} from './server/storage-adapter-checkpoint-saver';
+export type {
+  CreateCheckpointerClientOptions,
+  CheckpointerService,
+  CheckpointerServiceOptions,
+  CheckpointStorageOptions,
+  CheckpointProperties,
+  CheckpointWriteProperties,
+  CheckpointsStorage,
+  CheckpointWritesStorage,
+} from './server/storage-adapter-checkpoint-saver';

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/moon.yml
@@ -21,7 +21,7 @@ dependsOn:
   - '@kbn/core-test-helpers-kbn-server'
   - '@kbn/core'
   - '@kbn/core-logging-server-mocks'
-  - '@kbn/core-saved-objects-utils-server'
+  - '@kbn/storage-adapter'
 tags:
   - shared-server
   - package

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/README.md
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/README.md
@@ -1,0 +1,271 @@
+# Storage Adapter Checkpoint Saver
+
+A LangGraph checkpoint saver implementation that uses Elasticsearch for persistent storage, integrated with Kibana's Storage Index Adapter pattern for automatic index management.
+
+## Overview
+
+The `storage-adapter-checkpoint-saver` package provides a checkpoint saver for LangGraph that:
+- Stores checkpoints and checkpoint writes in Elasticsearch indices
+- Automatically creates and manages indices using the Storage Index Adapter pattern
+- Supports scoped Elasticsearch clients for security context handling
+- Provides both direct client creation and service-based patterns
+
+## Installation
+
+```ts
+import {
+  createCheckpointerClient,
+  CheckpointerServiceImpl,
+  type CheckpointerService,
+} from '@kbn/langgraph-checkpoint-saver/server';
+```
+
+## Usage
+
+### Option 1: Direct Client Creation
+
+Use `createCheckpointerClient` when you have direct access to an Elasticsearch client and logger:
+
+```ts
+import { createCheckpointerClient } from '@kbn/langgraph-checkpoint-saver/server';
+import type { Logger, ElasticsearchClient } from '@kbn/core/server';
+
+// Create a checkpointer client
+const checkpointer = createCheckpointerClient({
+  indexPrefix: '.chat-', // Creates indices: .chat-checkpoints, .chat-checkpoint-writes
+  logger: core.logger.get('checkpointer'),
+  esClient: elasticsearch.client.asInternalUser,
+});
+
+// Use with LangGraph
+const graph = new StateGraph({...})
+  .compile({
+    checkpointer,
+  });
+```
+
+### Option 2: Service Pattern (Recommended for Plugins)
+
+Use `CheckpointerServiceImpl` when you need request-scoped checkpointers that respect the user's security context:
+
+```ts
+import { CheckpointerServiceImpl } from '@kbn/langgraph-checkpoint-saver/server';
+import type { CheckpointerService } from '@kbn/langgraph-checkpoint-saver/server';
+
+// In plugin setup
+export class MyPlugin {
+  private checkpointerService?: CheckpointerService;
+
+  setup(core: CoreSetup) {
+    // Service is created but not initialized yet
+  }
+
+  start(core: CoreStart) {
+    // Initialize the service
+    this.checkpointerService = new CheckpointerServiceImpl({
+      indexPrefix: '.chat-',
+      logger: core.logger.get('checkpointer'),
+      elasticsearch: core.elasticsearch,
+    });
+
+    return {
+      getCheckpointerService: () => this.checkpointerService!,
+    };
+  }
+}
+
+// In route handler
+router.post(
+  { path: '/api/my-route', validate: false },
+  async (context, request, response) => {
+    // Get a scoped checkpointer for this request
+    const checkpointer = await checkpointerService.getCheckpointer({ request });
+
+    // Use with LangGraph
+    const graph = new StateGraph({...})
+      .compile({
+        checkpointer,
+      });
+
+    // ... rest of handler
+  }
+);
+```
+
+## Index Naming
+
+The package creates two indices based on the provided prefix:
+
+- **Checkpoints Index**: `{prefix}checkpoints`
+  - Example: `.chat-checkpoints` (with prefix `.chat-`)
+  - Stores checkpoint snapshots
+
+- **Checkpoint Writes Index**: `{prefix}checkpoint-writes`
+  - Example: `.chat-checkpoint-writes` (with prefix `.chat-`)
+  - Stores checkpoint write operations
+
+### Index Prefix Guidelines
+
+- Use dot-prefixed names for system indices (e.g., `.chat-`, `.observability-`, `.security-`)
+- Choose a prefix that matches your solution or plugin name
+- Ensure the prefix is unique to avoid conflicts
+
+## Index Schema
+
+### Checkpoints Index Schema
+
+```ts
+{
+  '@timestamp': Date,
+  thread_id: string,
+  checkpoint_ns: string,
+  checkpoint_id: string,
+  parent_checkpoint_id: string,
+  type: string,
+  checkpoint: Binary, // Serialized checkpoint data
+  metadata: Binary,   // Serialized metadata
+}
+```
+
+### Checkpoint Writes Index Schema
+
+```ts
+{
+  '@timestamp': Date,
+  thread_id: string,
+  checkpoint_ns: string,
+  checkpoint_id: string,
+  task_id: string,
+  idx: number,
+  channel: string,
+  type: string,
+  value: Binary, // Serialized write value
+}
+```
+
+## Automatic Index Management
+
+The package uses Kibana's Storage Index Adapter pattern, which means:
+
+- **Indices are created automatically** on first write
+- **Index templates are managed** by the storage adapter
+- **Mappings are applied** according to the defined schema
+- **No manual index setup required**
+
+## Integration with LangGraph
+
+The returned `ElasticSearchSaver` instance implements LangGraph's `BaseCheckpointSaver` interface and can be used directly with LangGraph:
+
+```ts
+import { StateGraph } from '@langchain/langgraph';
+
+const graph = new StateGraph({
+  channels: {
+    // Your state channels
+  },
+})
+  .addNode('node1', node1Function)
+  .addNode('node2', node2Function)
+  .addEdge('node1', 'node2')
+  .compile({
+    checkpointer, // Use the checkpointer here
+  });
+
+// Invoke with thread_id for checkpoint persistence
+const result = await graph.invoke(
+  { /* initial state */ },
+  { configurable: { thread_id: 'my-thread-id' } }
+);
+```
+
+## API Reference
+
+### `createCheckpointerClient(options)`
+
+Creates a checkpointer client instance.
+
+**Parameters:**
+- `options.indexPrefix` (string): Index name prefix (e.g., `.chat-`)
+- `options.logger` (Logger): Kibana logger instance
+- `options.esClient` (ElasticsearchClient): Elasticsearch client
+
+**Returns:** `ElasticSearchSaver` instance
+
+### `CheckpointerServiceImpl`
+
+Service class for managing request-scoped checkpointers.
+
+**Constructor Options:**
+- `options.indexPrefix` (string): Index name prefix
+- `options.logger` (Logger): Kibana logger instance
+- `options.elasticsearch` (ElasticsearchServiceStart): Elasticsearch service
+
+**Methods:**
+- `getCheckpointer({ request })`: Returns a scoped checkpointer for the given request
+
+## Examples
+
+### Basic Usage in a Plugin
+
+```ts
+// plugin.ts
+import { CheckpointerServiceImpl } from '@kbn/langgraph-checkpoint-saver/server';
+
+export class MyPlugin implements Plugin {
+  private checkpointerService?: CheckpointerService;
+
+  start(core: CoreStart) {
+    this.checkpointerService = new CheckpointerServiceImpl({
+      indexPrefix: '.my-plugin-',
+      logger: core.logger.get('my-plugin'),
+      elasticsearch: core.elasticsearch,
+    });
+
+    return {
+      checkpointerService: this.checkpointerService,
+    };
+  }
+}
+
+// routes.ts
+router.post(
+  { path: '/api/my-action', validate: false },
+  async (context, request, response) => {
+    const checkpointer = await checkpointerService.getCheckpointer({ request });
+    
+    const graph = createMyGraph(checkpointer);
+    const result = await graph.invoke(
+      { input: request.body.input },
+      { configurable: { thread_id: request.body.threadId } }
+    );
+
+    return response.ok({ body: result });
+  }
+);
+```
+
+### Direct Client Usage
+
+```ts
+import { createCheckpointerClient } from '@kbn/langgraph-checkpoint-saver/server';
+
+// In a service or utility function
+function createMyGraph(esClient: ElasticsearchClient, logger: Logger) {
+  const checkpointer = createCheckpointerClient({
+    indexPrefix: '.my-service-',
+    logger,
+    esClient,
+  });
+
+  return new StateGraph({...})
+    .compile({ checkpointer });
+}
+```
+
+## Notes
+
+- The checkpointer uses `wait_for` refresh policy by default for consistency
+- Checkpoints are stored as binary data (serialized)
+- Thread IDs are used to scope checkpoints to specific conversation threads
+- The service pattern automatically handles security context scoping for multi-tenancy
+

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/elastic-search-checkpoint-saver/index.ts
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/elastic-search-checkpoint-saver/index.ts
@@ -213,12 +213,12 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
       parentConfig:
         doc.parent_checkpoint_id != null
           ? {
-            configurable: {
-              thread_id: threadId,
-              checkpoint_ns: checkpointNs,
-              checkpoint_id: doc.parent_checkpoint_id,
-            },
-          }
+              configurable: {
+                thread_id: threadId,
+                checkpoint_ns: checkpointNs,
+                checkpoint_id: doc.parent_checkpoint_id,
+              },
+            }
           : undefined,
     };
   }
@@ -290,12 +290,12 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
         metadata,
         parentConfig: source.parent_checkpoint_id
           ? {
-            configurable: {
-              thread_id: source.thread_id,
-              checkpoint_ns: source.checkpoint_ns,
-              checkpoint_id: source.parent_checkpoint_id,
-            },
-          }
+              configurable: {
+                thread_id: source.thread_id,
+                checkpoint_ns: source.checkpoint_ns,
+                checkpoint_id: source.parent_checkpoint_id,
+              },
+            }
           : undefined,
       };
     }
@@ -347,7 +347,7 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
     // Use storage adapter which handles index creation automatically
     await this.checkpointsStorage.update({
       id: compositeId,
-      doc: doc,
+      doc,
       doc_as_upsert: true,
       refresh: this.refreshPolicy,
       retry_on_conflict: 3,
@@ -437,7 +437,6 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
           `Failed to index writes for checkpoint ${checkpointId}. Errors: ${errorDetails}`
         );
       }
-
     } catch (error) {
       console.error(error);
       throw new Error(`Failed to index writes for checkpoint ${checkpointId}`);
@@ -445,5 +444,5 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
   }
 
   // TODO: Implement this
-  async deleteThread() { }
+  async deleteThread() {}
 }

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/elastic-search-checkpoint-saver/index.ts
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/elastic-search-checkpoint-saver/index.ts
@@ -6,7 +6,7 @@
  */
 
 import type { estypes } from '@elastic/elasticsearch';
-import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { Logger } from '@kbn/core/server';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { CheckpointPendingWrite } from '@langchain/langgraph-checkpoint';
 import {
@@ -18,8 +18,10 @@ import {
   type PendingWrite,
   type CheckpointMetadata,
 } from '@langchain/langgraph-checkpoint';
+import type { InternalIStorageClient } from '@kbn/storage-adapter';
 
 interface CheckpointDocument {
+  _id?: string;
   '@timestamp': string;
   thread_id: string;
   checkpoint_ns: string;
@@ -30,7 +32,8 @@ interface CheckpointDocument {
   metadata: string;
 }
 
-interface WritesDocument {
+interface CheckpointWriteDocument {
+  _id?: string;
   '@timestamp': string;
   thread_id: string;
   checkpoint_ns: string;
@@ -38,16 +41,24 @@ interface WritesDocument {
   task_id: string;
   idx: number;
   channel: string;
-  value: string;
   type: string;
+  value: string;
 }
-
 export interface ElasticSearchSaverParams {
-  client: ElasticsearchClient;
   logger: Logger;
   checkpointIndex?: string;
   checkpointWritesIndex?: string;
   refreshPolicy?: estypes.Refresh;
+  /**
+   * Storage adapter for checkpoints index.
+   * Ensures index templates and indices are created automatically.
+   */
+  checkpointsStorage: InternalIStorageClient<CheckpointDocument>;
+  /**
+   * Storage adapter for checkpoint writes index.
+   * Ensures index templates and indices are created automatically.
+   */
+  checkpointWritesStorage: InternalIStorageClient<CheckpointWriteDocument>;
 }
 
 /**
@@ -58,44 +69,6 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
 
   static defaultCheckpointWritesIndex = 'checkpoint_writes';
 
-  /**
-   * When modifying the field maps, ensure you perform upgrade testing for all graphs depending on this saver.
-   */
-  static readonly checkpointsFieldMap = {
-    '@timestamp': {
-      type: 'date',
-      required: true,
-      array: false,
-    },
-    thread_id: { type: 'keyword', required: true, array: false },
-    checkpoint_ns: { type: 'keyword', required: true, array: false },
-    checkpoint_id: { type: 'keyword', required: false, array: false },
-    parent_checkpoint_id: { type: 'keyword', required: true, array: false },
-    type: { type: 'keyword', required: true, array: false },
-    checkpoint: { type: 'binary', required: true, array: false },
-    metadata: { type: 'binary', required: true, array: false },
-  } as const;
-
-  /**
-   * When modifying the field maps, ensure you perform upgrade testing for all graphs depending on this saver.
-   */
-  static readonly checkpointWritesFieldMap = {
-    '@timestamp': {
-      type: 'date',
-      required: true,
-      array: false,
-    },
-    thread_id: { type: 'keyword', required: true, array: false },
-    checkpoint_ns: { type: 'keyword', required: true, array: false },
-    checkpoint_id: { type: 'keyword', required: true, array: false },
-    task_id: { type: 'keyword', required: true, array: false },
-    idx: { type: 'unsigned_long', required: true, array: false },
-    channel: { type: 'keyword', required: true, array: false },
-    type: { type: 'keyword', required: true, array: false },
-    value: { type: 'binary', required: true, array: false },
-  } as const;
-
-  protected client: ElasticsearchClient;
   protected logger: Logger;
 
   checkpointIndex: string;
@@ -104,23 +77,28 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
 
   refreshPolicy: estypes.Refresh = 'wait_for';
 
+  private checkpointsStorage: InternalIStorageClient<CheckpointDocument>;
+  private checkpointWritesStorage: InternalIStorageClient<CheckpointWriteDocument>;
+
   constructor(
     {
-      client,
       checkpointIndex,
       checkpointWritesIndex,
       refreshPolicy = 'wait_for',
       logger,
+      checkpointsStorage,
+      checkpointWritesStorage,
     }: ElasticSearchSaverParams,
     serde?: SerializerProtocol
   ) {
     super(serde);
-    this.client = client;
     this.checkpointIndex = checkpointIndex ?? ElasticSearchSaver.defaultCheckpointIndex;
     this.checkpointWritesIndex =
       checkpointWritesIndex ?? ElasticSearchSaver.defaultCheckpointWritesIndex;
     this.refreshPolicy = refreshPolicy;
     this.logger = logger;
+    this.checkpointsStorage = checkpointsStorage;
+    this.checkpointWritesStorage = checkpointWritesStorage;
   }
 
   /**
@@ -136,8 +114,8 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
       checkpoint_id: checkpointId,
     } = config.configurable ?? {};
 
-    const result = await this.client.search<CheckpointDocument>({
-      index: this.checkpointIndex,
+    const result = await this.checkpointsStorage.search({
+      track_total_hits: true,
       size: 1,
       sort: [{ checkpoint_id: { order: 'desc' } }],
       query: {
@@ -151,14 +129,17 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
       },
     });
 
-    if (result.hits.hits.length === 0 || result.hits.hits[0]?._source === undefined) {
+    const hit = result.hits.hits.at(0);
+
+    if (!hit) {
       return undefined;
     }
 
-    const doc = result.hits.hits[0]._source;
+    const doc = hit._source;
 
-    const serializedWrites = await this.client.search<WritesDocument>({
-      index: this.checkpointWritesIndex,
+    const serializedWrites = await this.checkpointWritesStorage.search({
+      track_total_hits: true,
+      size: 10000,
       sort: [{ idx: { order: 'asc' } }],
       query: {
         bool: {
@@ -203,7 +184,7 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
 
     const pendingWrites: CheckpointPendingWrite[] = await Promise.all(
       serializedWrites.hits.hits.map(async (serializedWrite) => {
-        const source = serializedWrite._source!;
+        const source = serializedWrite._source;
         return [
           source.task_id,
           source.channel,
@@ -232,12 +213,12 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
       parentConfig:
         doc.parent_checkpoint_id != null
           ? {
-              configurable: {
-                thread_id: threadId,
-                checkpoint_ns: checkpointNs,
-                checkpoint_id: doc.parent_checkpoint_id,
-              },
-            }
+            configurable: {
+              thread_id: threadId,
+              checkpoint_ns: checkpointNs,
+              checkpoint_id: doc.parent_checkpoint_id,
+            },
+          }
           : undefined,
     };
   }
@@ -252,7 +233,7 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
     options?: CheckpointListOptions
   ): AsyncGenerator<CheckpointTuple> {
     const { limit, before } = options ?? {};
-    const mustClauses = [];
+    const mustClauses: estypes.QueryDslQueryContainer[] = [];
 
     if (config?.configurable?.thread_id) {
       mustClauses.push({ term: { thread_id: config.configurable.thread_id } });
@@ -273,9 +254,9 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
       });
     }
 
-    const result = await this.client.search<CheckpointDocument>({
-      index: this.checkpointIndex,
-      ...(limit ? { size: limit } : {}),
+    const result = await this.checkpointsStorage.search({
+      track_total_hits: true,
+      ...(limit ? { size: limit } : { size: 10000 }),
       sort: [{ checkpoint_id: { order: 'desc' } }, { '@timestamp': { order: 'desc' } }],
       query: {
         bool: {
@@ -286,7 +267,7 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
 
     for await (const hit of result.hits.hits) {
       const source = hit._source;
-      if (source === undefined) {
+      if (!source) {
         continue;
       }
       const checkpoint = (await this.serde.loadsTyped(
@@ -309,12 +290,12 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
         metadata,
         parentConfig: source.parent_checkpoint_id
           ? {
-              configurable: {
-                thread_id: source.thread_id,
-                checkpoint_ns: source.checkpoint_ns,
-                checkpoint_id: source.parent_checkpoint_id,
-              },
-            }
+            configurable: {
+              thread_id: source.thread_id,
+              checkpoint_ns: source.checkpoint_ns,
+              checkpoint_id: source.parent_checkpoint_id,
+            },
+          }
           : undefined,
       };
     }
@@ -363,12 +344,13 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
 
     const compositeId = `thread_id:${threadId}|checkpoint_ns:${checkpointNs}|checkpoint_id:${checkpointId}`;
 
-    await this.client.update({
-      index: this.checkpointIndex,
+    // Use storage adapter which handles index creation automatically
+    await this.checkpointsStorage.update({
       id: compositeId,
-      doc,
+      doc: doc,
       doc_as_upsert: true,
       refresh: this.refreshPolicy,
+      retry_on_conflict: 3,
     });
 
     return {
@@ -396,54 +378,72 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
       );
     }
 
-    const operations = (
-      await Promise.all(
-        writes.map(async (write, idx) => {
-          const [channel, value] = write;
+    // Use storage adapter which handles index creation automatically
+    const operations = await Promise.all(
+      writes.map(async (write, idx) => {
+        const [channel, value] = write;
 
-          const compositeId = `thread_id:${threadId}|checkpoint_ns:${checkpointNs}|checkpoint_id:${checkpointId}|task_id:${taskId}|idx:${idx}`;
-          const [type, serializedValue] = await this.serde.dumpsTyped(value);
+        const compositeId = `thread_id:${threadId}|checkpoint_ns:${checkpointNs}|checkpoint_id:${checkpointId}|task_id:${taskId}|idx:${idx}`;
+        const [type, serializedValue] = await this.serde.dumpsTyped(value);
 
-          const doc: WritesDocument = {
-            '@timestamp': new Date().toISOString(),
-            thread_id: threadId,
-            checkpoint_ns: checkpointNs,
-            checkpoint_id: checkpointId,
-            task_id: taskId,
-            idx,
-            channel,
-            value: Buffer.from(serializedValue).toString('base64'),
-            type,
-          };
+        const doc = {
+          '@timestamp': new Date().toISOString(),
+          thread_id: threadId,
+          checkpoint_ns: checkpointNs,
+          checkpoint_id: checkpointId,
+          task_id: taskId,
+          idx,
+          channel,
+          value: Buffer.from(serializedValue).toString('base64'),
+          type,
+        };
 
-          this.logger.debug(`Indexing write operation for checkpoint ${checkpointId}`);
+        this.logger.debug(`Upserting write operation for checkpoint ${checkpointId}`);
 
-          return [
-            {
-              update: {
-                _index: this.checkpointWritesIndex,
-                _id: compositeId,
-              },
-            },
-            { doc, doc_as_upsert: true },
-          ];
-        })
-      )
-    ).flat();
+        return {
+          update: {
+            _id: compositeId,
+            doc,
+            doc_as_upsert: true,
+            retry_on_conflict: 3,
+          },
+        };
+      })
+    );
 
-    const result = await this.client.bulk({
-      operations,
-      refresh: this.refreshPolicy,
-      error_trace: true,
-    });
+    try {
+      const result = await this.checkpointWritesStorage.bulk({
+        operations,
+        refresh: this.refreshPolicy,
+      });
 
-    if (result.errors) {
-      this.logger.error(`Failed to index writes for checkpoint ${checkpointId}`);
+      if (result.errors) {
+        const errorDetails = result.items
+          .map((item, idx) => {
+            const operation = item.update || item.index || item.delete;
+            if (operation?.error) {
+              return `Operation ${idx}: ${JSON.stringify(operation.error)}`;
+            }
+            return null;
+          })
+          .filter(Boolean)
+          .join(', ');
 
+        console.error(errorDetails);
+        this.logger.error(
+          `Failed to index writes for checkpoint ${checkpointId}. Errors: ${errorDetails}`
+        );
+        throw new Error(
+          `Failed to index writes for checkpoint ${checkpointId}. Errors: ${errorDetails}`
+        );
+      }
+
+    } catch (error) {
+      console.error(error);
       throw new Error(`Failed to index writes for checkpoint ${checkpointId}`);
     }
   }
 
   // TODO: Implement this
-  async deleteThread() {}
+  async deleteThread() { }
 }

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/elastic-search-checkpoint-saver/index.ts
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/elastic-search-checkpoint-saver/index.ts
@@ -401,11 +401,9 @@ export class ElasticSearchSaver extends BaseCheckpointSaver {
         this.logger.debug(`Upserting write operation for checkpoint ${checkpointId}`);
 
         return {
-          update: {
+          index: {
             _id: compositeId,
-            doc,
-            doc_as_upsert: true,
-            retry_on_conflict: 3,
+            document: doc,
           },
         };
       })

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/elastic-search-checkpoint-saver/integration_tests/elastic_search_checkpoint_saver.test.ts
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/elastic-search-checkpoint-saver/integration_tests/elastic_search_checkpoint_saver.test.ts
@@ -11,8 +11,11 @@ import { Client as ESClient } from '@elastic/elasticsearch';
 import { ElasticSearchSaver } from '..';
 import type { Checkpoint, CheckpointTuple } from '@langchain/langgraph-checkpoint';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
-import { DEFAULT_NAMESPACE_STRING } from '@kbn/core-saved-objects-utils-server';
 import { uuid6 } from '@langchain/langgraph-checkpoint';
+import {
+  createCheckpointsStorage,
+  createCheckpointWritesStorage,
+} from '../../storage-adapter-checkpoint-saver/storage';
 
 const mockLoggerFactory = loggingSystemMock.create();
 const mockLogger = mockLoggerFactory.get('mock logger');
@@ -76,47 +79,6 @@ describe('ElasticSearchSaver', () => {
     });
   });
 
-  async function setupIndices(esClient: ESClient): Promise<void> {
-    // Set up checkpoints index
-    const checkpointIndexName = `checkpoints-${DEFAULT_NAMESPACE_STRING}`;
-    await esClient.indices.create({
-      index: checkpointIndexName,
-      mappings: {
-        properties: {
-          // TODO(@KDKHD) Replace this field map with the one from ElasticSearchSaver.
-          '@timestamp': { type: 'date' },
-          thread_id: { type: 'keyword' },
-          checkpoint_ns: { type: 'keyword' },
-          checkpoint_id: { type: 'keyword' },
-          parent_checkpoint_id: { type: 'keyword' },
-          type: { type: 'keyword' },
-          checkpoint: { type: 'binary' },
-          metadata: { type: 'binary' },
-        },
-      },
-    });
-
-    // Set up checkpoint-writes index
-    const checkpointWritesIndexName = `checkpoint-writes-${DEFAULT_NAMESPACE_STRING}`;
-    await esClient.indices.create({
-      index: checkpointWritesIndexName,
-      mappings: {
-        properties: {
-          // TODO(@KDKHD) Replace this field map with the one from ElasticSearchSaver.
-          '@timestamp': { type: 'date' },
-          thread_id: { type: 'keyword' },
-          checkpoint_ns: { type: 'keyword' },
-          checkpoint_id: { type: 'keyword' },
-          task_id: { type: 'keyword' },
-          idx: { type: 'unsigned_long' },
-          channel: { type: 'keyword' },
-          type: { type: 'keyword' },
-          value: { type: 'binary' },
-        },
-      },
-    });
-  }
-
   async function deleteIndices(indexPattern: string) {
     // Use indices.get to find indices matching the pattern
     const response = await client.indices
@@ -142,19 +104,32 @@ describe('ElasticSearchSaver', () => {
 
   beforeEach(async () => {
     // Clean up indices before each test
-    await deleteIndices('checkpoints*');
-    await deleteIndices('checkpoint-writes*');
+    await deleteIndices('.chat-checkpoints*');
+    await deleteIndices('.chat-checkpoint-writes*');
 
-    // Re-setup indices for each test
-    await setupIndices(client);
+    const checkpointIndexPrefix = '.chat-';
+
+    // Create storage adapters - they will create indices automatically on first write
+    const checkpointsStorage = createCheckpointsStorage({
+      indexPrefix: checkpointIndexPrefix,
+      logger: mockLogger,
+      esClient: client,
+    });
+
+    const checkpointWritesStorage = createCheckpointWritesStorage({
+      indexPrefix: checkpointIndexPrefix,
+      logger: mockLogger,
+      esClient: client,
+    });
 
     // Create a fresh saver for each test
     saver = new ElasticSearchSaver({
-      client,
       refreshPolicy: 'wait_for',
       logger: mockLogger,
-      checkpointIndex: `${ElasticSearchSaver.defaultCheckpointIndex}-${DEFAULT_NAMESPACE_STRING}`,
-      checkpointWritesIndex: `${ElasticSearchSaver.defaultCheckpointWritesIndex}-${DEFAULT_NAMESPACE_STRING}`,
+      checkpointIndex: `${checkpointIndexPrefix}${ElasticSearchSaver.defaultCheckpointIndex}`,
+      checkpointWritesIndex: `${checkpointIndexPrefix}${ElasticSearchSaver.defaultCheckpointWritesIndex}`,
+      checkpointsStorage: checkpointsStorage.getClient(),
+      checkpointWritesStorage: checkpointWritesStorage.getClient(),
     });
   });
 
@@ -267,4 +242,280 @@ describe('ElasticSearchSaver', () => {
       expect(checkpointTuple2.checkpoint.ts).toBe('2025-07-22T17:42:34.754Z');
     }
   );
+
+  describe('upsert operations', () => {
+    it('should upsert checkpoint when calling put with the same checkpoint_id', async () => {
+      const initialCheckpoint: Checkpoint = {
+        v: 1,
+        id: uuid6(-1),
+        ts: '2025-07-22T17:42:34.754Z',
+        channel_values: {
+          initialKey: 'initialValue',
+        },
+        channel_versions: {
+          version: 1,
+        },
+        versions_seen: {
+          seen: {
+            initial: 1,
+          },
+        },
+      };
+
+      const updatedCheckpoint: Checkpoint = {
+        v: 1,
+        id: initialCheckpoint.id, // Same ID
+        ts: initialCheckpoint.ts, // Same timestamp
+        channel_values: {
+          initialKey: 'updatedValue', // Changed value
+          newKey: 'newValue', // Added new key
+        },
+        channel_versions: {
+          version: 2, // Updated version
+        },
+        versions_seen: {
+          seen: {
+            initial: 2,
+          },
+        },
+      };
+
+      // Save initial checkpoint
+      await saver.put(
+        { configurable: { thread_id: THREAD_ID, checkpoint_ns: CHECKPOINT_NS } },
+        initialCheckpoint,
+        {
+          source: 'update',
+          step: -1,
+          parents: {},
+        }
+      );
+
+      // Verify initial checkpoint was saved
+      const firstTuple = await saver.getTuple({
+        configurable: { thread_id: THREAD_ID, checkpoint_ns: CHECKPOINT_NS },
+      });
+      expect(firstTuple?.checkpoint.channel_values).toEqual({ initialKey: 'initialValue' });
+
+      // Upsert with updated checkpoint (same ID)
+      await saver.put(
+        { configurable: { thread_id: THREAD_ID, checkpoint_ns: CHECKPOINT_NS } },
+        updatedCheckpoint,
+        {
+          source: 'update',
+          step: -1,
+          parents: {},
+        }
+      );
+
+      // Verify checkpoint was updated, not duplicated
+      const updatedTuple = await saver.getTuple({
+        configurable: { thread_id: THREAD_ID, checkpoint_ns: CHECKPOINT_NS },
+      });
+      expect(updatedTuple?.checkpoint.channel_values).toEqual({
+        initialKey: 'updatedValue',
+        newKey: 'newValue',
+      });
+      expect(updatedTuple?.checkpoint.channel_versions.version).toBe(2);
+
+      // List all checkpoints and verify only one exists
+      const checkpointTupleGenerator = saver.list({
+        configurable: { thread_id: THREAD_ID, checkpoint_ns: CHECKPOINT_NS },
+      });
+      const checkpointTuples: CheckpointTuple[] = [];
+      for await (const checkpoint of checkpointTupleGenerator) {
+        checkpointTuples.push(checkpoint);
+      }
+      expect(checkpointTuples.length).toBe(1);
+      expect(checkpointTuples[0].checkpoint.id).toBe(initialCheckpoint.id);
+    });
+
+    it('should upsert writes when calling putWrites multiple times with the same checkpoint_id', async () => {
+      const testCheckpoint: Checkpoint = {
+        v: 1,
+        id: uuid6(-1),
+        ts: '2025-07-22T17:42:34.754Z',
+        channel_values: {
+          someKey: 'someValue',
+        },
+        channel_versions: {
+          version: 1,
+        },
+        versions_seen: {},
+      };
+
+      // Save checkpoint first
+      await saver.put(
+        { configurable: { thread_id: THREAD_ID, checkpoint_ns: CHECKPOINT_NS } },
+        testCheckpoint,
+        {
+          source: 'update',
+          step: -1,
+          parents: {},
+        }
+      );
+
+      // Add first set of writes
+      await saver.putWrites(
+        {
+          configurable: {
+            checkpoint_id: testCheckpoint.id,
+            checkpoint_ns: CHECKPOINT_NS,
+            thread_id: THREAD_ID,
+          },
+        },
+        [['write1', 'data1']],
+        'task1'
+      );
+
+      // Verify first writes
+      const firstTuple = await saver.getTuple({
+        configurable: { thread_id: THREAD_ID, checkpoint_ns: CHECKPOINT_NS },
+      });
+      expect(firstTuple?.pendingWrites).toEqual([['task1', 'write1', 'data1']]);
+
+      // Add second set of writes with same checkpoint_id
+      await saver.putWrites(
+        {
+          configurable: {
+            checkpoint_id: testCheckpoint.id,
+            checkpoint_ns: CHECKPOINT_NS,
+            thread_id: THREAD_ID,
+          },
+        },
+        [['write2', 'data2']],
+        'task2'
+      );
+
+      // Verify both writes are present
+      const secondTuple = await saver.getTuple({
+        configurable: { thread_id: THREAD_ID, checkpoint_ns: CHECKPOINT_NS },
+      });
+      expect(secondTuple?.pendingWrites).toHaveLength(2);
+      expect(secondTuple?.pendingWrites).toEqual(
+        expect.arrayContaining([
+          ['task1', 'write1', 'data1'],
+          ['task2', 'write2', 'data2'],
+        ])
+      );
+    });
+
+    it('should handle multiple upserts of the same checkpoint in rapid succession', async () => {
+      const checkpointId = uuid6(-1);
+      const baseCheckpoint: Checkpoint = {
+        v: 1,
+        id: checkpointId,
+        ts: '2025-07-22T17:42:34.754Z',
+        channel_values: {},
+        channel_versions: {},
+        versions_seen: {},
+      };
+
+      // Perform multiple rapid upserts
+      const upsertPromises = [];
+      for (let i = 0; i < 5; i++) {
+        const checkpoint = {
+          ...baseCheckpoint,
+          channel_values: { counter: i },
+        };
+        upsertPromises.push(
+          saver.put(
+            { configurable: { thread_id: THREAD_ID, checkpoint_ns: CHECKPOINT_NS } },
+            checkpoint,
+            {
+              source: 'update',
+              step: -1,
+              parents: {},
+            }
+          )
+        );
+      }
+
+      await Promise.all(upsertPromises);
+
+      // Verify only one checkpoint exists
+      const checkpointTupleGenerator = saver.list({
+        configurable: { thread_id: THREAD_ID, checkpoint_ns: CHECKPOINT_NS },
+      });
+      const checkpointTuples: CheckpointTuple[] = [];
+      for await (const checkpoint of checkpointTupleGenerator) {
+        checkpointTuples.push(checkpoint);
+      }
+      expect(checkpointTuples.length).toBe(1);
+      expect(checkpointTuples[0].checkpoint.id).toBe(checkpointId);
+      // The final value should be one of the upserted values
+      expect(checkpointTuples[0].checkpoint.channel_values.counter).toBeGreaterThanOrEqual(0);
+      expect(checkpointTuples[0].checkpoint.channel_values.counter).toBeLessThanOrEqual(4);
+    });
+
+    it('should handle upserts across different namespaces independently', async () => {
+      const checkpointId = uuid6(-1);
+      const namespace1 = 'namespace-1';
+      const namespace2 = 'namespace-2';
+
+      const checkpoint1: Checkpoint = {
+        v: 1,
+        id: checkpointId,
+        ts: '2025-07-22T17:42:34.754Z',
+        channel_values: { namespace: 'first' },
+        channel_versions: {},
+        versions_seen: {},
+      };
+
+      const checkpoint2: Checkpoint = {
+        v: 1,
+        id: checkpointId,
+        ts: '2025-07-22T17:42:34.754Z',
+        channel_values: { namespace: 'second' },
+        channel_versions: {},
+        versions_seen: {},
+      };
+
+      // Save checkpoint with same ID to different namespaces
+      await saver.put(
+        { configurable: { thread_id: THREAD_ID, checkpoint_ns: namespace1 } },
+        checkpoint1,
+        { source: 'update', step: -1, parents: {} }
+      );
+
+      await saver.put(
+        { configurable: { thread_id: THREAD_ID, checkpoint_ns: namespace2 } },
+        checkpoint2,
+        { source: 'update', step: -1, parents: {} }
+      );
+
+      // Verify both checkpoints exist independently
+      const tuple1 = await saver.getTuple({
+        configurable: { thread_id: THREAD_ID, checkpoint_ns: namespace1 },
+      });
+      expect(tuple1?.checkpoint.channel_values).toEqual({ namespace: 'first' });
+
+      const tuple2 = await saver.getTuple({
+        configurable: { thread_id: THREAD_ID, checkpoint_ns: namespace2 },
+      });
+      expect(tuple2?.checkpoint.channel_values).toEqual({ namespace: 'second' });
+
+      // Upsert namespace1 checkpoint
+      const updatedCheckpoint1: Checkpoint = {
+        ...checkpoint1,
+        channel_values: { namespace: 'first-updated' },
+      };
+      await saver.put(
+        { configurable: { thread_id: THREAD_ID, checkpoint_ns: namespace1 } },
+        updatedCheckpoint1,
+        { source: 'update', step: -1, parents: {} }
+      );
+
+      // Verify only namespace1 was updated
+      const updatedTuple1 = await saver.getTuple({
+        configurable: { thread_id: THREAD_ID, checkpoint_ns: namespace1 },
+      });
+      expect(updatedTuple1?.checkpoint.channel_values).toEqual({ namespace: 'first-updated' });
+
+      const unchangedTuple2 = await saver.getTuple({
+        configurable: { thread_id: THREAD_ID, checkpoint_ns: namespace2 },
+      });
+      expect(unchangedTuple2?.checkpoint.channel_values).toEqual({ namespace: 'second' });
+    });
+  });
 });

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/elastic-search-checkpoint-saver/integration_tests/elastic_search_checkpoint_saver.test.ts
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/elastic-search-checkpoint-saver/integration_tests/elastic_search_checkpoint_saver.test.ts
@@ -453,7 +453,7 @@ describe('ElasticSearchSaver', () => {
       const namespace1 = 'namespace-1';
       const namespace2 = 'namespace-2';
 
-      const checkpoint1: Checkpoint = {
+      const namespace1Checkpoint: Checkpoint = {
         v: 1,
         id: checkpointId,
         ts: '2025-07-22T17:42:34.754Z',
@@ -462,7 +462,7 @@ describe('ElasticSearchSaver', () => {
         versions_seen: {},
       };
 
-      const checkpoint2: Checkpoint = {
+      const namespace2Checkpoint: Checkpoint = {
         v: 1,
         id: checkpointId,
         ts: '2025-07-22T17:42:34.754Z',
@@ -474,13 +474,13 @@ describe('ElasticSearchSaver', () => {
       // Save checkpoint with same ID to different namespaces
       await saver.put(
         { configurable: { thread_id: THREAD_ID, checkpoint_ns: namespace1 } },
-        checkpoint1,
+        namespace1Checkpoint,
         { source: 'update', step: -1, parents: {} }
       );
 
       await saver.put(
         { configurable: { thread_id: THREAD_ID, checkpoint_ns: namespace2 } },
-        checkpoint2,
+        namespace2Checkpoint,
         { source: 'update', step: -1, parents: {} }
       );
 
@@ -497,7 +497,7 @@ describe('ElasticSearchSaver', () => {
 
       // Upsert namespace1 checkpoint
       const updatedCheckpoint1: Checkpoint = {
-        ...checkpoint1,
+        ...namespace1Checkpoint,
         channel_values: { namespace: 'first-updated' },
       };
       await saver.put(

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/storage-adapter-checkpoint-saver/client.ts
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/storage-adapter-checkpoint-saver/client.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger, ElasticsearchClient } from '@kbn/core/server';
+import { ElasticSearchSaver } from '../elastic-search-checkpoint-saver';
+import {
+  getCheckpointsIndexName,
+  getCheckpointWritesIndexName,
+  createCheckpointsStorage,
+  createCheckpointWritesStorage,
+} from './storage';
+
+export interface CreateCheckpointerClientOptions {
+  /**
+   * Index name prefix for checkpoint indices.
+   * Examples: '.chat-', '.observability-', '.security-'
+   */
+  indexPrefix: string;
+  logger: Logger;
+  esClient: ElasticsearchClient;
+}
+
+/**
+ * Creates an ElasticSearchSaver instance configured with the specified index prefix.
+ * This factory function integrates the StorageIndexAdapter pattern with LangGraph's
+ * checkpoint saver, ensuring indices are created with proper mappings on first write.
+ *
+ * @param options Configuration options including index prefix, logger, and ES client
+ * @returns Configured ElasticSearchSaver instance
+ *
+ * @example
+ * ```ts
+ * const checkpointer = createCheckpointerClient({
+ *   indexPrefix: '.chat-',
+ *   logger,
+ *   esClient,
+ * });
+ * ```
+ */
+export const createCheckpointerClient = ({
+  indexPrefix,
+  logger,
+  esClient,
+}: CreateCheckpointerClientOptions): ElasticSearchSaver => {
+  // Create storage adapters for automatic index management
+  const checkpointsStorage = createCheckpointsStorage({
+    indexPrefix,
+    logger,
+    esClient,
+  });
+
+  const checkpointWritesStorage = createCheckpointWritesStorage({
+    indexPrefix,
+    logger,
+    esClient,
+  });
+
+  return new ElasticSearchSaver({
+    logger,
+    checkpointIndex: getCheckpointsIndexName(indexPrefix),
+    checkpointWritesIndex: getCheckpointWritesIndexName(indexPrefix),
+    refreshPolicy: 'wait_for',
+    checkpointsStorage: checkpointsStorage.getClient(),
+    checkpointWritesStorage: checkpointWritesStorage.getClient(),
+  });
+};

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/storage-adapter-checkpoint-saver/index.ts
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/storage-adapter-checkpoint-saver/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { createCheckpointerClient } from './client';
+export type { CreateCheckpointerClientOptions } from './client';
+
+export { CheckpointerServiceImpl } from './service';
+export type { CheckpointerService, CheckpointerServiceOptions } from './service';
+
+export {
+  createCheckpointsStorage,
+  createCheckpointWritesStorage,
+  getCheckpointsIndexName,
+  getCheckpointWritesIndexName,
+} from './storage';
+export type {
+  CheckpointStorageOptions,
+  CheckpointProperties,
+  CheckpointWriteProperties,
+  CheckpointsStorage,
+  CheckpointWritesStorage,
+} from './storage';

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/storage-adapter-checkpoint-saver/service.ts
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/storage-adapter-checkpoint-saver/service.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest, Logger, ElasticsearchServiceStart } from '@kbn/core/server';
+import type { ElasticSearchSaver } from '../elastic-search-checkpoint-saver';
+import { createCheckpointerClient } from './client';
+
+export interface CheckpointerServiceOptions {
+  /**
+   * Index name prefix for checkpoint indices.
+   * Examples: '.chat-', '.observability-', '.security-'
+   */
+  indexPrefix: string;
+  logger: Logger;
+  elasticsearch: ElasticsearchServiceStart;
+}
+
+/**
+ * Service interface for managing LangGraph checkpoints with Elasticsearch storage.
+ */
+export interface CheckpointerService {
+  /**
+   * Gets a scoped checkpointer instance for the given request.
+   * The checkpointer will use the request's security context for ES operations.
+   */
+  getCheckpointer(options: { request: KibanaRequest }): Promise<ElasticSearchSaver>;
+}
+
+/**
+ * Service implementation for managing LangGraph checkpoints with Elasticsearch storage.
+ * This service handles scoping checkpoint storage to the request's security context.
+ *
+ * @example
+ * ```ts
+ * // In plugin setup
+ * const checkpointerService = new CheckpointerServiceImpl({
+ *   indexPrefix: '.chat-',
+ *   logger: core.logger.get('checkpointer'),
+ *   elasticsearch: core.elasticsearch,
+ * });
+ *
+ * // In route handler
+ * const checkpointer = await checkpointerService.getCheckpointer({ request });
+ * ```
+ */
+export class CheckpointerServiceImpl implements CheckpointerService {
+  private readonly indexPrefix: string;
+  private readonly logger: Logger;
+  private readonly elasticsearch: ElasticsearchServiceStart;
+
+  constructor({ indexPrefix, logger, elasticsearch }: CheckpointerServiceOptions) {
+    this.indexPrefix = indexPrefix;
+    this.logger = logger;
+    this.elasticsearch = elasticsearch;
+  }
+
+  async getCheckpointer({ request }: { request: KibanaRequest }): Promise<ElasticSearchSaver> {
+    const esClient = this.elasticsearch.client.asScoped(request).asInternalUser;
+
+    return createCheckpointerClient({
+      indexPrefix: this.indexPrefix,
+      esClient,
+      logger: this.logger,
+    });
+  }
+}

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/storage-adapter-checkpoint-saver/storage.ts
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/server/storage-adapter-checkpoint-saver/storage.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger, ElasticsearchClient } from '@kbn/core/server';
+import type { IndexStorageSettings } from '@kbn/storage-adapter';
+import { StorageIndexAdapter, types } from '@kbn/storage-adapter';
+
+export interface CheckpointStorageOptions {
+  /**
+   * Index name prefix for checkpoint indices.
+   * Examples: '.chat-', '.observability-', '.security-'
+   */
+  indexPrefix: string;
+  logger: Logger;
+  esClient: ElasticsearchClient;
+}
+
+export const getCheckpointsIndexName = (prefix: string): string => {
+  return `${prefix}checkpoints`;
+};
+
+export const getCheckpointWritesIndexName = (prefix: string): string => {
+  return `${prefix}checkpoint-writes`;
+};
+
+const createCheckpointsStorageSettings = (indexName: string) => {
+  return {
+    name: indexName,
+    schema: {
+      properties: {
+        '@timestamp': types.date({}),
+        thread_id: types.keyword({}),
+        checkpoint_ns: types.keyword({}),
+        checkpoint_id: types.keyword({}),
+        parent_checkpoint_id: types.keyword({}),
+        type: types.keyword({}),
+        checkpoint: types.binary({}),
+        metadata: types.binary({}),
+      },
+    },
+  } satisfies IndexStorageSettings;
+};
+
+const createCheckpointWritesStorageSettings = (indexName: string) => {
+  return {
+    name: indexName,
+    schema: {
+      properties: {
+        '@timestamp': types.date({}),
+        thread_id: types.keyword({}),
+        checkpoint_ns: types.keyword({}),
+        checkpoint_id: types.keyword({}),
+        task_id: types.keyword({}),
+        idx: types.long({}),
+        channel: types.keyword({}),
+        type: types.keyword({}),
+        value: types.binary({}),
+      },
+    },
+  } satisfies IndexStorageSettings;
+};
+
+export interface CheckpointProperties {
+  '@timestamp': string;
+  thread_id: string;
+  checkpoint_ns: string;
+  checkpoint_id: string;
+  parent_checkpoint_id: string;
+  type: string;
+  checkpoint: string;
+  metadata: string;
+}
+
+export interface CheckpointWriteProperties {
+  '@timestamp': string;
+  thread_id: string;
+  checkpoint_ns: string;
+  checkpoint_id: string;
+  task_id: string;
+  idx: number;
+  channel: string;
+  type: string;
+  value: string;
+}
+
+export type CheckpointsStorage = StorageIndexAdapter<
+  ReturnType<typeof createCheckpointsStorageSettings>,
+  CheckpointProperties
+>;
+
+export type CheckpointWritesStorage = StorageIndexAdapter<
+  ReturnType<typeof createCheckpointWritesStorageSettings>,
+  CheckpointWriteProperties
+>;
+
+export const createCheckpointsStorage = ({
+  indexPrefix,
+  logger,
+  esClient,
+}: CheckpointStorageOptions): CheckpointsStorage => {
+  const indexName = getCheckpointsIndexName(indexPrefix);
+  const storageSettings = createCheckpointsStorageSettings(indexName);
+  return new StorageIndexAdapter(esClient, logger, storageSettings);
+};
+
+export const createCheckpointWritesStorage = ({
+  indexPrefix,
+  logger,
+  esClient,
+}: CheckpointStorageOptions): CheckpointWritesStorage => {
+  const indexName = getCheckpointWritesIndexName(indexPrefix);
+  const storageSettings = createCheckpointWritesStorageSettings(indexName);
+  return new StorageIndexAdapter(esClient, logger, storageSettings);
+};

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../../../tsconfig.base.json",
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
   "compilerOptions": {
     "outDir": "target/types",
     "types": [

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/tsconfig.json
@@ -8,7 +8,7 @@
     ]
   },
   "include": [
-    "**/*.ts",
+    "**/*.ts"
   ],
   "exclude": [
     "target/**/*"
@@ -17,6 +17,6 @@
     "@kbn/core-test-helpers-kbn-server",
     "@kbn/core",
     "@kbn/core-logging-server-mocks",
-    "@kbn/storage-adapter",
+    "@kbn/storage-adapter"
   ]
 }

--- a/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-langgraph-checkpoint-saver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "extends": "../../../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "target/types",
     "types": [
@@ -17,6 +17,6 @@
     "@kbn/core-test-helpers-kbn-server",
     "@kbn/core",
     "@kbn/core-logging-server-mocks",
-    "@kbn/core-saved-objects-utils-server",
+    "@kbn/storage-adapter",
   ]
 }

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/index.test.ts
@@ -175,8 +175,6 @@ describe('AI Assistant Service', () => {
         '.kibana-elastic-ai-assistant-component-template-anonymization-fields',
         '.kibana-elastic-ai-assistant-component-template-defend-insights',
         '.kibana-elastic-ai-assistant-component-template-alert-summary',
-        '.kibana-elastic-ai-assistant-component-template-checkpoints',
-        '.kibana-elastic-ai-assistant-component-template-checkpoint-writes',
       ];
       clusterClient.cluster.putComponentTemplate.mock.calls.forEach((call, i) => {
         expect(call[0].name).toEqual(expectedTemplates[i]);
@@ -692,8 +690,6 @@ describe('AI Assistant Service', () => {
         '.kibana-elastic-ai-assistant-component-template-anonymization-fields',
         '.kibana-elastic-ai-assistant-component-template-defend-insights',
         '.kibana-elastic-ai-assistant-component-template-alert-summary',
-        '.kibana-elastic-ai-assistant-component-template-checkpoints',
-        '.kibana-elastic-ai-assistant-component-template-checkpoint-writes',
       ];
 
       clusterClient.cluster.putComponentTemplate.mock.calls.forEach((call, i) => {
@@ -732,8 +728,6 @@ describe('AI Assistant Service', () => {
         '.kibana-elastic-ai-assistant-index-template-anonymization-fields',
         '.kibana-elastic-ai-assistant-index-template-defend-insights',
         '.kibana-elastic-ai-assistant-index-template-alert-summary',
-        '.kibana-elastic-ai-assistant-index-template-checkpoints',
-        '.kibana-elastic-ai-assistant-index-template-checkpoint-writes',
       ];
       clusterClient.indices.putIndexTemplate.mock.calls.forEach((call, i) => {
         expect(call[0].name).toEqual(expectedTemplates[i]);


### PR DESCRIPTION
## Summary

Adds a storage adapter for the langgraph checkpointer to make it easier to set up the checkpointer.

## Overview
Refactors LangGraph checkpoint persistence to use the Storage Adapter pattern, introducing a `CheckpointerService` that manages checkpoint indices automatically.

## Key Changes

### Storage Adapter Integration
- Created `storage-adapter-checkpoint-saver` module with client factory, service implementation, and storage schemas
- Refactored `ElasticSearchSaver` to use storage adapters instead of direct ES client operations
- Indices are now created automatically with proper mappings on first write

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [X] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [X] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [X] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [X] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [X] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [X] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



