### PR TITLE
[Infra] Fix inventory home page tests

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/saved_views/toolbar_control.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/saved_views/toolbar_control.tsx
@@ -110,7 +110,9 @@ export function SavedViewsToolbarControls<TSingleSavedViewState extends SavedVie
           <EuiButton
             size="s"
             onClick={togglePopoverAndLoad}
-            data-test-subj="savedViews-openPopover"
+            data-test-subj={`savedViews-openPopover-${
+              isFetchingCurrentView ? 'loading' : 'loaded'
+            }`}
             buttonRef={openPopoverButtonRef}
             iconType="arrowDown"
             iconSide="right"

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -64,30 +64,12 @@ export class InventoryPage {
     this.noDataPageActionButton = this.noDataPage.getByTestId('noDataDefaultActionButton');
   }
 
-  private async waitForNodesToLoad(opts: { waitForSnapshotRequest?: boolean } = {}) {
-    if (opts.waitForSnapshotRequest) {
-      // Wait for successful API completion
-      await this.page.waitForResponse(
-        (resp) => resp.url().includes('/api/metrics/snapshot') && resp.status() === 200
-      );
-    }
-
-    await this.page.getByTestId('infraNodesOverviewLoadingPanel').waitFor({ state: 'hidden' });
-  }
-
-  private async waitForPageToLoad() {
-    await this.page.getByTestId('infraMetricsPage').waitFor();
-    await this.waitForNodesToLoad();
-  }
-
   public async goToPage() {
     await this.page.goto(`${this.kbnUrl.app('metrics')}/inventory`);
-    await this.waitForPageToLoad();
   }
 
   public async reload() {
     await this.page.reload();
-    await this.waitForPageToLoad();
   }
 
   public async toggleTimeline() {
@@ -108,7 +90,7 @@ export class InventoryPage {
 
   public async goToTime(time: string) {
     await this.datePickerInput.fill(time);
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
+    await this.datePickerInput.press('Escape');
   }
 
   public async getWaffleNode(nodeName: string) {
@@ -124,19 +106,16 @@ export class InventoryPage {
   public async showHosts() {
     await this.inventorySwitcherButton.click();
     await this.inventorySwitcherHostsButton.click();
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
   }
 
   public async showPods() {
     await this.inventorySwitcherButton.click();
     await this.inventorySwitcherPodsButton.click();
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
   }
 
   public async showContainers() {
     await this.inventorySwitcherButton.click();
     await this.inventorySwitcherContainersButton.click();
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
   }
 
   public async clickNoDataPageAddDataButton() {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -110,9 +110,9 @@ export class InventoryPage {
 
   public async goToTime(time: string) {
     await this.datePickerInput.fill(time);
+    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
     await this.queryInput.click();
     await this.queryInput.press('Escape');
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
   }
 
   public async getWaffleNode(nodeName: string) {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -6,6 +6,7 @@
  */
 
 import { type KibanaUrl, type Locator, type ScoutPage } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt';
 
 export class InventoryPage {
   public readonly feedbackLink: Locator;
@@ -109,12 +110,13 @@ export class InventoryPage {
   }
 
   public async goToTime(time: string) {
-    // eslint-disable-next-line playwright/no-force-option
-    await this.datePickerInput.fill(time, { force: true });
-    if ((await this.datePickerInput.inputValue()) !== time) {
+    let inputValue = '';
+    do {
       // eslint-disable-next-line playwright/no-force-option
       await this.datePickerInput.fill(time, { force: true });
-    }
+      inputValue = await this.datePickerInput.inputValue();
+    } while (inputValue !== time);
+    await expect(this.datePickerInput).toHaveValue(time);
     await this.datePickerInput.press('Escape');
     await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
   }

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -6,13 +6,11 @@
  */
 
 import { type KibanaUrl, type Locator, type ScoutPage } from '@kbn/scout-oblt';
-import { expect } from '@kbn/scout-oblt';
 
 export class InventoryPage {
   public readonly feedbackLink: Locator;
   public readonly k8sFeedbackLink: Locator;
 
-  public readonly queryInput: Locator;
   public readonly datePickerInput: Locator;
 
   public readonly inventorySwitcherButton: Locator;
@@ -41,7 +39,6 @@ export class InventoryPage {
     this.feedbackLink = this.page.getByTestId('infraInventoryFeedbackLink');
     this.k8sFeedbackLink = this.page.getByTestId('infra-kubernetes-feedback-link');
 
-    this.queryInput = this.page.getByTestId('queryInput');
     this.datePickerInput = this.page.getByTestId('waffleDatePicker').getByRole('textbox');
 
     this.inventorySwitcherButton = this.page.getByTestId('openInventorySwitcher');
@@ -67,20 +64,14 @@ export class InventoryPage {
     this.noDataPageActionButton = this.noDataPage.getByTestId('noDataDefaultActionButton');
   }
 
-  private async waitForNodesToLoad(opts: { waitForSnapshotRequest?: boolean } = {}) {
-    if (opts.waitForSnapshotRequest) {
-      // Wait for successful API completion
-      await this.page.waitForResponse(
-        (resp) => resp.url().includes('/api/metrics/snapshot') && resp.status() === 200
-      );
-    }
-
+  private async waitForNodesToLoad() {
     await this.page.getByTestId('infraNodesOverviewLoadingPanel').waitFor({ state: 'hidden' });
   }
 
   private async waitForPageToLoad() {
     await this.page.getByTestId('infraMetricsPage').waitFor();
     await this.waitForNodesToLoad();
+    await this.page.getByTestId('savedViews-openPopover-loaded').waitFor();
   }
 
   public async goToPage() {
@@ -110,15 +101,9 @@ export class InventoryPage {
   }
 
   public async goToTime(time: string) {
-    let inputValue = '';
-    do {
-      // eslint-disable-next-line playwright/no-force-option
-      await this.datePickerInput.fill(time, { force: true });
-      inputValue = await this.datePickerInput.inputValue();
-    } while (inputValue !== time);
-    await expect(this.datePickerInput).toHaveValue(time);
+    await this.datePickerInput.fill(time);
     await this.datePickerInput.press('Escape');
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
+    await this.waitForNodesToLoad();
   }
 
   public async getWaffleNode(nodeName: string) {
@@ -134,19 +119,19 @@ export class InventoryPage {
   public async showHosts() {
     await this.inventorySwitcherButton.click();
     await this.inventorySwitcherHostsButton.click();
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
+    await this.waitForNodesToLoad();
   }
 
   public async showPods() {
     await this.inventorySwitcherButton.click();
     await this.inventorySwitcherPodsButton.click();
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
+    await this.waitForNodesToLoad();
   }
 
   public async showContainers() {
     await this.inventorySwitcherButton.click();
     await this.inventorySwitcherContainersButton.click();
-    await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
+    await this.waitForNodesToLoad();
   }
 
   public async clickNoDataPageAddDataButton() {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -109,6 +109,7 @@ export class InventoryPage {
   }
 
   public async goToTime(time: string) {
+    // eslint-disable-next-line playwright/no-force-option
     await this.datePickerInput.fill(time, { force: true });
     await this.datePickerInput.press('Escape');
     await this.waitForNodesToLoad({ waitForSnapshotRequest: true });

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -111,6 +111,9 @@ export class InventoryPage {
   public async goToTime(time: string) {
     await this.datePickerInput.fill(time);
     await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
+    // Focusing the date picker input will cause the calendar popover to open, which covers parts of the UI and can interfere with test assertions.
+    // Closing it by pressing Escape on the date input itself was leading to flaky behaviour where the input value wouldn't be properly set sometimes.
+    // So instead, we click and escape the query input to get rid of all popovers while not interfering with input values as the query input is not being filled.
     await this.queryInput.click();
     await this.queryInput.press('Escape');
   }

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -107,8 +107,6 @@ export class InventoryPage {
   }
 
   public async goToTime(time: string) {
-    await this.datePickerInput.focus();
-    await this.datePickerInput.clear();
     await this.datePickerInput.fill(time);
     await this.datePickerInput.press('Enter');
     await this.waitForNodesToLoad({ waitForSnapshotRequest: true });

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -74,9 +74,11 @@ export class InventoryPage {
     await this.page.getByTestId('savedViews-openPopover-loaded').waitFor();
   }
 
-  public async goToPage() {
+  public async goToPage(opts: { skipLoadWait?: boolean } = {}) {
     await this.page.goto(`${this.kbnUrl.app('metrics')}/inventory`);
-    await this.waitForPageToLoad();
+    if (!opts.skipLoadWait) {
+      await this.waitForPageToLoad();
+    }
   }
 
   public async reload() {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -108,7 +108,6 @@ export class InventoryPage {
 
   public async goToTime(time: string) {
     await this.datePickerInput.fill(time);
-    await this.datePickerInput.press('Enter');
     await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
   }
 

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -111,6 +111,10 @@ export class InventoryPage {
   public async goToTime(time: string) {
     // eslint-disable-next-line playwright/no-force-option
     await this.datePickerInput.fill(time, { force: true });
+    if ((await this.datePickerInput.inputValue()) !== time) {
+      // eslint-disable-next-line playwright/no-force-option
+      await this.datePickerInput.fill(time, { force: true });
+    }
     await this.datePickerInput.press('Escape');
     await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
   }

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -109,13 +109,9 @@ export class InventoryPage {
   }
 
   public async goToTime(time: string) {
-    await this.datePickerInput.fill(time);
+    await this.datePickerInput.fill(time, { force: true });
+    await this.datePickerInput.press('Escape');
     await this.waitForNodesToLoad({ waitForSnapshotRequest: true });
-    // Focusing the date picker input will cause the calendar popover to open, which covers parts of the UI and can interfere with test assertions.
-    // Closing it by pressing Escape on the date input itself was leading to flaky behaviour where the input value wouldn't be properly set sometimes.
-    // So instead, we click and escape the query input to get rid of all popovers while not interfering with input values as the query input is not being filled.
-    await this.queryInput.click();
-    await this.queryInput.press('Escape');
   }
 
   public async getWaffleNode(nodeName: string) {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
@@ -33,7 +33,7 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
     await inventoryPage.goToTime(DATE_WITH_HOSTS_DATA);
   });
 
-  test('Render expected content', async ({ page, pageObjects: { inventoryPage } }) => {
+  test.only('Render expected content', async ({ page, pageObjects: { inventoryPage } }) => {
     await test.step('set the correct browser page title', async () => {
       const title = await page.title();
       expect(title).toBe('Infrastructure inventory - Infrastructure - Observability - Elastic');

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory.spec.ts
@@ -33,7 +33,7 @@ test.describe('Infrastructure Inventory', { tag: ['@ess', '@svlOblt'] }, () => {
     await inventoryPage.goToTime(DATE_WITH_HOSTS_DATA);
   });
 
-  test.only('Render expected content', async ({ page, pageObjects: { inventoryPage } }) => {
+  test('Render expected content', async ({ page, pageObjects: { inventoryPage } }) => {
     await test.step('set the correct browser page title', async () => {
       const title = await page.title();
       expect(title).toBe('Infrastructure inventory - Infrastructure - Observability - Elastic');

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/inventory/inventory.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/tests/inventory/inventory.spec.ts
@@ -11,7 +11,8 @@ import { test } from '../../fixtures';
 test.describe('Infrastructure Inventory - Onboarding', { tag: ['@ess', '@svlOblt'] }, () => {
   test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
     await browserAuth.loginAsViewer();
-    await inventoryPage.goToPage();
+    // Skip load wait as there is no data to load in empty data test cases
+    await inventoryPage.goToPage({ skipLoadWait: true });
   });
 
   test('Renders no data page and redirects to onboarding page when no data is present', async ({

--- a/x-pack/solutions/observability/test/functional/page_objects/infra_saved_views.ts
+++ b/x-pack/solutions/observability/test/functional/page_objects/infra_saved_views.ts
@@ -75,7 +75,7 @@ export function InfraSavedViewsProvider({ getService }: FtrProviderContext) {
 
     async ensureViewIsLoaded(name: string) {
       await retry.tryForTime(config.get('timeouts.try'), async () => {
-        const subject = await testSubjects.find('savedViews-openPopover');
+        const subject = await testSubjects.find('savedViews-openPopover-loaded');
         expect(await subject.getVisibleText()).to.be(name);
       });
     },

--- a/x-pack/solutions/observability/test/functional/page_objects/infra_saved_views.ts
+++ b/x-pack/solutions/observability/test/functional/page_objects/infra_saved_views.ts
@@ -17,7 +17,7 @@ export function InfraSavedViewsProvider({ getService }: FtrProviderContext) {
 
   return {
     async clickSavedViewsButton() {
-      const button = await testSubjects.find('savedViews-openPopover');
+      const button = await testSubjects.find('savedViews-openPopover-loaded');
 
       await retry.waitFor('Wait for button to be enabled', async () => {
         const isDisabled = Boolean(await button.getAttribute('disabled'));


### PR DESCRIPTION
## Summary

Closes #249003

This PR addresses the flakiness detected in infrastructure inventory tests. The problem originated from an incorrect handling of the loading state of the page during the first load. Previously, the page object for the home page was simply waiting for the waffle chart loading state to go away. The assumption was that, once the chart had loaded the data (even if it was empty) the page was fully loaded and ready to be interacted with. But, this is not entirely the case as there is another component in the page that interacts with the waffle chart that should be awaited as well. 

Said component is the saved views selector (which will have a whole test suite for itself coming soon) that is capable of interacting with the selected waffle time. Upon page load, this component starts fetching saved views in the background. Once that process finishes, the selected saved view will update the waffle time. In these test cases, as saved views aren't being tested, the saved views selector will set a default view by omission. The timeframe of this default view that will be applied by default sets the date to the current time.

So, knowing that behaviour for saved views the issue is now clear. Because the test wasn't properly waiting for saved views to be loaded, sometimes the waffle chart could load faster than saved views. When this happened, the test case would continue running while saved views were still being fetched. Tests would set their desired date during the beforeEach block. But, by the time test assertions started, the default views would have finished loading and acted on the waffle time date. This caused chart data to be fetched again targeting the current date which would result in an empty waffle chart, which would in turn lead the test assertions to failed. Flakiness comes from the fact that the issue depended on requests timing relative to each other, thus why it couldn't be reliably reproduced.

The changes included in the PR will make sure that saved views are properly awaited while setting the stage for test runs. 
Also, following the recommended best practices, the saved views component's test id has been updated to reflect it's loading state (loading vs loaded) so we can confidently have a marker for when saved views have fully loaded.


### Checklist

- [X] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->