### PR TITLE
Fix flaky test in Custom Threshold Preview Chart

### DIFF
--- a/src/platform/packages/shared/kbn-test/src/auth/saml_auth.ts
+++ b/src/platform/packages/shared/kbn-test/src/auth/saml_auth.ts
@@ -117,7 +117,6 @@ export const createCloudSession = async (
     try {
       sessionResponse = await axios.request(requestConfig(cloudLoginUrl));
       if (sessionResponse?.status !== 200) {
-        console.error(JSON.stringify(sessionResponse?.data, null, 2));
         throw new Error(
           `Failed to create the new cloud session: 'POST ${cloudLoginUrl}' returned ${sessionResponse?.status}`
         );

--- a/src/platform/packages/shared/kbn-test/src/auth/saml_auth.ts
+++ b/src/platform/packages/shared/kbn-test/src/auth/saml_auth.ts
@@ -117,6 +117,7 @@ export const createCloudSession = async (
     try {
       sessionResponse = await axios.request(requestConfig(cloudLoginUrl));
       if (sessionResponse?.status !== 200) {
+        console.error(JSON.stringify(sessionResponse?.data, null, 2));
         throw new Error(
           `Failed to create the new cloud session: 'POST ${cloudLoginUrl}' returned ${sessionResponse?.status}`
         );

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/rules/custom_threshold_rule/custom_threshold_preview_chart.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/rules/custom_threshold_rule/custom_threshold_preview_chart.spec.ts
@@ -8,7 +8,7 @@ import { expect } from '@kbn/scout-oblt';
 import { test } from '../../../fixtures';
 
 // FLAKY: https://github.com/elastic/kibana/issues/247632
-test.describe.skip('Custom threshold preview chart', { tag: ['@ess', '@svlOblt'] }, () => {
+test.describe('Custom threshold preview chart', { tag: ['@ess', '@svlOblt'] }, () => {
   const previewChartDataTestSubj = 'thresholdRulePreviewChart';
 
   test.beforeEach(async ({ browserAuth, pageObjects }) => {
@@ -27,25 +27,29 @@ test.describe.skip('Custom threshold preview chart', { tag: ['@ess', '@svlOblt']
   });
 
   test('should handle the error message correctly', async ({ page }) => {
-    const customEquationField = page.testSubj.locator('thresholdRuleCustomEquationEditorFieldText');
+    await expect(async () => {
+      const customEquationField = page.testSubj.locator(
+        'thresholdRuleCustomEquationEditorFieldText'
+      );
 
-    // Introduce an error in the equation
-    await page.testSubj.click('customEquation');
-    await customEquationField.click();
-    await customEquationField.fill('A +');
-    await page.testSubj.click('o11yClosablePopoverTitleButton');
+      // Introduce an error in the equation
+      await page.testSubj.click('customEquation');
+      await customEquationField.click();
+      await customEquationField.fill('A +');
+      await page.testSubj.click('o11yClosablePopoverTitleButton');
 
-    const lensFailure = page.testSubj.locator('embeddable-lens-failure');
-    await expect(lensFailure).toBeVisible();
-    await expect(lensFailure).toContainText('An error occurred while rendering the chart');
+      const lensFailure = page.testSubj.locator('embeddable-lens-failure');
+      await expect(lensFailure).toBeVisible();
+      await expect(lensFailure).toContainText('An error occurred while rendering the chart');
 
-    // Fix the introduced error
-    await page.testSubj.click('customEquation');
-    await customEquationField.click();
-    await customEquationField.fill('A');
-    await page.testSubj.click('o11yClosablePopoverTitleButton');
+      // Fix the introduced error
+      await page.testSubj.click('customEquation');
+      await customEquationField.click();
+      await customEquationField.fill('A');
+      await page.testSubj.click('o11yClosablePopoverTitleButton');
 
-    // Wait for the chart to re-render after fixing the equation
-    await expect(lensFailure).toBeHidden({ timeout: 15000 });
+      // Wait for the chart to re-render after fixing the equation
+      await expect(lensFailure).toBeHidden();
+    }).toPass({ timeout: 15_000, intervals: [1000] });
   });
 });

--- a/x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/rules/custom_threshold_rule/custom_threshold_preview_chart.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability/test/scout/ui/parallel_tests/rules/custom_threshold_rule/custom_threshold_preview_chart.spec.ts
@@ -7,7 +7,6 @@
 import { expect } from '@kbn/scout-oblt';
 import { test } from '../../../fixtures';
 
-// FLAKY: https://github.com/elastic/kibana/issues/247632
 test.describe('Custom threshold preview chart', { tag: ['@ess', '@svlOblt'] }, () => {
   const previewChartDataTestSubj = 'thresholdRulePreviewChart';
 


### PR DESCRIPTION
## Summary

closes #247632 

According to t[hese logs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10243/steps/canvas?jid=019b5124-2ddd-4cf0-8c88-ed12f809e35f), this test fails sometimes because of network failures not related with the test itself. 

This PR retries the failing block so transient network errors don't make the entire test fail.

## Testing

I ran the Flaky Test Runner on this PR with 200 executions and they all were successful: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/10534/steps/canvas