### PR TITLE
[Search] Add descriptions to semantic_text field inference endpoint select

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.helpers.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.helpers.tsx
@@ -26,10 +26,30 @@ export const createMockLocator = () => ({
 export const mockResendRequest = jest.fn();
 
 export const DEFAULT_ENDPOINTS: InferenceAPIConfigResponse[] = [
-  { inference_id: '.preconfigured-elser', task_type: 'sparse_embedding' },
-  { inference_id: '.preconfigured-e5', task_type: 'text_embedding' },
-  { inference_id: 'endpoint-1', task_type: 'text_embedding' },
-  { inference_id: 'endpoint-2', task_type: 'sparse_embedding' },
+  {
+    inference_id: '.preconfigured-elser',
+    task_type: 'sparse_embedding',
+    service: 'elastic',
+    service_settings: { model_id: 'elser' },
+  },
+  {
+    inference_id: '.preconfigured-e5',
+    task_type: 'text_embedding',
+    service: 'elastic',
+    service_settings: { model_id: 'e5' },
+  },
+  {
+    inference_id: 'endpoint-1',
+    task_type: 'text_embedding',
+    service: 'openai',
+    service_settings: { model_id: 'text-embedding-3-large' },
+  },
+  {
+    inference_id: 'endpoint-2',
+    task_type: 'sparse_embedding',
+    service: 'elastic',
+    service_settings: { model_id: 'elser' },
+  },
 ] as InferenceAPIConfigResponse[];
 
 export const defaultProps: SelectInferenceIdProps = {

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -94,31 +94,42 @@ jest.mock('../../../public/application/components/mappings_editor/mappings_state
   useDispatch: () => mockDispatch,
 }));
 
-const MockInferenceFlyoutWrapper = ({
-  onFlyoutClose,
-  onSubmitSuccess,
-}: {
-  onFlyoutClose: () => void;
-  onSubmitSuccess: (id: string) => void;
-  http?: unknown;
-  toasts?: unknown;
-  isEdit?: boolean;
-  enforceAdaptiveAllocations?: boolean;
-}) => (
-  <div data-test-subj="inference-flyout-wrapper">
-    <button data-test-subj="mock-flyout-close" onClick={onFlyoutClose}>
-      Close Flyout
-    </button>
-    <button data-test-subj="mock-flyout-submit" onClick={() => onSubmitSuccess('new-endpoint-id')}>
-      Submit
-    </button>
-  </div>
-);
+jest.mock('@kbn/inference-endpoint-ui-common', () => {
+  const SERVICE_PROVIDERS = {
+    elastic: { name: 'Elastic' },
+    openai: { name: 'OpenAI' },
+  };
 
-jest.mock('@kbn/inference-endpoint-ui-common', () => ({
-  __esModule: true,
-  default: MockInferenceFlyoutWrapper,
-}));
+  const MockInferenceFlyoutWrapper = ({
+    onFlyoutClose,
+    onSubmitSuccess,
+  }: {
+    onFlyoutClose: () => void;
+    onSubmitSuccess: (id: string) => void;
+    http?: unknown;
+    toasts?: unknown;
+    isEdit?: boolean;
+    enforceAdaptiveAllocations?: boolean;
+  }) => (
+    <div data-test-subj="inference-flyout-wrapper">
+      <button data-test-subj="mock-flyout-close" onClick={onFlyoutClose}>
+        Close Flyout
+      </button>
+      <button
+        data-test-subj="mock-flyout-submit"
+        onClick={() => onSubmitSuccess('new-endpoint-id')}
+      >
+        Submit
+      </button>
+    </div>
+  );
+
+  return {
+    __esModule: true,
+    default: MockInferenceFlyoutWrapper,
+    SERVICE_PROVIDERS,
+  };
+});
 
 jest.mock('../../../public/application/services/api', () => ({
   ...jest.requireActual('../../../public/application/services/api'),
@@ -414,9 +425,24 @@ describe('SelectInferenceId', () => {
       it('SHOULD prioritize .elser-2-elastic over other endpoints IF has enterprise license', async () => {
         setupInferenceEndpointsMocks({
           data: [
-            { inference_id: '.elser-2-elastic', task_type: 'sparse_embedding' },
-            { inference_id: '.preconfigured-elser', task_type: 'sparse_embedding' },
-            { inference_id: 'endpoint-1', task_type: 'text_embedding' },
+            {
+              inference_id: '.elser-2-elastic',
+              task_type: 'sparse_embedding',
+              service: 'elastic',
+              service_settings: { model_id: 'elser-2-elastic' },
+            },
+            {
+              inference_id: '.preconfigured-elser',
+              task_type: 'sparse_embedding',
+              service: 'elastic',
+              service_settings: { model_id: 'elser' },
+            },
+            {
+              inference_id: 'endpoint-1',
+              task_type: 'text_embedding',
+              service: 'openai',
+              service_settings: { model_id: 'text-embedding-3-large' },
+            },
           ] as InferenceAPIConfigResponse[],
         });
 
@@ -432,9 +458,24 @@ describe('SelectInferenceId', () => {
 
         setupInferenceEndpointsMocks({
           data: [
-            { inference_id: '.elser-2-elastic', task_type: 'sparse_embedding' },
-            { inference_id: '.preconfigured-elser', task_type: 'sparse_embedding' },
-            { inference_id: 'endpoint-1', task_type: 'text_embedding' },
+            {
+              inference_id: '.elser-2-elastic',
+              task_type: 'sparse_embedding',
+              service: 'elastic',
+              service_settings: { model_id: 'elser-2-elastic' },
+            },
+            {
+              inference_id: '.preconfigured-elser',
+              task_type: 'sparse_embedding',
+              service: 'elastic',
+              service_settings: { model_id: 'elser' },
+            },
+            {
+              inference_id: 'endpoint-1',
+              task_type: 'text_embedding',
+              service: 'openai',
+              service_settings: { model_id: 'text-embedding-3-large' },
+            },
           ] as InferenceAPIConfigResponse[],
         });
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -168,19 +168,16 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
 
   const selectedOptionLabel = options.find((option) => option.checked)?.label;
 
-  const renderEndpointOption = useCallback(
-    (option: EuiSelectableOption<EndpointOptionData>, searchValue: string) => {
-      return (
-        <>
-          <EuiText size="s">{option.label}</EuiText>
-          <EuiText size="xs" color="subdued" className="eui-displayBlock">
-            <small>{option.description}</small>
-          </EuiText>
-        </>
-      );
-    },
-    []
-  );
+  const renderEndpointOption = useCallback((option: EuiSelectableOption<EndpointOptionData>) => {
+    return (
+      <>
+        <EuiText size="s">{option.label}</EuiText>
+        <EuiText size="xs" color="subdued" className="eui-displayBlock">
+          <small>{option.description}</small>
+        </EuiText>
+      </>
+    );
+  }, []);
 
   /**
    * Auto-select default inference endpoint when:

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -45,6 +45,10 @@ type SelectInferenceIdContentProps = SelectInferenceIdProps & {
   value: string;
 };
 
+interface EndpointOptionData {
+  description: string;
+}
+
 export const SelectInferenceId: React.FC<SelectInferenceIdProps> = ({
   'data-test-subj': dataTestSubj,
 }: SelectInferenceIdProps) => {
@@ -116,13 +120,15 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
    * Only includes endpoints compatible with semantic_text (text_embedding and sparse_embedding).
    * Includes optimistic updates for newly created endpoints that may not be in the list yet.
    */
-  const options: EuiSelectableOption[] = useMemo(() => {
-    const selectableOptions: EuiSelectableOption[] =
+  const options: EuiSelectableOption<EndpointOptionData>[] = useMemo(() => {
+    const selectableOptions: EuiSelectableOption<EndpointOptionData>[] =
       compatibleEndpoints?.endpointDefinitions?.map((endpoint) => {
         return {
+          key: endpoint.inference_id,
           label: endpoint.inference_id,
           'data-test-subj': `custom-inference_${endpoint.inference_id}`,
           checked: value === endpoint.inference_id ? 'on' : undefined,
+          description: endpoint.description,
           disabled: !endpoint.accessible,
           append: !endpoint.accessible && endpoint.requiredLicense && (
             <EuiBadge color="hollow" iconType="lock">
@@ -150,15 +156,31 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
     const isValueInOptions = selectableOptions.some((option) => option.label === value);
     if (value && !isValueInOptions) {
       selectableOptions.push({
+        key: value,
         label: value,
         checked: 'on',
         'data-test-subj': `custom-inference_${value}`,
+        description: '',
       });
     }
     return selectableOptions;
   }, [compatibleEndpoints, value]);
 
   const selectedOptionLabel = options.find((option) => option.checked)?.label;
+
+  const renderEndpointOption = useCallback(
+    (option: EuiSelectableOption<EndpointOptionData>, searchValue: string) => {
+      return (
+        <>
+          <EuiText size="s">{option.label}</EuiText>
+          <EuiText size="xs" color="subdued" className="eui-displayBlock">
+            <small>{option.description}</small>
+          </EuiText>
+        </>
+      );
+    },
+    []
+  );
 
   /**
    * Auto-select default inference endpoint when:
@@ -282,7 +304,8 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
                     }
                   )}
                 >
-                  <EuiSelectable
+                  <EuiSelectable<EndpointOptionData>
+                    id="inferenceEndpointsSelectable"
                     aria-label={i18n.translate(
                       'xpack.idxMgmt.mappingsEditor.parameters.inferenceId.popover.selectable.ariaLabel',
                       {
@@ -307,6 +330,11 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
                     onChange={(newOptions) => {
                       setValue(newOptions.find((option) => option.checked)?.label || '');
                     }}
+                    renderOption={renderEndpointOption}
+                    listProps={{
+                      isVirtualized: false,
+                    }}
+                    height={euiTheme.base * 15}
                   >
                     {(list, search) => (
                       <>

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.test.tsx
@@ -17,7 +17,9 @@ import type { Index } from '@kbn/index-management-shared-types';
 import { notificationService } from '../../../../services/notification';
 import { navigateToIndexDetailsPage, getIndexDetailsLink } from '../../../../services/routing';
 
-const user = userEvent.setup();
+// EUI context menus keep inactive panels mounted with `pointer-events: none`,
+// which can cause user-event to throw when interacting with menu items.
+const user = userEvent.setup({ pointerEventsCheck: 0, delay: null });
 
 jest.mock('../../../../services/routing', () => ({
   ...jest.requireActual('../../../../services/routing'),
@@ -299,7 +301,8 @@ describe('IndexActionsContextMenu', () => {
         renderWithProviders(<IndexActionsContextMenu {...closed} />);
 
         await openContextMenu();
-        const openBtn = await screen.findByTestId('openIndexMenuButton');
+        const menu = await screen.findByTestId('indexContextMenu');
+        const openBtn = await within(menu).findByTestId('openIndexMenuButton');
 
         await user.click(openBtn);
 
@@ -406,15 +409,18 @@ describe('IndexActionsContextMenu', () => {
         );
 
         await openContextMenu();
-        const overviewBtn = await screen.findByText(/show index overview/i);
+        const menu = await screen.findByTestId('indexContextMenu');
+        const overviewBtn = await within(menu).findByText(/show index overview/i);
         await user.click(overviewBtn);
 
         await openContextMenu();
-        const settingsBtn = await screen.findByText(/show index settings/i);
+        const menu2 = await screen.findByTestId('indexContextMenu');
+        const settingsBtn = await within(menu2).findByText(/show index settings/i);
         await user.click(settingsBtn);
 
         await openContextMenu();
-        const mappingBtn = await screen.findByText(/show index mapping/i);
+        const menu3 = await screen.findByTestId('indexContextMenu');
+        const mappingBtn = await within(menu3).findByText(/show index mapping/i);
         await user.click(mappingBtn);
 
         expect(navigateToIndexDetailsPage).toHaveBeenCalledTimes(3);

--- a/x-pack/platform/plugins/shared/index_management/public/hooks/use_compatible_inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/hooks/use_compatible_inference_endpoints.ts
@@ -9,6 +9,7 @@ import { useMemo } from 'react';
 import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import type { LicenseType } from '@kbn/licensing-types';
 import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
+import { SERVICE_PROVIDERS } from '@kbn/inference-endpoint-ui-common';
 import { useLicense } from './use_license';
 
 const COMPATIBLE_TASK_TYPES = ['text_embedding', 'sparse_embedding'] as const;
@@ -28,6 +29,7 @@ interface EndpointDefinition {
   requiredLicense: string | undefined;
   /** Whether the endpoint is accessible to the current license. Defaults to true if no license requirement is specified. */
   accessible: boolean;
+  description: string;
 }
 interface CompatibleEndpointsData {
   defaultInferenceId: string | undefined;
@@ -56,6 +58,9 @@ export const useCompatibleInferenceEndpoints = (
       if (!COMPATIBLE_TASK_TYPES.includes(endpoint.task_type as CompatibleTaskType)) {
         return;
       }
+      const provider = SERVICE_PROVIDERS[endpoint.service];
+      const service = provider ? provider.name : endpoint.service;
+      const modelId = endpoint.service_settings.model_id;
       const isElserInEis =
         endpoint.inference_id === defaultInferenceEndpoints.ELSER_IN_EIS_INFERENCE_ID;
       const requiredLicense = INFERENCE_ENDPOINT_LICENSE_MAP[endpoint.inference_id];
@@ -74,6 +79,7 @@ export const useCompatibleInferenceEndpoints = (
         inference_id: endpoint.inference_id,
         requiredLicense,
         accessible,
+        description: `${service} - ${modelId}`,
       });
     });
     return {

--- a/x-pack/platform/plugins/shared/index_management/public/hooks/use_compatible_inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/hooks/use_compatible_inference_endpoints.ts
@@ -59,8 +59,10 @@ export const useCompatibleInferenceEndpoints = (
         return;
       }
       const provider = SERVICE_PROVIDERS[endpoint.service];
-      const service = provider ? provider.name : endpoint.service;
-      const modelId = endpoint.service_settings.model_id;
+      const modelId = endpoint.service_settings.model_id ?? endpoint.service_settings.model;
+      const service = provider?.name ?? endpoint.service;
+      const description = modelId ? `${service} - ${modelId}` : service;
+
       const isElserInEis =
         endpoint.inference_id === defaultInferenceEndpoints.ELSER_IN_EIS_INFERENCE_ID;
       const requiredLicense = INFERENCE_ENDPOINT_LICENSE_MAP[endpoint.inference_id];
@@ -75,11 +77,12 @@ export const useCompatibleInferenceEndpoints = (
           defaultInferenceId = endpoint.inference_id;
         }
       }
+
       endpointDefinitions.push({
         inference_id: endpoint.inference_id,
         requiredLicense,
         accessible,
-        description: `${service} - ${modelId}`,
+        description,
       });
     });
     return {


### PR DESCRIPTION
## Summary

When configuring a `semantic_text` field in an index mapping, users must select an inference endpoint from a dropdown list. Previously, this list provided no contextual information, making it difficult to understand the differences between available endpoints.

This change enhances the endpoint selection experience by adding descriptive text to each inference endpoint in the dropdown. These descriptions help users better understand the characteristics of each endpoint, enabling more informed and confident selection during mapping configuration.

### Screenshots

<img width="1509" height="825" alt="Screenshot 2026-01-30 at 15 34 55" src="https://github.com/user-attachments/assets/50d55b3b-5bc3-43d1-8922-8a1d7928decf" />

### Testing

You will need to run EIS locally to test this PR. Instructions for running EIS can be found here: https://github.com/elastic/kibana/blob/main/x-pack/platform/packages/shared/kbn-inference-cli/README.md#eis

1. Create an index
2. Navigate to the mappings tab of the index details page
3. Click the `Add field` button
4. Select the `Semantic text` field type
5. Click on the inference endpoint selector
6. Confirm you can see the description under the inference ID, and can successfully search for and select an endpoint in the popover

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~

