### PR TITLE
[9.3] [ES|QL] Fix autocomplete after chained logical operators (#248286)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/autocomplete/expressions/positions/after_operator.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/autocomplete/expressions/positions/after_operator.ts
@@ -14,7 +14,6 @@ import type { FunctionDefinition, SupportedDataType } from '../../../../types';
 import { FunctionDefinitionTypes, isArrayType } from '../../../../types';
 import { SignatureAnalyzer } from '../signature_analyzer';
 import { getExpressionType, getMatchingSignatures } from '../../../expressions';
-import { getRightmostNonVariadicOperator } from '../utils';
 import { getFunctionDefinition } from '../../../functions';
 import { removeFinalUnknownIdentiferArg, getOverlapRange } from '../../../shared';
 import { logicalOperators } from '../../../../all_operators';
@@ -35,14 +34,16 @@ export async function suggestAfterOperator(ctx: ExpressionContext): Promise<ISug
     return [];
   }
 
-  const specialSuggestions = await dispatchOperators(ctx);
+  const rightmostOperator = getRightmostOperatorInFunctionTree(expressionRoot as ESQLFunction);
+  // If we don't pass rightmostOperator, for "field IN (x) AND field NOT IN (y"
+  // dispatchOperators sees AND (no handler) instead of NOT IN, failing to suggest comma.
+  const ctxWithRightmostOperator = { ...ctx, expressionRoot: rightmostOperator };
+
+  const specialSuggestions = await dispatchOperators(ctxWithRightmostOperator);
 
   if (specialSuggestions) {
     return specialSuggestions;
   }
-
-  const fn = expressionRoot as ESQLFunction;
-  const rightmostOperator = getRightmostNonVariadicOperator(fn) as ESQLFunction;
   const getExprType = (expression: ESQLAstItem) => getExpressionType(expression, context?.columns);
 
   const { complete, reason } = isOperatorComplete(rightmostOperator, getExprType);
@@ -273,4 +274,26 @@ async function handleIncompleteOperator(
       rangeToReplace: overlap,
     };
   });
+}
+
+/**
+ * Finds the deepest binary operator in the right branch of an expression tree.
+ *
+ * Uses structural right-first traversal instead of position-based detection
+ * to avoid ANTLR error recovery issues where incomplete expressions get
+ * positions that corrupt location.min values.
+ */
+function getRightmostOperatorInFunctionTree(fn: ESQLFunction): ESQLFunction {
+  const rightArg = fn.args[1];
+
+  if (
+    fn.subtype === 'binary-expression' &&
+    rightArg &&
+    !Array.isArray(rightArg) &&
+    rightArg.type === 'function'
+  ) {
+    return getRightmostOperatorInFunctionTree(rightArg as ESQLFunction);
+  }
+
+  return fn;
 }

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/autocomplete/expressions/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/definitions/utils/autocomplete/expressions/utils.ts
@@ -7,14 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ESQLFunction, ESQLSingleAstItem } from '../../../../../types';
+import type { ESQLFunction } from '../../../../../types';
 import { nullCheckOperators, inOperators } from '../../../all_operators';
 import type { FunctionParameterContext } from './types';
 import type { ICommandContext } from '../../../../registry/types';
 import { getFunctionDefinition } from '../..';
 import { SignatureAnalyzer } from './signature_analyzer';
 import type { Signature } from '../../../types';
-import { Walker } from '../../../../../ast';
 
 export type SpecialFunctionName = 'case' | 'count' | 'bucket';
 
@@ -103,27 +102,4 @@ export function buildExpressionFunctionParameterContext(
     currentParameterIndex: analyzer.getCurrentParameterIndex(),
     validSignatures: analyzer.getValidSignatures(),
   };
-}
-
-/**
- * Finds the rightmost non-variadic operator in an expression tree.
- * Useful for locating the most specific node near the cursor.
- */
-export function getRightmostNonVariadicOperator(root: ESQLSingleAstItem): ESQLSingleAstItem {
-  if (root?.type !== 'function') {
-    return root;
-  }
-
-  let rightmostFn = root;
-  const walker = new Walker({
-    visitFunction: (fn) => {
-      if (fn.subtype !== 'variadic-call' && fn.location.min > rightmostFn.location.min) {
-        rightmostFn = fn;
-      }
-    },
-  });
-
-  walker.walkFunction(root);
-
-  return rightmostFn;
 }

--- a/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/where/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/commands/registry/where/autocomplete.test.ts
@@ -168,6 +168,27 @@ describe('WHERE Autocomplete', () => {
         );
       }
     });
