### PR TITLE
[One Workflow] Workflows license gating

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/kibana.jsonc
+++ b/src/platform/plugins/shared/workflows_execution_engine/kibana.jsonc
@@ -10,6 +10,11 @@
     "id": "workflowsExecutionEngine",
     "browser": false,
     "server": true,
-    "requiredPlugins": ["taskManager", "actions", "workflowsExtensions"]
+    "requiredPlugins": [
+      "taskManager",
+      "actions",
+      "workflowsExtensions",
+      "licensing"
+    ],
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/moon.yml
+++ b/src/platform/plugins/shared/workflows_execution_engine/moon.yml
@@ -32,6 +32,7 @@ dependsOn:
   - '@kbn/data-streams'
   - '@kbn/es-mappings'
   - '@kbn/workflows-extensions'
+  - '@kbn/licensing-plugin'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/check_license.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/check_license.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
+
+export const checkLicense = async (licensing: LicensingPluginStart) => {
+  const license = await licensing.getLicense();
+
+  if (!license.isAvailable || !license.isActive) {
+    throw new Error('License information is not available or license is inactive.');
+  }
+
+  if (!license.hasAtLeast('enterprise')) {
+    throw new Error(
+      'Your license does not support Workflows Execution Engine. Please upgrade to an Enterprise license.'
+    );
+  }
+};

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -30,6 +30,7 @@ import {
   resumeWorkflow,
   runWorkflow,
 } from './execution_functions';
