### PR TITLE
[Obs Agent] add get_correlations tool

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -29,6 +29,7 @@ export const AGENT_BUILDER_BUILTIN_TOOLS: string[] = [
   `${internalNamespaces.observability}.get_log_change_points`,
   `${internalNamespaces.observability}.get_metric_change_points`,
   `${internalNamespaces.observability}.get_index_info`,
+  `${internalNamespaces.observability}.get_correlations`,
 
   // Dashboards
   'platform.dashboard.create_dashboard',

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/tools/get_correlations.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/tools/get_correlations.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { termQuery } from '@kbn/observability-plugin/server';
+import { ProcessorEvent } from '@kbn/observability-plugin/common';
+import type { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
+import { fetchDurationFieldCandidates } from '../../routes/correlations/queries/fetch_duration_field_candidates';
+import { fetchFieldValuePairs } from '../../routes/correlations/queries/fetch_field_value_pairs';
+import { fetchSignificantCorrelations } from '../../routes/correlations/queries/fetch_significant_correlations';
+import { SERVICE_NAME, TRANSACTION_NAME, TRANSACTION_TYPE } from '../../../common/es_fields/apm';
+import { fetchPValues } from '../../routes/correlations/queries/fetch_p_values';
+
+export async function getCorrelations({
+  apmEventClient,
+  start,
+  end,
+  kqlFilter = '',
+  type,
+  serviceName,
+  transactionName,
+  transactionType,
+  environment,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  kqlFilter?: string;
+  type: 'latency' | 'failures';
+  serviceName: string;
+  transactionName: string;
+  transactionType: string;
+  environment: string;
+}) {
+  const { fieldCandidates } = await fetchDurationFieldCandidates({
+    eventType: ProcessorEvent.transaction,
+    start,
+    end,
+    environment,
+    kuery: kqlFilter,
+    query: {
+      bool: {
+        filter: [
+          ...termQuery(SERVICE_NAME, serviceName),
+          ...termQuery(TRANSACTION_TYPE, transactionType),
+          ...termQuery(TRANSACTION_NAME, transactionName),
+        ],
+      },
+    },
+    apmEventClient,
+  });
+
+  if (type === 'failures') {
+    const significantCorrelations = await Promise.all(
+      fieldCandidates.map(async (fieldCandidate) => {
+        const failedTransactionCorrelations = await await fetchPValues({
+          apmEventClient,
+          start,
+          end,
+          environment,
+          kuery: kqlFilter,
+          query: {
+            bool: {
+              filter: [
+                ...termQuery(SERVICE_NAME, serviceName),
+                ...termQuery(TRANSACTION_TYPE, transactionType),
+                ...termQuery(TRANSACTION_NAME, transactionName),
+              ],
+            },
+          },
+          fieldCandidates: [fieldCandidate],
+        });
+        return failedTransactionCorrelations;
+      })
+    );
+    return significantCorrelations.filter(
+      (correlation) => correlation.failedTransactionsCorrelations.length > 0
+    );
+  } else {
+    const { fieldValuePairs } = await fetchFieldValuePairs({
+      apmEventClient,
+      eventType: ProcessorEvent.transaction,
+      start,
+      end,
+      environment,
+      kuery: kqlFilter,
+      query: {
+        bool: {
+          filter: [
+            ...termQuery(SERVICE_NAME, serviceName),
+            ...termQuery(TRANSACTION_TYPE, transactionType),
+            ...termQuery(TRANSACTION_NAME, transactionName),
+          ],
+        },
+      },
+      fieldCandidates,
+    });
+
+    const significantCorrelations = await Promise.all(
+      fieldValuePairs.map(async (fieldValuePair) => {
+        const latencyCorrelations = await fetchSignificantCorrelations({
+          apmEventClient,
+          start,
+          end,
+          environment,
+          kuery: kqlFilter,
+          query: {
+            bool: {
+              filter: [
+                ...termQuery(SERVICE_NAME, serviceName),
+                ...termQuery(TRANSACTION_TYPE, transactionType),
+                ...termQuery(TRANSACTION_NAME, transactionName),
+              ],
+            },
+          },
+          fieldValuePairs: [fieldValuePair],
+        });
+
+        return latencyCorrelations;
+      })
+    );
+
+    return significantCorrelations.filter((correlation) => !!correlation.fallbackResult);
+  }
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/data_registry/data_registry_types.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/data_registry/data_registry_types.ts
@@ -212,4 +212,16 @@ export interface ObservabilityAgentBuilderDataRegistryTypes {
     query: Record<string, unknown> | undefined;
     hostNames?: string[];
   }) => Promise<InfraHostsResponse>;
+
+  apmCorrelations: (params: {
+    request: KibanaRequest;
+    start: string;
+    end: string;
+    kqlFilter?: string;
+    type: 'latency' | 'failures';
+    serviceName: string;
+    transactionName: string;
+    transactionType: string;
+    environment: string;
+  }) => Promise<any>;
 }

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_correlations/README.md
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_correlations/README.md
@@ -1,0 +1,22 @@
+# get_correlations
+
+Detect
+
+## Examples
+
+### Get correlations
+
+```
+POST kbn://api/agent_builder/tools/_execute
+{
+  "tool_id": "observability.get_correlations",
+  "tool_params": {
+    "start": "now-1h",
+    "end": "now",
+    "serviceName": "my-service",
+    "transactionName": "GET /api/product",
+    "transactionType": "request",
+    "type": "failures"
+  }
+}
+```

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_correlations/handler.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_correlations/handler.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, KibanaRequest, Logger } from '@kbn/core/server';
+import type {
+  ObservabilityAgentBuilderPluginSetupDependencies,
+  ObservabilityAgentBuilderPluginStart,
+  ObservabilityAgentBuilderPluginStartDependencies,
+} from '../../types';
+import type { ObservabilityAgentBuilderDataRegistry } from '../../data_registry/data_registry';
+
+export async function getToolHandler({
+  core,
+  plugins,
+  request,
+  dataRegistry,
+  logger,
+  start,
+  end,
+  kqlFilter,
+  type,
+  serviceName,
+  transactionName,
+  transactionType,
+  environment,
+}: {
+  core: CoreSetup<
+    ObservabilityAgentBuilderPluginStartDependencies,
+    ObservabilityAgentBuilderPluginStart
+  >;
+  request: KibanaRequest;
+  dataRegistry: ObservabilityAgentBuilderDataRegistry;
+  plugins: ObservabilityAgentBuilderPluginSetupDependencies;
+  logger: Logger;
+  start: string;
+  end: string;
+  kqlFilter?: string;
+  type: 'latency' | 'failures';
+  serviceName: string;
+  transactionName: string;
+  transactionType: string;
+  environment: string;
+}) {
+  const correlations = await dataRegistry.getData('apmCorrelations', {
+    request,
+    start,
+    end,
+    kqlFilter,
+    type,
+    serviceName,
+    transactionName,
+    transactionType,
+    environment,
+  });
+
+  return correlations;
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_correlations/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/get_correlations/tool.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import type { CoreSetup, Logger } from '@kbn/core/server';
+import type { BuiltinToolDefinition, StaticToolRegistration } from '@kbn/agent-builder-server';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type {
+  ObservabilityAgentBuilderPluginSetupDependencies,
+  ObservabilityAgentBuilderPluginStart,
+  ObservabilityAgentBuilderPluginStartDependencies,
+} from '../../types';
+import { timeRangeSchemaRequired } from '../../utils/tool_schemas';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import { getToolHandler } from './handler';
+import type { ObservabilityAgentBuilderDataRegistry } from '../../data_registry/data_registry';
+
+export const OBSERVABILITY_GET_CORRELATIONS_TOOL_ID = 'observability.get_correlations';
+
+const getCorrelationsSchema = z.object({
+  ...timeRangeSchemaRequired,
+  kqlFilter: z.string().optional().describe('Optional KQL query to filter the trace documents'),
+  serviceName: z
+    .string()
+    .describe(
+      'Service name to analyze correlations for. Example: "my-service", "frontend", "checkout-api"'
+    ),
+  transactionName: z
+    .string()
+    .describe('Transaction name to analyze. Example: "POST /api/cart", "GET /api/products"'),
+  transactionType: z.string().describe('Transaction type to filter by'),
+  type: z
+    .enum(['latency', 'failures'])
+    .describe(
+      'Type of correlation analysis: "latency" finds field-value pairs correlated with slow transactions, "failures" finds field-value pairs correlated with failed transactions'
+    ),
+  environment: z
+    .string()
+    .optional()
+    .describe(
+      "Optional filter the services by the environments that they are running in. e.g., production. Defaults to 'ENVIRONMENT_ALL'"
+    ),
+});
+
+export function createGetCorrelationsTool({
+  core,
+  dataRegistry,
+  plugins,
+  logger,
+}: {
+  core: CoreSetup<
+    ObservabilityAgentBuilderPluginStartDependencies,
+    ObservabilityAgentBuilderPluginStart
+  >;
+  dataRegistry: ObservabilityAgentBuilderDataRegistry;
+  plugins: ObservabilityAgentBuilderPluginSetupDependencies;
+  logger: Logger;
+}): StaticToolRegistration<typeof getCorrelationsSchema> {
+  const toolDefinition: BuiltinToolDefinition<typeof getCorrelationsSchema> = {
+    id: OBSERVABILITY_GET_CORRELATIONS_TOOL_ID,
+    type: ToolType.builtin,
+    description: `Identifies statistically significant field-value pairs correlated with latency or failures in APM transactions.`,
+    schema: getCorrelationsSchema,
+    tags: ['observability'],
+    availability: {
+      cacheMode: 'space',
+      handler: async ({ request }) => {
+        return getAgentBuilderResourceAvailability({ core, request, logger });
+      },
+    },
+    handler: async (
+      {
+        start,
+        end,
+        kqlFilter,
+        type,
+        serviceName,
+        transactionName,
+        transactionType,
+        environment = 'ENVIRONMENT_ALL',
+      },
+      { request }
+    ) => {
+      try {
+        const correlations = await getToolHandler({
+          core,
+          plugins,
+          request,
+          dataRegistry,
+          logger,
+          start,
+          end,
+          kqlFilter,
+          type,
+          serviceName,
+          transactionName,
+          transactionType,
+          environment,
+        });
+
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data: {
+                correlations,
+              },
+            },
+          ],
+        };
+      } catch (error) {
+        logger.error(`Error getting correlations: ${error.message}`);
+        logger.debug(error);
+
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Failed to fetch correlations: ${error.message}`,
+                stack: error.stack,
+              },
+            },
+          ],
+        };
+      }
+    },
+  };
+
+  return toolDefinition;
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/register_tools.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/register_tools.ts
@@ -50,6 +50,10 @@ import {
   createGetMetricChangePointsTool,
 } from './get_metric_change_points/tool';
 import { OBSERVABILITY_GET_INDEX_INFO_TOOL_ID, createGetIndexInfoTool } from './get_index_info';
+import {
+  OBSERVABILITY_GET_CORRELATIONS_TOOL_ID,
+  createGetCorrelationsTool,
+} from './get_correlations/tool';
 
 const PLATFORM_TOOL_IDS = [
   platformCoreTools.search,
@@ -72,6 +76,7 @@ const OBSERVABILITY_TOOL_IDS = [
   OBSERVABILITY_GET_LOG_CHANGE_POINTS_TOOL_ID,
   OBSERVABILITY_GET_METRIC_CHANGE_POINTS_TOOL_ID,
   OBSERVABILITY_GET_INDEX_INFO_TOOL_ID,
+  OBSERVABILITY_GET_CORRELATIONS_TOOL_ID,
 ];
 
 export const OBSERVABILITY_AGENT_TOOL_IDS = [...PLATFORM_TOOL_IDS, ...OBSERVABILITY_TOOL_IDS];
@@ -103,6 +108,7 @@ export async function registerTools({
     createGetLogChangePointsTool({ core, plugins, logger }),
     createGetMetricChangePointsTool({ core, plugins, logger }),
     createGetIndexInfoTool({ core, plugins, logger }),
+    createGetCorrelationsTool({ core, dataRegistry, plugins, logger }),
   ];
 
   for (const tool of observabilityTools) {


### PR DESCRIPTION
## Summary

This PR adds the get_correlation tool, which identifies statistically significant field-value pairs correlated with latency or failures in APM transactions.

Dependency: [Correlations API for observability metrics #15](https://github.com/elastic/observability-aiops/issues/15)
