### PR TITLE
[ES|QL] Improvements to cascade document helpers

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -51,7 +51,6 @@ export {
   convertTimeseriesCommandToFrom,
   getESQLStatsQueryMeta,
   constructCascadeQuery,
-  mutateQueryStatsGrouping,
   appendFilteringWhereClauseForCascadeLayout,
   getESQLSources,
   getEsqlColumns,

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -59,7 +59,6 @@ export { getLookupIndicesFromQuery } from './utils/get_lookup_indices';
 export {
   getESQLStatsQueryMeta,
   constructCascadeQuery,
-  mutateQueryStatsGrouping,
   appendFilteringWhereClauseForCascadeLayout,
 } from './utils/cascaded_documents_helpers';
 export { getProjectRoutingFromEsqlQuery } from './utils/set_instructions_helpers';

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/cascaded_documents_helpers.ts
@@ -7,13 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { type AggregateQuery } from '@kbn/es-query';
+import { type AggregateQuery, getDataViewFieldSubtypeMulti } from '@kbn/es-query';
 import {
   BasicPrettyPrinter,
   Builder,
   EsqlQuery,
   isColumn,
-  isOptionNode,
   isFunctionExpression,
   isSubQuery,
   mutate,
@@ -21,7 +20,6 @@ import {
   type ESQLCommand,
   type ESQLFunction,
   type ESQLAstItem,
-  type ESQLCommandOption,
   type ESQLColumn,
   isBinaryExpression,
   Walker,
@@ -86,7 +84,14 @@ export const isSupportedFieldType = (fieldType: unknown): fieldType is Supported
 
 // if value is a text or keyword field and it's not "aggregatable", we opt to use match phrase for the where command
 const requiresMatchPhrase = (fieldName: string, dataViewFields: DataView['fields']) => {
-  const dataViewField = dataViewFields.getByName(fieldName);
+  let dataViewField = dataViewFields.getByName(fieldName);
+
+  const multiSubtype = dataViewField && getDataViewFieldSubtypeMulti(dataViewField);
+
+  if (multiSubtype) {
+    // if the field is a subtype, we want to use the parent field to determine wether to use the match phrase
+    dataViewField = dataViewFields.getByName(multiSubtype.multi.parent);
+  }
 
   return (
     (dataViewField?.esTypes?.includes('text') || dataViewField?.esTypes?.includes('keyword')) &&
@@ -187,6 +192,9 @@ export const getESQLStatsQueryMeta = (queryString: string): ESQLStatsQueryMeta =
 
   const dataSourceCommand = getESQLQueryDataSourceCommand(esqlQuery);
   const summarizedStatsCommand = getStatsCommandToOperateOn(esqlQuery);
+  const operatingStatsCommandIndex = esqlQuery.ast.commands.findIndex(
+    (cmd) => cmd.text === summarizedStatsCommand?.command.text
+  );
 
   if (
     dataSourceCommand?.args.some(isSubQuery) ||
@@ -195,10 +203,6 @@ export const getESQLStatsQueryMeta = (queryString: string): ESQLStatsQueryMeta =
   ) {
     return { groupByFields, appliedFunctions };
   }
-
-  // get all the new fields created by the stats commands in the query,
-  // so we might tell if the command we are operating on is referencing a field that was defined by a preceding command
-  const statsCommandRuntimeFields = getStatsCommandRuntimeFields(esqlQuery);
 
   const grouping = Object.values(summarizedStatsCommand.grouping);
 
@@ -210,29 +214,74 @@ export const getESQLStatsQueryMeta = (queryString: string): ESQLStatsQueryMeta =
       return { groupByFields: [], appliedFunctions: [] };
     }
 
+    // unnamed grouping functions are wrapped in backticks in the generated AST so we strip them off if they exist,
+    // so the value displayed in the UI is the same as the value used in the query
     const groupFieldName = removeBackticks(group.field);
+
+    // this is a placeholder for the index of the stats command that declared the group field
+    // we start off assuming it's index is the same as the stats command we are operating on,
+    // it however will be updated if the group field is determined to be declared by some other stats command
+    let groupDeclarationStatsCommandIndex = operatingStatsCommandIndex;
+
+    // this is a placeholder for the group field node,
+    // it will be updated to the actual definition of the group field if it was declared by a preceding stats command
     let groupFieldNode = group;
 
-    const groupDeclarationCommandIndex = statsCommandRuntimeFields.findIndex((field) =>
-      field.has(groupFieldName)
-    );
+    if (!summarizedStatsCommand.newFields.has(groupFieldName)) {
+      // get all the new fields created by the stats commands in the query,
+      // so we might tell if the command we are operating on is referencing a field that was defined by a preceding command
+      const statsCommandRuntimeFields = getStatsCommandRuntimeFields(esqlQuery);
 
-    let groupDeclarationCommandSummary: StatsCommandSummary | null = null;
+      const groupDeclarationStatsCommandLookupIndex = statsCommandRuntimeFields.findIndex((field) =>
+        field.has(groupFieldName)
+      );
 
-    if (
-      groupDeclarationCommandIndex >= 0 &&
-      (groupDeclarationCommandSummary = getStatsCommandAtIndexSummary(
-        esqlQuery,
-        groupDeclarationCommandIndex
-      ))
-    ) {
-      // update the group field node to it's actual definition
-      groupFieldNode = groupDeclarationCommandSummary.grouping[groupFieldName];
+      let groupDeclarationCommandSummary: StatsCommandSummary | null = null;
+
+      if (
+        groupDeclarationStatsCommandLookupIndex >= 0 &&
+        (groupDeclarationCommandSummary = getStatsCommandAtIndexSummary(
+          esqlQuery,
+          groupDeclarationStatsCommandLookupIndex
+        ))
+      ) {
+        groupDeclarationStatsCommandIndex = groupDeclarationStatsCommandLookupIndex;
+        // update the group field node to it's actual definition
+        groupFieldNode = groupDeclarationCommandSummary.grouping[groupFieldName];
+      }
+    }
+
+    // given that keep commands strip fields from the resulting records,
+    // we need to ascertain that if a keep command exists after the operating stats command, it specifies the current group field
+    const offendingKeepCommand = esqlQuery.ast.commands
+      .slice(groupDeclarationStatsCommandIndex)
+      .reduce((acc, cmd) => {
+        if (cmd.name !== 'keep') {
+          return acc || false;
+        }
+
+        let offending = false;
+
+        Walker.walk(cmd, {
+          visitColumn: (node) => {
+            // if we don't find a node that targets the current group field,
+            // then we know the keep command is invalidating the possibility of grouping by the current group field
+            offending = node.name !== groupFieldName;
+          },
+        });
+
+        return acc || offending;
+      }, false);
+
+    if (offendingKeepCommand) {
+      // we found a keep command that strips the current group field from the resulting records,
+      // so we break out of the loop as that invalidates the possibility of grouping by the current group field
+      break;
     }
 
     // check if there is a where command after the operating stats command targeting any of it's grouping options
     const whereCommandGroupFieldSearch = esqlQuery.ast.commands
-      .slice(groupDeclarationCommandIndex)
+      .slice(groupDeclarationStatsCommandIndex)
       .find((cmd) => {
         if (cmd.name !== 'where') {
           return false;
@@ -241,7 +290,7 @@ export const getESQLStatsQueryMeta = (queryString: string): ESQLStatsQueryMeta =
         let found = false;
 
         Walker.walk(cmd, {
-          visitIdentifier: (node) => {
+          visitColumn: (node) => {
             if (found) {
               return;
             }
@@ -274,11 +323,11 @@ export const getESQLStatsQueryMeta = (queryString: string): ESQLStatsQueryMeta =
       break;
     }
 
-    if (isFunctionExpression(groupFieldNode.definition)) {
-      const functionName = groupFieldNode.definition.name;
-      if (!isSupportedStatsFunction(functionName)) {
-        continue;
-      }
+    if (
+      isFunctionExpression(groupFieldNode.definition) &&
+      !isSupportedStatsFunction(groupFieldNode.definition.name)
+    ) {
+      continue;
     }
 
     groupByFields.push({
@@ -440,20 +489,6 @@ function handleStatsByColumnLeafOperation(
   // create a new query to populate with the cascade operation query
   const cascadeOperationQuery = EsqlQuery.fromSrc('');
 
-  // include all the existing commands up to the operating stats command in the cascade operation query
-  editorQuery.ast.commands.slice(0, operatingStatsCommandIndex + 1).forEach((cmd, idx, arr) => {
-    if (idx === arr.length - 1 && cmd.name === 'stats') {
-      // We know the operating stats command is the last command in the array,
-      // so we modify it into an INLINE STATS command
-      mutate.generic.commands.append(
-        cascadeOperationQuery.ast,
-        synth.cmd(`INLINE ${BasicPrettyPrinter.print(cmd)}`, { withFormatting: false })
-      );
-    } else {
-      mutate.generic.commands.append(cascadeOperationQuery.ast, cmd);
-    }
-  });
-
   let operationColumnName = columnNode.definition.name;
 
   let operationColumnNameParamValue;
@@ -473,6 +508,28 @@ function handleStatsByColumnLeafOperation(
 
   const shouldUseMatchPhrase = requiresMatchPhrase(operationColumnName, dataViewFields);
 
+  // include all the existing commands up to the operating stats command in the cascade operation query
+  editorQuery.ast.commands.slice(0, operatingStatsCommandIndex + 1).forEach((cmd, idx, arr) => {
+    if (idx === arr.length - 1 && cmd.name === 'stats') {
+      const hasAggregates = cmd.args.some(isFunctionExpression);
+
+      if (hasAggregates && !shouldUseMatchPhrase) {
+        // We know the operating stats command is the last command in the array,
+        // so we modify it into an INLINE STATS command
+        mutate.generic.commands.append(
+          cascadeOperationQuery.ast,
+          synth.cmd(`INLINE ${BasicPrettyPrinter.print(cmd)}`, { withFormatting: false })
+        );
+      } else {
+        // if the stats command does not have any aggregates, or will require a match phrase query,
+        // then we omit the STATS command to simply apply the where command to the query
+        return;
+      }
+    } else {
+      mutate.generic.commands.append(cascadeOperationQuery.ast, cmd);
+    }
+  });
+
   // build a where command with match expressions for the selected column
   const filterCommand = Builder.command({
     name: 'where',
@@ -486,7 +543,8 @@ function handleStatsByColumnLeafOperation(
             Builder.expression.column({
               args: [Builder.identifier({ name: operationColumnName })],
             }),
-            Number.isNaN(Number(operationValue))
+            Number.isNaN(Number(operationValue)) ||
+            dataViewFields.getByName(operationColumnName)?.type === 'string'
               ? Builder.expression.literal.string(operationValue as string)
               : Builder.expression.literal.integer(Number(operationValue)),
           ]),
@@ -515,11 +573,12 @@ function handleStatsByCategorizeLeafOperation(
 
   // include all the existing commands right up until the operating stats command
   editorQuery.ast.commands.slice(0, operatingStatsCommandIndex).forEach((cmd, idx, arr) => {
-    if (idx === arr.length - 1 && cmd.name === 'stats') {
+    if (idx === arr.length - 1 && (cmd.name === 'stats' || cmd.name === 'sample')) {
       // however, when the last command is a stats command, we don't want to include it in the cascade operation query
-      // since where commands that use either the MATCH or MATCH_PHRASE function cannot be immediately followed by a stats command
+      // since WHERE commands that use either the MATCH or MATCH_PHRASE function cannot be immediately followed by a STATS command
       // and moreover this STATS command doesn't provide any useful context even if it defines new runtime fields
-      // as we would have already selected the definition of the field if our operation stats command references it
+      // as we would have already selected the definition of the field if our operation stats command references it.
+      // Similarly, when the last command is a SAMPLE command, we don't want to include it in the cascade operation query since we want all matching documents to be considered.
       return;
     }
 
@@ -588,96 +647,6 @@ function handleStatsByCategorizeLeafOperation(
 }
 
 /**
- * Modifies the provided ESQL query to only include the specified columns in the stats by option.
- */
-export function mutateQueryStatsGrouping(query: AggregateQuery, pick: string[]): AggregateQuery {
-  const EditorESQLQuery = EsqlQuery.fromSrc(query.esql);
-
-  const dataSourceCommand = getESQLQueryDataSourceCommand(EditorESQLQuery);
-
-  if (!dataSourceCommand) {
-    throw new Error('Query does not have a data source');
-  }
-
-  const statsCommands = Array.from(mutate.commands.stats.list(EditorESQLQuery.ast));
-
-  if (statsCommands.length === 0) {
-    throw new Error(`Query does not include a "stats" command`);
-  }
-
-  const { grouping: statsCommandToOperateOnGrouping, command: statsCommandToOperateOn } =
-    getStatsCommandToOperateOn(EditorESQLQuery) ?? {};
-
-  if (!statsCommandToOperateOn) {
-    throw new Error(`No valid "stats" command was found in the query`);
-  }
-
-  const isValidPick = pick.every(
-    (col) =>
-      Object.keys(statsCommandToOperateOnGrouping!).includes(col) ||
-      Object.keys(statsCommandToOperateOnGrouping!).includes(`\`${col}\``)
-  );
-
-  if (!isValidPick) {
-    // nothing to do, return query as is
-    return {
-      esql: BasicPrettyPrinter.print(EditorESQLQuery.ast),
-    };
-  }
-
-  // Create a modified stats command with only the specified column as args for the "by" option
-  const modifiedStatsCommand = Builder.command({
-    name: 'stats',
-    args: statsCommandToOperateOn.args.map((statsCommandArg) => {
-      if (isOptionNode(statsCommandArg) && statsCommandArg.name === 'by') {
-        return Builder.option({
-          name: statsCommandArg.name,
-          args: statsCommandArg.args.reduce<Array<ESQLAstItem>>((acc, cur) => {
-            if (isColumn(cur) && pick.includes(removeBackticks(cur.name))) {
-              acc.push(synth.exp(cur.text, { withFormatting: false }));
-            } else if (
-              isFunctionExpression(cur) &&
-              isSupportedStatsFunction(
-                cur.subtype === 'variadic-call'
-                  ? cur.name
-                  : (cur.args[1] as ESQLAstItem[]).find(isFunctionExpression)?.name ?? ''
-              ) &&
-              pick.includes(
-                cur.subtype === 'variadic-call'
-                  ? cur.text
-                  : removeBackticks(cur.args.find(isColumn)?.name ?? '')
-              )
-            ) {
-              acc.push(synth.exp(cur.text, { withFormatting: false }));
-            }
-
-            return acc;
-          }, []),
-        });
-      }
-
-      // leverage synth to clone the rest of the args since we'd want to use those parts as is
-      return synth.exp((statsCommandArg as ESQLCommandOption).text, { withFormatting: false });
-    }),
-  });
-
-  // Get the position of the original stats command
-  const statsCommandIndex = EditorESQLQuery.ast.commands.findIndex(
-    (cmd) => cmd.text === statsCommandToOperateOn.text
-  );
-
-  // remove stats command
-  mutate.generic.commands.remove(EditorESQLQuery.ast, statsCommandToOperateOn);
-
-  // insert modified stats command at same position previous one was at
-  mutate.generic.commands.insert(EditorESQLQuery.ast, modifiedStatsCommand, statsCommandIndex);
-
-  return {
-    esql: BasicPrettyPrinter.print(EditorESQLQuery.ast),
-  };
-}
-
-/**
  * Handles the computation and appending of a filtering where clause,
  * for ES|QL query containing a stats command in the cascade layout experience
  */
@@ -698,12 +667,17 @@ export const appendFilteringWhereClauseForCascadeLayout = <
   let fieldDeclarationCommandSummary = getStatsCommandToOperateOn(ESQLQuery)!;
 
   // when the grouping option is an unnamed function, it's wrapped in backticks in the generated AST so we test for that first, else we assume this does not apply
-  let normalizedFieldName = fieldDeclarationCommandSummary.grouping[`\`${fieldName}\``]
+  const rawFieldName = fieldDeclarationCommandSummary.grouping[`\`${fieldName}\``]
     ? `\`${fieldName}\``
     : fieldName;
 
-  const isFieldUsedInOperatingStatsCommand =
-    fieldDeclarationCommandSummary.grouping[normalizedFieldName];
+  // This is a placeholder for the normalized field name returned by the parser,
+  // and in the case where we received a field name that maps to a variable, it's value will be the field's variable value
+  let normalizedFieldName = rawFieldName;
+
+  const isFieldUsedInOperatingStatsCommand = Boolean(
+    fieldDeclarationCommandSummary.grouping[rawFieldName]
+  );
 
   // create placeholder for the insertion anchor command which is the command that is most suited to accept the user's requested filtering operation
   let insertionAnchorCommand: ESQLCommand;
@@ -717,7 +691,7 @@ export const appendFilteringWhereClauseForCascadeLayout = <
   if (isFieldUsedInOperatingStatsCommand) {
     // if the field name is marked as a new field then we know it was declared by the stats command driving the cascade experience,
     // so we set the flag to true and use the stats command as the insertion anchor command
-    if (fieldDeclarationCommandSummary.newFields.has(normalizedFieldName)) {
+    if (fieldDeclarationCommandSummary.newFields.has(rawFieldName)) {
       isFieldRuntimeDeclared = true;
     } else {
       // otherwise, we need to ascertain that the field was not created by a preceding stats command
@@ -726,7 +700,7 @@ export const appendFilteringWhereClauseForCascadeLayout = <
 
       // attempt to find the index of the stats command that declared the field
       const groupDeclarationCommandIndex = statsCommandRuntimeFields.findIndex((field) =>
-        field.has(normalizedFieldName)
+        field.has(rawFieldName)
       );
 
       // if the field was declared in a stats command, then we set the flag to true
@@ -748,11 +722,12 @@ export const appendFilteringWhereClauseForCascadeLayout = <
     insertionAnchorCommand = fieldDeclarationCommandSummary.command;
 
     let fieldNameParamValue;
+    const fieldDeclaration = fieldDeclarationCommandSummary.grouping[rawFieldName];
 
     if (
       (fieldNameParamValue = getFieldParamDefinition(
         fieldName,
-        fieldDeclarationCommandSummary.grouping[normalizedFieldName].terminals,
+        fieldDeclaration.terminals,
         esqlVariables
       ))
     ) {
@@ -760,6 +735,15 @@ export const appendFilteringWhereClauseForCascadeLayout = <
         // we expect the field name parameter value to be a string, so we check for that and update the normalized field name to the param value if it is
         normalizedFieldName = fieldNameParamValue;
       }
+    } else {
+      // This corrects for scenarios in the initial query where the user doesn't adhere to the expected syntax for calling a function,
+      // especially when the function is unnamed for example if the user inputs "CATEGORIZE (message)" elasticsearch is able to understand this because the parser fixes it, and precisely because of that is why
+      // we can't use this as-is when constructing the filtering query, so we appropriately extract correct value from the parsed AST
+      normalizedFieldName =
+        isFunctionExpression(fieldDeclaration.arg) &&
+        fieldDeclaration.arg.subtype === 'variadic-call'
+          ? fieldDeclaration.definition.text
+          : fieldDeclaration.column.name;
     }
   } else {
     // if the requested field doesn't exist on the stats command that's driving the cascade experience,


### PR DESCRIPTION
## Summary

This PR is a follow up to https://github.com/elastic/kibana/pull/241107. 

The changes in this PR have resulted from the feedback resulted from testing https://github.com/elastic/kibana/pull/220119

Notable among this; 

- When an ES|QL operation specifies a [`KEEP`](https://www.elastic.co/docs/reference/query-languages/esql/commands/keep) command, it must include the record on which the operation STATS command is built on for said query to qualify for the cascade experience, consider; 
    
	```
	FROM kibana_sample_data_logs | STATS count = COUNT(*) BY clientip | KEEP count, clientip
   ```
   The query above would be a valid cascade qualifying query, whilst the one below wouldn't be
	```
	FROM kibana_sample_data_logs | STATS count = COUNT(*) BY clientip | KEEP count
	```
- A modification to the heuristics for deciding when to use either standard boolean expressions or [`MATCH_PHRASE`](https://www.elastic.co/docs/reference/query-languages/esql/functions-operators/search-functions#esql-match-phrase) with the [`WHERE`](https://www.elastic.co/docs/reference/query-languages/esql/commands/where) commands that get generated for fetching matching document results.
- Queries that specify a sample rate, will have this stripped out when fetching the matching documents for groups selected on the query
- Accommodate user input errors;
	- We noticed a scenario where a whitespace between the grouping function resulted in errors in fetching it's matching documents, for example; 
		```
		FROM kibana_sample_data_logs | STATS count = COUNT(bytes), average = AVG(memory) BY CATEGORIZE (message) | SORT average ASC
		```
		notice the whitespace between the `CATEGORIZE` and the parenthesis


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
<!--
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md) 
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials -->
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->