+import { checkLicense } from './lib/check_license';
 import { initializeLogsRepositoryDataStream } from './repositories/logs_repository/data_stream';
 import { WorkflowExecutionRepository } from './repositories/workflow_execution_repository';
 import type {
@@ -108,6 +109,8 @@ export class WorkflowsExecutionEnginePlugin
               const { workflowRunId, spaceId } =
                 taskInstance.params as StartWorkflowExecutionParams;
               const [coreStart, pluginsStart] = await core.getStartServices();
+              await checkLicense(pluginsStart.licensing);
+
               await this.initialize(coreStart);
               const dependencies: ContextDependencies = {
                 ...setupDependencies,
@@ -153,6 +156,8 @@ export class WorkflowsExecutionEnginePlugin
               const { workflowRunId, spaceId } =
                 taskInstance.params as ResumeWorkflowExecutionParams;
               const [coreStart, pluginsStart] = await core.getStartServices();
+              await checkLicense(pluginsStart.licensing);
+
               await this.initialize(coreStart);
               const dependencies: ContextDependencies = {
                 ...setupDependencies,
@@ -201,6 +206,8 @@ export class WorkflowsExecutionEnginePlugin
                 triggerType: string;
               };
               const [coreStart, pluginsStart] = await core.getStartServices();
+              await checkLicense(pluginsStart.licensing);
+
               await this.initialize(coreStart);
               const dependencies: ContextDependencies = {
                 ...setupDependencies,
@@ -408,6 +415,8 @@ export class WorkflowsExecutionEnginePlugin
     };
 
     const executeWorkflow: ExecuteWorkflow = async (workflow, context, request) => {
+      await checkLicense(plugins.licensing);
+
       // AUTO-DETECT: Check if we're already running in a Task Manager context
       // We can determine this from context and request before creating the execution
       const isRunningInTaskManager =
@@ -463,6 +472,8 @@ export class WorkflowsExecutionEnginePlugin
     };
 
     const scheduleWorkflow: ScheduleWorkflow = async (workflow, context, request) => {
+      await checkLicense(plugins.licensing);
+
       const { workflowExecution } = await createAndPersistWorkflowExecution(
         workflow,
         context,
@@ -500,6 +511,8 @@ export class WorkflowsExecutionEnginePlugin
       contextOverride,
       request
     ) => {
+      await checkLicense(plugins.licensing);
+
       // Check if request is required before creating execution
       // Workflow steps require user context to run with proper permissions
       if (!request) {
@@ -562,6 +575,8 @@ export class WorkflowsExecutionEnginePlugin
       workflowExecutionId,
       spaceId
     ) => {
+      await checkLicense(plugins.licensing);
+
       await this.initialize(coreStart);
       const workflowExecution = await workflowExecutionRepository.getWorkflowExecutionById(
         workflowExecutionId,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/types.ts
@@ -13,6 +13,7 @@
 import type { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/server';
 import type { KibanaRequest } from '@kbn/core/server';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
 import type {
   TaskManagerSetupContract,
   TaskManagerStartContract,
@@ -53,6 +54,7 @@ export interface WorkflowsExecutionEnginePluginStartDeps {
   actions: ActionsPluginStartContract;
   cloud: CloudStart;
   workflowsExtensions: WorkflowsExtensionsServerPluginStart;
+  licensing: LicensingPluginStart;
 }
 
 export type ExecuteWorkflow = (

--- a/src/platform/plugins/shared/workflows_execution_engine/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_execution_engine/tsconfig.json
@@ -27,6 +27,7 @@
     "@kbn/data-streams",
     "@kbn/es-mappings",
     "@kbn/workflows-extensions",
+    "@kbn/licensing-plugin",
   ],
   "exclude": [
     "target/**/*"

--- a/src/platform/plugins/shared/workflows_management/kibana.jsonc
+++ b/src/platform/plugins/shared/workflows_management/kibana.jsonc
@@ -27,7 +27,8 @@
       "dataViews",
       "fieldFormats",
       "unifiedSearch",
-      "embeddable"
+      "embeddable",
+      "licensing"
     ],
     "optionalPlugins": [
       "alerting",

--- a/src/platform/plugins/shared/workflows_management/public/mocks.ts
+++ b/src/platform/plugins/shared/workflows_management/public/mocks.ts
@@ -12,6 +12,7 @@ import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
+import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
 import { navigationPluginMock } from '@kbn/navigation-plugin/public/mocks';
 import { serverlessMock } from '@kbn/serverless/public/mocks';
 import { spacesPluginMock } from '@kbn/spaces-plugin/public/mocks';
@@ -31,4 +32,5 @@ export const createStartServicesMock = () => ({
   spaces: spacesPluginMock.createStartContract(),
   triggersActionsUi: triggersActionsUiMock.createStart(),
   workflowsExtensions: workflowsExtensionsMock.createStart(),
+  licensing: licensingMock.createStart(),
 });

--- a/src/platform/plugins/shared/workflows_management/public/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/public/plugin.ts
@@ -7,8 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { Subject } from 'rxjs';
 import {
+  type AppDeepLinkLocations,
   type AppMountParameters,
+  AppStatus,
+  type AppUpdater,
   type CoreSetup,
   type CoreStart,
   DEFAULT_APP_CATEGORIES,
@@ -27,6 +31,8 @@ import type {
 import { PLUGIN_ID, PLUGIN_NAME } from '../common';
 import { stepSchemas } from '../common/step_schemas';
 
+const VisibleIn: AppDeepLinkLocations[] = ['globalSearch', 'home', 'kibanaOverview', 'sideNav'];
+
 export class WorkflowsPlugin
   implements
     Plugin<
@@ -36,6 +42,12 @@ export class WorkflowsPlugin
       WorkflowsPublicPluginStartDependencies
     >
 {
+  private appUpdater$: Subject<AppUpdater>;
+
+  constructor() {
+    this.appUpdater$ = new Subject<AppUpdater>();
+  }
+
   public setup(
     core: CoreSetup<WorkflowsPublicPluginStartDependencies, WorkflowsPublicPluginStart>,
     plugins: WorkflowsPublicPluginSetupDependencies
@@ -64,9 +76,10 @@ export class WorkflowsPlugin
       title: PLUGIN_NAME,
       appRoute: '/app/workflows',
       euiIconType: 'workflowsApp',
-      visibleIn: ['globalSearch', 'home', 'kibanaOverview', 'sideNav'],
+      visibleIn: VisibleIn,
       category: DEFAULT_APP_CATEGORIES.management,
       order: 9015,
+      updater$: this.appUpdater$,
       mount: async (params: AppMountParameters) => {
         // Load application bundle
         const { renderApp } = await import('./application');
@@ -93,6 +106,15 @@ export class WorkflowsPlugin
   ): WorkflowsPublicPluginStart {
     // Initialize StepSchemas singleton with workflowExtensions
     stepSchemas.initialize(plugins.workflowsExtensions);
+
+    // License check to set app status
+    plugins.licensing.license$.subscribe((license) => {
+      if (license.isActive && license.hasAtLeast('enterprise')) {
+        this.appUpdater$.next(() => ({ status: AppStatus.accessible, visibleIn: VisibleIn }));
+      } else {
+        this.appUpdater$.next(() => ({ status: AppStatus.inaccessible, visibleIn: [] }));
+      }
+    });
 
     return {};
   }

--- a/src/platform/plugins/shared/workflows_management/public/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/types.ts
@@ -12,6 +12,7 @@ import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { NavigationPublicPluginStart } from '@kbn/navigation-plugin/public';
 import type { ServerlessPluginStart } from '@kbn/serverless/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
@@ -42,6 +43,7 @@ export interface WorkflowsPublicPluginStartDependencies {
   spaces: SpacesPluginStart;
   triggersActionsUi: TriggersAndActionsUIPublicPluginStart;
   workflowsExtensions: WorkflowsExtensionsPublicPluginStart;
+  licensing: LicensingPluginStart;
 }
 
 export interface WorkflowsPublicPluginStartAdditionalServices {

--- a/src/platform/plugins/shared/workflows_management/server/features.ts
+++ b/src/platform/plugins/shared/workflows_management/server/features.ts
@@ -26,6 +26,7 @@ export const WorkflowsManagementFeatureConfig: KibanaFeatureConfig = {
   category: DEFAULT_APP_CATEGORIES.kibana,
   app: [],
   order: 3000,
+  minimumLicense: 'enterprise',
   privileges: {
     // Nothing at top level privileges, all specific actions are managed by sub_features privileges below
     all: { app: [], api: [], savedObject: { all: [], read: [] }, ui: [] },

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/__mocks__/with_license_check.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/__mocks__/with_license_check.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const withLicenseCheck = jest.fn((handler) => handler);

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/with_license_check.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/with_license_check.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { RequestHandler, RouteMethod } from '@kbn/core/server';
+import type { WorkflowsRequestHandlerContext } from '../../types';
+
+/**
+ * Wraps a request handler with a check for the Enterprise license.
+ * If the license is not valid, it will return a 403 error with a message.
+ */
+export const withLicenseCheck = <
+  P = unknown,
+  Q = unknown,
+  B = unknown,
+  Method extends RouteMethod = never
+>(
+  handler: RequestHandler<P, Q, B, WorkflowsRequestHandlerContext, Method>
+): RequestHandler<P, Q, B, WorkflowsRequestHandlerContext, Method> => {
+  return async (context, request, response) => {
+    const { licensing } = await context.resolve(['licensing']);
+
+    if (!licensing.license.isAvailable || !licensing.license.isActive) {
+      return response.forbidden({
+        body: {
+          message: 'License information is not available or license is inactive.',
+        },
+      });
+    }
+
+    if (!licensing.license.hasAtLeast('enterprise')) {
+      return response.forbidden({
+        body: {
+          message:
+            'Your license does not support Workflows Management. Please upgrade to an Enterprise license.',
+        },
+      });
+    }
+
+    return handler(context, request, response);
+  };
+};

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/delete_workflow_by_id.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/delete_workflow_by_id.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('DELETE /api/workflows/{id}', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/delete_workflow_by_id.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/delete_workflow_by_id.ts
@@ -12,6 +12,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_DELETE_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerDeleteWorkflowByIdRoute({
   router,
@@ -30,7 +31,7 @@ export function registerDeleteWorkflowByIdRoute({
         }),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { id } = request.params as { id: string };
         const spaceId = spaces.getSpaceId(request);
@@ -39,6 +40,6 @@ export function registerDeleteWorkflowByIdRoute({
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/delete_workflows_bulk.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/delete_workflows_bulk.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('DELETE /api/workflows', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/delete_workflows_bulk.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/delete_workflows_bulk.ts
@@ -12,6 +12,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_DELETE_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerDeleteWorkflowsBulkRoute({
   router,
@@ -30,7 +31,7 @@ export function registerDeleteWorkflowsBulkRoute({
         }),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { ids } = request.body as { ids: string[] };
         const spaceId = spaces.getSpaceId(request);
@@ -39,6 +40,6 @@ export function registerDeleteWorkflowsBulkRoute({
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_connectors.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_connectors.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('GET /api/workflows/connectors', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_connectors.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_connectors.ts
@@ -11,6 +11,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerGetConnectorsRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.get(
@@ -20,7 +21,7 @@ export function registerGetConnectorsRoute({ router, api, logger, spaces }: Rout
       security: WORKFLOW_READ_SECURITY,
       validate: false,
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const spaceId = spaces.getSpaceId(request);
         const { connectorsByType, totalConnectors } = await api.getAvailableConnectors(
@@ -37,6 +38,6 @@ export function registerGetConnectorsRoute({ router, api, logger, spaces }: Rout
         logger.error(`Failed to fetch connectors: ${error.message}`);
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_step_execution.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_step_execution.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('GET /api/workflowExecutions/{executionId}/steps/{id}', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_step_execution.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_step_execution.ts
@@ -11,6 +11,7 @@ import { schema } from '@kbn/config-schema';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_EXECUTION_READ_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerGetStepExecutionRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.get(
@@ -24,7 +25,7 @@ export function registerGetStepExecutionRoute({ router, api, logger, spaces }: R
         }),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { executionId, id } = request.params;
         const stepExecution = await api.getStepExecution(
@@ -40,6 +41,6 @@ export function registerGetStepExecutionRoute({ router, api, logger, spaces }: R
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_aggs.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_aggs.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('GET /api/workflows/aggs', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_aggs.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_aggs.ts
@@ -12,6 +12,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerGetWorkflowAggsRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.get(
@@ -21,7 +22,7 @@ export function registerGetWorkflowAggsRoute({ router, api, logger, spaces }: Ro
       security: WORKFLOW_READ_SECURITY,
       validate: { query: schema.object({ fields: schema.arrayOf(schema.string()) }) },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { fields } = request.query as { fields: string[] };
         const spaceId = spaces.getSpaceId(request);
@@ -31,6 +32,6 @@ export function registerGetWorkflowAggsRoute({ router, api, logger, spaces }: Ro
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_by_id.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_by_id.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('GET /api/workflows/{id}', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_by_id.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_by_id.ts
@@ -12,6 +12,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerGetWorkflowByIdRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.get(
@@ -25,7 +26,7 @@ export function registerGetWorkflowByIdRoute({ router, api, logger, spaces }: Ro
         }),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { id } = request.params as { id: string };
         const spaceId = spaces.getSpaceId(request);
@@ -41,6 +42,6 @@ export function registerGetWorkflowByIdRoute({ router, api, logger, spaces }: Ro
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_execution_by_id.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_execution_by_id.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('GET /api/workflowExecutions/{workflowExecutionId}', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_execution_by_id.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_execution_by_id.ts
@@ -12,6 +12,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_EXECUTION_READ_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerGetWorkflowExecutionByIdRoute({
   router,
@@ -30,7 +31,7 @@ export function registerGetWorkflowExecutionByIdRoute({
         }),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { workflowExecutionId } = request.params;
         const spaceId = spaces.getSpaceId(request);
@@ -44,6 +45,6 @@ export function registerGetWorkflowExecutionByIdRoute({
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_execution_logs.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_execution_logs.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('GET /api/workflowExecutions/{workflowExecutionId}/logs', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_execution_logs.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_execution_logs.ts
@@ -12,6 +12,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_EXECUTION_READ_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerGetWorkflowExecutionLogsRoute({
   router,
@@ -37,7 +38,7 @@ export function registerGetWorkflowExecutionLogsRoute({
         }),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { workflowExecutionId } = request.params;
         const { size, page, sortField, sortOrder, stepExecutionId } = request.query;
@@ -59,6 +60,6 @@ export function registerGetWorkflowExecutionLogsRoute({
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_executions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_executions.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('GET /api/workflowExecutions', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_executions.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_executions.ts
@@ -15,6 +15,7 @@ import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_EXECUTION_READ_SECURITY } from './route_security';
 import { MAX_PAGE_SIZE, parseExecutionStatuses, parseExecutionTypes } from './types';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 import type { SearchWorkflowExecutionsParams } from '../workflows_management_service';
 
 export function registerGetWorkflowExecutionsRoute({
@@ -75,7 +76,7 @@ export function registerGetWorkflowExecutionsRoute({
         }),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const spaceId = spaces.getSpaceId(request);
         const params: SearchWorkflowExecutionsParams = {
@@ -91,6 +92,6 @@ export function registerGetWorkflowExecutionsRoute({
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_json_schema.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_json_schema.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('GET /api/workflows/workflow-json-schema', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_json_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_json_schema.ts
@@ -12,6 +12,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerGetWorkflowJsonSchemaRoute({
   router,
@@ -30,7 +31,7 @@ export function registerGetWorkflowJsonSchemaRoute({
         }),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { loose } = request.query;
         const spaceId = spaces.getSpaceId(request);
@@ -50,6 +51,6 @@ export function registerGetWorkflowJsonSchemaRoute({
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_stats.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_stats.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('GET /api/workflows/stats', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_stats.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_stats.ts
@@ -11,6 +11,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerGetWorkflowStatsRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.get(
@@ -20,7 +21,7 @@ export function registerGetWorkflowStatsRoute({ router, api, logger, spaces }: R
       security: WORKFLOW_READ_SECURITY,
       validate: false,
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const spaceId = spaces.getSpaceId(request);
         const stats = await api.getWorkflowStats(spaceId);
@@ -29,6 +30,6 @@ export function registerGetWorkflowStatsRoute({ router, api, logger, spaces }: R
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_cancel_workflow_execution.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_cancel_workflow_execution.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('POST /api/workflowExecutions/{workflowExecutionId}/cancel', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_cancel_workflow_execution.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_cancel_workflow_execution.ts
@@ -12,6 +12,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_EXECUTION_CANCEL_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerPostCancelWorkflowExecutionRoute({
   router,
@@ -30,7 +31,7 @@ export function registerPostCancelWorkflowExecutionRoute({
         }),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { workflowExecutionId } = request.params;
         const spaceId = spaces.getSpaceId(request);
@@ -40,6 +41,6 @@ export function registerPostCancelWorkflowExecutionRoute({
       } catch (error) {
         return handleRouteError(response, error, { checkNotFound: true });
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_clone_workflow.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_clone_workflow.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('POST /api/workflows/{id}/clone', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_clone_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_clone_workflow.ts
@@ -12,6 +12,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_CREATE_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerPostCloneWorkflowRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.post(
@@ -25,7 +26,7 @@ export function registerPostCloneWorkflowRoute({ router, api, logger, spaces }: 
         }),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { id } = request.params as { id: string };
         const spaceId = spaces.getSpaceId(request);
@@ -38,6 +39,6 @@ export function registerPostCloneWorkflowRoute({ router, api, logger, spaces }: 
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_create_workflow.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_create_workflow.test.ts
@@ -19,6 +19,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('POST /api/workflows', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_create_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_create_workflow.ts
@@ -12,6 +12,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_CREATE_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerPostCreateWorkflowRoute({
   router,
@@ -28,7 +29,7 @@ export function registerPostCreateWorkflowRoute({
         body: CreateWorkflowCommandSchema,
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const spaceId = spaces.getSpaceId(request);
         const createdWorkflow = await api.createWorkflow(request.body, spaceId, request);
@@ -36,6 +37,6 @@ export function registerPostCreateWorkflowRoute({
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_run_workflow.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_run_workflow.test.ts
@@ -18,6 +18,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('POST /api/workflows/{id}/run', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_run_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_run_workflow.ts
@@ -13,6 +13,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_EXECUTE_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 import { preprocessAlertInputs } from '../utils/preprocess_alert_inputs';
 
 export function registerPostRunWorkflowRoute({ router, api, logger, spaces }: RouteDependencies) {
@@ -30,7 +31,7 @@ export function registerPostRunWorkflowRoute({ router, api, logger, spaces }: Ro
         }),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { id } = request.params as { id: string };
         const spaceId = spaces.getSpaceId(request);
@@ -91,6 +92,6 @@ export function registerPostRunWorkflowRoute({ router, api, logger, spaces }: Ro
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_search_workflows.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_search_workflows.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('POST /api/workflows/search', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_search_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_search_workflows.ts
@@ -12,6 +12,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 import type { GetWorkflowsParams } from '../workflows_management_api';
 
 export function registerPostSearchWorkflowsRoute({
@@ -29,7 +30,7 @@ export function registerPostSearchWorkflowsRoute({
         body: SearchWorkflowCommandSchema,
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { size, page, enabled, createdBy, query } =
           request.body as unknown as GetWorkflowsParams;
@@ -50,6 +51,6 @@ export function registerPostSearchWorkflowsRoute({
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_test_step.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_test_step.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('POST /api/workflows/testStep', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_test_step.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_test_step.ts
@@ -12,6 +12,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_EXECUTE_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerPostTestStepRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.post(
@@ -27,7 +28,7 @@ export function registerPostTestStepRoute({ router, api, logger, spaces }: Route
         }),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const spaceId = spaces.getSpaceId(request);
 
@@ -47,6 +48,6 @@ export function registerPostTestStepRoute({ router, api, logger, spaces }: Route
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_test_workflow.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_test_workflow.test.ts
@@ -18,6 +18,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('POST /api/workflows/test', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_test_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/post_test_workflow.ts
@@ -13,6 +13,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_EXECUTE_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 import { preprocessAlertInputs } from '../utils/preprocess_alert_inputs';
 
 export function registerPostTestWorkflowRoute({ router, api, logger, spaces }: RouteDependencies) {
@@ -36,7 +37,7 @@ export function registerPostTestWorkflowRoute({ router, api, logger, spaces }: R
         ),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const spaceId = spaces.getSpaceId(request);
 
@@ -67,7 +68,7 @@ export function registerPostTestWorkflowRoute({ router, api, logger, spaces }: R
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }
 

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/put_update_workflow.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/put_update_workflow.test.ts
@@ -17,6 +17,8 @@ import {
 } from './test_utils';
 import type { WorkflowsManagementApi } from '../workflows_management_api';
 
+jest.mock('../lib/with_license_check');
+
 describe('PUT /api/workflows/{id}', () => {
   let workflowsApi: WorkflowsManagementApi;
   let mockRouter: any;

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/put_update_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/put_update_workflow.ts
@@ -13,6 +13,7 @@ import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
 import { handleRouteError } from './route_error_handlers';
 import { WORKFLOW_UPDATE_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
+import { withLicenseCheck } from '../lib/with_license_check';
 
 export function registerPutUpdateWorkflowRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.put(
@@ -27,7 +28,7 @@ export function registerPutUpdateWorkflowRoute({ router, api, logger, spaces }: 
         body: UpdateWorkflowCommandSchema.partial(),
       },
     },
-    async (context, request, response) => {
+    withLicenseCheck(async (context, request, response) => {
       try {
         const { id } = request.params as { id: string };
         const spaceId = spaces.getSpaceId(request);
@@ -41,6 +42,6 @@ export function registerPutUpdateWorkflowRoute({ router, api, logger, spaces }: 
       } catch (error) {
         return handleRouteError(response, error);
       }
-    }
+    })
   );
 }


### PR DESCRIPTION
## Summary

closes: https://github.com/elastic/security-team/issues/15355

Adds enterprise license checks to `workflows_management` UI and API, and `workflows_execution_engine` tasks.



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->