### PR TITLE
[App Menu Standardization] Add collapse and triggerElement to app menu

### DIFF
--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/index.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/index.ts
@@ -16,6 +16,7 @@ export { AppMenuPopoverActionButtons } from './src';
 
 export type {
   AppMenuRunAction,
+  AppMenuRunActionParams,
   AppMenuConfig,
   AppMenuItemType,
   AppMenuSecondaryActionItem,

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/index.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/index.ts
@@ -15,6 +15,7 @@ export { AppMenuPopover } from './src';
 export { AppMenuPopoverActionButtons } from './src';
 
 export type {
+  AppMenuRunAction,
   AppMenuConfig,
   AppMenuItemType,
   AppMenuSecondaryActionItem,

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.tsx
@@ -18,12 +18,21 @@ import type { AppMenuConfig } from '../types';
 export interface AppMenuItemsProps {
   config?: AppMenuConfig;
   visible?: boolean;
+  /**
+   * Whether to render the app menu in a collapsed state (showing only the overflow button).
+   * Only available for the standalone app menu component.
+   */
+  isCollapsed?: boolean;
 }
 
 const hasNoItems = (config: AppMenuConfig) =>
   !config.items?.length && !config?.primaryActionItem && !config?.secondaryActionItem;
 
-export const AppMenuComponent = ({ config, visible = true }: AppMenuItemsProps) => {
+export const AppMenuComponent = ({
+  config,
+  visible = true,
+  isCollapsed = false,
+}: AppMenuItemsProps) => {
   const [openPopoverId, setOpenPopoverId] = useState<string | null>(null);
   const isBetweenMandXlBreakpoint = useIsWithinBreakpoints(['m', 'l']);
   const isAboveXlBreakpoint = useIsWithinBreakpoints(['xl']);
@@ -77,6 +86,21 @@ export const AppMenuComponent = ({ config, visible = true }: AppMenuItemsProps) 
     />
   ) : undefined;
 
+  const collapsedComponent = (
+    <AppMenuOverflowButton
+      items={[...displayedItems, ...overflowItems]}
+      isPopoverOpen={openPopoverId === showMoreButtonId}
+      secondaryActionItem={secondaryActionItem}
+      primaryActionItem={primaryActionItem}
+      onPopoverToggle={() => handlePopoverToggle(showMoreButtonId)}
+      onPopoverClose={handleOnPopoverClose}
+    />
+  );
+
+  if (isCollapsed) {
+    return <EuiHeaderLinks {...headerLinksProps}>{collapsedComponent}</EuiHeaderLinks>;
+  }
+
   if (isBetweenMandXlBreakpoint) {
     return (
       <EuiHeaderLinks {...headerLinksProps}>
@@ -119,16 +143,5 @@ export const AppMenuComponent = ({ config, visible = true }: AppMenuItemsProps) 
     );
   }
 
-  return (
-    <EuiHeaderLinks {...headerLinksProps}>
-      <AppMenuOverflowButton
-        items={[...displayedItems, ...overflowItems]}
-        isPopoverOpen={openPopoverId === showMoreButtonId}
-        secondaryActionItem={secondaryActionItem}
-        primaryActionItem={primaryActionItem}
-        onPopoverToggle={() => handlePopoverToggle(showMoreButtonId)}
-        onPopoverClose={handleOnPopoverClose}
-      />
-    </EuiHeaderLinks>
-  );
+  return <EuiHeaderLinks {...headerLinksProps}>{collapsedComponent}</EuiHeaderLinks>;
 };

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu.tsx
@@ -21,6 +21,7 @@ export interface AppMenuItemsProps {
   /**
    * Whether to render the app menu in a collapsed state (showing only the overflow button).
    * Only available for the standalone app menu component.
+   * TODO: Remove this in favour of container queries once EUI supports them https://github.com/elastic/eui/issues/8822
    */
   isCollapsed?: boolean;
 }

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_action_button.test.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_action_button.test.tsx
@@ -46,7 +46,6 @@ describe('AppMenuActionButton', () => {
     await user.click(screen.getByTestId('test-action-button'));
 
     expect(defaultProps.run).toHaveBeenCalledTimes(1);
-    expect(defaultProps.run).toHaveBeenCalledWith();
   });
 
   it('should render as split button', () => {

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_action_button.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_action_button.tsx
@@ -86,7 +86,7 @@ export const AppMenuActionButton = (props: AppMenuActionButtonProps) => {
       return;
     }
 
-    run?.(event.currentTarget);
+    run?.({ triggerElement: event.currentTarget });
   };
 
   const handleSecondaryButtonClick = (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
@@ -97,7 +97,7 @@ export const AppMenuActionButton = (props: AppMenuActionButtonProps) => {
       return;
     }
 
-    splitButtonRun?.(event.currentTarget);
+    splitButtonRun?.({ triggerElement: event.currentTarget });
   };
 
   const commonProps = {

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_action_button.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_action_button.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { type MouseEvent } from 'react';
 import { SplitButtonWithNotification } from '@kbn/split-button';
 import { upperFirst } from 'lodash';
 import type { EuiButtonColor, PopoverAnchorPosition } from '@elastic/eui';
@@ -78,7 +78,7 @@ export const AppMenuActionButton = (props: AppMenuActionButtonProps) => {
   const hasItems = items && items.length > 0;
   const hasSplitItems = splitButtonItems && splitButtonItems.length > 0;
 
-  const handleClick = () => {
+  const handleClick = (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
     if (isDisabled(disableButton)) return;
 
     if (hasItems) {
@@ -86,10 +86,10 @@ export const AppMenuActionButton = (props: AppMenuActionButtonProps) => {
       return;
     }
 
-    run?.();
+    run?.(event.currentTarget);
   };
 
-  const handleSecondaryButtonClick = () => {
+  const handleSecondaryButtonClick = (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
     if (isDisabled(splitButtonProps?.isSecondaryButtonDisabled)) return;
 
     if (hasSplitItems) {
@@ -97,7 +97,7 @@ export const AppMenuActionButton = (props: AppMenuActionButtonProps) => {
       return;
     }
 
-    splitButtonRun?.();
+    splitButtonRun?.(event.currentTarget);
   };
 
   const commonProps = {

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_item.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_item.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { type MouseEvent } from 'react';
 import { EuiHeaderLink, EuiHideFor, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { upperFirst } from 'lodash';
 import { css } from '@emotion/react';
@@ -49,7 +49,7 @@ export const AppMenuItem = ({
   const showTooltip = Boolean(content || title);
   const hasItems = items && items.length > 0;
 
-  const handleClick = () => {
+  const handleClick = (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
     if (isDisabled(disableButton)) return;
 
     if (hasItems) {
@@ -57,7 +57,7 @@ export const AppMenuItem = ({
       return;
     }
 
-    run?.();
+    run?.(event.currentTarget);
   };
 
   const buttonCss = css`

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_item.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_item.tsx
@@ -57,7 +57,7 @@ export const AppMenuItem = ({
       return;
     }
 
-    run?.(event.currentTarget);
+    run?.({ triggerElement: event.currentTarget });
   };
 
   const buttonCss = css`

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_popover_action_buttons.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_popover_action_buttons.tsx
@@ -57,8 +57,8 @@ export const AppMenuPopoverActionButtons = ({
         <EuiFlexItem grow={false}>
           <AppMenuActionButton
             {...secondaryActionItem}
-            run={(triggerElement) => {
-              secondaryActionItem?.run?.(triggerElement);
+            run={(params) => {
+              secondaryActionItem?.run?.(params);
               onCloseOverflowButton?.();
             }}
             isPopoverOpen={openPopoverId === secondaryActionItem.id}
@@ -75,8 +75,8 @@ export const AppMenuPopoverActionButtons = ({
         <EuiFlexItem grow={false}>
           <AppMenuActionButton
             {...primaryActionItem}
-            run={(triggerElement) => {
-              primaryActionItem?.run?.(triggerElement);
+            run={(params) => {
+              primaryActionItem?.run?.(params);
               onCloseOverflowButton?.();
             }}
             isPopoverOpen={openPopoverId === primaryActionItem.id}

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_popover_action_buttons.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_popover_action_buttons.tsx
@@ -57,8 +57,8 @@ export const AppMenuPopoverActionButtons = ({
         <EuiFlexItem grow={false}>
           <AppMenuActionButton
             {...secondaryActionItem}
-            run={() => {
-              secondaryActionItem?.run?.();
+            run={(triggerElement) => {
+              secondaryActionItem?.run?.(triggerElement);
               onCloseOverflowButton?.();
             }}
             isPopoverOpen={openPopoverId === secondaryActionItem.id}
@@ -75,8 +75,8 @@ export const AppMenuPopoverActionButtons = ({
         <EuiFlexItem grow={false}>
           <AppMenuActionButton
             {...primaryActionItem}
-            run={() => {
-              primaryActionItem?.run?.();
+            run={(triggerElement) => {
+              primaryActionItem?.run?.(triggerElement);
               onCloseOverflowButton?.();
             }}
             isPopoverOpen={openPopoverId === primaryActionItem.id}

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/index.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/index.ts
@@ -16,6 +16,7 @@ export { AppMenuPopoverActionButtons } from './components';
 
 export type {
   AppMenuRunAction,
+  AppMenuRunActionParams,
   AppMenuConfig,
   AppMenuItemType,
   AppMenuSecondaryActionItem,

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/index.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/index.ts
@@ -15,6 +15,7 @@ export { AppMenuPopover } from './components';
 export { AppMenuPopoverActionButtons } from './components';
 
 export type {
+  AppMenuRunAction,
   AppMenuConfig,
   AppMenuItemType,
   AppMenuSecondaryActionItem,

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
@@ -11,10 +11,25 @@ import type { EuiButtonColor, EuiButtonProps, EuiHideForProps, IconType } from '
 import type { SplitButtonWithNotificationProps } from '@kbn/split-button';
 
 /**
- * Type for the function that runs when an app menu item is clicked
- * @param triggerElement - The HTML element that triggered the action. Do not use this to open popovers. Use `items` property to define popover items instead.
+ * Parameters passed to AppMenuRunAction
  */
-export type AppMenuRunAction = (triggerElement: HTMLElement) => void;
+export interface AppMenuRunActionParams {
+  /**
+   * The HTML element that triggered the action. Do not use this to open popovers. Use `items` property to define popover items instead.
+   */
+  triggerElement: HTMLElement;
+  /**
+   * Generic context object that can be used to pass additional data to the run action.
+   * Consumers can extend this to add custom properties as needed.
+   */
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Type for the function that runs when an app menu item is clicked
+ * @param params - Optional parameters object
+ */
+export type AppMenuRunAction = (params?: AppMenuRunActionParams) => void;
 
 /**
  * Subset of SplitButtonWithNotificationProps.

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
@@ -11,6 +11,12 @@ import type { EuiButtonColor, EuiButtonProps, EuiHideForProps, IconType } from '
 import type { SplitButtonWithNotificationProps } from '@kbn/split-button';
 
 /**
+ * Type for the function that runs when an app menu item is clicked
+ * @param triggerElement - The HTML element that triggered the action. Do not use this to open popovers. Use `items` property to define popover items instead.
+ */
+export type AppMenuRunAction = (triggerElement: HTMLElement) => void;
+
+/**
  * Subset of SplitButtonWithNotificationProps.
  */
 type BaseSplitProps = Pick<
@@ -42,7 +48,7 @@ export type AppMenuSplitButtonProps =
       /**
        * Function to run when the item is clicked. Only used if `items` is not provided.
        */
-      run: () => void;
+      run: AppMenuRunAction;
     })
   | (BaseSplitProps & {
       /**
@@ -114,7 +120,7 @@ export type AppMenuItemCommon =
       /**
        * Function to run when the item is clicked. Only used if `items` is not provided.
        */
-      run: () => void;
+      run: AppMenuRunAction;
       /**
        * Sub-items to show in a popover when the item is clicked. Only used if `run` is not provided.
        */

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
@@ -122,8 +122,7 @@ export const mapAppMenuItemToPanelItem = (
       return;
     }
 
-    const shouldClosePopover =
-      !item?.href && childPanelId === undefined && item.run?.length === 0 && onClose;
+    const shouldClosePopover = !item?.href && childPanelId === undefined && onClose;
 
     item.run?.(event?.currentTarget as HTMLElement);
 

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { type MouseEvent } from 'react';
 import { isArray, isFunction, upperFirst } from 'lodash';
 import {
   type EuiButtonColor,
@@ -117,7 +117,7 @@ export const mapAppMenuItemToPanelItem = (
     tooltipTitle: item?.tooltipTitle,
   });
 
-  const handleClick = () => {
+  const handleClick = (event: MouseEvent) => {
     if (isDisabled(item?.disableButton)) {
       return;
     }
@@ -125,7 +125,7 @@ export const mapAppMenuItemToPanelItem = (
     const shouldClosePopover =
       !item?.href && childPanelId === undefined && item.run?.length === 0 && onClose;
 
-    item.run?.();
+    item.run?.(event?.currentTarget as HTMLElement);
 
     if (shouldClosePopover) {
       onClose();

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
@@ -124,7 +124,7 @@ export const mapAppMenuItemToPanelItem = (
 
     const shouldClosePopover = !item?.href && childPanelId === undefined && onClose;
 
-    item.run?.(event?.currentTarget as HTMLElement);
+    item.run?.({ triggerElement: event?.currentTarget as HTMLElement });
 
     if (shouldClosePopover) {
       onClose();


### PR DESCRIPTION
## Summary

This PR adds a way to collapse the standalone app menu component and provides access to the HTML that triggered the `run` function.

Closes: https://github.com/elastic/kibana-team/issues/2656


