### PR TITLE
Fix Create CSPM GCP Credentials for Agentless

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/gcp_credentials_form/gcp_credentials_form_agentless.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/gcp_credentials_form/gcp_credentials_form_agentless.test.tsx
@@ -339,7 +339,7 @@ describe('GcpCredentialsFormAgentless', () => {
 
       expect(screen.getByTestId('guide-organization-state')).toHaveTextContent('true');
       expect(screen.getByTestId('guide-command-text')).toHaveTextContent(
-        'gcloud config set project <PROJECT_ID> && ORG_ID=<ORG_ID_VALUE> && ./deploy_service_account.sh'
+        'gcloud config set project <PROJECT_ID> && ORG_ID=<ORG_ID_VALUE> ./deploy_service_account.sh'
       );
     });
   });

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/gcp_credentials_form/gcp_credentials_form_agentless.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/fleet_extensions/gcp_credentials_form/gcp_credentials_form_agentless.tsx
@@ -72,8 +72,8 @@ export const GcpCredentialsFormAgentless = ({
     SUPPORTED_TEMPLATES_URL_FROM_PACKAGE_INFO_INPUT_VARS.CLOUD_SHELL_URL
   )?.replace(TEMPLATE_URL_ACCOUNT_TYPE_ENV_VAR, accountType);
 
-  const commandText = `gcloud config set project ${
-    isOrganization ? `<PROJECT_ID> && ORG_ID=<ORG_ID_VALUE> && ` : `<PROJECT_ID> && `
+  const commandText = `gcloud config set project <PROJECT_ID> && ${
+    isOrganization ? `ORG_ID=<ORG_ID_VALUE> ` : ``
   }./deploy_service_account.sh`;
 
   return (


### PR DESCRIPTION
## Summary

Updated the deployment command to ensure `ORG_ID` is passed as an environment variable rather than a local shell variable.

### Technical Change
Old: `ORG_ID=val && ./script.sh` (Variable stayed in the parent shell).
New: `ORG_ID=val ./script.sh` (Variable is exported to the script's environment).

### Related
- https://github.com/elastic/kibana/pull/243504

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



