### PR TITLE
Use Zod v4 in the logs overview component

### DIFF
--- a/x-pack/platform/packages/shared/logs-overview/src/services/categorize_logs_service/categorize_documents.ts
+++ b/x-pack/platform/packages/shared/logs-overview/src/services/categorize_logs_service/categorize_documents.ts
@@ -9,7 +9,7 @@ import type { ISearchGeneric } from '@kbn/search-types';
 import { lastValueFrom } from 'rxjs';
 import { fromPromise } from 'xstate5';
 import { createRandomSamplerWrapper } from '@kbn/ml-random-sampler-utils';
-import { z } from '@kbn/zod';
+import { z } from '@kbn/zod/v4';
 import type { LogCategorizationParams } from './types';
 import { createCategorizationRequestParams } from './queries';
 import type { LogCategory, LogCategoryChange } from '../../types';


### PR DESCRIPTION
## :memo: Summary

The ensures zod is imported via the versioned import.

addresses part of https://github.com/elastic/kibana/issues/243450 for the obs-exploration team