### PR TITLE
[9.1] [SharedUX] Fix share modal time range issues (#248804)

### DIFF
--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.test.tsx
@@ -195,4 +195,52 @@ describe('LinkContent', () => {
     expect(createFromLongUrlSpy).toHaveBeenCalledTimes(1);
     expect(copyButton.getAttribute('data-share-url')).toBe(shortURL);
   });
+
+  it('should show toggle when time range is relative', () => {
+    const shareableUrlLocatorParams = {
+      locator: new MockLocatorDefinition('TEST_LOCATOR'),
+      params: {
+        timeRange: { from: 'now-15m', to: 'now' },
+      },
+    };
+
+    renderComponent({
+      objectType: 'dashboard',
+      isDirty: false,
+      shareableUrl,
+      shortUrlService,
+      allowShortUrl: false,
+      // @ts-expect-error Test mock - MockLocatorDefinition is sufficient for testing but doesn't match full LocatorPublic type
+      shareableUrlLocatorParams,
+    });
+
+    const toggle = screen.getByTestId('timeRangeSwitch');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('should not show toggle and show callout when time range is absolute', () => {
+    const shareableUrlLocatorParams = {
+      locator: new MockLocatorDefinition('TEST_LOCATOR'),
+      params: {
+        timeRange: {
+          from: '2024-01-01T00:00:00.000Z',
+          to: '2024-01-02T00:00:00.000Z',
+        },
+      },
+    };
+
+    renderComponent({
+      objectType: 'dashboard',
+      isDirty: false,
+      shareableUrl,
+      shortUrlService,
+      allowShortUrl: false,
+      // @ts-expect-error Test mock - MockLocatorDefinition is sufficient for testing but doesn't match full LocatorPublic type
+      shareableUrlLocatorParams,
+    });
+
+    expect(screen.queryByTestId('timeRangeSwitch')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('relativeTimeCallout')).toBeInTheDocument();
+  });
 });

--- a/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/link_content.tsx
@@ -19,6 +19,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useState, useRef, useEffect } from 'react';
+import { isTimeRangeAbsoluteTime } from '../../../lib/time_utils';
 import { TimeTypeSection } from './time_type_section';
 import type { IShareContext } from '../../context';
 import type { LinkShareConfig, LinkShareUIConfig } from '../../../types';
