### PR TITLE
[WorkplaceAI][Bugfix] Add datasource name in namespace

### DIFF
--- a/x-pack/platform/plugins/shared/data_connectors/server/routes/connectors_helpers.ts
+++ b/x-pack/platform/plugins/shared/data_connectors/server/routes/connectors_helpers.ts
@@ -13,6 +13,7 @@ import type { Logger } from '@kbn/logging';
 import type { DataTypeDefinition } from '@kbn/data-sources-registry-plugin/common';
 import { DEFAULT_NAMESPACE_STRING } from '@kbn/core-saved-objects-utils-server';
 import { connectorsSpecs } from '@kbn/connector-specs';
+import { updateYamlField } from '@kbn/workflows-management-plugin/common/lib/yaml';
 import type {
   DataConnectorsServerSetupDependencies,
   DataConnectorsServerStartDependencies,
@@ -147,8 +148,14 @@ export async function createConnectorAndRelatedResources(
   const toolIds: string[] = [];
 
   for (const workflowInfo of workflowInfos) {
+    // Extract original workflow name from YAML and prefix it with the data source name
+    const nameMatch = workflowInfo.content.match(/^name:\s*['"]?([^'"\n]+)['"]?/m);
+    const originalName = nameMatch?.[1]?.trim() ?? 'workflow';
+    const prefixedName = `${slugify(name)}.${originalName}`;
+    const prefixedContent = updateYamlField(workflowInfo.content, 'name', prefixedName);
+
     const workflow = await workflowManagement.management.createWorkflow(
-      { yaml: workflowInfo.content },
+      { yaml: prefixedContent },
       spaceId,
       request
     );


### PR DESCRIPTION
## Summary

To unblock creating multiple sources of the same type. Not a huge fan of this approach but will want to re-evaluate workflows interaction as part of https://github.com/elastic/kibana/pull/248995

<img width="1228" height="289" alt="Screenshot 2026-01-15 at 10 48 23" src="https://github.com/user-attachments/assets/97a49bf3-adc4-4919-ab48-eba5b774b698" />
<img width="1386" height="345" alt="Screenshot 2026-01-15 at 10 48 34" src="https://github.com/user-attachments/assets/09d04b60-6357-42bd-8756-4396890a8de9" />
<img width="1201" height="388" alt="Screenshot 2026-01-15 at 10 49 06" src="https://github.com/user-attachments/assets/29efd53a-fa2e-4f96-8a86-729ada715afa" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