+
+    test('after chained logical operators', async () => {
+      await whereExpectSuggestions(
+        `from a | where doubleField < 1 AND doubleField > 2 OR doubleField == 3 AND `,
+        [
+          ...getFieldNamesByType('any'),
+          ...getFunctionSignaturesByReturnType(Location.WHERE, 'any', { scalar: true }),
+        ]
+      );
+    });
+
+    test('after chained logical operator inside function', async () => {
+      await whereExpectSuggestions(
+        `from a | where CASE(doubleField < 1 AND doubleField > 2 OR doubleField == 3 AND `,
+        [
+          ...getFieldNamesByType('any'),
+          ...getFunctionSignaturesByReturnType(Location.WHERE, 'any', { scalar: true }),
+        ]
+      );
+    });
+
     test('after a logical operator numeric', async () => {
       const expectedFieldsNumeric = getFieldNamesByType(ESQL_COMMON_NUMERIC_TYPES);
       mockFieldsWithTypes(mockCallbacks, expectedFieldsNumeric);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[ES|QL] Fix autocomplete after chained logical operators (#248286)](https://github.com/elastic/kibana/pull/248286)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Valerio","email":"79913332+bartoval@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-09T09:37:26Z","message":"[ES|QL] Fix autocomplete after chained logical operators (#248286)\n\n#### Summary\nhttps://github.com/elastic/kibana/issues/235267 \n\nFixes incorrect autocomplete suggestions after sequences of logical\noperators (AND/OR) in ES|QL WHERE clauses.\n\n\n<img width=\"1226\" height=\"345\" alt=\"a (1)\"\nsrc=\"https://github.com/user-attachments/assets/9d7ca4be-d1d4-4326-9260-2bc7226eb2d2\"\n/>\n\n#### Problem\nWhen typing expressions like` field < 1 AND field > 2 OR field == 3 AND\n`|, the autocomplete would incorrectly suggest operators instead of\nfields/functions for the right-hand operand.\n \nRoot cause: `ANTLR `error recovery assigns fallback positions to\noperators in incomplete expressions, causing multiple operators to share\nthe same` location.min` value. The previous position-based detection\nselected the wrong suggestion.\n\n#### Solution\nReplaced position-based operator detection with simple structural\nright-first AST traversal (post-order) to find the innermost binary\noperator.\n \n#### Note:\n- here we need a simple and targeted function\n- Even if I want to complicate my life, the Walker, with backward mode\nand abort, doesn't do post-order traversing. The Visitor is a\ncomplication and isn't used here.","sha":"7989194261bf47bb02a03e8dbe3f446a7e34ea7d","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Feature:ES|QL","Team:ESQL","v9.4.0"],"title":"[ES|QL] Fix autocomplete after chained logical operators","number":248286,"url":"https://github.com/elastic/kibana/pull/248286","mergeCommit":{"message":"[ES|QL] Fix autocomplete after chained logical operators (#248286)\n\n#### Summary\nhttps://github.com/elastic/kibana/issues/235267 \n\nFixes incorrect autocomplete suggestions after sequences of logical\noperators (AND/OR) in ES|QL WHERE clauses.\n\n\n<img width=\"1226\" height=\"345\" alt=\"a (1)\"\nsrc=\"https://github.com/user-attachments/assets/9d7ca4be-d1d4-4326-9260-2bc7226eb2d2\"\n/>\n\n#### Problem\nWhen typing expressions like` field < 1 AND field > 2 OR field == 3 AND\n`|, the autocomplete would incorrectly suggest operators instead of\nfields/functions for the right-hand operand.\n \nRoot cause: `ANTLR `error recovery assigns fallback positions to\noperators in incomplete expressions, causing multiple operators to share\nthe same` location.min` value. The previous position-based detection\nselected the wrong suggestion.\n\n#### Solution\nReplaced position-based operator detection with simple structural\nright-first AST traversal (post-order) to find the innermost binary\noperator.\n \n#### Note:\n- here we need a simple and targeted function\n- Even if I want to complicate my life, the Walker, with backward mode\nand abort, doesn't do post-order traversing. The Visitor is a\ncomplication and isn't used here.","sha":"7989194261bf47bb02a03e8dbe3f446a7e34ea7d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248286","number":248286,"mergeCommit":{"message":"[ES|QL] Fix autocomplete after chained logical operators (#248286)\n\n#### Summary\nhttps://github.com/elastic/kibana/issues/235267 \n\nFixes incorrect autocomplete suggestions after sequences of logical\noperators (AND/OR) in ES|QL WHERE clauses.\n\n\n<img width=\"1226\" height=\"345\" alt=\"a (1)\"\nsrc=\"https://github.com/user-attachments/assets/9d7ca4be-d1d4-4326-9260-2bc7226eb2d2\"\n/>\n\n#### Problem\nWhen typing expressions like` field < 1 AND field > 2 OR field == 3 AND\n`|, the autocomplete would incorrectly suggest operators instead of\nfields/functions for the right-hand operand.\n \nRoot cause: `ANTLR `error recovery assigns fallback positions to\noperators in incomplete expressions, causing multiple operators to share\nthe same` location.min` value. The previous position-based detection\nselected the wrong suggestion.\n\n#### Solution\nReplaced position-based operator detection with simple structural\nright-first AST traversal (post-order) to find the innermost binary\noperator.\n \n#### Note:\n- here we need a simple and targeted function\n- Even if I want to complicate my life, the Walker, with backward mode\nand abort, doesn't do post-order traversing. The Visitor is a\ncomplication and isn't used here.","sha":"7989194261bf47bb02a03e8dbe3f446a7e34ea7d"}}]}] BACKPORT-->