### PR TITLE
docs: update security url

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
 Thanks for your interest in the security of our products.
-Our security policy can be found at [https://www.elastic.co/community/security](https://www.elastic.co/community/security).
+Our security policy can be found at [https://www.elastic.co/product-security](https://www.elastic.co/product-security).
 
 ## Reporting a Vulnerability
 Please send security vulnerability reports to security@elastic.co.


### PR DESCRIPTION
This PR updates the security URL from `https://www.elastic.co/community/security` to `https://www.elastic.co/product-security`.