### PR TITLE
[One Workflow]: bugfix - Inputs section incorrectly selectable as "test step"

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/utils/build_workflow_lookup.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/utils/build_workflow_lookup.test.ts
@@ -547,4 +547,33 @@ steps:
       },
     });
   });
+
+  it('should not treat inputs as steps', () => {
+    const yaml = `
+name: test
+inputs:
+  - name: people
+    type: array
+    default:
+      - alice
+      - bob
+  - name: greeting
+    type: string
+    default: Hello
+steps:
+  - name: step1
+    type: console
+`;
+    const lineCounter = new LineCounter();
+    const yamlDocument = parseDocument(yaml, { lineCounter, keepSourceTokens: true });
+    const result = buildWorkflowLookup(yamlDocument, lineCounter);
+
+    // Should only have step1, not the inputs
+    expect(Object.keys(result.steps)).toHaveLength(1);
+    expect(result.steps).toHaveProperty('step1');
+    expect(result.steps).not.toHaveProperty('people');
+    expect(result.steps).not.toHaveProperty('greeting');
+    expect(result.steps.step1.stepId).toBe('step1');
+    expect(result.steps.step1.stepType).toBe('console');
+  });
 });

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/utils/build_workflow_lookup.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/utils/build_workflow_lookup.ts
@@ -74,10 +74,15 @@ export function buildWorkflowLookup(
     };
   }
 
-  Object.assign(
-    steps,
-    inspectStep(yamlDocument?.contents, lineCounter) // stepItems can be null if there are no steps defined yet
-  );
+  // Only process the 'steps' section, not the entire document
+  // This prevents inputs (which also have 'name' and 'type') from being treated as steps
+  const stepsNode = (yamlDocument.contents as any).get('steps');
+  if (stepsNode) {
+    Object.assign(
+      steps,
+      inspectStep(stepsNode, lineCounter) // stepItems can be null if there are no steps defined yet
+    );
+  }
 
   return {
     steps,


### PR DESCRIPTION
## Summary

Fixes an issue where workflow inputs were incorrectly selectable as test steps.

<img width="1016" height="686" alt="Image" src="https://github.com/user-attachments/assets/25e433c8-c7eb-40ac-b8f9-efa279b9607a" />

## Problem

The `buildWorkflowLookup` function was processing the entire YAML document and searching for sections with `name` and `type` fields, which caused inputs (that also contain `name` and `type`) to be mistakenly identified as steps.

## Solution

Modified `buildWorkflowLookup` to only process the `steps` section instead of the entire document, preventing inputs from being treated as steps.

## Testing

Added test case to verify inputs are not treated as steps.


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->