### PR TITLE
[Streams] Refactor task client with helper methods and consolidate route handlers

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/significant_events_queries_generation.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/significant_events_queries_generation.ts
@@ -8,7 +8,6 @@
 import type { TaskDefinitionRegistry } from '@kbn/task-manager-plugin/server';
 import { isInferenceProviderError } from '@kbn/inference-common';
 import {
-  TaskStatus,
   getStreamTypeFromDefinition,
   type SignificantEventsQueriesGenerationResult,
   type System,
@@ -118,23 +117,10 @@ export function createStreamsSignificantEventsQueriesGenerationTask(taskContext:
                   output_tokens_used: combinedResults.tokensUsed.completion,
                 });
 
-                await taskClient.update<
+                await taskClient.complete<
                   SignificantEventsQueriesGenerationTaskParams,
                   SignificantEventsQueriesGenerationResult
-                >({
-                  ..._task,
-                  status: TaskStatus.Completed,
-                  task: {
-                    params: {
-                      connectorId,
-                      start,
-                      end,
-                      systems,
-                      sampleDocsSize,
-                    },
-                    payload: combinedResults,
-                  },
-                });
+                >(_task, { connectorId, start, end, systems, sampleDocsSize }, combinedResults);
               } catch (error) {
                 // Get connector info for error enrichment
                 const connector = await inferenceClient.getConnectorById(connectorId);
@@ -154,20 +140,11 @@ export function createStreamsSignificantEventsQueriesGenerationTask(taskContext:
                   `Task ${runContext.taskInstance.id} failed: ${errorMessage}`
                 );
 
-                await taskClient.update<SignificantEventsQueriesGenerationTaskParams>({
-                  ..._task,
-                  status: TaskStatus.Failed,
-                  task: {
-                    params: {
-                      connectorId,
-                      start,
-                      end,
-                      systems,
-                      sampleDocsSize,
-                    },
-                    error: errorMessage,
-                  },
-                });
+                await taskClient.fail<SignificantEventsQueriesGenerationTaskParams>(
+                  _task,
+                  { connectorId, start, end, systems, sampleDocsSize },
+                  errorMessage
+                );
               }
             },
             runContext,

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/types.ts
@@ -7,6 +7,22 @@
 
 import type { TaskStatus } from '@kbn/streams-schema';
 
