### PR TITLE
[9.2] [Discover] Prevent document-level doc viewer tabs from re-mounting when refreshing (#248203)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/__snapshots__/doc_viewer.test.tsx.snap
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/__snapshots__/doc_viewer.test.tsx.snap
@@ -15,8 +15,8 @@ exports[`<DocViewer /> Render <DocViewer/> with 3 different tabs 1`] = `
           aria-controls="generated-id"
           aria-selected="true"
           class="euiTab euiTab-isSelected emotion-euiTab-selected"
-          data-test-subj="docViewerTab-function"
-          id="kbn_doc_viewer_tab_function"
+          data-test-subj="docViewerTab-view1"
+          id="kbn_doc_viewer_tab_view1"
           role="tab"
           tabindex="0"
           type="button"
@@ -24,15 +24,15 @@ exports[`<DocViewer /> Render <DocViewer/> with 3 different tabs 1`] = `
           <span
             class="euiTab__content eui-textTruncate emotion-euiTab__content-s"
           >
-            Render function
+            Render 1
           </span>
         </button>
         <button
           aria-controls="generated-id"
           aria-selected="false"
           class="euiTab emotion-euiTab"
-          data-test-subj="docViewerTab-component"
-          id="kbn_doc_viewer_tab_component"
+          data-test-subj="docViewerTab-view2"
+          id="kbn_doc_viewer_tab_view2"
           role="tab"
           tabindex="-1"
           type="button"
@@ -40,7 +40,7 @@ exports[`<DocViewer /> Render <DocViewer/> with 3 different tabs 1`] = `
           <span
             class="euiTab__content eui-textTruncate emotion-euiTab__content-s"
           >
-            React component
+            Render 2
           </span>
         </button>
         <button
@@ -61,7 +61,7 @@ exports[`<DocViewer /> Render <DocViewer/> with 3 different tabs 1`] = `
         </button>
       </div>
       <div
-        aria-labelledby="kbn_doc_viewer_tab_function"
+        aria-labelledby="kbn_doc_viewer_tab_view1"
         id="generated-id"
         role="tabpanel"
       />

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.test.tsx
@@ -41,23 +41,30 @@ const WrappedDocViewer = (props: DocViewerProps) => (
   </KibanaErrorBoundaryProvider>
 );
 
+const ThrowingComponent = ({ message }: { message?: string }) => {
+  throw new Error(message ?? 'Invalid');
+};
+
 describe('<DocViewer />', () => {
   test('Render <DocViewer/> with 3 different tabs', () => {
     const registry = new DocViewsRegistry();
-    registry.add({ id: 'function', order: 10, title: 'Render function', component: jest.fn() });
     registry.add({
-      id: 'component',
+      id: 'view1',
+      order: 10,
+      title: 'Render 1',
+      render: jest.fn(() => <></>),
+    });
+    registry.add({
+      id: 'view2',
       order: 20,
-      title: 'React component',
-      component: () => <div>test</div>,
+      title: 'Render 2',
+      render: () => <div>test</div>,
     });
     registry.add({
       id: 'invalid',
       order: 30,
       title: 'Invalid doc view',
-      component: () => {
-        throw new Error('Invalid');
-      },
+      render: () => <ThrowingComponent message="Invalid" />,
     });
 
     const renderProps = { hit: {} } as DocViewRenderProps;
@@ -73,12 +80,10 @@ describe('<DocViewer />', () => {
     const errorMsg = 'Catch me if you can!';
     const registry = new DocViewsRegistry();
     registry.add({
-      id: 'component',
+      id: 'throwingView',
       order: 10,
-      title: 'React component',
-      component: () => {
-        throw new Error(errorMsg);
-      },
+      title: 'Failed view',
+      render: () => <ThrowingComponent message={errorMsg} />,
     });
     const renderProps = {
       hit: buildDataTableRecord({ _index: 't', _id: '1' }),
@@ -95,15 +100,13 @@ describe('<DocViewer />', () => {
       id: 'valid',
       order: 10,
       title: 'Valid doc view',
-      component: () => <div>Valid</div>,
+      render: () => <div>Valid</div>,
     });
     registry.add({
       id: 'error',
       order: 20,
       title: 'Error doc view',
-      component: () => {
-        throw new Error('Invalid');
-      },
+      render: () => <ThrowingComponent />,
     });
     const renderProps = {
       hit: buildDataTableRecord({ _index: 't', _id: '1' }),
@@ -118,8 +121,18 @@ describe('<DocViewer />', () => {
 
   test('should save active tab to local storage', () => {
     const registry = new DocViewsRegistry();
-    registry.add({ id: 'test1', order: 10, title: 'Render function', component: jest.fn() });
-    registry.add({ id: 'test2', order: 20, title: 'Render function', component: jest.fn() });
+    registry.add({
+      id: 'test1',
+      order: 10,
+      title: 'Render function',
+      render: jest.fn(() => <></>),
+    });
+    registry.add({
+      id: 'test2',
+      order: 20,
+      title: 'Render function',
+      render: jest.fn(() => <></>),
+    });
 
     render(
       <WrappedDocViewer docViews={registry.getAll()} hit={records[0]} dataView={dataViewMock} />
@@ -147,8 +160,18 @@ describe('<DocViewer />', () => {
 
   test('should restore active tab from local storage', () => {
     const registry = new DocViewsRegistry();
-    registry.add({ id: 'test1', order: 10, title: 'Render function', component: jest.fn() });
-    registry.add({ id: 'test2', order: 20, title: 'Render function', component: jest.fn() });
+    registry.add({
+      id: 'test1',
+      order: 10,
+      title: 'Render function',
+      render: jest.fn(() => <></>),
+    });
+    registry.add({
+      id: 'test2',
+      order: 20,
+      title: 'Render function',
+      render: jest.fn(() => <></>),
+    });
 
     mockTestInitialLocalStorageValue = 'kbn_doc_viewer_tab_test2';
 
@@ -164,8 +187,18 @@ describe('<DocViewer />', () => {
 
   test('should not restore a tab from local storage if unavailable', () => {
     const registry = new DocViewsRegistry();
-    registry.add({ id: 'test1', order: 10, title: 'Render function', component: jest.fn() });
-    registry.add({ id: 'test2', order: 20, title: 'Render function', component: jest.fn() });
+    registry.add({
+      id: 'test1',
+      order: 10,
+      title: 'Render function',
+      render: jest.fn(() => <></>),
+    });
+    registry.add({
+      id: 'test2',
+      order: 20,
+      title: 'Render function',
+      render: jest.fn(() => <></>),
+    });
 
     mockTestInitialLocalStorageValue = 'kbn_doc_viewer_tab_test3';
 
@@ -183,9 +216,14 @@ describe('<DocViewer />', () => {
     const initialTabId = 'test2';
 
     const registry = new DocViewsRegistry();
-    registry.add({ id: 'test1', order: 10, title: 'Render 1st Tab', component: jest.fn() });
-    registry.add({ id: initialTabId, order: 20, title: 'Render 2nd Tab', component: jest.fn() });
-    registry.add({ id: 'test3', order: 30, title: 'Render 3rd Tab', component: jest.fn() });
+    registry.add({ id: 'test1', order: 10, title: 'Render 1st Tab', render: jest.fn(() => <></>) });
+    registry.add({
+      id: initialTabId,
+      order: 20,
+      title: 'Render 2nd Tab',
+      render: jest.fn(() => <></>),
+    });
+    registry.add({ id: 'test3', order: 30, title: 'Render 3rd Tab', render: jest.fn(() => <></>) });
 
     render(
       <WrappedDocViewer

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
@@ -37,19 +37,17 @@ export const DocViewer = forwardRef<DocViewerApi, DocViewerInternalProps>(
   ({ docViews, initialTabId, ...renderProps }, ref) => {
     const tabs = docViews
       .filter(({ enabled }) => enabled) // Filter out disabled doc views
-      .map(({ id, title, component }: DocView) => ({
-        id: getFullTabId(id), // `id` value is used to persist the selected tab in localStorage
-        name: title,
+      .map((docView: DocView) => ({
+        id: getFullTabId(docView.id), // `id` value is used to persist the selected tab in localStorage
+        name: docView.title,
         content: (
           <DocViewerTab
-            key={id}
-            id={id}
-            title={title}
-            component={component}
+            key={`${renderProps.hit.id}_${docView.id}`}
+            docView={docView}
             renderProps={renderProps}
           />
         ),
-        ['data-test-subj']: `docViewerTab-${id}`,
+        ['data-test-subj']: `docViewerTab-${docView.id}`,
       }));
 
     const [storedInitialTabId, setInitialTabId] = useLocalStorage<string>(INITIAL_TAB);

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer_tab.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer_tab.tsx
@@ -9,13 +9,11 @@
 
 import React from 'react';
 import { KibanaSectionErrorBoundary } from '@kbn/shared-ux-error-boundary';
-import type { DocViewRenderProps } from '../../types';
+import type { DocView, DocViewRenderProps } from '../../types';
 
 interface Props {
-  id: string;
+  docView: DocView;
   renderProps: DocViewRenderProps;
-  title: string;
-  component: React.ComponentType<DocViewRenderProps>;
 }
 
 /**
@@ -23,12 +21,10 @@ interface Props {
  * Displays an error message when it encounters exceptions, thanks to
  * Error Boundaries.
  */
-export const DocViewerTab = (props: Props) => {
-  const { component: Component, renderProps, title } = props;
-
+export const DocViewerTab = ({ docView, renderProps }: Props) => {
   return (
-    <KibanaSectionErrorBoundary sectionName={title}>
-      <Component {...renderProps} />
+    <KibanaSectionErrorBoundary sectionName={docView.title}>
+      {docView.render(renderProps)}
     </KibanaSectionErrorBoundary>
   );
 };

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/doc_views_registry.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/doc_views_registry.test.tsx
@@ -7,31 +7,31 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
 import { DocViewsRegistry } from './doc_views_registry';
 
-const fnDocView = {
-  id: 'function-doc-view',
+const docView1 = {
+  id: 'doc-view-1',
   order: 10,
   title: 'Render function',
-  component: jest.fn(),
+  render: jest.fn(),
 };
-const componentDocView = {
-  id: 'component-doc-view',
+
+const docView2 = {
+  id: 'doc-view-2',
   order: 20,
-  title: 'React component',
-  component: () => <div>test</div>,
+  title: 'Render function',
+  render: jest.fn(),
 };
 
 describe('DocViewerRegistry', () => {
   test('can be initialized from an array of doc views', () => {
-    const registry = new DocViewsRegistry([fnDocView, componentDocView]);
+    const registry = new DocViewsRegistry([docView1, docView2]);
 
     expect(registry.getAll()).toHaveLength(2);
   });
 
   test('can be initialized from another DocViewsRegistry instance', () => {
-    const registry = new DocViewsRegistry([fnDocView, componentDocView]);
+    const registry = new DocViewsRegistry([docView1, docView2]);
     const newRegistry = new DocViewsRegistry(registry);
 
     expect(registry.getAll()).toHaveLength(2);
@@ -41,54 +41,54 @@ describe('DocViewerRegistry', () => {
 
   describe('#add', () => {
     test('should add a doc view to the registry in the correct order', () => {
-      const registry = new DocViewsRegistry([componentDocView]);
+      const registry = new DocViewsRegistry([docView1]);
 
-      registry.add(fnDocView);
+      registry.add(docView2);
 
       const docViews = registry.getAll();
 
-      expect(docViews[0]).toHaveProperty('id', 'function-doc-view');
-      expect(docViews[1]).toHaveProperty('id', 'component-doc-view');
+      expect(docViews[0]).toHaveProperty('id', 'doc-view-1');
+      expect(docViews[1]).toHaveProperty('id', 'doc-view-2');
     });
 
     test('should throw an error when the passed doc view already exists for the given id', () => {
-      const registry = new DocViewsRegistry([fnDocView]);
+      const registry = new DocViewsRegistry([docView1]);
 
-      expect(() => registry.add(fnDocView)).toThrow(
-        'DocViewsRegistry#add: a DocView is already registered with id "function-doc-view".'
+      expect(() => registry.add(docView1)).toThrow(
+        'DocViewsRegistry#add: a DocView is already registered with id "doc-view-1".'
       );
     });
   });
 
   describe('#removeById', () => {
     test('should remove a doc view given the passed id', () => {
-      const registry = new DocViewsRegistry([fnDocView, componentDocView]);
+      const registry = new DocViewsRegistry([docView1, docView2]);
 
       const docViews = registry.getAll();
 
-      expect(docViews[0]).toHaveProperty('id', 'function-doc-view');
-      expect(docViews[1]).toHaveProperty('id', 'component-doc-view');
+      expect(docViews[0]).toHaveProperty('id', 'doc-view-1');
+      expect(docViews[1]).toHaveProperty('id', 'doc-view-2');
 
-      registry.removeById('function-doc-view');
+      registry.removeById('doc-view-1');
 
-      expect(registry.getAll()[0]).toHaveProperty('id', 'component-doc-view');
+      expect(registry.getAll()[0]).toHaveProperty('id', 'doc-view-2');
     });
   });
 
   describe('#enableById & #disableById', () => {
     test('should enable/disable a doc view given the passed id', () => {
-      const registry = new DocViewsRegistry([fnDocView, componentDocView]);
+      const registry = new DocViewsRegistry([docView1, docView2]);
 
       const docViews = registry.getAll();
 
       expect(docViews[0]).toHaveProperty('enabled', true);
       expect(docViews[1]).toHaveProperty('enabled', true);
 
-      registry.disableById('function-doc-view');
+      registry.disableById('doc-view-1');
 
       expect(registry.getAll()[0]).toHaveProperty('enabled', false);
 
-      registry.enableById('function-doc-view');
+      registry.enableById('doc-view-1');
 
       expect(registry.getAll()[0]).toHaveProperty('enabled', true);
     });
@@ -96,28 +96,28 @@ describe('DocViewerRegistry', () => {
 
   describe('#clone', () => {
     test('should return a new DocViewRegistry instance starting from the current one', () => {
-      const registry = new DocViewsRegistry([fnDocView, componentDocView]);
+      const registry = new DocViewsRegistry([docView1, docView2]);
 
       const clonedRegistry = registry.clone();
       const docViews = clonedRegistry.getAll();
 
-      expect(docViews[0]).toHaveProperty('id', 'function-doc-view');
-      expect(docViews[1]).toHaveProperty('id', 'component-doc-view');
+      expect(docViews[0]).toHaveProperty('id', 'doc-view-1');
+      expect(docViews[1]).toHaveProperty('id', 'doc-view-2');
       expect(registry).not.toBe(clonedRegistry);
 
       // Test against shared references between clones
       expect(clonedRegistry).not.toBe(registry);
 
       // Mutating a cloned registry should not affect the original registry
-      registry.disableById('function-doc-view');
+      registry.disableById('doc-view-1');
       expect(registry.getAll()[0]).toHaveProperty('enabled', false);
       expect(clonedRegistry.getAll()[0]).toHaveProperty('enabled', true);
 
       clonedRegistry.add({
         id: 'additional-doc-view',
-        order: 20,
+        order: 30,
         title: 'Render function',
-        component: jest.fn(),
+        render: jest.fn(),
       });
 
       expect(registry.getAll().length).toBe(2);

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/doc_views_registry.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/doc_views_registry.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DocView, DocViewFactory } from './types';
+import type { DocView } from './types';
 
 export enum ElasticRequestState {
   Loading,
@@ -40,9 +40,7 @@ export class DocViewsRegistry {
     return [...this.docViews.values()];
   }
 
-  add(docViewRaw: DocView | DocViewFactory) {
-    const docView = typeof docViewRaw === 'function' ? docViewRaw() : docViewRaw;
-
+  add(docView: DocView) {
     if (this.docViews.has(docView.id)) {
       throw new Error(
         `DocViewsRegistry#add: a DocView is already registered with id "${docView.id}".`

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/types.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/types.ts
@@ -10,6 +10,7 @@
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { AggregateQuery, Query } from '@kbn/es-query';
 import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils/types';
+import type { ReactElement } from 'react';
 import type { DocViewsRegistry } from './doc_views_registry';
 
 export interface FieldMapping {
@@ -53,8 +54,6 @@ export interface DocView {
   id: string;
   order: number;
   title: string;
-  component: DocViewerComponent;
   enabled?: boolean;
+  render: (props: DocViewRenderProps) => ReactElement;
 }
-
-export type DocViewFactory = () => DocView;

--- a/src/platform/plugins/shared/discover/public/context_awareness/__mocks__/context_awareness.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/__mocks__/context_awareness.tsx
@@ -145,9 +145,7 @@ export const createContextAwarenessMocks = ({
               id: 'doc_view_mock',
               title: 'Mock tab',
               order: 10,
-              component: () => {
-                return null;
-              },
+              render: () => <></>,
             });
             return prevValue.docViewsRegistry(registry);
           },

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
@@ -87,7 +87,7 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
               id: 'doc_view_example',
               title: 'Example',
               order: 0,
-              component: () => (
+              render: () => (
                 <EuiPanel color="transparent" hasShadow={false}>
                   <div data-test-subj="exampleDataSourceProfileDocView">Example Doc View</div>
                   <pre data-test-subj="exampleDataSourceProfileDocViewRecord">

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/log_document_profile/accessors/get_doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/log_document_profile/accessors/get_doc_viewer.tsx
@@ -9,10 +9,9 @@
 
 import type {
   ObservabilityLogsAIAssistantFeature,
-  ObservabilityLogsAIInsightFeature,
   ObservabilityStreamsFeature,
 } from '@kbn/discover-shared-plugin/public';
-import type { ObservabilityIndexes } from '@kbn/discover-utils/src';
+import type { TraceIndexes } from '@kbn/discover-utils/src';
 import { i18n } from '@kbn/i18n';
 import {
   UnifiedDocViewerLogsOverview,
@@ -77,7 +76,7 @@ interface LogOverviewTabProps extends DocViewRenderProps {
   logOverviewContext$: BehaviorSubject<LogOverviewContext | undefined>;
   logsAIAssistantFeature: ObservabilityLogsAIAssistantFeature | undefined;
   streamsFeature: ObservabilityStreamsFeature | undefined;
-  indexes: ObservabilityIndexes;
+  indexes: TraceIndexes;
 }
 
 const LogOverviewTab = ({

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/log_document_profile/accessors/get_doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/log_document_profile/accessors/get_doc_viewer.tsx
@@ -7,14 +7,23 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import type {
+  ObservabilityLogsAIAssistantFeature,
+  ObservabilityLogsAIInsightFeature,
+  ObservabilityStreamsFeature,
+} from '@kbn/discover-shared-plugin/public';
+import type { ObservabilityIndexes } from '@kbn/discover-utils/src';
 import { i18n } from '@kbn/i18n';
 import {
   UnifiedDocViewerLogsOverview,
   type UnifiedDocViewerLogsOverviewApi,
 } from '@kbn/unified-doc-viewer-plugin/public';
+import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import React, { useEffect, useRef, useState } from 'react';
+import type { BehaviorSubject } from 'rxjs';
 import { filter, skip } from 'rxjs';
 import type { ProfileProviderServices } from '../../../profile_provider_services';
+import type { LogOverviewContext } from '../../logs_data_source_profile/profile';
 import type { LogDocumentProfileProvider } from '../profile';
 
 export const createGetDocViewer =
@@ -46,55 +55,14 @@ export const createGetDocViewer =
             defaultMessage: 'Log overview',
           }),
           order: 0,
-          component: function LogOverviewTab(props) {
-            const [logsOverviewApi, setLogsOverviewApi] =
-              useState<UnifiedDocViewerLogsOverviewApi | null>(null);
-            const initialAccordionSection = useRef(
-              context.logOverviewContext$.getValue()?.initialAccordionSection
-            );
-
-            useEffect(() => {
-              if (!logsOverviewApi) {
-                return;
-              }
-
-              context.logOverviewContext$.next(undefined);
-
-              if (initialAccordionSection.current) {
-                logsOverviewApi.openAndScrollToSection(initialAccordionSection.current);
-              }
-
-              initialAccordionSection.current = undefined;
-
-              const subscription = context.logOverviewContext$
-                .pipe(
-                  skip(1),
-                  filter((overviewContext) => {
-                    return (
-                      overviewContext !== undefined &&
-                      overviewContext.initialAccordionSection !== undefined &&
-                      overviewContext.recordId === props.hit.id
-                    );
-                  })
-                )
-                .subscribe((overviewContext) => {
-                  logsOverviewApi.openAndScrollToSection(overviewContext!.initialAccordionSection!);
-                  context.logOverviewContext$.next(undefined);
-                });
-
-              return () => {
-                subscription.unsubscribe();
-              };
-            }, [logsOverviewApi, props.hit.id]);
-
+          render: (props: DocViewRenderProps) => {
             return (
-              <UnifiedDocViewerLogsOverview
-                {...props}
-                ref={setLogsOverviewApi}
-                renderAIAssistant={logsAIAssistantFeature?.render}
-                renderFlyoutStreamField={streamsFeature?.renderFlyoutStreamField}
-                renderFlyoutStreamProcessingLink={streamsFeature?.renderFlyoutStreamProcessingLink}
+              <LogOverviewTab
+                logOverviewContext$={context.logOverviewContext$}
+                logsAIAssistantFeature={logsAIAssistantFeature}
+                streamsFeature={streamsFeature}
                 indexes={indexes}
+                {...props}
               />
             );
           },
@@ -104,3 +72,76 @@ export const createGetDocViewer =
       },
     };
   };
+
+interface LogOverviewTabProps extends DocViewRenderProps {
+  logOverviewContext$: BehaviorSubject<LogOverviewContext | undefined>;
+  logsAIAssistantFeature: ObservabilityLogsAIAssistantFeature | undefined;
+  streamsFeature: ObservabilityStreamsFeature | undefined;
+  indexes: ObservabilityIndexes;
+}
+
+const LogOverviewTab = ({
+  logOverviewContext$,
+  logsAIAssistantFeature,
+  streamsFeature,
+  indexes,
+  ...props
+}: LogOverviewTabProps) => {
+  const [logsOverviewApi, setLogsOverviewApi] = useState<UnifiedDocViewerLogsOverviewApi | null>(
+    null
+  );
+  useAccordionExpansionEffect(logOverviewContext$, logsOverviewApi, props.hit.id);
+
+  return (
+    <UnifiedDocViewerLogsOverview
+      {...props}
+      ref={setLogsOverviewApi}
+      renderAIAssistant={logsAIAssistantFeature?.render}
+      renderFlyoutStreamField={streamsFeature?.renderFlyoutStreamField}
+      renderFlyoutStreamProcessingLink={streamsFeature?.renderFlyoutStreamProcessingLink}
+      indexes={indexes}
+    />
+  );
+};
+
+const useAccordionExpansionEffect = (
+  logOverviewContext$: BehaviorSubject<LogOverviewContext | undefined>,
+  logsOverviewApi: UnifiedDocViewerLogsOverviewApi | null,
+  recordId: string
+) => {
+  const initialAccordionSection = useRef(logOverviewContext$.getValue()?.initialAccordionSection);
+
+  useEffect(() => {
+    if (!logsOverviewApi) {
+      return;
+    }
+
+    logOverviewContext$.next(undefined);
+
+    if (initialAccordionSection.current) {
+      logsOverviewApi.openAndScrollToSection(initialAccordionSection.current);
+    }
+
+    initialAccordionSection.current = undefined;
+
+    const subscription = logOverviewContext$
+      .pipe(
+        skip(1),
+        filter((overviewContext) => {
+          return (
+            overviewContext !== undefined &&
+            overviewContext.initialAccordionSection !== undefined &&
+            overviewContext.recordId === recordId
+          );
+        })
+      )
+      .subscribe((overviewContext) => {
+        logsOverviewApi.openAndScrollToSection(overviewContext!.initialAccordionSection!);
+        logOverviewContext$.next(undefined);
+      });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [logOverviewContext$, logsOverviewApi, recordId]);
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/log_document_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/log_document_profile/profile.test.ts
@@ -197,7 +197,7 @@ describe('logDocumentProfileProvider', () => {
           id: 'doc_view_logs_overview',
           title: 'Log overview',
           order: 0,
-          component: expect.any(Function),
+          render: expect.any(Function),
         })
       );
     });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_document_profile/document_profile/accessors/doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_document_profile/document_profile/accessors/doc_viewer.tsx
@@ -30,7 +30,7 @@ export const createGetDocViewer =
           id: 'doc_view_obs_generic_overview',
           title: tabTitle,
           order: 0,
-          component: (props) => (
+          render: (props) => (
             <UnifiedDocViewerObservabilityGenericOverview {...props} indexes={indexes} />
           ),
         });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/get_doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/get_doc_viewer.tsx
@@ -31,7 +31,7 @@ export const getDocViewer: ObservabilityRootProfileProvider['profile']['getDocVi
             id: 'doc_view_obs_attributes_overview',
             title: tabTitle,
             order: 9,
-            component: (props) => {
+            render: (props) => {
               return <UnifiedDocViewerObservabilityAttributesOverview {...props} />;
             },
           });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile/profile.test.ts
@@ -156,7 +156,7 @@ describe('observabilityRootProfileProvider', () => {
           id: 'doc_view_obs_attributes_overview',
           title: 'Attributes',
           order: 9,
-          component: expect.any(Function),
+          render: expect.any(Function),
         })
       );
     });
@@ -193,7 +193,7 @@ describe('observabilityRootProfileProvider', () => {
           id: 'doc_view_obs_attributes_overview',
           title: 'Attributes',
           order: 9,
-          component: expect.any(Function),
+          render: expect.any(Function),
         })
       );
     });
@@ -230,7 +230,7 @@ describe('observabilityRootProfileProvider', () => {
           id: 'doc_view_obs_attributes_overview',
           title: 'Attributes',
           order: 9,
-          component: expect.any(Function),
+          render: expect.any(Function),
         })
       );
     });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/document_profile/accessors/doc_viewer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile/document_profile/accessors/doc_viewer.tsx
@@ -30,7 +30,7 @@ export const createGetDocViewer =
           id: 'doc_view_obs_traces_overview',
           title: tabTitle,
           order: 0,
-          component: (props) => (
+          render: (props) => (
             <UnifiedDocViewerObservabilityTracesOverview {...props} indexes={indexes} />
           ),
         });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_document_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_document_profile/profile.tsx
@@ -8,6 +8,7 @@
  */
 
 import { getFieldValue } from '@kbn/discover-utils';
+import React from 'react';
 import type { DocumentProfileProvider } from '../../../profiles';
 import { DocumentType, SolutionType } from '../../../profiles';
 import type { ProfileProviderServices } from '../../profile_provider_services';
@@ -34,7 +35,7 @@ export const createSecurityDocumentProfileProvider: SecurityProfileProviderFacto
               id: 'doc_view_alerts_overview',
               title: i18n.overviewTabTitle(isAlert),
               order: 0,
-              component: AlertEventOverviewLazy,
+              render: (props) => <AlertEventOverviewLazy {...props} />,
             });
 
             return prevDocViewer.docViewsRegistry(registry);

--- a/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
@@ -62,7 +62,7 @@ export class UnifiedDocViewerPublicPlugin
         defaultMessage: 'Table',
       }),
       order: 10,
-      component: (props) => {
+      render: (props) => {
         return <LazyDocViewerTable {...props} />;
       },
     });
@@ -73,7 +73,7 @@ export class UnifiedDocViewerPublicPlugin
         defaultMessage: 'JSON',
       }),
       order: 20,
-      component: ({ hit, dataView, textBasedHits, decreaseAvailableHeightBy }) => {
+      render: ({ hit, dataView, textBasedHits, decreaseAvailableHeightBy }) => {
         return (
           <LazySourceViewer
             index={hit.raw._index}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/doc_viewer_diff.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/doc_viewer_diff.tsx
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import type { DocView, DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
 import React, { useEffect, useState, useRef, useMemo, useLayoutEffect } from 'react';
 import { flattenObjectNestedLast } from '@kbn/object-utils';
 import {
@@ -47,7 +47,7 @@ function orderObjectKeys(obj: unknown): unknown {
 
 export const DOC_VIEW_DIFF_ID = 'doc_view_diff';
 
-export const docViewDiff = {
+export const docViewDiff: DocView = {
   id: DOC_VIEW_DIFF_ID,
   title: i18n.translate(
     'xpack.streams.streamDetailView.managementTab.enrichment.simulationPlayground.docViews.diff.diffTitle',
@@ -56,7 +56,7 @@ export const docViewDiff = {
     }
   ),
   order: 15,
-  component: JsonDiffViewer,
+  render: (props) => <JsonDiffViewer {...props} />,
 };
 
 function JsonDiffViewer({ hit, decreaseAvailableHeightBy }: DocViewRenderProps) {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/doc_viewer_json.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/doc_viewer_json.tsx
@@ -7,13 +7,13 @@
 
 import { i18n } from '@kbn/i18n';
 import { JsonCodeEditor } from '@kbn/unified-doc-viewer-plugin/public';
-import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import type { DocView, DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
 import React, { useEffect, useMemo, useState, useRef } from 'react';
 import { DEFAULT_MARGIN_BOTTOM, getTabContentAvailableHeight } from './get_height';
 
 export const DOC_VIEW_JSON_ID = 'doc_view_json';
 
-export const docViewJson = {
+export const docViewJson: DocView = {
   id: DOC_VIEW_JSON_ID,
   title: i18n.translate(
     'xpack.streams.streamDetailView.managementTab.enrichment.simulationPlayground.docViews.json.jsonTitle',
@@ -22,7 +22,7 @@ export const docViewJson = {
     }
   ),
   order: 20,
-  component: JsonDocViewer,
+  render: (props) => <JsonDocViewer {...props} />,
 };
 
 function JsonDocViewer({ hit, decreaseAvailableHeightBy }: DocViewRenderProps) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Discover] Prevent document-level doc viewer tabs from re-mounting when refreshing (#248203)](https://github.com/elastic/kibana/pull/248203)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2026-01-15T17:16:35Z","message":"[Discover] Prevent document-level doc viewer tabs from re-mounting when refreshing (#248203)\n\n## :memo: Summary\n\nThis PR fixes an issue where document-level doc viewer tabs were\nunnecessarily re-mounting on every refresh, causing poor performance and\ndegraded user experience.\n\ncloses #248047\n\n## :mag_right: Background\n\nThe doc viewer registry was using inline components that lacked stable\ncomponent identities, causing React to treat them as new components on\neach render cycle. This in turn caused a complete loss of component\nstate (like the AI insights as reported in #248047) in the React\nhierarchy, which can interrupt the user's workflow.\n\nAfter this change doc viewer registry to use render functions instead of\ncomponents. This ensures component identity remains stable across\nrenders, preventing unnecessary re-mounts. This is aligned with the\nimplementation of the Discover chart section extension point from\nhttps://github.com/elastic/kibana/pull/245035.\n\n## :art: Previews\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/27efbc9a-810b-4c26-81ff-7947a92cfb76\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/d0a164c2-7334-4e3b-bf74-003f05c129ed\n\n## :wrench: Detailed Changes\n\n- Modified doc viewer registry API to accept `render` functions instead\nof `component` props\n- Updated all doc viewer tab implementations to provide render functions\n\n## 🔢 Testing Hints\n\n- Open the Discover fly-out for a document matching a specialized data\nsource and document profile such as logs, traces or security events.\n- Modify the fly-out state by expanding an accordion section and\nstarting an AI insight request.\n- Click refresh in the Discover query bar or enable auto-refresh.\n- Verify document viewer tabs no longer flicker and retain their state\nwhen the refresh finishes.\n- Verify that the hit index in the fly-out header is updated correctly.\n- Test with multiple data views and document types\n\n## Release Notes\n\nPrevent loss of UI state in signal-specific Discover fly-out tabs when\nrefreshing a query\n\n---------\n\nCo-authored-by: Felix Stürmer <felix.stuermer@elastic.co>\nCo-authored-by: Felix Stürmer <weltenwort@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"244764a170a2aa1bb53409262f88abdb623546da","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:DataDiscovery","backport:version","v9.3.0","Team:obs-exploration","v9.4.0","v9.2.5"],"title":"[Discover] Prevent document-level doc viewer tabs from re-mounting when refreshing","number":248203,"url":"https://github.com/elastic/kibana/pull/248203","mergeCommit":{"message":"[Discover] Prevent document-level doc viewer tabs from re-mounting when refreshing (#248203)\n\n## :memo: Summary\n\nThis PR fixes an issue where document-level doc viewer tabs were\nunnecessarily re-mounting on every refresh, causing poor performance and\ndegraded user experience.\n\ncloses #248047\n\n## :mag_right: Background\n\nThe doc viewer registry was using inline components that lacked stable\ncomponent identities, causing React to treat them as new components on\neach render cycle. This in turn caused a complete loss of component\nstate (like the AI insights as reported in #248047) in the React\nhierarchy, which can interrupt the user's workflow.\n\nAfter this change doc viewer registry to use render functions instead of\ncomponents. This ensures component identity remains stable across\nrenders, preventing unnecessary re-mounts. This is aligned with the\nimplementation of the Discover chart section extension point from\nhttps://github.com/elastic/kibana/pull/245035.\n\n## :art: Previews\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/27efbc9a-810b-4c26-81ff-7947a92cfb76\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/d0a164c2-7334-4e3b-bf74-003f05c129ed\n\n## :wrench: Detailed Changes\n\n- Modified doc viewer registry API to accept `render` functions instead\nof `component` props\n- Updated all doc viewer tab implementations to provide render functions\n\n## 🔢 Testing Hints\n\n- Open the Discover fly-out for a document matching a specialized data\nsource and document profile such as logs, traces or security events.\n- Modify the fly-out state by expanding an accordion section and\nstarting an AI insight request.\n- Click refresh in the Discover query bar or enable auto-refresh.\n- Verify document viewer tabs no longer flicker and retain their state\nwhen the refresh finishes.\n- Verify that the hit index in the fly-out header is updated correctly.\n- Test with multiple data views and document types\n\n## Release Notes\n\nPrevent loss of UI state in signal-specific Discover fly-out tabs when\nrefreshing a query\n\n---------\n\nCo-authored-by: Felix Stürmer <felix.stuermer@elastic.co>\nCo-authored-by: Felix Stürmer <weltenwort@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"244764a170a2aa1bb53409262f88abdb623546da"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248203","number":248203,"mergeCommit":{"message":"[Discover] Prevent document-level doc viewer tabs from re-mounting when refreshing (#248203)\n\n## :memo: Summary\n\nThis PR fixes an issue where document-level doc viewer tabs were\nunnecessarily re-mounting on every refresh, causing poor performance and\ndegraded user experience.\n\ncloses #248047\n\n## :mag_right: Background\n\nThe doc viewer registry was using inline components that lacked stable\ncomponent identities, causing React to treat them as new components on\neach render cycle. This in turn caused a complete loss of component\nstate (like the AI insights as reported in #248047) in the React\nhierarchy, which can interrupt the user's workflow.\n\nAfter this change doc viewer registry to use render functions instead of\ncomponents. This ensures component identity remains stable across\nrenders, preventing unnecessary re-mounts. This is aligned with the\nimplementation of the Discover chart section extension point from\nhttps://github.com/elastic/kibana/pull/245035.\n\n## :art: Previews\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/27efbc9a-810b-4c26-81ff-7947a92cfb76\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/d0a164c2-7334-4e3b-bf74-003f05c129ed\n\n## :wrench: Detailed Changes\n\n- Modified doc viewer registry API to accept `render` functions instead\nof `component` props\n- Updated all doc viewer tab implementations to provide render functions\n\n## 🔢 Testing Hints\n\n- Open the Discover fly-out for a document matching a specialized data\nsource and document profile such as logs, traces or security events.\n- Modify the fly-out state by expanding an accordion section and\nstarting an AI insight request.\n- Click refresh in the Discover query bar or enable auto-refresh.\n- Verify document viewer tabs no longer flicker and retain their state\nwhen the refresh finishes.\n- Verify that the hit index in the fly-out header is updated correctly.\n- Test with multiple data views and document types\n\n## Release Notes\n\nPrevent loss of UI state in signal-specific Discover fly-out tabs when\nrefreshing a query\n\n---------\n\nCo-authored-by: Felix Stürmer <felix.stuermer@elastic.co>\nCo-authored-by: Felix Stürmer <weltenwort@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"244764a170a2aa1bb53409262f88abdb623546da"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->