### PR TITLE
[9.3] [Discover] Wrap error boundary around `chartSectionConfig.renderChartSection` (#249107)

### DIFF
--- a/src/platform/plugins/shared/discover/moon.yml
+++ b/src/platform/plugins/shared/discover/moon.yml
@@ -127,6 +127,7 @@ dependsOn:
   - '@kbn/unified-metrics-grid'
   - '@kbn/shared-ux-link-redirect-app'
   - '@kbn/react-query'
+  - '@kbn/shared-ux-error-boundary'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/chart_portals_renderer.tsx
@@ -14,6 +14,8 @@ import { UnifiedHistogramChart, useUnifiedHistogram } from '@kbn/unified-histogr
 import { useChartStyles } from '@kbn/unified-histogram/components/chart/hooks/use_chart_styles';
 import { useServicesBootstrap } from '@kbn/unified-histogram/hooks/use_services_bootstrap';
 import type { UnifiedMetricsGridRestorableState } from '@kbn/unified-metrics-grid';
+import { KibanaSectionErrorBoundary } from '@kbn/shared-ux-error-boundary';
+import { i18n } from '@kbn/i18n';
 import { useProfileAccessor } from '../../../../context_awareness';
 import { DiscoverCustomizationProvider } from '../../../../customizations';
 import {
@@ -247,10 +249,7 @@ const CustomChartSectionWrapper = ({
   const setMetricsGridState = useCurrentTabAction(internalStateActions.setMetricsGridState);
   const onInitialStateChange = useCallback(
     (newMetricsGridState: Partial<UnifiedMetricsGridRestorableState>) => {
-      // Defer dispatch to next tick - ensures React render cycle is complete
-      // setTimeout(() => {
       dispatch(setMetricsGridState({ metricsGridState: newMetricsGridState }));
-      // }, 0);
     },
     [setMetricsGridState, dispatch]
   );
@@ -293,15 +292,23 @@ const CustomChartSectionWrapper = ({
 
   const isComponentVisible = !!layoutProps.chart && !layoutProps.chart.hidden;
 
-  return chartSectionConfig.renderChartSection({
-    histogramCss,
-    chartToolbarCss,
-    renderToggleActions: renderCustomChartToggleActions,
-    fetch$,
-    fetchParams,
-    isComponentVisible,
-    ...unifiedHistogramProps,
-    initialState: metricsGridState,
-    onInitialStateChange,
-  });
+  return (
+    <KibanaSectionErrorBoundary
+      sectionName={i18n.translate('discover.chart.errorBoundarySectionName', {
+        defaultMessage: 'Discover chart section',
+      })}
+    >
+      {chartSectionConfig.renderChartSection({
+        histogramCss,
+        chartToolbarCss,
+        renderToggleActions: renderCustomChartToggleActions,
+        fetch$,
+        fetchParams,
+        isComponentVisible,
+        ...unifiedHistogramProps,
+        initialState: metricsGridState,
+        onInitialStateChange,
+      })}
+    </KibanaSectionErrorBoundary>
+  );
 };

--- a/src/platform/plugins/shared/discover/tsconfig.json
+++ b/src/platform/plugins/shared/discover/tsconfig.json
@@ -120,7 +120,8 @@
     "@kbn/unified-metrics-grid",
     "@kbn/shared-ux-link-redirect-app",
     "@kbn/react-query",
-    "@kbn/lens-common"
+    "@kbn/lens-common",
+    "@kbn/shared-ux-error-boundary"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Discover] Wrap error boundary around `chartSectionConfig.renderChartSection` (#249107)](https://github.com/elastic/kibana/pull/249107)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2026-01-15T15:06:43Z","message":"[Discover] Wrap error boundary around `chartSectionConfig.renderChartSection` (#249107)\n\n## Summary\n\nThis PR wraps a `KibanaSectionErrorBoundary` around\n`chartSectionConfig.renderChartSection` so Discover doesn't completely\nbreak when a custom chart section component throws an error.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/b20156ae-85b8-455a-9276-1507f658ff3d\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/0f828640-9c88-451a-ac16-0735a409cd3d\n\nRelated to #249075.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d4cd5909f03f73a693eef879c1876d86d0d1a7d5","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:skip","Team:DataDiscovery","backport:version","v9.3.0","v9.4.0","v9.2.5"],"title":"[Discover] Wrap error boundary around `chartSectionConfig.renderChartSection`","number":249107,"url":"https://github.com/elastic/kibana/pull/249107","mergeCommit":{"message":"[Discover] Wrap error boundary around `chartSectionConfig.renderChartSection` (#249107)\n\n## Summary\n\nThis PR wraps a `KibanaSectionErrorBoundary` around\n`chartSectionConfig.renderChartSection` so Discover doesn't completely\nbreak when a custom chart section component throws an error.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/b20156ae-85b8-455a-9276-1507f658ff3d\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/0f828640-9c88-451a-ac16-0735a409cd3d\n\nRelated to #249075.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d4cd5909f03f73a693eef879c1876d86d0d1a7d5"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249107","number":249107,"mergeCommit":{"message":"[Discover] Wrap error boundary around `chartSectionConfig.renderChartSection` (#249107)\n\n## Summary\n\nThis PR wraps a `KibanaSectionErrorBoundary` around\n`chartSectionConfig.renderChartSection` so Discover doesn't completely\nbreak when a custom chart section component throws an error.\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/b20156ae-85b8-455a-9276-1507f658ff3d\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/0f828640-9c88-451a-ac16-0735a409cd3d\n\nRelated to #249075.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d4cd5909f03f73a693eef879c1876d86d0d1a7d5"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->