### PR TITLE
[9.2] [Discover] Fix query drafts when switching tabs (#247968)

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -175,7 +175,7 @@ pageLoadAssetSize:
   uiActions: 24712
   uiActionsEnhanced: 20189
   unifiedDocViewer: 14513
-  unifiedSearch: 24000
+  unifiedSearch: 25000
   upgradeAssistant: 6898
   uptime: 48184
   urlDrilldown: 21563

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.test.tsx
@@ -711,6 +711,26 @@ describe('QueryBarTopRowTopRow', () => {
         expect(onDraftChange).toHaveBeenCalledWith(undefined);
       });
     });
+
+    it('should call onDraftChange only once even if unmounted', async () => {
+      const onDraftChange = jest.fn();
+      const state = {
+        query: kqlQuery,
+        dateRangeFrom: 'now-7d',
+        dateRangeTo: 'now',
+      };
+      const { unmount } = render(
+        wrapQueryBarTopRowInContext({
+          isDirty: false,
+          onDraftChange,
+          ...state,
+        })
+      );
+
+      unmount();
+
+      expect(onDraftChange).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -551,6 +551,12 @@ export const QueryBarTopRow = React.memo(
       onDraftChangeDebounced?.(draft);
     }, [onDraftChangeDebounced, draft]);
 
+    useEffect(() => {
+      return () => {
+        onDraftChangeDebounced?.flush(); // immediately invoke pending debounced calls on unmount
+      };
+    }, [onDraftChangeDebounced]);
+
     function shouldRenderQueryInput(): boolean {
       return Boolean(showQueryInput && props.query && storage);
     }

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_string_input.test.mocks.ts
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_string_input.test.mocks.ts
@@ -34,5 +34,10 @@ import _ from 'lodash';
 // Using doMock to avoid hoisting so that I can override only the debounce method in lodash
 jest.doMock('lodash', () => ({
   ..._,
-  debounce: (func: () => any) => func,
+  debounce: (func: any) => {
+    const debounced: any = func;
+    debounced.flush = jest.fn();
+    debounced.cancel = jest.fn();
+    return debounced;
+  },
 }));

--- a/src/platform/plugins/shared/unified_search/public/search_bar/lib/use_filter_manager.ts
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/lib/use_filter_manager.ts
@@ -7,12 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Subscription } from 'rxjs';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { Filter } from '@kbn/es-query';
 
 interface UseFilterManagerProps {
+  disabled?: boolean;
   filters?: Filter[];
   filterManager: DataPublicPluginStart['query']['filterManager'];
 }
@@ -20,7 +21,12 @@ interface UseFilterManagerProps {
 export const useFilterManager = (props: UseFilterManagerProps) => {
   // Filters should be either what's passed in the initial state or the current state of the filter manager
   const [filters, setFilters] = useState(props.filters || props.filterManager.getFilters());
+
   useEffect(() => {
+    if (props.disabled) {
+      return;
+    }
+
     const subscriptions = new Subscription();
 
     subscriptions.add(
@@ -35,7 +41,9 @@ export const useFilterManager = (props: UseFilterManagerProps) => {
     return () => {
       subscriptions.unsubscribe();
     };
-  }, [props.filterManager]);
+  }, [props.filterManager, props.disabled]);
 
-  return { filters };
+  const propsFilters = useMemo(() => props.filters || [], [props.filters]);
+
+  return { filters: props.disabled ? propsFilters : filters };
 };

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.test.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.test.tsx
@@ -442,7 +442,7 @@ describe('SearchBar', () => {
       });
 
       jest.advanceTimersByTime(500);
-      expect(onDraftChange).toHaveBeenCalledWith(draft);
+      expect(onDraftChange).not.toHaveBeenCalled(); // no change to draft
     });
 
     it('should check for query type mismatch', async () => {

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -327,6 +327,12 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
     );
   };
 
+  private onDraftChange = (draft: UnifiedSearchDraft | undefined) => {
+    if (this.props.onDraftChange && !isEqual(this.props.draft, draft)) {
+      this.props.onDraftChange(draft);
+    }
+  };
+
   componentWillUnmount() {
     this.renderSavedQueryManagement.clear();
   }
@@ -744,7 +750,7 @@ export class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> ex
           onRefreshChange={this.props.onRefreshChange}
           onCancel={this.props.onCancel}
           onChange={this.onQueryBarChange}
