### PR TITLE
[9.3] [Obs AI] Move `observability_agent_builder` API tests out of feature flag configs (#248569)

### DIFF
--- a/.buildkite/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr_oblt_serverless_configs.yml
@@ -44,7 +44,7 @@ disabled:
   - x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts
   - x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts
   - x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/serverless/oblt.serverless.config.ts
-  - x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/serverless/oblt.ai_agent.serverless.config.ts
+  - x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.serverless.config.ts
 
 defaultQueue: 'n2-4-spot'
 enabled:

--- a/.buildkite/ftr_oblt_stateful_configs.yml
+++ b/.buildkite/ftr_oblt_stateful_configs.yml
@@ -57,5 +57,5 @@ enabled:
   - x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts
   - x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant.stateful.config.ts
   - x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.stateful.config.ts
-  - x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.ai_agent.stateful.config.ts
+  - x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts
   - x-pack/solutions/observability/test/functional_solution_sidenav/config.ts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1504,7 +1504,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/observability_ai_assistant_functional @elastic/obs-ai-team
 /x-pack/solutions/observability/test/fixtures/es_archives/observability/ai_assistant @elastic/obs-ai-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder @elastic/obs-ai-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant.index.ts @elastic/obs-ai-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts @elastic/obs-ai-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant.index.ts @elastic/obs-ai-team
@@ -1515,10 +1514,11 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_assistant_local.stateful.config.ts  @elastic/obs-ai-team
 
 # Observability Agent Builder
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.ai_agent.index.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.ai_agent.stateful.config.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/serverless/oblt.ai_agent.index.ts @elastic/obs-ai-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/serverless/oblt.ai_agent.serverless.config.ts @elastic/obs-ai-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder @elastic/obs-ai-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.index.ts @elastic/obs-ai-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.serverless.config.ts @elastic/obs-ai-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.index.ts @elastic/obs-ai-team
+/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts @elastic/obs-ai-team
 
 # Infra Obs
 ## This plugin mostly contains the codebase for the infra services, but also includes some code for the Logs UI app.

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/AGENTS.md
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/AGENTS.md
@@ -291,7 +291,7 @@ The Elasticsearch test server: http://elastic:changeme@localhost:9220
 To run the API tests for a tool:
 
 ```
-node scripts/functional_test_runner --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.ai_agent.stateful.config.ts --grep="<tool_name>"
+node scripts/functional_test_runner --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts --grep="<tool_name>"
 ```
 
 The API tests for tools must be added to: `x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/`

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.index.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.index.ts
@@ -7,7 +7,9 @@
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
-  describe('Serverless Observability feature flag testing - Deployment-agnostic Observability Agent Builder API integration tests', function () {
-    loadTestFile(require.resolve('../../apis/observability_agent_builder/index.ts'));
+  describe('Serverless Observability - Deployment-agnostic Observability Agent Builder API integration tests', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('../../apis/observability_agent_builder'));
   });
 }

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.serverless.config.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.serverless.config.ts
@@ -5,15 +5,15 @@
  * 2.0.
  */
 
-import { createServerlessFeatureFlagTestConfig } from '@kbn/test-suites-xpack-platform/api_integration_deployment_agnostic/default_configs/feature_flag.serverless.config.base';
+import { createServerlessTestConfig } from '@kbn/test-suites-xpack-platform/api_integration_deployment_agnostic/default_configs/serverless.config.base';
 import { services } from '../../services';
 
