### PR TITLE
Address `@elastic/eui/require-table-caption` lint violations across `@elastic/security-threat-hunting` files

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/index.tsx
@@ -47,6 +47,7 @@ import { useGetMigrationTranslationStats } from '../../logic/use_get_migration_t
 import { useMigrationDashboardDetailsFlyout } from '../../hooks/use_migration_dashboard_details_flyout';
 import { useStartDashboardsMigrationModal } from '../../hooks/use_start_dashboard_migration_modal';
 import { useStartMigration } from '../../logic/use_start_migration';
+import { DASHBOARD_MIGRATION_TABLE_CAPTION, MIGRATION_DASHBOARD_TABLE_TABLE } from './translations';
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_SORT_FIELD = 'translation_result';
@@ -321,6 +322,7 @@ export const MigrationDashboardsTable: React.FC<MigrationDashboardsTableProps> =
                 </EuiFlexGroup>
                 <EuiSpacer size="m" />
                 <EuiBasicTable<DashboardMigrationDashboard>
+                  tableCaption={i18n.DASHBOARDS_MIGRATION_TABLE_CAPTION}
                   loading={false}
                   items={migrationDashboards}
                   pagination={pagination}

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/index.tsx
@@ -47,7 +47,6 @@ import { useGetMigrationTranslationStats } from '../../logic/use_get_migration_t
 import { useMigrationDashboardDetailsFlyout } from '../../hooks/use_migration_dashboard_details_flyout';
 import { useStartDashboardsMigrationModal } from '../../hooks/use_start_dashboard_migration_modal';
 import { useStartMigration } from '../../logic/use_start_migration';
-import { DASHBOARD_MIGRATION_TABLE_CAPTION, MIGRATION_DASHBOARD_TABLE_TABLE } from './translations';
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_SORT_FIELD = 'translation_result';

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/dashboard_table/translations.ts
@@ -20,3 +20,10 @@ export const NOT_TRANSLATED_DASHBOARD_TOOLTIP = i18n.translate(
     defaultMessage: 'Not translated migration dashboard',
   }
 );
+
+export const DASHBOARDS_MIGRATION_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.siemMigrations.dashboards.table.caption',
+  {
+    defaultMessage: 'Dashboards migration status',
+  }
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/migration_result_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/migration_result_panel.tsx
@@ -41,6 +41,7 @@ import { MigrationsLastError } from '../../../common/components/migration_panels
 import { MigrationPanelTitle } from '../../../common/components/migration_panels/migration_title';
 import { useCompleteBadgeStyles } from '../../../common/hooks/use_complete_status_badge_styles';
 import { TotalExecutionTime } from '../../../common/components/total_execution_time';
+import { DASHBOARD_MIGRATION_SUMMARY_TITLE } from './translations';
 
 const headerStyle = css`
   &:hover {
@@ -306,6 +307,7 @@ const TranslationResultsTable = React.memo<{
       items={items}
       columns={columns}
       compressed
+      tableCaption={i18n.DASHBOARD_MIGRATION_SUMMARY_TITLE}
     />
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/migration_result_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/dashboards/components/migration_status_panels/migration_result_panel.tsx
@@ -41,7 +41,6 @@ import { MigrationsLastError } from '../../../common/components/migration_panels
 import { MigrationPanelTitle } from '../../../common/components/migration_panels/migration_title';
 import { useCompleteBadgeStyles } from '../../../common/hooks/use_complete_status_badge_styles';
 import { TotalExecutionTime } from '../../../common/components/total_execution_time';
-import { DASHBOARD_MIGRATION_SUMMARY_TITLE } from './translations';
 
 const headerStyle = css`
   &:hover {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/migration_result_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/migration_result_panel.tsx
@@ -42,7 +42,6 @@ import { RuleMigrationsUploadMissingPanel } from './upload_missing_panel';
 import { MigrationsLastError } from '../../../common/components/migration_panels/last_error';
 import { MigrationPanelTitle } from '../../../common/components/migration_panels/migration_title';
 import { TotalExecutionTime } from '../../../common/components/total_execution_time';
-import { RULE_MIGRATION_SUMMARY_TITLE } from './translations';
 
 const headerStyle = css`
   &:hover {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/migration_result_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/migration_status_panels/migration_result_panel.tsx
@@ -42,6 +42,7 @@ import { RuleMigrationsUploadMissingPanel } from './upload_missing_panel';
 import { MigrationsLastError } from '../../../common/components/migration_panels/last_error';
 import { MigrationPanelTitle } from '../../../common/components/migration_panels/migration_title';
 import { TotalExecutionTime } from '../../../common/components/total_execution_time';
+import { RULE_MIGRATION_SUMMARY_TITLE } from './translations';
 
 const headerStyle = css`
   &:hover {
@@ -309,6 +310,7 @@ const TranslationResultsTable = React.memo<{
       data-test-subj="translatedResultsTable"
       items={items}
       columns={columns}
+      tableCaption={i18n.RULE_MIGRATION_SUMMARY_TITLE}
       compressed
     />
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/index.tsx
@@ -54,7 +54,6 @@ import {
 } from '../../../../common/components/utility_bar';
 import { useStartRulesMigrationModal } from '../../hooks/use_start_rules_migration_modal';
 import { useStartMigration } from '../../logic/use_start_migration';
-import { RULES_MIGRAION_TABLE_CAPTION, RULES_MIGRATION_TABLE_CAPTION } from './translations';
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_SORT_FIELD = 'translation_result';

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/index.tsx
@@ -54,6 +54,7 @@ import {
 } from '../../../../common/components/utility_bar';
 import { useStartRulesMigrationModal } from '../../hooks/use_start_rules_migration_modal';
 import { useStartMigration } from '../../logic/use_start_migration';
+import { RULES_MIGRAION_TABLE_CAPTION, RULES_MIGRATION_TABLE_CAPTION } from './translations';
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_SORT_FIELD = 'translation_result';
@@ -452,6 +453,7 @@ export const MigrationRulesTable: React.FC<MigrationRulesTableProps> = React.mem
                   itemId={'id'}
                   data-test-subj={'rules-translation-table'}
                   columns={rulesColumns}
+                  tableCaption={i18n.RULES_MIGRATION_TABLE_CAPTION}
                 />
               </>
             )

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/rules_table/translations.ts
@@ -7,6 +7,13 @@
 
 import { i18n } from '@kbn/i18n';
 
+export const RULES_MIGRATION_TABLE_CAPTION = i18n.translate(
+  'xpack.securitySolution.siemMigrations.rules.table.caption',
+  {
+    defaultMessage: 'Rules migration status',
+  }
+);
+
 export const ALREADY_TRANSLATED_RULE_TOOLTIP = i18n.translate(
   'xpack.securitySolution.siemMigrations.rules.table.alreadyTranslatedTooltip',
   {


### PR DESCRIPTION
> [!CAUTION]
> ⚠️ **Changes / translations were made by GenAI**. I’ve reviewed them carefully, but your code owners’ expert eyes will ensure they’re 100% right.

## Summary
This PR applies the auto-fix for the newly introduced `@elastic/eui/require-table-caption`.
This rule ensure `EuiInMemoryTable`, `EuiBasicTable` have a `tableCaption` prop for accessibility.

## Changes

1. 🎯 Added missing `tableCaption` attributes to elements flagged by `@elastic/eui/require-table-caption` — accessibility leveled up!  

## Related
- https://github.com/elastic/eui/pull/9168

This time, to avoid annoying approvals collection, we've broken files down by teams. Now, we are waiting a review only from your team! 


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->