### PR TITLE
[One Workflow] Remove synchronous cancellation check

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.test.ts
@@ -1,0 +1,248 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { EsWorkflowExecution, StackFrame } from '@kbn/workflows';
+import { ExecutionStatus } from '@kbn/workflows';
+import type { GraphNodeUnion } from '@kbn/workflows/graph';
+
+import { runNode } from './run_node';
+import type { WorkflowExecutionLoopParams } from './types';
+import type { NodeImplementation } from '../step/node_implementation';
+import type { StepExecutionRuntime } from '../workflow_context_manager/step_execution_runtime';
+import type { WorkflowExecutionState } from '../workflow_context_manager/workflow_execution_state';
+import { WorkflowScopeStack } from '../workflow_context_manager/workflow_scope_stack';
+
+// Mock the dependencies
+const mockRunStackMonitor = jest
+  .fn()
+  .mockImplementation(
+    async (
+      _params: WorkflowExecutionLoopParams,
+      _stepExecutionRuntime: StepExecutionRuntime,
+      _monitorAbortController: AbortController
+    ) => {
+      // Simulate the monitoring loop running briefly
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      // Don't abort by default - let the step run to completion
+    }
+  );
+
+const mockCatchError = jest.fn().mockResolvedValue(undefined);
+const mockHandleExecutionDelay = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('./run_stack_monitor/run_stack_monitor', () => ({
+  runStackMonitor: mockRunStackMonitor,
+}));
+
+jest.mock('./catch_error', () => ({
+  catchError: mockCatchError,
+}));
+
+jest.mock('./handle_execution_delay', () => ({
+  handleExecutionDelay: mockHandleExecutionDelay,
+}));
+
+describe('runNode', () => {
+  let mockParams: jest.Mocked<WorkflowExecutionLoopParams>;
+  let workflowExecution: EsWorkflowExecution;
+  let mockNode: GraphNodeUnion;
+  let mockNodeImplementation: jest.Mocked<NodeImplementation>;
+  let mockStepExecutionRuntime: jest.Mocked<StepExecutionRuntime>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    workflowExecution = {
+      id: 'test-workflow-execution-id',
+      workflowId: 'test-workflow-id',
+      spaceId: 'default',
+      status: ExecutionStatus.RUNNING,
+      cancelRequested: false,
+      startedAt: '2025-08-05T20:00:00.000Z',
+    } as EsWorkflowExecution;
+
+    mockNode = {
+      id: 'node1',
+      stepId: 'test-step-id',
+      stepType: 'data.set',
+    } as GraphNodeUnion;
+
+    const emptyStackFrames: StackFrame[] = [];
+    const scopeStack = WorkflowScopeStack.fromStackFrames(emptyStackFrames);
+
+    mockStepExecutionRuntime = {
+      stepExecutionId: 'test-step-execution-id',
+      node: mockNode,
+      scopeStack,
+      abortController: new AbortController(),
+    } as unknown as jest.Mocked<StepExecutionRuntime>;
+
+    mockNodeImplementation = {
+      run: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<NodeImplementation>;
+
+    mockParams = {
+      workflowRuntime: {
+        getCurrentNode: jest.fn().mockReturnValue(mockNode),
+        exitScope: jest.fn(),
+        enterScope: jest.fn(),
+        getWorkflowExecution: jest.fn().mockReturnValue(workflowExecution),
+        getCurrentNodeScope: jest.fn().mockReturnValue(emptyStackFrames),
+        setWorkflowError: jest.fn(),
+        saveState: jest.fn().mockResolvedValue(undefined),
+      },
+      stepExecutionRuntimeFactory: {
+        createStepExecutionRuntime: jest.fn().mockReturnValue(mockStepExecutionRuntime),
+      },
+      nodesFactory: {
+        create: jest.fn().mockReturnValue(mockNodeImplementation),
+      },
+      workflowExecutionState: {
+        getWorkflowExecution: jest.fn().mockReturnValue(workflowExecution),
+      } as unknown as jest.Mocked<WorkflowExecutionState>,
+    } as unknown as jest.Mocked<WorkflowExecutionLoopParams>;
+  });
+
+  describe('when workflow is running', () => {
+    it('should start step execution immediately without blocking ES call', async () => {
+      await runNode(mockParams);
+
+      // Verify that step execution started
+      expect(mockNodeImplementation.run).toHaveBeenCalled();
+
+      // Verify the in-memory status check was used (not an ES call)
+      expect(mockParams.workflowRuntime.getWorkflowExecution).toHaveBeenCalled();
+
+      // Verify step execution runtime was created
+      expect(
+        mockParams.stepExecutionRuntimeFactory.createStepExecutionRuntime
+      ).toHaveBeenCalledWith({
+        nodeId: 'node1',
+        stackFrames: [],
+      });
+
+      // Verify node implementation was created
+      expect(mockParams.nodesFactory.create).toHaveBeenCalledWith(mockStepExecutionRuntime);
+    });
+
+    it('should run monitoring in parallel with step execution', async () => {
+      await runNode(mockParams);
+
+      // Verify monitoring was started
+      expect(mockRunStackMonitor).toHaveBeenCalledWith(
+        mockParams,
+        mockStepExecutionRuntime,
+        expect.any(AbortController)
+      );
+
+      // Verify both step and monitoring ran
+      expect(mockNodeImplementation.run).toHaveBeenCalled();
+    });
+
+    it('should save state after step execution', async () => {
+      await runNode(mockParams);
+
+      expect(mockParams.workflowRuntime.saveState).toHaveBeenCalled();
+    });
+  });
+
+  describe('when workflow is cancelled before step starts', () => {
+    it('should skip step execution if workflow status is not RUNNING', async () => {
+      // Set workflow status to CANCELLED
+      workflowExecution.status = ExecutionStatus.CANCELLED;
+
+      await runNode(mockParams);
+
+      // Verify step execution was skipped
+      expect(mockNodeImplementation.run).not.toHaveBeenCalled();
+
+      // Verify in-memory check was performed
+      expect(mockParams.workflowRuntime.getWorkflowExecution).toHaveBeenCalled();
+
+      // Verify state was still saved
+      expect(mockParams.workflowRuntime.saveState).toHaveBeenCalled();
+    });
+
+    it('should skip step execution if workflow status is FAILED', async () => {
+      workflowExecution.status = ExecutionStatus.FAILED;
+
+      await runNode(mockParams);
+
+      expect(mockNodeImplementation.run).not.toHaveBeenCalled();
+    });
+
+    it('should skip step execution if workflow status is COMPLETED', async () => {
+      workflowExecution.status = ExecutionStatus.COMPLETED;
+
+      await runNode(mockParams);
+
+      expect(mockNodeImplementation.run).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when there is no current node', () => {
+    it('should return early without executing step', async () => {
+      (mockParams.workflowRuntime.getCurrentNode as jest.Mock).mockReturnValue(undefined);
+
+      await runNode(mockParams);
+
+      expect(mockNodeImplementation.run).not.toHaveBeenCalled();
+      expect(mockParams.workflowRuntime.saveState).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle step execution errors', async () => {
+      const error = new Error('Step execution failed');
+      mockNodeImplementation.run.mockRejectedValue(error);
+
+      await runNode(mockParams);
+
+      expect(mockParams.workflowRuntime.setWorkflowError).toHaveBeenCalledWith(error);
+      expect(mockParams.workflowRuntime.saveState).toHaveBeenCalled();
+    });
+
+    it('should call catchError when error occurs', async () => {
+      const error = new Error('Step execution failed');
+      (mockNodeImplementation.run as jest.Mock).mockRejectedValue(error);
+
+      await runNode(mockParams);
+
+      expect(mockCatchError).toHaveBeenCalledWith(mockParams, mockStepExecutionRuntime);
+    });
+  });
+
+  describe('monitoring integration', () => {
+    it('should abort monitoring when step completes', async () => {
+      await runNode(mockParams);
+
+      // The monitoring abort controller should be aborted in the finally block
+      // We can't directly test this, but we can verify the flow completed
+      expect(mockParams.workflowRuntime.saveState).toHaveBeenCalled();
+    });
+
+    it('should handle monitoring preventing step execution via abort signal', async () => {
+      // Mock monitoring that aborts immediately
+      mockRunStackMonitor.mockImplementation(
+        async (
+          _params: WorkflowExecutionLoopParams,
+          _stepExecutionRuntime: StepExecutionRuntime,
+          monitorAbortController: AbortController
+        ) => {
+          monitorAbortController.abort();
+        }
+      );
+
+      await runNode(mockParams);
+
+      // Step should still be created but may not run depending on timing
+      expect(mockParams.stepExecutionRuntimeFactory.createStepExecutionRuntime).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.test.ts
@@ -11,15 +11,15 @@ import type { EsWorkflowExecution, StackFrame } from '@kbn/workflows';
 import { ExecutionStatus } from '@kbn/workflows';
 import type { GraphNodeUnion } from '@kbn/workflows/graph';
 
+import * as catchErrorModule from './catch_error';
+import * as handleExecutionDelayModule from './handle_execution_delay';
 import { runNode } from './run_node';
+import * as runStackMonitorModule from './run_stack_monitor/run_stack_monitor';
 import type { WorkflowExecutionLoopParams } from './types';
 import type { NodeImplementation } from '../step/node_implementation';
 import type { StepExecutionRuntime } from '../workflow_context_manager/step_execution_runtime';
 import type { WorkflowExecutionState } from '../workflow_context_manager/workflow_execution_state';
 import { WorkflowScopeStack } from '../workflow_context_manager/workflow_scope_stack';
-import * as catchErrorModule from './catch_error';
-import * as handleExecutionDelayModule from './handle_execution_delay';
-import * as runStackMonitorModule from './run_stack_monitor/run_stack_monitor';
 
 jest.mock('./run_stack_monitor/run_stack_monitor');
 jest.mock('./catch_error');
@@ -51,7 +51,7 @@ describe('runNode', () => {
         // Don't abort by default - let the step run to completion
       }
     );
-    
+
     mockCatchError.mockResolvedValue(undefined);
     mockHandleExecutionDelay.mockResolvedValue(undefined);
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
@@ -80,9 +80,9 @@ export async function runNode(params: WorkflowExecutionLoopParams): Promise<void
 
     // Sometimes monitoring can prevent the step from running, e.g. when the workflow is cancelled, timeout occured right before running step, etc.
     if (!monitorAbortController.signal.aborted) {
-      runStepPromise = nodeImplementation.run().then(
-        () => stepExecutionRuntime && handleExecutionDelay(params, stepExecutionRuntime)
-      );
+      runStepPromise = nodeImplementation
+        .run()
+        .then(() => stepExecutionRuntime && handleExecutionDelay(params, stepExecutionRuntime));
     }
 
     await Promise.race([runMonitorPromise, runStepPromise]);

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
@@ -80,7 +80,7 @@ export async function runNode(params: WorkflowExecutionLoopParams): Promise<void
 
     // Sometimes monitoring can prevent the step from running, e.g. when the workflow is cancelled, timeout occured right before running step, etc.
     if (!monitorAbortController.signal.aborted) {
-      runStepPromise = Promise.resolve(nodeImplementation.run()).then(
+      runStepPromise = nodeImplementation.run().then(
         () => stepExecutionRuntime && handleExecutionDelay(params, stepExecutionRuntime)
       );
     }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
@@ -10,7 +10,6 @@
 import { ExecutionStatus } from '@kbn/workflows';
 import { catchError } from './catch_error';
 import { handleExecutionDelay } from './handle_execution_delay';
-import { processNodeStackMonitoring } from './run_stack_monitor/process_node_stack_monitoring';
 import { runStackMonitor } from './run_stack_monitor/run_stack_monitor';
 import type { WorkflowExecutionLoopParams } from './types';
 import type { StepExecutionRuntime } from '../workflow_context_manager/step_execution_runtime';
@@ -20,13 +19,14 @@ import type { StepExecutionRuntime } from '../workflow_context_manager/step_exec
  *
  * This function orchestrates the execution of a workflow node by:
  * 1. Creating a context manager for the current step
- * 2. Creating and running the node implementation
- * 3. Running monitoring in parallel to handle cancellation, timeouts, and other control flow
- * 4. Managing error handling and state persistence
+ * 2. Checking in-memory workflow state to skip execution if already cancelled
+ * 3. Creating and running the node implementation
+ * 4. Running monitoring in parallel to handle cancellation, timeouts, and other control flow
+ * 5. Managing error handling and state persistence
  *
  * The execution uses a race condition between the step execution and monitoring to ensure
- * proper cancellation and timeout handling. Monitoring can prevent step execution if
- * conditions like workflow cancellation or timeout occur before the step runs.
+ * proper cancellation and timeout handling. The async monitoring loop runs every 500ms in
+ * parallel with step execution to detect cancellations without blocking step startup.
  *
  * @param params - The workflow execution loop parameters containing:
  *   - workflowRuntime: Runtime instance managing workflow state and navigation
@@ -58,14 +58,8 @@ export async function runNode(params: WorkflowExecutionLoopParams): Promise<void
     });
 
     /**
-     * Before running the node, we run monitoring once to handle cases where
-     * the step should not be executed at all, e.g., if the workflow has been
-     * cancelled or a timeout has already occurred.
-     */
-    await processNodeStackMonitoring(params, stepExecutionRuntime);
-
-    /**
-     * If the workflow is no longer running after processing the node stack (e.g., cancelled), we skip executing the step.
+     * Check in-memory workflow state to skip execution if workflow is no longer running.
+     * This is instant (no ES call) and catches cancellations that were already detected.
      */
     if (params.workflowRuntime.getWorkflowExecution().status !== ExecutionStatus.RUNNING) {
       return;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
@@ -72,15 +72,15 @@ export async function runNode(params: WorkflowExecutionLoopParams): Promise<void
      * Run monitoring in parallel with step execution to handle:
      * - Cancellation detection
      * - Timeout monitoring
-     * - Custom monitoring logic for monitorable nodes
+     * - Custom monitoring logic for monitor-able nodes
      * The order of these promises is important - we want to stop monitoring
      */
     const runMonitorPromise = runStackMonitor(params, stepExecutionRuntime, monitorAbortController);
     let runStepPromise: Promise<void> = Promise.resolve();
 
-    // Sometimes monitoring can prevent the step from running, e.g. when the workflow is cancelled, timeout occured right before running step, etc.
+    // Sometimes monitoring can prevent the step from running, e.g. when the workflow is cancelled, timeout occurred right before running step, etc.
     if (!monitorAbortController.signal.aborted) {
-      runStepPromise = nodeImplementation.run().then(
+      runStepPromise = Promise.resolve(nodeImplementation.run()).then(
         () => stepExecutionRuntime && handleExecutionDelay(params, stepExecutionRuntime)
       );
     }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_node.ts
@@ -60,6 +60,8 @@ export async function runNode(params: WorkflowExecutionLoopParams): Promise<void
     /**
      * Check in-memory workflow state to skip execution if workflow is no longer running.
      * This is instant (no ES call) and catches cancellations that were already detected.
+     * When cancelRequested is true, status is always updated to CANCELLED, so this check
+     * covers both cancellation and other terminal states (COMPLETED, FAILED, etc.).
      */
     if (params.workflowRuntime.getWorkflowExecution().status !== ExecutionStatus.RUNNING) {
       return;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_stack_monitor/run_stack_monitor.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_execution_loop/run_stack_monitor/run_stack_monitor.ts
@@ -68,6 +68,14 @@ export async function runStackMonitor(
   monitorAbortController: AbortController
 ): Promise<void> {
   while (!monitorAbortController.signal.aborted) {
+    // Check cancellation immediately before waiting - ensures fast cancellation detection
+    await processNodeStackMonitoring(params, monitoredStepExecutionRuntime);
+
+    // If monitoring was aborted during the check, exit early
+    if (monitorAbortController.signal.aborted) {
+      return;
+    }
+
     try {
       await abortableTimeout(500, monitorAbortController.signal);
     } catch (error) {
@@ -78,7 +86,5 @@ export async function runStackMonitor(
 
       throw error;
     }
-
-    await processNodeStackMonitoring(params, monitoredStepExecutionRuntime);
   }
 }


### PR DESCRIPTION
## Summary

The workflow execution engine performed a blocking Elasticsearch call before every step to check for cancellation, causing delays when ES was slow/unavailable. This removes the synchronous check and relies solely on the existing async monitoring loop (500ms interval).

## Changes

**`run_node.ts`**
- Removed blocking `await processNodeStackMonitoring()` call before step execution
- Kept instant in-memory state check to catch already-detected cancellations
- Updated JSDoc to reflect async-only monitoring approach

**Before:**
```typescript
// Blocking ES call before every step
await processNodeStackMonitoring(params, stepExecutionRuntime);
if (params.workflowRuntime.getWorkflowExecution().status !== ExecutionStatus.RUNNING) {
  return;
}
```

**After:**
```typescript
// Instant in-memory check only
if (params.workflowRuntime.getWorkflowExecution().status !== ExecutionStatus.RUNNING) {
  return;
}
```

**`run_node.test.ts`** (new)
- Added 11 test cases covering immediate step execution, in-memory state checks, async monitoring integration, and error handling

## Impact

- Steps start immediately without ES roundtrip (eliminates potential 9-30s per-step delay)
- One less blocking ES call per step (reduced load)
- Cancellation detection now happens within 500ms via async loop (acceptable trade-off for performance gain)
- Steps supporting cancellation still abort immediately via AbortController

## Why is the cancellation check executed before the 500 ms delay now?
**The Problem:**
- Each step gets a new monitoring loop that checks cancellation every 500ms
- If a step completes in < 500ms, the monitoring loop never checks cancellation before the step finishes
- This created a cascading issue: Step 1 misses cancellation → Step 2 misses cancellation → Step 3 misses cancellation, etc.
**The Solution:**
- Immediate check: Monitoring loop checks cancellation at the start of each cycle (before delay)
- Update status in memory so it'll be available for next step