### PR TITLE
[9.3][One Workflow] Drop connector name support as connector-id in the UI

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.ts
@@ -126,23 +126,6 @@ export function useYamlValidation(
             source: 'variable-validation',
           });
         }
-        const decorationOptions: monaco.editor.IModelDecorationOptions = {
-          stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-          hoverMessage: validationResult.hoverMessage
-            ? createMarkdownContent(validationResult.hoverMessage)
-            : null,
-          before: validationResult.beforeMessage
-            ? {
-                content: validationResult.beforeMessage,
-                cursorStops: monaco.editor.InjectedTextCursorStops.None,
-                inlineClassName: `connector-name-badge`,
-              }
-            : null,
-        };
-        // Only add inlineClassName for errors, not for valid connectors
-        if (validationResult.severity !== null) {
-          decorationOptions.inlineClassName = `template-variable-${validationResult.severity}`;
-        }
         // handle valid variables
         decorations.push({
           range: new monaco.Range(
@@ -151,7 +134,13 @@ export function useYamlValidation(
             validationResult.endLineNumber,
             validationResult.endColumn
           ),
-          options: decorationOptions,
+          options: {
+            inlineClassName: `template-variable-${validationResult.severity ?? 'valid'}`,
+            hoverMessage: validationResult.hoverMessage
+              ? createMarkdownContent(validationResult.hoverMessage)
+              : null,
+            stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+          },
         });
       } else if (validationResult.owner === 'liquid-template-validation') {
         markers.push({
@@ -214,6 +203,24 @@ export function useYamlValidation(
             source: 'connector-id-validation',
           });
         }
+        const decorationOptions: monaco.editor.IModelDecorationOptions = {
+          stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+          hoverMessage: validationResult.hoverMessage
+            ? createMarkdownContent(validationResult.hoverMessage)
+            : null,
+          before: validationResult.beforeMessage
+            ? {
+                content: validationResult.beforeMessage,
+                cursorStops: monaco.editor.InjectedTextCursorStops.None,
+                inlineClassName: `connector-name-badge`,
+              }
+            : null,
+        };
+        // Only add inlineClassName for errors, not for valid connectors
+        if (validationResult.severity !== null) {
+          decorationOptions.inlineClassName = `template-variable-${validationResult.severity}`;
+        }
+
         decorations.push({
           range: new monaco.Range(
             validationResult.startLineNumber,
@@ -221,20 +228,7 @@ export function useYamlValidation(
             validationResult.endLineNumber,
             validationResult.endColumn
           ),
-          options: {
-            inlineClassName: `template-variable-${validationResult.severity ?? 'valid'}`,
-            stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-            hoverMessage: validationResult.hoverMessage
-              ? createMarkdownContent(validationResult.hoverMessage)
-              : null,
-            after: validationResult.afterMessage
-              ? {
-                  content: validationResult.afterMessage,
-                  cursorStops: monaco.editor.InjectedTextCursorStops.None,
-                  inlineClassName: `after-text`,
-                }
-              : null,
-          },
+          options: decorationOptions,
         });
       }
     }

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.ts
@@ -126,6 +126,23 @@ export function useYamlValidation(
             source: 'variable-validation',
           });
         }
