### PR TITLE
[One Workflow] Fix UI setting to enable workflows

### DIFF
--- a/src/platform/packages/shared/serverless/settings/observability_project/index.ts
+++ b/src/platform/packages/shared/serverless/settings/observability_project/index.ts
@@ -8,6 +8,7 @@
  */
 
 import * as settings from '@kbn/management-settings-ids';
+import { WORKFLOWS_UI_SETTING_ID } from '@kbn/workflows/common/constants';
 
 export const OBSERVABILITY_PROJECT_SETTINGS = [
   settings.DEFAULT_ROUTE_ID,
@@ -33,6 +34,8 @@ export const OBSERVABILITY_PROJECT_SETTINGS = [
 export const OBSERVABILITY_STREAMS_TIERED_PROJECT_SETTINGS = [
   settings.OBSERVABILITY_STREAMS_ENABLE_SIGNIFICANT_EVENTS,
   settings.OBSERVABILITY_STREAMS_ENABLE_SIGNIFICANT_EVENTS_DISCOVERY,
+  // This setting is only registered in complete tier. It's temporary, will be removed on 9.4.0 release.
+  WORKFLOWS_UI_SETTING_ID,
 ];
 
 export const OBSERVABILITY_AI_ASSISTANT_PROJECT_SETTINGS = [

--- a/src/platform/packages/shared/serverless/settings/observability_project/moon.yml
+++ b/src/platform/packages/shared/serverless/settings/observability_project/moon.yml
@@ -19,6 +19,7 @@ project:
     sourceRoot: src/platform/packages/shared/serverless/settings/observability_project
 dependsOn:
   - '@kbn/management-settings-ids'
+  - '@kbn/workflows'
 tags:
   - shared-common
   - package

--- a/src/platform/packages/shared/serverless/settings/observability_project/tsconfig.json
+++ b/src/platform/packages/shared/serverless/settings/observability_project/tsconfig.json
@@ -15,5 +15,6 @@
   ],
   "kbn_references": [
     "@kbn/management-settings-ids",
+    "@kbn/workflows",
   ]
 }

--- a/src/platform/packages/shared/serverless/settings/search_project/index.ts
+++ b/src/platform/packages/shared/serverless/settings/search_project/index.ts
@@ -18,6 +18,7 @@ import {
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
 } from '@kbn/management-settings-ids';
 import { ENABLE_DOCKED_CONSOLE_UI_SETTING_ID } from '@kbn/dev-tools-plugin/common';
+import { WORKFLOWS_UI_SETTING_ID } from '@kbn/workflows/common/constants';
 
 export const SEARCH_PROJECT_SETTINGS = [
   COURIER_IGNORE_FILTER_IF_FIELD_NOT_IN_INDEX_ID,
@@ -29,4 +30,6 @@ export const SEARCH_PROJECT_SETTINGS = [
   AGENT_BUILDER_DASHBOARD_TOOLS_SETTING_ID,
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR,
   GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR_DEFAULT_ONLY,
+  // This setting is temporary, will be removed on 9.4.0 release.
+  WORKFLOWS_UI_SETTING_ID,
 ];

--- a/src/platform/packages/shared/serverless/settings/search_project/moon.yml
+++ b/src/platform/packages/shared/serverless/settings/search_project/moon.yml
@@ -20,6 +20,7 @@ project:
 dependsOn:
   - '@kbn/management-settings-ids'
   - '@kbn/dev-tools-plugin'
+  - '@kbn/workflows'
 tags:
   - shared-common
   - package

--- a/src/platform/packages/shared/serverless/settings/search_project/tsconfig.json
+++ b/src/platform/packages/shared/serverless/settings/search_project/tsconfig.json
@@ -16,5 +16,6 @@
   "kbn_references": [
     "@kbn/management-settings-ids",
     "@kbn/dev-tools-plugin",
+    "@kbn/workflows",
   ]
 }

--- a/src/platform/plugins/shared/workflows_management/moon.yml
+++ b/src/platform/plugins/shared/workflows_management/moon.yml
@@ -42,7 +42,6 @@ dependsOn:
   - '@kbn/css-utils'
   - '@kbn/triggers-actions-ui-plugin'
   - '@kbn/alerting-plugin'
-  - '@kbn/core-ui-settings-server'
   - '@kbn/logging-mocks'
   - '@kbn/discover-utils'
   - '@kbn/storybook'
@@ -82,6 +81,7 @@ dependsOn:
   - '@kbn/alerts-as-data-utils'
   - '@kbn/shared-ux-utility'
   - '@kbn/licensing-types'
+  - '@kbn/core-lifecycle-server-mocks'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/workflows_management/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/server/plugin.ts
@@ -65,7 +65,7 @@ export class WorkflowsPlugin
   ) {
     this.logger.debug('Workflows Management: Setup');
 
-    registerUISettings({ uiSettings: core.uiSettings });
+    registerUISettings(core, plugins);
 
     // Register workflows connector if actions plugin is available
     if (plugins.actions) {

--- a/src/platform/plugins/shared/workflows_management/server/types.ts
+++ b/src/platform/plugins/shared/workflows_management/server/types.ts
@@ -21,6 +21,7 @@ import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 
 import type { LicensingApiRequestHandlerContext } from '@kbn/licensing-plugin/server';
 import type { SecurityPluginStart } from '@kbn/security-plugin-types-server';
+import type { ServerlessServerSetup } from '@kbn/serverless/server/types';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type {
   TaskManagerSetupContract,
@@ -45,6 +46,7 @@ export interface WorkflowsServerPluginSetupDeps {
   actions?: ActionsPluginSetupContract;
   alerting?: AlertingServerSetup;
   spaces?: SpacesPluginStart;
+  serverless?: ServerlessServerSetup;
   workflowsExtensions: WorkflowsExtensionsServerPluginSetup;
 }
 

--- a/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
+++ b/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
@@ -19,10 +19,9 @@ export const registerUISettings = (
 ) => {
   let licenseText = '';
 
-  // Only show license text in non-serverless projects
-  if (plugins.serverless == null) {
+  if (!plugins.serverless) {
     licenseText = i18n.translate('workflowsManagement.uiSettings.ui.licenseText', {
-      defaultMessage: 'License required: {license}.',
+      defaultMessage: 'Requires {license} license.',
       values: { license: '<b>enterprise</b>' },
     });
   }
@@ -33,8 +32,11 @@ export const registerUISettings = (
         defaultMessage:
           'Enables Elastic Workflows and related experiences. {licenseText} {learnMoreLink}',
         values: {
+          learnMoreLink: `<a href="https://ela.st/workflows-docs" target="_blank">${i18n.translate(
+            'workflowsManagement.uiSettings.ui.learnMore',
+            { defaultMessage: 'Learn more' }
+          )}</a>.`,
           licenseText,
-          learnMoreLink: '<a href="https://ela.st/workflows-docs" target="_blank">Learn more</a>.',
         },
       }),
       name: i18n.translate('workflowsManagement.uiSettings.ui.name', {
@@ -47,6 +49,4 @@ export const registerUISettings = (
       category: ['general'],
     },
   });
-
-  uiSettings.setAllowlist([WORKFLOWS_UI_SETTING_ID]);
 };

--- a/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
+++ b/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
@@ -8,15 +8,34 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import type { UiSettingsServiceSetup } from '@kbn/core-ui-settings-server';
+import type { CoreSetup } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import { WORKFLOWS_UI_SETTING_ID } from '@kbn/workflows/common/constants';
+import type { WorkflowsServerPluginSetupDeps } from './types';
 
-export const registerUISettings = ({ uiSettings }: { uiSettings: UiSettingsServiceSetup }) => {
+export const registerUISettings = (
+  { uiSettings }: CoreSetup,
+  plugins: WorkflowsServerPluginSetupDeps
+) => {
+  let licenseText = '';
+
+  // Only show license text in non-serverless projects
+  if (plugins.serverless == null) {
+    licenseText = i18n.translate('workflowsManagement.uiSettings.ui.licenseText', {
+      defaultMessage: 'License required: {license}.',
+      values: { license: '<b>enterprise</b>' },
+    });
+  }
+
   uiSettings.register({
     [WORKFLOWS_UI_SETTING_ID]: {
       description: i18n.translate('workflowsManagement.uiSettings.ui.description', {
-        defaultMessage: 'Enables Elastic Workflows and related experiences.',
+        defaultMessage:
+          'Enables Elastic Workflows and related experiences. {licenseText} {learnMoreLink}',
+        values: {
+          licenseText,
+          learnMoreLink: '<a href="https://ela.st/workflows-docs">Learn more</a>.',
+        },
       }),
       name: i18n.translate('workflowsManagement.uiSettings.ui.name', {
         defaultMessage: 'Elastic Workflows',
@@ -24,9 +43,10 @@ export const registerUISettings = ({ uiSettings }: { uiSettings: UiSettingsServi
       schema: schema.boolean(),
       value: false,
       readonly: false,
-      technicalPreview: true,
       requiresPageReload: true,
       category: ['general'],
     },
   });
+
+  uiSettings.setAllowlist([WORKFLOWS_UI_SETTING_ID]);
 };

--- a/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
+++ b/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
@@ -32,7 +32,7 @@ export const registerUISettings = (
         defaultMessage:
           'Enables Elastic Workflows and related experiences. {licenseText} {learnMoreLink}',
         values: {
-          learnMoreLink: `<a href="https://ela.st/workflows-docs" target="_blank">${i18n.translate(
+          learnMoreLink: `<a href="https://ela.st/workflows-docs" target="_blank" rel="noreferrer noopener">${i18n.translate(
             'workflowsManagement.uiSettings.ui.learnMore',
             { defaultMessage: 'Learn more' }
           )}</a>.`,

--- a/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
+++ b/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
@@ -34,7 +34,7 @@ export const registerUISettings = (
           'Enables Elastic Workflows and related experiences. {licenseText} {learnMoreLink}',
         values: {
           licenseText,
-          learnMoreLink: '<a href="https://ela.st/workflows-docs">Learn more</a>.',
+          learnMoreLink: '<a href="https://ela.st/workflows-docs" target="_blank">Learn more</a>.',
         },
       }),
       name: i18n.translate('workflowsManagement.uiSettings.ui.name', {

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -38,7 +38,6 @@
     "@kbn/css-utils",
     "@kbn/triggers-actions-ui-plugin",
     "@kbn/alerting-plugin",
-    "@kbn/core-ui-settings-server",
     "@kbn/logging-mocks",
     "@kbn/discover-utils",
     "@kbn/storybook",
@@ -77,7 +76,8 @@
     "@kbn/securitysolution-rules",
     "@kbn/alerts-as-data-utils",
     "@kbn/shared-ux-utility",
-    "@kbn/licensing-types"
+    "@kbn/licensing-types",
+    "@kbn/core-lifecycle-server-mocks"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/solutions/security/plugins/security_solution_serverless/moon.yml
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/moon.yml
@@ -54,6 +54,7 @@ dependsOn:
   - '@kbn/connector-schemas'
   - '@kbn/management-settings-ids'
   - '@kbn/ai-assistant-common'
+  - '@kbn/workflows'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
@@ -87,7 +87,7 @@ export class SecuritySolutionServerlessPlugin
 
     const projectSettings = SECURITY_PROJECT_SETTINGS;
 
-    // This setting is not registered in essentials tier. Adding it to the project settings in essentials tier causes the server to crash.
+    // This setting is only registered in complete and ease tiers. Adding it to the project settings list while in the essentials tier causes an error.
     // This is a temporary UI setting to enable workflows, it's planned to be removed on 9.4.0 release.
     if (this.config.productTypes.some((productType) => productType.product_tier !== 'essentials')) {
       projectSettings.push(WORKFLOWS_UI_SETTING_ID);

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
@@ -14,6 +14,7 @@ import type {
 } from '@kbn/core/server';
 
 import { SECURITY_PROJECT_SETTINGS } from '@kbn/serverless-security-settings';
+import { WORKFLOWS_UI_SETTING_ID } from '@kbn/workflows/common/constants';
 import { getEnabledProductFeatures } from '../common/pli/pli_features';
 
 import type { ServerlessSecurityConfig } from './config';
@@ -85,6 +86,12 @@ export class SecuritySolutionServerlessPlugin
     telemetryEvents.forEach((eventConfig) => coreSetup.analytics.registerEventType(eventConfig));
 
     const projectSettings = SECURITY_PROJECT_SETTINGS;
+
+    // This setting is not registered in essentials tier. Adding it to the project settings in essentials tier causes the server to crash.
+    // This is a temporary UI setting to enable workflows, it's planned to be removed on 9.4.0 release.
+    if (this.config.productTypes.some((productType) => productType.product_tier !== 'essentials')) {
+      projectSettings.push(WORKFLOWS_UI_SETTING_ID);
+    }
 
     // Setup project uiSettings whitelisting
     pluginsSetup.serverless.setupProjectSettings(projectSettings);

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
@@ -85,7 +85,7 @@ export class SecuritySolutionServerlessPlugin
     // Register telemetry events
     telemetryEvents.forEach((eventConfig) => coreSetup.analytics.registerEventType(eventConfig));
 
-    const projectSettings = SECURITY_PROJECT_SETTINGS;
+    const projectSettings = [...SECURITY_PROJECT_SETTINGS];
 
     // This setting is only registered in complete and ease tiers. Adding it to the project settings list while in the essentials tier causes an error.
     // This is a temporary UI setting to enable workflows, it's planned to be removed on 9.4.0 release.

--- a/x-pack/solutions/security/plugins/security_solution_serverless/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/tsconfig.json
@@ -49,5 +49,6 @@
     "@kbn/connector-schemas",
     "@kbn/management-settings-ids",
     "@kbn/ai-assistant-common",
+    "@kbn/workflows",
   ]
 }


### PR DESCRIPTION
## Summary

From: https://github.com/elastic/security-team/issues/15355 

- In serverless projects, the UI setting to enable Workflows was not showing up in the Advanced Settings page. Fixed adding it to the proper solutions (es, oblt, security) settings lists.
- Added docs link to the UI setting description.
- Added `Requires enterprise license` text in ECH.

### Screenshots

#### ECH / on-prem

<img width="1186" height="236" alt="Captura de pantalla 2026-01-13 a les 19 26 03" src="https://github.com/user-attachments/assets/1dd8bd60-14ce-4009-87ee-c3ec103ca167" />


#### Security
- complete / ease
<img width="1409" height="467" alt="Captura de pantalla 2026-01-13 a les 18 51 48" src="https://github.com/user-attachments/assets/8e6702fb-5047-44b3-b08e-f12c557691ad" />

- essentials
<img width="1409" height="467" alt="Captura de pantalla 2026-01-13 a les 18 52 47" src="https://github.com/user-attachments/assets/55c0f2fa-4f20-4cc4-8e3a-b66a22aebee1" />

#### Observability
- complete
<img width="1409" height="404" alt="Captura de pantalla 2026-01-13 a les 18 47 24" src="https://github.com/user-attachments/assets/112319c8-ae32-42db-bac5-f5d796cd2f2e" />

- logs essentials
<img width="1409" height="404" alt="Captura de pantalla 2026-01-13 a les 18 45 00" src="https://github.com/user-attachments/assets/4bd45da4-ba7c-4180-b3d9-426e58979d53" />

#### Search

<img width="1409" height="404" alt="Captura de pantalla 2026-01-13 a les 18 49 09" src="https://github.com/user-attachments/assets/cad2edbc-766f-4553-a1b6-bd45ae6f4dbb" />



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->