+/**
+ * Generic result type for task status/actions endpoints.
+ * Uses discriminated union based on status to properly type the payload.
+ */
+export type TaskResult<TPayload> =
+  | {
+      status:
+        | TaskStatus.NotStarted
+        | TaskStatus.InProgress
+        | TaskStatus.Stale
+        | TaskStatus.BeingCanceled
+        | TaskStatus.Canceled;
+    }
+  | { status: TaskStatus.Failed; error: string }
+  | ({ status: TaskStatus.Completed | TaskStatus.Acknowledged } & TPayload);
+
 interface PersistedTaskBase<TParams extends {} = {}> {
   id: string;
   type: string;

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/significant_events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/significant_events/route.ts
@@ -4,9 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { conflict } from '@hapi/boom';
 import {
-  TaskStatus,
   systemSchema,
   type SignificantEventsQueriesGenerationResult,
   type SignificantEventsQueriesGenerationTaskResult,
@@ -14,17 +12,15 @@ import {
 } from '@kbn/streams-schema';
 import { z } from '@kbn/zod';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
-import { AcknowledgingIncompleteError } from '../../../../lib/tasks/acknowledging_incomplete_error';
-import { CancellationInProgressError } from '../../../../lib/tasks/cancellation_in_progress_error';
-import { isStale } from '../../../../lib/tasks/is_stale';
 import {
   SIGNIFICANT_EVENTS_QUERIES_GENERATION_TASK_TYPE,
   type SignificantEventsQueriesGenerationTaskParams,
 } from '../../../../lib/tasks/task_definitions/significant_events_queries_generation';
 import { createServerRoute } from '../../../create_server_route';
 import { assertSignificantEventsAccess } from '../../../utils/assert_significant_events_access';
-import { resolveConnectorId } from '../../../utils/resolve_connector_id';
 import { readSignificantEventsFromAlertsIndices } from '../../../../lib/significant_events/read_significant_events_from_alerts_indices';
+import { handleTaskAction } from '../../../utils/task_helpers';
+import { resolveConnectorId } from '../../../utils/resolve_connector_id';
 
 // Make sure strings are expected for input, but still converted to a
 // Date, without breaking the OpenAPI generator
@@ -65,29 +61,10 @@ const significantEventsQueriesGenerationStatusRoute = createServerRoute({
 
     const { name } = params.path;
 
-    const task = await taskClient.get<
+    return taskClient.getStatus<
       SignificantEventsQueriesGenerationTaskParams,
       SignificantEventsQueriesGenerationResult
     >(getSignificantEventsQueriesGenerationTaskId(name));
-
-    if (task.status === TaskStatus.InProgress) {
-      return isStale(task.created_at) ? { status: TaskStatus.Stale } : { status: task.status };
-    } else if (task.status === TaskStatus.Failed) {
-      return {
-        status: task.status,
-        error: task.task.error,
-      };
-    } else if (task.status === TaskStatus.Completed || task.status === TaskStatus.Acknowledged) {
-      return {
-        status: task.status,
-        ...task.task.payload,
-      };
-    }
-
-    // Return status for remaining states: not_started, canceled, being_canceled
-    return {
-      status: task.status,
-    };
   },
 });
 
@@ -148,76 +125,44 @@ const significantEventsQueriesGenerationTaskRoute = createServerRoute({
     await streamsClient.ensureStream(params.path.name);
 
     const { name } = params.path;
-    const { action } = params.body;
+    const { body } = params;
+    const taskId = getSignificantEventsQueriesGenerationTaskId(name);
 
-    if (action === 'schedule') {
-      const {
-        from: start,
-        to: end,
-        connectorId: connectorIdParam,
-        sampleDocsSize,
-        systems,
-      } = params.body;
+    const actionParams =
+      body.action === 'schedule'
+        ? ({
+            action: body.action,
+            scheduleConfig: {
+              taskType: SIGNIFICANT_EVENTS_QUERIES_GENERATION_TASK_TYPE,
+              taskId,
+              streamName: name,
+              params: await (async (): Promise<SignificantEventsQueriesGenerationTaskParams> => {
+                const connectorId = await resolveConnectorId({
+                  connectorId: body.connectorId,
+                  uiSettingsClient,
+                  logger,
+                });
+                return {
+                  connectorId,
+                  start: body.from.getTime(),
+                  end: body.to.getTime(),
+                  systems: body.systems,
+                  sampleDocsSize: body.sampleDocsSize,
+                };
+              })(),
+              request,
+            },
+          } as const)
+        : ({ action: body.action } as const);
 
-      try {
-        const connectorId = await resolveConnectorId({
-          connectorId: connectorIdParam,
-          uiSettingsClient,
-          logger,
-        });
-        await taskClient.schedule<SignificantEventsQueriesGenerationTaskParams>({
-          task: {
-            type: SIGNIFICANT_EVENTS_QUERIES_GENERATION_TASK_TYPE,
-            id: getSignificantEventsQueriesGenerationTaskId(name),
-            space: '*',
-            stream: name,
-          },
-          params: {
-            connectorId,
-            start: start.getTime(),
-            end: end.getTime(),
-            systems,
-            sampleDocsSize,
-          },
-          request,
-        });
-
-        return {
-          status: TaskStatus.InProgress,
-        };
-      } catch (error) {
-        if (error instanceof CancellationInProgressError) {
-          throw conflict(error.message);
-        }
-
-        throw error;
-      }
-    } else if (action === 'cancel') {
-      await taskClient.cancel(getSignificantEventsQueriesGenerationTaskId(name));
-
-      return {
-        status: TaskStatus.BeingCanceled,
-      };
-    }
-
-    // action === 'acknowledge'
-    try {
-      const task = await taskClient.acknowledge<
-        SignificantEventsQueriesGenerationTaskParams,
-        SignificantEventsQueriesGenerationResult
-      >(getSignificantEventsQueriesGenerationTaskId(name));
-
-      return {
-        status: TaskStatus.Acknowledged,
-        ...task.task.payload,
-      };
-    } catch (error) {
-      if (error instanceof AcknowledgingIncompleteError) {
-        throw conflict(error.message);
-      }
-
-      throw error;
-    }
+    return handleTaskAction<
+      SignificantEventsQueriesGenerationTaskParams,
+      SignificantEventsQueriesGenerationResult
+    >({
+      taskClient,
+      taskId,
+      ...actionParams,
+    });
   },
 });
 

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/systems/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/systems/route.ts
@@ -7,7 +7,7 @@
 
 import { z } from '@kbn/zod';
 import type { System } from '@kbn/streams-schema';
