### PR TITLE
[Discover][Traces] Update trace chart definitions to handle errors in query parsing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -633,7 +633,7 @@ src/platform/packages/shared/kbn-unified-data-table @elastic/kibana-data-discove
 src/platform/packages/shared/kbn-unified-doc-viewer @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-field-list @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-histogram @elastic/kibana-data-discovery
-src/platform/packages/shared/kbn-unified-metrics-grid @elastic/obs-exploration-team
+src/platform/packages/shared/kbn-unified-metrics-grid @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-unified-tabs @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unsaved-changes-prompt @elastic/kibana-management
 src/platform/packages/shared/kbn-use-tracked-promise @elastic/obs-onboarding-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -633,7 +633,7 @@ src/platform/packages/shared/kbn-unified-data-table @elastic/kibana-data-discove
 src/platform/packages/shared/kbn-unified-doc-viewer @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-field-list @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-histogram @elastic/kibana-data-discovery
-src/platform/packages/shared/kbn-unified-metrics-grid @elastic/obs-presentation-team @elastic/obs-exploration-team
+src/platform/packages/shared/kbn-unified-metrics-grid @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-unified-tabs @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unsaved-changes-prompt @elastic/kibana-management
 src/platform/packages/shared/kbn-use-tracked-promise @elastic/obs-onboarding-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -633,7 +633,7 @@ src/platform/packages/shared/kbn-unified-data-table @elastic/kibana-data-discove
 src/platform/packages/shared/kbn-unified-doc-viewer @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-field-list @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-histogram @elastic/kibana-data-discovery
-src/platform/packages/shared/kbn-unified-metrics-grid @elastic/obs-presentation-team @elastic/obs-exploration-team
+src/platform/packages/shared/kbn-unified-metrics-grid @elastic/obs-exploration-team
 src/platform/packages/shared/kbn-unified-tabs @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unsaved-changes-prompt @elastic/kibana-management
 src/platform/packages/shared/kbn-use-tracked-promise @elastic/obs-onboarding-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -633,7 +633,7 @@ src/platform/packages/shared/kbn-unified-data-table @elastic/kibana-data-discove
 src/platform/packages/shared/kbn-unified-doc-viewer @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-field-list @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-histogram @elastic/kibana-data-discovery
-src/platform/packages/shared/kbn-unified-metrics-grid @elastic/obs-presentation-team
+src/platform/packages/shared/kbn-unified-metrics-grid @elastic/obs-presentation-team @elastic/obs-exploration-team
 src/platform/packages/shared/kbn-unified-tabs @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unsaved-changes-prompt @elastic/kibana-management
 src/platform/packages/shared/kbn-use-tracked-promise @elastic/obs-onboarding-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -633,7 +633,7 @@ src/platform/packages/shared/kbn-unified-data-table @elastic/kibana-data-discove
 src/platform/packages/shared/kbn-unified-doc-viewer @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-field-list @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unified-histogram @elastic/kibana-data-discovery
-src/platform/packages/shared/kbn-unified-metrics-grid @elastic/obs-presentation-team
+src/platform/packages/shared/kbn-unified-metrics-grid @elastic/obs-exploration-team
 src/platform/packages/shared/kbn-unified-tabs @elastic/kibana-data-discovery
 src/platform/packages/shared/kbn-unsaved-changes-prompt @elastic/kibana-management
 src/platform/packages/shared/kbn-use-tracked-promise @elastic/obs-onboarding-team

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-browser",
   "id": "@kbn/unified-metrics-grid",
-  "owner": "@elastic/obs-presentation-team",
+  "owner": "@elastic/obs-exploration-team",
   "group": "platform",
   "visibility": "shared"
 }

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/moon.yml
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/unified-metrics-grid'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-presentation-team'
+  defaultOwner: '@elastic/obs-exploration-team'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/unified-metrics-grid'
   description: Moon project for @kbn/unified-metrics-grid
   channel: ''
-  owner: '@elastic/obs-presentation-team'
+  owner: '@elastic/obs-exploration-team'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-unified-metrics-grid
 dependsOn:

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/error_rate.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/error_rate.tsx
@@ -16,33 +16,31 @@ import { getErrorRateChart } from './trace_charts_definition';
 
 const ERROR_RATE_Y_BOUNDS: LensYBoundsConfig = { mode: 'custom', lowerBound: 0, upperBound: 1 };
 
