### PR TITLE
[9.3] [Agent Builder] Support bulk import MCP tools into existing namespace if KSC is same (#248563)

### DIFF
--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/bulk_import/sections/source.tsx
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/bulk_import/sections/source.tsx
@@ -26,7 +26,8 @@ const mcpActionLinkStyles = (euiThemeContext: UseEuiTheme) => css`
 
 export const SourceSection = () => {
   const euiThemeContext = useEuiTheme();
-  const { control, formState, setValue } = useFormContext<BulkImportMcpToolsFormData>();
+  const { control, formState, setValue, trigger, getFieldState } =
+    useFormContext<BulkImportMcpToolsFormData>();
   const { errors } = formState;
 
   const handleConnectorCreated = useCallback(
@@ -100,6 +101,9 @@ export const SourceSection = () => {
                   onBlur();
                   // Clear tool selection when connector changes
                   setValue('tools', []);
+                  if (getFieldState('namespace').isDirty) {
+                    trigger('namespace');
+                  }
                 }}
                 isLoading={isLoadingConnectors}
                 inputRef={ref}

--- a/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/validation/bulk_import_mcp_tool_form_validation.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/components/tools/form/validation/bulk_import_mcp_tool_form_validation.ts
@@ -72,44 +72,50 @@ export const useBulkImportMcpToolFormValidationSchema = () => {
   const { toolsService } = useOnechatServices();
   const queryClient = useQueryClient();
 
-  return z.object({
-    connectorId: z
-      .string()
-      .min(1, { message: bulkImportMcpI18nMessages.connectorId.requiredError }),
-    tools: z
-      .array(
-        z.object({
-          name: z.string(),
-          description: z.string(),
-        })
-      )
-      .min(1, { message: bulkImportMcpI18nMessages.tools.requiredError }),
-    namespace: z
-      .string()
-      .min(1, { message: bulkImportMcpI18nMessages.namespace.requiredError })
-      .max(toolIdMaxLength, { message: bulkImportMcpI18nMessages.namespace.tooLongError })
-      .regex(toolIdRegexp, { message: bulkImportMcpI18nMessages.namespace.formatError })
-      .refine(
-        (name) => !isInProtectedNamespace(name) && !hasNamespaceName(name),
-        (name) => ({
-          message: bulkImportMcpI18nMessages.namespace.protectedNamespaceError(name),
-        })
-      )
-      .superRefine(async (value, ctx) => {
-        if (value.length > 0) {
-          const { isValid } = await queryClient.fetchQuery({
-            queryKey: queryKeys.tools.namespace.validate(value),
-            queryFn: () => toolsService.validateNamespace({ namespace: value }),
-            staleTime: 0,
+  return z
+    .object({
+      connectorId: z
+        .string()
+        .min(1, { message: bulkImportMcpI18nMessages.connectorId.requiredError }),
+      tools: z
+        .array(
+          z.object({
+            name: z.string(),
+            description: z.string(),
+          })
+        )
+        .min(1, { message: bulkImportMcpI18nMessages.tools.requiredError }),
+      namespace: z
+        .string()
+        .min(1, { message: bulkImportMcpI18nMessages.namespace.requiredError })
+        .max(toolIdMaxLength, { message: bulkImportMcpI18nMessages.namespace.tooLongError })
+        .regex(toolIdRegexp, { message: bulkImportMcpI18nMessages.namespace.formatError })
+        .refine(
+          (name) => !isInProtectedNamespace(name) && !hasNamespaceName(name),
+          (name) => ({
+            message: bulkImportMcpI18nMessages.namespace.protectedNamespaceError(name),
+          })
+        ),
+      labels: z.array(z.string()),
+    })
+    .superRefine(async (data, ctx) => {
+      if (data.namespace.length > 0 && data.connectorId.length > 0) {
+        const { isValid } = await queryClient.fetchQuery({
+          queryKey: queryKeys.tools.namespace.validate(data.namespace, data.connectorId),
+          queryFn: () =>
+            toolsService.validateNamespace({
+              namespace: data.namespace,
+              connectorId: data.connectorId,
+            }),
+          staleTime: 0,
+        });
+        if (!isValid) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: bulkImportMcpI18nMessages.namespace.conflictError,
+            path: ['namespace'],
           });
-          if (!isValid) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: bulkImportMcpI18nMessages.namespace.conflictError,
-            });
-          }
         }
-      }),
-    labels: z.array(z.string()),
-  });
+      }
+    });
 };

--- a/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_validate_namespace.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/hooks/tools/use_validate_namespace.ts
@@ -11,17 +11,22 @@ import { useOnechatServices } from '../use_onechat_service';
 
 export interface UseValidateNamespaceOptions {
   namespace: string;
+  connectorId?: string;
   enabled?: boolean;
 }
 
-export const useValidateNamespace = ({ namespace, enabled }: UseValidateNamespaceOptions) => {
+export const useValidateNamespace = ({
+  namespace,
+  connectorId,
+  enabled,
+}: UseValidateNamespaceOptions) => {
   const { toolsService } = useOnechatServices();
 
   const isEnabled = enabled ?? namespace.length > 0;
 
   const { data, isLoading, error, isError, isFetching } = useQuery({
-    queryKey: queryKeys.tools.namespace.validate(namespace),
-    queryFn: () => toolsService.validateNamespace({ namespace }),
+    queryKey: queryKeys.tools.namespace.validate(namespace, connectorId),
+    queryFn: () => toolsService.validateNamespace({ namespace, connectorId }),
     enabled: isEnabled,
     staleTime: 0,
   });

--- a/x-pack/platform/plugins/shared/onechat/public/application/query_keys.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/application/query_keys.ts
@@ -40,7 +40,8 @@ export const queryKeys = {
       mcp: () => ['tools', 'health', 'mcp'] as const,
     },
     namespace: {
-      validate: (namespace: string) => ['tools', 'namespace', 'validate', namespace] as const,
+      validate: (namespace: string, connectorId?: string) =>
+        ['tools', 'namespace', 'validate', namespace, connectorId] as const,
     },
   },
 };

--- a/x-pack/platform/plugins/shared/onechat/public/services/tools/tools_service.ts
+++ b/x-pack/platform/plugins/shared/onechat/public/services/tools/tools_service.ts
@@ -168,10 +168,10 @@ export class ToolsService {
     );
   }
 
-  async validateNamespace({ namespace }: { namespace: string }) {
+  async validateNamespace({ namespace, connectorId }: { namespace: string; connectorId?: string }) {
     return await this.http.get<ValidateNamespaceResponse>(
       `${internalApiPath}/tools/_validate_namespace`,
-      { query: { namespace } }
+      { query: { namespace, connector_id: connectorId } }
     );
   }
 }

--- a/x-pack/platform/plugins/shared/onechat/server/routes/internal/tools.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/routes/internal/tools.ts
@@ -238,6 +238,7 @@ export function registerInternalToolsRoutes({
       validate: {
         query: schema.object({
           namespace: schema.string(),
+          connector_id: schema.maybe(schema.string()),
         }),
       },
       options: { access: 'internal' },
@@ -246,33 +247,54 @@ export function registerInternalToolsRoutes({
       },
     },
     wrapHandler(async (ctx, request, response) => {
-      const { namespace } = request.query;
+      const { namespace, connector_id: connectorId } = request.query;
       const { tools: toolService } = getInternalServices();
       const registry = await toolService.getRegistry({ request });
 
       const allTools = await registry.list({});
 
-      // Extract namespaces from tool IDs
-      // A tool ID like "mcp.github.tool_name" has namespace "mcp.github"
-      // A tool ID like "mcp.tool_name" has namespace "mcp"
-      // A tool ID like "tool_name" has no namespace
-      const existingNamespaces = new Set<string>();
-      allTools.forEach((tool) => {
+      const toolsInNamespace = allTools.filter((tool) => {
         const lastDotIndex = tool.id.lastIndexOf('.');
         if (lastDotIndex > 0) {
           const toolNamespace = tool.id.substring(0, lastDotIndex);
-          existingNamespaces.add(toolNamespace);
+          return toolNamespace === namespace;
         }
+        return false;
       });
 
-      const conflictingNamespaces = Array.from(existingNamespaces).filter(
-        (existingNamespace) => existingNamespace === namespace
-      );
+      if (toolsInNamespace.length === 0) {
+        return response.ok<ValidateNamespaceResponse>({
+          body: {
+            isValid: true,
+            conflictingNamespaces: [],
+          },
+        });
+      }
+
+      // If connectorId is provided, check if all tools in the namespace belong to the same connector
+      // This allows reusing a namespace for the same MCP server
+      if (connectorId) {
+        const allToolsBelongToSameConnector = toolsInNamespace.every((tool) => {
+          if (isMcpTool(tool)) {
+            return tool.configuration.connector_id === connectorId;
+          }
+          return false;
+        });
+
+        if (allToolsBelongToSameConnector) {
+          return response.ok<ValidateNamespaceResponse>({
+            body: {
+              isValid: true,
+              conflictingNamespaces: [],
+            },
+          });
+        }
+      }
 
       return response.ok<ValidateNamespaceResponse>({
         body: {
-          isValid: conflictingNamespaces.length === 0,
-          conflictingNamespaces,
+          isValid: false,
+          conflictingNamespaces: [namespace],
         },
       });
     })


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Agent Builder] Support bulk import MCP tools into existing namespace if KSC is same (#248563)](https://github.com/elastic/kibana/pull/248563)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dennis Tismenko","email":"dennis.tismenko@elastic.co"},"sourceCommit":{"committedDate":"2026-01-12T18:04:04Z","message":"[Agent Builder] Support bulk import MCP tools into existing namespace if KSC is same (#248563)\n\n## Summary\n\nUpdates namespace validation to allow users to bulk import MCP tools\ninto existing namespace as long as the MCP Kibana stack connector is the\nsame.\n\n\nhttps://github.com/user-attachments/assets/fdaec099-c409-4955-b3f5-76e60bb43399\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"90fd64c69234b1b04f6e6e5862cf7d0a7b6b23d7","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.3.0","v9.4.0"],"title":"[Agent Builder] Support bulk import MCP tools into existing namespace if KSC is same","number":248563,"url":"https://github.com/elastic/kibana/pull/248563","mergeCommit":{"message":"[Agent Builder] Support bulk import MCP tools into existing namespace if KSC is same (#248563)\n\n## Summary\n\nUpdates namespace validation to allow users to bulk import MCP tools\ninto existing namespace as long as the MCP Kibana stack connector is the\nsame.\n\n\nhttps://github.com/user-attachments/assets/fdaec099-c409-4955-b3f5-76e60bb43399\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"90fd64c69234b1b04f6e6e5862cf7d0a7b6b23d7"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248563","number":248563,"mergeCommit":{"message":"[Agent Builder] Support bulk import MCP tools into existing namespace if KSC is same (#248563)\n\n## Summary\n\nUpdates namespace validation to allow users to bulk import MCP tools\ninto existing namespace as long as the MCP Kibana stack connector is the\nsame.\n\n\nhttps://github.com/user-attachments/assets/fdaec099-c409-4955-b3f5-76e60bb43399\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"90fd64c69234b1b04f6e6e5862cf7d0a7b6b23d7"}}]}] BACKPORT-->