### PR TITLE
[9.3] [Agent Builder] Improve MCP tool call error message (#248549)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-mcp-client/mcp/src/client.ts
+++ b/x-pack/platform/packages/shared/kbn-mcp-client/mcp/src/client.ts
@@ -180,14 +180,18 @@ export class McpClient {
       arguments: params.arguments,
     });
 
-    if (response.isError) {
-      throw new Error(
-        `Error calling tool ${params.name} with ${params.arguments}: ${response.error}`
-      );
-    }
-
     const content = response.content as Array<ContentPart | null | undefined>;
     const textParts = content.filter(isTextPart);
+
+    if (response.isError) {
+      // Tool execution errors are returned as text content parts
+      // See https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling
+      throw new Error(
+        `Error calling tool '${params.name}' with arguments '${JSON.stringify(
+          params.arguments
+        )}': ${textParts.map((part) => part.text).join('\n')}`
+      );
+    }
 
     return {
       content: textParts,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Agent Builder] Improve MCP tool call error message (#248549)](https://github.com/elastic/kibana/pull/248549)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dennis Tismenko","email":"dennis.tismenko@elastic.co"},"sourceCommit":{"committedDate":"2026-01-12T18:03:14Z","message":"[Agent Builder] Improve MCP tool call error message (#248549)\n\n## Summary\n\nImproves MCP tool call error messages by extracting and displaying the\nactual error content from the response. Per the [MCP\nspecification](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling),\ntool execution errors are returned as text content parts, so the error\nmessage now properly surfaces this information instead of showing an\nundefined response.error property.\n\n\n\n<img width=\"1290\" height=\"1241\" alt=\"CleanShot 2026-01-09 at 17 16 03\"\nsrc=\"https://github.com/user-attachments/assets/94e0b0cb-7d4b-4bae-9266-38c65b334cfe\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"89257138a7985b0a1020215e6c78b913de8b3a64","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.4.0"],"title":"[Agent Builder] Improve MCP tool call error message","number":248549,"url":"https://github.com/elastic/kibana/pull/248549","mergeCommit":{"message":"[Agent Builder] Improve MCP tool call error message (#248549)\n\n## Summary\n\nImproves MCP tool call error messages by extracting and displaying the\nactual error content from the response. Per the [MCP\nspecification](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling),\ntool execution errors are returned as text content parts, so the error\nmessage now properly surfaces this information instead of showing an\nundefined response.error property.\n\n\n\n<img width=\"1290\" height=\"1241\" alt=\"CleanShot 2026-01-09 at 17 16 03\"\nsrc=\"https://github.com/user-attachments/assets/94e0b0cb-7d4b-4bae-9266-38c65b334cfe\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"89257138a7985b0a1020215e6c78b913de8b3a64"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248549","number":248549,"mergeCommit":{"message":"[Agent Builder] Improve MCP tool call error message (#248549)\n\n## Summary\n\nImproves MCP tool call error messages by extracting and displaying the\nactual error content from the response. Per the [MCP\nspecification](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling),\ntool execution errors are returned as text content parts, so the error\nmessage now properly surfaces this information instead of showing an\nundefined response.error property.\n\n\n\n<img width=\"1290\" height=\"1241\" alt=\"CleanShot 2026-01-09 at 17 16 03\"\nsrc=\"https://github.com/user-attachments/assets/94e0b0cb-7d4b-4bae-9266-38c65b334cfe\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"89257138a7985b0a1020215e6c78b913de8b3a64"}}]}] BACKPORT-->