### PR TITLE
Add span.id to serverless synthtrace scenario

### DIFF
--- a/src/platform/packages/shared/kbn-synthtrace-client/src/lib/apm/serverless.ts
+++ b/src/platform/packages/shared/kbn-synthtrace-client/src/lib/apm/serverless.ts
@@ -18,12 +18,14 @@ export class Serverless extends BaseSpan {
   private readonly metric: Metricset<ApmFields>;
 
   constructor(fields: ApmFields) {
+    const transactionId = generateShortId();
     const faasExection = generateLongId();
     const triggerType = 'other';
     super({
       ...fields,
       'processor.event': 'transaction',
-      'transaction.id': generateShortId(),
+      'transaction.id': transactionId,
+      'span.id': transactionId,
       'transaction.sampled': true,
       'faas.execution': faasExection,
       'faas.trigger.type': triggerType,


### PR DESCRIPTION
## Summary

This PR addresses an issue where serverless span documents generated by Synthtrace were missing the `span.id` field, which was causing issues when the generated data was used to check the traces unified waterfall 

#### Testing

- Collect data using aws_lambda scenario without using this PR:

  ```bash
  node scripts/synthtrace aws_lambda --clean
  ```
- Look for traces using the `aws_lambdas` as `service.name`
- Check that those documents don't have a `span.id` defined
- Run the synthtrace script again with the PR changes applied
- Inspect any of the above mentioned documents
- `span.id` should now be defined