### PR TITLE
Improvements to cascade component informed from usage in discover

### DIFF
--- a/src/platform/packages/private/shared-ux/storybook/config/main.ts
+++ b/src/platform/packages/private/shared-ux/storybook/config/main.ts
@@ -14,7 +14,6 @@ module.exports = {
   stories: [
     '../../**/*.stories.+(tsx|mdx)',
     '../../../../shared/shared-ux/**/*.stories.+(tsx|mdx)',
-    '../../../../shared/shared-ux/**/guide.mdx',
     '../../../../../../core/packages/chrome/**/*.stories.+(tsx|mdx)',
     '../../../../shared/kbn-developer-toolbar/**/*.stories.+(tsx|mdx)',
   ],

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/__stories__/data_cascade.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/__stories__/data_cascade.stories.tsx
@@ -33,6 +33,7 @@ import {
   EuiFilterGroup,
   EuiFilterButton,
   type HorizontalAlignment,
+  EuiTextColor,
 } from '@elastic/eui';
 import { faker } from '@faker-js/faker';
 import { getESQLStatsQueryMeta } from '@kbn/esql-utils';
@@ -208,6 +209,7 @@ export const CascadeNestedGridImplementation: StoryObj<
         return rowDepth === groupByFields.length - 1
           ? [
               <EuiStat
+                reverse
                 title={rowData.count}
                 textAlign="right"
                 description={
@@ -366,6 +368,9 @@ export const CascadeNestedGridImplementation: StoryObj<
   },
 };
 
+/**
+ * This story demonstrates a custom header with one level of grouping,
+ */
 export const CascadeCustomHeaderImplementation: StoryObj<
   { query: string } & Pick<ComponentProps<typeof DataCascade>, 'size'>
 > = {
@@ -489,6 +494,7 @@ export const CascadeCustomHeaderImplementation: StoryObj<
     >(({ rowData }) => {
       return [
         <EuiStat
+          reverse
           title={rowData.count}
           textAlign="right"
           description={
@@ -637,6 +643,326 @@ export const CascadeCustomHeaderImplementation: StoryObj<
 
 CascadeCustomHeaderImplementation.parameters = { docs: { disable: true } };
 
+/**
+ * This story demonstrates how multiple stats per row can be shown in the row header.
+ */
+export const CascadeMultipleStatsPerRow: StoryObj<
+  { query: string } & Pick<ComponentProps<typeof DataCascade>, 'size'>
+> = {
+  name: 'Show casing multiple stats per row',
+  render: function DataCascadeWrapper(args) {
+    const groupByFields = useMemo(
+      () => getESQLStatsQueryMeta(args.query).groupByFields.map(({ field }) => field),
+      [args.query]
+    );
+
+    const generateGroupFieldRecord = useCallback(
+      (nodePath?: string[], nodePathMap?: Record<string, string>) => {
+        return groupByFields.reduce<Record<string, string>>((acc, field) => {
+          return {
+            ...acc,
+            [field]:
+              nodePathMap && nodePath?.indexOf(field) !== -1
+                ? nodePathMap[field]
+                : /purchase_date/.test(field)
+                ? faker.date.past({ years: 2 }).toLocaleDateString()
+                : /order_value/.test(field)
+                ? faker.commerce.price({ min: 100, max: 10000, symbol: '$' })
+                : faker.person.fullName(),
+          };
+        }, {} as Record<string, string>);
+      },
+      [groupByFields]
+    );
+
+    const initData: MockGroupData[] = new Array(100).fill(null).map(() => {
+      return {
+        id: faker.string.uuid(),
+        count: faker.number.int({ min: 1, max: 100 }),
+        ...generateGroupFieldRecord(),
+      };
+    });
+
+    const customTableHeader = useCallback<
+      NonNullable<ComponentProps<typeof DataCascade<MockGroupData>>['customTableHeader']>
+    >(
+      ({ currentSelectedColumns, availableColumns, onGroupSelection }) => (
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup alignItems="center" gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiIcon type="database" size="xl" />
+              </EuiFlexItem>
+              <EuiFlexItem grow={true}>
+                <EuiText>
+                  <h2>Customer Orders Overview</h2>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup justifyContent="center" alignItems="center" gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiText size="s" color="subdued">
+                  <strong>Group by:</strong>
+                </EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiButtonGroup
+                  legend="select columns"
+                  idSelected={currentSelectedColumns[0]}
+                  options={availableColumns.map((col) => ({ id: col, label: col }))}
+                  onChange={(id) => {
+                    onGroupSelection([id]);
+                  }}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ),
+      []
+    );
+
+    const onCascadeGroupingChange = useCallback<
+      NonNullable<ComponentProps<typeof DataCascade<MockGroupData>>['onCascadeGroupingChange']>
+    >((groupBy) => {
+      // eslint-disable-next-line no-console -- Handle group by change if needed
+      console.log('Group By Changed:', groupBy);
+    }, []);
+
+    const onCascadeGroupNodeExpanded = useCallback<
+      DataCascadeRowProps<MockGroupData, LeafNode>['onCascadeGroupNodeExpanded']
+    >(
+      async ({ row, nodePath, nodePathMap }) => {
+        // Simulate a data fetch on row expansion
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(
+              new Array(row.count).fill(null).map(() => {
+                return {
+                  id: faker.string.uuid(),
+                  count: faker.number.int({ min: 1, max: row.count }),
+                  ...generateGroupFieldRecord(nodePath, nodePathMap),
+                };
+              })
+            );
+          }, 3000);
+        });
+      },
+      [generateGroupFieldRecord]
+    );
+
+    const rowHeaderTitleSlot = useCallback<
+      NonNullable<DataCascadeRowProps<MockGroupData, LeafNode>['rowHeaderTitleSlot']>
+    >(({ rowData, nodePath }) => {
+      const rowGroup = nodePath[nodePath.length - 1];
+      return (
+        <EuiText>
+          <h2>{rowData[rowGroup]}</h2>
+        </EuiText>
+      );
+    }, []);
+
+    const rowHeaderMetaSlots = useCallback<
+      NonNullable<DataCascadeRowProps<MockGroupData, LeafNode>['rowHeaderMetaSlots']>
+    >(({ rowData }) => {
+      return [
+        <EuiStat
+          reverse
+          title={rowData.count}
+          textAlign="right"
+          description={
+            <FormattedMessage
+              id="sharedUXPackages.data_cascade.demo.row.count"
+              defaultMessage="<indicator>record count</indicator>"
+              values={{
+                indicator: (chunks) => <EuiHealth color="subdued">{chunks}</EuiHealth>,
+              }}
+            />
+          }
+        />,
+        <EuiStat
+          title="2,000"
+          textAlign="left"
+          titleColor="accent"
+          description={
+            <EuiTextColor color="accent">
+              <span>
+                <EuiIcon type="clock" color="accent" /> 70,29%
+              </span>
+            </EuiTextColor>
+          }
+        >
+          Pending widget
+        </EuiStat>,
+        <EuiStat title="1,554" textAlign="left" titleColor="danger" description="Good news">
+          <EuiTextColor color="accent">
+            <span>
+              <EuiIcon type="error" color="danger" /> 66,55%
+            </span>
+          </EuiTextColor>
+        </EuiStat>,
+        <EuiStat
+          title="22,550"
+          textAlign="left"
+          titleColor="success"
+          description={
+            <EuiTextColor color="success">
+              <span>
+                <EuiIcon type="check" color="success" /> 88,88%
+              </span>
+            </EuiTextColor>
+          }
+        >
+          Success widget
+        </EuiStat>,
+        <EuiStat title="8,888" description="Great news" textAlign="left">
+          <EuiTextColor color="success">
+            <span>
+              <EuiIcon type="sortUp" /> 27,83%
+            </span>
+          </EuiTextColor>
+        </EuiStat>,
+      ];
+    }, []);
+
+    const rowHeaderActions = useCallback<
+      NonNullable<DataCascadeRowProps<MockGroupData, LeafNode>['rowHeaderActions']>
+    >(
+      () => [
+        {
+          iconType: 'arrowDown',
+          iconSide: 'right',
+          onClick: () => {
+            /** Noop click handler */
+          },
+          label: (
+            <FormattedMessage
+              id="sharedUXPackages.data_cascade.demo.row.action"
+              defaultMessage="Take action"
+            />
+          ),
+        },
+      ],
+      []
+    );
+
+    const onCascadeLeafNodeExpanded = useCallback<
+      DataCascadeRowCellProps<MockGroupData, LeafNode>['onCascadeLeafNodeExpanded']
+    >(
+      async ({ row, nodePathMap, nodePath }) => {
+        // Simulate a data fetch for the expanded leaf,
+        // ideally we'd want to use nodePath information to fetch this data
+        return new Promise<LeafNode[]>((resolve) => {
+          setTimeout(() => {
+            resolve(
+              new Array(row.count).fill(null).map(() => {
+                return {
+                  id: faker.string.uuid(),
+                  ...generateGroupFieldRecord(nodePath, nodePathMap),
+                };
+              })
+            );
+          }, 3000);
+        });
+      },
+      [generateGroupFieldRecord]
+    );
+
+    const cascadeLeafCellRenderer = useCallback<
+      DataCascadeRowCellProps<MockGroupData, LeafNode>['children']
+    >(
+      ({ data }) => {
+        return (
+          <EuiBasicTable
+            tableCaption="custom header with one level of grouping table"
+            columns={[
+              {
+                field: 'id',
+                name: 'ID',
+              },
+              ...groupByFields.map((field, index, groupArray) => ({
+                field,
+                name: field.replace(/_/g, ' '),
+                ...(index === groupArray.length - 1
+                  ? { align: 'right' as HorizontalAlignment }
+                  : {}),
+              })),
+            ]}
+            items={(data ?? []).map((datum) => ({
+              id: datum.id,
+              ...groupByFields.reduce(
+                (acc, field) => ({
+                  ...acc,
+                  [field]: datum[field],
+                }),
+                {} as Record<string, string>
+              ),
+            }))}
+          />
+        );
+      },
+      [groupByFields]
+    );
+
+    return (
+      <EuiFlexGroup direction="column" css={{ height: 'calc(100svh - 2rem)' }}>
+        <EuiFlexItem grow={false}>
+          <EuiText>
+            <div>
+              <h1>Data Cascade</h1>
+              <p>ES|QL Query: {args.query}</p>
+            </div>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <DataCascade
+            size={args.size}
+            data={initData}
+            cascadeGroups={groupByFields}
+            customTableHeader={customTableHeader}
+            onCascadeGroupingChange={onCascadeGroupingChange}
+          >
+            <DataCascadeRow
+              onCascadeGroupNodeExpanded={onCascadeGroupNodeExpanded}
+              rowHeaderTitleSlot={rowHeaderTitleSlot}
+              rowHeaderMetaSlots={rowHeaderMetaSlots}
+              rowHeaderActions={rowHeaderActions}
+            >
+              <DataCascadeRowCell onCascadeLeafNodeExpanded={onCascadeLeafNodeExpanded}>
+                {cascadeLeafCellRenderer}
+              </DataCascadeRowCell>
+            </DataCascadeRow>
+          </DataCascade>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  },
+  argTypes: {
+    query: {
+      type: 'string' as const,
+      description: 'Simulation of The ES|QL query that the user provided into the esql editor',
+    },
+    size: {
+      name: 'Size',
+      control: 'radio',
+      options: ['s', 'm', 'l'],
+      description: 'Size of the cascade rows',
+    },
+  },
+  args: {
+    query:
+      'FROM kibana_sample_data_ecommerce | STATS count = COUNT(*) by customer_full_name, purchase_date , order_value ',
+    size: 'm',
+  },
+};
+
+CascadeMultipleStatsPerRow.parameters = { docs: { disable: true } };
+
+/**
+ * This story demonstrates a custom header with custom row actions,
+ */
 export const CascadeCustomHeaderWithCustomRowActionsImplementation: StoryObj<
   { query: string } & Pick<ComponentProps<typeof DataCascade>, 'size'>
 > = {
@@ -733,6 +1059,7 @@ export const CascadeCustomHeaderWithCustomRowActionsImplementation: StoryObj<
     >(({ rowData }) => {
       return [
         <EuiStat
+          reverse
           title={rowData.count}
           textAlign="right"
           description={
@@ -913,6 +1240,9 @@ export const CascadeCustomHeaderWithCustomRowActionsImplementation: StoryObj<
 
 CascadeCustomHeaderWithCustomRowActionsImplementation.parameters = { docs: { disable: true } };
 
+/**
+ * This story demonstrates a custom header with hidden row actions,
+ */
 export const CascadeCustomHeaderWithHiddenRowActions: StoryObj<
   { query: string } & Pick<ComponentProps<typeof DataCascade>, 'size'>
 > = {
@@ -1006,6 +1336,7 @@ export const CascadeCustomHeaderWithHiddenRowActions: StoryObj<
     >(({ rowData }) => {
       return [
         <EuiStat
+          reverse
           title={rowData.count}
           textAlign="right"
           description={
@@ -1095,21 +1426,21 @@ export const CascadeCustomHeaderWithHiddenRowActions: StoryObj<
           },
           label: (
             <FormattedMessage
-              id="sharedUXPackages.data_cascade.demo.row.edit"
+              id="sharedUXPackages.data_cascade.demo.row.favorite"
               defaultMessage="Favorite"
             />
           ),
         },
         {
-          iconType: 'filter',
-          'aria-label': `filter for ${groupValue}`,
+          iconType: 'flag',
+          'aria-label': `flag ${groupValue}`,
           onClick: () => {
-            /** Noop Click handler for filter */
+            /** Noop Click handler for flagging */
           },
           label: (
             <FormattedMessage
-              id="sharedUXPackages.data_cascade.demo.row.edit"
-              defaultMessage="Filter"
+              id="sharedUXPackages.data_cascade.demo.row.flag"
+              defaultMessage="Flag"
             />
           ),
         },
@@ -1121,7 +1452,7 @@ export const CascadeCustomHeaderWithHiddenRowActions: StoryObj<
           },
           label: (
             <FormattedMessage
-              id="sharedUXPackages.data_cascade.demo.row.edit"
+              id="sharedUXPackages.data_cascade.demo.row.create_alerts"
               defaultMessage="Create alerts"
             />
           ),
@@ -1134,7 +1465,7 @@ export const CascadeCustomHeaderWithHiddenRowActions: StoryObj<
           },
           label: (
             <FormattedMessage
-              id="sharedUXPackages.data_cascade.demo.row.edit"
+              id="sharedUXPackages.data_cascade.demo.row.download"
               defaultMessage="Download"
             />
           ),
@@ -1196,6 +1527,11 @@ export const CascadeCustomHeaderWithHiddenRowActions: StoryObj<
 
 CascadeCustomHeaderWithHiddenRowActions.parameters = { docs: { disable: true } };
 
+/**
+ * This story demonstrates a custom header with row selection action enabled,
+ * this is useful for scenarios where one might want to select rows in the cascade component
+ * and perform actions on the selected rows.
+ */
 export const CascadeCustomHeaderWithRowSelectionActionEnabled: StoryObj<
   { query: string } & Pick<ComponentProps<typeof DataCascade>, 'size'>
 > = {
@@ -1341,6 +1677,7 @@ export const CascadeCustomHeaderWithRowSelectionActionEnabled: StoryObj<
     >(({ rowData }) => {
       return [
         <EuiStat
+          reverse
           title={rowData.count}
           textAlign="right"
           description={
@@ -1423,28 +1760,28 @@ export const CascadeCustomHeaderWithRowSelectionActionEnabled: StoryObj<
 
       return [
         {
-          iconType: 'starEmpty',
-          'aria-label': `favorite ${groupValue}`,
+          iconType: 'reporter',
+          'aria-label': `investigate ${groupValue}`,
           onClick: () => {
-            /** Noop Click handler for favorite */
+            /** Noop Click handler for starting an investigation */
           },
           label: (
             <FormattedMessage
-              id="sharedUXPackages.data_cascade.demo.row.edit"
-              defaultMessage="Favorite"
+              id="sharedUXPackages.data_cascade.demo.row.investigate"
+              defaultMessage="Investigate"
             />
           ),
         },
         {
-          iconType: 'filter',
-          'aria-label': `filter for ${groupValue}`,
+          iconType: 'flag',
+          'aria-label': `flag ${groupValue}`,
           onClick: () => {
-            /** Noop Click handler for filter */
+            /** Noop Click handler for flagging */
           },
           label: (
             <FormattedMessage
-              id="sharedUXPackages.data_cascade.demo.row.edit"
-              defaultMessage="Filter"
+              id="sharedUXPackages.data_cascade.demo.row.flag"
+              defaultMessage="Flag"
             />
           ),
         },
@@ -1456,7 +1793,7 @@ export const CascadeCustomHeaderWithRowSelectionActionEnabled: StoryObj<
           },
           label: (
             <FormattedMessage
-              id="sharedUXPackages.data_cascade.demo.row.edit"
+              id="sharedUXPackages.data_cascade.demo.row.create_alerts"
               defaultMessage="Create alerts"
             />
           ),
@@ -1469,7 +1806,7 @@ export const CascadeCustomHeaderWithRowSelectionActionEnabled: StoryObj<
           },
           label: (
             <FormattedMessage
-              id="sharedUXPackages.data_cascade.demo.row.edit"
+              id="sharedUXPackages.data_cascade.demo.row.download"
               defaultMessage="Download"
             />
           ),

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/__stories__/data_cascade.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/__stories__/data_cascade.stories.tsx
@@ -283,6 +283,7 @@ export const CascadeNestedGridImplementation: StoryObj<
       ({ data }) => {
         return (
           <EuiBasicTable
+            tableCaption="nested groups with default header table"
             columns={[
               {
                 field: 'id',
@@ -552,6 +553,7 @@ export const CascadeCustomHeaderImplementation: StoryObj<
       ({ data }) => {
         return (
           <EuiBasicTable
+            tableCaption="custom header with one level of grouping table"
             columns={[
               {
                 field: 'id',
@@ -774,6 +776,7 @@ export const CascadeCustomHeaderWithCustomRowActionsImplementation: StoryObj<
       ({ data }) => {
         return (
           <EuiBasicTable
+            tableCaption="custom header with custom row actions table"
             columns={[
               {
                 field: 'id',
@@ -1046,6 +1049,7 @@ export const CascadeCustomHeaderWithHiddenRowActions: StoryObj<
       ({ data }) => {
         return (
           <EuiBasicTable
+            tableCaption="custom header with hidden row actions table"
             columns={[
               {
                 field: 'id',
@@ -1380,6 +1384,7 @@ export const CascadeCustomHeaderWithRowSelectionActionEnabled: StoryObj<
       ({ data }) => {
         return (
           <EuiBasicTable
+            tableCaption="custom header with row selection action enabled table"
             columns={[
               {
                 field: 'id',

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/__stories__/guide.mdx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/__stories__/guide.mdx
@@ -53,6 +53,28 @@ The cascade component by default supports up to 3 levels of visual nesting, for 
 virtualized for performance, and it's also possible to have a cell's content virtualized, and connect it to the overall virtualization strategy,
 such that the scroll of the entire component also controls the cell and it turns determines the content the cell renders.
 
+#### Nested virtualization at the cell level
+
+For a scenario where one might want to roll a cell that's also has it's content virtualized so all items in the cascade component are presented as a continuous list
+there’s some accommodation to support this, the data cascade component exposes the following props; 
+`getScrollMargin`, `getScrollOffset`, `getScrollElement` in the render prop of the child value it expects to facilitate this;
+
+```tsx
+import { DataCascade, DataCascadeRow, DataCascadeRowCell } from '@kbn/shared-ux-document-data-cascade';
+
+<DataCascade {...dataCascadeProps}>
+  <DataCascadeRow {...dataCascadeRowProps}>
+    <DataCascadeRowCell {...dataCascadeRowCellProps}>
+          {({ data, getScrollMargin, getScrollOffset, getScrollElement  }) => {
+            // getScrollElement - Provides the scroll element for the cascade component
+            // getScrollMargin - Provides the configured scroll margin of the scroll component
+            // getScrollOffset - Provides the scrollOffset at the cell level, this can be passed along to ensure rendering is smooth, and items are placed properly
+          }}
+    </DataCascadeRowCell>
+  </DataCascadeRow>
+</DataCascade>
+```
+
 ## Component Props
 
 {/* Note: Excluding `query` from the controls as it's not a prop of the component, but rather a simulation of user input for generating group by fields. */}

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.tsx
@@ -29,6 +29,7 @@ import {
   useRegisterCascadeAccessibilityHelpers,
   useTreeGridContainerARIAAttributes,
 } from '../../lib/core/accessibility';
+import { ScrollSyncProvider } from '../../lib/core/scroll_sync';
 import { dataCascadeImplStyles, relativePosition } from './data_cascade_impl.styles';
 import type { DataCascadeImplProps, DataCascadeRowProps, DataCascadeRowCellProps } from './types';
 
@@ -147,6 +148,7 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
     virtualizedRowComputedTranslateValue,
     scrollToVirtualizedIndex,
     scrollOffset: virtualizerScrollOffset,
+    isScrolling,
   } = virtualizerInstance.current;
 
   useRegisterCascadeAccessibilityHelpers<G>({
@@ -214,15 +216,17 @@ export function DataCascadeImpl<G extends GroupNode, L extends LeafNode>({
                 </>
                 <div css={styles.cascadeTreeGridWrapper} style={{ height: getTotalSize() }}>
                   <div {...treeGridContainerARIAAttributes} css={relativePosition}>
-                    <VirtualizedCascadeRowList<G>
-                      {...{
-                        activeStickyIndex,
-                        getVirtualItems,
-                        virtualizedRowComputedTranslateValue,
-                        rows,
-                        listItemRenderer: virtualCascadeRowRenderer,
-                      }}
-                    />
+                    <ScrollSyncProvider disableScrollSync={isScrolling}>
+                      <VirtualizedCascadeRowList<G>
+                        {...{
+                          activeStickyIndex,
+                          getVirtualItems,
+                          virtualizedRowComputedTranslateValue,
+                          rows,
+                          listItemRenderer: virtualCascadeRowRenderer,
+                        }}
+                      />
+                    </ScrollSyncProvider>
                   </div>
                 </div>
               </div>

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header.tsx
@@ -218,10 +218,7 @@ export function CascadeRowHeaderPrimitive<G extends GroupNode, L extends LeafNod
                 <React.Fragment>
                   {Boolean(headerMetaSlots?.length) && (
                     <EuiFlexItem css={flexHelper} grow>
-                      <CascadeRowHeaderSlotsRenderer
-                        headerMetaSlots={headerMetaSlots!}
-                        size={size}
-                      />
+                      <CascadeRowHeaderSlotsRenderer headerMetaSlots={headerMetaSlots!} />
                     </EuiFlexItem>
                   )}
                 </React.Fragment>

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.styles.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.styles.tsx
@@ -72,6 +72,8 @@ export const useStyles = (scrollState: ScrollState) => {
 
   const slotsScrollButtonBaseStyles = css([
     {
+      label: 'slots-scroll-button-base-styles',
+      display: 'none',
       position: 'absolute',
       // raise the button higher than the stacking index of the slot container
       zIndex: 1,
@@ -83,6 +85,13 @@ export const useStyles = (scrollState: ScrollState) => {
   return {
     slotsContainerWrapper: css({
       position: 'relative',
+      '&:hover': {
+        // use specified label to target the scroll button base styles
+        // see {@link https://github.com/emotion-js/emotion/issues/1217}
+        '[class*="slots-scroll-button-base-styles"]': {
+          display: 'block',
+        },
+      },
     }),
     slotsLeftScrollButton: css([
       slotsScrollButtonBaseStyles,

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.styles.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.styles.tsx
@@ -9,7 +9,7 @@
 
 import { useMemo } from 'react';
 import { css } from '@emotion/react';
-import { type UseEuiTheme, euiShadow, useEuiTheme } from '@elastic/eui';
+import { type UseEuiTheme, useEuiTheme } from '@elastic/eui';
 
 export interface ScrollState {
   isScrollable: boolean;
@@ -68,8 +68,6 @@ export const useStyles = (scrollState: ScrollState) => {
     scrollState
   );
 
-  const shadow = euiShadow(euiThemeContext, 'xl', { direction: 'down' });
-
   const slotsScrollButtonBaseStyles = css([
     {
       label: 'slots-scroll-button-base-styles',
@@ -79,7 +77,6 @@ export const useStyles = (scrollState: ScrollState) => {
       zIndex: 1,
       margin: euiThemeContext.euiTheme.size.xxs,
     },
-    shadow,
   ]);
 
   return {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.styles.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.styles.tsx
@@ -9,7 +9,7 @@
 
 import { useMemo } from 'react';
 import { css } from '@emotion/react';
-import { type UseEuiTheme, useEuiOverflowScroll } from '@elastic/eui';
+import { type UseEuiTheme, euiShadow, useEuiTheme } from '@elastic/eui';
 
 export interface ScrollState {
   isScrollable: boolean;
@@ -49,11 +49,8 @@ const useSlotContainerInnerStyles = (
     return { 'mask-image': maskStyle };
   }, [scrollState, euiTheme.size.m]);
 
-  const scrollOverflowStyles = useEuiOverflowScroll('x', true);
-
   return css`
     overflow-x: auto;
-    ${scrollOverflowStyles}
     scrollbar-width: none;
     scroll-behavior: smooth;
     &::-webkit-scrollbar {
@@ -63,10 +60,42 @@ const useSlotContainerInnerStyles = (
   `;
 };
 
-export const useStyles = (euiTheme: UseEuiTheme['euiTheme'], scrollState: ScrollState) => {
-  const slotContainerInnerStyles = useSlotContainerInnerStyles(euiTheme, scrollState);
+export const useStyles = (scrollState: ScrollState) => {
+  const euiThemeContext = useEuiTheme();
+
+  const slotContainerInnerStyles = useSlotContainerInnerStyles(
+    euiThemeContext.euiTheme,
+    scrollState
+  );
+
+  const shadow = euiShadow(euiThemeContext, 'xl', { direction: 'down' });
+
+  const slotsScrollButtonBaseStyles = css([
+    {
+      position: 'absolute',
+      // raise the button higher than the stacking index of the slot container
+      zIndex: 1,
+      margin: euiThemeContext.euiTheme.size.xxs,
+    },
+    shadow,
+  ]);
 
   return {
+    slotsContainerWrapper: css({
+      position: 'relative',
+    }),
+    slotsLeftScrollButton: css([
+      slotsScrollButtonBaseStyles,
+      {
+        left: 0,
+      },
+    ]),
+    slotsRightScrollButton: css([
+      slotsScrollButtonBaseStyles,
+      {
+        right: 0,
+      },
+    ]),
     slotsContainer: css`
       min-width: 0;
       width: 100%;
@@ -83,8 +112,8 @@ export const useStyles = (euiTheme: UseEuiTheme['euiTheme'], scrollState: Scroll
     slotItemWrapper: css({
       justifyContent: 'center',
       alignItems: 'center',
-      borderLeft: `${euiTheme.border.width.thin} solid ${euiTheme.border.color}`,
-      paddingLeft: euiTheme.size.s,
+      borderLeft: `${euiThemeContext.euiTheme.border.width.thin} solid ${euiThemeContext.euiTheme.border.color}`,
+      paddingLeft: euiThemeContext.euiTheme.size.s,
       flexGrow: 0,
 
       '& > *': {

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.styles.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.styles.tsx
@@ -7,8 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { useMemo } from 'react';
 import { css } from '@emotion/react';
-import type { UseEuiTheme } from '@elastic/eui';
+import { type UseEuiTheme, useEuiOverflowScroll } from '@elastic/eui';
 
 export interface ScrollState {
   isScrollable: boolean;
@@ -16,47 +17,55 @@ export interface ScrollState {
   canScrollRight: boolean;
 }
 
-const getSlotContainerInnerStyles = (
+const useSlotContainerInnerStyles = (
   euiTheme: UseEuiTheme['euiTheme'],
   scrollState: ScrollState
 ) => {
-  let maskImage = 'none';
-
   // Build gradient mask based on scroll position
-  if (scrollState.canScrollLeft && scrollState.canScrollRight) {
-    maskImage = `linear-gradient(
+  const maskImage = useMemo(() => {
+    let maskStyle = 'none';
+
+    if (scrollState.canScrollLeft && scrollState.canScrollRight) {
+      maskStyle = `linear-gradient(
         to right,
         transparent 0%,
         black ${euiTheme.size.m},
         black calc(100% - ${euiTheme.size.m}),
         transparent 100%
       )`;
-  } else if (scrollState.canScrollLeft) {
-    maskImage = `linear-gradient(
+    } else if (scrollState.canScrollLeft) {
+      maskStyle = `linear-gradient(
         to right,
         transparent 0%,
         black ${euiTheme.size.m}
       )`;
-  } else if (scrollState.canScrollRight) {
-    maskImage = `linear-gradient(
+    } else if (scrollState.canScrollRight) {
+      maskStyle = `linear-gradient(
         to right,
         black calc(100% - ${euiTheme.size.m}),
         transparent 100%
       )`;
-  }
+    }
+    return { 'mask-image': maskStyle };
+  }, [scrollState, euiTheme.size.m]);
+
+  const scrollOverflowStyles = useEuiOverflowScroll('x', true);
 
   return css`
     overflow-x: auto;
+    ${scrollOverflowStyles}
     scrollbar-width: none;
     scroll-behavior: smooth;
     &::-webkit-scrollbar {
       display: none;
     }
-    mask-image: ${maskImage};
+    ${maskImage};
   `;
 };
 
-export const styles = (euiTheme: UseEuiTheme['euiTheme'], scrollState: ScrollState) => {
+export const useStyles = (euiTheme: UseEuiTheme['euiTheme'], scrollState: ScrollState) => {
+  const slotContainerInnerStyles = useSlotContainerInnerStyles(euiTheme, scrollState);
+
   return {
     slotsContainer: css`
       min-width: 0;
@@ -69,7 +78,7 @@ export const styles = (euiTheme: UseEuiTheme['euiTheme'], scrollState: ScrollSta
       {
         width: 'max-content',
       },
-      getSlotContainerInnerStyles(euiTheme, scrollState),
+      slotContainerInnerStyles,
     ]),
     slotItemWrapper: css({
       justifyContent: 'center',

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.tsx
@@ -7,12 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFlexItem, EuiFlexGroup, EuiButtonIcon, useEuiTheme } from '@elastic/eui';
 import { type CascadeSizing } from '../../types';
 import {
-  styles as cascadeRowHeaderSlotsRendererStyles,
+  useStyles as useCascadeRowHeaderSlotsRendererStyles,
   type ScrollState,
 } from './cascade_row_header_slots_renderer.styles';
 
@@ -47,10 +47,7 @@ const CascadeRowHeaderSlotsRenderer = ({
     canScrollRight: false,
   });
 
-  const styles = useMemo(
-    () => cascadeRowHeaderSlotsRendererStyles(euiTheme, scrollState),
-    [euiTheme, scrollState]
-  );
+  const styles = useCascadeRowHeaderSlotsRendererStyles(euiTheme, scrollState);
 
   const updateScrollState = useCallback(() => {
     setScrollState(calculateScrollState(containerRef.current));
@@ -103,6 +100,19 @@ const CascadeRowHeaderSlotsRenderer = ({
 
   return (
     <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} wrap={false}>
+      {scrollState.isScrollable && (
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            iconType="arrowLeft"
+            color="text"
+            size="xs"
+            disabled={!scrollState.canScrollLeft}
+            aria-label={scrollLeftLabel}
+            onClick={scrollLeft}
+            data-test-subj="cascadeHeaderSlots-scrollLeft"
+          />
+        </EuiFlexItem>
+      )}
       <EuiFlexItem grow ref={containerRef} onScroll={handleScroll} css={styles.slotsContainer}>
         <EuiFlexGroup
           css={styles.slotsContainerInner}
@@ -118,19 +128,6 @@ const CascadeRowHeaderSlotsRenderer = ({
           ))}
         </EuiFlexGroup>
       </EuiFlexItem>
-      {scrollState.isScrollable && (
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            iconType="arrowLeft"
-            color="text"
-            size="xs"
-            disabled={!scrollState.canScrollLeft}
-            aria-label={scrollLeftLabel}
-            onClick={scrollLeft}
-            data-test-subj="cascadeHeaderSlots-scrollLeft"
-          />
-        </EuiFlexItem>
-      )}
       {scrollState.isScrollable && (
         <EuiFlexItem grow={false}>
           <EuiButtonIcon

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.tsx
@@ -9,7 +9,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiFlexItem, EuiFlexGroup, EuiButtonIcon, useEuiTheme } from '@elastic/eui';
+import { EuiFlexItem, EuiFlexGroup, EuiButtonIcon } from '@elastic/eui';
 import { type CascadeSizing } from '../../types';
 import {
   useStyles as useCascadeRowHeaderSlotsRendererStyles,
@@ -39,7 +39,6 @@ const CascadeRowHeaderSlotsRenderer = ({
   headerMetaSlots: React.ReactNode[];
   size: CascadeSizing;
 }) => {
-  const { euiTheme } = useEuiTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const [scrollState, setScrollState] = useState<ScrollState>({
     isScrollable: false,
@@ -47,7 +46,7 @@ const CascadeRowHeaderSlotsRenderer = ({
     canScrollRight: false,
   });
 
-  const styles = useCascadeRowHeaderSlotsRendererStyles(euiTheme, scrollState);
+  const styles = useCascadeRowHeaderSlotsRendererStyles(scrollState);
 
   const updateScrollState = useCallback(() => {
     setScrollState(calculateScrollState(containerRef.current));
@@ -99,21 +98,33 @@ const CascadeRowHeaderSlotsRenderer = ({
   }
 
   return (
-    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} wrap={false}>
-      {scrollState.isScrollable && (
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            iconType="arrowLeft"
-            color="text"
-            size="xs"
-            disabled={!scrollState.canScrollLeft}
-            aria-label={scrollLeftLabel}
-            onClick={scrollLeft}
-            data-test-subj="cascadeHeaderSlots-scrollLeft"
-          />
-        </EuiFlexItem>
+    <EuiFlexGroup
+      gutterSize="xs"
+      alignItems="center"
+      responsive={false}
+      wrap={false}
+      css={styles.slotsContainerWrapper}
+      className="eui-xScrollWithShadows"
+    >
+      {scrollState.isScrollable && scrollState.canScrollLeft && (
+        <EuiButtonIcon
+          iconType="arrowLeft"
+          color="text"
+          size="xs"
+          aria-label={scrollLeftLabel}
+          display="base"
+          onClick={scrollLeft}
+          data-test-subj="cascadeHeaderSlots-scrollLeft"
+          css={styles.slotsLeftScrollButton}
+        />
       )}
-      <EuiFlexItem grow ref={containerRef} onScroll={handleScroll} css={styles.slotsContainer}>
+      <EuiFlexItem
+        grow
+        ref={containerRef}
+        onScroll={handleScroll}
+        css={styles.slotsContainer}
+        tabIndex={0}
+      >
         <EuiFlexGroup
           css={styles.slotsContainerInner}
           gutterSize={size}
@@ -128,18 +139,17 @@ const CascadeRowHeaderSlotsRenderer = ({
           ))}
         </EuiFlexGroup>
       </EuiFlexItem>
-      {scrollState.isScrollable && (
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            iconType="arrowRight"
-            color="text"
-            size="xs"
-            disabled={!scrollState.canScrollRight}
-            aria-label={scrollRightLabel}
-            onClick={scrollRight}
-            data-test-subj="cascadeHeaderSlots-scrollRight"
-          />
-        </EuiFlexItem>
+      {scrollState.isScrollable && scrollState.canScrollRight && (
+        <EuiButtonIcon
+          iconType="arrowRight"
+          color="text"
+          size="xs"
+          aria-label={scrollRightLabel}
+          display="base"
+          onClick={scrollRight}
+          data-test-subj="cascadeHeaderSlots-scrollRight"
+          css={styles.slotsRightScrollButton}
+        />
       )}
     </EuiFlexGroup>
   );

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_row/components/cascade_row_header_slots_renderer.tsx
@@ -9,8 +9,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiFlexItem, EuiFlexGroup, EuiButtonIcon } from '@elastic/eui';
-import { type CascadeSizing } from '../../types';
+import { EuiFlexItem, EuiFlexGroup, EuiButtonIcon, EuiPanel } from '@elastic/eui';
 import {
   useStyles as useCascadeRowHeaderSlotsRendererStyles,
   type ScrollState,
@@ -18,13 +17,17 @@ import {
 
 const SCROLL_STEP = 150;
 
+interface CascadeRowHeaderSlotsRendererProps {
+  headerMetaSlots: React.ReactNode[];
+}
+
 const calculateScrollState = (element: HTMLDivElement | null): ScrollState => {
   if (!element) {
     return { isScrollable: false, canScrollLeft: false, canScrollRight: false };
   }
   const { scrollLeft, scrollWidth, clientWidth } = element;
-
   const isScrollable = scrollWidth > clientWidth;
+
   return {
     isScrollable,
     canScrollLeft: scrollLeft > 0,
@@ -32,13 +35,7 @@ const calculateScrollState = (element: HTMLDivElement | null): ScrollState => {
   };
 };
 
-const CascadeRowHeaderSlotsRenderer = ({
-  headerMetaSlots,
-  size,
-}: {
-  headerMetaSlots: React.ReactNode[];
-  size: CascadeSizing;
-}) => {
+const CascadeRowHeaderSlotsRenderer = ({ headerMetaSlots }: CascadeRowHeaderSlotsRendererProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [scrollState, setScrollState] = useState<ScrollState>({
     isScrollable: false,
@@ -104,19 +101,19 @@ const CascadeRowHeaderSlotsRenderer = ({
       responsive={false}
       wrap={false}
       css={styles.slotsContainerWrapper}
-      className="eui-xScrollWithShadows"
     >
       {scrollState.isScrollable && scrollState.canScrollLeft && (
-        <EuiButtonIcon
-          iconType="arrowLeft"
-          color="text"
-          size="xs"
-          aria-label={scrollLeftLabel}
-          display="base"
-          onClick={scrollLeft}
-          data-test-subj="cascadeHeaderSlots-scrollLeft"
-          css={styles.slotsLeftScrollButton}
-        />
+        <EuiPanel grow={false} paddingSize="none" css={styles.slotsLeftScrollButton}>
+          <EuiButtonIcon
+            iconType="arrowLeft"
+            color="text"
+            size="xs"
+            aria-label={scrollLeftLabel}
+            onClick={scrollLeft}
+            data-test-subj="cascadeHeaderSlots-scrollLeft"
+            display="empty"
+          />
+        </EuiPanel>
       )}
       <EuiFlexItem
         grow
@@ -127,7 +124,7 @@ const CascadeRowHeaderSlotsRenderer = ({
       >
         <EuiFlexGroup
           css={styles.slotsContainerInner}
-          gutterSize={size}
+          gutterSize="s"
           justifyContent="flexEnd"
           wrap={false}
           responsive={false}
@@ -140,16 +137,17 @@ const CascadeRowHeaderSlotsRenderer = ({
         </EuiFlexGroup>
       </EuiFlexItem>
       {scrollState.isScrollable && scrollState.canScrollRight && (
-        <EuiButtonIcon
-          iconType="arrowRight"
-          color="text"
-          size="xs"
-          aria-label={scrollRightLabel}
-          display="base"
-          onClick={scrollRight}
-          data-test-subj="cascadeHeaderSlots-scrollRight"
-          css={styles.slotsRightScrollButton}
-        />
+        <EuiPanel grow={false} paddingSize="none" css={styles.slotsRightScrollButton}>
+          <EuiButtonIcon
+            iconType="arrowRight"
+            color="text"
+            size="xs"
+            aria-label={scrollRightLabel}
+            onClick={scrollRight}
+            data-test-subj="cascadeHeaderSlots-scrollRight"
+            display="empty"
+          />
+        </EuiPanel>
       )}
     </EuiFlexGroup>
   );

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
@@ -81,29 +81,37 @@ export interface CascadeRowCellPrimitiveProps<G extends GroupNode, L extends Lea
   ) => React.ReactNode;
 }
 
-interface OnCascadeGroupNodeExpandedArgs<G extends GroupNode> {
+interface CascadeGroupNodeUIInteraction<G extends GroupNode> {
+  /**
+   * The row instance that was interacted with in the group by hierarchy.
+   */
   row: G;
   /**
-   * @description The path of the row that was expanded in the group by hierarchy.
-   */
-  nodePath: string[];
-  /**
-   * @description KV record of the path values for the row node.
-   */
-  nodePathMap: Record<string, string>;
-}
-
-interface OnCascadeGroupNodeCollapsedArgs<G extends GroupNode> {
-  row: G;
-  /**
-   * The path of the row that was collapsed in the group by hierarchy.
+   * The path of the row that was interacted with in the group by hierarchy.
+   *
+   * @example
+   * ```
+   * ['@timestamp', 'geo.src.country_name']
+   * ```
    */
   nodePath: string[];
   /**
    * KV record of the path values for the row node.
+   *
+   * @example
+   * ```
+   * {
+   *   '@timestamp': '2026-01-13T00:00:00.000Z',
+   *   'geo.src.country_name': 'United States'
+   * }
+   * ```
    */
   nodePathMap: Record<string, string>;
 }
+
+type OnCascadeGroupNodeExpandedArgs<G extends GroupNode> = CascadeGroupNodeUIInteraction<G>;
+
+type OnCascadeGroupNodeCollapsedArgs<G extends GroupNode> = CascadeGroupNodeUIInteraction<G>;
 
 export interface CascadeRowActionProps {
   maxActionCount?: number;
@@ -136,7 +144,7 @@ export interface CascadeRowHeaderPrimitiveProps<G extends GroupNode, L extends L
    */
   isGroupNode: boolean;
   /**
-   * @description Callback function that is called when a cascade node is expanded.
+   * Callback function that is called when a cascade node is expanded.
    */
   onCascadeGroupNodeExpanded: (args: OnCascadeGroupNodeExpandedArgs<G>) => Promise<G[]>;
   /**
@@ -144,15 +152,15 @@ export interface CascadeRowHeaderPrimitiveProps<G extends GroupNode, L extends L
    */
   onCascadeGroupNodeCollapsed?: (args: OnCascadeGroupNodeCollapsedArgs<G>) => void;
   /**
-   * @description The row instance for the cascade row.
+   * The row instance for the cascade row.
    */
   rowInstance: Row<G>;
   /**
-   * @description The row header title slot for the cascade row.
+   * The row header title slot for the cascade row.
    */
   rowHeaderTitleSlot: React.FC<{ rowData: G; nodePath: string[] }>;
   /**
-   * @description The row header meta slots for the cascade row.
+   * The row header meta slots for the cascade row.
    */
   rowHeaderMetaSlots?: (props: {
     rowDepth: number;
@@ -160,14 +168,14 @@ export interface CascadeRowHeaderPrimitiveProps<G extends GroupNode, L extends L
     nodePath: string[];
   }) => React.ReactNode[];
   /**
-   * @description The row header actions slot for the cascade row.
+   * The row header actions slot for the cascade row.
    */
   rowHeaderActions?: (params: {
     rowData: G;
     nodePath: string[];
   }) => CascadeRowActionProps['headerRowActions'];
   /**
-   * @description The size of the row component, can be 's' (small), 'm' (medium), or 'l' (large).
+   * The size of the row component, can be 's' (small), 'm' (medium), or 'l' (large).
    */
   size: CascadeRowCellPrimitiveProps<G, L>['size'];
 }
@@ -179,17 +187,23 @@ export interface CascadeRowHeaderPrimitiveProps<G extends GroupNode, L extends L
 export interface CascadeRowPrimitiveProps<G extends GroupNode, L extends LeafNode>
   extends Omit<CascadeRowHeaderPrimitiveProps<G, L>, 'isGroupNode'> {
   /**
-   * ref used to portal the active sticky header.
+   * Ref that provides a reference to the DOM element that will be used to portal the active sticky header.
    */
   activeStickyRenderSlotRef: React.RefObject<HTMLDivElement | null>;
+  /**
+   * Denotes if the row is sticky.
+   */
   isActiveSticky: boolean;
+  /**
+   * Ref that provides a reference to the DOM element that renders the cascade row.
+   */
   innerRef: React.LegacyRef<HTMLDivElement>;
   /**
-   * @description The virtual row for the cascade row.
+   * The virtual row for the cascade row.
    */
   virtualRow: VirtualItem;
   /**
-   * @description The virtual row style for the cascade row.
+   * Style for the virtual row of the cascade row.
    */
   virtualRowStyle: React.CSSProperties;
 }

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/types.ts
@@ -20,29 +20,37 @@ import type { SelectionDropdownProps } from './data_cascade_header/group_selecti
  */
 export type CascadeSizing = keyof Pick<EuiThemeShape['size'], 's' | 'm' | 'l'>;
 
-interface OnCascadeLeafNodeExpandedArgs<G extends GroupNode> {
+interface CascadeGroupNodeUIInteraction<G extends GroupNode> {
+  /**
+   * The row instance that was interacted with in the group by hierarchy.
+   */
   row: G;
   /**
-   * The path of the row that was expanded in the group by hierarchy.
+   * The path of the row that was interacted with in the group by hierarchy.
+   *
+   * @example
+   * ```
+   * ['@timestamp', 'geo.src.country_name']
+   * ```
    */
   nodePath: string[];
   /**
    * KV record of the path values for the row node.
+   *
+   * @example
+   * ```
+   * {
+   *   '@timestamp': '2026-01-13T00:00:00.000Z',
+   *   'geo.src.country_name': 'United States'
+   * }
+   * ```
    */
   nodePathMap: Record<string, string>;
 }
 
-interface OnCascadeLeafNodeCollapsedArgs<G extends GroupNode> {
-  row: G;
-  /**
-   * The path of the row that was collapsed in the group by hierarchy.
-   */
-  nodePath: string[];
-  /**
-   * KV record of the path values for the row node.
-   */
-  nodePathMap: Record<string, string>;
-}
+type OnCascadeLeafNodeExpandedArgs<G extends GroupNode> = CascadeGroupNodeUIInteraction<G>;
+
+type OnCascadeLeafNodeCollapsedArgs<G extends GroupNode> = CascadeGroupNodeUIInteraction<G>;
 
 /**
  * Provides the props required to anchor another virtualized list
@@ -79,34 +87,6 @@ export interface CascadeRowCellPrimitiveProps<G extends GroupNode, L extends Lea
       nodePath: string[];
     } & CascadeRowCellNestedVirtualizationAnchorProps<G>
   ) => React.ReactNode;
-}
-
-interface CascadeGroupNodeUIInteraction<G extends GroupNode> {
-  /**
-   * The row instance that was interacted with in the group by hierarchy.
-   */
-  row: G;
-  /**
-   * The path of the row that was interacted with in the group by hierarchy.
-   *
-   * @example
-   * ```
-   * ['@timestamp', 'geo.src.country_name']
-   * ```
-   */
-  nodePath: string[];
-  /**
-   * KV record of the path values for the row node.
-   *
-   * @example
-   * ```
-   * {
-   *   '@timestamp': '2026-01-13T00:00:00.000Z',
-   *   'geo.src.country_name': 'United States'
-   * }
-   * ```
-   */
-  nodePathMap: Record<string, string>;
 }
 
 type OnCascadeGroupNodeExpandedArgs<G extends GroupNode> = CascadeGroupNodeUIInteraction<G>;

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/scroll_sync/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/scroll_sync/index.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { createContext, useContext, useRef, useCallback } from 'react';
+
+interface ScrollSyncContextValue {
+  register: (el: HTMLDivElement) => void;
+  unregister: (el: HTMLDivElement) => void;
+  syncScroll: (source: HTMLDivElement) => void;
+}
+
+const ScrollSyncContext = createContext<ScrollSyncContextValue | null>(null);
+
+export const useScrollSync = () => {
+  const context = useContext(ScrollSyncContext);
+  if (!context) {
+    throw new Error('useScrollSync must be used within a ScrollSyncProvider');
+  }
+  return context;
+};
+
+/**
+ * Co-ordinates the scroll position of multiple scrollable elements.
+ * Uses a "scroll leader" pattern - only the element actively being scrolled
+ * by the user drives the sync, preventing feedback loops.
+ */
+export const ScrollSyncProvider: React.FC<{
+  children: React.ReactNode;
+  disableScrollSync?: boolean;
+}> = ({ children, disableScrollSync = false }) => {
+  const containers = useRef<Set<HTMLDivElement>>(new Set());
+  const scrollLeader = useRef<HTMLDivElement | null>(null);
+  const scrollTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Canonical scroll position - always tracked, used to initialize new containers
+  const canonicalScrollLeft = useRef(0);
+
+  const register = useCallback((el: HTMLDivElement) => {
+    // New containers adopt the canonical scroll position immediately
+    el.scrollLeft = canonicalScrollLeft.current;
+    containers.current.add(el);
+  }, []);
+
+  const unregister = useCallback((el: HTMLDivElement) => {
+    containers.current.delete(el);
+    if (scrollLeader.current === el) {
+      scrollLeader.current = null;
+    }
+  }, []);
+
+  const syncScroll = useCallback(
+    (source: HTMLDivElement) => {
+      // If another element is the scroll leader, ignore this event
+      // (it's a programmatic scroll from syncing)
+      if ((scrollLeader.current && scrollLeader.current !== source) || disableScrollSync) {
+        return;
+      }
+
+      // This element becomes the scroll leader
+      scrollLeader.current = source;
+
+      // Clear any pending timeout
+      if (scrollTimeout.current) {
+        clearTimeout(scrollTimeout.current);
+      }
+
+      const { scrollLeft } = source;
+
+      // track the canonical position
+      canonicalScrollLeft.current = scrollLeft;
+
+      // perform the sync
+      containers.current.forEach((el) => {
+        if (el !== source && el.scrollLeft !== scrollLeft) {
+          el.scrollLeft = scrollLeft;
+        }
+      });
+
+      // Release leadership after scrolling stops (50ms debounce)
+      scrollTimeout.current = setTimeout(() => {
+        scrollLeader.current = null;
+      }, 50);
+    },
+    [disableScrollSync]
+  );
+
+  return (
+    <ScrollSyncContext.Provider value={{ register, unregister, syncScroll }}>
+      {children}
+    </ScrollSyncContext.Provider>
+  );
+};


### PR DESCRIPTION
## Summary

Includes changes resulting from the feedback received from testing https://github.com/elastic/kibana/pull/220119

- Fixes an issue where the documentation for cascade component was showing up as a story in the storybook
- Adds  `onCascadeGroupNodeCollapsed` and `onCascadeLeafNodeCollapsed` prop to the `DataCascadeRow` and `DataCascadeRowCell` components respectively.
- Adds rudimentary implementation for handling multiple stats in the cascade component alongside a story for show casing this. [See here](https://ci-artifacts.kibana.dev/storybooks/pr-248838/shared_ux/index.html?path=/story/data-cascade-configuration-examples--cascade-multiple-stats-per-row) for example

## How to test

- Spin up the shared ux storybook like so; `yarn storybook shared_ux` and look for the multiple stats per row story
- Testing in discover;
	-	add the config value; `feature_flags.overrides.discover.cascadeLayoutEnabled: true`	to your `kibana.dev.yml`, this enables the cascade experience.
	- Navigate to discover and select ES|QL mode
	- Type in a query that includes a `STATS` command with one group and multiple aggregations, or simply add in the following query if you'd rather not come up with yours; 
		```
		FROM kibana_sample_data_logs | STATS count = COUNT(*), avg_bytes = AVG(bytes), p95 = PERCENTILE(memory, 95), median_ram_size = MEDIAN(machine.ram) BY CATEGORIZE(message)
		```
		You might need to resize the browser window if you're on a wide screen till the aggregates are cut off, when this happens hovering on a row should show the directional arrows, and clicking on them should cause the hovered row to scroll with the other rows scrolling to match the scroll position shortly after.

## Visual change for discover

#### Before
<img width="1486" height="436" alt="Screenshot 2026-01-16 at 19 58 12" src="https://github.com/user-attachments/assets/87e65e50-372e-45f2-9943-93d44189850a" />


#### After
<img width="1155" height="482" alt="Screenshot 2026-01-26 at 12 58 28" src="https://github.com/user-attachments/assets/bdd0abde-ecc3-4579-891f-f5a4875dbada" />

_N.B. directional arrows only show on hover now, and scrolling one row will scroll all the other rows so that the stats are always aligned._

<!--

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->
