### PR TITLE
[Write-restricted dashboards] Fix edge case during creation where user can not own a dashboard

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/open_save_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/open_save_modal.tsx
@@ -63,7 +63,7 @@ export async function openSaveModal({
       return undefined;
     }
     const shouldAddAccessControl =
-      Boolean(!lastSavedId) && Boolean((await coreServices.userProfile.getCurrent()).uid);
+      Boolean(!lastSavedId) && Boolean(await coreServices.userProfile.getCurrent());
 
     const saveAsTitle = lastSavedId ? await getSaveAsTitle(title) : title;
     return new Promise<(SaveDashboardReturn & { savedState: DashboardState }) | undefined>(

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/open_save_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/open_save_modal.tsx
@@ -62,6 +62,9 @@ export async function openSaveModal({
     if (viewMode === 'edit' && isManaged) {
       return undefined;
     }
+    const shouldAddAccessControl =
+      Boolean(!lastSavedId) && Boolean((await coreServices.userProfile.getCurrent()).uid);
+
     const saveAsTitle = lastSavedId ? await getSaveAsTitle(title) : title;
     return new Promise<(SaveDashboardReturn & { savedState: DashboardState }) | undefined>(
       (resolve) => {
@@ -116,8 +119,8 @@ export async function openSaveModal({
               saveOptions,
               dashboardState: dashboardStateToSave,
               lastSavedId,
-              // Only pass access mode for new dashboard creation (no lastSavedId)
-              accessMode: !lastSavedId && newAccessMode ? newAccessMode : undefined,
+              // Only pass access mode for new dashboard creation (no lastSavedId) and when user can own a dashboard
+              accessMode: shouldAddAccessControl && newAccessMode ? newAccessMode : undefined,
             });
 
             const addDuration = window.performance.now() - beforeAddTime;
@@ -154,7 +157,7 @@ export async function openSaveModal({
             onSave={onSaveAttempt}
             accessControl={accessControl}
             customModalTitle={getCustomModalTitle(viewMode)}
-            isDuplicateAction={Boolean(lastSavedId)}
+            shouldShowAccessContainer={shouldAddAccessControl}
           />
         );
       }

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/open_save_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/open_save_modal.tsx
@@ -170,7 +170,7 @@ export async function openSaveModal({
             onSave={onSaveAttempt}
             accessControl={accessControl}
             customModalTitle={getCustomModalTitle(viewMode)}
-            shouldShowAccessContainer={shouldAddAccessControl}
+            showAccessContainer={shouldAddAccessControl}
           />
         );
       }

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/save_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/save_modal.tsx
@@ -55,7 +55,7 @@ interface DashboardSaveModalProps {
   showStoreProjectRoutingOnSave?: boolean;
   customModalTitle?: string;
   accessControl?: Partial<SavedObjectAccessControl>;
-  isDuplicateAction?: boolean;
+  shouldShowAccessContainer?: boolean;
 }
 
 type SaveDashboardHandler = (args: {
@@ -79,7 +79,7 @@ export const DashboardSaveModal: React.FC<DashboardSaveModalProps> = ({
   timeRestore,
   projectRoutingRestore,
   accessControl,
-  isDuplicateAction,
+  shouldShowAccessContainer,
 }) => {
   const [selectedTags, setSelectedTags] = React.useState<string[]>(tags ?? []);
   const [persistSelectedTimeInterval, setPersistSelectedTimeInterval] = React.useState(timeRestore);
@@ -196,7 +196,7 @@ export const DashboardSaveModal: React.FC<DashboardSaveModalProps> = ({
             </EuiFlexGroup>
           </EuiFormRow>
         ) : null}
-        {!isDuplicateAction && (
+        {shouldShowAccessContainer && (
           <>
             <EuiSpacer size="l" />
             <AccessModeContainer
@@ -218,7 +218,7 @@ export const DashboardSaveModal: React.FC<DashboardSaveModalProps> = ({
     showStoreTimeOnSave,
     showStoreProjectRoutingOnSave,
     accessControl,
-    isDuplicateAction,
+    shouldShowAccessContainer,
   ]);
 
   return (

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/save_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/save_modal.tsx
@@ -55,7 +55,7 @@ interface DashboardSaveModalProps {
   showStoreProjectRoutingOnSave?: boolean;
   customModalTitle?: string;
   accessControl?: Partial<SavedObjectAccessControl>;
-  shouldShowAccessContainer?: boolean;
+  showAccessContainer?: boolean;
 }
 
 type SaveDashboardHandler = (args: {
@@ -79,7 +79,7 @@ export const DashboardSaveModal: React.FC<DashboardSaveModalProps> = ({
   timeRestore,
   projectRoutingRestore,
   accessControl,
-  shouldShowAccessContainer,
+  showAccessContainer,
 }) => {
   const [selectedTags, setSelectedTags] = React.useState<string[]>(tags ?? []);
   const [persistSelectedTimeInterval, setPersistSelectedTimeInterval] = React.useState(timeRestore);
@@ -196,7 +196,7 @@ export const DashboardSaveModal: React.FC<DashboardSaveModalProps> = ({
             </EuiFlexGroup>
           </EuiFormRow>
         ) : null}
-        {shouldShowAccessContainer && (
+        {showAccessContainer && (
           <>
             <EuiSpacer size="l" />
             <AccessModeContainer
@@ -218,7 +218,7 @@ export const DashboardSaveModal: React.FC<DashboardSaveModalProps> = ({
     showStoreTimeOnSave,
     showStoreProjectRoutingOnSave,
     accessControl,
-    shouldShowAccessContainer,
+    showAccessContainer,
   ]);
 
   return (


### PR DESCRIPTION
## Summary

This PR fixes an edge case when dashboard creation would fail if a user can't own a dashboard because they're an anonymous user or user authenticated via authenticating proxy.

Closes: https://github.com/elastic/kibana/issues/248752


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->