### PR TITLE
[9.2] [Traces][Discover] Fix missing spans in trace in discover (#247689)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/moon.yml
+++ b/x-pack/solutions/observability/plugins/apm/moon.yml
@@ -149,6 +149,7 @@ dependsOn:
   - '@kbn/discover-shared-plugin'
   - '@kbn/core-chrome-browser'
   - '@kbn/react-query'
+  - '@kbn/core-chrome-layout-constants'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/index.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/index.test.tsx
@@ -142,7 +142,6 @@ describe('TraceWaterfall', () => {
       duration: 100,
       timestampUs: 0,
       errors: [],
-      spanLinksCount: { incoming: 0, outgoing: 0 },
     },
     {
       id: 'span-1',
@@ -153,7 +152,6 @@ describe('TraceWaterfall', () => {
       duration: 50,
       timestampUs: 0,
       errors: [],
-      spanLinksCount: { incoming: 0, outgoing: 0 },
     },
     {
       id: 'span-2',
@@ -164,7 +162,6 @@ describe('TraceWaterfall', () => {
       duration: 30,
       timestampUs: 0,
       errors: [],
-      spanLinksCount: { incoming: 0, outgoing: 0 },
     },
   ];
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/index.tsx
@@ -146,12 +146,12 @@ function TraceTree() {
     }, {})
   );
 
-  function toggleAccordionState(id: string) {
+  const toggleAccordionState = useCallback((id: string) => {
     setAccordionStateMap((prevStates) => ({
       ...prevStates,
       [id]: prevStates[id] === 'open' ? 'closed' : 'open',
     }));
-  }
+  }, []);
 
   const rowHeightCache = useRef(
     new CellMeasurerCache({

--- a/x-pack/solutions/observability/plugins/apm/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/apm/tsconfig.json
@@ -146,7 +146,8 @@
     "@kbn/esql-composer",
     "@kbn/discover-shared-plugin",
     "@kbn/core-chrome-browser",
-    "@kbn/react-query"
+    "@kbn/react-query",
+    "@kbn/core-chrome-layout-constants"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Traces][Discover] Fix missing spans in trace in discover (#247689)](https://github.com/elastic/kibana/pull/247689)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Lucas Francisco López","email":"lucaslopezf@gmail.com"},"sourceCommit":{"committedDate":"2026-01-14T13:57:33Z","message":"[Traces][Discover] Fix missing spans in trace in discover (#247689)\n\nCloses: #247513\n\n## Summary\n\n### Problem\n\nWhen viewing a trace with a large number of spans, the spans at the end\nof the trace are missing and rendered as empty blocks.\n\n### Symptom\n\nWhen scrolling in the Discover flyout, most spans are visible but **the\nlast spans never appear**. When you scroll to the end and stop, the list\n\"jumps back\" to show items from the beginning instead of the final\nitems.\n\n### Possible Root Cause\n\nThe `TraceWaterfall` component was mixing `react-window` (`List`) with\n`react-virtualized` (`WindowScroller`). Even though both libraries are\nmaintained by the same author, they serve different purposes, and mixing\nthem can lead to inconsistent behavior.\n\nThe original implementation relied on scroll synchronization \"hacks\":\n\n```jsx\n<WindowScroller scrollElement={scrollElement}>\n  {({ scrollTop }) => (\n    <List  // ← react-window\n      ref={listRef}\n      style={{ height: '100%' }}     // Causes container to expand to content size\n      height={window.innerHeight}    // Fixed height, doesn't adapt to scroll container\n    />\n  )}\n</WindowScroller>\n\n// And inside onScroll:\nlistRef.current?.scrollTo(scrollTop);  // ← Hack to synchronize scroll (react-virtualized List accepts scrollTop as prop natively)\n```\n\nThis approach works in APM because the environment is more simple. In\nDiscover, however, the component is mounted inside EUI's flyout system,\nwhich has a more complex CSS structure.\n\n### Temporary Fix\n\nBy removing `style={{ height: '100%' }}` and replacing\n`height={window.innerHeight}` with\n`height={scrollElement?.clientHeight}`, the issue is mitigated. However,\nthis introduces a double scrollbar.\n\nWhile this could potentially be addressed with additional CSS, it would\nresult in layered hacks and fragile behavior.\n\n### Proper Solution\n\nUse `react-virtualized` consistently across the component, following the\nsame approach used [in\nFleet](https://github.com/elastic/kibana/blob/b6b64ee983eda9b6308442d589171e1ca3b3985d/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx#L146):\n\n```jsx\n<WindowScroller scrollElement={scrollElement}>\n  {({ height, scrollTop, isScrolling }) => (\n    <List  // ← react-virtualized\n      autoHeight\n      height={height}\n      scrollTop={scrollTop}  // ← Native prop, no hack\n      style={{ overflowY: 'hidden' }}\n    />\n  )}\n</WindowScroller>\n```\n\n---\n\n### Technical Root Cause\n\n#### Key concepts\n\nThere are 3 different scroll values:\n\n| Name | What it is | Where |\n|------|------------|-------|\n| `wsScrollTop` | Scroll position of the flyout | WindowScroller |\n| `scrollOffset` | react-window's internal state (used to decide which\nitems to render) | React state |\n| `outerRef.scrollTop` | Scroll position of the List's DOM container |\nDOM |\n\n#### The core issue\n\n`style={{ height: '100%' }}` expands the List container to fit all\ncontent:\n\n```\nscrollHeight ≈ clientHeight → maxScrollTop ≈ 0\n```\n\nThe container \"**cannot scroll**\" because there's nothing hidden.\n\n\n### FAQ: If the container can't scroll, why do items render correctly\nmost of the time?\n\n**Because react-window decides which items to render based on its\nINTERNAL STATE (`scrollOffset`), NOT the DOM scroll position\n(`outerRef.scrollTop`).**\n\nThe DOM scroll is only used to sync the visual position, but the\nrendering logic uses React state:\n\n```\nscrollTo(2000) → sets state: scrollOffset = 2000\n                          ↓\n              react-window calculates: \"with offset 2000, show items 40-57\"\n                          ↓\n              React renders items 40-57 ✅ (based on STATE)\n                          ↓\n              componentDidUpdate tries: outerRef.scrollTop = 2000\n                          ↓\n              Browser clamps to 0 → but items already rendered correctly!\n```\n\nThe problem only occurs when the DOM change triggers a scroll event that\n**overwrites** the state.\n\n#### The flow\n\n1. WindowScroller detects flyout scroll → `wsScrollTop = 2000`\n2. We call `scrollTo(2000)` → react-window sets `scrollOffset = 2000` in\nstate\n3. React renders items based on `scrollOffset` ✅\n4. react-window's `componentDidUpdate` tries to sync DOM:\n`outerRef.scrollTop = 2000`\n5. Browser clamps to `maxScrollTop` (≈0) → `outerRef.scrollTop` stays at\n0\n6. **If DOM didn't change** (was 0, still 0) → no scroll event → state\nOK ✅\n7. **If DOM changed** (0 → 4) → scroll event fires → react-window reads\nDOM → overwrites `scrollOffset` ❌\n\n#### Why it breaks only at the end\n\nDuring most of the scroll:\n- react-window tries `outerRef.scrollTop = 2000`\n- Browser clamps to 0 (max)\n- `outerRef.scrollTop` was already 0 → **nothing changed** → **no scroll\nevent**\n- State remains correct ✅\n\nAt the end, when the last items render:\n- `scrollHeight` briefly exceeds `clientHeight` by ~4px\n- `maxScrollTop` becomes 4 (instead of 0)\n- react-window tries `outerRef.scrollTop = 2843`\n- Browser clamps to 4\n- `outerRef.scrollTop` **changed** (0 → 4) → **scroll event fires**\n- react-window reads DOM value (4) → overwrites `scrollOffset = 4`\n- Items 0-14 render instead of items 56-73 ❌\n\n#### Why it works in APM\n\nThe List's parent has a fixed height, so `clientHeight < scrollHeight`.\n`outerRef.scrollTop` can be set to any value without clamping.\n\n#### Code references\n\n- react-window sets `outerRef.scrollTop`:\n[createListComponent.ts#L291](https://github.com/bvaughn/react-window/blob/38ab7c4b42886462108630e0d4761f2358f52002/src/createListComponent.ts#L291)\n- react-window overwrites state on scroll event:\n[createListComponent.ts#L579-L590](https://github.com/bvaughn/react-window/blob/38ab7c4b42886462108630e0d4761f2358f52002/src/createListComponent.ts#L579-L590)\n\n---\n\n### Debugging Evidence\n\n#### Debug code\n\nThe debug logs are available in a separate branch:\n\n📎 [index.tsx with debug\nlogs](https://github.com/lucaslopezf/kibana/blob/247511-debug/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/index.tsx)\n\nTo reproduce:\n\n1. Checkout the `247511-debug` branch\n2. Open browser DevTools Console\n3. Filter by `[SCROLL_DEBUG]`\n4. Scroll the trace waterfall in Discover flyout until the bug occurs\n\n#### Expected output when bug occurs:\n\n**Before the bug (normal scrolling, maxScrollTop = 0):**\n```\n[SCROLL_DEBUG] items: 54-71 | scrollOffset: 2744 | scrollH: 3628 | clientH: 3628 | maxScrollTop: 0\n[SCROLL_DEBUG] items: 55-72 | scrollOffset: 2793 | scrollH: 3627 | clientH: 3627 | maxScrollTop: 0\n```\n\n**When the bug triggers (maxScrollTop changes to 4):**\n```\n[SCROLL_DEBUG] items: 56-73 | scrollOffset: 2843 | scrollH: 3630 | clientH: 3626 | maxScrollTop: 4  ← maxScrollTop changed!\n[SCROLL_DEBUG] items: 0-14  | scrollOffset: 4    | scrollH: 3626 | clientH: 3626 | maxScrollTop: 0  ← Bug triggered\n[SCROLL_DEBUG] Native scroll on List container\n[SCROLL_DEBUG] _outerRef.scrollTop: 0\n```\n\nThis shows:\n1. During normal scroll, `maxScrollTop = 0` always, no scroll events\nfire\n2. When items 56-73 render, `scrollHeight` increases to 3630, making\n`maxScrollTop = 4`\n3. react-window sets `outerRef.scrollTop = 2843`, browser clamps to 4\n4. `scrollTop` **changed** from 0 to 4 → native scroll event fires\n5. `_onScrollVertical` reads `scrollTop` from DOM → resets state to 4\n(or 0)\n6. Items 0-14 render incorrectly\n\n#### Video demonstration\n\n\n\nhttps://github.com/user-attachments/assets/65e11c66-411d-4d91-9375-717b9cdc739b\n\n### Demo (fixed bug)\n\n\n\nhttps://github.com/user-attachments/assets/a627a47e-e8b5-4fef-8bc6-b20b0b94e866\n\n\n---\n\n## Performance \n\nIt shouldn’t affect anything, but we tested anyway\n\n1. \n\nWithout react-window\n<img width=\"2260\" height=\"1266\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/6b1ffebd-8f5a-4cbd-bdd2-5354fe302c40\"\n/>\n\nWith react-window\n\n<img width=\"2248\" height=\"1258\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/43d7e804-2899-4859-a4d7-7b42e72f6624\"\n/>\n\n2.\n\nWithout react-window after 1hr\n\n<img width=\"2238\" height=\"1258\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fca21cc0-6c31-4388-af33-ca39e60ca080\"\n/>\n\nWith react-window after 1hr\n\n<img width=\"2270\" height=\"1270\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/4fe81f58-1d11-49dd-b8c4-923a2d437b96\"\n/>\n\n\n---\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9a2ba7801a51aa2648c75604b628063ecde72504","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","ci:project-deploy-observability","backport:version","v9.3.0","Team:obs-exploration","v9.4.0","Team:obs-presentation","v9.2.5"],"title":"[Traces][Discover] Fix missing spans in trace in discover","number":247689,"url":"https://github.com/elastic/kibana/pull/247689","mergeCommit":{"message":"[Traces][Discover] Fix missing spans in trace in discover (#247689)\n\nCloses: #247513\n\n## Summary\n\n### Problem\n\nWhen viewing a trace with a large number of spans, the spans at the end\nof the trace are missing and rendered as empty blocks.\n\n### Symptom\n\nWhen scrolling in the Discover flyout, most spans are visible but **the\nlast spans never appear**. When you scroll to the end and stop, the list\n\"jumps back\" to show items from the beginning instead of the final\nitems.\n\n### Possible Root Cause\n\nThe `TraceWaterfall` component was mixing `react-window` (`List`) with\n`react-virtualized` (`WindowScroller`). Even though both libraries are\nmaintained by the same author, they serve different purposes, and mixing\nthem can lead to inconsistent behavior.\n\nThe original implementation relied on scroll synchronization \"hacks\":\n\n```jsx\n<WindowScroller scrollElement={scrollElement}>\n  {({ scrollTop }) => (\n    <List  // ← react-window\n      ref={listRef}\n      style={{ height: '100%' }}     // Causes container to expand to content size\n      height={window.innerHeight}    // Fixed height, doesn't adapt to scroll container\n    />\n  )}\n</WindowScroller>\n\n// And inside onScroll:\nlistRef.current?.scrollTo(scrollTop);  // ← Hack to synchronize scroll (react-virtualized List accepts scrollTop as prop natively)\n```\n\nThis approach works in APM because the environment is more simple. In\nDiscover, however, the component is mounted inside EUI's flyout system,\nwhich has a more complex CSS structure.\n\n### Temporary Fix\n\nBy removing `style={{ height: '100%' }}` and replacing\n`height={window.innerHeight}` with\n`height={scrollElement?.clientHeight}`, the issue is mitigated. However,\nthis introduces a double scrollbar.\n\nWhile this could potentially be addressed with additional CSS, it would\nresult in layered hacks and fragile behavior.\n\n### Proper Solution\n\nUse `react-virtualized` consistently across the component, following the\nsame approach used [in\nFleet](https://github.com/elastic/kibana/blob/b6b64ee983eda9b6308442d589171e1ca3b3985d/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx#L146):\n\n```jsx\n<WindowScroller scrollElement={scrollElement}>\n  {({ height, scrollTop, isScrolling }) => (\n    <List  // ← react-virtualized\n      autoHeight\n      height={height}\n      scrollTop={scrollTop}  // ← Native prop, no hack\n      style={{ overflowY: 'hidden' }}\n    />\n  )}\n</WindowScroller>\n```\n\n---\n\n### Technical Root Cause\n\n#### Key concepts\n\nThere are 3 different scroll values:\n\n| Name | What it is | Where |\n|------|------------|-------|\n| `wsScrollTop` | Scroll position of the flyout | WindowScroller |\n| `scrollOffset` | react-window's internal state (used to decide which\nitems to render) | React state |\n| `outerRef.scrollTop` | Scroll position of the List's DOM container |\nDOM |\n\n#### The core issue\n\n`style={{ height: '100%' }}` expands the List container to fit all\ncontent:\n\n```\nscrollHeight ≈ clientHeight → maxScrollTop ≈ 0\n```\n\nThe container \"**cannot scroll**\" because there's nothing hidden.\n\n\n### FAQ: If the container can't scroll, why do items render correctly\nmost of the time?\n\n**Because react-window decides which items to render based on its\nINTERNAL STATE (`scrollOffset`), NOT the DOM scroll position\n(`outerRef.scrollTop`).**\n\nThe DOM scroll is only used to sync the visual position, but the\nrendering logic uses React state:\n\n```\nscrollTo(2000) → sets state: scrollOffset = 2000\n                          ↓\n              react-window calculates: \"with offset 2000, show items 40-57\"\n                          ↓\n              React renders items 40-57 ✅ (based on STATE)\n                          ↓\n              componentDidUpdate tries: outerRef.scrollTop = 2000\n                          ↓\n              Browser clamps to 0 → but items already rendered correctly!\n```\n\nThe problem only occurs when the DOM change triggers a scroll event that\n**overwrites** the state.\n\n#### The flow\n\n1. WindowScroller detects flyout scroll → `wsScrollTop = 2000`\n2. We call `scrollTo(2000)` → react-window sets `scrollOffset = 2000` in\nstate\n3. React renders items based on `scrollOffset` ✅\n4. react-window's `componentDidUpdate` tries to sync DOM:\n`outerRef.scrollTop = 2000`\n5. Browser clamps to `maxScrollTop` (≈0) → `outerRef.scrollTop` stays at\n0\n6. **If DOM didn't change** (was 0, still 0) → no scroll event → state\nOK ✅\n7. **If DOM changed** (0 → 4) → scroll event fires → react-window reads\nDOM → overwrites `scrollOffset` ❌\n\n#### Why it breaks only at the end\n\nDuring most of the scroll:\n- react-window tries `outerRef.scrollTop = 2000`\n- Browser clamps to 0 (max)\n- `outerRef.scrollTop` was already 0 → **nothing changed** → **no scroll\nevent**\n- State remains correct ✅\n\nAt the end, when the last items render:\n- `scrollHeight` briefly exceeds `clientHeight` by ~4px\n- `maxScrollTop` becomes 4 (instead of 0)\n- react-window tries `outerRef.scrollTop = 2843`\n- Browser clamps to 4\n- `outerRef.scrollTop` **changed** (0 → 4) → **scroll event fires**\n- react-window reads DOM value (4) → overwrites `scrollOffset = 4`\n- Items 0-14 render instead of items 56-73 ❌\n\n#### Why it works in APM\n\nThe List's parent has a fixed height, so `clientHeight < scrollHeight`.\n`outerRef.scrollTop` can be set to any value without clamping.\n\n#### Code references\n\n- react-window sets `outerRef.scrollTop`:\n[createListComponent.ts#L291](https://github.com/bvaughn/react-window/blob/38ab7c4b42886462108630e0d4761f2358f52002/src/createListComponent.ts#L291)\n- react-window overwrites state on scroll event:\n[createListComponent.ts#L579-L590](https://github.com/bvaughn/react-window/blob/38ab7c4b42886462108630e0d4761f2358f52002/src/createListComponent.ts#L579-L590)\n\n---\n\n### Debugging Evidence\n\n#### Debug code\n\nThe debug logs are available in a separate branch:\n\n📎 [index.tsx with debug\nlogs](https://github.com/lucaslopezf/kibana/blob/247511-debug/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/index.tsx)\n\nTo reproduce:\n\n1. Checkout the `247511-debug` branch\n2. Open browser DevTools Console\n3. Filter by `[SCROLL_DEBUG]`\n4. Scroll the trace waterfall in Discover flyout until the bug occurs\n\n#### Expected output when bug occurs:\n\n**Before the bug (normal scrolling, maxScrollTop = 0):**\n```\n[SCROLL_DEBUG] items: 54-71 | scrollOffset: 2744 | scrollH: 3628 | clientH: 3628 | maxScrollTop: 0\n[SCROLL_DEBUG] items: 55-72 | scrollOffset: 2793 | scrollH: 3627 | clientH: 3627 | maxScrollTop: 0\n```\n\n**When the bug triggers (maxScrollTop changes to 4):**\n```\n[SCROLL_DEBUG] items: 56-73 | scrollOffset: 2843 | scrollH: 3630 | clientH: 3626 | maxScrollTop: 4  ← maxScrollTop changed!\n[SCROLL_DEBUG] items: 0-14  | scrollOffset: 4    | scrollH: 3626 | clientH: 3626 | maxScrollTop: 0  ← Bug triggered\n[SCROLL_DEBUG] Native scroll on List container\n[SCROLL_DEBUG] _outerRef.scrollTop: 0\n```\n\nThis shows:\n1. During normal scroll, `maxScrollTop = 0` always, no scroll events\nfire\n2. When items 56-73 render, `scrollHeight` increases to 3630, making\n`maxScrollTop = 4`\n3. react-window sets `outerRef.scrollTop = 2843`, browser clamps to 4\n4. `scrollTop` **changed** from 0 to 4 → native scroll event fires\n5. `_onScrollVertical` reads `scrollTop` from DOM → resets state to 4\n(or 0)\n6. Items 0-14 render incorrectly\n\n#### Video demonstration\n\n\n\nhttps://github.com/user-attachments/assets/65e11c66-411d-4d91-9375-717b9cdc739b\n\n### Demo (fixed bug)\n\n\n\nhttps://github.com/user-attachments/assets/a627a47e-e8b5-4fef-8bc6-b20b0b94e866\n\n\n---\n\n## Performance \n\nIt shouldn’t affect anything, but we tested anyway\n\n1. \n\nWithout react-window\n<img width=\"2260\" height=\"1266\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/6b1ffebd-8f5a-4cbd-bdd2-5354fe302c40\"\n/>\n\nWith react-window\n\n<img width=\"2248\" height=\"1258\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/43d7e804-2899-4859-a4d7-7b42e72f6624\"\n/>\n\n2.\n\nWithout react-window after 1hr\n\n<img width=\"2238\" height=\"1258\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fca21cc0-6c31-4388-af33-ca39e60ca080\"\n/>\n\nWith react-window after 1hr\n\n<img width=\"2270\" height=\"1270\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/4fe81f58-1d11-49dd-b8c4-923a2d437b96\"\n/>\n\n\n---\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9a2ba7801a51aa2648c75604b628063ecde72504"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247689","number":247689,"mergeCommit":{"message":"[Traces][Discover] Fix missing spans in trace in discover (#247689)\n\nCloses: #247513\n\n## Summary\n\n### Problem\n\nWhen viewing a trace with a large number of spans, the spans at the end\nof the trace are missing and rendered as empty blocks.\n\n### Symptom\n\nWhen scrolling in the Discover flyout, most spans are visible but **the\nlast spans never appear**. When you scroll to the end and stop, the list\n\"jumps back\" to show items from the beginning instead of the final\nitems.\n\n### Possible Root Cause\n\nThe `TraceWaterfall` component was mixing `react-window` (`List`) with\n`react-virtualized` (`WindowScroller`). Even though both libraries are\nmaintained by the same author, they serve different purposes, and mixing\nthem can lead to inconsistent behavior.\n\nThe original implementation relied on scroll synchronization \"hacks\":\n\n```jsx\n<WindowScroller scrollElement={scrollElement}>\n  {({ scrollTop }) => (\n    <List  // ← react-window\n      ref={listRef}\n      style={{ height: '100%' }}     // Causes container to expand to content size\n      height={window.innerHeight}    // Fixed height, doesn't adapt to scroll container\n    />\n  )}\n</WindowScroller>\n\n// And inside onScroll:\nlistRef.current?.scrollTo(scrollTop);  // ← Hack to synchronize scroll (react-virtualized List accepts scrollTop as prop natively)\n```\n\nThis approach works in APM because the environment is more simple. In\nDiscover, however, the component is mounted inside EUI's flyout system,\nwhich has a more complex CSS structure.\n\n### Temporary Fix\n\nBy removing `style={{ height: '100%' }}` and replacing\n`height={window.innerHeight}` with\n`height={scrollElement?.clientHeight}`, the issue is mitigated. However,\nthis introduces a double scrollbar.\n\nWhile this could potentially be addressed with additional CSS, it would\nresult in layered hacks and fragile behavior.\n\n### Proper Solution\n\nUse `react-virtualized` consistently across the component, following the\nsame approach used [in\nFleet](https://github.com/elastic/kibana/blob/b6b64ee983eda9b6308442d589171e1ca3b3985d/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/grid.tsx#L146):\n\n```jsx\n<WindowScroller scrollElement={scrollElement}>\n  {({ height, scrollTop, isScrolling }) => (\n    <List  // ← react-virtualized\n      autoHeight\n      height={height}\n      scrollTop={scrollTop}  // ← Native prop, no hack\n      style={{ overflowY: 'hidden' }}\n    />\n  )}\n</WindowScroller>\n```\n\n---\n\n### Technical Root Cause\n\n#### Key concepts\n\nThere are 3 different scroll values:\n\n| Name | What it is | Where |\n|------|------------|-------|\n| `wsScrollTop` | Scroll position of the flyout | WindowScroller |\n| `scrollOffset` | react-window's internal state (used to decide which\nitems to render) | React state |\n| `outerRef.scrollTop` | Scroll position of the List's DOM container |\nDOM |\n\n#### The core issue\n\n`style={{ height: '100%' }}` expands the List container to fit all\ncontent:\n\n```\nscrollHeight ≈ clientHeight → maxScrollTop ≈ 0\n```\n\nThe container \"**cannot scroll**\" because there's nothing hidden.\n\n\n### FAQ: If the container can't scroll, why do items render correctly\nmost of the time?\n\n**Because react-window decides which items to render based on its\nINTERNAL STATE (`scrollOffset`), NOT the DOM scroll position\n(`outerRef.scrollTop`).**\n\nThe DOM scroll is only used to sync the visual position, but the\nrendering logic uses React state:\n\n```\nscrollTo(2000) → sets state: scrollOffset = 2000\n                          ↓\n              react-window calculates: \"with offset 2000, show items 40-57\"\n                          ↓\n              React renders items 40-57 ✅ (based on STATE)\n                          ↓\n              componentDidUpdate tries: outerRef.scrollTop = 2000\n                          ↓\n              Browser clamps to 0 → but items already rendered correctly!\n```\n\nThe problem only occurs when the DOM change triggers a scroll event that\n**overwrites** the state.\n\n#### The flow\n\n1. WindowScroller detects flyout scroll → `wsScrollTop = 2000`\n2. We call `scrollTo(2000)` → react-window sets `scrollOffset = 2000` in\nstate\n3. React renders items based on `scrollOffset` ✅\n4. react-window's `componentDidUpdate` tries to sync DOM:\n`outerRef.scrollTop = 2000`\n5. Browser clamps to `maxScrollTop` (≈0) → `outerRef.scrollTop` stays at\n0\n6. **If DOM didn't change** (was 0, still 0) → no scroll event → state\nOK ✅\n7. **If DOM changed** (0 → 4) → scroll event fires → react-window reads\nDOM → overwrites `scrollOffset` ❌\n\n#### Why it breaks only at the end\n\nDuring most of the scroll:\n- react-window tries `outerRef.scrollTop = 2000`\n- Browser clamps to 0 (max)\n- `outerRef.scrollTop` was already 0 → **nothing changed** → **no scroll\nevent**\n- State remains correct ✅\n\nAt the end, when the last items render:\n- `scrollHeight` briefly exceeds `clientHeight` by ~4px\n- `maxScrollTop` becomes 4 (instead of 0)\n- react-window tries `outerRef.scrollTop = 2843`\n- Browser clamps to 4\n- `outerRef.scrollTop` **changed** (0 → 4) → **scroll event fires**\n- react-window reads DOM value (4) → overwrites `scrollOffset = 4`\n- Items 0-14 render instead of items 56-73 ❌\n\n#### Why it works in APM\n\nThe List's parent has a fixed height, so `clientHeight < scrollHeight`.\n`outerRef.scrollTop` can be set to any value without clamping.\n\n#### Code references\n\n- react-window sets `outerRef.scrollTop`:\n[createListComponent.ts#L291](https://github.com/bvaughn/react-window/blob/38ab7c4b42886462108630e0d4761f2358f52002/src/createListComponent.ts#L291)\n- react-window overwrites state on scroll event:\n[createListComponent.ts#L579-L590](https://github.com/bvaughn/react-window/blob/38ab7c4b42886462108630e0d4761f2358f52002/src/createListComponent.ts#L579-L590)\n\n---\n\n### Debugging Evidence\n\n#### Debug code\n\nThe debug logs are available in a separate branch:\n\n📎 [index.tsx with debug\nlogs](https://github.com/lucaslopezf/kibana/blob/247511-debug/x-pack/solutions/observability/plugins/apm/public/components/shared/trace_waterfall/index.tsx)\n\nTo reproduce:\n\n1. Checkout the `247511-debug` branch\n2. Open browser DevTools Console\n3. Filter by `[SCROLL_DEBUG]`\n4. Scroll the trace waterfall in Discover flyout until the bug occurs\n\n#### Expected output when bug occurs:\n\n**Before the bug (normal scrolling, maxScrollTop = 0):**\n```\n[SCROLL_DEBUG] items: 54-71 | scrollOffset: 2744 | scrollH: 3628 | clientH: 3628 | maxScrollTop: 0\n[SCROLL_DEBUG] items: 55-72 | scrollOffset: 2793 | scrollH: 3627 | clientH: 3627 | maxScrollTop: 0\n```\n\n**When the bug triggers (maxScrollTop changes to 4):**\n```\n[SCROLL_DEBUG] items: 56-73 | scrollOffset: 2843 | scrollH: 3630 | clientH: 3626 | maxScrollTop: 4  ← maxScrollTop changed!\n[SCROLL_DEBUG] items: 0-14  | scrollOffset: 4    | scrollH: 3626 | clientH: 3626 | maxScrollTop: 0  ← Bug triggered\n[SCROLL_DEBUG] Native scroll on List container\n[SCROLL_DEBUG] _outerRef.scrollTop: 0\n```\n\nThis shows:\n1. During normal scroll, `maxScrollTop = 0` always, no scroll events\nfire\n2. When items 56-73 render, `scrollHeight` increases to 3630, making\n`maxScrollTop = 4`\n3. react-window sets `outerRef.scrollTop = 2843`, browser clamps to 4\n4. `scrollTop` **changed** from 0 to 4 → native scroll event fires\n5. `_onScrollVertical` reads `scrollTop` from DOM → resets state to 4\n(or 0)\n6. Items 0-14 render incorrectly\n\n#### Video demonstration\n\n\n\nhttps://github.com/user-attachments/assets/65e11c66-411d-4d91-9375-717b9cdc739b\n\n### Demo (fixed bug)\n\n\n\nhttps://github.com/user-attachments/assets/a627a47e-e8b5-4fef-8bc6-b20b0b94e866\n\n\n---\n\n## Performance \n\nIt shouldn’t affect anything, but we tested anyway\n\n1. \n\nWithout react-window\n<img width=\"2260\" height=\"1266\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/6b1ffebd-8f5a-4cbd-bdd2-5354fe302c40\"\n/>\n\nWith react-window\n\n<img width=\"2248\" height=\"1258\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/43d7e804-2899-4859-a4d7-7b42e72f6624\"\n/>\n\n2.\n\nWithout react-window after 1hr\n\n<img width=\"2238\" height=\"1258\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/fca21cc0-6c31-4388-af33-ca39e60ca080\"\n/>\n\nWith react-window after 1hr\n\n<img width=\"2270\" height=\"1270\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/4fe81f58-1d11-49dd-b8c4-923a2d437b96\"\n/>\n\n\n---\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9a2ba7801a51aa2648c75604b628063ecde72504"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->