### PR TITLE
[ML] Removes "tech preview" badge for Jina Embeddings v3 and Jina Reranker v2 default endpoints in Kibana

### DIFF
--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/utils/reranker_helper.test.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/utils/reranker_helper.test.ts
@@ -47,12 +47,12 @@ describe('Reranker Tech preview badge', () => {
     expect(isProviderTechPreview(mockProvider)).toEqual(true);
   });
 
-  it('should return true for jina-embeddings-v3 model', () => {
-    expect(isProviderTechPreview(mockJinaEmbeddingsV3Provider)).toEqual(true);
+  it('should return false for jina-embeddings-v3 model', () => {
+    expect(isProviderTechPreview(mockJinaEmbeddingsV3Provider)).toEqual(false);
   });
 
-  it('should return true for jina-reranker-v2 model', () => {
-    expect(isProviderTechPreview(mockJinaRerankerV2Provider)).toEqual(true);
+  it('should return false for jina-reranker-v2 model', () => {
+    expect(isProviderTechPreview(mockJinaRerankerV2Provider)).toEqual(false);
   });
 
   it('return false for rainbow-sprinkles', () => {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/utils/reranker_helper.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/utils/reranker_helper.ts
@@ -27,10 +27,7 @@ export const isProviderTechPreview = (provider: InferenceInferenceEndpointInfo) 
   */
   if (
     (taskType === 'rerank' && modelId.startsWith('.')) ||
-    ((modelId === 'multilingual-embed-v1' ||
-      modelId === 'rerank-v1' ||
-      modelId === 'jina-embeddings-v3' ||
-      modelId === 'jina-reranker-v2') &&
+    ((modelId === 'multilingual-embed-v1' || modelId === 'rerank-v1') &&
       inferenceId.startsWith('.') &&
       service === ServiceProviderKeys.elastic)
   ) {


### PR DESCRIPTION
## Summary

The Jina embeddings (.jina-embeddings-v3-elastic) and Jina reranker (.jina-reranker-v2-elastic) will now be marked as GA. 
This PR removes the tech preview label for both.
Fixes https://github.com/elastic/kibana/issues/245060

### NOTE: 
This PR needs to be merged on January 14th


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->