### PR TITLE
[Dashboard] POC to showcase how frontend caching of embeddables could be beneficial

### DIFF
--- a/src/platform/plugins/shared/discover/public/embeddable/initialize_fetch.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/initialize_fetch.ts
@@ -63,6 +63,11 @@ export const isEsqlMode = (savedSearch: Pick<SavedSearch, 'searchSource'>): bool
   return isOfAggregateQueryType(query);
 };
 
+export const recentState = {
+  totalHitCount: undefined,
+  rows: [] as unknown[],
+};
+
 const getExecutionContext = async (
   api: SavedSearchPartialFetchApi,
   discoverServices: DiscoverServices
@@ -283,6 +288,9 @@ export function initializeFetch({
         setBlockingError(next?.error);
         return;
       }
+
+      recentState.totalHitCount = next.hitCount;
+      recentState.rows = next.rows;
 
       stateManager.rows.next(next.rows ?? []);
       stateManager.totalHitCount.next(next.hitCount);

--- a/src/platform/plugins/shared/embeddable/public/ui_actions/add_panel_groups.ts
+++ b/src/platform/plugins/shared/embeddable/public/ui_actions/add_panel_groups.ts
@@ -30,6 +30,15 @@ export const ADD_PANEL_ANNOTATION_GROUP = {
   order: 900, // This is the order of the group in the context menu
 };
 
+export const ADD_PANEL_DISCOVER_GROUP = {
+  id: 'Discover',
+  getDisplayName: () =>
+    i18n.translate('embeddableApi.common.constants.grouping.annotations', {
+      defaultMessage: 'Discover',
+    }),
+  order: 899, // This is the order of the group in the context menu
+};
+
 export const ADD_PANEL_OTHER_GROUP = {
   id: 'other',
   getDisplayName: () =>


### PR DESCRIPTION
## Summary

Just a quick and dirty POC to showcase the impact if we would at least partially cache embeddable results in the browser, allowing super quick restoring of the previous data state, given that the Dashboard is loaded again. 

In the given example there are 2 slow ESQL queries displayed, the Dashboard was visited before, and when visited again, the cached Discover session embeddable renders super quick (using the internal cache), while the results are being fetched in the background and updated when finished, while the other embeddable shows the current behavior of a long loading state without results.

 
![CleanShot 2026-01-19 at 18 43 10](https://github.com/user-attachments/assets/ce191db8-80f6-4c74-a141-21a3797806ec)



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



