### PR TITLE
[Discover] Wrap error boundary around `chartSectionConfig.renderChartSection`

### DIFF
--- a/src/platform/plugins/shared/discover/moon.yml
+++ b/src/platform/plugins/shared/discover/moon.yml
@@ -130,6 +130,7 @@ dependsOn:
   - '@kbn/zod'
   - '@kbn/cps'
   - '@kbn/controls-renderer'
+  - '@kbn/shared-ux-error-boundary'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
@@ -14,7 +14,8 @@ import { UnifiedHistogramChart, useUnifiedHistogram } from '@kbn/unified-histogr
 import { useChartStyles } from '@kbn/unified-histogram/components/chart/hooks/use_chart_styles';
 import { useServicesBootstrap } from '@kbn/unified-histogram/hooks/use_services_bootstrap';
 import type { UnifiedMetricsGridRestorableState } from '@kbn/unified-metrics-grid';
-import { EuiErrorBoundary } from '@elastic/eui';
+import { KibanaSectionErrorBoundary } from '@kbn/shared-ux-error-boundary';
+import { i18n } from '@kbn/i18n';
 import { useProfileAccessor } from '../../../../context_awareness';
 import { DiscoverCustomizationProvider } from '../../../../customizations';
 import {
@@ -292,7 +293,11 @@ const CustomChartSectionWrapper = ({
   const isComponentVisible = !!layoutProps.chart && !layoutProps.chart.hidden;
 
   return (
-    <EuiErrorBoundary>
+    <KibanaSectionErrorBoundary
+      sectionName={i18n.translate('discover.chart.errorBoundarySectionName', {
+        defaultMessage: 'Discover chart section',
+      })}
+    >
       {chartSectionConfig.renderChartSection({
         histogramCss,
         chartToolbarCss,
@@ -304,6 +309,6 @@ const CustomChartSectionWrapper = ({
         initialState: metricsGridState,
         onInitialStateChange,
       })}
-    </EuiErrorBoundary>
+    </KibanaSectionErrorBoundary>
   );
 };

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
@@ -14,6 +14,7 @@ import { UnifiedHistogramChart, useUnifiedHistogram } from '@kbn/unified-histogr
 import { useChartStyles } from '@kbn/unified-histogram/components/chart/hooks/use_chart_styles';
 import { useServicesBootstrap } from '@kbn/unified-histogram/hooks/use_services_bootstrap';
 import type { UnifiedMetricsGridRestorableState } from '@kbn/unified-metrics-grid';
+import { EuiErrorBoundary } from '@elastic/eui';
 import { useProfileAccessor } from '../../../../context_awareness';
 import { DiscoverCustomizationProvider } from '../../../../customizations';
 import {
@@ -247,10 +248,7 @@ const CustomChartSectionWrapper = ({
   const setMetricsGridState = useCurrentTabAction(internalStateActions.setMetricsGridState);
   const onInitialStateChange = useCallback(
     (newMetricsGridState: Partial<UnifiedMetricsGridRestorableState>) => {
-      // Defer dispatch to next tick - ensures React render cycle is complete
-      // setTimeout(() => {
       dispatch(setMetricsGridState({ metricsGridState: newMetricsGridState }));
-      // }, 0);
     },
     [setMetricsGridState, dispatch]
   );
@@ -293,15 +291,19 @@ const CustomChartSectionWrapper = ({
 
   const isComponentVisible = !!layoutProps.chart && !layoutProps.chart.hidden;
 
-  return chartSectionConfig.renderChartSection({
-    histogramCss,
-    chartToolbarCss,
-    renderToggleActions: renderCustomChartToggleActions,
-    fetch$,
-    fetchParams,
-    isComponentVisible,
-    ...unifiedHistogramProps,
-    initialState: metricsGridState,
-    onInitialStateChange,
-  });
+  return (
+    <EuiErrorBoundary>
+      {chartSectionConfig.renderChartSection({
+        histogramCss,
+        chartToolbarCss,
+        renderToggleActions: renderCustomChartToggleActions,
+        fetch$,
+        fetchParams,
+        isComponentVisible,
+        ...unifiedHistogramProps,
+        initialState: metricsGridState,
+        onInitialStateChange,
+      })}
+    </EuiErrorBoundary>
+  );
 };

--- a/src/platform/plugins/shared/discover/tsconfig.json
+++ b/src/platform/plugins/shared/discover/tsconfig.json
@@ -122,7 +122,8 @@
     "@kbn/controls-schemas",
     "@kbn/zod",
     "@kbn/cps",
-    "@kbn/controls-renderer"
+    "@kbn/controls-renderer",
+    "@kbn/shared-ux-error-boundary"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

This PR wraps a `KibanaSectionErrorBoundary` around `chartSectionConfig.renderChartSection` so Discover doesn't completely break when a custom chart section component throws an error.

Before:

https://github.com/user-attachments/assets/b20156ae-85b8-455a-9276-1507f658ff3d

After:

https://github.com/user-attachments/assets/0f828640-9c88-451a-ac16-0735a409cd3d

Related to #249075.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->