### PR TITLE
[Security solution][Attacks][Take action] Assign attack from group panel

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -15,6 +15,7 @@ import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type {
   DynamicGroupingProps,
   GroupChildComponentRenderer,
+  GroupingBucket,
   ParsedGroupingAggregation,
 } from '@kbn/grouping/src';
 import { parseGroupingQuery } from '@kbn/grouping/src';
@@ -314,12 +315,17 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
   );
 
   const getTakeActionItems = useCallback(
-    (groupFilters: Filter[], groupNumber: number) => {
+    (
+      groupFilters: Filter[],
+      groupNumber: number,
+      groupBucket: GroupingBucket<AlertsGroupingAggregation>
+    ) => {
       const takeActionParams = {
         groupNumber,
         query: getGlobalQuery([...(defaultFilters ?? []), ...groupFilters])?.filterQuery,
         selectedGroup,
         tableId,
+        groupBucket,
       };
 
       return groupTakeActionItems?.(takeActionParams);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/types.ts
@@ -11,6 +11,7 @@ import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import type { AlertsTablePropsWithRef } from '@kbn/response-ops-alerts-table/types';
 import type { TableId } from '@kbn/securitysolution-data-table';
 import type { EuiContextMenuPanelItemDescriptor } from '@elastic/eui';
+import type { GroupingBucket } from '@kbn/grouping/src';
 import type { PageScope } from '../../../data_view_manager/constants';
 import type { AlertsUserProfilesData } from '../../configurations/security_solution_detections/fetch_page_context';
 import type { Status } from '../../../../common/api/detection_engine';
@@ -18,6 +19,7 @@ import type { Note } from '../../../../common/api/timeline';
 import type { DataProvider } from '../../../timelines/components/timeline/data_providers/data_provider';
 import type { TimelineModel } from '../../../timelines/store/model';
 import type { ControlColumnProps, RowRenderer } from '../../../../common/types';
+import type { AlertsGroupingAggregation } from './grouping_settings/types';
 
 export interface SetEventsLoadingProps {
   eventIds: string[];
@@ -99,4 +101,8 @@ export type GroupTakeActionItems = (props: {
    * Selected group to know which group is extended/visible. This is coming from the getLevel function in the detections alert grouping code.
    */
   selectedGroup: string;
+  /**
+   * Meta-data about the selected group
+   */
+  groupBucket: GroupingBucket<AlertsGroupingAggregation>;
 }) => JSX.Element | undefined;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
+import { EuiContextMenu } from '@elastic/eui';
+import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
+import React, { useCallback, useMemo } from 'react';
+import { useInvalidateFindAttackDiscoveries } from '../../../../attack_discovery/pages/use_find_attack_discoveries';
+import type { inputsModel } from '../../../../common/store';
+import { inputsSelectors } from '../../../../common/store';
+import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+import { useAttackAssigneesContextMenuItems } from '../../../hooks/attacks/bulk_actions/context_menu_items/use_attack_assignees_context_menu_items';
+
+interface AttacksGroupTakeActionItemsProps {
+  attack?: AttackDiscoveryAlert;
+}
+
+export function AttacksGroupTakeActionItems({ attack }: AttacksGroupTakeActionItemsProps) {
+  const invalidateAttackDiscoveriesCache = useInvalidateFindAttackDiscoveries();
+  const getGlobalQuerySelector = useMemo(() => inputsSelectors.globalQuery(), []);
+  const globalQueries = useDeepEqualSelector(getGlobalQuerySelector);
+  const refetchQuery = useCallback(() => {
+    globalQueries.forEach((q) => q.refetch && (q.refetch as inputsModel.Refetch)());
+  }, [globalQueries]);
+
+  const attacksWithAssignees = useMemo(() => {
+    if (attack?.id) {
+      return [
+        {
+          attackId: attack.id,
+          assignees: attack?.assignees,
+          relatedAlertIds: attack?.alertIds ?? [],
+        },
+      ];
+    }
+    return [];
+  }, [attack]);
+
+  const onAssignSuccess = useCallback(() => {
+    invalidateAttackDiscoveriesCache();
+    refetchQuery();
+  }, [invalidateAttackDiscoveriesCache, refetchQuery]);
+
+  const { items: assignItems, panels: assignPanels } = useAttackAssigneesContextMenuItems({
+    attacksWithAssignees,
+    onSuccess: onAssignSuccess,
+  });
+
+  const defaultPanel: EuiContextMenuPanelDescriptor = useMemo(
+    () => ({
+      id: 0,
+      items: [...assignItems],
+    }),
+    [assignItems]
+  );
+
+  const panels: EuiContextMenuPanelDescriptor[] = useMemo(
+    () => [defaultPanel, ...assignPanels],
+    [assignPanels, defaultPanel]
+  );
+
+  return <EuiContextMenu initialPanelId={defaultPanel.id} panels={panels} />;
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
@@ -17,7 +17,6 @@ import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { AttackDetailsRightPanelKey } from '../../../../flyout/attack_details/constants/panel_keys';
 import { ALERT_ATTACK_IDS } from '../../../../../common/field_maps/field_names';
 import { PageScope } from '../../../../data_view_manager/constants';
-import { useGroupTakeActionsItems } from '../../../hooks/alerts_table/use_group_take_action_items';
 import {
   defaultGroupStatsAggregations,
   defaultGroupStatsRenderer,
@@ -46,6 +45,8 @@ import { EmptyResultsPrompt } from './empty_results_prompt';
 import { groupingOptions, groupingSettings } from './grouping_configs';
 import * as i18n from './translations';
 import { buildConnectorIdFilter } from './filtering_configs';
+import type { GroupTakeActionItems } from '../../alerts_table/types';
+import { AttacksGroupTakeActionItems } from './attacks_group_take_action_items';
 
 export const TABLE_SECTION_TEST_ID = 'attacks-page-table-section';
 export const EXPAND_ATTACK_BUTTON_TEST_ID = 'expand-attack-button';
@@ -105,7 +106,7 @@ export const TableSection = React.memo(
 
     const { to, from } = useGlobalTime();
 
-    const [{ loading: userInfoLoading, hasIndexWrite, hasIndexMaintenance }] = useUserData();
+    const [{ loading: userInfoLoading }] = useUserData();
 
     const { loading: listsConfigLoading } = useListsConfig();
 
@@ -210,10 +211,14 @@ export const TableSection = React.memo(
       [defaultFilters, getAttack, isLoading, showAnonymized]
     );
 
-    const groupTakeActionItems = useGroupTakeActionsItems({
-      currentStatus: statusFilter,
-      showAlertStatusActions: Boolean(hasIndexWrite) && Boolean(hasIndexMaintenance),
-    });
+    const groupTakeActionItems: GroupTakeActionItems = useCallback(
+      ({ selectedGroup, groupBucket }) => {
+        const attack = getAttack(selectedGroup, groupBucket);
+        if (!attack) return;
+        return <AttacksGroupTakeActionItems attack={attack} />;
+      },
+      [getAttack]
+    );
 
     const accordionExtraActionGroupStats = useMemo(
       () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alerts_table/use_group_take_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alerts_table/use_group_take_action_items.test.tsx
@@ -21,6 +21,12 @@ describe('useGroupTakeActionsItems', () => {
     tableId: 'mock-id',
     groupNumber: 0,
     selectedGroup: 'test',
+    groupBucket: {
+      key: ['bucket-test'],
+      key_as_string: 'bucket-test',
+      selectedGroup: 'test',
+      doc_count: 0,
+    },
   };
   it('returns all take actions items if showAlertStatusActions is true and currentStatus is undefined', async () => {
     const { result } = renderHook(


### PR DESCRIPTION
## Summary

Implement the "assign" and "un-assign" actions for in the group panel of the new attack discovery page

## Code overview 🗺️ 

- to make this possible I had to update the `_find` endpoint of attack discovery to return the assignees of an attack
- this information is not available at the group level of the table, where we can use it to identify which users are assigned to the attack (if any)


> [!warning]
> if an attack is not assigned to anyone, but any of its alerts is assigned to the user the page is filtered for, the attack will be visible. Unfortunately, we do not have the list of users assigned to the underlying alerts, because it would require an ad-hoc query to retrieve that information.
> At present moment, other pages — like the alerts page — do not show a list of assignees if the selection of alerts exceeds the visible page.

## Screen-recording 🎬 

https://github.com/user-attachments/assets/3e1ab0bc-4ddd-4574-8f51-022f46c2aeea

