### PR TITLE
fix: dark mode on yaml editor

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/test_step_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/test_step_modal.tsx
@@ -28,6 +28,10 @@ import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { z } from '@kbn/zod/v4';
 import type { ContextOverrideData } from '../../../shared/utils/build_step_context_override/build_step_context_override';
+import {
+  useWorkflowsMonacoTheme,
+  WORKFLOWS_MONACO_EDITOR_THEME,
+} from '../../../widgets/workflow_yaml_editor/styles/use_workflows_monaco_theme';
 
 export function TestStepModal({
   initialcontextOverride,
@@ -40,6 +44,7 @@ export function TestStepModal({
 }) {
   const [overflowWidgetsDomNode, setOverflowWidgetsDomNode] = useState<HTMLDivElement | null>(null);
   const styles = useMemoCss(componentStyles);
+  useWorkflowsMonacoTheme();
   const [inputsJson, setInputsJson] = React.useState<string>(
     JSON.stringify(initialcontextOverride.stepContext, null, 2)
   );
@@ -169,7 +174,7 @@ export function TestStepModal({
                 language: 'json',
                 overflowWidgetsDomNode,
                 fixedOverflowWidgets: true,
-                theme: 'workflows-subdued',
+                theme: WORKFLOWS_MONACO_EDITOR_THEME,
                 automaticLayout: true,
                 fontSize: 12,
                 minimap: {


### PR DESCRIPTION
## Summary
<img width="2556" height="1296" alt="CleanShot 2026-01-18 at 10 58 20" src="https://github.com/user-attachments/assets/cb415ba7-ab31-414c-9ac9-3fbf219fa17c" />

Fixes the "Test step" modal to respect dark mode theme, making it consistent with the "Test Workflow" modal.

Closes https://github.com/elastic/security-team/issues/15438

## Problem

When using the inline "Run step" execution on a step that references workflow input data, the "Test step" modal loses dark mode styling. The modal's JSON editor turns white, breaking the dark theme.

The "Test Workflow" modal (full workflow run) correctly maintains dark mode - the bug only affected the "Test step" modal for inline step execution.

| Modal | Before | After |
|-------|--------|-------|
| **Test Workflow** | Dark mode works ✅ | Dark mode works ✅ |
| **Test step** | White background ❌ | Dark mode works ✅ |

## Root Cause

The `TestStepModal` component was using a hardcoded theme (`'workflows-subdued'`) for the Monaco code editor, which doesn't respond to dark mode changes.

The `WorkflowExecuteModal` (Test Workflow) correctly uses `WORKFLOWS_MONACO_EDITOR_THEME` with the `useWorkflowsMonacoTheme()` hook, which dynamically registers theme colors based on the current EUI color mode.

## Solution

Updated `TestStepModal` to use the same theme system as `WorkflowExecuteModal`:

1. Import and call `useWorkflowsMonacoTheme()` hook to register the dynamic theme
2. Use `WORKFLOWS_MONACO_EDITOR_THEME` constant instead of hardcoded `'workflows-subdued'`

## Testing

1. Enable dark mode in Kibana
2. Create a workflow with inputs defined
3. Add a step that references the input (e.g., `{{ inputs.message }}`)
4. Click the inline "Run step" button on that step
5. Verify the "Test step" modal maintains dark mode styling


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->