-          onDraftChange={this.props.onDraftChange}
+          onDraftChange={this.onDraftChange}
           onSendToBackground={this.onBackgroundSearch}
           isDirty={this.isDirty()}
           customSubmitButton={

--- a/src/platform/test/functional/apps/discover/context_awareness/_telemetry.ts
+++ b/src/platform/test/functional/apps/discover/context_awareness/_telemetry.ts
@@ -434,15 +434,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('trackSubmittingQuery telemetry', () => {
       beforeEach(async () => {
         await common.navigateToApp('discover');
-        await header.waitUntilLoadingHasFinished();
-        await discover.waitUntilSearchingHasFinished();
+        await discover.waitUntilTabIsLoaded();
         await ebtUIHelper.setOptIn(true);
       });
 
       it('should track field usage for KQL queries', async () => {
         await queryBar.setQuery('agent.name: "java" and log.level : "debug"');
         await queryBar.submitQuery();
-        await discover.waitUntilSearchingHasFinished();
+        await discover.waitUntilTabIsLoaded();
 
         const [event] = await ebtUIHelper.getEvents(Number.MAX_SAFE_INTEGER, {
           eventTypes: ['discover_query_fields_usage'],
@@ -461,7 +460,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           'from my-example-* | where agent.name == "java" and log.level == "debug"'
         );
         await testSubjects.click('querySubmitButton');
-        await discover.waitUntilSearchingHasFinished();
+        await discover.waitUntilTabIsLoaded();
 
         const [event] = await ebtUIHelper.getEvents(Number.MAX_SAFE_INTEGER, {
           eventTypes: ['discover_query_fields_usage'],
@@ -480,7 +479,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           'from my-example-* | where agent.name == "java" and KQL("""log.level:"debug" """)'
         );
         await testSubjects.click('querySubmitButton');
-        await discover.waitUntilSearchingHasFinished();
+        await discover.waitUntilTabIsLoaded();
 
         const [event] = await ebtUIHelper.getEvents(Number.MAX_SAFE_INTEGER, {
           eventTypes: ['discover_query_fields_usage'],
@@ -496,7 +495,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should track free text search as __FREE_TEXT__ placeholder', async () => {
         await queryBar.setQuery('error occurred');
         await queryBar.submitQuery();
-        await discover.waitUntilSearchingHasFinished();
+        await discover.waitUntilTabIsLoaded();
 
         const [event] = await ebtUIHelper.getEvents(Number.MAX_SAFE_INTEGER, {
           eventTypes: ['discover_query_fields_usage'],

--- a/src/platform/test/functional/apps/discover/tabs/_restorable_state.ts
+++ b/src/platform/test/functional/apps/discover/tabs/_restorable_state.ts
@@ -389,6 +389,49 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(await discover.getHitCount()).to.be('50');
       });
 
+      it('should restore the search bar state also after running the updated query', async () => {
+        await discover.selectTextBaseLang();
+        await discover.waitUntilTabIsLoaded();
+        const defaultQuery = 'FROM logstash-*';
+
+        const expectState = async (query: string, isDirty: boolean) => {
+          await retry.try(async () => {
+            expect(await monacoEditor.getCodeEditorValue()).to.be(query);
+          });
+          expect(await testSubjects.getAttribute('querySubmitButton', 'aria-label')).to.be(
+            isDirty ? 'Run query' : 'Refresh query'
+          );
+        };
+
+        const draftQuery0 =
+          'from logstash-* | sort @timestamp desc | limit 50 // edit and run this';
+        await expectState(defaultQuery, false);
+        await monacoEditor.setCodeEditorValue(draftQuery0);
+        await expectState(draftQuery0, true);
+        await queryBar.clickQuerySubmitButton();
+        await discover.waitUntilTabIsLoaded();
+        await expectState(draftQuery0, false);
+        expect(await discover.getHitCount()).to.be('50');
+
+        const draftQuery1 = 'from logstash-* | sort @timestamp desc | limit 150 // only edit this';
+        await unifiedTabs.createNewTab();
+        await discover.waitUntilTabIsLoaded();
+        await expectState(defaultQuery, false);
+        await monacoEditor.setCodeEditorValue(draftQuery1);
+        await expectState(draftQuery1, true);
+        expect(await discover.getHitCount()).to.be('1,000');
+
+        await unifiedTabs.selectTab(0);
+        await discover.waitUntilTabIsLoaded();
+        await expectState(draftQuery0, false);
+        expect(await discover.getHitCount()).to.be('50');
+
+        await unifiedTabs.selectTab(1);
+        await discover.waitUntilTabIsLoaded();
+        await expectState(draftQuery1, true);
+        expect(await discover.getHitCount()).to.be('1,000');
+      });
+
       it('should restore ES|QL editor state', async () => {
         await discover.selectTextBaseLang();
         await discover.waitUntilTabIsLoaded();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Discover] Fix query drafts when switching tabs (#247968)](https://github.com/elastic/kibana/pull/247968)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2026-01-13T16:51:23Z","message":"[Discover] Fix query drafts when switching tabs (#247968)\n\n- Resolves https://github.com/elastic/kibana/issues/246896\n\n## Summary\n\nThis PR makes sure that the latest query draft is captured and restored\nwhen switching tabs. The issue was hidden in UnifiedSearch because it\nwas listening to the global services changes (query, filters, refresh\ninterval) instead of simply using the passed props. This was creating\ninconsistency between the controlled by Discover props and the\ncontrolled by Unified Search props.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"4930daea2f8e10d6d05325f2e21c9c086d675113","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:DataDiscovery","backport:version","v9.3.0","v9.4.0","v9.2.5"],"title":"[Discover] Fix query drafts when switching tabs","number":247968,"url":"https://github.com/elastic/kibana/pull/247968","mergeCommit":{"message":"[Discover] Fix query drafts when switching tabs (#247968)\n\n- Resolves https://github.com/elastic/kibana/issues/246896\n\n## Summary\n\nThis PR makes sure that the latest query draft is captured and restored\nwhen switching tabs. The issue was hidden in UnifiedSearch because it\nwas listening to the global services changes (query, filters, refresh\ninterval) instead of simply using the passed props. This was creating\ninconsistency between the controlled by Discover props and the\ncontrolled by Unified Search props.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"4930daea2f8e10d6d05325f2e21c9c086d675113"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247968","number":247968,"mergeCommit":{"message":"[Discover] Fix query drafts when switching tabs (#247968)\n\n- Resolves https://github.com/elastic/kibana/issues/246896\n\n## Summary\n\nThis PR makes sure that the latest query draft is captured and restored\nwhen switching tabs. The issue was hidden in UnifiedSearch because it\nwas listening to the global services changes (query, filters, refresh\ninterval) instead of simply using the passed props. This was creating\ninconsistency between the controlled by Discover props and the\ncontrolled by Unified Search props.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"4930daea2f8e10d6d05325f2e21c9c086d675113"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->