### PR TITLE
[ES|QL] Fix hover not hiding after clicking it

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/lookup_join/use_lookup_index_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/lookup_join/use_lookup_index_editor.tsx
@@ -288,6 +288,16 @@ export const useLookupIndexCommand = (
       canEditIndex = true,
       triggerSource = 'esql_autocomplete'
     ) => {
+      if (editorRef.current) {
+        // Hiding the hover widget is easier in newer monaco versions, we can improve this if we update.
+        // In new versions there is a comamnd: editorRef.current.trigger('command', 'editor.action.hideHover', {});
+        const hoverController =
+          editorRef.current.getContribution<HoverController>('editor.contrib.hover');
+        if (hoverController?._contentWidget?.widget?.hide) {
+          hoverController._contentWidget.widget.hide();
+        }
+      }
+
       await uiActions.getTrigger('EDIT_LOOKUP_INDEX_CONTENT_TRIGGER_ID').exec({
         indexName,
         doesIndexExist,
@@ -308,7 +318,7 @@ export const useLookupIndexCommand = (
         onOpenIndexInDiscover,
       } as EditLookupIndexContentContext);
     },
-    [onFlyoutClose, onOpenIndexInDiscover, uiActions]
+    [editorRef, onFlyoutClose, onOpenIndexInDiscover, uiActions]
   );
 
   const openFlyoutRef = useRef(openFlyout);
@@ -316,31 +326,18 @@ export const useLookupIndexCommand = (
     openFlyoutRef.current = openFlyout;
   }, [openFlyout]);
 
-  useEffect(
-    function registerCommandOnMount() {
-      const disposable = monaco.editor.registerCommand(
-        COMMAND_ID,
-        async (_, args: IndexEditorCommandArgs) => {
-          if (editorRef.current) {
-            // Hiding the hover widget is easier in newer monaco versions, we can improve this if we update.
-            // In new versions there is a comamnd: editorRef.current.trigger('command', 'editor.action.hideHover', {});
-            const hoverController =
-              editorRef.current.getContribution<HoverController>('editor.contrib.hover');
-            if (hoverController?._contentWidget?.widget?.hide) {
-              hoverController._contentWidget.widget.hide();
-            }
-          }
-
-          const { indexName, doesIndexExist, canEditIndex, triggerSource } = args;
-          await openFlyoutRef.current(indexName, doesIndexExist, canEditIndex, triggerSource);
-        }
-      );
-      return () => {
-        disposable.dispose();
-      };
-    },
-    [editorRef]
-  );
+  useEffect(function registerCommandOnMount() {
+    const disposable = monaco.editor.registerCommand(
+      COMMAND_ID,
+      async (_, args: IndexEditorCommandArgs) => {
+        const { indexName, doesIndexExist, canEditIndex, triggerSource } = args;
+        await openFlyoutRef.current(indexName, doesIndexExist, canEditIndex, triggerSource);
+      }
+    );
+    return () => {
+      disposable.dispose();
+    };
+  }, []);
 
   return {
     addLookupIndicesDecorator,


### PR DESCRIPTION
## Summary
After [changes](https://github.com/elastic/kibana/pull/248091) in monaco popups z-index, the hover message was now visible over the index editor flyout.
Before, it was hidden below the overlay.

<img width="719" height="378" alt="image" src="https://github.com/user-attachments/assets/2f6edda8-926f-47fd-9b36-4c1c988dd792" />


Best solution is to hide the hover message after clicking it. Modifying again the z-index creates a circular problem as some of them needs to be hidden and others don't.

To hide the hover cleanly we would need a newer version of `monaco-editor`, the proposed solution is not clean, but follows similar approaches taken in Kibana for similar issues where monaco controllers needs to be accessed. Hopefully we can update monaco soon and use their public api.