+        const decorationOptions: monaco.editor.IModelDecorationOptions = {
+          stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+          hoverMessage: validationResult.hoverMessage
+            ? createMarkdownContent(validationResult.hoverMessage)
+            : null,
+          before: validationResult.beforeMessage
+            ? {
+                content: validationResult.beforeMessage,
+                cursorStops: monaco.editor.InjectedTextCursorStops.None,
+                inlineClassName: `connector-name-badge`,
+              }
+            : null,
+        };
+        // Only add inlineClassName for errors, not for valid connectors
+        if (validationResult.severity !== null) {
+          decorationOptions.inlineClassName = `template-variable-${validationResult.severity}`;
+        }
         // handle valid variables
         decorations.push({
           range: new monaco.Range(
@@ -134,13 +151,7 @@ export function useYamlValidation(
             validationResult.endLineNumber,
             validationResult.endColumn
           ),
-          options: {
-            inlineClassName: `template-variable-${validationResult.severity ?? 'valid'}`,
-            hoverMessage: validationResult.hoverMessage
-              ? createMarkdownContent(validationResult.hoverMessage)
-              : null,
-            stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-          },
+          options: decorationOptions,
         });
       } else if (validationResult.owner === 'liquid-template-validation') {
         markers.push({

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_connector_ids.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_connector_ids.test.ts
@@ -53,7 +53,7 @@ describe('validateConnectorIds', () => {
     id: 'test-id-1-2-3-4',
     connectorType: 'slack',
     type: 'connector-id',
-    key: 'My Slack Connector',
+    key: 'slack-connector-1', // Default to UUID
     startLineNumber: 5,
     startColumn: 10,
     endLineNumber: 5,
@@ -79,16 +79,17 @@ describe('validateConnectorIds', () => {
         endLineNumber: 0,
         endColumn: 0,
         afterMessage: null,
+        beforeMessage: null,
         hoverMessage: null,
       });
     });
   });
 
-  describe('when connector is found by name', () => {
-    it('should return valid result with afterMessage containing connector details', () => {
+  describe('when connector is found by UUID', () => {
+    it('should return valid result with beforeMessage containing connector name', () => {
       const connectorIdItems: ConnectorIdItem[] = [
         createConnectorIdItem({
-          key: 'My Slack Connector',
+          key: 'slack-connector-1',
           connectorType: 'slack',
         }),
       ];
@@ -105,17 +106,18 @@ describe('validateConnectorIds', () => {
         startColumn: 10,
         endLineNumber: 5,
         endColumn: 30,
-        afterMessage: '✓ Connected (slack connector, ID: slack-connector-1)',
+        beforeMessage: '✓ My Slack Connector',
+        afterMessage: null,
         hoverMessage: null,
       });
     });
   });
 
-  describe('when connector is found by id', () => {
-    it('should return valid result with afterMessage containing connector details', () => {
+  describe('when connector name is used instead of UUID', () => {
+    it('should return error indicating UUID is required', () => {
       const connectorIdItems: ConnectorIdItem[] = [
         createConnectorIdItem({
-          key: 'slack-connector-1',
+          key: 'My Slack Connector',
           connectorType: 'slack',
         }),
       ];
@@ -125,11 +127,11 @@ describe('validateConnectorIds', () => {
       expect(results).toHaveLength(1);
       expect(results[0]).toMatchObject({
         id: 'test-id-1-2-3-4',
-        severity: null,
-        message: null,
+        severity: 'error',
+        message: expect.stringContaining('UUID "My Slack Connector" not found'),
         owner: 'connector-id-validation',
-        afterMessage: '✓ Connected (slack connector, ID: slack-connector-1)',
-        hoverMessage: null,
+        beforeMessage: null,
+        afterMessage: null,
       });
     });
   });
@@ -150,13 +152,14 @@ describe('validateConnectorIds', () => {
         id: 'test-id-1-2-3-4',
         severity: 'error',
         message:
-          'Slack connector "non-existent-connector" not found. Add a new connector or choose an existing one',
+          'Slack connector UUID "non-existent-connector" not found. Add a new connector or choose an existing one',
         owner: 'connector-id-validation',
         startLineNumber: 5,
         startColumn: 10,
         endLineNumber: 5,
         endColumn: 30,
         afterMessage: null,
+        beforeMessage: null,
         hoverMessage: null,
       });
     });
@@ -193,7 +196,7 @@ describe('validateConnectorIds', () => {
 
       const results = validateConnectorIds(connectorIdItems, mockConnectorTypes);
 
-      expect(results[0].message).toContain('Slack connector');
+      expect(results[0].message).toContain('Slack connector UUID');
     });
 
     it('should use connector type as fallback if displayName not available', () => {
@@ -206,7 +209,7 @@ describe('validateConnectorIds', () => {
 
       const results = validateConnectorIds(connectorIdItems, mockConnectorTypes);
 
-      expect(results[0].message).toContain('unknown-type connector');
+      expect(results[0].message).toContain('unknown-type connector UUID');
     });
   });
 
@@ -274,7 +277,7 @@ describe('validateConnectorIds', () => {
       const connectorIdItems: ConnectorIdItem[] = [
         createConnectorIdItem({
           id: 'test-id-1',
-          key: 'My Slack Connector',
+          key: 'slack-connector-1', // Valid UUID
           connectorType: 'slack',
           startLineNumber: 5,
         }),
@@ -286,7 +289,7 @@ describe('validateConnectorIds', () => {
         }),
         createConnectorIdItem({
           id: 'test-id-3',
-          key: 'OpenAI Connector',
+          key: 'openai-connector-1', // Valid UUID
           connectorType: 'inference.unified_completion',
           startLineNumber: 15,
         }),
@@ -301,6 +304,7 @@ describe('validateConnectorIds', () => {
         id: 'test-id-1',
         severity: null,
         message: null,
+        beforeMessage: '✓ My Slack Connector',
       });
 
       // Second connector should have error
@@ -315,6 +319,7 @@ describe('validateConnectorIds', () => {
         id: 'test-id-3',
         severity: null,
         message: null,
+        beforeMessage: '✓ OpenAI Connector',
       });
     });
 
@@ -322,7 +327,7 @@ describe('validateConnectorIds', () => {
       const connectorIdItems: ConnectorIdItem[] = [
         createConnectorIdItem({
           id: 'test-id-1',
-          key: 'My Slack Connector',
+          key: 'slack-connector-1', // Valid UUID
           connectorType: 'slack',
         }),
         createConnectorIdItem({
@@ -349,7 +354,7 @@ describe('validateConnectorIds', () => {
     it('should validate connectors with sub-action types', () => {
       const connectorIdItems: ConnectorIdItem[] = [
         createConnectorIdItem({
-          key: 'OpenAI Connector',
+          key: 'openai-connector-1', // Valid UUID
           connectorType: 'inference.unified_completion',
         }),
       ];
@@ -360,8 +365,8 @@ describe('validateConnectorIds', () => {
       expect(results[0]).toMatchObject({
         severity: null,
         message: null,
-        afterMessage:
-          '✓ Connected (inference.unified_completion connector, ID: openai-connector-1)',
+        beforeMessage: '✓ OpenAI Connector',
+        afterMessage: null,
       });
     });
 
@@ -392,7 +397,7 @@ describe('validateConnectorIds', () => {
       expect(results[0]).toMatchObject({
         severity: 'error',
         message:
-          'Email connector "some-email-connector" not found. Add a new connector or choose an existing one',
+          'Email connector UUID "some-email-connector" not found. Add a new connector or choose an existing one',
       });
     });
   });
@@ -409,7 +414,7 @@ describe('validateConnectorIds', () => {
     it('should preserve exact position information from connector items', () => {
       const connectorIdItems: ConnectorIdItem[] = [
         createConnectorIdItem({
-          key: 'My Slack Connector',
+          key: 'slack-connector-1', // Valid UUID
           connectorType: 'slack',
           startLineNumber: 10,
           startColumn: 5,

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_connector_ids.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_connector_ids.ts
@@ -19,20 +19,20 @@ export function validateConnectorIds(
   const results: YamlValidationResult[] = [];
 
   if (!dynamicConnectorTypes) {
-    return [
-      {
-        id: 'connector-id-validation',
-        severity: 'error',
-        message: 'Dynamic connector types not found',
-        owner: 'connector-id-validation',
-        startLineNumber: 0,
-        startColumn: 0,
-        endLineNumber: 0,
-        endColumn: 0,
-        afterMessage: null,
-        hoverMessage: null,
-      },
-    ];
+    const errorResult: YamlValidationResult = {
+      id: 'connector-id-validation',
+      severity: 'error',
+      message: 'Dynamic connector types not found',
+      owner: 'connector-id-validation',
+      startLineNumber: 0,
+      startColumn: 0,
+      endLineNumber: 0,
+      endColumn: 0,
+      afterMessage: null,
+      beforeMessage: null,
+      hoverMessage: null,
+    };
+    return [errorResult];
   }
 
   const notReferenceConnectorIds = connectorIdItems.filter(
@@ -47,27 +47,27 @@ export function validateConnectorIds(
       dynamicConnectorTypes
     );
 
-    const instance = instances.find(
-      (ins) => ins.id === connectorIdItem.key || ins.name === connectorIdItem.key
-    );
+    const instance = instances.find((ins) => ins.id === connectorIdItem.key);
 
     if (!instance) {
-      results.push({
+      const errorResult: YamlValidationResult = {
         id: connectorIdItem.id,
         severity: 'error',
-        message: `${displayName} connector "${connectorIdItem.key}" not found. Add a new connector or choose an existing one`,
+        message: `${displayName} connector UUID "${connectorIdItem.key}" not found. Add a new connector or choose an existing one`,
         owner: 'connector-id-validation',
         startLineNumber: connectorIdItem.startLineNumber,
         startColumn: connectorIdItem.startColumn,
         endLineNumber: connectorIdItem.endLineNumber,
         endColumn: connectorIdItem.endColumn,
         afterMessage: null,
+        beforeMessage: null,
         hoverMessage: connectorsManagementUrl
           ? `[Open connectors management](${connectorsManagementUrl})`
           : null,
-      });
+      };
+      results.push(errorResult);
     } else {
-      results.push({
+      const validResult: YamlValidationResult = {
         id: connectorIdItem.id,
         severity: null,
         message: null,
@@ -76,9 +76,11 @@ export function validateConnectorIds(
         startColumn: connectorIdItem.startColumn,
         endLineNumber: connectorIdItem.endLineNumber,
         endColumn: connectorIdItem.endColumn,
-        afterMessage: `✓ Connected (${connectorIdItem.connectorType} connector, ID: ${instance.id})`,
+        beforeMessage: `✓ ${instance.name}`,
+        afterMessage: null,
         hoverMessage: null,
-      });
+      };
+      results.push(validResult);
     }
   }
 

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/model/types.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/model/types.ts
@@ -49,6 +49,7 @@ interface YamlValidationResultBase {
   endColumn: number;
   hoverMessage: string | null;
   afterMessage?: string | null;
+  beforeMessage?: string | null;
   source?: string; // the source of the marker, details e.g. yaml schema uri
 }
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/connector_id/get_connector_id_suggestions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/connector_id/get_connector_id_suggestions.test.ts
@@ -63,8 +63,8 @@ describe('getConnectorIdSuggestions', () => {
     } as unknown as AutocompleteContext);
     expect(result).toHaveLength(2);
     expect(result[0].label).toBe('Public Slack • public-slack');
-    expect(result[0].insertText).toBe('Public Slack');
+    expect(result[0].insertText).toBe('public-slack');
     expect(result[1].label).toBe('Private Slack • private-slack');
-    expect(result[1].insertText).toBe('Private Slack');
+    expect(result[1].insertText).toBe('private-slack');
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/connector_id/get_connector_id_suggestions_items.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/connector_id/get_connector_id_suggestions_items.ts
@@ -40,7 +40,7 @@ export function getConnectorIdSuggestionsItems(
     suggestions.push({
       label: displayLabel, // Show both connector ID and name
       kind: monaco.languages.CompletionItemKind.Value, // Use generic value kind
-      insertText: instance.name,
+      insertText: instance.id, // Insert UUID
       range,
       detail: connectorType, // Show connector type as detail - this is what CSS targets
       documentation: `Connector ID: ${instance.id}\nName: ${

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/snippets/generate_connector_snippet.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/snippets/generate_connector_snippet.ts
@@ -48,10 +48,10 @@ export function generateConnectorSnippet(
     if (instances.length > 0) {
       // Use the first non-deprecated instance as default, or first instance if all are deprecated
       const defaultInstance = instances.find((i) => !i.isDeprecated) || instances[0];
-      connectorIdValue = defaultInstance.name;
+      connectorIdValue = defaultInstance.id; // Use UUID
     } else {
       // No instances configured, add placeholder comment
-      connectorIdValue = '# Enter connector ID here';
+      connectorIdValue = '# Enter connector UUID here';
     }
   }
 

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/use_workflow_editor_styles.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/use_workflow_editor_styles.ts
@@ -55,6 +55,19 @@ export const useWorkflowEditorStyles = () => {
           marginLeft: '0', // Remove padding for consecutive after-text spans
         },
 
+        // Connector name badge (before decoration)
+        '.connector-name-badge': {
+          display: 'inline-block',
+          backgroundColor: transparentize(euiTheme.colors.success, 0.1),
+          color: euiTheme.colors.successText,
+          padding: '2px 6px',
+          borderRadius: '4px',
+          marginRight: '8px',
+          fontSize: '12px',
+          fontWeight: 500,
+          lineHeight: '1.4',
+        },
+
         // Step highlighting decorations
         '.step-highlight': {
           backgroundColor: euiTheme.colors.backgroundBaseAccent,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - https://github.com/elastic/kibana/pull/249074

This is a cosmetic UI change only.

## Tested locally

<img width="1047" height="305" alt="Captura de pantalla 2026-01-16 a les 10 43 23" src="https://github.com/user-attachments/assets/e4401b46-f991-4cf6-8eea-5fb0eaeb06eb" />
<img width="1047" height="305" alt="Captura de pantalla 2026-01-16 a les 10 43 40" src="https://github.com/user-attachments/assets/aa09f2ea-61e9-47e9-ae09-5bde87a9c2b2" />
<img width="822" height="225" alt="Captura de pantalla 2026-01-16 a les 10 43 03" src="https://github.com/user-attachments/assets/e9511444-ed50-4567-afd3-e15112918d69" />


