### PR TITLE
[SharedUX] Fix share modal time range issues

### DIFF
--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.test.tsx
@@ -267,4 +267,52 @@ describe('LinkContent', () => {
     const saveButton = screen.queryByRole('button', { name: 'Save changes' });
     expect(saveButton).not.toBeInTheDocument();
   });
+
+  it('should show toggle when time range is relative', () => {
+    const shareableUrlLocatorParams = {
+      locator: new MockLocatorDefinition('TEST_LOCATOR'),
+      params: {
+        timeRange: { from: 'now-15m', to: 'now' },
+      },
+    };
+
+    renderComponent({
+      objectType: 'dashboard',
+      isDirty: false,
+      shareableUrl,
+      shortUrlService,
+      allowShortUrl: false,
+      // @ts-expect-error Test mock - MockLocatorDefinition is sufficient for testing but doesn't match full LocatorPublic type
+      shareableUrlLocatorParams,
+    });
+
+    const toggle = screen.getByTestId('timeRangeSwitch');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('should not show toggle and show callout when time range is absolute', () => {
+    const shareableUrlLocatorParams = {
+      locator: new MockLocatorDefinition('TEST_LOCATOR'),
+      params: {
+        timeRange: {
+          from: '2024-01-01T00:00:00.000Z',
+          to: '2024-01-02T00:00:00.000Z',
+        },
+      },
+    };
+
+    renderComponent({
+      objectType: 'dashboard',
+      isDirty: false,
+      shareableUrl,
+      shortUrlService,
+      allowShortUrl: false,
+      // @ts-expect-error Test mock - MockLocatorDefinition is sufficient for testing but doesn't match full LocatorPublic type
+      shareableUrlLocatorParams,
+    });
+
+    expect(screen.queryByTestId('timeRangeSwitch')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('relativeTimeCallout')).toBeInTheDocument();
+  });
 });

--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
@@ -19,6 +19,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useState, useRef, useEffect } from 'react';
+import { isTimeRangeAbsoluteTime } from '../../../lib/time_utils';
 import { TimeTypeSection } from './time_type_section';
 import { useShareContext, type IShareContext } from '../../context';
 import type { LinkShareConfig, LinkShareUIConfig } from '../../../types';
