### PR TITLE
[Field formatters] make static-lookup formatter work with aggregated boolean fields

### DIFF
--- a/src/platform/plugins/shared/field_formats/common/converters/static_lookup.ts
+++ b/src/platform/plugins/shared/field_formats/common/converters/static_lookup.ts
@@ -19,6 +19,19 @@ function convertLookupEntriesToMap(
   return lookupEntries.reduce(
     (lookupMap: Record<string, unknown>, lookupEntry: { key: string; value: unknown }) => {
       lookupMap[lookupEntry.key] = lookupEntry.value;
+
+      /**
+       * Do some key translations because Elasticsearch returns
+       * boolean-type aggregation results as 0 and 1
+       */
+      if (lookupEntry.key === 'true') {
+        lookupMap[1] = lookupEntry.value;
+      }
+
+      if (lookupEntry.key === 'false') {
+        lookupMap[0] = lookupEntry.value;
+      }
+
       return lookupMap;
     },
     {} as Record<string, unknown>


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/100832

Explanation on parent issue: https://github.com/elastic/kibana/issues/100832#issuecomment-3757365053


<img width="1663" height="918" alt="Screenshot 2026-01-15 at 4 41 34 PM" src="https://github.com/user-attachments/assets/fea0c4c1-9c07-46fc-842b-2c3aae7be5f3" />


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->