### PR TITLE
fix: one year ago workflow execution

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list_item.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_execution_list/ui/workflow_execution_list_item.tsx
@@ -22,10 +22,11 @@ import { css } from '@emotion/react';
 import React, { useMemo } from 'react';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage, FormattedRelative } from '@kbn/i18n-react';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { ExecutionStatus } from '@kbn/workflows';
 import { formatDuration } from '../../../shared/lib/format_duration';
 import { getStatusLabel } from '../../../shared/translations';
+import { FormattedRelativeEnhanced } from '../../../shared/ui/formatted_relative_enhanced/formatted_relative_enhanced';
 import { getExecutionStatusColors, getExecutionStatusIcon } from '../../../shared/ui/status_badge';
 import { useGetFormattedDateTime } from '../../../shared/ui/use_formatted_date';
 
@@ -91,7 +92,7 @@ export const WorkflowExecutionListItem = React.memo<WorkflowExecutionListItemPro
                 {startedAt ? (
                   <EuiToolTip position="left" content={formattedDate}>
                     <EuiText size="xs" tabIndex={0} color="subdued">
-                      <FormattedRelative value={startedAt} />
+                      <FormattedRelativeEnhanced value={startedAt} />
                     </EuiText>
                   </EuiToolTip>
                 ) : (

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/index.ts
@@ -8,11 +8,7 @@
  */
 
 export { StatusBadge, getExecutionStatusColors, getExecutionStatusIcon } from './status_badge';
-export {
-  useFormattedDate,
-  useFormattedDateTime,
-  useGetFormattedDateTime,
-} from './use_formatted_date';
+export { useFormattedDate, useFormattedDateTime } from './use_formatted_date';
 export { YamlEditor, type YamlEditorProps } from './yaml_editor';
 export { JSONDataTable, type JSONDataTableProps } from './execution_data_viewer/json_data_table';
 export { UnsavedChangesPrompt } from './unsaved_changes_prompt';

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/index.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/index.ts
@@ -8,7 +8,11 @@
  */
 
 export { StatusBadge, getExecutionStatusColors, getExecutionStatusIcon } from './status_badge';
-export { useFormattedDate, useFormattedDateTime } from './use_formatted_date';
+export {
+  useFormattedDate,
+  useFormattedDateTime,
+  useGetFormattedDateTime,
+} from './use_formatted_date';
 export { YamlEditor, type YamlEditorProps } from './yaml_editor';
 export { JSONDataTable, type JSONDataTableProps } from './execution_data_viewer/json_data_table';
 export { UnsavedChangesPrompt } from './unsaved_changes_prompt';

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/status_badge.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/status_badge.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { I18nProvider } from '@kbn/i18n-react';
+import { ExecutionStatus } from '@kbn/workflows';
+import { StatusBadge } from './status_badge';
+
+const renderWithI18n = (ui: React.ReactNode) => {
+  return render(<I18nProvider>{ui}</I18nProvider>);
+};
+
+describe('StatusBadge', () => {
+  describe('relative date display across year boundaries', () => {
+    beforeEach(() => {
+      // Mock the current date to be January 10, 2026
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-01-10T10:00:00Z'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('displays relative time instead of "last year" for dates 2-3 weeks in the past crossing year boundary', () => {
+      // This test verifies the fix for https://github.com/elastic/security-team/issues/15310
+      // When the current date is January 10, 2026, and the execution happened on December 20, 2025
+      // (only ~3 weeks ago), the UI should NOT show "last year"
+
+      const dateInLateDecember2025 = '2025-12-20T10:00:00Z'; // ~3 weeks ago
+
+      renderWithI18n(
+        <StatusBadge status={ExecutionStatus.COMPLETED} date={dateInLateDecember2025} />
+      );
+
+      // After the fix, should NOT show "last year"
+      expect(screen.queryByText('last year')).not.toBeInTheDocument();
+      // Should show days or weeks ago instead (moment.js will show "21 days ago" or similar)
+    });
+
+    it('displays months ago for dates 2 months in the past crossing year boundary', () => {
+      // For dates that are 2 months old but cross the year boundary,
+      // should show "2 months ago" instead of "last year"
+
+      const dateInNovember2025 = '2025-11-10T10:00:00Z'; // ~2 months ago
+
+      renderWithI18n(<StatusBadge status={ExecutionStatus.COMPLETED} date={dateInNovember2025} />);
+
+      // Should NOT show "last year" for dates less than 12 months old
+      expect(screen.queryByText('last year')).not.toBeInTheDocument();
+    });
+
+    it('displays relative time correctly when no year boundary is crossed', () => {
+      // When the date is within the same year, the relative time should work correctly
+      const dateInSameYear = '2026-01-03T10:00:00Z'; // 1 week ago (same year)
+
+      renderWithI18n(<StatusBadge status={ExecutionStatus.COMPLETED} date={dateInSameYear} />);
+
+      // Should show "last week" or "1 week ago" for dates within the same year
+      expect(screen.queryByText('last year')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('basic rendering', () => {
+    it('renders status without date', () => {
+      renderWithI18n(<StatusBadge status={ExecutionStatus.COMPLETED} />);
+      // The status label is "Success" for COMPLETED status
+      expect(screen.getByText(/success/i)).toBeInTheDocument();
+    });
+
+    it('returns null when status is undefined', () => {
+      const { container } = renderWithI18n(<StatusBadge status={undefined} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/status_badge.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/status_badge.tsx
@@ -25,8 +25,8 @@ import type { EuiIconType } from '@elastic/eui/src/components/icon/icon';
 import type { TokenColor } from '@elastic/eui/src/components/token/token_types';
 import { css } from '@emotion/react';
 import React from 'react';
-import { FormattedRelative } from '@kbn/i18n-react';
 import { ExecutionStatus } from '@kbn/workflows';
+import { FormattedRelativeEnhanced } from './formatted_relative_enhanced/formatted_relative_enhanced';
 import { getStatusLabel } from '../translations';
 interface ExecutionStatusColors {
   color: string;
@@ -157,7 +157,7 @@ export function StatusBadge({
               text-transform: capitalize;
             `}
           >
-            {date ? <FormattedRelative value={date} /> : statusLabel}
+            {date ? <FormattedRelativeEnhanced value={date} /> : statusLabel}
           </EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>


### PR DESCRIPTION
before:
<img width="730" height="580" alt="CleanShot 2026-01-18 at 16 53 49" src="https://github.com/user-attachments/assets/5542118b-2ee6-4de1-bb8b-8c4203fb3979" />

after:
<img width="725" height="584" alt="CleanShot 2026-01-18 at 17 00 21" src="https://github.com/user-attachments/assets/64790b0d-6281-41b6-b714-c6772d73b6aa" />

## Summary

Fixes misleading "last year" date display in workflow execution list when dates cross year boundaries.

**Issue:** https://github.com/elastic/security-team/issues/15310

### Problem

The "Last run" column in the workflows list was displaying "last year" for executions that happened only 2-3 weeks ago, simply because they crossed the calendar year boundary (e.g., Dec 20, 2025 viewed on Jan 10, 2026).

### Solution

Added a fix to `FormattedRelativeEnhanced`: when `selectUnit` from `@formatjs/intl-utils` returns "year" but less than 180 days (6 months) have actually passed, we use a more appropriate unit (weeks or months) instead.

### Changes

**`formatted_relative_enhanced.tsx`:**
- Added year boundary fix: converts "year" to "weeks" or "months" when < 180 days have passed
- Refactored tooltip logic into separate `WithTooltip` component to avoid calling `useFormattedDateTime` hook when `fullDateTooltip=false` (fixes unnecessary hook call and improves testability)

**`status_badge.tsx`** and **`workflow_execution_list_item.tsx`:**
- Use `FormattedRelativeEnhanced` instead of `FormattedRelative`

**`status_badge.test.tsx`:**
- Added tests for year boundary scenarios

### Before

| Execution Date | Current Date | Display |
|----------------|--------------|---------|
| Dec 20, 2025 | Jan 10, 2026 | "last year" |
| Nov 10, 2025 | Jan 10, 2026 | "last year" |

### After

| Execution Date | Current Date | Display |
|----------------|--------------|---------|
| Dec 20, 2025 | Jan 10, 2026 | "3 weeks ago" |
| Nov 10, 2025 | Jan 10, 2026 | "2 months ago" |

All other relative time displays (weeks, days, hours, etc.) remain unchanged.

## Test Plan

- [x] Unit tests verify dates crossing year boundaries don't show "last year" when < 180 days old
- [ ] Manual verification: View workflow execution list with executions from late December when current date is early January
- [ ] Verify "last week", "2 weeks ago" etc. still work as before


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->