### PR TITLE
fix: modal input

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/common/utils/extract_property_paths_from_kql/extract_property_paths_from_kql.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/extract_property_paths_from_kql/extract_property_paths_from_kql.test.ts
@@ -130,7 +130,7 @@ describe('extractPropertyPathsFromKql', () => {
     });
   });
 
-  describe('template expressions (Handlebars syntax)', () => {
+  describe('template expressions', () => {
     it('should extract both field names and template variables from KQL with template values', () => {
       const result = extractPropertyPathsFromKql('foreach.item: {{ consts.favorite_person }}');
       expect(result).toEqual(expect.arrayContaining(['foreach.item', 'consts.favorite_person']));

--- a/src/platform/packages/shared/kbn-workflows/common/utils/extract_property_paths_from_kql/extract_property_paths_from_kql.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/extract_property_paths_from_kql/extract_property_paths_from_kql.ts
@@ -9,12 +9,42 @@
 import type { KueryNode } from '@kbn/es-query';
 import { fromKueryExpression } from '@kbn/es-query';
 import type { KqlFunctionNode, KqlLiteralNode } from '@kbn/es-query/src/kuery/node_types';
+import { extractTemplateVariables } from '../extract_template_variables/extract_template_variables';
+
+// Placeholder value used to replace Handlebars expressions in KQL
+// This allows the KQL parser to process the query without failing on template syntax
+const TEMPLATE_PLACEHOLDER = '"__TEMPLATE_PLACEHOLDER__"';
+
+/**
+ * Replaces Handlebars template expressions ({{ ... }}) with a valid KQL placeholder.
+ * This allows the KQL parser to process queries that contain dynamic template values.
+ * Also handles malformed/unclosed template expressions to prevent KQL parsing errors.
+ *
+ * @param kql - The KQL query string potentially containing Handlebars expressions
+ * @returns The KQL string with template expressions replaced by placeholders
+ */
+function replaceTemplateExpressions(kql: string): string {
+  // First, match complete {{ ... }} patterns
+  let result = kql.replace(/\{\{[^}]*\}\}/g, TEMPLATE_PLACEHOLDER);
+
+  // Also handle unclosed template expressions (e.g., "{{ incomplete" without closing }})
+  // This ensures malformed templates don't break KQL parsing
+  result = result.replace(/\{\{[^}]*$/g, TEMPLATE_PLACEHOLDER);
+
+  return result;
+}
+
 /**
  * Extracts property paths from a KQL (Kibana Query Language) query string.
  *
  * This function parses a KQL query and extracts field names that appear before
  * colons in field:value expressions, ignoring quoted strings and handling
  * logical operators (AND, OR, NOT) and parentheses.
+ *
+ * It also handles Handlebars template expressions ({{ ... }}) by:
+ * 1. Replacing them with placeholders before KQL parsing
+ * 2. Extracting template variables separately
+ * 3. Combining both sets of results
  *
  * @param kql - The KQL query string to parse
  * @returns Array of unique property paths found in the query
@@ -26,6 +56,9 @@ import type { KqlFunctionNode, KqlLiteralNode } from '@kbn/es-query/src/kuery/no
  *
  * extractPropertyPathsFromKql('name:"John Doe" and age:30 or status:active')
  * // Returns: ['name', 'age', 'status']
+ *
+ * extractPropertyPathsFromKql('foreach.item: {{ consts.favorite_person }}')
+ * // Returns: ['foreach.item', 'consts.favorite_person']
  * ```
  */
 export function extractPropertyPathsFromKql(kql: string): string[] {
@@ -33,9 +66,29 @@ export function extractPropertyPathsFromKql(kql: string): string[] {
     return [];
   }
 
-  const ast = fromKueryExpression(kql);
   const accumulator = new Set<string>();
-  visitRecursive(ast, accumulator);
+
+  // Extract template variables first (e.g., from {{ consts.favorite_person }})
+  // Wrap in try-catch to handle malformed template expressions gracefully
+  try {
+    const templateVariables = extractTemplateVariables(kql);
+    templateVariables.forEach((variable) => accumulator.add(variable));
+  } catch {
+    // If template extraction fails (e.g., malformed {{ without closing }}),
+    // continue with KQL parsing to extract what we can
+  }
+
+  // Replace template expressions with placeholders so KQL parser can process the query
+  const sanitizedKql = replaceTemplateExpressions(kql);
+
+  try {
+    const ast = fromKueryExpression(sanitizedKql);
+    visitRecursive(ast, accumulator);
+  } catch {
+    // If KQL parsing fails even after sanitization, we still return the template variables
+    // This provides graceful degradation for edge cases
+  }
+
   // Filter out special KQL wildcards and sort the results
   return Array.from(accumulator);
 }

--- a/src/platform/packages/shared/kbn-workflows/common/utils/extract_property_paths_from_kql/extract_property_paths_from_kql.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/extract_property_paths_from_kql/extract_property_paths_from_kql.ts
@@ -11,7 +11,7 @@ import { fromKueryExpression } from '@kbn/es-query';
 import type { KqlFunctionNode, KqlLiteralNode } from '@kbn/es-query/src/kuery/node_types';
 import { extractTemplateVariables } from '../extract_template_variables/extract_template_variables';
 
-// Placeholder value used to replace Handlebars expressions in KQL
+// Placeholder value used to replace template expressions in KQL
 // This allows the KQL parser to process the query without failing on template syntax
 const TEMPLATE_PLACEHOLDER = '"__TEMPLATE_PLACEHOLDER__"';
 

--- a/src/platform/packages/shared/kbn-workflows/common/utils/extract_property_paths_from_kql/extract_property_paths_from_kql.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/extract_property_paths_from_kql/extract_property_paths_from_kql.ts
@@ -41,7 +41,7 @@ function replaceTemplateExpressions(kql: string): string {
  * colons in field:value expressions, ignoring quoted strings and handling
  * logical operators (AND, OR, NOT) and parentheses.
  *
- * It also handles Handlebars template expressions ({{ ... }}) by:
+ * It also handles template expressions ({{ ... }}) by:
  * 1. Replacing them with placeholders before KQL parsing
  * 2. Extracting template variables separately
  * 3. Combining both sets of results

--- a/src/platform/packages/shared/kbn-workflows/common/utils/find_inputs_in_graph/find_inputs_in_graph.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/find_inputs_in_graph/find_inputs_in_graph.ts
@@ -53,7 +53,14 @@ export function findInputsInGraph(workflowGraph: WorkflowGraph): Record<string, 
       }
 
       if (shouldInclude) {
-        stepInputs.push((node as EnterForeachNode).configuration.foreach);
+        // Extract template variables from the foreach expression (e.g., "{{ inputs.people }}" -> "inputs.people")
+        const foreachVariables = extractTemplateVariables(foreachInput);
+        if (foreachVariables.length > 0) {
+          stepInputs.push(...foreachVariables);
+        } else {
+          // If no template variables found, use the raw value (for cases like "steps.analysis.output")
+          stepInputs.push(foreachInput);
+        }
         stepInputsKey = enterForeachNode.stepId;
       }
     } else {

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/use_context_override_data.ts
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/use_context_override_data.ts
@@ -43,6 +43,7 @@ export function useContextOverrideData() {
           enabled: workflowDefinition.enabled || true,
           spaceId,
         },
+        inputsDefinition: workflowDefinition.inputs,
       });
     },
     [workflowGraph, workflowDefinition, spaceId]

--- a/src/platform/plugins/shared/workflows_management/public/shared/utils/build_step_context_override/build_step_context_override.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/utils/build_step_context_override/build_step_context_override.test.ts
@@ -315,6 +315,176 @@ describe('buildContextOverride', () => {
       });
       expect(result.schema).toBeDefined();
     });
+
+    it('should use input default values when inputsDefinition is provided', () => {
+      const workflowWithInputs = {
+        version: '1' as const,
+        name: 'test-workflow',
+        enabled: true,
+        triggers: [
+          {
+            type: 'manual' as const,
+            enabled: true,
+          },
+        ],
+        steps: [
+          {
+            name: 'log_input',
+            type: 'console.log',
+            with: {
+              message: '{{ inputs.message }}',
+              count: '{{ inputs.count }}',
+              flag: '{{ inputs.flag }}',
+            },
+          },
+        ],
+      };
+
+      const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithInputs);
+      const staticDataWithInputs = {
+        ...mockStaticData,
+        inputsDefinition: [
+          { name: 'message', type: 'string' as const, default: 'hello world' },
+          { name: 'count', type: 'number' as const, default: 42 },
+          { name: 'flag', type: 'boolean' as const, default: true },
+        ],
+      };
+      const result = buildContextOverride(workflowGraph, staticDataWithInputs);
+
+      expect(result.stepContext).toEqual({
+        inputs: {
+          message: 'hello world',
+          count: 42,
+          flag: true,
+        },
+      });
+      expect(result.schema).toBeDefined();
+    });
+
+    it('should fall back to placeholder for inputs without defaults', () => {
+      const workflowWithInputs = {
+        version: '1' as const,
+        name: 'test-workflow',
+        enabled: true,
+        triggers: [
+          {
+            type: 'manual' as const,
+            enabled: true,
+          },
+        ],
+        steps: [
+          {
+            name: 'log_input',
+            type: 'console.log',
+            with: {
+              messageWithDefault: '{{ inputs.messageWithDefault }}',
+              messageWithoutDefault: '{{ inputs.messageWithoutDefault }}',
+            },
+          },
+        ],
+      };
+
+      const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithInputs);
+      const staticDataWithInputs = {
+        ...mockStaticData,
+        inputsDefinition: [
+          { name: 'messageWithDefault', type: 'string' as const, default: 'default value' },
+          { name: 'messageWithoutDefault', type: 'string' as const },
+        ],
+      };
+      const result = buildContextOverride(workflowGraph, staticDataWithInputs);
+
+      expect(result.stepContext).toEqual({
+        inputs: {
+          messageWithDefault: 'default value',
+          messageWithoutDefault: 'replace with your data',
+        },
+      });
+      expect(result.schema).toBeDefined();
+    });
+
+    it('should handle array input defaults', () => {
+      const workflowWithArrayInput = {
+        version: '1' as const,
+        name: 'test-workflow',
+        enabled: true,
+        triggers: [
+          {
+            type: 'manual' as const,
+            enabled: true,
+          },
+        ],
+        steps: [
+          {
+            name: 'log_input',
+            type: 'console.log',
+            with: {
+              tags: '{{ inputs.tags }}',
+            },
+          },
+        ],
+      };
+
+      const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithArrayInput);
+      const staticDataWithInputs = {
+        ...mockStaticData,
+        inputsDefinition: [
+          { name: 'tags', type: 'array' as const, default: ['tag1', 'tag2', 'tag3'] },
+        ],
+      };
+      const result = buildContextOverride(workflowGraph, staticDataWithInputs);
+
+      expect(result.stepContext).toEqual({
+        inputs: {
+          tags: ['tag1', 'tag2', 'tag3'],
+        },
+      });
+      expect(result.schema).toBeDefined();
+    });
+
+    it('should handle choice input defaults', () => {
+      const workflowWithChoiceInput = {
+        version: '1' as const,
+        name: 'test-workflow',
+        enabled: true,
+        triggers: [
+          {
+            type: 'manual' as const,
+            enabled: true,
+          },
+        ],
+        steps: [
+          {
+            name: 'log_input',
+            type: 'console.log',
+            with: {
+              priority: '{{ inputs.priority }}',
+            },
+          },
+        ],
+      };
+
+      const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithChoiceInput);
+      const staticDataWithInputs = {
+        ...mockStaticData,
+        inputsDefinition: [
+          {
+            name: 'priority',
+            type: 'choice' as const,
+            options: ['low', 'medium', 'high'],
+            default: 'medium',
+          },
+        ],
+      };
+      const result = buildContextOverride(workflowGraph, staticDataWithInputs);
+
+      expect(result.stepContext).toEqual({
+        inputs: {
+          priority: 'medium',
+        },
+      });
+      expect(result.schema).toBeDefined();
+    });
   });
 
   describe('schema generation', () => {

--- a/src/platform/plugins/shared/workflows_management/public/shared/utils/build_step_context_override/build_step_context_override.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/utils/build_step_context_override/build_step_context_override.test.ts
@@ -183,9 +183,16 @@ describe('buildContextOverride', () => {
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithForeach);
       const result = buildContextOverride(workflowGraph, mockStaticData);
 
-      // The foreach workflow might not extract inputs as expected,
-      // let's just check that it handles it gracefully
-      expect(result.stepContext).toEqual({});
+      // The foreach step should extract inputs from the template expression
+      expect(result.stepContext).toEqual({
+        steps: {
+          data_step: {
+            output: {
+              items: 'replace with your data',
+            },
+          },
+        },
+      });
       expect(result.schema).toBeDefined();
     });
 


### PR DESCRIPTION
## Summary

<img width="1880" height="934" alt="CleanShot 2026-01-18 at 10 42 43" src="https://github.com/user-attachments/assets/73121ae0-ccaf-4d22-afe3-8394cbf8df40" />


https://github.com/user-attachments/assets/7a1a7391-54e1-424f-ac48-24e5f1c5b0f4




Fixes the "Test step" modal to pre-populate input fields with workflow-defined default values instead of showing generic placeholder text.

Closes https://github.com/elastic/security-team/issues/15439
Closes https://github.com/elastic/security-team/issues/15437

## Problem

When using the inline "Run step" execution, the test input modal showed generic placeholder text (`"replace with your data"`) for workflow inputs, even when those inputs had defined default values. The "Test Workflow" modal correctly used default values, creating an inconsistent experience.

**Example workflow:**
```yaml
inputs:
  - name: message
    default: "hello world"
    type: string

steps:
  - name: log_input
    type: console
    with:
      message: "{{ inputs.message }}"
```

| Modal | Before | After |
|-------|--------|-------|
| **Test Workflow** | `"hello world"` ✅ | `"hello world"` ✅ |
| **Test step** | `"replace with your data"` ❌ | `"hello world"` ✅ |

## Solution

The `buildContextOverride` function was only receiving `consts` and `workflow` as static data, but not the workflow's `inputs` definitions. When resolving `{{ inputs.* }}` references, it couldn't find default values and fell back to generic placeholders.

**Changes:**
- Extended `buildContextOverride` to accept an optional `inputsDefinition` parameter containing workflow input definitions with their defaults
- Updated `useContextOverrideData` hook to pass the workflow's inputs definition
- Added helper function `buildInputsFromDefinition` to convert input definitions into a lookup object

**Behavior:**
- If an input has a `default` value → pre-populate with that value
- If an input has no `default` → fall back to `"replace with your data"`

## Testing

Added unit tests covering:
- Using input default values when `inputsDefinition` is provided
- Falling back to placeholder for inputs without defaults  
- Handling array input defaults
- Handling choice input defaults


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->