### PR TITLE
[dashboards as code] update scope tooling to ignore empty enhancements

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/api/scope_tooling.test.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/scope_tooling.test.ts
@@ -160,7 +160,11 @@ describe('stripUnmappedKeys', () => {
         {
           config: {
             title: 'panel',
-            enhancements: {},
+            enhancements: {
+              dynamicActions: {
+                events: [],
+              },
+            },
           },
           grid: {
             h: 15,
@@ -177,7 +181,11 @@ describe('stripUnmappedKeys', () => {
             {
               config: {
                 title: 'panel in section',
-                enhancements: {},
+                enhancements: {
+                  dynamicActions: {
+                    events: [{}],
+                  },
+                },
               },
               grid: {
                 h: 15,
@@ -235,7 +243,6 @@ describe('stripUnmappedKeys', () => {
           "title": "my dashboard",
         },
         "warnings": Array [
-          "Dropped unmapped panel config key 'enhancements' from panel panel1",
           "Dropped unmapped panel config key 'enhancements' from panel panelInSection1",
         ],
       }

--- a/src/platform/plugins/shared/dashboard/server/api/scope_tooling.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/scope_tooling.ts
@@ -40,8 +40,14 @@ export function stripUnmappedKeys(dashboardState: DashboardState) {
   }
 
   function removeEnhancements(panel: DashboardPanel) {
-    const { enhancements, ...restOfConfig } = panel.config as { enhancements?: unknown };
-    if (enhancements) {
+    const { enhancements, ...restOfConfig } = panel.config as {
+      enhancements?: { dynamicActions: { events: [] } };
+    };
+    if (
+      typeof enhancements?.dynamicActions === 'object' &&
+      Array.isArray(enhancements?.dynamicActions?.events) &&
+      enhancements.dynamicActions.events.length
+    ) {
       warnings.push(`Dropped unmapped panel config key 'enhancements' from panel ${panel.uid}`);
     }
     return {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/248661

PR updates scope tooling to only provide a warning if enhancements.dynamicActions.events is populated.