### PR TITLE
[ES|QL] Temporarily comment out tests to allow ES promotion

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/validate.test.ts
@@ -73,7 +73,7 @@ describe('FROM Validation', () => {
         fromExpectErrors(`FROM index, missingIndex`, ['Unknown index "missingIndex"']);
         fromExpectErrors(`from average()`, ['Unknown index "average"']);
         fromExpectErrors(`fRom custom_function()`, ['Unknown index "custom_function"']);
-        fromExpectErrors(`FROM indexes*`, ['Unknown index "indexes*"']);
+        // fromExpectErrors(`FROM indexes*`, ['Unknown index "indexes*"']); // TODO: ES no longer returns error for wildcard patterns that don't match - see https://github.com/elastic/kibana/issues/217119
         fromExpectErrors('from numberField', ['Unknown index "numberField"']);
         fromExpectErrors('FROM policy', ['Unknown index "policy"']);
 
@@ -82,7 +82,7 @@ describe('FROM Validation', () => {
         fromExpectErrors('FROM *missingIndex, missingIndex2, index', [
           'Unknown index "missingIndex2"',
         ]);
-        fromExpectErrors('FROM missingIndex*', ['Unknown index "missingIndex*"']);
+        // fromExpectErrors('FROM missingIndex*', ['Unknown index "missingIndex*"']); // TODO: ES no longer returns error for wildcard patterns that don't match - see https://github.com/elastic/kibana/issues/217119
         fromExpectErrors('FROM *missingIndex, missing*Index2', [
           'Unknown index "*missingIndex"',
           'Unknown index "missing*Index2"',
@@ -111,7 +111,7 @@ describe('FROM Validation', () => {
   describe('CCS indices', () => {
     describe('... <sources> ...', () => {
       test('display errors on unknown indices', () => {
-        fromExpectErrors('fRoM remote-*:indexes*', ['Unknown index "remote-*:indexes*"']);
+        // fromExpectErrors('fRoM remote-*:indexes*', ['Unknown index "remote-*:indexes*"']); // TODO: ES no longer returns error for wildcard patterns that don't match - see https://github.com/elastic/kibana/issues/217119
         fromExpectErrors('fRoM remote-*:indexes', ['Unknown index "remote-*:indexes"']);
         fromExpectErrors('fRoM remote-ccs:indexes', ['Unknown index "remote-ccs:indexes"']);
         fromExpectErrors('fRoM a_index, remote-ccs:indexes', [

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/timeseries/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/timeseries/validate.test.ts
@@ -73,14 +73,14 @@ describe('TS Validation', () => {
         tsExpectErrors(`TS index, missingIndex`, ['Unknown index "missingIndex"']);
         tsExpectErrors(`TS average()`, ['Unknown index "average"']);
         tsExpectErrors(`TS custom_function()`, ['Unknown index "custom_function"']);
-        tsExpectErrors(`TS indexes*`, ['Unknown index "indexes*"']);
+        // tsExpectErrors(`TS indexes*`, ['Unknown index "indexes*"']); // TODO: ES no longer returns error for wildcard patterns that don't match - see https://github.com/elastic/kibana/issues/217119
         tsExpectErrors('TS numberField', ['Unknown index "numberField"']);
         tsExpectErrors('TS policy', ['Unknown index "policy"']);
 
         tsExpectErrors('TS index, missingIndex', ['Unknown index "missingIndex"']);
         tsExpectErrors('TS missingIndex, index', ['Unknown index "missingIndex"']);
         tsExpectErrors('TS *missingIndex, missingIndex2, index', ['Unknown index "missingIndex2"']);
-        tsExpectErrors('TS missingIndex*', ['Unknown index "missingIndex*"']);
+        // tsExpectErrors('TS missingIndex*', ['Unknown index "missingIndex*"']); // TODO: ES no longer returns error for wildcard patterns that don't match - see https://github.com/elastic/kibana/issues/217119
         tsExpectErrors('TS *missingIndex, missing*Index2', [
           'Unknown index "*missingIndex"',
           'Unknown index "missing*Index2"',

--- a/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/subqueries.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/subqueries.test.ts
@@ -50,9 +50,9 @@ describe('Subqueries Validation', () => {
       await expectErrors('FROM index, (FROM remote-ccs:indexes)', [
         'Unknown index "remote-ccs:indexes"',
       ]);
-      await expectErrors('FROM index, (FROM remote-*:indexes*)', [
-        'Unknown index "remote-*:indexes*"',
-      ]);
+      // await expectErrors('FROM index, (FROM remote-*:indexes*)', [
+      //   'Unknown index "remote-*:indexes*"',
+      // ]); // TODO: ES no longer returns error for wildcard patterns that don't match - see https://github.com/elastic/kibana/issues/217119
     });
 
     it('should validate custom command validation inside deeply nested subqueries', async () => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/217119

ES now https://github.com/elastic/elasticsearch/pull/139181 doesnt fail when the user queries an unknown index with a wildcard.  Our tests (and our code) have not been adjusted yet so the promotion fails. 

I am unblocking the promotion by commenting out the tests and we will adapt to the change in a follow up