-export const ErrorRateChart = () => {
-  const {
-    filters,
-    services,
-    fetchParams,
-    discoverFetch$,
-    dataSource,
-    indexes,
-    onBrushEnd,
-    onFilter,
-  } = useTraceMetricsContext();
+type UseChartLayersFromEsqlArgs = Parameters<typeof useChartLayersFromEsql>[0];
+
+type ErrorRateChartContentProps = Pick<
+  UseChartLayersFromEsqlArgs,
+  'query' | 'seriesType' | 'unit' | 'color'
+> & {
+  title: string;
+};
+
+const ErrorRateChartContent = ({
+  query,
+  seriesType,
+  unit,
+  color,
+  title,
+}: ErrorRateChartContentProps) => {
+  const { services, fetchParams, discoverFetch$, onBrushEnd, onFilter } = useTraceMetricsContext();
   const { abortController, timeRange } = fetchParams;
-
-  const errorRateChart = getErrorRateChart({
-    dataSource,
-    indexes,
-    filters,
-  });
-
-  const { esqlQuery, seriesType, unit, color, title } = errorRateChart || {};
 
   const {
     layers: chartLayers,
     loading: isLoadingColumns,
     error: columnsError,
   } = useChartLayersFromEsql({
-    query: esqlQuery || '',
+    query,
     seriesType,
     services,
     timeRange,
@@ -51,13 +49,9 @@ export const ErrorRateChart = () => {
     abortController,
   });
 
-  if (!errorRateChart) {
-    return null;
-  }
-
   return (
     <Chart
-      esqlQuery={esqlQuery}
+      esqlQuery={query}
       size="s"
       discoverFetch$={discoverFetch$}
       fetchParams={fetchParams}
@@ -71,6 +65,32 @@ export const ErrorRateChart = () => {
       yBounds={ERROR_RATE_Y_BOUNDS}
       isLoading={isLoadingColumns}
       error={columnsError}
+    />
+  );
+};
+
+export const ErrorRateChart = () => {
+  const { filters, dataSource, indexes } = useTraceMetricsContext();
+
+  const errorRateChart = getErrorRateChart({
+    dataSource,
+    indexes,
+    filters,
+  });
+
+  if (!errorRateChart) {
+    return null;
+  }
+
+  const { esqlQuery, seriesType, unit, color, title } = errorRateChart;
+
+  return (
+    <ErrorRateChartContent
+      query={esqlQuery}
+      seriesType={seriesType}
+      unit={unit}
+      color={color}
+      title={title}
     />
   );
 };

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/error_rate.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/error_rate.tsx
@@ -29,18 +29,20 @@ export const ErrorRateChart = () => {
   } = useTraceMetricsContext();
   const { abortController, timeRange } = fetchParams;
 
-  const { esqlQuery, seriesType, unit, color, title } = getErrorRateChart({
+  const errorRateChart = getErrorRateChart({
     dataSource,
     indexes,
     filters,
   });
+
+  const { esqlQuery, seriesType, unit, color, title } = errorRateChart || {};
 
   const {
     layers: chartLayers,
     loading: isLoadingColumns,
     error: columnsError,
   } = useChartLayersFromEsql({
-    query: esqlQuery,
+    query: esqlQuery || '',
     seriesType,
     services,
     timeRange,
@@ -48,6 +50,10 @@ export const ErrorRateChart = () => {
     color,
     abortController,
   });
+
+  if (!errorRateChart) {
+    return null;
+  }
 
   return (
     <Chart

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/latency.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/latency.tsx
@@ -25,11 +25,12 @@ export const LatencyChart = () => {
     onFilter,
   } = useTraceMetricsContext();
 
-  const { esqlQuery, seriesType, unit, color, title } = getLatencyChart({
+  const latencyChart = getLatencyChart({
     dataSource,
     indexes,
     filters,
   });
+  const { esqlQuery, seriesType, unit, color, title } = latencyChart || {};
 
   const chartLayers = useChartLayers({
     metric: {
@@ -43,6 +44,10 @@ export const LatencyChart = () => {
     color,
     seriesType,
   });
+
+  if (!latencyChart) {
+    return null;
+  }
 
   return (
     <Chart

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/latency.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/latency.tsx
@@ -13,24 +13,17 @@ import { Chart } from '../chart';
 import { useChartLayers } from '../chart/hooks/use_chart_layers';
 import { getLatencyChart } from './trace_charts_definition';
 
-export const LatencyChart = () => {
-  const {
-    filters,
-    services,
-    fetchParams,
-    discoverFetch$,
-    dataSource,
-    indexes,
-    onBrushEnd,
-    onFilter,
-  } = useTraceMetricsContext();
+type LatencyChartContentProps = NonNullable<ReturnType<typeof getLatencyChart>>;
 
-  const latencyChart = getLatencyChart({
-    dataSource,
-    indexes,
-    filters,
-  });
-  const { esqlQuery, seriesType, unit, color, title } = latencyChart || {};
+const LatencyChartContent = ({
+  esqlQuery,
+  seriesType,
+  unit,
+  color,
+  title,
+}: LatencyChartContentProps) => {
+  const { services, fetchParams, discoverFetch$, indexes, onBrushEnd, onFilter } =
+    useTraceMetricsContext();
 
   const chartLayers = useChartLayers({
     metric: {
@@ -44,10 +37,6 @@ export const LatencyChart = () => {
     color,
     seriesType,
   });
-
-  if (!latencyChart) {
-    return null;
-  }
 
   return (
     <Chart
@@ -64,4 +53,20 @@ export const LatencyChart = () => {
       syncTooltips
     />
   );
+};
+
+export const LatencyChart = () => {
+  const { filters, dataSource, indexes } = useTraceMetricsContext();
+
+  const latencyChart = getLatencyChart({
+    dataSource,
+    indexes,
+    filters,
+  });
+
+  if (!latencyChart) {
+    return null;
+  }
+
+  return <LatencyChartContent {...latencyChart} />;
 };

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/throughput.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/throughput.tsx
@@ -26,13 +26,13 @@ export const ThroughputChart = () => {
     onFilter,
   } = useTraceMetricsContext();
   const fieldName = dataSource === 'apm' ? TRANSACTION_ID : SPAN_ID;
-
-  const { esqlQuery, seriesType, unit, color, title } = getThroughputChart({
+  const throughputChart = getThroughputChart({
     dataSource,
     indexes,
     filters,
     fieldName,
   });
+  const { esqlQuery, seriesType, unit, color, title } = throughputChart || {};
 
   const chartLayers = useChartLayers({
     metric: {
@@ -47,6 +47,10 @@ export const ThroughputChart = () => {
     seriesType,
     customFunction: 'COUNT',
   });
+
+  if (!throughputChart) {
+    return null;
+  }
 
   return (
     <Chart

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/throughput.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/throughput.tsx
@@ -14,25 +14,20 @@ import { Chart } from '../chart';
 import { useChartLayers } from '../chart/hooks/use_chart_layers';
 import { getThroughputChart } from './trace_charts_definition';
 
-export const ThroughputChart = () => {
-  const {
-    filters,
-    services,
-    fetchParams,
-    discoverFetch$,
-    dataSource,
-    indexes,
-    onBrushEnd,
-    onFilter,
-  } = useTraceMetricsContext();
-  const fieldName = dataSource === 'apm' ? TRANSACTION_ID : SPAN_ID;
-  const throughputChart = getThroughputChart({
-    dataSource,
-    indexes,
-    filters,
-    fieldName,
-  });
-  const { esqlQuery, seriesType, unit, color, title } = throughputChart || {};
+type ThroughputChartContentProps = NonNullable<ReturnType<typeof getThroughputChart>> & {
+  fieldName: string;
+};
+
+const ThroughputChartContent = ({
+  esqlQuery,
+  seriesType,
+  unit,
+  color,
+  title,
+  fieldName,
+}: ThroughputChartContentProps) => {
+  const { services, fetchParams, discoverFetch$, indexes, onBrushEnd, onFilter } =
+    useTraceMetricsContext();
 
   const chartLayers = useChartLayers({
     metric: {
@@ -47,10 +42,6 @@ export const ThroughputChart = () => {
     seriesType,
     customFunction: 'COUNT',
   });
-
-  if (!throughputChart) {
-    return null;
-  }
 
   return (
     <Chart
@@ -67,4 +58,21 @@ export const ThroughputChart = () => {
       syncCursor
     />
   );
+};
+
+export const ThroughputChart = () => {
+  const { filters, dataSource, indexes } = useTraceMetricsContext();
+  const fieldName = dataSource === 'apm' ? TRANSACTION_ID : SPAN_ID;
+  const throughputChart = getThroughputChart({
+    dataSource,
+    indexes,
+    filters,
+    fieldName,
+  });
+
+  if (!throughputChart) {
+    return null;
+  }
+
+  return <ThroughputChartContent {...throughputChart} fieldName={fieldName} />;
 };

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/trace_charts_definition.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/trace_charts_definition.test.ts
@@ -171,8 +171,8 @@ describe('trace_charts_definition', () => {
         esqlQuery: expect.stringContaining('FROM traces-*'),
       });
 
-      expect(result.esqlQuery).toContain('COUNT(transaction.id)');
-      expect(result.esqlQuery).toContain('processor.event == "transaction"');
+      expect(result?.esqlQuery).toContain('COUNT(transaction.id)');
+      expect(result?.esqlQuery).toContain('processor.event == "transaction"');
     });
 
     it('should return throughput chart configuration for OTEL data source', () => {
@@ -194,8 +194,8 @@ describe('trace_charts_definition', () => {
         esqlQuery: expect.stringContaining('FROM traces-*'),
       });
 
-      expect(result.esqlQuery).toContain('COUNT(span.id)');
-      expect(result.esqlQuery).not.toContain('processor.event == "transaction"');
+      expect(result?.esqlQuery).toContain('COUNT(span.id)');
+      expect(result?.esqlQuery).not.toContain('processor.event == "transaction"');
     });
 
     it('should include all provided filters in the ESQL query', () => {
@@ -208,9 +208,9 @@ describe('trace_charts_definition', () => {
         fieldName: 'transaction.id',
       });
 
-      expect(result.esqlQuery).toContain('service.name == "test-service"');
-      expect(result.esqlQuery).toContain('environment == "production"');
-      expect(result.esqlQuery).toContain('processor.event == "transaction"');
+      expect(result?.esqlQuery).toContain('service.name == "test-service"');
+      expect(result?.esqlQuery).toContain('environment == "production"');
+      expect(result?.esqlQuery).toContain('processor.event == "transaction"');
     });
 
     it('should handle empty filters array', () => {
@@ -223,7 +223,7 @@ describe('trace_charts_definition', () => {
         fieldName: 'transaction.id',
       });
 
-      expect(result.esqlQuery).toContain('FROM traces-*');
+      expect(result?.esqlQuery).toContain('FROM traces-*');
     });
 
     it('should generate valid ESQL query structure', () => {
@@ -237,8 +237,8 @@ describe('trace_charts_definition', () => {
       });
 
       // Verify basic ESQL structure
-      expect(result.esqlQuery).toMatch(/FROM .+/);
-      expect(result.esqlQuery).toContain('STATS');
+      expect(result?.esqlQuery).toMatch(/FROM .+/);
+      expect(result?.esqlQuery).toContain('STATS');
     });
   });
 

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/trace_charts_definition.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/trace_charts_definition.test.ts
@@ -13,6 +13,7 @@ import { chartPalette, type DataSource } from '.';
 describe('trace_charts_definition', () => {
   const mockIndexes = 'traces-*';
   const mockFilters = ['service.name == "test-service"', 'environment == "production"'];
+  const mockInvalidFilters = ['service.name:test-service'];
 
   describe('getErrorRateChart', () => {
     it('should return error rate chart configuration for APM data source', () => {
@@ -238,6 +239,45 @@ describe('trace_charts_definition', () => {
       // Verify basic ESQL structure
       expect(result.esqlQuery).toMatch(/FROM .+/);
       expect(result.esqlQuery).toContain('STATS');
+    });
+  });
+
+  describe('when invalid filters are provided', () => {
+    it('getErrorRateChart should return null', () => {
+      const dataSource: DataSource = 'apm';
+
+      const result = getErrorRateChart({
+        dataSource,
+        indexes: mockIndexes,
+        filters: mockInvalidFilters,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('getLatencyChart should return null', () => {
+      const dataSource: DataSource = 'apm';
+
+      const result = getLatencyChart({
+        dataSource,
+        indexes: mockIndexes,
+        filters: mockInvalidFilters,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('getThroughputChart should return null', () => {
+      const dataSource: DataSource = 'apm';
+
+      const result = getThroughputChart({
+        dataSource,
+        indexes: mockIndexes,
+        filters: mockInvalidFilters,
+        fieldName: 'transaction.id',
+      });
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/trace_charts_definition.test.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/trace_charts_definition.test.ts
@@ -30,7 +30,7 @@ describe('trace_charts_definition', () => {
         esqlQuery: expect.stringContaining('FROM traces-*'),
       });
 
-      expect(result.esqlQuery).toContain('event.outcome == "failure"');
+      expect(result?.esqlQuery).toContain('event.outcome == "failure"');
     });
 
     it('should return error rate chart configuration for OTEL data source', () => {
@@ -47,8 +47,8 @@ describe('trace_charts_definition', () => {
         esqlQuery: expect.stringContaining('FROM traces-*'),
       });
 
-      expect(result.esqlQuery).toContain('status.code == "Error"');
-      expect(result.esqlQuery).not.toContain('event.outcome');
+      expect(result?.esqlQuery).toContain('status.code == "Error"');
+      expect(result?.esqlQuery).not.toContain('event.outcome');
     });
 
     it('should include all provided filters in the ESQL query', () => {
@@ -56,9 +56,9 @@ describe('trace_charts_definition', () => {
 
       const result = getErrorRateChart({ dataSource, indexes: mockIndexes, filters: mockFilters });
 
-      expect(result.esqlQuery).toContain('service.name == "test-service"');
-      expect(result.esqlQuery).toContain('environment == "production"');
-      expect(result.esqlQuery).toContain('processor.event == "transaction"');
+      expect(result?.esqlQuery).toContain('service.name == "test-service"');
+      expect(result?.esqlQuery).toContain('environment == "production"');
+      expect(result?.esqlQuery).toContain('processor.event == "transaction"');
     });
 
     it('should handle empty filters array', () => {
@@ -66,8 +66,8 @@ describe('trace_charts_definition', () => {
 
       const result = getErrorRateChart({ dataSource, indexes: mockIndexes, filters: [] });
 
-      expect(result.esqlQuery).toContain('processor.event == "transaction"');
-      expect(result.esqlQuery).toContain('FROM traces-*');
+      expect(result?.esqlQuery).toContain('processor.event == "transaction"');
+      expect(result?.esqlQuery).toContain('FROM traces-*');
     });
 
     it('should generate valid ESQL query structure', () => {
@@ -75,12 +75,12 @@ describe('trace_charts_definition', () => {
 
       const result = getErrorRateChart({ dataSource, indexes: mockIndexes, filters: mockFilters });
 
-      expect(result.esqlQuery).toMatch(/FROM .+/);
-      expect(result.esqlQuery).toContain('STATS');
-      expect(result.esqlQuery).toContain('EVAL');
-      expect(result.esqlQuery).toContain('KEEP');
-      expect(result.esqlQuery).toContain('SORT');
-      expect(result.esqlQuery).toContain('BUCKET(@timestamp, 100, ?_tstart, ?_tend)');
+      expect(result?.esqlQuery).toMatch(/FROM .+/);
+      expect(result?.esqlQuery).toContain('STATS');
+      expect(result?.esqlQuery).toContain('EVAL');
+      expect(result?.esqlQuery).toContain('KEEP');
+      expect(result?.esqlQuery).toContain('SORT');
+      expect(result?.esqlQuery).toContain('BUCKET(@timestamp, 100, ?_tstart, ?_tend)');
     });
   });
 
@@ -99,7 +99,7 @@ describe('trace_charts_definition', () => {
         esqlQuery: expect.stringContaining('FROM traces-*'),
       });
 
-      expect(result.esqlQuery).toContain('ROUND(transaction.duration.us) / 1000');
+      expect(result?.esqlQuery).toContain('ROUND(transaction.duration.us) / 1000');
     });
 
     it('should return latency chart configuration for OTEL data source', () => {
@@ -116,7 +116,7 @@ describe('trace_charts_definition', () => {
         esqlQuery: expect.stringContaining('FROM traces-*'),
       });
 
-      expect(result.esqlQuery).toContain('ROUND(duration) / 1000 / 1000');
+      expect(result?.esqlQuery).toContain('ROUND(duration) / 1000 / 1000');
     });
 
     it('should include all provided filters in the ESQL query', () => {
@@ -124,9 +124,9 @@ describe('trace_charts_definition', () => {
 
       const result = getLatencyChart({ dataSource, indexes: mockIndexes, filters: mockFilters });
 
-      expect(result.esqlQuery).toContain('service.name == "test-service"');
-      expect(result.esqlQuery).toContain('environment == "production"');
-      expect(result.esqlQuery).toContain('processor.event == "transaction"');
+      expect(result?.esqlQuery).toContain('service.name == "test-service"');
+      expect(result?.esqlQuery).toContain('environment == "production"');
+      expect(result?.esqlQuery).toContain('processor.event == "transaction"');
     });
 
     it('should handle empty filters array', () => {
@@ -134,7 +134,7 @@ describe('trace_charts_definition', () => {
 
       const result = getLatencyChart({ dataSource, indexes: mockIndexes, filters: [] });
 
-      expect(result.esqlQuery).toContain('FROM traces-*');
+      expect(result?.esqlQuery).toContain('FROM traces-*');
     });
 
     it('should generate valid ESQL query structure', () => {
@@ -143,11 +143,11 @@ describe('trace_charts_definition', () => {
       const result = getLatencyChart({ dataSource, indexes: mockIndexes, filters: mockFilters });
 
       // Verify basic ESQL structure
-      expect(result.esqlQuery).toMatch(/FROM .+/);
-      expect(result.esqlQuery).toContain('EVAL');
-      expect(result.esqlQuery).toContain('STATS');
-      expect(result.esqlQuery).toContain('AVG(duration_ms)');
-      expect(result.esqlQuery).toContain('BUCKET(@timestamp, 100, ?_tstart, ?_tend)');
+      expect(result?.esqlQuery).toMatch(/FROM .+/);
+      expect(result?.esqlQuery).toContain('EVAL');
+      expect(result?.esqlQuery).toContain('STATS');
+      expect(result?.esqlQuery).toContain('AVG(duration_ms)');
+      expect(result?.esqlQuery).toContain('BUCKET(@timestamp, 100, ?_tstart, ?_tend)');
     });
   });
 

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/trace_charts_definition.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/trace_charts_definition.ts
@@ -44,17 +44,10 @@ export function getErrorRateChart({
   dataSource: DataSource;
   indexes: string;
   filters: string[];
-}): TraceChart {
-  const whereClauses = getWhereClauses(dataSource, filters);
-  return {
-    id: 'error_rate',
-    title: i18n.translate('metricsExperience.grid.error_rate.label', {
-      defaultMessage: 'Error Rate',
-    }),
-    color: chartPalette[6],
-    unit: 'percent',
-    seriesType: 'line',
-    esqlQuery: from(indexes)
+}): TraceChart | null {
+  try {
+    const whereClauses = getWhereClauses(dataSource, filters);
+    const esqlQuery = from(indexes)
       .pipe(
         ...whereClauses,
         dataSource === 'apm'
@@ -68,8 +61,21 @@ export function getErrorRateChart({
         keep('timestamp, error_rate'),
         sort('timestamp')
       )
-      .toString(),
-  };
+      .toString();
+
+    return {
+      id: 'error_rate',
+      title: i18n.translate('metricsExperience.grid.error_rate.label', {
+        defaultMessage: 'Error Rate',
+      }),
+      color: chartPalette[6],
+      unit: 'percent',
+      seriesType: 'line',
+      esqlQuery,
+    };
+  } catch (error) {
+    return null;
+  }
 }
 
 export function getLatencyChart({
@@ -80,17 +86,11 @@ export function getLatencyChart({
   dataSource: DataSource;
   indexes: string;
   filters: string[];
-}): TraceChart {
-  const whereClauses = getWhereClauses(dataSource, filters);
-  return {
-    id: 'latency',
-    title: i18n.translate('metricsExperience.grid.latency.label', {
-      defaultMessage: 'Latency',
-    }),
-    color: chartPalette[2],
-    unit: 'ms',
-    seriesType: 'line',
-    esqlQuery: from(indexes)
+}): TraceChart | null {
+  try {
+    const whereClauses = getWhereClauses(dataSource, filters);
+
+    const esqlQuery = from(indexes)
       .pipe(
         ...whereClauses,
         dataSource === 'apm'
@@ -98,8 +98,21 @@ export function getLatencyChart({
           : evaluate(`duration_ms = ROUND(${DURATION})/1000/1000`), // otel duration is in ns
         stats(`AVG(duration_ms) BY BUCKET(${AT_TIMESTAMP}, 100, ?_tstart, ?_tend)`)
       )
-      .toString(),
-  };
+      .toString();
+
+    return {
+      id: 'latency',
+      title: i18n.translate('metricsExperience.grid.latency.label', {
+        defaultMessage: 'Latency',
+      }),
+      color: chartPalette[2],
+      unit: 'ms',
+      seriesType: 'line',
+      esqlQuery,
+    };
+  } catch (error) {
+    return null;
+  }
 }
 
 export function getThroughputChart({
@@ -112,21 +125,28 @@ export function getThroughputChart({
   filters: string[];
   dataSource: DataSource;
   fieldName: string;
-}): TraceChart {
-  const whereClauses = getWhereClauses(dataSource, filters);
-  return {
-    id: 'throughput',
-    title: i18n.translate('metricsExperience.grid.throughput.label', {
-      defaultMessage: 'Throughput',
-    }),
-    color: chartPalette[0],
-    unit: 'count',
-    seriesType: 'line',
-    esqlQuery: from(indexes)
+}): TraceChart | null {
+  try {
+    const whereClauses = getWhereClauses(dataSource, filters);
+
+    const esqlQuery = from(indexes)
       .pipe(
         ...whereClauses,
         stats(`COUNT(${fieldName}) BY BUCKET(${AT_TIMESTAMP}, 100, ?_tstart, ?_tend)`)
       )
-      .toString(),
-  };
+      .toString();
+
+    return {
+      id: 'throughput',
+      title: i18n.translate('metricsExperience.grid.throughput.label', {
+        defaultMessage: 'Throughput',
+      }),
+      color: chartPalette[0],
+      unit: 'count',
+      seriesType: 'line',
+      esqlQuery,
+    };
+  } catch (error) {
+    return null;
+  }
 }

--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/trace_charts_definition.ts
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/trace_metrics_grid/trace_charts_definition.ts
@@ -89,7 +89,6 @@ export function getLatencyChart({
 }): TraceChart | null {
   try {
     const whereClauses = getWhereClauses(dataSource, filters);
-
     const esqlQuery = from(indexes)
       .pipe(
         ...whereClauses,
@@ -128,7 +127,6 @@ export function getThroughputChart({
 }): TraceChart | null {
   try {
     const whereClauses = getWhereClauses(dataSource, filters);
-
     const esqlQuery = from(indexes)
       .pipe(
         ...whereClauses,


### PR DESCRIPTION
## Summary

We recently discovered that for ESQL, querying specific traces schema indexes such as `traces*apm*` or `traces*otel*` was not handling errors gracefully.

This PR provides a **quick fix** to prevent the entire experience from being blocked. 
The error that occurs should not actually block anything, as the charts that are failing to load aren’t supposed to be displayed if the query fails.

|Before|After|
|-|-|
|<img width="1189" height="1003" alt="Screenshot 2026-01-14 at 17 29 51" src="https://github.com/user-attachments/assets/34808656-cc5e-4b90-bf79-ac0f955eddd7" />|<img width="1284" height="967" alt="Screenshot 2026-01-14 at 17 23 52" src="https://github.com/user-attachments/assets/b58b1933-5aa7-41d1-a017-51dac388193b" />|



>[!NOTE]
> I’ll also create a separate issue to review the error handling strategy for the charts section. Currently, it seems we’re not wrapping it in a proper error boundary, which causes the whole page to be blocked and prevents any error events from being captured in telemetry. 
>
>**Update**
A PR to address this has already been opened:
>- https://github.com/elastic/kibana/pull/249107

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->