@@ -54,11 +55,12 @@ export const LinkContent = ({
   const [snapshotUrl, setSnapshotUrl] = useState<string>('');
   const [isTextCopied, setTextCopied] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [isAbsoluteTime, setIsAbsoluteTime] = useState(true);
   const urlParamsRef = useRef<UrlParams | undefined>(undefined);
   const urlToCopy = useRef<string | undefined>(undefined);
   const copiedTextToolTipCleanupIdRef = useRef<ReturnType<typeof setTimeout>>();
   const timeRange = shareableUrlLocatorParams?.params?.timeRange;
+  const isAbsoluteTimeByDefault = isTimeRangeAbsoluteTime(timeRange);
+  const [isAbsoluteTime, setIsAbsoluteTime] = useState(isAbsoluteTimeByDefault);
 
   const { delegatedShareUrlHandler, draftModeCallOut: DraftModeCallout } = objectConfig;
 
@@ -138,7 +140,7 @@ export const LinkContent = ({
         <TimeTypeSection
           timeRange={timeRange}
           onTimeTypeChange={handleTimeTypeChange}
-          isAbsoluteTimeByDefault={isAbsoluteTime}
+          isAbsoluteTimeByDefault={isAbsoluteTimeByDefault}
         />
         {isDirty && DraftModeCallout && (
           <>

--- a/src/platform/plugins/shared/share/public/components/tabs/link/time_type_section.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/link/time_type_section.tsx
@@ -165,6 +165,7 @@ export const TimeTypeSection = ({
             })}
             checked={isAbsoluteTime}
             onChange={handleTimeTypeChange}
+            data-test-subj="timeRangeSwitch"
           />
           <EuiSpacer size="m" />
         </>
@@ -192,6 +193,7 @@ export const TimeTypeSection = ({
           title={i18n.translate('share.link.timeRange.relativeTimeCallout', {
             defaultMessage: 'To use a relative time range, select it in the time picker first.',
           })}
+          data-test-subj="relativeTimeCallout"
         />
       )}
     </>

--- a/src/platform/plugins/shared/share/public/url_service/short_urls/short_url_client.test.ts
+++ b/src/platform/plugins/shared/share/public/url_service/short_urls/short_url_client.test.ts
@@ -416,29 +416,6 @@ describe('createWithLocator()', () => {
     expect(sentBody.params.timeRange.to).toBe('2026-01-12T12:00:00.000Z');
   });
 
-  test('converts both timeRange and time_range when both exist', async () => {
-    const { service, http } = setup();
-    const fetchSpy = http.fetch as unknown as jest.SpyInstance;
-
-    await service.shortUrls.get(null).createWithLocator(
-      {
-        locator: mockLocator,
-        params: {
-          timeRange: { from: 'now-15m', to: 'now' },
-          time_range: { from: 'now-15m', to: 'now' },
-        },
-      },
-      true
-    );
-
-    const sentBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
-    // Both fields should be converted
-    expect(sentBody.params.timeRange.from).toBe('2026-01-12T11:45:00.000Z');
-    expect(sentBody.params.timeRange.to).toBe('2026-01-12T12:00:00.000Z');
-    expect(sentBody.params.time_range.from).toBe('2026-01-12T11:45:00.000Z');
-    expect(sentBody.params.time_range.to).toBe('2026-01-12T12:00:00.000Z');
-  });
-
   test('preserves relative time when isAbsoluteTime is false', async () => {
     const { service, http } = setup();
     const fetchSpy = http.fetch as unknown as jest.SpyInstance;

--- a/src/platform/plugins/shared/share/public/url_service/short_urls/short_url_client.test.ts
+++ b/src/platform/plugins/shared/share/public/url_service/short_urls/short_url_client.test.ts
@@ -373,3 +373,88 @@ describe('delete()', () => {
     expect(err).toStrictEqual(error);
   });
 });
+
+describe('createWithLocator()', () => {
+  const mockLocator = {
+    id: 'MOCK_LOCATOR',
+    getLocation: jest.fn(),
+    navigate: jest.fn(),
+    getUrl: jest.fn(),
+    navigateSync: jest.fn(),
+    getRedirectUrl: jest.fn(),
+    extract: jest.fn(),
+    inject: jest.fn(),
+    telemetry: jest.fn(),
+    migrations: {},
+    useUrl: jest.fn(),
+  };
+
+  // Mock Date.now() for consistent results
+  const fixedNow = new Date('2026-01-12T12:00:00.000Z');
+  jest.spyOn(Date, 'now').mockImplementation(() => fixedNow.getTime());
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('converts relative timeRange to absolute when isAbsoluteTime is true', async () => {
+    const { service, http } = setup();
+    const fetchSpy = http.fetch as unknown as jest.SpyInstance;
+
+    await service.shortUrls.get(null).createWithLocator(
+      {
+        locator: mockLocator,
+        params: {
+          timeRange: { from: 'now-15m', to: 'now' },
+        },
+      },
+      true
+    );
+
+    const sentBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(sentBody.params.timeRange.from).toBe('2026-01-12T11:45:00.000Z');
+    expect(sentBody.params.timeRange.to).toBe('2026-01-12T12:00:00.000Z');
+  });
+
+  test('converts both timeRange and time_range when both exist', async () => {
+    const { service, http } = setup();
+    const fetchSpy = http.fetch as unknown as jest.SpyInstance;
+
+    await service.shortUrls.get(null).createWithLocator(
+      {
+        locator: mockLocator,
+        params: {
+          timeRange: { from: 'now-15m', to: 'now' },
+          time_range: { from: 'now-15m', to: 'now' },
+        },
+      },
+      true
+    );
+
+    const sentBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    // Both fields should be converted
+    expect(sentBody.params.timeRange.from).toBe('2026-01-12T11:45:00.000Z');
+    expect(sentBody.params.timeRange.to).toBe('2026-01-12T12:00:00.000Z');
+    expect(sentBody.params.time_range.from).toBe('2026-01-12T11:45:00.000Z');
+    expect(sentBody.params.time_range.to).toBe('2026-01-12T12:00:00.000Z');
+  });
+
+  test('preserves relative time when isAbsoluteTime is false', async () => {
+    const { service, http } = setup();
+    const fetchSpy = http.fetch as unknown as jest.SpyInstance;
+
+    await service.shortUrls.get(null).createWithLocator(
+      {
+        locator: mockLocator,
+        params: {
+          timeRange: { from: 'now-15m', to: 'now' },
+        },
+      },
+      false
+    );
+
+    const sentBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(sentBody.params.timeRange.from).toBe('now-15m');
+    expect(sentBody.params.timeRange.to).toBe('now');
+  });
+});

--- a/src/platform/plugins/shared/share/public/url_service/short_urls/short_url_client.ts
+++ b/src/platform/plugins/shared/share/public/url_service/short_urls/short_url_client.ts
@@ -80,35 +80,19 @@ export class BrowserShortUrlClient implements IShortUrlClient {
     isAbsoluteTime?: boolean
   ): Promise<ShortUrlCreateResponse<P>> {
     const getUpdatedParams = (inputParams: ShortUrlCreateParams<P>) => {
-      if (!isAbsoluteTime) return inputParams;
-
       const timeRange = inputParams.params?.timeRange as SerializableRecord;
-      const timeRangeSnakeCase = inputParams.params?.time_range as SerializableRecord;
-
-      const timeRanges: {
-        timeRange?: { from: string | undefined; to: string | undefined };
-        time_range?: { from: string | undefined; to: string | undefined };
-      } = {};
-
-      if (timeRange?.from && timeRange?.to) {
-        timeRanges.timeRange = {
-          from: convertRelativeTimeStringToAbsoluteTimeString(timeRange.from as string),
-          to: convertRelativeTimeStringToAbsoluteTimeString(timeRange.to as string),
+      if (isAbsoluteTime && timeRange?.from && timeRange?.to)
+        return {
+          ...inputParams,
+          params: {
+            ...inputParams.params,
+            timeRange: {
+              from: convertRelativeTimeStringToAbsoluteTimeString(timeRange.from as string),
+              to: convertRelativeTimeStringToAbsoluteTimeString(timeRange.to as string),
+            },
+          },
         };
-      }
-      if (timeRangeSnakeCase?.from && timeRangeSnakeCase?.to) {
-        timeRanges.time_range = {
-          from: convertRelativeTimeStringToAbsoluteTimeString(timeRangeSnakeCase.from as string),
-          to: convertRelativeTimeStringToAbsoluteTimeString(timeRangeSnakeCase.to as string),
-        };
-      }
-      return {
-        ...inputParams,
-        params: {
-          ...inputParams.params,
-          ...timeRanges,
-        },
-      };
+      return inputParams;
     };
 
     const result = await this.create(getUpdatedParams(params));

--- a/src/platform/plugins/shared/share/public/url_service/short_urls/short_url_client.ts
+++ b/src/platform/plugins/shared/share/public/url_service/short_urls/short_url_client.ts
@@ -80,19 +80,35 @@ export class BrowserShortUrlClient implements IShortUrlClient {
     isAbsoluteTime?: boolean
   ): Promise<ShortUrlCreateResponse<P>> {
     const getUpdatedParams = (inputParams: ShortUrlCreateParams<P>) => {
+      if (!isAbsoluteTime) return inputParams;
+
       const timeRange = inputParams.params?.timeRange as SerializableRecord;
-      if (isAbsoluteTime && timeRange?.from && timeRange?.to)
-        return {
-          ...inputParams,
-          params: {
-            ...inputParams.params,
-            timeRange: {
-              from: convertRelativeTimeStringToAbsoluteTimeString(timeRange.from as string),
-              to: convertRelativeTimeStringToAbsoluteTimeString(timeRange.to as string),
-            },
-          },
+      const timeRangeSnakeCase = inputParams.params?.time_range as SerializableRecord;
+
+      const timeRanges: {
+        timeRange?: { from: string | undefined; to: string | undefined };
+        time_range?: { from: string | undefined; to: string | undefined };
+      } = {};
+
+      if (timeRange?.from && timeRange?.to) {
+        timeRanges.timeRange = {
+          from: convertRelativeTimeStringToAbsoluteTimeString(timeRange.from as string),
+          to: convertRelativeTimeStringToAbsoluteTimeString(timeRange.to as string),
         };
-      return inputParams;
+      }
+      if (timeRangeSnakeCase?.from && timeRangeSnakeCase?.to) {
+        timeRanges.time_range = {
+          from: convertRelativeTimeStringToAbsoluteTimeString(timeRangeSnakeCase.from as string),
+          to: convertRelativeTimeStringToAbsoluteTimeString(timeRangeSnakeCase.to as string),
+        };
+      }
+      return {
+        ...inputParams,
+        params: {
+          ...inputParams.params,
+          ...timeRanges,
+        },
+      };
     };
 
     const result = await this.create(getUpdatedParams(params));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[SharedUX] Fix share modal time range issues (#248804)](https://github.com/elastic/kibana/pull/248804)

## Testing

https://github.com/user-attachments/assets/27827e18-b702-4bff-9a7b-a3b4a298fc46

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ángeles Martínez Barrio","email":"angeles.martinezbarrio@elastic.co"},"sourceCommit":{"committedDate":"2026-01-14T14:00:58Z","message":"[SharedUX] Fix share modal time range issues (#248804)\n\nCloses https://github.com/elastic/kibana/issues/246977\n\n## Summary\n\n- This PR fixes 3 issues in share modal:\n  1. Relative to absolute time range toggle never showing up\n  2. Callout to use a relative time range always showing up\n3. Anywhere but dashboards: short URL generated not honoring the time\nrange indicator selected (always shared as absolute)\n- Added test cases to avoid this from happening in the future\n\n### Testing\n\nManually tested both in Discover and Dashboards that all UI elements are\nshown as expected and the following use cases:\n- Set a rel time range, copy URL, verify object is shared with relative\ntime range\n- Set a rel time range, toggle to abs, copy URL, verify object is shared\nwith absolute time range\n- Set an abs time range, copy URL, verify object is shared with absolute\ntime range\n- Set a mixed rel and abs time range, copy URL, verify object is shared\nwith mixed relative and absolute time range\n- Set a mixed rel and abs time range, copy URL, toggle to abs, verify\nobject is shared with absolute time range\n\nDiscover with rel time range selected:\n\n<img width=\"410\" height=\"280\" alt=\"Screenshot 2026-01-13 at 10 02 00\"\nsrc=\"https://github.com/user-attachments/assets/fbc07552-1764-4c96-8bbf-181d7e8d2635\"\n/>\n\nDiscover with abs time range selected:\n\n<img width=\"400\" height=\"285\" alt=\"Screenshot 2026-01-13 at 10 01 41\"\nsrc=\"https://github.com/user-attachments/assets/8095e8ac-6c46-460b-94cd-810f9398e391\"\n/>\n\nDashboards with rel time range selected:\n\n<img width=\"400\" height=\"370\" alt=\"Screenshot 2026-01-13 at 10 00 58\"\nsrc=\"https://github.com/user-attachments/assets/887c585e-8d12-49be-955c-eba4c8921d1e\"\n/>\n\nDashboards with abs time range selected:\n\n<img width=\"400\" height=\"400\" alt=\"Screenshot 2026-01-13 at 10 00 29\"\nsrc=\"https://github.com/user-attachments/assets/a6a4b1df-5312-4322-883e-cc74f7bc5865\"\n/>","sha":"16e4d956229a45fbf0c91f57ac8da0f1145d31a4","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:SharedUX","backport:version","v9.3.0","v9.4.0","v9.2.4","v9.1.10","v8.19.10"],"title":"[SharedUX] Fix share modal time range issues","number":248804,"url":"https://github.com/elastic/kibana/pull/248804","mergeCommit":{"message":"[SharedUX] Fix share modal time range issues (#248804)\n\nCloses https://github.com/elastic/kibana/issues/246977\n\n## Summary\n\n- This PR fixes 3 issues in share modal:\n  1. Relative to absolute time range toggle never showing up\n  2. Callout to use a relative time range always showing up\n3. Anywhere but dashboards: short URL generated not honoring the time\nrange indicator selected (always shared as absolute)\n- Added test cases to avoid this from happening in the future\n\n### Testing\n\nManually tested both in Discover and Dashboards that all UI elements are\nshown as expected and the following use cases:\n- Set a rel time range, copy URL, verify object is shared with relative\ntime range\n- Set a rel time range, toggle to abs, copy URL, verify object is shared\nwith absolute time range\n- Set an abs time range, copy URL, verify object is shared with absolute\ntime range\n- Set a mixed rel and abs time range, copy URL, verify object is shared\nwith mixed relative and absolute time range\n- Set a mixed rel and abs time range, copy URL, toggle to abs, verify\nobject is shared with absolute time range\n\nDiscover with rel time range selected:\n\n<img width=\"410\" height=\"280\" alt=\"Screenshot 2026-01-13 at 10 02 00\"\nsrc=\"https://github.com/user-attachments/assets/fbc07552-1764-4c96-8bbf-181d7e8d2635\"\n/>\n\nDiscover with abs time range selected:\n\n<img width=\"400\" height=\"285\" alt=\"Screenshot 2026-01-13 at 10 01 41\"\nsrc=\"https://github.com/user-attachments/assets/8095e8ac-6c46-460b-94cd-810f9398e391\"\n/>\n\nDashboards with rel time range selected:\n\n<img width=\"400\" height=\"370\" alt=\"Screenshot 2026-01-13 at 10 00 58\"\nsrc=\"https://github.com/user-attachments/assets/887c585e-8d12-49be-955c-eba4c8921d1e\"\n/>\n\nDashboards with abs time range selected:\n\n<img width=\"400\" height=\"400\" alt=\"Screenshot 2026-01-13 at 10 00 29\"\nsrc=\"https://github.com/user-attachments/assets/a6a4b1df-5312-4322-883e-cc74f7bc5865\"\n/>","sha":"16e4d956229a45fbf0c91f57ac8da0f1145d31a4"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.1"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/249019","number":249019,"state":"OPEN"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248804","number":248804,"mergeCommit":{"message":"[SharedUX] Fix share modal time range issues (#248804)\n\nCloses https://github.com/elastic/kibana/issues/246977\n\n## Summary\n\n- This PR fixes 3 issues in share modal:\n  1. Relative to absolute time range toggle never showing up\n  2. Callout to use a relative time range always showing up\n3. Anywhere but dashboards: short URL generated not honoring the time\nrange indicator selected (always shared as absolute)\n- Added test cases to avoid this from happening in the future\n\n### Testing\n\nManually tested both in Discover and Dashboards that all UI elements are\nshown as expected and the following use cases:\n- Set a rel time range, copy URL, verify object is shared with relative\ntime range\n- Set a rel time range, toggle to abs, copy URL, verify object is shared\nwith absolute time range\n- Set an abs time range, copy URL, verify object is shared with absolute\ntime range\n- Set a mixed rel and abs time range, copy URL, verify object is shared\nwith mixed relative and absolute time range\n- Set a mixed rel and abs time range, copy URL, toggle to abs, verify\nobject is shared with absolute time range\n\nDiscover with rel time range selected:\n\n<img width=\"410\" height=\"280\" alt=\"Screenshot 2026-01-13 at 10 02 00\"\nsrc=\"https://github.com/user-attachments/assets/fbc07552-1764-4c96-8bbf-181d7e8d2635\"\n/>\n\nDiscover with abs time range selected:\n\n<img width=\"400\" height=\"285\" alt=\"Screenshot 2026-01-13 at 10 01 41\"\nsrc=\"https://github.com/user-attachments/assets/8095e8ac-6c46-460b-94cd-810f9398e391\"\n/>\n\nDashboards with rel time range selected:\n\n<img width=\"400\" height=\"370\" alt=\"Screenshot 2026-01-13 at 10 00 58\"\nsrc=\"https://github.com/user-attachments/assets/887c585e-8d12-49be-955c-eba4c8921d1e\"\n/>\n\nDashboards with abs time range selected:\n\n<img width=\"400\" height=\"400\" alt=\"Screenshot 2026-01-13 at 10 00 29\"\nsrc=\"https://github.com/user-attachments/assets/a6a4b1df-5312-4322-883e-cc74f7bc5865\"\n/>","sha":"16e4d956229a45fbf0c91f57ac8da0f1145d31a4"}},{"branch":"9.2","label":"v9.2.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.10","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/249028","number":249028,"state":"OPEN"}]}] BACKPORT-->