### PR TITLE
[kbn/scout] change default deploymentType "general" -> "classic"

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
@@ -1055,7 +1055,7 @@ describe('runDiscoverPlaywrightConfigs', () => {
           g.group === 'platform' &&
           g.scoutCommand === 'node scripts/scout run-tests --stateful --testTarget=cloud'
       );
-      // For stateful (ECH), deploymentType should be based on group: 'test' => 'classic' (unknown group defaults to general)
+      // For stateful (ECH), deploymentType should be based on group: 'test' => 'classic' (unknown group defaults to classic)
       expect(statefulGroup).toBeDefined();
       expect(statefulGroup.deploymentType).toBe('classic');
       expect(statefulGroup.configs).toContain('pluginMultiMode/config1.playwright.config.ts');

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
@@ -953,7 +953,7 @@ describe('runDiscoverPlaywrightConfigs', () => {
           g.scoutCommand === 'node scripts/scout run-tests --stateful --testTarget=cloud'
       );
       expect(statefulPlatformGroup).toBeDefined();
-      expect(statefulPlatformGroup.deploymentType).toBe('general');
+      expect(statefulPlatformGroup.deploymentType).toBe('classic');
       expect(statefulPlatformGroup.configs).toContain(
         'pluginPlatform/config1.playwright.config.ts'
       );
@@ -1055,9 +1055,9 @@ describe('runDiscoverPlaywrightConfigs', () => {
           g.group === 'platform' &&
           g.scoutCommand === 'node scripts/scout run-tests --stateful --testTarget=cloud'
       );
-      // For stateful (ECH), deploymentType should be based on group: 'test' => 'general' (unknown group defaults to general)
+      // For stateful (ECH), deploymentType should be based on group: 'test' => 'classic' (unknown group defaults to general)
       expect(statefulGroup).toBeDefined();
-      expect(statefulGroup.deploymentType).toBe('general');
+      expect(statefulGroup.deploymentType).toBe('classic');
       expect(statefulGroup.configs).toContain('pluginMultiMode/config1.playwright.config.ts');
 
       const serverlessEsGroup = savedData.find(

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/transform_utils.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/transform_utils.ts
@@ -27,12 +27,12 @@ export const countModulesByType = (
 
 /**
  * Determines deployment type for ECH (stateful) based on group
- * - 'platform' => 'general'
+ * - 'platform' => 'classic'
  * - Other groups => solution name from group (e.g., 'search' => 'elasticsearch')
  */
 const getDeploymentTypeForEch = (group: string): DeploymentType => {
   if (group === 'platform') {
-    return 'general';
+    return 'classic';
   }
   // Map group to solution name
   if (group === 'search') {

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/types.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/types.ts
@@ -14,7 +14,7 @@ export type TargetType = 'all' | 'mki' | 'ech';
 export const TARGET_TYPES: TargetType[] = ['all', 'mki', 'ech'];
 
 export type DeploymentType =
-  | 'general'
+  | 'classic'
   | 'elasticsearch'
   | 'security'
   | 'observability'


### PR DESCRIPTION
## Summary
closes https://github.com/elastic/appex-qa-team/issues/627

This PR makes a small default value update to be aligned with QAF, that uses `classic`

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->