### PR TITLE
[Synthetics] Remove cmd/status events filter from steps query

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_steps.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_steps.test.ts
@@ -91,7 +91,6 @@ describe('getJourneySteps request module', () => {
         Object {
           "terms": Object {
             "synthetics.type": Array [
-              "cmd/status",
               "journey/browserconsole",
               "step/end",
               "step/screenshot",
@@ -156,7 +155,6 @@ describe('getJourneySteps request module', () => {
         Object {
           "terms": Object {
             "synthetics.type": Array [
-              "cmd/status",
               "journey/browserconsole",
               "step/end",
               "step/screenshot",

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_steps.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_steps.ts
@@ -29,7 +29,6 @@ export const getJourneySteps = async ({
           {
             terms: {
               'synthetics.type': [
-                'cmd/status',
                 'journey/browserconsole',
                 'step/end',
                 'step/screenshot',


### PR DESCRIPTION
Closes #166530  

Removed `cmd/status` step in two files: 
- `x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_steps.test.ts`
- `x-pack/solutions/observability/plugins/synthetics/server/queries/get_journey_steps.ts`

