### PR TITLE
[Privmon] [Bug] FTR Flaky Tests: Full Investigation and Fixes.

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/data_sources/sync/update_detection/index/update_detection.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/data_sources/sync/update_detection/index/update_detection.ts
@@ -6,7 +6,7 @@
  */
 
 import type { SavedObjectsClientContract } from '@kbn/core/server';
-import { uniq } from 'lodash';
+import { uniqBy } from 'lodash';
 import type { MonitoringEntitySource } from '../../../../../../../../common/api/entity_analytics';
 import type { PrivilegeMonitoringDataClient } from '../../../../engine/data_client';
 import type { PrivMonBulkUser } from '../../../../types';
@@ -28,7 +28,7 @@ export const createIndexUpdateDetectionService = (
       source
     );
 
-    await statusUpdateService.updatePrivilegedStatus(uniq(users), source); // ensure users are unique before updating
+    await statusUpdateService.updatePrivilegedStatus(uniqBy(users, 'username'), source); // ensure users are unique by username before updating
     dataClient.log(
       'info',
       `Index Update Detection: Found ${users.length} users from index source ${source.id}`

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/data_sources/sync/update_detection/integrations/update_detection.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/data_sources/sync/update_detection/integrations/update_detection.ts
@@ -6,6 +6,7 @@
  */
 
 import type { SavedObjectsClientContract } from '@kbn/core/server';
+import { uniqBy } from 'lodash';
 import type { MonitoringEntitySource } from '../../../../../../../../common/api/entity_analytics';
 import type { PrivilegeMonitoringDataClient } from '../../../../engine/data_client';
 import type { PrivMonBulkUser } from '../../../../types';
@@ -26,7 +27,7 @@ export const createUpdateDetectionService = (
     const users: PrivMonBulkUser[] = await patternMatcherService.findPrivilegedUsersFromMatchers(
       source
     );
-    await statusUpdateService.updatePrivilegedStatus(users, source);
+    await statusUpdateService.updatePrivilegedStatus(uniqBy(users, 'username'), source); // ensure users are unique by username before updating
     dataClient.log(
       'info',
       `Completed update detection for source ${source.id}. Processed ${users.length} users.`

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_integrations_sync.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_integrations_sync.ts
@@ -12,6 +12,7 @@ import { PrivMonUtils } from './utils';
 export default ({ getService }: FtrProviderContext) => {
   const api = getService('entityAnalyticsApi');
   const esArchiver = getService('esArchiver');
+  const log = getService('log');
   const privMonUtils = PrivMonUtils(getService);
 
   describe('@ess @serverless @skipInServerlessMKI Entity Privilege Monitoring Engine Integrations Sync', () => {
@@ -140,6 +141,12 @@ export default ({ getService }: FtrProviderContext) => {
         const snapB = await privMonUtils.scheduleEngineAndWaitForUserCount(4);
         expect(new Set(snapB)).toEqual(new Set(snapA));
 
+        // Wait for marker to be updated before checking
+        await privMonUtils.integrationsSync.waitForMarkerUpdate(
+          privMonUtils.integrationsSync.OKTA_INDEX,
+          privMonUtils.integrationsSync.DEFAULT_INTEGRATIONS_RELATIVE_TIMESTAMP,
+          120000
+        );
         const markerAfterPhase2 = await privMonUtils.integrationsSync.getLastProcessedMarker(
           privMonUtils.integrationsSync.OKTA_INDEX
         );
@@ -157,7 +164,8 @@ export default ({ getService }: FtrProviderContext) => {
         // Wait for marker to be updated before checking
         await privMonUtils.integrationsSync.waitForMarkerUpdate(
           privMonUtils.integrationsSync.OKTA_INDEX,
-          nowMinus1w
+          nowMinus1w,
+          120000
         );
         const markerAfterPhase3 = await privMonUtils.integrationsSync.getLastProcessedMarker(
           privMonUtils.integrationsSync.OKTA_INDEX
@@ -180,7 +188,8 @@ export default ({ getService }: FtrProviderContext) => {
         // Wait for marker to be updated before checking
         await privMonUtils.integrationsSync.waitForMarkerUpdate(
           privMonUtils.integrationsSync.OKTA_INDEX,
-          nowMinus6d
+          nowMinus6d,
+          120000
         );
         const markerAfterPhase4 = await privMonUtils.integrationsSync.getLastProcessedMarker(
           privMonUtils.integrationsSync.OKTA_INDEX

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_integrations_sync.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_integrations_sync.ts
@@ -12,7 +12,6 @@ import { PrivMonUtils } from './utils';
 export default ({ getService }: FtrProviderContext) => {
   const api = getService('entityAnalyticsApi');
   const esArchiver = getService('esArchiver');
-  const log = getService('log');
   const privMonUtils = PrivMonUtils(getService);
 
   describe('@ess @serverless @skipInServerlessMKI Entity Privilege Monitoring Engine Integrations Sync', () => {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_integrations_sync.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_integrations_sync.ts
@@ -15,7 +15,7 @@ export default ({ getService }: FtrProviderContext) => {
   const privMonUtils = PrivMonUtils(getService);
 
   describe('@ess @serverless @skipInServerlessMKI Entity Privilege Monitoring Engine Integrations Sync', () => {
-    describe('integrations sync', async () => {
+    describe.only('integrations sync', async () => {
       beforeEach(async () => {
         await esArchiver.load(
           'x-pack/solutions/security/test/fixtures/es_archives/privileged_monitoring/integrations/okta',
@@ -154,6 +154,11 @@ export default ({ getService }: FtrProviderContext) => {
           privMonUtils.integrationsSync.OKTA_INDEX
         );
         await privMonUtils.scheduleEngineAndWaitForUserCount(4);
+        // Wait for marker to be updated before checking
+        await privMonUtils.integrationsSync.waitForMarkerUpdate(
+          privMonUtils.integrationsSync.OKTA_INDEX,
+          nowMinus1w
+        );
         const markerAfterPhase3 = await privMonUtils.integrationsSync.getLastProcessedMarker(
           privMonUtils.integrationsSync.OKTA_INDEX
         );
@@ -172,7 +177,11 @@ export default ({ getService }: FtrProviderContext) => {
         );
 
         await privMonUtils.scheduleEngineAndWaitForUserCount(5);
-
+        // Wait for marker to be updated before checking
+        await privMonUtils.integrationsSync.waitForMarkerUpdate(
+          privMonUtils.integrationsSync.OKTA_INDEX,
+          nowMinus6d
+        );
         const markerAfterPhase4 = await privMonUtils.integrationsSync.getLastProcessedMarker(
           privMonUtils.integrationsSync.OKTA_INDEX
         );

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_integrations_sync.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_integrations_sync.ts
@@ -15,7 +15,7 @@ export default ({ getService }: FtrProviderContext) => {
   const privMonUtils = PrivMonUtils(getService);
 
   describe('@ess @serverless @skipInServerlessMKI Entity Privilege Monitoring Engine Integrations Sync', () => {
-    describe.only('integrations sync', async () => {
+    describe('integrations sync', async () => {
       beforeEach(async () => {
         await esArchiver.load(
           'x-pack/solutions/security/test/fixtures/es_archives/privileged_monitoring/integrations/okta',

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_plain_index_sync.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/engine_plain_index_sync.ts
@@ -20,12 +20,12 @@ export default ({ getService }: FtrProviderContext) => {
       const indexSyncUtils = PlainIndexSyncUtils(getService, indexName);
 
       beforeEach(async () => {
-        await indexSyncUtils.createIndex();
+        await privMonUtils.createIndex(indexName);
         await privMonUtils.initPrivMonEngine();
       });
 
       afterEach(async () => {
-        await indexSyncUtils.deleteIndex();
+        await privMonUtils.deleteIndex(indexName);
         await api.deleteMonitoringEngine({ query: { data: true } });
       });
 
@@ -42,12 +42,14 @@ export default ({ getService }: FtrProviderContext) => {
           'Darth Vader',
         ];
 
-        const repeatedUsers = Array.from({ length: 150 }).map(() => 'C-3PO');
+        const repeatedUsers = Array.from({ length: 10 }).map(() => 'C-3PO');
 
         await indexSyncUtils.addUsersToIndex([...uniqueUsernames, ...repeatedUsers]);
         await indexSyncUtils.createEntitySourceForIndex();
 
-        const users = await privMonUtils.scheduleEngineAndWaitForUserCount(uniqueUsernames.length);
+        const users = await privMonUtils.scheduleEngineAndWaitForUserCountWithoutDuplicates(
+          uniqueUsernames.length
+        );
 
         // Check if the users are indexed
         const userNames = users.map((u: any) => u.user.name);

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_users/cross_source_sync.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_users/cross_source_sync.ts
@@ -34,7 +34,7 @@ export default ({ getService }: FtrProviderContext) => {
       await privMonUtils.deleteIndex(index1);
     });
 
-    it('should merge sources when the same user is added through different methods (API, CSV, index)', async () => {
+    it(`should merge sources when the same user is added through different methods (API, CSV, index)`, async () => {
       await privMonUtils.initPrivMonEngine();
 
       // Step 1: Add user via API
@@ -65,15 +65,7 @@ export default ({ getService }: FtrProviderContext) => {
       expect(user?.labels?.sources).toContain('csv');
 
       // Step 3: Add same user via index sync - should merge all three sources
-      const createEntitySourceResponse = await entityAnalyticsApi.createEntitySource({
-        body: {
-          type: 'index',
-          name: 'User Monitored Indices - Multi-Source Test',
-          indexPattern: index1,
-        },
-      });
-
-      expect(createEntitySourceResponse.status).toBe(200);
+      await indexSyncUtils.createEntitySourceForIndex();
       // Can't use scheduleEngineAndWaitForUserCount(1) because count is already 1 from API/CSV sources.
       // It would return immediately before the index sync merges the 'index' source into user labels.
       // Instead, manually trigger the sync and wait for the actual source merge to complete.

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_users/task.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/privileged_users/task.ts
@@ -18,36 +18,20 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
   const privMonUtils = PrivMonUtils(getService);
 
-  const createSourceIndex = async (indexName: string) =>
-    es.indices.create({
-      index: indexName,
-      mappings: {
-        properties: {
-          user: {
-            properties: {
-              name: {
-                type: 'keyword',
-              },
-            },
-          },
-        },
-      },
-    });
-
-  describe('@ess @serverless @skipInServerlessMKI Entity Monitoring Privileged Users APIs', () => {
+  describe('@ess @serverless @skipInServerlessMKI Privileged Users Monitoring task behavior', () => {
     after(async () => {
       await entityAnalyticsApi.deleteMonitoringEngine({ query: { data: true } });
     });
 
-    describe('Index Entity Source APIs', () => {
+    describe('Index entity source updates and sync', () => {
       const index1 = 'privmon_index1';
       const index2 = 'privmon_index2';
       const user1 = { name: 'user_1' };
       const user2 = { name: 'user_2' };
 
       beforeEach(async () => {
-        await createSourceIndex(index1);
-        await createSourceIndex(index2);
+        await privMonUtils.createIndex(index1);
+        await privMonUtils.createIndex(index2);
 
         await es.index({
           index: index1,
@@ -63,8 +47,7 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       afterEach(async () => {
-        await es.indices.delete({ index: index1 });
-        await es.indices.delete({ index: index2 });
+        await Promise.all([privMonUtils.deleteIndex(index1), privMonUtils.deleteIndex(index2)]);
       });
 
       it('should delete privileged users when the index pattern changes', async () => {

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/utils/plain_index_sync_utils.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/trial_license_complete_tier/utils/plain_index_sync_utils.ts
@@ -18,28 +18,6 @@ export const PlainIndexSyncUtils = (
 
   log.info(`Monitoring: Privileged Users: Using namespace ${namespace}`);
 
-  const createIndex = async () =>
-    es.indices.create({
-      index: indexName,
-      mappings: {
-        properties: {
-          user: {
-            properties: {
-              name: {
-                type: 'keyword',
-                fields: {
-                  text: { type: 'text' },
-                },
-              },
-              role: {
-                type: 'keyword',
-              },
-            },
-          },
-        },
-      },
-    });
-
   const addUsersToIndex = async (users: string[]) => {
     const ops = users.flatMap((name) => [{ index: {} }, { user: { name, role: 'admin' } }]);
     await es.bulk({
@@ -80,19 +58,9 @@ export const PlainIndexSyncUtils = (
     return response;
   };
 
-  const deleteIndex = async () => {
-    try {
-      await es.indices.delete({ index: indexName }, { ignore: [404] });
-    } catch (err) {
-      log.error(`Error deleting index ${indexName}: ${err}`);
-    }
-  };
-
   return {
-    createIndex,
     addUsersToIndex,
     deleteUserFromIndex,
     createEntitySourceForIndex,
-    deleteIndex,
   };
 };


### PR DESCRIPTION
🚧 Please DO NOT approve. Using this for investigation and running flaky test runner against. 

## Summary

Latest Flaky Test Runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10496

**All AI Summary, because I am praying and testing 🙏 :** 
This pull request improves the privileged user monitoring system by ensuring that users are uniquely identified by their username during sync operations, refactors test utilities for clearer and safer index management, and enhances the reliability of integration tests by adding explicit waits for sync completion and deduplication. These changes help prevent duplicate user entries, make test setup and teardown more robust, and improve test accuracy and maintainability.

**User Deduplication Improvements**
* Updated sync logic in both `index/update_detection.ts` and `integrations/update_detection.ts` to use `uniqBy(users, 'username')`, ensuring users are uniquely identified by their username before updating statuses. This prevents duplicate privileged user entries during sync. [[1]](diffhunk://#diff-7c62e5bbc20e5539c4797cdb786b19e4321120408e70d29404e94040015aa2d5L9-R9) [[2]](diffhunk://#diff-7c62e5bbc20e5539c4797cdb786b19e4321120408e70d29404e94040015aa2d5L31-R31) [[3]](diffhunk://#diff-a0bd44871d8961f61f82b0998322ad47309134340377ce1af61a67a0a9a9e94fR9) [[4]](diffhunk://#diff-a0bd44871d8961f61f82b0998322ad47309134340377ce1af61a67a0a9a9e94fL29-R30)

**Test Utilities Refactoring**
* Moved index management (`createIndex`, `deleteIndex`) out of `PlainIndexSyncUtils` and into `PrivMonUtils`, centralizing index setup/teardown and improving reliability by handling race conditions and full index deletion before creation. [[1]](diffhunk://#diff-65f9fa53cbe3fdc5c1b1bee496e9f5adf0cb83186c94d4f140bd718f8052cb99L21-L42) [[2]](diffhunk://#diff-65f9fa53cbe3fdc5c1b1bee496e9f5adf0cb83186c94d4f140bd718f8052cb99L83-L96) [[3]](diffhunk://#diff-5a92c64fbcf2af10ab70e76dcdca497771a78f06cdfa9760b5a9e0cb96a04133R87-R133)
* Updated all test suites to use the new `PrivMonUtils.createIndex` and `PrivMonUtils.deleteIndex` methods for consistent and safer index management. [[1]](diffhunk://#diff-ea60094c55c43939fe0c7db22f58368d2d9710a0cd1e9eb6b5b86413865dd236L23-R28) [[2]](diffhunk://#diff-0f7c010360c8d09690c9c9936ae9095424cfedbcadc29cd75fb0a40a35f55ec0L30-R34) [[3]](diffhunk://#diff-671013c9d8f62cfae430d9634b640e59504346ba9e1b2bdf63b85183bc8bb3cbL21-R34) [[4]](diffhunk://#diff-671013c9d8f62cfae430d9634b640e59504346ba9e1b2bdf63b85183bc8bb3cbL66-R50)

**Integration Test Reliability**
* Added explicit waits (`waitForMarkerUpdate`, `waitForSyncTaskRun`, and improved polling) in test cases to ensure sync tasks and marker updates are complete before assertions, reducing flakiness and improving accuracy of test results. [[1]](diffhunk://#diff-48ae9cc07664580c2fcaf48b65fb547db95327dcaf124d36a90be1867f8272bdR144-R149) [[2]](diffhunk://#diff-48ae9cc07664580c2fcaf48b65fb547db95327dcaf124d36a90be1867f8272bdR164-R169) [[3]](diffhunk://#diff-48ae9cc07664580c2fcaf48b65fb547db95327dcaf124d36a90be1867f8272bdL175-R193) [[4]](diffhunk://#diff-5a92c64fbcf2af10ab70e76dcdca497771a78f06cdfa9760b5a9e0cb96a04133R236) [[5]](diffhunk://#diff-0f7c010360c8d09690c9c9936ae9095424cfedbcadc29cd75fb0a40a35f55ec0L78-R115)

**Deduplication Verification in Tests**
* Introduced `scheduleEngineAndWaitForUserCountWithoutDuplicates` and `_waitForPrivMonUsersToBeSyncedWithoutDuplicates` in `PrivMonUtils` to verify that user sync completes without duplicates, and updated tests to use these new utilities. [[1]](diffhunk://#diff-ea60094c55c43939fe0c7db22f58368d2d9710a0cd1e9eb6b5b86413865dd236L45-R52) [[2]](diffhunk://#diff-5a92c64fbcf2af10ab70e76dcdca497771a78f06cdfa9760b5a9e0cb96a04133R296-R348)

**Minor Test Suite Cleanups**
* Renamed and clarified test suite descriptions for better readability and removed unused or redundant code in test files. [[1]](diffhunk://#diff-0f7c010360c8d09690c9c9936ae9095424cfedbcadc29cd75fb0a40a35f55ec0L19-R19) [[2]](diffhunk://#diff-671013c9d8f62cfae430d9634b640e59504346ba9e1b2bdf63b85183bc8bb3cbL21-R34)

Let me know if you'd like a deeper dive into any of the changes or the reasoning behind them!
