### PR TITLE
[Renovate] Update dotenv reviewers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4698,15 +4698,13 @@
         "dotenv"
       ],
       "reviewers": [
-        "team:obs-onboarding-team",
-        "team:appex-qa"
+        "team:kibana-operations"
       ],
       "matchBaseBranches": [
         "main"
       ],
       "labels": [
-        "Team:obs-onboarding",
-        "Team:QA",
+        "Team:Operations",
         "release_note:skip",
         "backport:all-open"
       ],


### PR DESCRIPTION
## 📓 Summary

Move ownership of `dotenv` dependency to operations team.