-import { streamObjectNameSchema, systemSchema, TaskStatus } from '@kbn/streams-schema';
+import { streamObjectNameSchema, systemSchema } from '@kbn/streams-schema';
 import type {
   StorageClientBulkResponse,
   StorageClientDeleteResponse,
@@ -15,11 +15,9 @@ import type {
 } from '@kbn/storage-adapter';
 import type { Observable } from 'rxjs';
 import { catchError, from, map } from 'rxjs';
-import { conflict } from '@hapi/boom';
 import { generateStreamDescription, type IdentifySystemsResult, sumTokens } from '@kbn/streams-ai';
-import { AcknowledgingIncompleteError } from '../../../../lib/tasks/acknowledging_incomplete_error';
-import { CancellationInProgressError } from '../../../../lib/tasks/cancellation_in_progress_error';
-import { isStale } from '../../../../lib/tasks/is_stale';
+import type { TaskResult } from '../../../../lib/tasks/types';
+import { handleTaskAction } from '../../../utils/task_helpers';
 import { PromptsConfigService } from '../../../../lib/saved_objects/significant_events/prompts_config_service';
 import {
   SYSTEMS_IDENTIFICATION_TASK_TYPE,
@@ -274,22 +272,7 @@ export const bulkSystemsRoute = createServerRoute({
   },
 });
 
-export type SystemIdentificationTaskResult =
-  | {
-      status:
-        | TaskStatus.NotStarted
-        | TaskStatus.InProgress
-        | TaskStatus.Stale
-        | TaskStatus.BeingCanceled
-        | TaskStatus.Canceled;
-    }
-  | {
-      status: TaskStatus.Failed;
-      error: string;
-    }
-  | ({
-      status: TaskStatus.Completed | TaskStatus.Acknowledged;
-    } & IdentifySystemsResult);
+export type SystemIdentificationTaskResult = TaskResult<IdentifySystemsResult>;
 
 export const systemsStatusRoute = createServerRoute({
   endpoint: 'GET /internal/streams/{name}/systems/_status',
@@ -331,29 +314,9 @@ export const systemsStatusRoute = createServerRoute({
       throw new SecurityError(`Cannot read systems for stream ${name}, insufficient privileges`);
     }
 
-    const task = await taskClient.get<SystemIdentificationTaskParams, IdentifySystemsResult>(
+    return taskClient.getStatus<SystemIdentificationTaskParams, IdentifySystemsResult>(
       getSystemsIdentificationTaskId(name)
     );
-
-    if (task.status === TaskStatus.InProgress && isStale(task.created_at)) {
-      return {
-        status: TaskStatus.Stale,
-      };
-    } else if (task.status === TaskStatus.Failed) {
-      return {
-        status: TaskStatus.Failed,
-        error: task.task.error,
-      };
-    } else if (task.status === TaskStatus.Completed || task.status === TaskStatus.Acknowledged) {
-      return {
-        status: task.status,
-        ...task.task.payload,
-      };
-    }
-
-    return {
-      status: task.status,
-    };
   },
 });
 
@@ -417,69 +380,38 @@ export const systemsTaskRoute = createServerRoute({
       throw new SecurityError(`Cannot update systems for stream ${name}, insufficient privileges`);
     }
 
-    const { action } = body;
     const taskId = getSystemsIdentificationTaskId(name);
 
-    if (action === 'schedule') {
-      const { from: start, to: end, connectorId: connectorIdParam } = body;
+    const actionParams =
+      body.action === 'schedule'
+        ? ({
+            action: body.action,
+            scheduleConfig: {
+              taskType: SYSTEMS_IDENTIFICATION_TASK_TYPE,
+              taskId,
+              streamName: name,
+              params: await (async (): Promise<SystemIdentificationTaskParams> => {
+                const connectorId = await resolveConnectorId({
+                  connectorId: body.connectorId,
+                  uiSettingsClient,
+                  logger,
+                });
+                return {
+                  connectorId,
+                  start: body.from.getTime(),
+                  end: body.to.getTime(),
+                };
+              })(),
+              request,
+            },
+          } as const)
+        : ({ action: body.action } as const);
 
-      const connectorId = await resolveConnectorId({
-        connectorId: connectorIdParam,
-        uiSettingsClient,
-        logger,
-      });
-
-      try {
-        await taskClient.schedule<SystemIdentificationTaskParams>({
-          task: {
-            type: SYSTEMS_IDENTIFICATION_TASK_TYPE,
-            id: taskId,
-            space: '*',
-            stream: name,
-          },
-          params: {
-            connectorId,
-            start: start.getTime(),
-            end: end.getTime(),
-          },
-          request,
-        });
-
-        return {
-          status: TaskStatus.InProgress,
-        };
-      } catch (error) {
-        if (error instanceof CancellationInProgressError) {
-          throw conflict(error.message);
-        }
-
-        throw error;
-      }
-    } else if (action === 'cancel') {
-      await taskClient.cancel(taskId);
-
-      return {
-        status: TaskStatus.BeingCanceled,
-      };
-    }
-
-    try {
-      const task = await taskClient.acknowledge<
-        SystemIdentificationTaskParams,
-        IdentifySystemsResult
-      >(taskId);
-
-      return {
-        status: TaskStatus.Acknowledged,
-        ...task.task.payload,
-      };
-    } catch (error) {
-      if (error instanceof AcknowledgingIncompleteError) {
-        throw conflict(error.message);
-      }
-
-      throw error;
-    }
+    return handleTaskAction<SystemIdentificationTaskParams, IdentifySystemsResult>({
+      taskClient,
+      taskId,
+      ...actionParams,
+    });
   },
 });
 

