### PR TITLE
[App Menu Standardization] Add margin-left when badges is the only extension

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -418,7 +418,9 @@ export class ChromeService {
           return [
             ...extensions,
             {
-              content: mountReactNode(<HeaderBreadcrumbsBadges badges={badges} />),
+              content: mountReactNode(
+                <HeaderBreadcrumbsBadges badges={badges} hasLeftMargin={extensions.length === 0} />
+              ),
             },
           ];
         }),

--- a/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.tsx
@@ -419,7 +419,7 @@ export class ChromeService {
             ...extensions,
             {
               content: mountReactNode(
-                <HeaderBreadcrumbsBadges badges={badges} hasLeftMargin={extensions.length === 0} />
+                <HeaderBreadcrumbsBadges badges={badges} isFirst={extensions.length === 0} />
               ),
             },
           ];

--- a/src/core/packages/chrome/browser-internal/src/ui/header/header_breadcrumbs_badges.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header_breadcrumbs_badges.tsx
@@ -11,7 +11,7 @@ import type { ReactElement } from 'react';
 import React, { Fragment } from 'react';
 
 import type { EuiBadgeProps, EuiToolTipProps } from '@elastic/eui';
-import { EuiBadge, EuiBadgeGroup, EuiToolTip } from '@elastic/eui';
+import { EuiBadge, EuiBadgeGroup, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 
 export type HeaderBreadcrumbsBadgeProps = EuiBadgeProps & {
@@ -27,12 +27,13 @@ export const HeaderBreadcrumbsBadges = ({
   badges: HeaderBreadcrumbsBadgeProps[] | undefined;
   hasLeftMargin: boolean;
 }) => {
+  const { euiTheme } = useEuiTheme();
   if (!badges || badges.length === 0) return null;
   return (
     <EuiBadgeGroup
       data-test-subj="header-breadcrumbs-badge-group"
       css={css`
-        margin-left: ${hasLeftMargin ? '4px' : '0px'};
+        margin-left: ${hasLeftMargin ? euiTheme.size.xs : 0};
       `}
     >
       {badges.map(createBadge)}

--- a/src/core/packages/chrome/browser-internal/src/ui/header/header_breadcrumbs_badges.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header_breadcrumbs_badges.tsx
@@ -22,10 +22,10 @@ export type HeaderBreadcrumbsBadgeProps = EuiBadgeProps & {
 
 export const HeaderBreadcrumbsBadges = ({
   badges,
-  hasLeftMargin,
+  isFirst,
 }: {
   badges: HeaderBreadcrumbsBadgeProps[] | undefined;
-  hasLeftMargin: boolean;
+  isFirst: boolean;
 }) => {
   const { euiTheme } = useEuiTheme();
   if (!badges || badges.length === 0) return null;
@@ -33,7 +33,7 @@ export const HeaderBreadcrumbsBadges = ({
     <EuiBadgeGroup
       data-test-subj="header-breadcrumbs-badge-group"
       css={css`
-        margin-left: ${hasLeftMargin ? euiTheme.size.xs : 0};
+        margin-left: ${isFirst ? euiTheme.size.xs : 0};
       `}
     >
       {badges.map(createBadge)}

--- a/src/core/packages/chrome/browser-internal/src/ui/header/header_breadcrumbs_badges.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header_breadcrumbs_badges.tsx
@@ -12,6 +12,7 @@ import React, { Fragment } from 'react';
 
 import type { EuiBadgeProps, EuiToolTipProps } from '@elastic/eui';
 import { EuiBadge, EuiBadgeGroup, EuiToolTip } from '@elastic/eui';
+import { css } from '@emotion/react';
 
 export type HeaderBreadcrumbsBadgeProps = EuiBadgeProps & {
   badgeText: string;
@@ -21,12 +22,19 @@ export type HeaderBreadcrumbsBadgeProps = EuiBadgeProps & {
 
 export const HeaderBreadcrumbsBadges = ({
   badges,
+  hasLeftMargin,
 }: {
   badges: HeaderBreadcrumbsBadgeProps[] | undefined;
+  hasLeftMargin: boolean;
 }) => {
   if (!badges || badges.length === 0) return null;
   return (
-    <EuiBadgeGroup data-test-subj="header-breadcrumbs-badge-group">
+    <EuiBadgeGroup
+      data-test-subj="header-breadcrumbs-badge-group"
+      css={css`
+        margin-left: ${hasLeftMargin ? '4px' : '0px'};
+      `}
+    >
       {badges.map(createBadge)}
     </EuiBadgeGroup>
   );


### PR DESCRIPTION
## Summary

This PR adds left margin to chrome breadcrumb badges when they're the only item, to prevent them being too close to breadcrumbs. 

Closes: https://github.com/elastic/kibana-team/issues/2638


