### PR TITLE
[Profiling] Max call stack exception in Flamegraph

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/public/components/flamegraph/flamegraph_tooltip.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/flamegraph/flamegraph_tooltip.tsx
@@ -19,8 +19,8 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import { isNumber } from 'lodash';
-import React from 'react';
+import { isEqual, isNumber, omit } from 'lodash';
+import React, { memo } from 'react';
 import { useCalculateImpactEstimate } from '../../hooks/use_calculate_impact_estimates';
 import { asCost } from '../../utils/formatters/as_cost';
 import { asPercentage } from '../../utils/formatters/as_percentage';
@@ -51,7 +51,7 @@ interface Props {
   totalSeconds: number;
 }
 
-export function FlameGraphTooltip({
+function FlameGraphTooltipComponent({
   annualCO2KgsInclusive,
   annualCostsUSDInclusive,
   baselineScaleFactor,
@@ -238,3 +238,11 @@ export function FlameGraphTooltip({
     </TooltipContainer>
   );
 }
+
+// Memoize the component to prevent re-renders when props haven't changed
+// This was added to prevents recalculation when mouse moves but tooltip data is the same
+const arePropsEqual = (prevProps: Props, nextProps: Props): boolean => {
+  return isEqual(omit(prevProps, 'onShowMoreClick'), omit(nextProps, 'onShowMoreClick'));
+};
+
+export const FlameGraphTooltip = memo(FlameGraphTooltipComponent, arePropsEqual);

--- a/x-pack/solutions/observability/plugins/profiling/public/hooks/use_calculate_impact_estimates.test.ts
+++ b/x-pack/solutions/observability/plugins/profiling/public/hooks/use_calculate_impact_estimates.test.ts
@@ -92,4 +92,110 @@ describe('useCalculateImpactEstimate', () => {
       annualizedCoreSeconds: 17520000,
     });
   });
+
+  it('handles division by zero when totalSamples is 0', () => {
+    const calculateImpactEstimates = useCalculateImpactEstimate();
+    const { selfCPU, totalCPU, totalSamples } = calculateImpactEstimates({
+      countExclusive: 100,
+      countInclusive: 200,
+      totalSamples: 0,
+      totalSeconds: 15 * 60, // 15m
+    });
+
+    expect(totalCPU).toEqual({
+      percentage: 0,
+      coreSeconds: 0,
+      annualizedCoreSeconds: 0,
+    });
+
+    expect(selfCPU).toEqual({
+      percentage: 0,
+      coreSeconds: 0,
+      annualizedCoreSeconds: 0,
+    });
+
+    expect(totalSamples).toEqual({
+      percentage: 0,
+      coreSeconds: 0,
+      annualizedCoreSeconds: 0,
+    });
+  });
+
+  it('handles division by zero when totalSeconds is 0', () => {
+    const calculateImpactEstimates = useCalculateImpactEstimate();
+    const { selfCPU, totalCPU, totalSamples } = calculateImpactEstimates({
+      countExclusive: 100,
+      countInclusive: 200,
+      totalSamples: 9500,
+      totalSeconds: 0,
+    });
+
+    expect(totalCPU).toEqual({
+      percentage: 0,
+      coreSeconds: 0,
+      annualizedCoreSeconds: 0,
+    });
+
+    expect(selfCPU).toEqual({
+      percentage: 0,
+      coreSeconds: 0,
+      annualizedCoreSeconds: 0,
+    });
+
+    expect(totalSamples).toEqual({
+      percentage: 0,
+      coreSeconds: 0,
+      annualizedCoreSeconds: 0,
+    });
+  });
+
+  it('handles division by zero when both totalSamples and totalSeconds are 0', () => {
+    const calculateImpactEstimates = useCalculateImpactEstimate();
+    const { selfCPU, totalCPU, totalSamples } = calculateImpactEstimates({
+      countExclusive: 100,
+      countInclusive: 200,
+      totalSamples: 0,
+      totalSeconds: 0,
+    });
+
+    expect(totalCPU).toEqual({
+      percentage: 0,
+      coreSeconds: 0,
+      annualizedCoreSeconds: 0,
+    });
+
+    expect(selfCPU).toEqual({
+      percentage: 0,
+      coreSeconds: 0,
+      annualizedCoreSeconds: 0,
+    });
+
+    expect(totalSamples).toEqual({
+      percentage: 0,
+      coreSeconds: 0,
+      annualizedCoreSeconds: 0,
+    });
+  });
+
+  it('handles zero samples with non-zero totalSamples', () => {
+    const calculateImpactEstimates = useCalculateImpactEstimate();
+    const { selfCPU, totalCPU } = calculateImpactEstimates({
+      countExclusive: 0,
+      countInclusive: 0,
+      totalSamples: 9500,
+      totalSeconds: 15 * 60, // 15m
+    });
+
+    expect(totalCPU).toEqual({
+      percentage: 0,
+      coreSeconds: 0,
+      annualizedCoreSeconds: 0,
+    });
+
+    expect(selfCPU).toEqual({
+      percentage: 0,
+      coreSeconds: 0,
+      annualizedCoreSeconds: 0,
+    });
+  });
 });