--- a/x-pack/platform/plugins/shared/streams/server/routes/utils/task_helpers.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/utils/task_helpers.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { conflict } from '@hapi/boom';
+import type { KibanaRequest } from '@kbn/core/server';
+import { TaskStatus } from '@kbn/streams-schema';
+import { AcknowledgingIncompleteError } from '../../lib/tasks/acknowledging_incomplete_error';
+import { CancellationInProgressError } from '../../lib/tasks/cancellation_in_progress_error';
+import type { TaskClient } from '../../lib/tasks/task_client';
+import type { StreamsTaskType } from '../../lib/tasks/task_definitions';
+import type { TaskResult } from '../../lib/tasks/types';
+
+interface ScheduleTaskConfig<TParams extends object> {
+  taskType: StreamsTaskType;
+  taskId: string;
+  streamName: string;
+  params: TParams;
+  request: KibanaRequest;
+}
+
+interface HandleTaskActionBaseParams {
+  taskClient: TaskClient<StreamsTaskType>;
+  taskId: string;
+}
+
+interface HandleScheduleActionParams<TParams extends object> extends HandleTaskActionBaseParams {
+  action: 'schedule';
+  scheduleConfig: ScheduleTaskConfig<TParams>;
+}
+
+interface HandleCancelOrAcknowledgeActionParams extends HandleTaskActionBaseParams {
+  action: 'cancel' | 'acknowledge';
+  scheduleConfig?: undefined;
+}
+
+type HandleTaskActionParams<TParams extends object> =
+  | HandleScheduleActionParams<TParams>
+  | HandleCancelOrAcknowledgeActionParams;
+
+/**
+ * Handles task lifecycle actions: schedule, cancel, and acknowledge.
+ * Returns the appropriate response based on the action.
+ */
+export async function handleTaskAction<TParams extends object, TPayload extends object>(
+  params: HandleTaskActionParams<TParams>
+): Promise<TaskResult<TPayload>> {
+  const { taskClient, taskId, action } = params;
+
+  if (action === 'schedule') {
+    const { scheduleConfig } = params;
+
+    try {
+      await taskClient.schedule<TParams>({
+        task: {
+          type: scheduleConfig.taskType,
+          id: scheduleConfig.taskId,
+          space: '*',
+          stream: scheduleConfig.streamName,
+        },
+        params: scheduleConfig.params,
+        request: scheduleConfig.request,
+      });
+
+      return {
+        status: TaskStatus.InProgress,
+      };
+    } catch (error) {
+      if (error instanceof CancellationInProgressError) {
+        throw conflict(error.message);
+      }
+      throw error;
+    }
+  } else if (action === 'cancel') {
+    await taskClient.cancel(taskId);
+
+    return {
+      status: TaskStatus.BeingCanceled,
+    };
+  }
+
+  // action === 'acknowledge'
+  try {
+    const task = await taskClient.acknowledge<TParams, TPayload>(taskId);
+
+    return {
+      status: TaskStatus.Acknowledged,
+      ...task.task.payload,
+    };
+  } catch (error) {
+    if (error instanceof AcknowledgingIncompleteError) {
+      throw conflict(error.message);
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Refactors the task client and route handlers to reduce code duplication and improve the ergonomics of task lifecycle management in the Streams plugin.

## Changes

### TaskClient Improvements

- Added `getStatus<TParams, TPayload>(id)` method that encapsulates the status retrieval logic including stale detection and proper payload typing
- Added `complete<TParams, TPayload>(task, params, payload)` method to mark tasks as completed with a payload
- Added `fail<TParams>(task, params, error)` method to mark tasks as failed with an error message
- Added `markCanceled(task)` method to mark tasks as canceled after abortion

### New `TaskResult<TPayload>` Type

Added a discriminated union type that properly types task results based on their status:
- Status-only types: `NotStarted`, `InProgress`, `Stale`, `BeingCanceled`, `Canceled`
- Error type: `Failed` with `error` string
- Payload type: `Completed` or `Acknowledged` with `TPayload` spread

### New `handleTaskAction` Utility

Created `task_helpers.ts` with a generic `handleTaskAction` function that consolidates the common task action handling logic (schedule/cancel/acknowledge) used by multiple route handlers.