### PR TITLE
[Unified Rules] Navigation improvements

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/breadcrumb.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/breadcrumb.ts
@@ -89,3 +89,22 @@ export const getAlertingSectionBreadcrumb = (
       };
   }
 };
+
+/**
+ * Get the rules breadcrumb with the appropriate href based on app registration
+ */
+export const getRulesBreadcrumbWithHref = (
+  isAppRegistered: (appId: string) => boolean,
+  getUrlForApp: (appId: string, options?: { path?: string }) => string
+) => {
+  const rulesBreadcrumb = getAlertingSectionBreadcrumb('rules', true);
+
+  const breadcrumbHref = isAppRegistered('rules')
+    ? getUrlForApp('rules', { path: '/' })
+    : getUrlForApp('management', { path: 'insightsAndAlerting/triggersActions/rules' });
+
+  return {
+    ...rulesBreadcrumb,
+    href: breadcrumbHref,
+  };
+};

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_details.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_details.tsx
@@ -37,7 +37,7 @@ import {
   hasExecuteActionsCapability,
   hasManageApiKeysCapability,
 } from '../../../lib/capabilities';
-import { getAlertingSectionBreadcrumb } from '../../../lib/breadcrumb';
+import { getRulesBreadcrumbWithHref } from '../../../lib/breadcrumb';
 import { getCurrentDocTitle } from '../../../lib/doc_title';
 import type {
   Rule,
@@ -123,16 +123,7 @@ export const RuleDetails: React.FunctionComponent<RuleDetailsProps> = ({
 
   // Set breadcrumb and page title
   useEffect(() => {
-    const rulesBreadcrumb = getAlertingSectionBreadcrumb('rules', true);
-
-    const breadcrumbHref = isAppRegistered('rules')
-      ? getUrlForApp('rules', { path: '/' })
-      : getUrlForApp('management', { path: 'insightsAndAlerting/triggersActions/rules' });
-
-    const rulesBreadcrumbWithAppPath = {
-      ...rulesBreadcrumb,
-      href: breadcrumbHref,
-    };
+    const rulesBreadcrumbWithAppPath = getRulesBreadcrumbWithHref(isAppRegistered, getUrlForApp);
     setBreadcrumbs([rulesBreadcrumbWithAppPath, { text: rule.name }]);
     chrome.docTitle.change(getCurrentDocTitle('rules'));
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_page/rules_page.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_page/rules_page.tsx
@@ -15,7 +15,7 @@ import { getCreateRuleRoute, getEditRuleRoute } from '@kbn/rule-data-utils';
 import { useGetRuleTypesPermissions } from '@kbn/alerts-ui-shared';
 import { RulesPageTemplate } from './rules_page_template';
 import { useKibana } from '../../../common/lib/kibana';
-import { getAlertingSectionBreadcrumb } from '../../lib/breadcrumb';
+import { getAlertingSectionBreadcrumb, getRulesBreadcrumbWithHref } from '../../lib/breadcrumb';
 import { getCurrentDocTitle } from '../../lib/doc_title';
 import { NON_SIEM_CONSUMERS } from '../alerts_search_bar/constants';
 import type { Section } from '../../constants';
@@ -30,7 +30,7 @@ const RulesPage = () => {
   const {
     chrome: { docTitle },
     setBreadcrumbs,
-    application: { navigateToApp },
+    application: { navigateToApp, getUrlForApp, isAppRegistered },
     http,
     notifications: { toasts },
   } = useKibana().services;
@@ -141,10 +141,18 @@ const RulesPage = () => {
 
   useEffect(() => {
     if (setBreadcrumbs) {
-      setBreadcrumbs([getAlertingSectionBreadcrumb(currentSection || 'rules')]);
+      if (currentSection === 'logs') {
+        const rulesBreadcrumbWithAppPath = getRulesBreadcrumbWithHref(
+          isAppRegistered,
+          getUrlForApp
+        );
+        setBreadcrumbs([rulesBreadcrumbWithAppPath, getAlertingSectionBreadcrumb('logs')]);
+      } else {
+        setBreadcrumbs([getAlertingSectionBreadcrumb('rules')]);
+      }
     }
     docTitle.change(getCurrentDocTitle(currentSection || 'rules'));
-  }, [docTitle, setBreadcrumbs, currentSection]);
+  }, [docTitle, setBreadcrumbs, currentSection, getUrlForApp, isAppRegistered]);
 
   return (
     <RulesPageTemplate

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_page/rules_page.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_page/rules_page.tsx
@@ -151,7 +151,7 @@ const RulesPage = () => {
         setBreadcrumbs([getAlertingSectionBreadcrumb('rules')]);
       }
     }
-    docTitle.change(getCurrentDocTitle(currentSection || 'rules'));
+    docTitle.change(getCurrentDocTitle('rules'));
   }, [docTitle, setBreadcrumbs, currentSection, getUrlForApp, isAppRegistered]);
 
   return (


### PR DESCRIPTION
## Summary

Followup to the unified list PR #239815 

- Breadcrumbs have been updated for the logs tab to provide more context

**Before**
<img width="424" height="391" alt="Screenshot 2026-01-15 at 3 10 40 PM" src="https://github.com/user-attachments/assets/4c66c72d-a94d-4f1b-bfd6-90a49074bf67" />

**After**
<img width="139" height="45" alt="Screenshot 2026-01-15 at 3 05 14 PM" src="https://github.com/user-attachments/assets/45ed587d-95e0-4985-9797-1f21a8897114" />

- Document title retains the rules title for the logs tab 