### PR TITLE
[One Workflow] Fix: Enhance validation for bulk delete and aggregation routes to bound input arrays

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/delete_workflows_bulk.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/delete_workflows_bulk.ts
@@ -14,6 +14,8 @@ import { WORKFLOW_DELETE_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
 import { withLicenseCheck } from '../lib/with_license_check';
 
+const MAX_BULK_DELETE_BATCH_SIZE = 1000;
+
 export function registerDeleteWorkflowsBulkRoute({
   router,
   api,
@@ -27,7 +29,7 @@ export function registerDeleteWorkflowsBulkRoute({
       security: WORKFLOW_DELETE_SECURITY,
       validate: {
         body: schema.object({
-          ids: schema.arrayOf(schema.string()),
+          ids: schema.arrayOf(schema.string(), { maxSize: MAX_BULK_DELETE_BATCH_SIZE }),
         }),
       },
     },

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_aggs.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_aggs.ts
@@ -14,13 +14,19 @@ import { WORKFLOW_READ_SECURITY } from './route_security';
 import type { RouteDependencies } from './types';
 import { withLicenseCheck } from '../lib/with_license_check';
 
+const MAX_AGG_FIELDS = 25;
+
 export function registerGetWorkflowAggsRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.get(
     {
       path: '/api/workflows/aggs',
       options: WORKFLOW_ROUTE_OPTIONS,
       security: WORKFLOW_READ_SECURITY,
-      validate: { query: schema.object({ fields: schema.arrayOf(schema.string()) }) },
+      validate: {
+        query: schema.object({
+          fields: schema.arrayOf(schema.string(), { maxSize: MAX_AGG_FIELDS }),
+        }),
+      },
     },
     withLicenseCheck(async (context, request, response) => {
       try {


### PR DESCRIPTION
closes: https://github.com/elastic/kibana-team/issues/2641

- Added a maximum size constraint for the `ids` array in the bulk delete workflow route, limiting it to 1000 entries.
- Introduced a maximum size constraint for the `fields` array in the get workflow aggregations route, capping it at 25 entries.