### PR TITLE
[Entity Analytics][POC] `access_frequency` Entity Maintainer

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/all_definitions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/all_definitions.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// export * from './definitions/access_frequency';
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { EntityMaintainer } from './maintainer';
+
+const exportsMap: { [key: string]: EntityMaintainer } = {};
+const currentDir = __dirname;
+
+const excludedFiles = ['index.ts', 'index.js'];
+fs.readdirSync(`${currentDir}/definitions`)
+  .filter((file) => !excludedFiles.includes(file) && file.toLowerCase().endsWith('.ts'))
+  .forEach((file) => {
+    const fullPath = path.join(currentDir, 'definitions', file);
+    // Dynamically require and assign exports (adjust based on your export style)
+    // Note: 'require' may not have full TS support with dynamic paths.
+    // For ES Modules with Node, you would use dynamic import()
+    if (path.extname(file) === '.ts') {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const module = require(fullPath) as EntityMaintainer;
+      Object.assign(exportsMap, module);
+    }
+  });
+
+// For CommonJS (if your tsconfig module is set to CommonJS)
+module.exports = exportsMap;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/definitions/access_frequency.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/definitions/access_frequency.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment';
+import { get } from 'lodash';
+import {
+  EntityType,
+  EntityTypeToIdentifierField,
+} from '../../../../../common/entity_analytics/types';
+import { DEFAULT_LOOKBACK_WINDOW, DEFAULT_TIME_FIELD, type EntityMaintainer } from '../maintainer';
+
+const SECONDS_REGEX = /^[1-9][0-9]*s$/;
+const MINUTES_REGEX = /^[1-9][0-9]*m$/;
+const HOURS_REGEX = /^[1-9][0-9]*h$/;
+const DAYS_REGEX = /^[1-9][0-9]*d$/;
+
+const isSeconds = (duration: string) => {
+  return SECONDS_REGEX.test(duration);
+};
+
+const isMinutes = (duration: string) => {
+  return MINUTES_REGEX.test(duration);
+};
+
+const isHours = (duration: string) => {
+  return HOURS_REGEX.test(duration);
+};
+
+const isDays = (duration: string) => {
+  return DAYS_REGEX.test(duration);
+};
+
+const parseDuration = (duration: string): number => {
+  const parsed = parseInt(duration, 10);
+  if (isSeconds(duration)) {
+    return parsed * 1000;
+  } else if (isMinutes(duration)) {
+    return parsed * 60 * 1000;
+  } else if (isHours(duration)) {
+    return parsed * 60 * 60 * 1000;
+  } else if (isDays(duration)) {
+    return parsed * 24 * 60 * 60 * 1000;
+  }
+  throw new Error(
+    `Invalid duration "${duration}". Durations must be of the form {number}x. Example: 5s, 5m, 5h or 5d"`
+  );
+};
+
+const esqlQueries = {
+  // should be defined for each supported entity type
+  [EntityType.user]: {
+    getRelatedField: () => 'related.host',
+    getAccessFrequentlyField: () => `accesses_frequently`,
+    getAccessInfrequentlyField: () => `accesses_infrequently`,
+    getGroupByFields: (identifierField: string) => `${identifierField}, related.host`,
+  },
+  [EntityType.host]: {
+    getRelatedField: () => 'related.user',
+    getAccessFrequentlyField: () => `accessed_frequently_by`,
+    getAccessInfrequentlyField: () => `accessed_infrequently_by`,
+    getGroupByFields: (identifierField: string) => `${identifierField}, related.user`,
+  },
+};
+
+export const AccessFrequencyEntityMaintainer: EntityMaintainer = {
+  id: '.access_frequency',
+  entityTypes: [EntityType.user, EntityType.host],
+  getCompositeQuery: (
+    timeField: string = DEFAULT_TIME_FIELD,
+    lookbackInterval: string = DEFAULT_LOOKBACK_WINDOW
+  ) => ({
+    bool: {
+      filter: [
+        { range: { [timeField]: { lt: 'now', gte: `now-${lookbackInterval}` } } },
+        { term: { 'event.category': 'authentication' } },
+      ],
+    },
+  }),
+  getQuery: (
+    index: string,
+    entityType: EntityType,
+    rangeClause: string,
+    lookbackInterval: string = DEFAULT_LOOKBACK_WINDOW
+  ) => {
+    const identifierField = EntityTypeToIdentifierField[entityType];
+    const esqlQueriesEntry = get(esqlQueries, entityType);
+    if (!esqlQueriesEntry) {
+      throw new Error(`Unsupported entity type for Access Frequency maintainer: ${entityType}`);
+    }
+    const groupByFields = esqlQueriesEntry.getGroupByFields(identifierField);
+    const accessFrequentlyField = esqlQueriesEntry.getAccessFrequentlyField();
+    const accessInfrequentlyField = esqlQueriesEntry.getAccessInfrequentlyField();
+    const relatedField = esqlQueriesEntry.getRelatedField();
+
+    // threshold
+    const now = Date.now();
+    const durationInMillis = parseDuration(lookbackInterval);
+    const numWeeks = moment(now).diff(
+      moment(now).subtract(durationInMillis, 'milliseconds'),
+      'week'
+    );
+
+    if (numWeeks < 1) {
+      throw new Error(
+        `Lookback interval "${lookbackInterval}" is too short for Access Frequency maintainer. Must be at least 1 week.`
+      );
+    }
+
+    return `FROM ${index}
+      | WHERE event.category == "authentication"
+          AND KQL("${rangeClause}")
+      | STATS access_count = COUNT(*) BY ${groupByFields}
+      | EVAL access_type = CASE(access_count < ${
+        numWeeks + 1
+      }, "${accessInfrequentlyField}", access_count >= ${
+      numWeeks + 1
+    }, "${accessFrequentlyField}", ELSE "unknown")
+      | STATS users = TOP(${relatedField}, 10000) BY access_type,${identifierField}
+      | STATS ${accessFrequentlyField} = VALUES(users) WHERE access_type == "${accessFrequentlyField}", ${accessInfrequentlyField} = VALUES(users) WHERE access_type == "${accessInfrequentlyField}" BY ${identifierField}
+      | LIMIT 3500
+`;
+  },
+  formatRecord: (record: Record<string, unknown>) => {
+    if (!record.id) {
+      throw new Error('Record is missing id field');
+    }
+    const { id, ...recordWithoutId } = record;
+    return {
+      id,
+      relationships: recordWithoutId ?? {},
+    };
+  },
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/entity_maintainer_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/entity_maintainer_client.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  ElasticsearchClient,
+  ElasticsearchServiceStart,
+  IScopedClusterClient,
+  Logger,
+  SavedObjectsClientContract,
+} from '@kbn/core/server';
+import type {
+  ConcreteTaskInstance,
+  TaskManagerSetupContract,
+} from '@kbn/task-manager-plugin/server';
+import type { SpacesServiceStart } from '@kbn/spaces-plugin/server';
+import { runTask } from './lib';
+import type { EntityMaintainerRegistry } from './entity_maintainer_registry';
+import { EntityStoreCrudClient } from '../entity_store/entity_store_crud_client';
+
+export const ENTITY_MAINTAINER_TASK_TYPE = 'entity_analytics_maintainer';
+
+export interface EntityMaintainerContext {
+  entityMaintainerRegistry: EntityMaintainerRegistry;
+  entityStoreCrudClient: EntityStoreCrudClient;
+  esClient: ElasticsearchClient;
+  logger: Logger;
+  savedObjectsClient: SavedObjectsClientContract;
+}
+
+interface ConstructorOpts {
+  entityMaintainerRegistry: EntityMaintainerRegistry;
+  elasticsearchClientPromise: Promise<IScopedClusterClient>;
+  logger: Logger;
+  savedObjectsClient: SavedObjectsClientContract;
+  spacesService: Promise<SpacesServiceStart | undefined>;
+  taskManagerSetup: TaskManagerSetupContract;
+}
+
+export class EntityMaintainerClient {
+  constructor(private readonly opts: ConstructorOpts) {
+    // registers the task that handles entity maintenance
+    opts.taskManagerSetup.registerTaskDefinitions({
+      [ENTITY_MAINTAINER_TASK_TYPE]: {
+        title: 'Entity maintainer task',
+        createTaskRunner: ({
+          taskInstance,
+          abortController,
+        }: {
+          taskInstance: ConcreteTaskInstance;
+          abortController: AbortController;
+        }) => ({
+          run: async () => this.runTask(taskInstance, abortController),
+        }),
+      },
+    });
+  }
+
+  private runTask = async (
+    taskInstance: ConcreteTaskInstance,
+    abortController: AbortController
+  ) => {
+    const clusterClient = await this.opts.elasticsearchClientPromise;
+    const spacesService = await this.opts.spacesService;
+
+    const context = {
+      entityMaintainerRegistry: this.opts.entityMaintainerRegistry,
+      esClient: clusterClient.asInternalUser,
+      logger: this.opts.logger,
+      savedObjectsClient: this.opts.savedObjectsClient,
+    };
+
+    const entityStoreCrudClient = new EntityStoreCrudClient({
+      clusterClient,
+      namespace: taskInstance.params.spaceId,
+      logger: this.opts.logger,
+      dataClient: getEntityStoreDataClient(),
+    });
+    await runTask(context, taskInstance, abortController);
+  };
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/entity_maintainer_registry.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/entity_maintainer_registry.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EntityMaintainer } from './maintainer';
+
+export class EntityMaintainerRegistry {
+  private readonly entityMaintainerDefinitions: Map<string, EntityMaintainer> = new Map();
+
+  public has(id: string): boolean {
+    return this.entityMaintainerDefinitions.has(id);
+  }
+
+  public get(id: string): EntityMaintainer | undefined {
+    return this.entityMaintainerDefinitions.get(id);
+  }
+
+  public register(definition: EntityMaintainer): void {
+    this.entityMaintainerDefinitions.set(definition.id, definition);
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/apply_maintainer_logic.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/apply_maintainer_logic.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { EsqlEsqlResult } from '@elastic/elasticsearch/lib/api/types';
+import { processResponse } from './apply_maintainer_logic';
+import { EntityType } from '../../../../../common/entity_analytics/types';
+import { AccessFrequencyEntityMaintainer } from '../definitions/access_frequency';
+
+describe('processResponse', () => {
+  it('should process response correctly', async () => {
+    const mockResponse: EsqlEsqlResult = {
+      took: 189,
+      is_partial: false,
+      completion_time_in_millis: 1768321323769,
+      documents_found: 503209,
+      values_loaded: 1006418,
+      start_time_in_millis: 1768321323580,
+      expiration_time_in_millis: 1768753323669,
+      columns: [
+        {
+          name: 'accessed_frequently_by',
+          type: 'keyword',
+        },
+        {
+          name: 'accessed_infrequently_by',
+          type: 'keyword',
+        },
+        {
+          name: 'host.name',
+          type: 'keyword',
+        },
+      ],
+      values: [
+        ['root', ['adm', 'dip', 'docker', 'google-sudoers', 'plugdev', 'video'], 'host-1'],
+        ['root', ['adm', 'dip', 'docker', 'google-sudoers', 'plugdev', 'video'], 'host-2'],
+        [
+          ['root', 'user-1'],
+          [
+            'adm',
+            'audio',
+            'cdrom',
+            'dialout',
+            'dip',
+            'floppy',
+            'google-sudoers',
+            'lxd',
+            'netdev',
+            'plugdev',
+            'ubuntu',
+            'video',
+          ],
+          'host-3',
+        ],
+      ],
+    };
+    expect(
+      processResponse({
+        entityType: EntityType.host,
+        response: mockResponse,
+        maintainerDef: AccessFrequencyEntityMaintainer,
+      })
+    ).toEqual([
+      {
+        type: 'host',
+        record: {
+          id: 'host-1',
+          relationships: {
+            accessed_frequently_by: ['root'],
+            accessed_infrequently_by: [
+              'adm',
+              'dip',
+              'docker',
+              'google-sudoers',
+              'plugdev',
+              'video',
+            ],
+          },
+        },
+      },
+      {
+        type: 'host',
+        record: {
+          id: 'host-2',
+          relationships: {
+            accessed_frequently_by: ['root'],
+            accessed_infrequently_by: [
+              'adm',
+              'dip',
+              'docker',
+              'google-sudoers',
+              'plugdev',
+              'video',
+            ],
+          },
+        },
+      },
+      {
+        type: 'host',
+        record: {
+          id: 'host-3',
+          relationships: {
+            accessed_frequently_by: ['root', 'user-1'],
+            accessed_infrequently_by: [
+              'adm',
+              'audio',
+              'cdrom',
+              'dialout',
+              'dip',
+              'floppy',
+              'google-sudoers',
+              'lxd',
+              'netdev',
+              'plugdev',
+              'ubuntu',
+              'video',
+            ],
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/apply_maintainer_logic.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/apply_maintainer_logic.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { EsqlEsqlResult, FieldValue } from '@elastic/elasticsearch/lib/api/types';
+import { isString } from 'lodash';
+import type { EntityContainer } from '../../../../../common/api/entity_analytics/entity_store/entities/upsert_entities_bulk.gen';
+import type { EntityAfterKey } from '../../../../../common/api/entity_analytics/common';
+import type { EntityType } from '../../../../../common/entity_analytics/types';
+import { EntityTypeToIdentifierField } from '../../../../../common/entity_analytics/types';
+import type { EntityMaintainer, EntityMaintainerConfig } from '../maintainer';
+
+interface ApplyMaintainerLogicOpts {
+  abortController: AbortController;
+  entityType: EntityType;
+  esClient: ElasticsearchClient;
+  index: string;
+  logger: Logger;
+  lowerBounds?: EntityAfterKey;
+  upperBounds: EntityAfterKey;
+  maintainerDef: EntityMaintainer;
+  maintainerConfig: EntityMaintainerConfig;
+}
+
+export const applyMaintainerLogic = async (
+  opts: ApplyMaintainerLogicOpts
+): Promise<EntityContainer[]> => {
+  const identifierField = EntityTypeToIdentifierField[opts.entityType];
+
+  const lower = opts.lowerBounds?.[identifierField]
+    ? `${identifierField} > ${opts.lowerBounds[identifierField]}`
+    : undefined;
+  const upper = `${identifierField} <= ${opts.upperBounds[identifierField]}`;
+  if (!lower && !upper) {
+    throw new Error('Either lower or upper after key must be provided for pagination');
+  }
+  const rangeClause = [lower, upper].filter(Boolean).join(' and ');
+
+  const esqlQuery = opts.maintainerDef.getQuery(opts.index, opts.entityType, rangeClause);
+  if (!esqlQuery) {
+    throw new Error(
+      `No ES|QL query generated for entity type ${opts.entityType} in maintainer ${opts.maintainerDef.id}`
+    );
+  }
+
+  // Execute the ES|QL query
+  const response = await opts.esClient.esql.query(
+    {
+      query: esqlQuery,
+      filter: {
+        bool: {
+          filter: [
+            {
+              range: {
+                [opts.maintainerConfig.timeField]: {
+                  lt: 'now',
+                  gte: `now-${opts.maintainerConfig.lookbackWindow}`,
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    { signal: opts.abortController.signal }
+  );
+
+  return processResponse({
+    entityType: opts.entityType,
+    maintainerDef: opts.maintainerDef,
+    response,
+  });
+};
+
+interface ProcessResponseOpts {
+  entityType: EntityType;
+  response: EsqlEsqlResult;
+  maintainerDef: EntityMaintainer;
+}
+export const processResponse = ({
+  entityType,
+  maintainerDef,
+  response,
+}: ProcessResponseOpts): EntityContainer[] => {
+  const identifierField = EntityTypeToIdentifierField[entityType];
+  const columns = response.columns.map((col: { name: string; type: string }) => col.name);
+  const values = response.values || [];
+  return values.map((row: FieldValue[]) => {
+    const record = row.reduce((obj, value, index) => {
+      if (columns[index] === identifierField) {
+        obj.id = value;
+      } else {
+        const normalizedVal: string[] = isString(value) ? [value] : (value as unknown as string[]);
+        obj[columns[index]] = normalizedVal;
+      }
+      return obj;
+    }, {} as Record<string, unknown>);
+
+    const formattedRecord = maintainerDef.formatRecord
+      ? maintainerDef.formatRecord(record)
+      : record;
+
+    return { type: entityType, record: formattedRecord } as EntityContainer;
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/get_configuration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/get_configuration.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EntityMaintainerConfig } from '../maintainer';
+
+export const getConfiguration = async (
+  savedObjectId: string,
+  spaceId: string
+): Promise<EntityMaintainerConfig> => {
+  // Placeholder configuration
+  return {
+    id: '.access_frequency',
+    // can use data view ID...do we have it?
+    input: `.alerts-security.alerts-default,apm-*-transaction*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,traces-apm*,winlogbeat-*,-*elastic-cloud-logs-*/_search`,
+    schedule: { interval: '1d' },
+    enabled: true,
+    pageSize: 3500,
+    timeField: '@timestamp',
+    lookbackWindow: '30d',
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/get_entities_to_process.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/get_entities_to_process.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { processResponse } from './get_entities_to_process';
+
+describe('processResponse', () => {
+  it('should process response correctly', async () => {
+    const mockResponse = {
+      took: 4394,
+      timed_out: false,
+      _shards: { total: 410, successful: 410, skipped: 381, failed: 0 },
+      hits: { total: { value: 1609025, relation: 'eq' }, max_score: null, hits: [] },
+      aggregations: {
+        host: {
+          after_key: { 'host.name': 'host-2' },
+          buckets: [
+            { key: { 'host.name': 'host-1' }, doc_count: 155644 },
+            { key: { 'host.name': 'host-2' }, doc_count: 191832 },
+          ],
+        },
+        user: {
+          after_key: { 'user.name': 'test-2-user' },
+          buckets: [
+            { key: { 'user.name': 'test-1-user' }, doc_count: 739 },
+            { key: { 'user.name': 'test-2-user' }, doc_count: 1 },
+          ],
+        },
+      },
+    };
+    expect(processResponse(mockResponse)).toEqual({
+      host: {
+        afterKey: { 'host.name': 'host-2' },
+        values: ['host-1', 'host-2'],
+      },
+      user: {
+        afterKey: { 'user.name': 'test-2-user' },
+        values: ['test-1-user', 'test-2-user'],
+      },
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/get_entities_to_process.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/get_entities_to_process.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type {
+  AggregationsCompositeAggregate,
+  MappingRuntimeFields,
+  SearchResponse,
+} from '@elastic/elasticsearch/lib/api/types';
+import type { AfterKeys } from '../../../../../common/api/entity_analytics/common';
+import type { EntityType } from '../../../../../common/entity_analytics/types';
+import { EntityTypeToIdentifierField } from '../../../../../common/entity_analytics/types';
+import type { EntityMaintainer, EntityMaintainerConfig } from '../maintainer';
+
+interface GetBatchOfEntitiesOpts {
+  abortController: AbortController;
+  afterKeys: AfterKeys;
+  esClient: ElasticsearchClient;
+  index: string;
+  logger: Logger;
+  maintainerConfig: EntityMaintainerConfig;
+  maintainerDef: EntityMaintainer;
+  runtimeMappings: MappingRuntimeFields;
+}
+
+export const processResponse = (
+  response: SearchResponse<unknown, Record<string, AggregationsCompositeAggregate>>
+) => {
+  const processedResponse: Record<string, { afterKey: Record<string, string>; values: string[] }> =
+    {};
+  const aggregations = response.aggregations || {};
+  Object.keys(aggregations).forEach((entityType) => {
+    const afterKey = aggregations[entityType].after_key as Record<string, string>;
+    const values = (aggregations[entityType].buckets ?? []).map(
+      (bucket) => bucket.key[EntityTypeToIdentifierField[entityType as EntityType]]
+    );
+
+    processedResponse[entityType] = {
+      afterKey,
+      values,
+    };
+  });
+
+  return processedResponse;
+};
+
+export const getEntitiesToProcess = async (opts: GetBatchOfEntitiesOpts) => {
+  const { logger, maintainerConfig, maintainerDef, esClient } = opts;
+
+  const query = maintainerDef.getCompositeQuery(
+    maintainerConfig.timeField,
+    maintainerConfig.lookbackWindow
+  );
+  const aggregation = maintainerDef.entityTypes.reduce((aggs, entityType: EntityType) => {
+    const idField = EntityTypeToIdentifierField[entityType];
+    return {
+      ...aggs,
+      [entityType]: {
+        composite: {
+          size: 3500,
+          sources: [{ [idField]: { terms: { field: idField } } }],
+          after: opts.afterKeys[entityType],
+        },
+      },
+    };
+  }, {});
+
+  logger.info(
+    `Executing query for entity maintainer ${maintainerDef.id} - ${JSON.stringify({
+      query,
+      aggregation,
+    })}`
+  );
+
+  const response = await esClient.search<unknown, Record<string, AggregationsCompositeAggregate>>(
+    {
+      size: 0,
+      index: opts.index,
+      ignore_unavailable: true,
+      runtime_mappings: opts.runtimeMappings,
+      query,
+      aggs: aggregation,
+    },
+    { signal: opts.abortController.signal }
+  );
+
+  // TODO - error handling
+
+  return processResponse(response);
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { runTask } from './run';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/run.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/lib/run.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
+import { asyncForEach } from '@kbn/std';
+import type { EntityContainer } from '../../../../../common/api/entity_analytics/entity_store/entities/upsert_entities_bulk.gen';
+import type { AfterKeys } from '../../../../../common/api/entity_analytics/common';
+import type { EntityMaintainerContext } from '../entity_maintainer_client';
+import { getConfiguration } from './get_configuration';
+import { getRiskInputsIndex } from '../../risk_score/get_risk_inputs_index';
+import { getEntitiesToProcess } from './get_entities_to_process';
+import { applyMaintainerLogic } from './apply_maintainer_logic';
+
+// circuit breaker to avoid infinite loops
+const MAX_ITERATIONS = 1000;
+
+export const isCalculationComplete = (
+  result: Record<string, { afterKeys: AfterKeys; values: string[] }>
+): boolean => {
+  return true; // TODO implement
+};
+
+export const runTask = async (
+  context: EntityMaintainerContext,
+  taskInstance: ConcreteTaskInstance,
+  abortController: AbortController
+) => {
+  try {
+    const savedObjectId = taskInstance.params.savedObjectId;
+    const spaceId = taskInstance.params.spaceId;
+
+    if (!spaceId || !savedObjectId) {
+      throw new Error(`Invalid task parameters: ${JSON.stringify(taskInstance.params)}`);
+    }
+
+    // Read the saved object
+    const configuration = await getConfiguration(savedObjectId, spaceId);
+
+    // Get the input index
+    const { index, runtimeMappings } = await getRiskInputsIndex({
+      dataViewId: configuration.input,
+      logger: context.logger,
+      soClient: context.savedObjectsClient,
+    });
+
+    // Get maintainer definition from registry
+    if (!context.entityMaintainerRegistry.has(configuration.id)) {
+      throw new Error(`No entity maintainer definition found for id: ${configuration.id}`);
+    }
+    const maintainerDef = context.entityMaintainerRegistry.get(configuration.id);
+
+    if (!maintainerDef) {
+      throw new Error(`No entity maintainer definition found for id: ${configuration.id}`);
+    }
+
+    // Main loop
+    let numIterations = 0;
+    const afterKeys: AfterKeys = {};
+
+    while (true) {
+      if (numIterations >= MAX_ITERATIONS) {
+        context.logger.warn(
+          `Max iterations of ${MAX_ITERATIONS} reached for entity maintainer ${maintainerDef.id}. Exiting loop to avoid infinite processing.`
+        );
+        break;
+      }
+
+      numIterations++;
+
+      // Step 1: determine entities to process
+      const entitiesToProcess = await getEntitiesToProcess({
+        afterKeys,
+        abortController,
+        esClient: context.esClient,
+        index,
+        logger: context.logger,
+        maintainerConfig: configuration,
+        maintainerDef,
+        runtimeMappings,
+      });
+
+      // Step 2: apply entity maintainer logic for each supported entity type (perform ES|QL query from definition)
+      const allEntities: EntityContainer[] = [];
+      asyncForEach(maintainerDef.entityTypes, async (entityType) => {
+        if (entitiesToProcess[entityType].values.length > 0) {
+          // we have entities to process!
+          const entities = await applyMaintainerLogic({
+            abortController,
+            esClient: context.esClient,
+            index,
+            entityType,
+            logger: context.logger,
+            lowerBounds: afterKeys[entityType],
+            upperBounds: entitiesToProcess[entityType].afterKey,
+            maintainerDef,
+            maintainerConfig: configuration,
+          });
+
+          allEntities.push(...entities);
+        } else {
+          context.logger.info(
+            `No entities to process for entity type ${entityType} in maintainer ${maintainerDef.id}`
+          );
+        }
+      });
+
+      // Step 3: apply post-processing logic if applicable (from definition)
+      if (maintainerDef.postProcessRecords) {
+        maintainerDef.postProcessRecords(allEntities);
+      }
+
+      // Step 4: update entity store using bulk API
+      await context.entityStoreCrudClient.upsertEntitiesBulk(allEntities, false);
+
+      // Check if we're done
+      if (isCalculationComplete(entitiesToProcess) || abortController.signal.aborted) {
+        break;
+      }
+
+      // Update after keys for pagination
+      // TODO
+    }
+  } catch (err) {
+    context.logger.error(`Error encountered while running entity maintainer task: ${err.message}`, {
+      error: { stack_trace: err.stack },
+    });
+  }
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/maintainer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/maintainer.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { EntityContainer } from '../../../../common/api/entity_analytics/entity_store/entities/upsert_entities_bulk.gen';
+import type { EntityType } from '../../../../common/entity_analytics/types';
+
+export const DEFAULT_TIME_FIELD = '@timestamp';
+export const DEFAULT_LOOKBACK_WINDOW = '30d';
+
+export interface EntityMaintainer {
+  id: string;
+  defaults: {
+    input: string;
+    lookbackWindow: string;
+    timeField: string;
+  };
+  entityTypes: EntityType[];
+  getCompositeQuery: (timeField?: string, lookbackInterval?: string) => QueryDslQueryContainer;
+  getQuery: (index: string, entityType: EntityType, rangeClause: string) => string;
+  formatRecord?: (record: Record<string, unknown>) => Record<string, unknown>;
+  postProcessRecords?: (records: EntityContainer[]) => void;
+}
+
+export type EntityMaintainerConfig = Pick<EntityMaintainer, 'id'> & {
+  input: string;
+  schedule: { interval: string };
+  enabled: boolean;
+  pageSize: number;
+  timeField: string;
+  lookbackWindow: string;
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/register_entity_maintainers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/maintainers/register_entity_maintainers.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { get } from 'lodash';
+import type { EntityMaintainerRegistry } from './entity_maintainer_registry';
+import * as maintainerDefs from './all_definitions';
+
+export const registerEntityMaintainers = (registry: EntityMaintainerRegistry) => {
+  for (const defName of Object.keys(maintainerDefs).filter((key) => key !== 'default')) {
+    const def = get(maintainerDefs, defName);
+    if (def) registry.register(def);
+  }
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -153,6 +153,9 @@ import type { HealthDiagnosticService } from './lib/telemetry/diagnostic/health_
 import { ENTITY_RISK_SCORE_TOOL_ID } from './assistant/tools/entity_risk_score/entity_risk_score';
 import type { TelemetryQueryConfiguration } from './lib/telemetry/types';
 import { AIValueReportLocatorDefinition } from '../common/locators/ai_value_report/locator';
+import { EntityMaintainerRegistry } from './lib/entity_analytics/maintainers/entity_maintainer_registry';
+import { registerEntityMaintainers } from './lib/entity_analytics/maintainers/register_entity_maintainers';
+import { EntityMaintainerClient } from './lib/entity_analytics/maintainers/entity_maintainer_client';
 
 export type { SetupPlugins, StartPlugins, PluginSetup, PluginStart } from './plugin_contract';
 
@@ -183,6 +186,9 @@ export class Plugin implements ISecuritySolutionPlugin {
   private checkMetadataTransformsTask: CheckMetadataTransformsTask | undefined;
   private telemetryUsageCounter?: UsageCounter;
   private endpointContext: EndpointAppContext;
+
+  private entityMaintainerRegistry?: EntityMaintainerRegistry;
+  private entityMaintainerClient?: EntityMaintainerClient;
 
   private isServerless: boolean;
 
@@ -297,6 +303,14 @@ export class Plugin implements ISecuritySolutionPlugin {
     });
 
     this.ruleMonitoringService.setup(core, plugins);
+
+    this.entityMaintainerRegistry = new EntityMaintainerRegistry();
+    registerEntityMaintainers(this.entityMaintainerRegistry);
+
+    this.entityMaintainerClient = new EntityMaintainerClient({
+      entityMaintainerRegistry: this.entityMaintainerRegistry,
+      logger: this.logger,
+    });
 
     registerDeprecations({ core, config: this.config, logger: this.logger });
 


### PR DESCRIPTION
## Summary

POC for maintaining the access frequency entity attributes, implemented as a generic entity maintainer task.

The generic entity maintainer task has the following steps:
1. Read the associated configuration for the entity maintainer from a saved object
2. Load the entity maintainer definition from the registry
3. Determine all entities that should be processed for this task run
4. Apply the entity maintainer logic (defined as an ES|QL query) to extract the attributes for this entity maintainer
5. Process the output of the previous step into a format consumable by the entity store bulk upsert API
6. Call the entity store bulk upsert API to update attributes for entities

For the `access_frequency` entity maintainer, the steps resolve to the following
1. Read the associated configuration for the entity maintainer from a saved object
2. Load the `access_frequency` entity maintainer definition from the registry
3. Perform a query with composite aggregation to identify all `host` and `user` entities to process in this task run

<details>
<summary>Query with composite aggregation</summary>

```
{
    "size": 0,
    "index": <input index>/_search",
    "ignore_unavailable": true,
    "runtime_mappings": {},
    "query": {
        "bool": {
            "filter": [
                {
                    "range": {
                        "@timestamp": {
                            "lt": "now",
                            "gte": "now-30d"
                        }
                    }
                },
                {
                    "term": {
                        "event.category": "authentication"
                    }
                }
            ],
        }
    },
    "aggs": {
        "host": {
            "composite": {
                "size": 3500,
                "sources": [
                    {
                        "host.name": {
                            "terms": {
                                "field": "host.name"
                            }
                        }
                    }
                ]
            }
        },
        "user": {
            "composite": {
                "size": 3500,
                "sources": [
                    {
                        "user.name": {
                            "terms": {
                                "field": "user.name"
                            }
                        }
                    }
                ]
            }
        }
    }
}

```
</details>

4. Apply the `access_frequency` ES|QL query to identify hosts with frequent access and users that access frequently

<details>
<summary>ES|QL query (for hosts)</summary>

```
FROM <input_index>
    | WHERE event.category == "authentication" 
          AND KQL("host.name <= release-sec-debian-11-obtc-estec-0") 
    | STATS access_count = COUNT(*) BY host.name, related.user 
    | EVAL access_type = CASE(access_count <5, "accessed_infrequently_by",access_count >= 5, "accessed_frequently_by") 
    | STATS users = TOP(related.user, 10000) BY access_type,host.name
    | STATS accessed_frequently_by = VALUES(users) WHERE access_type == "accessed_frequently_by", accessed_infrequently_by = VALUES(users) WHERE access_type == "accessed_infrequently_by" BY host.name
```
</details>

5. Transform the ES|QL response to the format accepted by the entity store bulk upsert API
6. Call the entity store bulk upsert API