### PR TITLE
[AI Infra] Fixes Elastic documentation automatically uninstalling when Security Labs is uninstalled

### DIFF
--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/product_doc_install_service.test.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/product_doc_install_service.test.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Logger, SavedObjectsFindResult } from '@kbn/core/server';
-import { DocumentationProduct } from '@kbn/product-doc-common';
+import { DocumentationProduct, ResourceTypes } from '@kbn/product-doc-common';
 import type { ProductDocInstallStatusAttributes as TypeAttributes } from '../../saved_objects';
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { ProductDocInstallClient } from './product_doc_install_service';
@@ -64,6 +64,108 @@ describe('ProductDocInstallClient', () => {
       expect(installStatus.security).toEqual({
         status: 'uninstalled',
       });
+    });
+
+    it('filters out security_labs saved objects so they do not overwrite product docs status', async () => {
+      soClient.find.mockResolvedValue({
+        saved_objects: [
+          // Product docs "security" should win
+          createObj({
+            product_name: 'security',
+            product_version: '9.2',
+            installation_status: 'installed',
+            resource_type: ResourceTypes.productDoc,
+            inference_id: inferenceId,
+          }),
+          // Security Labs record uses product_name=security too, but must be ignored by product docs status
+          createObj({
+            product_name: 'security',
+            product_version: '2025.12.12',
+            installation_status: 'uninstalled',
+            resource_type: ResourceTypes.securityLabs,
+            inference_id: inferenceId,
+          }),
+        ],
+        total: 2,
+        per_page: 100,
+        page: 1,
+      });
+
+      const installStatus = await service.getInstallationStatus({ inferenceId });
+
+      expect(installStatus.security).toEqual({
+        status: 'installed',
+        version: '9.2',
+      });
+    });
+
+    it('treats missing resource_type as product_doc (backwards compatibility)', async () => {
+      soClient.find.mockResolvedValue({
+        saved_objects: [
+          createObj({
+            product_name: 'security',
+            product_version: '9.2',
+            installation_status: 'installed',
+            // resource_type omitted
+            inference_id: inferenceId,
+          }),
+        ],
+        total: 1,
+        per_page: 100,
+        page: 1,
+      });
+
+      const installStatus = await service.getInstallationStatus({ inferenceId });
+
+      expect(installStatus.security).toEqual({
+        status: 'installed',
+        version: '9.2',
+      });
+    });
+  });
+
+  describe('status setters', () => {
+    it('writes resource_type=product_doc when setting installation started', async () => {
+      soClient.update.mockResolvedValueOnce({} as any);
+
+      await service.setInstallationStarted({
+        productName: 'kibana',
+        productVersion: '9.2',
+        inferenceId,
+      });
+
+      expect(soClient.update).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('kb-product-doc-kibana'),
+        expect.objectContaining({
+          product_name: 'kibana',
+          product_version: '9.2',
+          installation_status: 'installing',
+          inference_id: inferenceId,
+          resource_type: ResourceTypes.productDoc,
+        }),
+        expect.objectContaining({
+          upsert: expect.objectContaining({
+            resource_type: ResourceTypes.productDoc,
+          }),
+        })
+      );
+    });
+
+    it('writes resource_type=product_doc when setting uninstalled', async () => {
+      soClient.update.mockResolvedValueOnce({} as any);
+
+      await service.setUninstalled('kibana', inferenceId);
+
+      expect(soClient.update).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('kb-product-doc-kibana'),
+        expect.objectContaining({
+          installation_status: 'uninstalled',
+          inference_id: inferenceId,
+          resource_type: ResourceTypes.productDoc,
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #248637: uninstalling Security Labs documentation from GenAI Settings no longer affects Elastic documentation status.
* Filter `security_labs` saved objects out of product-doc status computation to prevent “security” status contamination.
* Write `resource_type`: product_doc for product-doc install status records going forward (back-compat for missing `
resource_type`).
* Add unit tests covering the filtering + setter behavior.



https://github.com/user-attachments/assets/35deef85-1996-4a84-94cb-4f1ea1012072



_PR developed with Cursor + GPT 5.2_

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->