### PR TITLE
[Inference]  Add maxQueue backpressure to anonymization regex worker pool

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/regex_worker_service.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/regex_worker_service.test.ts
@@ -33,6 +33,7 @@ function createTestConfig(
     enabled: true,
     minThreads: 1,
     maxThreads: 3,
+    maxQueue: 20,
     idleTimeout: { asMilliseconds: () => 30000 },
     taskTimeout: { asMilliseconds: () => 15000 },
     ...overrides,

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/regex_worker_service.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/regex_worker_service.ts
@@ -36,6 +36,7 @@ export class RegexWorkerService {
         filename: require.resolve('./regex_worker_wrapper.js'),
         minThreads: this.config.minThreads,
         maxThreads: this.config.maxThreads,
+        maxQueue: this.config.maxQueue,
         idleTimeout: this.config.idleTimeout.asMilliseconds(),
       });
     }

--- a/x-pack/platform/plugins/shared/inference/server/config.ts
+++ b/x-pack/platform/plugins/shared/inference/server/config.ts
@@ -14,6 +14,7 @@ export const configSchema = schema.object({
       enabled: schema.boolean({ defaultValue: true }),
       minThreads: schema.number({ defaultValue: 0, min: 0 }),
       maxThreads: schema.number({ defaultValue: 3, min: 1 }),
+      maxQueue: schema.number({ defaultValue: 20, min: 1 }),
       idleTimeout: schema.duration({ defaultValue: '30s' }),
       taskTimeout: schema.duration({ defaultValue: '15s' }),
     }),


### PR DESCRIPTION
### Summary
Anonymization regex execution runs in a Piscina worker pool. Under saturation (e.g., slow regex tasks together with a surge of parallel requests), tasks can accumulate in the worker queue. Since Piscina’s queue is unbounded by default, this can lead to large backlogs and severe tail behavior (very slow requests / slow error responses).

### Changes
- Add `xpack.inference.workers.anonymization.maxQueue` (default `20`) to cap queued regex tasks.
- Pass `maxQueue` into the Piscina worker pool in `RegexWorkerService`.

### Expected behavior
- Normal load: unchanged (regex tasks complete quickly; queue stays near empty).
- Saturation: additional work fails fast once the queue is full, preventing unbounded backlog growth and reducing worst-case latency.




<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->