### PR TITLE
[Security Solution] Update filter parameter shape

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/common/prebuilt_rule_assets_filter.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/common/prebuilt_rule_assets_filter.ts
@@ -13,14 +13,14 @@ export const PrebuiltRuleAssetsFilter = z.object({
   fields: z.object({
     name: z
       .object({
-        include: z.array(z.string()).optional(),
-        exclude: z.array(z.string()).optional(),
+        include: z.object({ values: z.array(z.string()) }).optional(),
+        exclude: z.object({ values: z.array(z.string()) }).optional(),
       })
       .optional(),
     tags: z
       .object({
-        include: z.array(z.string()).optional(),
-        exclude: z.array(z.string()).optional(),
+        include: z.object({ values: z.array(z.string()) }).optional(),
+        exclude: z.object({ values: z.array(z.string()) }).optional(),
       })
       .optional(),
   }),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client/utils.ts
@@ -26,8 +26,8 @@ export function prepareQueryDslFilter(
     });
   }
 
-  if (filter?.fields?.name?.include) {
-    filter.fields.name.include.forEach((name) => {
+  if (filter?.fields?.name?.include?.values) {
+    filter.fields.name.include.values.forEach((name) => {
       queryFilter.push({
         wildcard: {
           [`${PREBUILT_RULE_ASSETS_SO_TYPE}.name.keyword`]: `*${name}*`,
@@ -36,8 +36,8 @@ export function prepareQueryDslFilter(
     });
   }
 
-  if (filter?.fields.tags?.include) {
-    filter.fields.tags.include.forEach((tag) => {
+  if (filter?.fields.tags?.include?.values) {
+    filter.fields.tags.include.values.forEach((tag) => {
       queryFilter.push({
         term: {
           [`${PREBUILT_RULE_ASSETS_SO_TYPE}.tags`]: tag,

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/install_prebuilt_rules/review_installation.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/common/install_prebuilt_rules/review_installation.ts
@@ -293,7 +293,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
         const response = await reviewPrebuiltRulesToInstall(supertest, {
-          filter: { fields: { tags: { include: ['tag-a'] } } },
+          filter: { fields: { tags: { include: { values: ['tag-a'] } } } },
         });
 
         expect(response.stats.tags).toEqual(['tag-a', 'tag-b', 'tag-c']);
@@ -519,7 +519,7 @@ export default ({ getService }: FtrProviderContext): void => {
             await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
             const emptyNameResponse = await reviewPrebuiltRulesToInstall(supertest, {
-              filter: { fields: { name: { include: [] } } },
+              filter: { fields: { name: { include: { values: [] } } } },
             });
 
             expect(emptyNameResponse.rules).toEqual([
@@ -536,7 +536,7 @@ export default ({ getService }: FtrProviderContext): void => {
             await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
             const emptyNameResponse = await reviewPrebuiltRulesToInstall(supertest, {
-              filter: { fields: { name: { include: [''] } } },
+              filter: { fields: { name: { include: { values: [''] } } } },
             });
 
             expect(emptyNameResponse.rules).toEqual([
@@ -556,7 +556,7 @@ export default ({ getService }: FtrProviderContext): void => {
             await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
             const response = await reviewPrebuiltRulesToInstall(supertest, {
-              filter: { fields: { name: { include: ['My rule 1'] } } },
+              filter: { fields: { name: { include: { values: ['My rule 1'] } } } },
             });
 
             expect(response.rules).toEqual([
@@ -573,7 +573,7 @@ export default ({ getService }: FtrProviderContext): void => {
             await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
             const response = await reviewPrebuiltRulesToInstall(supertest, {
-              filter: { fields: { name: { include: ['rule'] } } },
+              filter: { fields: { name: { include: { values: ['rule'] } } } },
             });
 
             expect(response.rules).toEqual([
@@ -592,7 +592,7 @@ export default ({ getService }: FtrProviderContext): void => {
             await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
             const response = await reviewPrebuiltRulesToInstall(supertest, {
-              filter: { fields: { name: { include: ['mY rulE 1'] } } },
+              filter: { fields: { name: { include: { values: ['mY rulE 1'] } } } },
             });
 
             expect(response.rules).toEqual([
@@ -618,7 +618,7 @@ export default ({ getService }: FtrProviderContext): void => {
             await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
             const emptyTagResponse = await reviewPrebuiltRulesToInstall(supertest, {
-              filter: { fields: { tags: { include: [] } } },
+              filter: { fields: { tags: { include: { values: [] } } } },
             });
 
             expect(emptyTagResponse.rules).toEqual([
@@ -653,7 +653,7 @@ export default ({ getService }: FtrProviderContext): void => {
             await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
             const singleTagResponse = await reviewPrebuiltRulesToInstall(supertest, {
-              filter: { fields: { tags: { include: ['tag-b'] } } },
+              filter: { fields: { tags: { include: { values: ['tag-b'] } } } },
             });
 
             expect(singleTagResponse.rules).toEqual([
@@ -686,7 +686,7 @@ export default ({ getService }: FtrProviderContext): void => {
             await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
             const singleTagResponse = await reviewPrebuiltRulesToInstall(supertest, {
-              filter: { fields: { tags: { include: ['tag-d'] } } },
+              filter: { fields: { tags: { include: { values: ['tag-d'] } } } },
             });
 
             expect(singleTagResponse.rules).toEqual([]);
@@ -712,7 +712,7 @@ export default ({ getService }: FtrProviderContext): void => {
             await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
             const multipleTagsResponse = await reviewPrebuiltRulesToInstall(supertest, {
-              filter: { fields: { tags: { include: ['tag-a', 'tag-b'] } } },
+              filter: { fields: { tags: { include: { values: ['tag-a', 'tag-b'] } } } },
             });
 
             expect(multipleTagsResponse.rules).toEqual([
@@ -741,7 +741,7 @@ export default ({ getService }: FtrProviderContext): void => {
             await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
             const multipleTagsResponse = await reviewPrebuiltRulesToInstall(supertest, {
-              filter: { fields: { tags: { include: ['tag-a', 'tag-c'] } } },
+              filter: { fields: { tags: { include: { values: ['tag-a', 'tag-c'] } } } },
             });
 
             expect(multipleTagsResponse.rules).toEqual([]);
@@ -784,7 +784,7 @@ export default ({ getService }: FtrProviderContext): void => {
               await createPrebuiltRuleAssetSavedObjects(es, [ruleAsset]);
 
               const response = await reviewPrebuiltRulesToInstall(supertest, {
-                filter: { fields: { tags: { include: [tag] } } },
+                filter: { fields: { tags: { include: { values: [tag] } } } },
               });
               expect(response.rules).toEqual([
                 expect.objectContaining({
@@ -807,7 +807,7 @@ export default ({ getService }: FtrProviderContext): void => {
           await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
           const response = await reviewPrebuiltRulesToInstall(supertest, {
-            filter: { fields: { name: { include: ['Rule'] } } },
+            filter: { fields: { name: { include: { values: ['Rule'] } } } },
           });
 
           expect(response).toMatchObject({
@@ -845,7 +845,7 @@ export default ({ getService }: FtrProviderContext): void => {
           await createPrebuiltRuleAssetSavedObjects(es, ruleAssets);
 
           const response = await reviewPrebuiltRulesToInstall(supertest, {
-            filter: { fields: { tags: { include: ['tag-a'] } } },
+            filter: { fields: { tags: { include: { values: ['tag-a'] } } } },
           });
 
           expect(response).toMatchObject({
@@ -882,7 +882,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         const response = await reviewPrebuiltRulesToInstall(supertest, {
           sort: [{ field: 'name', order: 'desc' }],
-          filter: { fields: { tags: { include: ['tag-b'] } } },
+          filter: { fields: { tags: { include: { values: ['tag-b'] } } } },
         });
 
         expect(response.rules).toEqual([


### PR DESCRIPTION
**Related comment in previous PR: https://github.com/elastic/kibana/pull/247375/files#r2691131621**

## Summary
Recently I've merged a PR with a mistake – the shape of the `filter` parameter is incorrect: the `values` property was missing. This PR fixes the shape and updates tests accordingly.

We need to merge this before the Serverless release on Monday, 19-Jan-2026.

This PR is for `main`. I will also backport these changes to the `9.3`, `9.2` and `8.19` branches by adding the change in separate PRs.