--- a/x-pack/solutions/observability/plugins/profiling/public/hooks/use_calculate_impact_estimates.ts
+++ b/x-pack/solutions/observability/plugins/profiling/public/hooks/use_calculate_impact_estimates.ts
@@ -27,6 +27,14 @@ export function useCalculateImpactEstimate() {
     totalSamples: number;
     totalSeconds: number;
   }) {
+    if (totalSamples === 0 || totalSeconds === 0) {
+      return {
+        percentage: 0,
+        coreSeconds: 0,
+        annualizedCoreSeconds: 0,
+      };
+    }
+
     const annualizedScaleUp = ANNUAL_SECONDS / totalSeconds;
     const totalCoreSeconds = totalSamples / 19;
     const percentage = samples / totalSamples;

--- a/x-pack/solutions/observability/plugins/profiling/public/utils/formatters/as_number.test.ts
+++ b/x-pack/solutions/observability/plugins/profiling/public/utils/formatters/as_number.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import { asNumber } from './as_number';
+import { NOT_AVAILABLE_LABEL } from '../../../common';
 
 describe('asNumber', () => {
   it('rounds numbers appropriately', () => {
@@ -27,5 +28,11 @@ describe('asNumber', () => {
     expect(asNumber(2.4991e7)).toBe('24.99m');
 
     expect(asNumber(9e9)).toBe('9b');
+  });
+
+  it('handles non-finite values', () => {
+    expect(asNumber(Infinity)).toBe(NOT_AVAILABLE_LABEL);
+    expect(asNumber(-Infinity)).toBe(NOT_AVAILABLE_LABEL);
+    expect(asNumber(NaN)).toBe(NOT_AVAILABLE_LABEL);
   });
 });

--- a/x-pack/solutions/observability/plugins/profiling/public/utils/formatters/as_number.ts
+++ b/x-pack/solutions/observability/plugins/profiling/public/utils/formatters/as_number.ts
@@ -8,7 +8,7 @@
 import { NOT_AVAILABLE_LABEL } from '../../../common';
 
 export function asNumber(value: number): string {
-  if (isNaN(value)) {
+  if (isNaN(value) || !Number.isFinite(value)) {
     return NOT_AVAILABLE_LABEL;
   }
 

--- a/x-pack/solutions/observability/plugins/profiling/public/utils/formatters/as_percentage.test.ts
+++ b/x-pack/solutions/observability/plugins/profiling/public/utils/formatters/as_percentage.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { asPercentage } from './as_percentage';
+import { NOT_AVAILABLE_LABEL } from '../../../common';
+
+describe('asPercentage', () => {
+  it('handles non-finite values', () => {
+    expect(asPercentage(Infinity)).toBe(`${NOT_AVAILABLE_LABEL}%`);
+    expect(asPercentage(-Infinity)).toBe(`${NOT_AVAILABLE_LABEL}%`);
+    expect(asPercentage(NaN)).toBe(`${NOT_AVAILABLE_LABEL}%`);
+  });
+
+  it('formats normal percentage values', () => {
+    expect(asPercentage(0)).toBe('0%');
+    expect(asPercentage(0.1)).toBe('10%');
+    expect(asPercentage(0.5)).toBe('50%');
+    expect(asPercentage(1)).toBe('100%');
+    expect(asPercentage(0.123)).toBe('12.3%');
+    expect(asPercentage(0.001)).toBe('0.1%');
+  });
+
+  it('handles large percentage values', () => {
+    expect(asPercentage(10)).toBe('1k%');
+    expect(asPercentage(100)).toBe('10k%');
+  });
+});


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/249150

## Summary

- Fixed FlameGraph crashing in certain scenarios by adding support for `Infinity` and `NaN` to the `asNumber` function.
- Added some protections to the FlameGraph in case it tries to divide by zero.
- Optimized FlameGraph Tooltip by making it not re-render every time the user moves it's mouse.

## Unit tests

`yarn test:jest x-pack/solutions/observability/plugins/profiling/public/hooks/use_calculate_impact_estimates.test.ts`

`yarn test:jest x-pack/solutions/observability/plugins/profiling/public/utils/formatters/as_number.test.ts`

`yarn test:jest x-pack/solutions/observability/plugins/profiling/public/utils/formatters/as_percentage.test.ts`



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.


- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->