### PR TITLE
[PoC] [Agent Builder] hooks

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/index.ts
@@ -22,6 +22,9 @@ export type {
   ToolsStart,
 } from './types';
 
+export { HookEvent, HookExecutionMode } from './services/hooks';
+export type { HookRegistration } from './services/hooks';
+
 export const plugin: PluginInitializer<
   AgentBuilderPluginSetup,
   AgentBuilderPluginStart,

--- a/x-pack/platform/plugins/shared/agent_builder/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/mocks.ts
@@ -20,6 +20,9 @@ const createSetupContractMock = (): jest.Mocked<AgentBuilderPluginSetup> => {
     attachments: {
       registerType: jest.fn(),
     },
+    hooks: {
+      register: jest.fn(),
+    },
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -116,6 +116,9 @@ export class AgentBuilderPlugin
       attachments: {
         registerType: serviceSetups.attachments.registerType.bind(serviceSetups.attachments),
       },
+      hooks: {
+        register: serviceSetups.hooks.register.bind(serviceSetups.hooks),
+      },
     };
   }
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/chat/chat_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/chat/chat_service.test.ts
@@ -34,6 +34,7 @@ import {
 import type { ChatService } from './types';
 import { createChatService } from './chat_service';
 import { isConversationIdSetEvent } from '@kbn/agent-builder-common/chat';
+import type { HooksServiceStart } from '../hooks';
 
 const createChatModel = (): InferenceChatModel => {
   // we don't really need it
@@ -52,6 +53,7 @@ describe('ChatService', () => {
   let savedObjects: ReturnType<typeof savedObjectsServiceMock.createStartContract>;
 
   let chatService: ChatService;
+  let hooks: HooksServiceStart;
 
   beforeEach(() => {
     logger = loggerMock.create();
@@ -61,6 +63,10 @@ describe('ChatService', () => {
     conversationService = createConversationServiceMock();
     uiSettings = uiSettingsServiceMock.createStartContract();
     savedObjects = savedObjectsServiceMock.createStartContract();
+    hooks = {
+      runBlocking: async (_event, context) => context,
+      runParallel: () => {},
+    };
 
     chatService = createChatService({
       inference,
@@ -69,6 +75,7 @@ describe('ChatService', () => {
       conversationService,
       uiSettings,
       savedObjects,
+      hooks,
     });
 
     const conversation = createEmptyConversation();
@@ -123,7 +130,7 @@ describe('ChatService', () => {
         request,
         agentService,
         defaultConnectorId: 'test-connector-id',
-        abortSignal: undefined,
+        abortSignal: expect.any(Object),
       })
     );
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -18,11 +18,13 @@ import { RunnerFactoryImpl } from './runner';
 import { ConversationServiceImpl } from './conversation';
 import { createChatService } from './chat';
 import { type AttachmentService, createAttachmentService } from './attachments';
+import { HooksService } from './hooks';
 
 interface ServiceInstances {
   tools: ToolsService;
   agents: AgentsService;
   attachments: AttachmentService;
+  hooks: HooksService;
 }
 
 export class ServiceManager {
@@ -35,12 +37,14 @@ export class ServiceManager {
       tools: new ToolsService(),
       agents: new AgentsService(),
       attachments: createAttachmentService(),
+      hooks: new HooksService(),
     };
 
     this.internalSetup = {
       tools: this.services.tools.setup({ logger, workflowsManagement }),
       agents: this.services.agents.setup({ logger }),
       attachments: this.services.attachments.setup(),
+      hooks: this.services.hooks.setup({ logger }),
     };
 
     return this.internalSetup;
@@ -92,6 +96,8 @@ export class ServiceManager {
       toolsService: tools,
     });
 
+    const hooks = this.services.hooks.start();
+
     const runnerFactory = new RunnerFactoryImpl({
       logger: logger.get('runnerFactory'),
       security,
@@ -103,6 +109,7 @@ export class ServiceManager {
       agentsService: agents,
       attachmentsService: attachments,
       trackingService,
+      hooks,
     });
     runner = runnerFactory.getRunner();
 
@@ -122,6 +129,7 @@ export class ServiceManager {
       savedObjects,
       trackingService,
       analyticsService,
+      hooks,
     });
 
     this.internalStart = {
@@ -131,6 +139,7 @@ export class ServiceManager {
       conversations,
       runnerFactory,
       chat,
+      hooks,
     };
 
     return this.internalStart;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/hooks/hooks_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/hooks/hooks_service.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createBadRequestError, isBadRequestError } from '@kbn/agent-builder-common';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { HooksService } from './hooks_service';
+import { HookEvent, HookExecutionMode } from './types';
+import type { ConversationRoundStartHookContext } from './types';
+
+describe('HooksService', () => {
+  const createService = () => {
+    const logger = loggingSystemMock.create().get('test');
+    const service = new HooksService();
+    const setup = service.setup({ logger });
+    const start = service.start();
+    return { setup, start };
+  };
+
+  const baseContext = {
+    event: HookEvent.onConversationRoundStart as const,
+    agentId: 'agent-1',
+    conversationId: 'conv-1',
+    conversation: {
+      id: 'conv-1',
+      agent_id: 'agent-1',
+      user: { id: 'u-1', name: 'User', username: 'user' },
+      title: 't',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      rounds: [],
+    },
+    nextInput: { message: 'hello' },
+    request: {} as any,
+  };
+
+  it('runs blocking hooks in priority order (desc) and applies nextInput mutation', async () => {
+    const { setup, start } = createService();
+    const calls: string[] = [];
+
+    setup.register({
+      id: 'h1',
+      event: HookEvent.onConversationRoundStart,
+      mode: HookExecutionMode.blocking,
+      priority: 5,
+      handler: async () => {
+        calls.push('h1');
+        return { nextInput: { message: 'mutated' } };
+      },
+    });
+    setup.register({
+      id: 'h2',
+      event: HookEvent.onConversationRoundStart,
+      mode: HookExecutionMode.blocking,
+      priority: 10,
+      handler: async (ctx: ConversationRoundStartHookContext) => {
+        calls.push(`h2:${ctx.nextInput.message}`);
+      },
+    });
+
+    const result = await start.runBlocking(HookEvent.onConversationRoundStart, baseContext);
+    expect(calls).toEqual(['h2:hello', 'h1']);
+    expect(result.nextInput.message).toBe('mutated');
+  });
+
+  it('aborts blocking execution when a hook throws a non-AgentBuilderError', async () => {
+    const { setup, start } = createService();
+
+    setup.register({
+      id: 'h1',
+      event: HookEvent.onConversationRoundStart,
+      mode: HookExecutionMode.blocking,
+      handler: async () => {
+        throw new Error('nope');
+      },
+    });
+
+    try {
+      await start.runBlocking(HookEvent.onConversationRoundStart, baseContext);
+      throw new Error('Expected hook execution to throw');
+    } catch (e) {
+      expect(e).toMatchObject({ message: 'nope' });
+      expect(isBadRequestError(e)).toBe(true);
+    }
+  });
+
+  it('preserves AgentBuilderErrors thrown by hooks and augments metadata', async () => {
+    const { setup, start } = createService();
+
+    setup.register({
+      id: 'h1',
+      event: HookEvent.onConversationRoundStart,
+      mode: HookExecutionMode.blocking,
+      handler: async () => {
+        throw createBadRequestError('blocked', { reason: 'test' });
+      },
+    });
+
+    await expect(
+      start.runBlocking(HookEvent.onConversationRoundStart, baseContext)
+    ).rejects.toMatchObject({
+      message: 'blocked',
+      meta: expect.objectContaining({
+        reason: 'test',
+        hookId: 'h1',
+        hookEvent: HookEvent.onConversationRoundStart,
+        hookMode: HookExecutionMode.blocking,
+      }),
+    });
+  });
+
+  it('runs parallel hooks without blocking and swallows errors', async () => {
+    const { setup, start } = createService();
+
+    const handler = jest.fn(async () => {
+      throw new Error('boom');
+    });
+
+    setup.register({
+      id: 'p1',
+      event: HookEvent.onConversationRoundStart,
+      mode: HookExecutionMode.parallel,
+      handler,
+    });
+
+    expect(() => start.runParallel(HookEvent.onConversationRoundStart, baseContext)).not.toThrow();
+  });
+
+  it('aborts via abortController when a parallel hook throws', async () => {
+    const { setup, start } = createService();
+
+    setup.register({
+      id: 'p1',
+      event: HookEvent.onConversationRoundStart,
+      mode: HookExecutionMode.parallel,
+      handler: async () => {
+        throw new Error('guardrails violation');
+      },
+    });
+
+    const abortController = new AbortController();
+    const context = { ...baseContext, abortController };
+
+    start.runParallel(HookEvent.onConversationRoundStart, context as any);
+
+    // allow the promise chain + catch handler to run
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(abortController.signal.aborted).toBe(true);
+    const reason = (abortController.signal as any).reason;
+    expect(reason).toMatchObject({ message: 'guardrails violation' });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/hooks/hooks_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/hooks/hooks_service.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import {
+  createBadRequestError,
+  createRequestAbortedError,
+  isAgentBuilderError,
+} from '@kbn/agent-builder-common';
+import type {
+  HookContext,
+  HookHandlerResult,
+  HookRegistration,
+  HooksServiceSetup,
+  HooksServiceStart,
+} from './types';
+import { HookEvent, HookExecutionMode } from './types';
+
+export interface HooksServiceSetupDeps {
+  logger: Logger;
+}
+
+const sortByPriorityDesc = <R extends { priority?: number }>(a: R, b: R) => {
+  return (b.priority ?? 0) - (a.priority ?? 0);
+};
+
+const hasAgentId = (
+  context: HookContext<HookEvent>
+): context is HookContext<HookEvent> & { agentId: string } => {
+  const agentId = (context as unknown as { agentId?: unknown }).agentId;
+  return typeof agentId === 'string' && agentId.length > 0;
+};
+
+const hasAbortController = (
+  context: HookContext<HookEvent>
+): context is HookContext<HookEvent> & { abortController: AbortController } => {
+  const abortController = (context as unknown as { abortController?: unknown }).abortController;
+  return abortController instanceof AbortController;
+};
+
+interface HookRegistrationLike {
+  id: string;
+  mode: HookExecutionMode;
+}
+
+const normalizeHookError = (event: HookEvent, hook: HookRegistrationLike, err: unknown) => {
+  if (isAgentBuilderError(err)) {
+    err.meta = {
+      ...err.meta,
+      hookEvent: event,
+      hookId: hook.id,
+      hookMode: hook.mode,
+    };
+    return err;
+  }
+  const error = err instanceof Error ? err : new Error(String(err));
+  return createBadRequestError(error.message, {
+    hookEvent: event,
+    hookId: hook.id,
+    hookMode: hook.mode,
+  });
+};
+
+export class HooksService {
+  private setupDeps?: HooksServiceSetupDeps;
+  /**
+   * Stored untyped to avoid generic variance issues for function-typed fields (handlers).
+   * Safe to cast back based on the map key (event) when reading.
+   */
+  private readonly registrationsByEvent = new Map<HookEvent, unknown[]>();
+
+  setup(deps: HooksServiceSetupDeps): HooksServiceSetup {
+    this.setupDeps = deps;
+
+    return {
+      register: (registration) => {
+        const existing = this.registrationsByEvent.get(registration.event) ?? [];
+        if (existing.some((r) => (r as { id?: unknown }).id === registration.id)) {
+          throw new Error(
+            `Hook with id "${registration.id}" is already registered for event "${registration.event}".`
+          );
+        }
+        this.registrationsByEvent.set(registration.event, [...existing, registration]);
+      },
+    };
+  }
+
+  start(): HooksServiceStart {
+    if (!this.setupDeps) {
+      throw new Error('#start called before #setup');
+    }
+
+    const logger = this.setupDeps.logger.get('hooks');
+
+    const getRelevantHooks = <E extends HookEvent>(
+      event: E,
+      mode: HookExecutionMode,
+      context: HookContext<E>
+    ): Array<HookRegistration<E>> => {
+      const hooks = (this.registrationsByEvent.get(event) ?? []) as unknown as Array<
+        HookRegistration<E>
+      >;
+      const agentId = hasAgentId(context) ? context.agentId : undefined;
+
+      return hooks
+        .filter((h) => h.mode === mode)
+        .filter((h) => {
+          if (!h.agentFilter) return true;
+          if (!agentId) return false;
+          return h.agentFilter.includes(agentId);
+        })
+        .slice()
+        .sort(sortByPriorityDesc);
+    };
+
+    const applyHookResult = <E extends HookEvent>(
+      event: E,
+      context: HookContext<E>,
+      result: void | HookHandlerResult<E>
+    ): HookContext<E> => {
+      if (!result || typeof result !== 'object') {
+        return context;
+      }
+
+      switch (event) {
+        case HookEvent.onConversationRoundStart: {
+          const { nextInput } = result as HookHandlerResult<HookEvent.onConversationRoundStart>;
+          return nextInput ? ({ ...context, nextInput } as HookContext<E>) : context;
+        }
+        case HookEvent.onConversationRoundEnd: {
+          const { round } = result as HookHandlerResult<HookEvent.onConversationRoundEnd>;
+          return round ? ({ ...context, round } as HookContext<E>) : context;
+        }
+        case HookEvent.preToolCall: {
+          const { toolParams } = result as HookHandlerResult<HookEvent.preToolCall>;
+          return toolParams ? ({ ...context, toolParams } as HookContext<E>) : context;
+        }
+        case HookEvent.postToolCall: {
+          const { toolReturn } = result as HookHandlerResult<HookEvent.postToolCall>;
+          return toolReturn ? ({ ...context, toolReturn } as HookContext<E>) : context;
+        }
+        case HookEvent.onAgentRunStart:
+        case HookEvent.onAgentRunEnd:
+          return context;
+        default:
+          return context;
+      }
+    };
+
+    const runBlocking: HooksServiceStart['runBlocking'] = async (event, context) => {
+      if ('abortSignal' in context && context.abortSignal?.aborted) {
+        throw createRequestAbortedError('Request aborted before executing hooks', {
+          hookEvent: event,
+        });
+      }
+
+      const hooks = getRelevantHooks(event, HookExecutionMode.blocking, context);
+      let currentContext = context;
+
+      for (const hook of hooks) {
+        if ('abortSignal' in currentContext && currentContext.abortSignal?.aborted) {
+          throw createRequestAbortedError('Request aborted while executing hooks', {
+            hookEvent: event,
+            hookId: hook.id,
+          });
+        }
+
+        try {
+          const result = await hook.handler(currentContext);
+          currentContext = applyHookResult(
+            event,
+            currentContext,
+            result as unknown as HookHandlerResult<typeof event>
+          );
+        } catch (err) {
+          throw normalizeHookError(event, hook, err);
+        }
+      }
+
+      return currentContext;
+    };
+
+    const runParallel: HooksServiceStart['runParallel'] = (event, context) => {
+      const hooks = getRelevantHooks(event, HookExecutionMode.parallel, context);
+      for (const hook of hooks) {
+        // Fire-and-forget. Must never throw to the caller.
+        Promise.resolve()
+          .then(() => hook.handler(context))
+          .catch((err) => {
+            const normalized = normalizeHookError(event, hook, err);
+            // If the triggering flow provided an abort controller, use it to cancel the main operation.
+            // This enables parallel hooks to "gate" a flow without blocking it.
+            if (hasAbortController(context) && !context.abortController.signal.aborted) {
+              try {
+                context.abortController.abort(normalized);
+              } catch (e) {
+                // ignore
+              }
+            }
+            logger.warn(
+              `Parallel hook "${hook.id}" failed for event "${event}": ${
+                normalized instanceof Error ? normalized.message : String(normalized)
+              }`
+            );
+          });
+      }
+    };
+
+    return { runBlocking, runParallel };
+  }
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/hooks/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/hooks/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { HooksService } from './hooks_service';
+export type { HooksServiceSetup, HooksServiceStart, HookRegistration } from './types';
+export { HookEvent, HookExecutionMode } from './types';
+
+

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/hooks/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/hooks/index.ts
@@ -8,5 +8,3 @@
 export { HooksService } from './hooks_service';
 export type { HooksServiceSetup, HooksServiceStart, HookRegistration } from './types';
 export { HookEvent, HookExecutionMode } from './types';
-
-

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/hooks/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/hooks/types.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type {
+  AgentCapabilities,
+  Conversation,
+  ConverseInput,
+  ConversationRound,
+} from '@kbn/agent-builder-common';
+import type { RunToolReturn } from '@kbn/agent-builder-server';
+
+/**
+ * Lifecycle events that can trigger hooks.
+ *
+ * Note: this is intentionally scoped to server-side agent execution lifecycle.
+ */
+export enum HookEvent {
+  onConversationRoundStart = 'onConversationRoundStart',
+  onConversationRoundEnd = 'onConversationRoundEnd',
+  preToolCall = 'preToolCall',
+  postToolCall = 'postToolCall',
+  onAgentRunStart = 'onAgentRunStart',
+  onAgentRunEnd = 'onAgentRunEnd',
+}
+
+/**
+ * Determines when the hook is executed relative to the main event flow.
+ *
+ * - blocking: executed before proceeding; errors abort the main event.
+ * - parallel: executed in the background; errors are logged and do not abort.
+ */
+export enum HookExecutionMode {
+  blocking = 'blocking',
+  parallel = 'parallel',
+}
+
+export interface ConversationRoundStartHookContext {
+  /**
+   * Event name.
+   */
+  event: HookEvent.onConversationRoundStart;
+  /**
+   * Agent id that will handle this round.
+   */
+  agentId: string;
+  /**
+   * Conversation id for this round.
+   */
+  conversationId: string;
+  /**
+   * Current conversation state.
+   */
+  conversation: Conversation;
+  /**
+   * Input that will be used to start / resume the round.
+   *
+   * Blocking hooks may return an updated value via {@link HookHandlerResult.nextInput}.
+   */
+  nextInput: ConverseInput;
+  /**
+   * Optional capabilities requested by the caller.
+   */
+  capabilities?: AgentCapabilities;
+  /**
+   * Original request driving the operation.
+   */
+  request: KibanaRequest;
+  /**
+   * Optional abort signal; hook implementations should respect it where appropriate.
+   */
+  abortSignal?: AbortSignal;
+  /**
+   * Optional abort controller that can be used to cancel the triggering operation from within hooks.
+   * Primarily used by parallel hooks to cancel an in-flight operation.
+   */
+  abortController?: AbortController;
+}
+
+export interface ConversationRoundEndHookContext {
+  event: HookEvent.onConversationRoundEnd;
+  agentId: string;
+  conversationId: string;
+  conversation: Conversation;
+  round: ConversationRound;
+  resumed: boolean;
+  capabilities?: AgentCapabilities;
+  request: KibanaRequest;
+  abortSignal?: AbortSignal;
+  abortController?: AbortController;
+}
+
+export interface ToolCallHookContextBase {
+  toolId: string;
+  toolCallId: string;
+  toolParams: Record<string, unknown>;
+  source: 'agent' | 'user' | 'mcp' | 'unknown';
+  request: KibanaRequest;
+  abortSignal?: AbortSignal;
+  abortController?: AbortController;
+}
+
+export interface PreToolCallHookContext extends ToolCallHookContextBase {
+  event: HookEvent.preToolCall;
+  /**
+   * Optional abort signal; hook implementations should respect it where appropriate.
+   */
+  abortSignal?: AbortSignal;
+}
+
+export interface PostToolCallHookContext extends ToolCallHookContextBase {
+  event: HookEvent.postToolCall;
+  toolReturn: RunToolReturn;
+}
+
+export interface AgentRunHookContextBase {
+  agentId: string;
+  request: KibanaRequest;
+  abortSignal?: AbortSignal;
+  abortController?: AbortController;
+  runId: string;
+  agentParams: unknown;
+}
+
+export interface AgentRunStartHookContext extends AgentRunHookContextBase {
+  event: HookEvent.onAgentRunStart;
+}
+
+export interface AgentRunEndHookContext extends AgentRunHookContextBase {
+  event: HookEvent.onAgentRunEnd;
+  result: unknown;
+}
+
+export interface HookContextByEvent {
+  [HookEvent.onConversationRoundStart]: ConversationRoundStartHookContext;
+  [HookEvent.onConversationRoundEnd]: ConversationRoundEndHookContext;
+  [HookEvent.preToolCall]: PreToolCallHookContext;
+  [HookEvent.postToolCall]: PostToolCallHookContext;
+  [HookEvent.onAgentRunStart]: AgentRunStartHookContext;
+  [HookEvent.onAgentRunEnd]: AgentRunEndHookContext;
+}
+
+export type HookContext<E extends HookEvent = HookEvent> = HookContextByEvent[E];
+
+export interface HookHandlerResultByEvent {
+  [HookEvent.onConversationRoundStart]: {
+    nextInput?: ConverseInput;
+  };
+  [HookEvent.onConversationRoundEnd]: {
+    round?: ConversationRound;
+  };
+  [HookEvent.preToolCall]: {
+    toolParams?: Record<string, unknown>;
+  };
+  [HookEvent.postToolCall]: {
+    toolReturn?: RunToolReturn;
+  };
+  [HookEvent.onAgentRunStart]: Record<string, never>;
+  [HookEvent.onAgentRunEnd]: Record<string, never>;
+}
+
+export type HookHandlerResult<E extends HookEvent = HookEvent> = HookHandlerResultByEvent[E] & {
+  /**
+   * Hook-specific arbitrary data for debugging/observability.
+   * Currently not persisted.
+   */
+  data?: Record<string, unknown>;
+};
+
+export type HookHandler<E extends HookEvent = HookEvent> = (
+  context: HookContext<E>
+) => Promise<void | HookHandlerResult<E>> | void | HookHandlerResult<E>;
+
+export interface HookRegistration<E extends HookEvent = HookEvent> {
+  /**
+   * Unique id used to manage and identify this hook.
+   */
+  id: string;
+  event: E;
+  mode: HookExecutionMode;
+  /**
+   * Optional priority for ordering hooks within the same event+mode.
+   * Higher values run earlier.
+   */
+  priority?: number;
+  description?: string;
+  /**
+   * Optional allowlist of agent ids for which this hook will run.
+   */
+  agentFilter?: string[];
+  handler: HookHandler<E>;
+}
+
+export interface HooksServiceSetup {
+  register: <E extends HookEvent>(registration: HookRegistration<E>) => void;
+}
+
+export interface HooksServiceStart {
+  runBlocking: <E extends HookEvent>(event: E, context: HookContext<E>) => Promise<HookContext<E>>;
+  runParallel: <E extends HookEvent>(event: E, context: HookContext<E>) => void;
+}

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/runner/runner.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/runner/runner.ts
@@ -35,6 +35,7 @@ import { createAttachmentStateManager } from '@kbn/agent-builder-server/attachme
 import type { ToolsServiceStart } from '../tools';
 import type { AgentsServiceStart } from '../agents';
 import type { AttachmentServiceStart } from '../attachments';
+import type { HooksServiceStart } from '../hooks';
 import type { ModelProviderFactoryFn } from './model_provider';
 import type { TrackingService } from '../../telemetry';
 import { createEmptyRunContext, createConversationStateManager } from './utils';
@@ -58,6 +59,7 @@ export interface CreateScopedRunnerDeps {
   promptManager: PromptManager;
   stateManager: ConversationStateManager;
   trackingService?: TrackingService;
+  hooks?: HooksServiceStart;
   // other deps
   logger: Logger;
   request: KibanaRequest;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/runner/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/runner/types.ts
@@ -15,6 +15,7 @@ import type { Runner } from '@kbn/agent-builder-server';
 import type { ToolsServiceStart } from '../tools';
 import type { AgentsServiceStart } from '../agents';
 import type { AttachmentServiceStart } from '../attachments';
+import type { HooksServiceStart } from '../hooks';
 import type { TrackingService } from '../../telemetry';
 
 export interface RunnerFactoryDeps {
@@ -31,6 +32,7 @@ export interface RunnerFactoryDeps {
   agentsService: AgentsServiceStart;
   attachmentsService: AttachmentServiceStart;
   trackingService?: TrackingService;
+  hooks?: HooksServiceStart;
 }
 
 export interface RunnerFactory {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/types.ts
@@ -20,6 +20,7 @@ import type { AgentsServiceSetup, AgentsServiceStart } from './agents';
 import type { ConversationService } from './conversation';
 import type { ChatService } from './chat';
 import type { AttachmentServiceSetup, AttachmentServiceStart } from './attachments';
+import type { HooksServiceSetup, HooksServiceStart } from './hooks';
 import type { TrackingService } from '../telemetry/tracking_service';
 import type { AnalyticsService } from '../telemetry';
 
@@ -27,6 +28,7 @@ export interface InternalSetupServices {
   tools: ToolsServiceSetup;
   agents: AgentsServiceSetup;
   attachments: AttachmentServiceSetup;
+  hooks: HooksServiceSetup;
 }
 
 export interface InternalStartServices {
@@ -36,6 +38,7 @@ export interface InternalStartServices {
   conversations: ConversationService;
   chat: ChatService;
   runnerFactory: RunnerFactory;
+  hooks: HooksServiceStart;
 }
 
 export interface ServiceSetupDeps {

--- a/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
@@ -26,6 +26,7 @@ import type { ConversationStateManager, PromptManager } from '@kbn/agent-builder
 import type { AttachmentStateManager } from '@kbn/agent-builder-server/attachments';
 import type { AttachmentServiceStart } from '../services/attachments';
 import type { CreateScopedRunnerDeps, CreateRunnerDeps } from '../services/runner/runner';
+import type { HooksServiceStart } from '../services/hooks';
 import type { ModelProviderMock, ModelProviderFactoryMock } from './model_provider';
 import { createModelProviderMock, createModelProviderFactoryMock } from './model_provider';
 import type { ToolsServiceStartMock } from './tools';
@@ -181,6 +182,7 @@ export const createScopedRunnerDepsMock = (): CreateScopedRunnerDepsMock => {
     attachmentsService: createAttachmentsServiceStartMock(),
     promptManager: createPromptManagerMock(),
     stateManager: createStateManagerMock(),
+    hooks: createHooksServiceStartMock(),
   };
 };
 
@@ -195,5 +197,13 @@ export const createRunnerDepsMock = (): CreateRunnerDepsMock => {
     agentsService: createAgentsServiceStartMock(),
     logger: loggerMock.create(),
     attachmentsService: createAttachmentsServiceStartMock(),
+    hooks: createHooksServiceStartMock(),
+  };
+};
+
+export const createHooksServiceStartMock = (): jest.Mocked<HooksServiceStart> => {
+  return {
+    runBlocking: jest.fn(async (_event: any, context: any) => context),
+    runParallel: jest.fn(),
   };
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/types.ts
@@ -22,6 +22,7 @@ import type {
 import type { BuiltInAgentDefinition } from '@kbn/agent-builder-server/agents';
 import type { ToolsServiceSetup, ToolRegistry } from './services/tools';
 import type { AttachmentServiceSetup } from './services/attachments';
+import type { HookRegistration } from './services/hooks';
 
 export interface AgentBuilderSetupDependencies {
   cloud?: CloudSetup;
@@ -96,6 +97,12 @@ export interface AgentBuilderPluginSetup {
    * Attachments setup contract, which can be used to register attachment types.
    */
   attachments: AttachmentsSetup;
+  /**
+   * Hooks setup contract, which can be used to register lifecycle event hooks.
+   */
+  hooks: {
+    register: (registration: HookRegistration) => void;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

resolves https://github.com/elastic/search-team/issues/12356

- [x] New hooks setup contract on agentBuilder (agentBuilder.hooks.register(...)) 
- [x] Hooks service + executor that:
 - Runs blocking hooks in priority order and aborts execution on error 
 - Allows parallel hooks which dont block the main execution
 - Parallel hooks can still abort the main execution
 - Supports limited, event-specific context mutation (e.g. nextInput, toolParams, toolReturn, round).
- [x] Wired hooks into agent builder:
 - onConversationRoundStart / onConversationRoundEnd 
 - preToolCall / postToolCall 
 - onAgentRunStart / onAgentRunEnd
