### PR TITLE
[ES|QL] Disable errors on unknown indexes with wildcards

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/validation/sources.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/validation/sources.ts
@@ -20,11 +20,6 @@ export function validateSources(sources: ESQLSource[], context?: ICommandContext
   const messages: ESQLMessage[] = [];
   const sourcesMap = new Set<string>(context?.sources?.map((source) => source.name) || []);
 
-  const knownIndexNames = [];
-  const knownIndexPatterns = [];
-  const unknownIndexNames = [];
-  const unknownIndexPatterns = [];
-
   for (const source of sources) {
     if (source.incomplete) {
       return messages;
@@ -35,29 +30,10 @@ export function validateSources(sources: ESQLSource[], context?: ICommandContext
       const sourceName = source.prefix ? source.name : index?.valueUnquoted;
       if (!sourceName) continue;
 
-      if (sourceExists(sourceName, sourcesMap) && !hasWildcard(sourceName)) {
-        knownIndexNames.push(source);
-      }
-      if (sourceExists(sourceName, sourcesMap) && hasWildcard(sourceName)) {
-        knownIndexPatterns.push(source);
-      }
       if (!sourceExists(sourceName, sourcesMap) && !hasWildcard(sourceName)) {
-        unknownIndexNames.push(source);
-      }
-      if (!sourceExists(sourceName, sourcesMap) && hasWildcard(sourceName)) {
-        unknownIndexPatterns.push(source);
+        messages.push(errors.unknownIndex(source));
       }
     }
-  }
-
-  unknownIndexNames.forEach((source) => {
-    messages.push(errors.unknownIndex(source));
-  });
-
-  if (knownIndexNames.length + unknownIndexNames.length + knownIndexPatterns.length === 0) {
-    unknownIndexPatterns.forEach((source) => {
-      messages.push(errors.unknownIndex(source));
-    });
   }
 
   return messages;

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/from/validate.test.ts
@@ -73,7 +73,6 @@ describe('FROM Validation', () => {
         fromExpectErrors(`FROM index, missingIndex`, ['Unknown index "missingIndex"']);
         fromExpectErrors(`from average()`, ['Unknown index "average"']);
         fromExpectErrors(`fRom custom_function()`, ['Unknown index "custom_function"']);
-        fromExpectErrors(`FROM indexes*`, ['Unknown index "indexes*"']);
         fromExpectErrors('from numberField', ['Unknown index "numberField"']);
         fromExpectErrors('FROM policy', ['Unknown index "policy"']);
 
@@ -82,11 +81,11 @@ describe('FROM Validation', () => {
         fromExpectErrors('FROM *missingIndex, missingIndex2, index', [
           'Unknown index "missingIndex2"',
         ]);
-        fromExpectErrors('FROM missingIndex*', ['Unknown index "missingIndex*"']);
-        fromExpectErrors('FROM *missingIndex, missing*Index2', [
-          'Unknown index "*missingIndex"',
-          'Unknown index "missing*Index2"',
-        ]);
+      });
+      test('no errors on unknown index if using wildcards', () => {
+        fromExpectErrors(`FROM indexes*`, []);
+        fromExpectErrors('FROM missingIndex*', []);
+        fromExpectErrors('FROM *missingIndex, missing*Index2', []);
       });
     });
 
@@ -111,12 +110,14 @@ describe('FROM Validation', () => {
   describe('CCS indices', () => {
     describe('... <sources> ...', () => {
       test('display errors on unknown indices', () => {
-        fromExpectErrors('fRoM remote-*:indexes*', ['Unknown index "remote-*:indexes*"']);
-        fromExpectErrors('fRoM remote-*:indexes', ['Unknown index "remote-*:indexes"']);
         fromExpectErrors('fRoM remote-ccs:indexes', ['Unknown index "remote-ccs:indexes"']);
         fromExpectErrors('fRoM a_index, remote-ccs:indexes', [
           'Unknown index "remote-ccs:indexes"',
         ]);
+      });
+      test('no errors on unknown index if using wildcards', () => {
+        fromExpectErrors('fRoM remote-*:indexes*', []);
+        fromExpectErrors('fRoM remote-*:indexes', []);
       });
     });
 
@@ -125,7 +126,7 @@ describe('FROM Validation', () => {
         fromExpectErrors(`from remote-ccs:indexes METADATA _id`, [
           'Unknown index "remote-ccs:indexes"',
         ]);
-        fromExpectErrors(`from *:indexes METADATA _id`, ['Unknown index "*:indexes"']);
+        fromExpectErrors(`from *:indexes METADATA _id`, []);
       });
     });
   });

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/timeseries/validate.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/timeseries/validate.test.ts
@@ -73,18 +73,18 @@ describe('TS Validation', () => {
         tsExpectErrors(`TS index, missingIndex`, ['Unknown index "missingIndex"']);
         tsExpectErrors(`TS average()`, ['Unknown index "average"']);
         tsExpectErrors(`TS custom_function()`, ['Unknown index "custom_function"']);
-        tsExpectErrors(`TS indexes*`, ['Unknown index "indexes*"']);
         tsExpectErrors('TS numberField', ['Unknown index "numberField"']);
         tsExpectErrors('TS policy', ['Unknown index "policy"']);
 
+        tsExpectErrors('TS *missingIndex, missingIndex2, index', ['Unknown index "missingIndex2"']);
         tsExpectErrors('TS index, missingIndex', ['Unknown index "missingIndex"']);
         tsExpectErrors('TS missingIndex, index', ['Unknown index "missingIndex"']);
-        tsExpectErrors('TS *missingIndex, missingIndex2, index', ['Unknown index "missingIndex2"']);
-        tsExpectErrors('TS missingIndex*', ['Unknown index "missingIndex*"']);
-        tsExpectErrors('TS *missingIndex, missing*Index2', [
-          'Unknown index "*missingIndex"',
-          'Unknown index "missing*Index2"',
-        ]);
+      });
+
+      test('no errors on unknown index if using wildcards', () => {
+        tsExpectErrors(`TS indexes*`, []);
+        tsExpectErrors('TS missingIndex*', []);
+        tsExpectErrors('TS *missingIndex, missing*Index2', []);
       });
     });
 

--- a/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/subqueries.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/validation/__tests__/subqueries.test.ts
@@ -50,9 +50,7 @@ describe('Subqueries Validation', () => {
       await expectErrors('FROM index, (FROM remote-ccs:indexes)', [
         'Unknown index "remote-ccs:indexes"',
       ]);
-      await expectErrors('FROM index, (FROM remote-*:indexes*)', [
-        'Unknown index "remote-*:indexes*"',
-      ]);
+      await expectErrors('FROM index, (FROM remote-*:indexes*)', []);
     });
 
     it('should validate custom command validation inside deeply nested subqueries', async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/249329
## Summary
With a new ES change https://github.com/elastic/elasticsearch/pull/139181 now ES doesn't complain when the user queries unknown indices with wildcards.