### PR TITLE
[Unified Search] Show milliseconds in date picker if needed only

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -558,6 +558,29 @@ export const QueryBarTopRow = React.memo(
       [onDraftChange]
     );
 
+    const settingsDateFormat = uiSettings.get('dateFormat');
+    // Hard-coding here for now to test the feature first
+    // TODO store the "no ms" format alongside the default format somewhere
+    // and get it from the same "central" place
+    const DATE_FORMAT_DEFAULT = 'MMM D, YYYY @ HH:mm:ss.SSS';
+    const DATE_FORMAT_NO_MS = 'MMM D, YYYY @ HH:mm:ss';
+
+    // Show milliseconds only if zoom level is within the second
+    const dateFormat = useMemo(() => {
+      if (settingsDateFormat !== DATE_FORMAT_DEFAULT || !draftDateRangeFrom || !draftDateRangeTo) {
+        return settingsDateFormat;
+      }
+
+      const from = dateMath.parse(draftDateRangeFrom);
+      const to = dateMath.parse(draftDateRangeTo);
+      if (!from?.isValid() || !to?.isValid()) {
+        return settingsDateFormat;
+      }
+      const diff = Math.abs(from.diff(to));
+
+      return diff <= 1000 ? DATE_FORMAT_DEFAULT : DATE_FORMAT_NO_MS;
+    }, [draftDateRangeFrom, draftDateRangeTo, settingsDateFormat]);
+
     useEffect(() => {
       onDraftChangeDebounced?.(draft);
     }, [onDraftChangeDebounced, draft]);
@@ -649,7 +672,7 @@ export const QueryBarTopRow = React.memo(
           recentlyUsedRanges={recentlyUsedRanges}
           locale={i18n.getLocale()}
           commonlyUsedRanges={commonlyUsedRanges}
-          dateFormat={uiSettings.get('dateFormat')}
+          dateFormat={dateFormat}
           isAutoRefreshOnly={showAutoRefreshOnly}
           className="kbnQueryBar__datePicker"
           isQuickSelectOnly={isMobile ? false : isQueryInputFocused}
@@ -983,7 +1006,7 @@ export const QueryBarTopRow = React.memo(
         <SharingMetaFields
           from={currentDateRange.from}
           to={currentDateRange.to}
-          dateFormat={uiSettings.get('dateFormat')}
+          dateFormat={settingsDateFormat}
         />
         {!isScreenshotMode && (
           <>


### PR DESCRIPTION
## Summary

> [!important]
> This is WIP, we mainly want to test the idea first

This PR adjusts the date format in the date picker in Unified Search, to show milliseconds only if zoom level is within the same second, AND the default format is being used.

By default the format will be `MMM D, YYYY @ HH:mm:ss` (no milliseconds), and it'll be `MMM D, YYYY @ HH:mm:ss.SSS` only if zoomed in to the second.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



