### PR TITLE
[9.3] [Fleet] Hide Add integrations button in benchmarks when privileges are not correct (#249045)

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
@@ -43,7 +43,8 @@ import { NoFindingsStates } from '../../components/no_findings_states';
 const SEARCH_DEBOUNCE_MS = 300;
 
 const AddCisIntegrationButton = () => {
-  const { http } = useKibana().services;
+  const { http, fleet } = useKibana().services;
+  const canInstallPackages = fleet?.authz?.integrations.installPackages;
 
   const integrationsPath = pagePathGetters
     .integrations_all({
@@ -51,7 +52,7 @@ const AddCisIntegrationButton = () => {
     })
     .join('');
 
-  return (
+  return canInstallPackages ? (
     <EuiButton
       data-test-subj={TEST_SUBJ.ADD_INTEGRATION_TEST_SUBJ}
       fill
@@ -63,7 +64,7 @@ const AddCisIntegrationButton = () => {
         defaultMessage="Add Integration"
       />
     </EuiButton>
-  );
+  ) : null;
 };
 
 const BenchmarkEmptyState = ({ name }: { name: string }) => (


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Fleet] Hide Add integrations button in benchmarks when privileges are not correct (#249045)](https://github.com/elastic/kibana/pull/249045)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cristina Amico","email":"criamico@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-16T11:24:11Z","message":"[Fleet] Hide Add integrations button in benchmarks when privileges are not correct (#249045)\n\nFixes https://github.com/elastic/kibana/issues/243970\n\n## Summary\n\nSmall fix that hides the \"Add Integrations\" under \"Security > Rules >\nBenchmarks\" when the user doesn't have correct Fleet privileges.\n\n\n### Testing\nCreate a user with following Fleet privileges:\n```\nIntegrations: None\nFleet: None\nAgents: None\nAgent policies: None\nSettings: None\n```\nSecurity privileges are all enabled:\n```\nSecurity: All\nEndpoint List: All\nTrusted Applications: All\nTrusted Devices: All\nHost Isolation Exceptions: All\nBlocklist: All\nEvent Filters: All\nResponse Actions History: All\n```\nNavigate to \"Security > Rules > Benchmarks\" and verify that the \"Add\nIntegrations\" button on top is not visible anymore\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"bb02972eca823c9807da10b58bbf6b2536cea84b","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Fleet","backport:version","v9.3.0","v9.4.0"],"title":"[Fleet] Hide Add integrations button in benchmarks when privileges are not correct","number":249045,"url":"https://github.com/elastic/kibana/pull/249045","mergeCommit":{"message":"[Fleet] Hide Add integrations button in benchmarks when privileges are not correct (#249045)\n\nFixes https://github.com/elastic/kibana/issues/243970\n\n## Summary\n\nSmall fix that hides the \"Add Integrations\" under \"Security > Rules >\nBenchmarks\" when the user doesn't have correct Fleet privileges.\n\n\n### Testing\nCreate a user with following Fleet privileges:\n```\nIntegrations: None\nFleet: None\nAgents: None\nAgent policies: None\nSettings: None\n```\nSecurity privileges are all enabled:\n```\nSecurity: All\nEndpoint List: All\nTrusted Applications: All\nTrusted Devices: All\nHost Isolation Exceptions: All\nBlocklist: All\nEvent Filters: All\nResponse Actions History: All\n```\nNavigate to \"Security > Rules > Benchmarks\" and verify that the \"Add\nIntegrations\" button on top is not visible anymore\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"bb02972eca823c9807da10b58bbf6b2536cea84b"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249045","number":249045,"mergeCommit":{"message":"[Fleet] Hide Add integrations button in benchmarks when privileges are not correct (#249045)\n\nFixes https://github.com/elastic/kibana/issues/243970\n\n## Summary\n\nSmall fix that hides the \"Add Integrations\" under \"Security > Rules >\nBenchmarks\" when the user doesn't have correct Fleet privileges.\n\n\n### Testing\nCreate a user with following Fleet privileges:\n```\nIntegrations: None\nFleet: None\nAgents: None\nAgent policies: None\nSettings: None\n```\nSecurity privileges are all enabled:\n```\nSecurity: All\nEndpoint List: All\nTrusted Applications: All\nTrusted Devices: All\nHost Isolation Exceptions: All\nBlocklist: All\nEvent Filters: All\nResponse Actions History: All\n```\nNavigate to \"Security > Rules > Benchmarks\" and verify that the \"Add\nIntegrations\" button on top is not visible anymore\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"bb02972eca823c9807da10b58bbf6b2536cea84b"}}]}] BACKPORT-->