### PR TITLE
[SharedUX] Change share modal new badge color

### DIFF
--- a/src/platform/packages/shared/content-management/access_control/access_control_public/src/components/access_mode_container.tsx
+++ b/src/platform/packages/shared/content-management/access_control/access_control_public/src/components/access_mode_container.tsx
@@ -19,6 +19,7 @@ import {
   EuiText,
   EuiTitle,
   EuiToolTip,
+  useEuiTheme,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -27,6 +28,7 @@ import type { SavedObjectAccessControl } from '@kbn/core-saved-objects-common';
 import type { Space } from '@kbn/spaces-plugin/common';
 import type { GetUserProfileResponse } from '@kbn/security-plugin/common';
 import type { UserProfileData } from '@kbn/user-profile-components';
+import { css } from '@emotion/react';
 import type { AccessControlClient } from '../access_control_client';
 
 const selectOptions = [
@@ -87,6 +89,7 @@ export const AccessModeContainer = ({
   accessControl,
   createdBy,
 }: Props) => {
+  const { euiTheme } = useEuiTheme();
   const [space, setSpace] = useState<Space>({} as Space);
   const [isUpdatingPermissions, setIsUpdatingPermissions] = useState(false);
   const [canManageAccessControl, setCanManageAccessControl] = useState(false);
@@ -172,7 +175,12 @@ export const AccessModeContainer = ({
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiBetaBadge
-              color="accent"
+              // TODO: use a proper EuiBetaBadge color variant once available https://github.com/elastic/eui/issues/9268
+              css={css`
+                background-color: ${euiTheme.colors.backgroundFilledPrimary};
+                color: ${euiTheme.colors.textInverse};
+                border: none;
+              `}
               label={i18n.translate(
                 'contentManagement.accessControl.accessMode.container.newBadgeLabel',
                 { defaultMessage: 'New' }


### PR DESCRIPTION
## Summary

- Replaced `accent` variant for 'new' badge with primary blue one. 

### Testing

| <img width="551" height="457" alt="Screenshot 2026-01-13 at 12 27 21" src="https://github.com/user-attachments/assets/075a298b-0b69-468e-88c2-5185553df86d" /> | <img width="567" height="450" alt="Screenshot 2026-01-13 at 12 28 17" src="https://github.com/user-attachments/assets/2db6f27b-e971-4bba-a4b8-fa1102c21800" /> |
|--------|--------|

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->