### PR TITLE
Revert "Enable security solution graph visualization by default"

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -226,7 +226,7 @@ export const initUiSettings = (
         }
       ),
       type: 'boolean',
-      value: true,
+      value: false,
       category: [APP_ID],
       requiresPageReload: true,
       schema: schema.boolean(),


### PR DESCRIPTION
Reverts elastic/kibana#246347

We revert the decision to enable the feature of the graph visualization by default

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->