-export default createServerlessFeatureFlagTestConfig<typeof services>({
+export default createServerlessTestConfig<typeof services>({
   services,
   serverlessProject: 'oblt',
   testFiles: [require.resolve('./oblt.ai_agent.index.ts')],
   junit: {
     reportName:
-      'Serverless Observability - Deployment-agnostic Feature Flag Observability Agent Builder API Integration Tests',
+      'Serverless Observability - Deployment-agnostic Observability Agent Builder API Integration Tests',
   },
 });

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.index.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.index.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
-  describe('Stateful Observability feature flag testing - Deployment-agnostic Observability Agent Builder API integration tests', () => {
-    loadTestFile(require.resolve('../../apis/observability_agent_builder/index.ts'));
+  describe('Stateful Observability - Deployment-agnostic Observability Agent Builder API integration tests', function () {
+    loadTestFile(require.resolve('../../apis/observability_agent_builder'));
   });
 }

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts
@@ -5,15 +5,15 @@
  * 2.0.
  */
 
-import { createStatefulFeatureFlagTestConfig } from '@kbn/test-suites-xpack-platform/api_integration_deployment_agnostic/default_configs/feature_flag.stateful.config.base';
+import { createStatefulTestConfig } from '@kbn/test-suites-xpack-platform/api_integration_deployment_agnostic/default_configs/stateful.config.base';
 import { services } from '../../services';
 
-export default createStatefulFeatureFlagTestConfig<typeof services>({
+export default createStatefulTestConfig<typeof services>({
   services,
   testFiles: [require.resolve('./oblt.ai_agent.index.ts')],
   junit: {
     reportName:
-      'Stateful Observability - Deployment-agnostic Feature Flag Observability Agent Builder API Integration Tests',
+      'Stateful Observability - Deployment-agnostic Observability Agent Builder API Integration Tests',
   },
   // @ts-expect-error
   kbnTestServer: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Obs AI] Move `observability_agent_builder` API tests out of feature flag configs (#248569)](https://github.com/elastic/kibana/pull/248569)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2026-01-14T22:28:30Z","message":"[Obs AI] Move `observability_agent_builder` API tests out of feature flag configs (#248569)\n\nCloses https://github.com/elastic/obs-ai-team/issues/462\n\n## Summary\n\nThis PR moves the `observability_agent_builder` API tests to the regular\nconfigs folder. Previously it was in the feature flag configs folder.\n\n### Commands to run the API tests\n\n#### Stateful\n\n```\nnode scripts/functional_test_runner --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts\n```\n\n#### Serverless\n\n```\nnode scripts/functional_test_runner --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.serverless.config.ts\n```\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"577627ee8e15daf80acc1c0c19973fc9bb92b5e4","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.3.0","Team:obs-ai","v9.4.0"],"title":"[Obs AI] Move `observability_agent_builder` API tests out of feature flag configs","number":248569,"url":"https://github.com/elastic/kibana/pull/248569","mergeCommit":{"message":"[Obs AI] Move `observability_agent_builder` API tests out of feature flag configs (#248569)\n\nCloses https://github.com/elastic/obs-ai-team/issues/462\n\n## Summary\n\nThis PR moves the `observability_agent_builder` API tests to the regular\nconfigs folder. Previously it was in the feature flag configs folder.\n\n### Commands to run the API tests\n\n#### Stateful\n\n```\nnode scripts/functional_test_runner --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts\n```\n\n#### Serverless\n\n```\nnode scripts/functional_test_runner --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.serverless.config.ts\n```\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"577627ee8e15daf80acc1c0c19973fc9bb92b5e4"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248569","number":248569,"mergeCommit":{"message":"[Obs AI] Move `observability_agent_builder` API tests out of feature flag configs (#248569)\n\nCloses https://github.com/elastic/obs-ai-team/issues/462\n\n## Summary\n\nThis PR moves the `observability_agent_builder` API tests to the regular\nconfigs folder. Previously it was in the feature flag configs folder.\n\n### Commands to run the API tests\n\n#### Stateful\n\n```\nnode scripts/functional_test_runner --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.ai_agent.stateful.config.ts\n```\n\n#### Serverless\n\n```\nnode scripts/functional_test_runner --config x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_agent.serverless.config.ts\n```\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"577627ee8e15daf80acc1c0c19973fc9bb92b5e4"}}]}] BACKPORT-->