### PR TITLE
Forward environment to optimizer workers

### DIFF
--- a/packages/kbn-optimizer/src/optimizer/observe_worker.ts
+++ b/packages/kbn-optimizer/src/optimizer/observe_worker.ts
@@ -75,6 +75,7 @@ function usingWorkerProc<T>(config: OptimizerConfig, fn: (proc: ChildProcess) =>
           // or just low powerful ones we need to default to polling instead of relying in the OS events watcher system.
           // That can be done in the worker/run_compilers file.
           WATCHPACK_WATCHER_LIMIT: '4000',
+          ...process.env,
         },
       });
 


### PR DESCRIPTION
## :memo: Summary

This forwards the environment to the worker processes spawned by the optimizer. Without it it's not possible to increase the memory limit of the nodejs process, causing OOMs while building the plugins.
