### PR TITLE
[Stack Monitoring] Fix Recent Log Entries timezone

### DIFF
--- a/x-pack/platform/plugins/private/monitoring/common/formatting.test.ts
+++ b/x-pack/platform/plugins/private/monitoring/common/formatting.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment-timezone';
+import { formatDateTimeLocal } from './formatting';
+
+describe('formatDateTimeLocal', () => {
+  const date = new Date('2020-01-02T03:04:05.000Z');
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('formats using an explicit timezone', () => {
+    expect(formatDateTimeLocal(date, 'UTC')).toEqual(moment.tz(date, 'UTC').format('LL LTS'));
+  });
+
+  it('treats dateFormat:tz=Browser as the guessed timezone', () => {
+    jest.spyOn(moment.tz, 'guess').mockReturnValue('America/Los_Angeles');
+
+    expect(formatDateTimeLocal(date, 'Browser')).toEqual(
+      moment.tz(date, 'America/Los_Angeles').format('LL LTS')
+    );
+  });
+
+  it('defaults to the guessed timezone when timezone is unset or null', () => {
+    jest.spyOn(moment.tz, 'guess').mockReturnValue('America/New_York');
+
+    expect(formatDateTimeLocal(date)).toEqual(moment.tz(date, 'America/New_York').format('LL LTS'));
+    expect(formatDateTimeLocal(date, null)).toEqual(
+      moment.tz(date, 'America/New_York').format('LL LTS')
+    );
+  });
+});

--- a/x-pack/platform/plugins/private/monitoring/common/formatting.ts
+++ b/x-pack/platform/plugins/private/monitoring/common/formatting.ts
@@ -16,14 +16,15 @@ export const LARGE = '0,0';
 export const ROUNDED_FLOAT = '00.[00]';
 
 /**
- * Format the {@code date} in the user's expected date/time format using their <em>guessed</em> local time zone.
+ * Format the {@code date} in the user's expected date/time format using the provided time zone.
+ * If {@code timezone} is unset, {@code null}, or {@code 'Browser'}, this uses the browser's guessed time zone.
  * @param date Either a numeric Unix timestamp or a {@code Date} object
+ * @param timezone The user's configured time zone (e.g. {@code 'UTC'}, {@code 'Asia/Seoul'}, {@code 'Browser'})
  * @returns The date formatted using 'LL LTS'
  */
-export function formatDateTimeLocal(date: number | Date, useUTC = false, timezone = null) {
-  return useUTC
-    ? moment.utc(date).format('LL LTS')
-    : moment.tz(date, timezone || moment.tz.guess()).format('LL LTS');
+export function formatDateTimeLocal(date: number | Date, timezone?: string | null): string {
+  const resolvedTz = !timezone || timezone === 'Browser' ? moment.tz.guess() : timezone;
+  return moment.tz(date, resolvedTz).format('LL LTS');
 }
 
 /**


### PR DESCRIPTION
Closes #120292

## Summary
The Stack Monitoring **Recent Log Entries** table now respects the Kibana `dateFormat:tz` advanced setting.

## Details
- Fixes `formatDateTimeLocal` to treat `dateFormat:tz` values of `Browser`/`null`/unset as the browser-guessed timezone
- Keeps explicit timezone values (e.g. `UTC`, `Asia/Seoul`) working as expected
- Adds unit tests covering explicit timezone, `Browser`, and default/unset behavior

## Demo

Current locale is UTC+1 (value should be 2:26)

### Before
<img width="1718" height="1407" alt="SCR-20260114-myjp" src="https://github.com/user-attachments/assets/18659259-1fe1-4341-a5ce-66593bbad868" />

### After
<img width="1720" height="1408" alt="SCR-20260114-mymj" src="https://github.com/user-attachments/assets/db5f5b96-5671-428f-8992-7bd017ce8378" />


## Test plan
- `node scripts/jest x-pack/platform/plugins/private/monitoring/common/formatting.test.ts`
- Manual: change **Stack Management → Advanced Settings → Time zone (`dateFormat:tz`)** and confirm the Recent Log Entries timestamp updates

## Manual test data (optional)
If you don't already have Stack Monitoring data available locally, you can create a minimal set of documents via **Kibana → Dev Tools → Console**.

Pick values for:
- `<ISO_TIMESTAMP>`: an ISO timestamp like `2026-01-14T16:07:52.324Z`
- `<EPOCH_MS>`: the same moment as epoch millis like `1768406872324`

Then run:

1) Create a minimal cluster stats doc (note the `timestamp` field):

```http
POST metrics-elasticsearch.stack_monitoring.cluster_stats-default/_doc?refresh=wait_for
{
  "@timestamp": "<ISO_TIMESTAMP>",
  "timestamp": <EPOCH_MS>,
  "type": "cluster_stats",
  "metricset": { "name": "cluster_stats" },
  "data_stream": { "type": "metrics", "dataset": "elasticsearch.stack_monitoring.cluster_stats", "namespace": "default" },
  "cluster_uuid": "tz-test-cluster",
  "cluster_name": "tz-test-cluster",
  "license": { "status": "active", "type": "trial", "expiry_date_in_millis": 1894665600000 }
}
```

2) Create a minimal Elasticsearch server log doc for the same cluster:

```http
POST logs-elasticsearch.server-default/_doc?refresh=wait_for
{
  "@timestamp": "<ISO_TIMESTAMP>",
  "message": "TZ regression test log entry - should show in browser timezone",
  "service": { "type": "elasticsearch" },
  "event": { "dataset": "elasticsearch.server" },
  "log": { "level": "INFO" },
  "elasticsearch": {
    "cluster": { "uuid": "tz-test-cluster" },
    "node": { "name": "test-node-1" },
    "component": "test-component"
  }
}
```

3) In Kibana:
- Set the time picker to a range that includes `<ISO_TIMESTAMP>` (e.g. **Last 15 minutes** if you used “now - 5m”)
- Go to **Stack Monitoring → Elasticsearch → Overview** and confirm **Recent Log Entries** shows the row
- Flip **Stack Management → Advanced Settings → Time zone (`dateFormat:tz`)** between `Browser` and `UTC` and confirm the displayed timestamp shifts accordingly

4) Cleanup (optional):

```http
POST metrics-elasticsearch.stack_monitoring.cluster_stats-default/_delete_by_query?refresh=true
{ "query": { "term": { "cluster_uuid": "tz-test-cluster" } } }
```

```http
POST logs-elasticsearch.*-*/_delete_by_query?refresh=true
{ "query": { "term": { "elasticsearch.cluster.uuid": "tz-test-cluster" } } }
```

# Release Note
Fix Stack Monitoring Recent Log Entries timestamps to respect Kibana's time zone setting (`dateFormat:tz`).

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->