### PR TITLE
[Obs AI] Decouple Agent Builder and AI Assistant helpers in the APM plugin

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/data_provider/register_data_providers.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/data_provider/register_data_providers.ts
@@ -9,16 +9,13 @@ import type { CoreSetup, Logger } from '@kbn/core/server';
 import { getRollupIntervalForTimeRange } from '@kbn/apm-data-access-plugin/server/utils';
 import { getErrorSampleDetails } from '../../routes/errors/get_error_groups/get_error_sample_details';
 import { parseDatemath } from '../utils/time';
-import { getApmServiceSummary } from '../../routes/assistant_functions/get_apm_service_summary';
-import { getApmDownstreamDependencies } from '../../routes/assistant_functions/get_apm_downstream_dependencies';
+import { getApmServiceSummary } from '../helpers/get_apm_service_summary';
+import { getApmDownstreamDependencies } from '../helpers/get_apm_downstream_dependencies';
 import { getServicesItems } from '../../routes/services/get_services/get_services_items';
-import { getApmErrors } from '../../routes/assistant_functions/get_observability_alert_details_context/get_apm_errors';
+import { getApmErrors } from '../helpers/get_apm_errors';
 import { ApmDocumentType } from '../../../common/document_type';
 import { ENVIRONMENT_ALL } from '../../../common/environment_filter_values';
