### PR TITLE
[8.15] [Docs] Add logSources missing advanced setting to 8.19 docs (#248658)

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -393,6 +393,9 @@ value is 10000.
 [[observability-advanced-settings]]
 ==== Observability
 
+[[observability-log-sources]]`observability:logSources`::
+Sources to use for logs data. If the data of these indices is not logs data, you can experience degraded functionality. Changes to this setting can potentially impact the sources queried in Log Threshold rules. `logs-*-*, logs-*, filebeat-*` by default.
+
 [horizontal]
 [[apm-enable-service-overview]]`apm:enableServiceOverview`::
 When enabled, displays the *Overview* tab for services in *APM*.


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.15`:
 - [[Docs] Add logSources missing advanced setting to 8.19 docs (#248658)](https://github.com/elastic/kibana/pull/248658)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"florent-leborgne","email":"florent.leborgne@elastic.co"},"sourceCommit":{"committedDate":"2026-01-12T18:00:48Z","message":"[Docs] Add logSources missing advanced setting to 8.19 docs (#248658)\n\nThis PR adds a missing logSources setting to the advanced settings docs\n\nRel:\nhttps://github.com/elastic/docs-content/issues/3487#issuecomment-3738403448\nRel: https://github.com/elastic/sdh-apm/issues/1937\n\n@jennypavlova For context, this will update the 8.19 docs page for these\nsettings:\nhttps://www.elastic.co/guide/en/kibana/8.19/advanced-options.html#observability-advanced-settings.\n\nAnd not\nhttps://www.elastic.co/docs/reference/kibana/advanced-settings#observability-advanced-settings\nwhich are the v9 docs\n\n\nPlease advise if this setting should also be added to previous versions.","sha":"a98ed8e2a4ac48f72011b3456748a8e942c35ad4","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","v8.15.0","v8.16.0","backport:version","v8.17.0","v8.18.0"],"title":"[Docs] Add logSources missing advanced setting to 8.19 docs","number":248658,"url":"https://github.com/elastic/kibana/pull/248658","mergeCommit":{"message":"[Docs] Add logSources missing advanced setting to 8.19 docs (#248658)\n\nThis PR adds a missing logSources setting to the advanced settings docs\n\nRel:\nhttps://github.com/elastic/docs-content/issues/3487#issuecomment-3738403448\nRel: https://github.com/elastic/sdh-apm/issues/1937\n\n@jennypavlova For context, this will update the 8.19 docs page for these\nsettings:\nhttps://www.elastic.co/guide/en/kibana/8.19/advanced-options.html#observability-advanced-settings.\n\nAnd not\nhttps://www.elastic.co/docs/reference/kibana/advanced-settings#observability-advanced-settings\nwhich are the v9 docs\n\n\nPlease advise if this setting should also be added to previous versions.","sha":"a98ed8e2a4ac48f72011b3456748a8e942c35ad4"}},"sourceBranch":"8.19","suggestedTargetBranches":["8.15","8.16","8.17","8.18"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.16.0","branchLabelMappingKey":"^v8.16.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->