### PR TITLE
[Fleet] Update agentless background sync interval

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -14,7 +14,7 @@ xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 xpack.fleet.internal.registry.spec.min: '3.0'
 xpack.fleet.internal.registry.spec.max: '3.5'
 xpack.fleet.agentless.backgroundSync.enabled: true
-xpack.fleet.agentless.backgroundSync.interval: '1h'
+xpack.fleet.agentless.backgroundSync.interval: '10m'
 
 ## Fine-tune the feature privileges.
 xpack.features.overrides:


### PR DESCRIPTION
## Summary

Update agentless background sync interval to be more reactive for disaster recovery.