### PR TITLE
[Synthetic Monitors] Hide SOs from the Global HTTP Apis

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/legacy_synthetics_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/legacy_synthetics_monitor.ts
@@ -35,6 +35,7 @@ export const getLegacySyntheticsMonitorSavedObjectType = (
     name: legacySyntheticsMonitorTypeSingle,
     hidden: false,
     namespaceType: 'single',
+    hiddenFromHttpApis: true,
     migrations: {
       '8.6.0': monitorMigrations['8.6.0'](encryptedSavedObjects),
       '8.8.0': monitorMigrations['8.8.0'](encryptedSavedObjects),

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/synthetics_monitor_config.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/synthetics_monitor_config.ts
@@ -14,6 +14,7 @@ export const getSyntheticsMonitorConfigSavedObjectType = (): SavedObjectsType =>
   return {
     name: syntheticsMonitorSavedObjectType,
     hidden: false,
+    hiddenFromHttpApis: true,
     namespaceType: 'multiple',
     mappings: monitorConfigMappings,
     management: {


### PR DESCRIPTION
## Summary

This PR hides from the Global SO HTTP APIs the Saved Objects defining Synthetics Monitors.

Since they already have their proper HTTP APIs (https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-synthetic-monitors), having them exposed through the Global SO HTTP APIs risks users corrupting their definition.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- [x] Customers might be relying on these deprecated APIs. They should migrate to the new APIs.


<!--ONMERGE {"backportTargets":["9.1","9.2","9.3"]} ONMERGE-->