### PR TITLE
[8.19][EDR Workflows] Unskip vagrant failures tests

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/response_actions/document_signing.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/response_actions/document_signing.cy.ts
@@ -22,10 +22,7 @@ import { enableAllPolicyProtections } from '../../tasks/endpoint_policy';
 import { createEndpointHost } from '../../tasks/create_endpoint_host';
 import { deleteAllLoadedEndpointData } from '../../tasks/delete_all_endpoint_data';
 
-// FLAKY: https://github.com/elastic/kibana/issues/209063
-// FLAKY: https://github.com/elastic/kibana/issues/209064
-// FLAKY: https://github.com/elastic/kibana/issues/206211
-describe.skip('Document signing:', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
+describe('Document signing:', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
   let indexedPolicy: IndexedFleetEndpointPolicyResponse;
   let policy: PolicyData;
   let createdHost: CreateAndEnrollEndpointHostResponse;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/tamper_protection/enabled/uninstall_agent_from_host.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/tamper_protection/enabled/uninstall_agent_from_host.cy.ts
@@ -22,8 +22,7 @@ import { login } from '../../../tasks/login';
 import { createEndpointHost } from '../../../tasks/create_endpoint_host';
 import { deleteAllLoadedEndpointData } from '../../../tasks/delete_all_endpoint_data';
 
-// FLAKY: https://github.com/elastic/kibana/issues/206208
-describe.skip(
+describe(
   'Uninstall agent from host when agent tamper protection is enabled',
   { tags: ['@ess'] },
   () => {


### PR DESCRIPTION
## Summary

Unskips the document signing Cypress test that was marked as flaky. Unskipping since there was an issue with instances running out of disk space in the CI when it was skipped.

Closes https://github.com/elastic/kibana/issues/209064
Closes https://github.com/elastic/kibana/issues/209063
Closes https://github.com/elastic/kibana/issues/206208