### PR TITLE
[9.3] Update code owners for the Obs DevEx team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -452,7 +452,7 @@ src/platform/packages/shared/kbn-avc-banner @elastic/security-defend-workflows
 src/platform/packages/shared/kbn-axe-config @elastic/appex-qa
 src/platform/packages/shared/kbn-babel-register @elastic/kibana-operations
 src/platform/packages/shared/kbn-background-search @elastic/kibana-data-discovery
-src/platform/packages/shared/kbn-bench @elastic/obs-ui-devex-team
+src/platform/packages/shared/kbn-bench @elastic/observability-ui
 src/platform/packages/shared/kbn-cache-cli @elastic/kibana-operations
 src/platform/packages/shared/kbn-calculate-auto @elastic/actionable-obs-team
 src/platform/packages/shared/kbn-calculate-width-from-char-count @elastic/kibana-visualizations
@@ -523,7 +523,7 @@ src/platform/packages/shared/kbn-i18n @elastic/kibana-core
 src/platform/packages/shared/kbn-i18n-react @elastic/kibana-core
 src/platform/packages/shared/kbn-interpreter @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-io-ts-utils @elastic/obs-knowledge-team
-src/platform/packages/shared/kbn-jest-benchmarks @elastic/obs-ui-devex-team
+src/platform/packages/shared/kbn-jest-benchmarks @elastic/observability-ui
 src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations
 src/platform/packages/shared/kbn-lens-common @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-lens-common-2 @elastic/kibana-visualizations
@@ -638,7 +638,7 @@ src/platform/packages/shared/kbn-visualization-utils @elastic/kibana-visualizati
 src/platform/packages/shared/kbn-visualizations-common @elastic/kibana-visualizations
 src/platform/packages/shared/kbn-workflows @elastic/workflows-eng
 src/platform/packages/shared/kbn-workflows-ui @elastic/workflows-eng
-src/platform/packages/shared/kbn-workspaces @elastic/obs-ui-devex-team
+src/platform/packages/shared/kbn-workspaces @elastic/observability-ui
 src/platform/packages/shared/kbn-xstate-utils @elastic/obs-onboarding-team
 src/platform/packages/shared/kbn-zod @elastic/kibana-core
 src/platform/packages/shared/kbn-zod-helpers @elastic/security-detection-rule-management
@@ -1875,7 +1875,7 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /.eslintrc.js @elastic/kibana-operations
 /.eslintignore @elastic/kibana-operations
 /.ci/.storybook @elastic/kibana-operations
-/src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations @elastic/obs-ui-devex-team
+/src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations @elastic/observability-ui
 
 # QA - Appex QA
 .buildkite/scout_ci_config.yml @elastic/appex-qa

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -62,7 +62,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/obs-knowledge-team',
     'elastic/obs-onboarding-team',
     'elastic/obs-presentation-team',
-    'elastic/obs-ui-devex-team',
+    'elastic/observability-ui',
     'elastic/obs-ux-management-team',
     'elastic/observability-design',
     'elastic/observability-ui',

--- a/src/platform/packages/shared/kbn-bench/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-bench/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/bench",
-  "owner": "@elastic/obs-ui-devex-team",
+  "owner": "@elastic/observability-ui",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/src/platform/packages/shared/kbn-bench/moon.yml
+++ b/src/platform/packages/shared/kbn-bench/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/bench'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ui-devex-team'
+  defaultOwner: '@elastic/observability-ui'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/bench'
   description: Moon project for @kbn/bench
   channel: ''
-  owner: '@elastic/obs-ui-devex-team'
+  owner: '@elastic/observability-ui'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-bench
 dependsOn:

--- a/src/platform/packages/shared/kbn-jest-benchmarks/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-jest-benchmarks/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/jest-benchmarks",
-  "owner": "@elastic/obs-ui-devex-team",
+  "owner": "@elastic/observability-ui",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/src/platform/packages/shared/kbn-jest-benchmarks/moon.yml
+++ b/src/platform/packages/shared/kbn-jest-benchmarks/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/jest-benchmarks'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ui-devex-team'
+  defaultOwner: '@elastic/observability-ui'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/jest-benchmarks'
   description: Moon project for @kbn/jest-benchmarks
   channel: ''
-  owner: '@elastic/obs-ui-devex-team'
+  owner: '@elastic/observability-ui'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-jest-benchmarks
 dependsOn:

--- a/src/platform/packages/shared/kbn-workspaces/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-workspaces/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-server",
   "id": "@kbn/workspaces",
-  "owner": "@elastic/obs-ui-devex-team",
+  "owner": "@elastic/observability-ui",
   "group": "platform",
   "visibility": "shared",
   "devOnly": true

--- a/src/platform/packages/shared/kbn-workspaces/moon.yml
+++ b/src/platform/packages/shared/kbn-workspaces/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/workspaces'
 type: unknown
 owners:
-  defaultOwner: '@elastic/obs-ui-devex-team'
+  defaultOwner: '@elastic/observability-ui'
 toolchain:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   name: '@kbn/workspaces'
   description: Moon project for @kbn/workspaces
   channel: ''
-  owner: '@elastic/obs-ui-devex-team'
+  owner: '@elastic/observability-ui'
   metadata:
     sourceRoot: src/platform/packages/shared/kbn-workspaces
 dependsOn:


### PR DESCRIPTION
Transferring ownership of relevant packages from the obs-ui-devex-team to the observability-ui team.

Backport for https://github.com/elastic/kibana/pull/248650