-import {
-  getExitSpanChangePoints,
-  getServiceChangePoints,
-} from '../../routes/assistant_functions/get_changepoints';
+import { getExitSpanChangePoints, getServiceChangePoints } from '../helpers/get_change_points';
 import { buildApmToolResources } from '../utils/build_apm_tool_resources';
 import type { APMPluginSetupDependencies, APMPluginStartDependencies } from '../../types';
 

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_apm_downstream_dependencies/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_apm_downstream_dependencies/index.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import datemath from '@elastic/datemath';
+import * as t from 'io-ts';
+import { termQuery } from '@kbn/observability-plugin/server';
+import type { RandomSampler } from '../../../lib/helpers/get_random_sampler';
+import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
+import { SERVICE_NAME } from '../../../../common/es_fields/apm';
+import { environmentQuery } from '../../../../common/utils/environment_query';
+import { getDestinationMap } from '../../../lib/connections/get_connection_stats/get_destination_map';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { NodeType } from '../../../../common/connections';
+
+export const downstreamDependenciesRouteRt = t.intersection([
+  t.type({
+    serviceName: t.string,
+    start: t.string,
+    end: t.string,
+  }),
+  t.partial({
+    serviceEnvironment: t.string,
+  }),
+]);
+
+export interface APMDownstreamDependency {
+  'service.name'?: string | undefined;
+  'span.destination.service.resource': string;
+  'span.type'?: string | undefined;
+  'span.subtype'?: string | undefined;
+}
+
+export async function getApmDownstreamDependencies({
+  arguments: args,
+  apmEventClient,
+  randomSampler,
+}: {
+  arguments: t.TypeOf<typeof downstreamDependenciesRouteRt>;
+  apmEventClient: APMEventClient;
+  randomSampler: RandomSampler;
+}): Promise<APMDownstreamDependency[]> {
+  const start = datemath.parse(args.start)?.valueOf()!;
+  const end = datemath.parse(args.end)?.valueOf()!;
+
+  const { nodesBydependencyName: map } = await getDestinationMap({
+    start,
+    end,
+    apmEventClient,
+    filter: [
+      ...termQuery(SERVICE_NAME, args.serviceName),
+      ...environmentQuery(args.serviceEnvironment ?? ENVIRONMENT_ALL.value),
+    ],
+    randomSampler,
+  });
+
+  const items: Array<{
+    'service.name'?: string;
+    'span.destination.service.resource': string;
+    'span.type'?: string;
+    'span.subtype'?: string;
+  }> = [];
+
+  for (const [_, node] of map) {
+    if (node.type === NodeType.service) {
+      items.push({
+        'service.name': node.serviceName,
+        // this should be set, as it's a downstream dependency, and there should be a connection
+        'span.destination.service.resource': node.dependencyName!,
+      });
+    } else {
+      items.push({
+        'span.destination.service.resource': node.dependencyName,
+        'span.type': node.spanType,
+        'span.subtype': node.spanSubtype,
+      });
+    }
+  }
+
+  return items;
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_apm_errors/get_downstream_service_resource.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_apm_errors/get_downstream_service_resource.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rangeQuery } from '@kbn/observability-plugin/server';
+import { accessKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
+import { asMutableArray } from '../../../../common/utils/as_mutable_array';
+import { maybe } from '../../../../common/utils/maybe';
+import { ApmDocumentType } from '../../../../common/document_type';
+import { termQuery } from '../../../../common/utils/term_query';
+import {
+  EVENT_OUTCOME,
+  SPAN_DESTINATION_SERVICE_RESOURCE,
+  TRACE_ID,
+} from '../../../../common/es_fields/apm';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { RollupInterval } from '../../../../common/rollup';
+
+export async function getDownstreamServiceResource({
+  traceId,
+  start,
+  end,
+  apmEventClient,
+}: {
+  traceId: string;
+  start: number;
+  end: number;
+  apmEventClient: APMEventClient;
+}) {
+  const requiredFields = asMutableArray([SPAN_DESTINATION_SERVICE_RESOURCE] as const);
+  const response = await apmEventClient.search('get_error_group_main_statistics', {
+    apm: {
+      sources: [
+        {
+          documentType: ApmDocumentType.SpanEvent,
+          rollupInterval: RollupInterval.None,
+        },
+      ],
+    },
+    track_total_hits: false,
+    size: 1,
+    _source: ['span.destination.service'],
+    query: {
+      bool: {
+        filter: [
+          ...termQuery(TRACE_ID, traceId),
+          ...termQuery(EVENT_OUTCOME, 'failure'),
+          ...rangeQuery(start, end),
+          { exists: { field: SPAN_DESTINATION_SERVICE_RESOURCE } },
+        ],
+      },
+    },
+    fields: requiredFields,
+  });
+
+  const fields = maybe(response.hits.hits[0])?.fields;
+
+  const event = fields && accessKnownApmEventFields(fields).requireFields(requiredFields);
+
+  return event?.[SPAN_DESTINATION_SERVICE_RESOURCE];
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_apm_errors/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_apm_errors/index.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import datemath from '@elastic/datemath';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { getErrorGroupMainStatistics } from '../../../routes/errors/get_error_groups/get_error_group_main_statistics';
+import { getDownstreamServiceResource } from './get_downstream_service_resource';
+
+export async function getApmErrors(params: {
+  apmEventClient: APMEventClient;
+  start: string;
+  end: string;
+  serviceName: string;
+  serviceEnvironment?: string;
+}) {
+  const { apmEventClient, serviceName, serviceEnvironment } = params;
+
+  const start = datemath.parse(params.start)?.valueOf()!;
+  const end = datemath.parse(params.end)?.valueOf()!;
+
+  const res = await getErrorGroupMainStatistics({
+    serviceName,
+    apmEventClient,
+    environment: serviceEnvironment,
+    start,
+    end,
+    maxNumberOfErrorGroups: 100,
+  });
+
+  const promises = res.errorGroups.map(async (errorGroup) => {
+    if (!errorGroup.traceId) {
+      return { ...errorGroup, downstreamServiceResource: undefined };
+    }
+
+    const downstreamServiceResource = await getDownstreamServiceResource({
+      traceId: errorGroup.traceId,
+      start,
+      end,
+      apmEventClient,
+    });
+
+    return { ...errorGroup, downstreamServiceResource };
+  });
+
+  return Promise.all(promises);
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_apm_service_summary/get_anomalies.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_apm_service_summary/get_anomalies.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { Logger } from '@kbn/core/server';
+import { rangeQuery } from '@kbn/observability-plugin/server';
+import { compact, keyBy } from 'lodash';
+import {
+  SERVICE_ENVIRONMENT,
+  SERVICE_NAME,
+  TRANSACTION_TYPE,
+} from '../../../../common/es_fields/apm';
+import {
+  AnomalyDetectorType,
+  getAnomalyDetectorType,
+} from '../../../../common/anomaly_detection/apm_ml_detectors';
+import { asMutableArray } from '../../../../common/utils/as_mutable_array';
+import { maybe } from '../../../../common/utils/maybe';
+import { anomalySearch } from '../../../lib/anomaly_detection/anomaly_search';
+import { apmMlAnomalyQuery } from '../../../lib/anomaly_detection/apm_ml_anomaly_query';
+import { apmMlJobsQuery } from '../../../lib/anomaly_detection/apm_ml_jobs_query';
+import { getMlJobsWithAPMGroup } from '../../../lib/anomaly_detection/get_ml_jobs_with_apm_group';
+import type { MlClient } from '../../../lib/helpers/get_ml_client';
+
+export type ApmAnomalies = Awaited<ReturnType<typeof getAnomalies>>;
+
+export async function getAnomalies({
+  serviceName,
+  transactionType,
+  environment,
+  start,
+  end,
+  mlClient,
+  logger,
+}: {
+  serviceName?: string;
+  transactionType?: string;
+  environment?: string;
+  start: number;
+  end: number;
+  mlClient?: MlClient;
+  logger: Logger;
+}) {
+  if (!mlClient) {
+    return [];
+  }
+
+  const mlJobs = (await getMlJobsWithAPMGroup(mlClient.anomalyDetectors)).filter(
+    (job) => job.environment === environment
+  );
+
+  if (!mlJobs.length) {
+    return [];
+  }
+
+  const anomaliesResponse = await anomalySearch(mlClient.mlSystem.mlAnomalySearch, {
+    size: 0,
+    query: {
+      bool: {
+        filter: [
+          ...apmMlAnomalyQuery({ serviceName, transactionType }),
+          ...rangeQuery(start, end, 'timestamp'),
+          ...apmMlJobsQuery(mlJobs),
+        ],
+      },
+    },
+    aggs: {
+      by_timeseries_id: {
+        composite: {
+          size: 5000,
+          sources: asMutableArray([
+            {
+              jobId: {
+                terms: {
+                  field: 'job_id',
+                },
+              },
+            },
+            {
+              detectorIndex: {
+                terms: {
+                  field: 'detector_index',
+                },
+              },
+            },
+            {
+              serviceName: {
+                terms: {
+                  field: 'partition_field_value',
+                },
+              },
+            },
+            {
+              transactionType: {
+                terms: {
+                  field: 'by_field_value',
+                },
+              },
+            },
+          ] as const),
+        },
+        aggs: {
+          record_scores: {
+            filter: {
+              term: {
+                result_type: 'record',
+              },
+            },
+            aggs: {
+              top_anomaly: {
+                top_metrics: {
+                  metrics: asMutableArray([
+                    { field: 'record_score' },
+                    { field: 'actual' },
+                    { field: 'timestamp' },
+                  ] as const),
+                  size: 1,
+                  sort: {
+                    record_score: 'desc',
+                  },
+                },
+              },
+            },
+          },
+          model_lower: {
+            min: {
+              field: 'model_lower',
+            },
+          },
+          model_upper: {
+            max: {
+              field: 'model_upper',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const jobsById = keyBy(mlJobs, (job) => job.jobId);
+
+  const anomalies = anomaliesResponse.aggregations?.by_timeseries_id.buckets.map((bucket) => {
+    const jobId = bucket.key.jobId as string;
+    const job = maybe(jobsById[jobId]);
+
+    if (!job) {
+      logger.debug(`Could not find job for id ${jobId}`);
+      return undefined;
+    }
+
+    const type = getAnomalyDetectorType(Number(bucket.key.detectorIndex));
+
+    // ml failure rate is stored as 0-100, we calculate failure rate as 0-1
+    const divider = type === AnomalyDetectorType.txFailureRate ? 100 : 1;
+
+    const metrics = bucket.record_scores.top_anomaly.top[0]?.metrics;
+
+    if (!metrics) {
+      return undefined;
+    }
+
+    return {
+      '@timestamp': new Date(metrics.timestamp as number).toISOString(),
+      metricName: type.replace('tx', 'transaction'),
+      [SERVICE_NAME]: bucket.key.serviceName as string,
+      [SERVICE_ENVIRONMENT]: job.environment,
+      [TRANSACTION_TYPE]: bucket.key.transactionType as string,
+      anomalyScore: metrics.record_score,
+      actualValue: Number(metrics.actual) / divider,
+      expectedBoundsLower: Number(bucket.model_lower.value) / divider,
+      expectedBoundsUpper: Number(bucket.model_upper.value) / divider,
+    };
+  });
+
+  return compact(anomalies);
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_apm_service_summary/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_apm_service_summary/index.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import datemath from '@elastic/datemath';
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { ScopedAnnotationsClient } from '@kbn/observability-plugin/server';
+import { rangeQuery } from '@kbn/observability-plugin/server';
+import {
+  ALERT_STATUS,
+  ALERT_STATUS_ACTIVE,
+} from '@kbn/rule-registry-plugin/common/technical_rule_data_field_names';
+import * as t from 'io-ts';
+import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
+import type { Environment } from '../../../../common/environment_rt';
+import { SERVICE_NAME } from '../../../../common/es_fields/apm';
+import { environmentQuery } from '../../../../common/utils/environment_query';
+import { termQuery } from '../../../../common/utils/term_query';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import type { ApmAlertsClient } from '../../../lib/helpers/get_apm_alerts_client';
+import type { MlClient } from '../../../lib/helpers/get_ml_client';
+import { getEnvironments } from '../../../routes/environments/get_environments';
+import { getServiceAnnotations } from '../../../routes/services/annotations';
+import { getServiceMetadataDetails } from '../../../routes/services/get_service_metadata_details';
+import { getAnomalies } from './get_anomalies';
+
+export const serviceSummaryRouteRt = t.intersection([
+  t.type({
+    'service.name': t.string,
+    start: t.string,
+    end: t.string,
+  }),
+  t.partial({
+    'service.environment': t.string,
+    'transaction.type': t.string,
+  }),
+]);
+
+export interface ServiceSummary {
+  'service.name': string;
+  'service.environment': string[];
+  'agent.name'?: string;
+  'service.version'?: string[];
+  'language.name'?: string;
+  'service.framework'?: string;
+  instances: number;
+  anomalies:
+    | Array<{
+        '@timestamp': string;
+        metricName: string;
+        'service.name': string;
+        'service.environment': Environment;
+        'transaction.type': string;
+        anomalyScore: string | number | null;
+        actualValue: number;
+        expectedBoundsLower: number;
+        expectedBoundsUpper: number;
+      }>
+    | {
+        error: unknown;
+      };
+  alerts: Array<{ type?: string; started: string }>;
+  deployments: Array<{ '@timestamp': string }>;
+}
+
+export async function getApmServiceSummary({
+  arguments: args,
+  apmEventClient,
+  mlClient,
+  esClient,
+  annotationsClient,
+  apmAlertsClient,
+  logger,
+}: {
+  arguments: t.TypeOf<typeof serviceSummaryRouteRt>;
+  apmEventClient: APMEventClient;
+  mlClient?: MlClient;
+  esClient: ElasticsearchClient;
+  annotationsClient?: ScopedAnnotationsClient;
+  apmAlertsClient: ApmAlertsClient;
+  logger: Logger;
+}): Promise<ServiceSummary> {
+  const start = datemath.parse(args.start)?.valueOf()!;
+  const end = datemath.parse(args.end)?.valueOf()!;
+
+  const serviceName = args['service.name'];
+  const environment = args['service.environment'] || ENVIRONMENT_ALL.value;
+  const transactionType = args['transaction.type'];
+
+  const [environments, metadataDetails, anomalies, annotations, alerts] = await Promise.all([
+    environment === ENVIRONMENT_ALL.value
+      ? getEnvironments({
+          apmEventClient,
+          start,
+          end,
+          size: 10,
+          serviceName,
+          searchAggregatedTransactions: true,
+        })
+      : Promise.resolve([environment]),
+    getServiceMetadataDetails({
+      apmEventClient,
+      start,
+      end,
+      serviceName,
+      environment,
+    }),
+    getAnomalies({
+      serviceName,
+      start,
+      end,
+      environment: args['service.environment'],
+      mlClient,
+      logger,
+      transactionType,
+    }).catch((error) => {
+      logger.warn('Failed to get anomalies', { error });
+      return {
+        error,
+      };
+    }),
+    getServiceAnnotations({
+      apmEventClient,
+      start,
+      end,
+      searchAggregatedTransactions: true,
+      client: esClient,
+      annotationsClient,
+      environment,
+      logger,
+      serviceName,
+    }),
+    apmAlertsClient.search({
+      size: 100,
+      track_total_hits: false,
+      query: {
+        bool: {
+          filter: [
+            ...termQuery(ALERT_STATUS, ALERT_STATUS_ACTIVE),
+            ...rangeQuery(start, end),
+            ...termQuery(SERVICE_NAME, serviceName),
+            ...environmentQuery(environment),
+          ],
+        },
+      },
+    }),
+  ]);
+
+  return {
+    'service.name': serviceName,
+    'service.environment': environments,
+    'agent.name': metadataDetails.service?.agent.name,
+    'service.version': metadataDetails.service?.versions,
+    'language.name': metadataDetails.service?.agent.name,
+    'service.framework': metadataDetails.service?.framework,
+    instances: metadataDetails.container?.totalNumberInstances ?? 1,
+    anomalies,
+    alerts: alerts.hits.hits.map((alert) => ({
+      type: alert._source?.['kibana.alert.rule.type'],
+      started: new Date(alert._source?.['kibana.alert.start']!).toISOString(),
+    })),
+    deployments: annotations.annotations.map((annotation) => ({
+      '@timestamp': new Date(annotation['@timestamp']).toISOString(),
+    })),
+  };
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/fetch_timeseries.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/fetch_timeseries.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AggregationsAggregationContainer,
+  QueryDslQueryContainer,
+} from '@elastic/elasticsearch/lib/api/types';
+import type { AggregationResultOf, AggregationResultOfMap } from '@kbn/es-types';
+import type { Unionize } from 'utility-types';
+import type { ApmDocumentType } from '../../../../common/document_type';
+import type { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+
+type ChangePointResult = AggregationResultOf<{ change_point: any }, unknown>;
+
+type ValueAggregationMap = Record<
+  'value',
+  Unionize<
+    Pick<
+      Required<AggregationsAggregationContainer>,
+      'min' | 'max' | 'sum' | 'bucket_script' | 'avg'
+    >
+  >
+>;
+
+interface ApmFetchedTimeseries<T extends ValueAggregationMap> {
+  groupBy: string;
+  data: Array<
+    {
+      key: number;
+      key_as_string: string;
+      doc_count: number;
+    } & AggregationResultOfMap<T, unknown>
+  >;
+  change_point: ChangePointResult;
+  value: number | null;
+  unit: string;
+}
+
+export interface FetchSeriesProps<T extends ValueAggregationMap> {
+  apmEventClient: APMEventClient;
+  operationName: string;
+  documentType: ApmDocumentType;
+  rollupInterval: RollupInterval;
+  intervalString: string;
+  start: number;
+  end: number;
+  filter?: QueryDslQueryContainer[];
+  groupByFields: string[];
+  aggs: T;
+  unit: 'ms' | 'rpm' | '%';
+}
+
+export async function fetchSeries<T extends ValueAggregationMap>({
+  apmEventClient,
+  operationName,
+  documentType,
+  rollupInterval,
+  intervalString,
+  start,
+  end,
+  filter,
+  groupByFields,
+  aggs,
+  unit,
+}: FetchSeriesProps<T>): Promise<Array<ApmFetchedTimeseries<T>>> {
+  const response = await apmEventClient.search(operationName, {
+    apm: {
+      sources: [{ documentType, rollupInterval }],
+    },
+    size: 0,
+    track_total_hits: false,
+    query: {
+      bool: {
+        filter,
+      },
+    },
+    aggs: {
+      groups: {
+        ...(groupByFields.length === 1
+          ? {
+              terms: {
+                size: 20,
+                field: groupByFields[0],
+              },
+            }
+          : {
+              multi_terms: {
+                size: 20,
+                terms: groupByFields.map((field) => ({ field })),
+              },
+            }),
+        aggs: {
+          ...aggs,
+          timeseries: {
+            date_histogram: {
+              field: '@timestamp',
+              fixed_interval: intervalString,
+              min_doc_count: 0,
+              extended_bounds: { min: start, max: end },
+            },
+            aggs,
+          },
+          change_point: {
+            change_point: {
+              buckets_path: 'timeseries>value',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!response.aggregations?.groups) {
+    return [];
+  }
+
+  return response.aggregations.groups.buckets.map((bucket) => {
+    const bucketValue = bucket.value as ValueAggregationMap | undefined;
+    let value =
+      bucketValue?.value === undefined || bucketValue?.value === null
+        ? null
+        : Number(bucketValue.value);
+
+    if (value !== null) {
+      value = Math.abs(value) < 100 ? Number(value.toPrecision(3)) : Math.round(value);
+    }
+
+    return {
+      groupBy: bucket.key_as_string || String(bucket.key),
+      data: bucket.timeseries.buckets,
+      value,
+      change_point: bucket.change_point,
+      unit,
+    };
+  });
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_apm_timeseries.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_apm_timeseries.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import datemath from '@elastic/datemath';
+import { kqlQuery, rangeQuery } from '@kbn/observability-plugin/server';
+import * as t from 'io-ts';
+import type { ChangePointType } from '@kbn/es-types/src';
+import { SERVICE_NAME } from '../../../../common/es_fields/apm';
+import { LatencyAggregationType } from '../../../../common/latency_aggregation_types';
+import { environmentQuery } from '../../../../common/utils/environment_query';
+import { getBucketSize } from '../../../../common/utils/get_bucket_size';
+import { termQuery } from '../../../../common/utils/term_query';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { getErrorEventRate } from './get_error_event_rate';
+import { getExitSpanFailureRate } from './get_exit_span_failure_rate';
+import { getExitSpanLatency } from './get_exit_span_latency';
+import { getExitSpanThroughput } from './get_exit_span_throughput';
+import { getTransactionFailureRate } from './get_transaction_failure_rate';
+import { getTransactionLatency } from './get_transaction_latency';
+import { getTransactionThroughput } from './get_transaction_throughput';
+
+export enum ApmTimeseriesType {
+  transactionThroughput = 'transaction_throughput',
+  transactionLatency = 'transaction_latency',
+  transactionFailureRate = 'transaction_failure_rate',
+  exitSpanThroughput = 'exit_span_throughput',
+  exitSpanLatency = 'exit_span_latency',
+  exitSpanFailureRate = 'exit_span_failure_rate',
+  errorEventRate = 'error_event_rate',
+}
+
+export const getApmTimeseriesRt = t.type({
+  stats: t.array(
+    t.intersection([
+      t.type({
+        'service.name': t.string,
+        title: t.string,
+        timeseries: t.union([
+          t.intersection([
+            t.type({
+              name: t.union([
+                t.literal(ApmTimeseriesType.transactionThroughput),
+                t.literal(ApmTimeseriesType.transactionFailureRate),
+              ]),
+            }),
+            t.partial({
+              'transaction.type': t.string,
+              'transaction.name': t.string,
+            }),
+          ]),
+          t.intersection([
+            t.type({
+              name: t.union([
+                t.literal(ApmTimeseriesType.exitSpanThroughput),
+                t.literal(ApmTimeseriesType.exitSpanFailureRate),
+                t.literal(ApmTimeseriesType.exitSpanLatency),
+              ]),
+            }),
+            t.partial({
+              'span.destination.service.resource': t.string,
+            }),
+          ]),
+          t.intersection([
+            t.type({
+              name: t.literal(ApmTimeseriesType.transactionLatency),
+              function: t.union([
+                t.literal(LatencyAggregationType.avg),
+                t.literal(LatencyAggregationType.p95),
+                t.literal(LatencyAggregationType.p99),
+              ]),
+            }),
+            t.partial({
+              'transaction.type': t.string,
+              'transaction.name': t.string,
+            }),
+          ]),
+          t.type({
+            name: t.literal(ApmTimeseriesType.errorEventRate),
+          }),
+        ]),
+      }),
+      t.partial({
+        filter: t.string,
+        offset: t.string,
+        'service.environment': t.string,
+      }),
+    ])
+  ),
+  start: t.string,
+  end: t.string,
+});
+
+type ApmTimeseriesArgs = t.TypeOf<typeof getApmTimeseriesRt>;
+
+export interface TimeseriesChangePoint {
+  change_point?: number | undefined;
+  r_value?: number | undefined;
+  trend?: string | undefined;
+  p_value?: number;
+  date: string | undefined;
+  type: ChangePointType;
+}
+
+export interface ApmTimeseries {
+  stat: ApmTimeseriesArgs['stats'][number];
+  group: string;
+  id: string;
+  data: Array<{ x: number; y: number | null }>;
+  value: number | null;
+  start: number;
+  end: number;
+  unit: string;
+  changes: TimeseriesChangePoint[];
+}
+
+export async function getApmTimeseries({
+  arguments: args,
+  apmEventClient,
+}: {
+  arguments: t.TypeOf<typeof getApmTimeseriesRt>;
+  apmEventClient: APMEventClient;
+}): Promise<ApmTimeseries[]> {
+  const start = datemath.parse(args.start)!.valueOf();
+  const end = datemath.parse(args.end)!.valueOf();
+
+  const { bucketSize, intervalString } = getBucketSize({
+    start,
+    end,
+    numBuckets: 100,
+  });
+
+  return (
+    await Promise.all(
+      args.stats.map(async (stat) => {
+        const parameters = {
+          apmEventClient,
+          start,
+          end,
+          bucketSize,
+          intervalString,
+          filter: [
+            ...rangeQuery(start, end),
+            ...termQuery(SERVICE_NAME, stat['service.name']),
+            ...kqlQuery(stat.filter),
+            ...environmentQuery(stat['service.environment']),
+          ],
+        };
+        const name = stat.timeseries.name;
+
+        async function fetchSeriesForStat() {
+          switch (name) {
+            case ApmTimeseriesType.transactionThroughput:
+              return await getTransactionThroughput({
+                ...parameters,
+                transactionType: stat.timeseries['transaction.type'],
+                transactionName: stat.timeseries['transaction.name'],
+              });
+
+            case ApmTimeseriesType.transactionFailureRate:
+              return await getTransactionFailureRate({
+                ...parameters,
+                transactionType: stat.timeseries['transaction.type'],
+                transactionName: stat.timeseries['transaction.name'],
+              });
+
+            case ApmTimeseriesType.transactionLatency:
+              return await getTransactionLatency({
+                ...parameters,
+                transactionType: stat.timeseries['transaction.type'],
+                transactionName: stat.timeseries['transaction.name'],
+                latencyAggregationType: stat.timeseries.function,
+              });
+
+            case ApmTimeseriesType.exitSpanThroughput:
+              return await getExitSpanThroughput({
+                ...parameters,
+                spanDestinationServiceResource:
+                  stat.timeseries['span.destination.service.resource'],
+              });
+
+            case ApmTimeseriesType.exitSpanFailureRate:
+              return await getExitSpanFailureRate({
+                ...parameters,
+                spanDestinationServiceResource:
+                  stat.timeseries['span.destination.service.resource'],
+              });
+
+            case ApmTimeseriesType.exitSpanLatency:
+              return await getExitSpanLatency({
+                ...parameters,
+                spanDestinationServiceResource:
+                  stat.timeseries['span.destination.service.resource'],
+              });
+
+            case ApmTimeseriesType.errorEventRate:
+              return await getErrorEventRate(parameters);
+          }
+        }
+
+        const allFetchedSeries = await fetchSeriesForStat();
+        return allFetchedSeries.map((series) => ({ ...series, stat }));
+      })
+    )
+  ).flatMap((statResults) =>
+    statResults.flatMap((statResult) => {
+      const changePointType = Object.keys(
+        statResult.change_point?.type ?? {}
+      )?.[0] as ChangePointType;
+
+      return {
+        stat: statResult.stat,
+        group: statResult.stat.title,
+        id: statResult.groupBy,
+        data: statResult.data,
+        value: statResult.value,
+        start,
+        end,
+        unit: statResult.unit,
+        changes: [
+          ...(changePointType &&
+          changePointType !== 'indeterminable' &&
+          changePointType !== 'stationary'
+            ? [
+                {
+                  date: statResult.change_point.bucket?.key,
+                  type: changePointType,
+                  ...statResult.change_point.type[changePointType],
+                },
+              ]
+            : []),
+        ],
+      };
+    })
+  );
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_error_event_rate.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_error_event_rate.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { ERROR_GROUP_NAME } from '../../../../common/es_fields/apm';
+import { ApmDocumentType } from '../../../../common/document_type';
+import { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getErrorEventRate({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  bucketSize,
+  filter,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+}) {
+  const bucketSizeInMinutes = bucketSize / 60;
+  const rangeInMinutes = (end - start) / 1000 / 60;
+
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_error_event_rate',
+      unit: 'rpm',
+      documentType: ApmDocumentType.ErrorEvent,
+      rollupInterval: RollupInterval.None,
+      intervalString,
+      filter,
+      groupByFields: [ERROR_GROUP_NAME],
+      aggs: {
+        sample: {
+          top_metrics: {
+            metrics: { field: ERROR_GROUP_NAME },
+            sort: '_score',
+          },
+        },
+        value: {
+          bucket_script: {
+            buckets_path: {
+              count: '_count',
+            },
+            script: {
+              lang: 'painless',
+              params: {
+                bucketSizeInMinutes,
+              },
+              source: 'params.count / params.bucketSizeInMinutes',
+            },
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      value: fetchedSerie.value !== null ? fetchedSerie.value / rangeInMinutes : null,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_exit_span_failure_rate.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_exit_span_failure_rate.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { termQuery } from '@kbn/observability-plugin/server';
+import { ApmDocumentType } from '../../../../common/document_type';
+import {
+  EVENT_OUTCOME,
+  SPAN_DESTINATION_SERVICE_RESOURCE,
+  SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT,
+} from '../../../../common/es_fields/apm';
+import { EventOutcome } from '../../../../common/event_outcome';
+import { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getExitSpanFailureRate({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  filter,
+  spanDestinationServiceResource,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+  spanDestinationServiceResource?: string;
+}) {
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_exit_span_failure_rate',
+      unit: '%',
+      documentType: ApmDocumentType.ServiceDestinationMetric,
+      rollupInterval: RollupInterval.OneMinute,
+      intervalString,
+      filter: filter.concat(
+        ...termQuery(SPAN_DESTINATION_SERVICE_RESOURCE, spanDestinationServiceResource)
+      ),
+      groupByFields: [SPAN_DESTINATION_SERVICE_RESOURCE],
+      aggs: {
+        successful: {
+          filter: {
+            terms: {
+              [EVENT_OUTCOME]: [EventOutcome.success],
+            },
+          },
+          aggs: {
+            count: {
+              sum: {
+                field: SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT,
+              },
+            },
+          },
+        },
+        successful_or_failed: {
+          filter: {
+            terms: {
+              [EVENT_OUTCOME]: [EventOutcome.success, EventOutcome.failure],
+            },
+          },
+          aggs: {
+            count: {
+              sum: {
+                field: SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT,
+              },
+            },
+          },
+        },
+        value: {
+          bucket_script: {
+            buckets_path: {
+              successful_or_failed: `successful_or_failed>count`,
+              successful: `successful>count`,
+            },
+            script: '100 * (1 - (params.successful / params.successful_or_failed))',
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number | null,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_exit_span_latency.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_exit_span_latency.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { termQuery } from '@kbn/observability-plugin/server';
+import { ApmDocumentType } from '../../../../common/document_type';
+import {
+  SPAN_DESTINATION_SERVICE_RESOURCE,
+  SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT,
+  SPAN_DESTINATION_SERVICE_RESPONSE_TIME_SUM,
+} from '../../../../common/es_fields/apm';
+import { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getExitSpanLatency({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  filter,
+  spanDestinationServiceResource,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+  spanDestinationServiceResource?: string;
+}) {
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_exit_span_latency',
+      unit: 'ms',
+      documentType: ApmDocumentType.ServiceDestinationMetric,
+      rollupInterval: RollupInterval.OneMinute,
+      intervalString,
+      filter: filter.concat(
+        ...termQuery(SPAN_DESTINATION_SERVICE_RESOURCE, spanDestinationServiceResource)
+      ),
+      groupByFields: [SPAN_DESTINATION_SERVICE_RESOURCE],
+      aggs: {
+        count: {
+          sum: {
+            field: SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT,
+          },
+        },
+        latency: {
+          sum: {
+            field: SPAN_DESTINATION_SERVICE_RESPONSE_TIME_SUM,
+          },
+        },
+        value: {
+          bucket_script: {
+            buckets_path: {
+              latency: 'latency',
+              count: 'count',
+            },
+            script: '(params.latency / params.count) / 1000',
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number | null,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_exit_span_throughput.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_exit_span_throughput.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { termQuery } from '@kbn/observability-plugin/server';
+import { ApmDocumentType } from '../../../../common/document_type';
+import { SPAN_DESTINATION_SERVICE_RESOURCE } from '../../../../common/es_fields/apm';
+import { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getExitSpanThroughput({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  bucketSize,
+  filter,
+  spanDestinationServiceResource,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+  spanDestinationServiceResource?: string;
+}) {
+  const bucketSizeInMinutes = bucketSize / 60;
+  const rangeInMinutes = (end - start) / 1000 / 60;
+
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_exit_span_throughput',
+      unit: 'rpm',
+      documentType: ApmDocumentType.ServiceDestinationMetric,
+      rollupInterval: RollupInterval.OneMinute,
+      intervalString,
+      filter: filter.concat(
+        ...termQuery(SPAN_DESTINATION_SERVICE_RESOURCE, spanDestinationServiceResource)
+      ),
+      groupByFields: [SPAN_DESTINATION_SERVICE_RESOURCE],
+      aggs: {
+        value: {
+          bucket_script: {
+            buckets_path: {
+              count: '_count',
+            },
+            script: {
+              lang: 'painless',
+              params: {
+                bucketSizeInMinutes,
+              },
+              source: 'params.count / params.bucketSizeInMinutes',
+            },
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      value:
+        fetchedSerie.value !== null
+          ? (fetchedSerie.value * bucketSizeInMinutes) / rangeInMinutes
+          : null,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_transaction_failure_rate.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_transaction_failure_rate.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { termQuery } from '@kbn/observability-plugin/server';
+import { getOutcomeAggregation } from '@kbn/apm-data-access-plugin/server/utils';
+import { ApmDocumentType } from '../../../../common/document_type';
+import { TRANSACTION_NAME, TRANSACTION_TYPE } from '../../../../common/es_fields/apm';
+import { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getTransactionFailureRate({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  filter,
+  transactionType,
+  transactionName,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+  transactionType?: string;
+  transactionName?: string;
+}) {
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_transaction_failure_rate',
+      unit: '%',
+      documentType: ApmDocumentType.TransactionMetric,
+      rollupInterval: RollupInterval.OneMinute,
+      intervalString,
+      filter: [
+        ...filter,
+        ...termQuery(TRANSACTION_TYPE, transactionType),
+        ...termQuery(TRANSACTION_NAME, transactionName),
+      ],
+      groupByFields: [TRANSACTION_TYPE, TRANSACTION_NAME],
+      aggs: {
+        ...getOutcomeAggregation(ApmDocumentType.TransactionMetric),
+        value: {
+          bucket_script: {
+            buckets_path: {
+              successful_or_failed: 'successful_or_failed>_count',
+              successful: 'successful>_count',
+            },
+            script: '100 * (1 - (params.successful / params.successful_or_failed))',
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number | null,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_transaction_latency.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_transaction_latency.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { termQuery } from '@kbn/observability-plugin/server';
+import { TRANSACTION_NAME } from '@kbn/observability-shared-plugin/common';
+import { ApmDocumentType } from '../../../../common/document_type';
+import { TRANSACTION_DURATION_HISTOGRAM, TRANSACTION_TYPE } from '../../../../common/es_fields/apm';
+import type { LatencyAggregationType } from '../../../../common/latency_aggregation_types';
+import { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { getLatencyAggregation } from '../../../lib/helpers/latency_aggregation_type';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getTransactionLatency({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  filter,
+  transactionType,
+  transactionName,
+  latencyAggregationType,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+  transactionType?: string;
+  transactionName?: string;
+  latencyAggregationType: LatencyAggregationType;
+}) {
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_transaction_latency',
+      unit: 'ms',
+      documentType: ApmDocumentType.TransactionMetric,
+      rollupInterval: RollupInterval.OneMinute,
+      intervalString,
+      filter: filter.concat(
+        ...termQuery(TRANSACTION_TYPE, transactionType),
+        ...termQuery(TRANSACTION_NAME, transactionName)
+      ),
+      groupByFields: [TRANSACTION_TYPE, TRANSACTION_NAME],
+      aggs: {
+        ...getLatencyAggregation(latencyAggregationType, TRANSACTION_DURATION_HISTOGRAM),
+        value: {
+          bucket_script: {
+            buckets_path: {
+              latency: 'latency',
+            },
+            script: 'params.latency / 1000',
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number | null,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_transaction_throughput.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/get_transaction_throughput.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { termQuery } from '@kbn/observability-plugin/server';
+import { ApmDocumentType } from '../../../../common/document_type';
+import { TRANSACTION_NAME, TRANSACTION_TYPE } from '../../../../common/es_fields/apm';
+import { RollupInterval } from '../../../../common/rollup';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { fetchSeries } from './fetch_timeseries';
+
+export async function getTransactionThroughput({
+  apmEventClient,
+  start,
+  end,
+  intervalString,
+  bucketSize,
+  filter,
+  transactionType,
+  transactionName,
+}: {
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+  intervalString: string;
+  bucketSize: number;
+  filter: QueryDslQueryContainer[];
+  transactionType?: string;
+  transactionName?: string;
+}) {
+  const bucketSizeInMinutes = bucketSize / 60;
+  const rangeInMinutes = (end - start) / 1000 / 60;
+
+  return (
+    await fetchSeries({
+      apmEventClient,
+      start,
+      end,
+      operationName: 'assistant_get_transaction_throughput',
+      unit: 'rpm',
+      documentType: ApmDocumentType.TransactionMetric,
+      rollupInterval: RollupInterval.OneMinute,
+      intervalString,
+      filter: [
+        ...filter,
+        ...termQuery(TRANSACTION_TYPE, transactionType),
+        ...termQuery(TRANSACTION_NAME, transactionName),
+      ],
+      groupByFields: [TRANSACTION_TYPE, TRANSACTION_NAME],
+      aggs: {
+        value: {
+          bucket_script: {
+            buckets_path: {
+              count: '_count',
+            },
+            script: {
+              lang: 'painless',
+              params: {
+                bucketSizeInMinutes,
+              },
+              source: 'params.count / params.bucketSizeInMinutes',
+            },
+          },
+        },
+      },
+    })
+  ).map((fetchedSerie) => {
+    return {
+      ...fetchedSerie,
+      value:
+        fetchedSerie.value !== null
+          ? (fetchedSerie.value * bucketSizeInMinutes) / rangeInMinutes
+          : null,
+      data: fetchedSerie.data.map((bucket) => {
+        return {
+          x: bucket.key,
+          y: bucket.value?.value as number,
+        };
+      }),
+    };
+  });
+}

--- a/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/agent_builder/helpers/get_change_points/index.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LatencyAggregationType } from '../../../../common/latency_aggregation_types';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import type { TimeseriesChangePoint } from './get_apm_timeseries';
+import { ApmTimeseriesType, getApmTimeseries } from './get_apm_timeseries';
+
+export interface ChangePointGrouping {
+  title: string;
+  grouping: string;
+  changes: TimeseriesChangePoint[];
+}
+
+export async function getServiceChangePoints({
+  apmEventClient,
+  start,
+  end,
+  serviceName,
+  serviceEnvironment,
+  transactionType,
+  transactionName,
+}: {
+  apmEventClient: APMEventClient;
+  start: string;
+  end: string;
+  serviceName: string | undefined;
+  serviceEnvironment: string | undefined;
+  transactionType: string | undefined;
+  transactionName: string | undefined;
+}): Promise<ChangePointGrouping[]> {
+  if (!serviceName) {
+    return [];
+  }
+
+  const res = await getApmTimeseries({
+    apmEventClient,
+    arguments: {
+      start,
+      end,
+      stats: [
+        {
+          title: 'Latency',
+          'service.name': serviceName,
+          'service.environment': serviceEnvironment,
+          timeseries: {
+            name: ApmTimeseriesType.transactionLatency,
+            function: LatencyAggregationType.p95,
+            'transaction.type': transactionType,
+            'transaction.name': transactionName,
+          },
+        },
+        {
+          title: 'Throughput',
+          'service.name': serviceName,
+          'service.environment': serviceEnvironment,
+          timeseries: {
+            name: ApmTimeseriesType.transactionThroughput,
+            'transaction.type': transactionType,
+            'transaction.name': transactionName,
+          },
+        },
+        {
+          title: 'Failure rate',
+          'service.name': serviceName,
+          'service.environment': serviceEnvironment,
+          timeseries: {
+            name: ApmTimeseriesType.transactionFailureRate,
+            'transaction.type': transactionType,
+            'transaction.name': transactionName,
+          },
+        },
+        {
+          title: 'Error events',
+          'service.name': serviceName,
+          'service.environment': serviceEnvironment,
+          timeseries: {
+            name: ApmTimeseriesType.errorEventRate,
+          },
+        },
+      ],
+    },
+  });
+
+  return res
+    .filter((timeseries) => timeseries.changes.length > 0)
+    .map((timeseries) => ({
+      title: timeseries.stat.title,
+      grouping: timeseries.id,
+      changes: timeseries.changes,
+    }));
+}
+
+export async function getExitSpanChangePoints({
+  apmEventClient,
+  start,
+  end,
+  serviceName,
+  serviceEnvironment,
+}: {
+  apmEventClient: APMEventClient;
+  start: string;
+  end: string;
+  serviceName: string | undefined;
+  serviceEnvironment: string | undefined;
+}): Promise<ChangePointGrouping[]> {
+  if (!serviceName) {
+    return [];
+  }
+
+  const res = await getApmTimeseries({
+    apmEventClient,
+    arguments: {
+      start,
+      end,
+      stats: [
+        {
+          title: 'Exit span latency',
+          'service.name': serviceName,
+          'service.environment': serviceEnvironment,
+          timeseries: {
+            name: ApmTimeseriesType.exitSpanLatency,
+          },
+        },
+        {
+          title: 'Exit span failure rate',
+          'service.name': serviceName,
+          'service.environment': serviceEnvironment,
+          timeseries: {
+            name: ApmTimeseriesType.exitSpanFailureRate,
+          },
+        },
+      ],
+    },
+  });
+
+  return res
+    .filter((timeseries) => timeseries.changes.length > 0)
+    .map((timeseries) => {
+      return {
+        title: timeseries.stat.title,
+        grouping: timeseries.id,
+        changes: timeseries.changes,
+      };
+    });
+}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/249404

## Summary

### Problem
The Observability Agent Builder tools and AI Insights utilizes a data provider from the APM plugin. This data provider reuses existing helper functions from the AI Assistant (`assistant_functions`)

Due to this tight coupling,
- We need to make sure any changes we introduce for agent builder functionality is also backwards compatible with the AI Assistant. This can be time consuming.
- It makes it harder to deprecate the AI Assistant in the future.

### Solution
This PR decouples the helpers used by Agent Builder tools and insights from the AI Assistant helpers.

This makes it easier to make changes to the helpers without worrying about backwards compatibility and also makes it easier to deprecate the AI Assistant in the future. 

The folder with the helper functions is named `helpers` and lives inside `apm/server/agent_builder`.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