@@ -56,11 +57,12 @@ export const LinkContent = ({
   const [snapshotUrl, setSnapshotUrl] = useState<string>('');
   const [isTextCopied, setTextCopied] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [isAbsoluteTime, setIsAbsoluteTime] = useState(true);
   const urlParamsRef = useRef<UrlParams | undefined>(undefined);
   const urlToCopy = useRef<string | undefined>(undefined);
   const copiedTextToolTipCleanupIdRef = useRef<ReturnType<typeof setTimeout>>();
   const timeRange = shareableUrlLocatorParams?.params?.timeRange;
+  const isAbsoluteTimeByDefault = isTimeRangeAbsoluteTime(timeRange);
+  const [isAbsoluteTime, setIsAbsoluteTime] = useState(isAbsoluteTimeByDefault);
 
   const { delegatedShareUrlHandler, draftModeCallOut } = objectConfig;
   const draftModeCalloutContent = typeof draftModeCallOut === 'object' ? draftModeCallOut : {};
@@ -141,7 +143,7 @@ export const LinkContent = ({
         <TimeTypeSection
           timeRange={timeRange}
           onTimeTypeChange={handleTimeTypeChange}
-          isAbsoluteTimeByDefault={isAbsoluteTime}
+          isAbsoluteTimeByDefault={isAbsoluteTimeByDefault}
         />
         {isDirty && draftModeCallOut && (
           <>

--- a/src/platform/plugins/shared/share/public/components/tabs/link/time_type_section.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/time_type_section.tsx
@@ -160,6 +160,7 @@ export const TimeTypeSection = ({
             })}
             checked={isAbsoluteTime}
             onChange={handleTimeTypeChange}
+            data-test-subj="timeRangeSwitch"
           />
           <EuiSpacer size="m" />
         </>
@@ -188,6 +189,7 @@ export const TimeTypeSection = ({
           title={i18n.translate('share.link.timeRange.relativeTimeCallout', {
             defaultMessage: 'To use a relative time range, select it in the time picker first.',
           })}
+          data-test-subj="relativeTimeCallout"
         />
       )}
     </>

--- a/src/platform/plugins/shared/share/public/url_service/short_urls/short_url_client.test.ts
+++ b/src/platform/plugins/shared/share/public/url_service/short_urls/short_url_client.test.ts
@@ -367,3 +367,88 @@ describe('delete()', () => {
     expect(err).toStrictEqual(error);
   });
 });
+
+describe('createWithLocator()', () => {
+  const mockLocator = {
+    id: 'MOCK_LOCATOR',
+    getLocation: jest.fn(),
+    navigate: jest.fn(),
+    getUrl: jest.fn(),
+    navigateSync: jest.fn(),
+    getRedirectUrl: jest.fn(),
+    extract: jest.fn(),
+    inject: jest.fn(),
+    telemetry: jest.fn(),
+    migrations: {},
+    useUrl: jest.fn(),
+  };
+
+  // Mock Date.now() for consistent results
+  const fixedNow = new Date('2026-01-12T12:00:00.000Z');
+  jest.spyOn(Date, 'now').mockImplementation(() => fixedNow.getTime());
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('converts relative timeRange to absolute when isAbsoluteTime is true', async () => {
+    const { service, http } = setup();
+    const fetchSpy = http.fetch as unknown as jest.SpyInstance;
+
+    await service.shortUrls.get(null).createWithLocator(
+      {
+        locator: mockLocator,
+        params: {
+          timeRange: { from: 'now-15m', to: 'now' },
+        },
+      },
+      true
+    );
+
+    const sentBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(sentBody.params.timeRange.from).toBe('2026-01-12T11:45:00.000Z');
+    expect(sentBody.params.timeRange.to).toBe('2026-01-12T12:00:00.000Z');
+  });
+
+  test('converts both timeRange and time_range when both exist', async () => {
+    const { service, http } = setup();
+    const fetchSpy = http.fetch as unknown as jest.SpyInstance;
+
+    await service.shortUrls.get(null).createWithLocator(
+      {
+        locator: mockLocator,
+        params: {
+          timeRange: { from: 'now-15m', to: 'now' },
+          time_range: { from: 'now-15m', to: 'now' },
+        },
+      },
+      true
+    );
+
+    const sentBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    // Both fields should be converted
+    expect(sentBody.params.timeRange.from).toBe('2026-01-12T11:45:00.000Z');
+    expect(sentBody.params.timeRange.to).toBe('2026-01-12T12:00:00.000Z');
+    expect(sentBody.params.time_range.from).toBe('2026-01-12T11:45:00.000Z');
+    expect(sentBody.params.time_range.to).toBe('2026-01-12T12:00:00.000Z');
+  });
+
+  test('preserves relative time when isAbsoluteTime is false', async () => {
+    const { service, http } = setup();
+    const fetchSpy = http.fetch as unknown as jest.SpyInstance;
+
+    await service.shortUrls.get(null).createWithLocator(
+      {
+        locator: mockLocator,
+        params: {
+          timeRange: { from: 'now-15m', to: 'now' },
+        },
+      },
+      false
+    );
+
+    const sentBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(sentBody.params.timeRange.from).toBe('now-15m');
+    expect(sentBody.params.timeRange.to).toBe('now');
+  });
+});

--- a/src/platform/plugins/shared/share/public/url_service/short_urls/short_url_client.ts
+++ b/src/platform/plugins/shared/share/public/url_service/short_urls/short_url_client.ts
@@ -76,19 +76,35 @@ export class BrowserShortUrlClient implements IShortUrlClient {
     isAbsoluteTime?: boolean
   ): Promise<ShortUrlCreateResponse<P>> {
     const getUpdatedParams = (inputParams: ShortUrlCreateParams<P>) => {
+      if (!isAbsoluteTime) return inputParams;
+
       const timeRange = inputParams.params?.timeRange as SerializableRecord;
-      if (isAbsoluteTime && timeRange?.from && timeRange?.to)
-        return {
-          ...inputParams,
-          params: {
-            ...inputParams.params,
-            timeRange: {
-              from: convertRelativeTimeStringToAbsoluteTimeString(timeRange.from as string),
-              to: convertRelativeTimeStringToAbsoluteTimeString(timeRange.to as string),
-            },
-          },
+      const timeRangeSnakeCase = inputParams.params?.time_range as SerializableRecord;
+
+      const timeRanges: {
+        timeRange?: { from: string | undefined; to: string | undefined };
+        time_range?: { from: string | undefined; to: string | undefined };
+      } = {};
+
+      if (timeRange?.from && timeRange?.to) {
+        timeRanges.timeRange = {
+          from: convertRelativeTimeStringToAbsoluteTimeString(timeRange.from as string),
+          to: convertRelativeTimeStringToAbsoluteTimeString(timeRange.to as string),
         };
-      return inputParams;
+      }
+      if (timeRangeSnakeCase?.from && timeRangeSnakeCase?.to) {
+        timeRanges.time_range = {
+          from: convertRelativeTimeStringToAbsoluteTimeString(timeRangeSnakeCase.from as string),
+          to: convertRelativeTimeStringToAbsoluteTimeString(timeRangeSnakeCase.to as string),
+        };
+      }
+      return {
+        ...inputParams,
+        params: {
+          ...inputParams.params,
+          ...timeRanges,
+        },
+      };
     };
 
     const result = await this.create(getUpdatedParams(params));


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/246977

## Summary

- This PR fixes 3 issues in share modal:
  1. Relative to absolute time range toggle never showing up
  2. Callout to use a relative time range always showing up
  3. Anywhere but dashboards: short URL generated not honoring the time range indicator selected (always shared as absolute)
- Added test cases to avoid this from happening in the future

### Testing

Manually tested both in Discover and Dashboards that all UI elements are shown as expected and the following use cases:
- Set a rel time range, copy URL, verify object is shared with relative time range
- Set a rel time range, toggle to abs, copy URL, verify object is shared with absolute time range
- Set an abs time range, copy URL, verify object is shared with absolute time range
- Set a mixed rel and abs time range, copy URL, verify object is shared with mixed relative and absolute time range 
- Set a mixed rel and abs time range, copy URL, toggle to abs, verify object is shared with absolute time range 

Discover with rel time range selected:

<img width="410" height="280" alt="Screenshot 2026-01-13 at 10 02 00" src="https://github.com/user-attachments/assets/fbc07552-1764-4c96-8bbf-181d7e8d2635" />

Discover with abs time range selected:

<img width="400" height="285" alt="Screenshot 2026-01-13 at 10 01 41" src="https://github.com/user-attachments/assets/8095e8ac-6c46-460b-94cd-810f9398e391" />

Dashboards with rel time range selected:

<img width="400" height="370" alt="Screenshot 2026-01-13 at 10 00 58" src="https://github.com/user-attachments/assets/887c585e-8d12-49be-955c-eba4c8921d1e" />

Dashboards with abs time range selected:

<img width="400" height="400" alt="Screenshot 2026-01-13 at 10 00 29" src="https://github.com/user-attachments/assets/a6a4b1df-5312-4322-883e-cc74f7bc5865" />


<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->

## Release Notes
Fixes an issue with share modal where all time ranges were being shared as absolute. 