### PR TITLE
[EDR Workflows] Fix trusted devices test error message expectation

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/trusted_devices.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/artifacts/trial_license_complete_tier/trusted_devices.ts
@@ -214,7 +214,7 @@ export default function ({ getService }: FtrProviderContext) {
               .expect(aValidationError)
               .expect(
                 anErrorMessageWith(
-                  /String must contain at least 1 character|No empty strings allowed/
+                  /String must contain at least 1 character|No empty strings allowed|Field value cannot be empty/
                 )
               );
           });


### PR DESCRIPTION
Fixes the trusted devices API integration test that was failing because the error message expectation didn't match the actual validator output.

The test expected `String must contain at least 1 character` or `No empty strings allowed` but the TrustedDeviceValidator returns `Field value cannot be empty`.

This test was prematurely re-enabled in #249231 - the underlying issue was never fixed when it was originally skipped.

Closes https://github.com/elastic/kibana/issues/249366
Closes https://github.com/elastic/kibana/issues/249365