### PR TITLE
[OAS]: Restrict mapping key prefixing only to Discriminator Object Mapping

### DIFF
--- a/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/process_document/document_processors/types/traverse_document_node_context.ts
+++ b/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/process_document/document_processors/types/traverse_document_node_context.ts
@@ -12,6 +12,7 @@ import type { DocumentNode } from '../../types/node';
 
 export type TraverseDocumentNodeContext = TraverseDocumentContext & {
   isRootNode: boolean;
+  parent?: TraverseDocumentNodeContext;
   parentNode: DocumentNode;
   parentKey: string | number;
 };

--- a/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/process_document/process_document.test.ts
+++ b/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/process_document/process_document.test.ts
@@ -431,6 +431,14 @@ describe('processDocument', () => {
             expect(context).toEqual({
               resolvedDocument,
               isRootNode: false,
+              parent: {
+                isRootNode: true,
+                parentKey: '',
+                parentNode: {
+                  childNode: {},
+                },
+                resolvedDocument,
+              },
               parentKey: 'childNode',
               parentNode: resolvedDocument.document,
             });
@@ -445,6 +453,14 @@ describe('processDocument', () => {
             expect(context).toEqual({
               resolvedDocument,
               isRootNode: false,
+              parent: {
+                isRootNode: true,
+                parentKey: '',
+                parentNode: {
+                  childNode: {},
+                },
+                resolvedDocument,
+              },
               parentKey: 'childNode',
               parentNode: resolvedDocument.document,
             });
@@ -457,6 +473,14 @@ describe('processDocument', () => {
             expect(context).toEqual({
               resolvedDocument,
               isRootNode: false,
+              parent: {
+                isRootNode: true,
+                parentKey: '',
+                parentNode: {
+                  childNode: {},
+                },
+                resolvedDocument,
+              },
               parentKey: 'childNode',
               parentNode: resolvedDocument.document,
             });
@@ -497,6 +521,16 @@ describe('processDocument', () => {
             expect(context).toEqual({
               resolvedDocument,
               isRootNode: false,
+              parent: {
+                isRootNode: true,
+                parent: undefined,
+                parentKey: '',
+                parentNode: {
+                  node: referencingNode,
+                  refNode: referencedNode,
+                },
+                resolvedDocument,
+              },
               parentKey: 'node',
               parentNode: resolvedDocument.document,
             });

--- a/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/process_document/process_document.ts
+++ b/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/process_document/process_document.ts
@@ -32,6 +32,7 @@ export async function processDocument(
         resolvedDocument,
       },
       visitedDocumentNodes: new Set(),
+      parent: undefined,
       parentNode: resolvedDocument.document,
       parentKey: '',
     },
@@ -88,6 +89,7 @@ export async function processDocument(
         node: resolvedRef.refNode,
         context: childContext,
         visitedDocumentNodes: new Set(),
+        parent: traverseItem,
         parentNode: traverseItem.parentNode,
         parentKey: traverseItem.parentKey,
       });
@@ -103,6 +105,7 @@ export async function processDocument(
           node: nodeItem as DocumentNode,
           context: traverseItem.context,
           visitedDocumentNodes: traverseItem.visitedDocumentNodes,
+          parent: traverseItem,
           parentNode: traverseItem.node,
           parentKey: i,
         });
@@ -117,6 +120,7 @@ export async function processDocument(
           node: value as DocumentNode,
           context: traverseItem.context,
           visitedDocumentNodes: traverseItem.visitedDocumentNodes,
+          parent: traverseItem,
           parentNode: traverseItem.node,
           parentKey: key,
         });

--- a/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/process_document/transform_traverse_item_to_node_context.ts
+++ b/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/process_document/transform_traverse_item_to_node_context.ts
@@ -10,11 +10,22 @@
 import type { TraverseDocumentNodeContext } from './document_processors/types/traverse_document_node_context';
 import type { TraverseItem } from './traverse_item';
 
+const contextCache = new WeakMap<TraverseItem, TraverseDocumentNodeContext>();
+
 export function createNodeContext(traverseItem: TraverseItem): TraverseDocumentNodeContext {
-  return {
+  if (contextCache.has(traverseItem)) {
+    return contextCache.get(traverseItem)!;
+  }
+
+  const node = {
     ...traverseItem.context,
     isRootNode: traverseItem.node === traverseItem.parentNode,
+    parent: traverseItem.parent ? createNodeContext(traverseItem.parent) : undefined,
     parentNode: traverseItem.parentNode,
     parentKey: traverseItem.parentKey,
   };
+
+  contextCache.set(traverseItem, node);
+
+  return node;
 }

--- a/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/process_document/traverse_item.ts
+++ b/src/platform/packages/shared/kbn-openapi-bundler/src/bundler/process_document/traverse_item.ts
@@ -18,6 +18,7 @@ export interface TraverseItem {
    * Keeps track of visited nodes to be able to detect circular references
    */
   visitedDocumentNodes: Set<DocumentNode>;
+  parent?: TraverseItem;
   parentNode: DocumentNode;
   parentKey: string | number;
   resolvedRef?: ResolvedRef;


### PR DESCRIPTION
## Summary

This PR fixes the bug @nickofthyme [stumbled](https://github.com/elastic/kibana/pull/249426#discussion_r2699894107) upon in https://github.com/elastic/kibana/pull/249426. The bug manifests as an `Error: Expected mappings to have local references but got ...` error.

## Details

`kbn-openapi-bundler` is used in the API documentation build tool chain. Besides bundling scattered OpenAPI declaration files it's responsible for merging large OpenAPI feature domain specification files. This merging process may lead to name conflicts. To avoid conflicts the bundler applies prefixing to the bundled schema names. For example `Foo` from `file1.schema.yaml` becomes `#/components/schemas/file1_Foo` while `Bar` from `file2.schema.yaml` becomes `#/components/schemas/file2_Bar`.

In particular prefixing is applied to the Discriminator Object Mappings. However, `mappings` key may appear in the usual schema declarations. It makes the documents processor thinking that it has to apply prefixing. But the prefixing has to be applied only for Discriminator Object Mappings.

This PR fixes the issue by exposing `parent` context to the document processors so it becomes possible to track the full path from the document root and apply transformation only when it's necessary.



<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->