### PR TITLE
[ESQL-composer] Add deprecation warning to migrate to platform esql composer lib

### DIFF
--- a/src/platform/packages/shared/kbn-esql-composer/README.md
+++ b/src/platform/packages/shared/kbn-esql-composer/README.md
@@ -1,5 +1,10 @@
 # ESQL Composer for Kibana
 
+>[!WARNING]
+> This package is deprecated and will be removed in a future version.
+> Please migrate to the Composer API in `@kbn/esql-language`.
+> See: [src/platform/packages/shared/kbn-esql-language/src/composer/README.md](../kbn-esql-language/src/composer/README.md)
+
 This package provides a high-level, functional ESQL composer for safely and programmatically building Elasticsearch queries. It serves as a user-friendly abstraction over the `@kbn/esql-language` package.
 
 This ESQL composer is designed to be used by importing individual command functions (`from`, `where`, `stats`, etc.) and chaining them together to form a query pipeline.

--- a/src/platform/packages/shared/kbn-esql-composer/src/commands/drop.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/src/commands/drop.ts
@@ -12,6 +12,7 @@ import { append } from '../pipeline/append';
 /**
  * Appends a `DROP` command to the ESQL composer pipeline.
  *
+ * @deprecated Migrate to `@kbn/esql-language` composer.
  * @param columns The columns to drop.
  * @returns A `QueryPipeline` instance with the `DROP` command appended.
  */

--- a/src/platform/packages/shared/kbn-esql-composer/src/commands/eval.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/src/commands/eval.ts
@@ -13,6 +13,7 @@ import { append } from '../pipeline/append';
 /**
  * Appends an `EVAL` command to the ESQL composer pipeline.
  *
+ * @deprecated Migrate to `@kbn/esql-language` composer.
  * @param body The body of the `EVAL` command.
  * @param params The parameters to use in the `EVAL` command.
  * @returns A `QueryPipeline` instance with the `EVAL` command appended.

--- a/src/platform/packages/shared/kbn-esql-composer/src/commands/from.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/src/commands/from.ts
@@ -32,9 +32,17 @@ function buildPipeline(
     params: [],
   });
 }
+
+/**
+ * @deprecated Migrate to `@kbn/esql-language` composer.
+ */
 export function timeseries(...patterns: Array<string | string[]>): QueryPipeline {
   return buildPipeline('TS', ...patterns);
 }
+
+/**
+ * @deprecated Migrate to `@kbn/esql-language` composer.
+ */
 export function from(...patterns: Array<string | string[]>): QueryPipeline {
   return buildPipeline('FROM', ...patterns);
 }

--- a/src/platform/packages/shared/kbn-esql-composer/src/commands/keep.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/src/commands/keep.ts
@@ -12,6 +12,7 @@ import { append } from '../pipeline/append';
 /**
  * Appends a `KEEP` command to the ESQL composer pipeline.
  *
+ * @deprecated Migrate to `@kbn/esql-language` composer.
  * @param columns The columns to keep.
  * @returns A `QueryPipeline` instance with the `KEEP` command appended.
  */

--- a/src/platform/packages/shared/kbn-esql-composer/src/commands/limit.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/src/commands/limit.ts
@@ -12,6 +12,7 @@ import { append } from '../pipeline/append';
 /**
  * Appends a `LIMIT` command to the ESQL composer pipeline.
  *
+ * @deprecated Migrate to `@kbn/esql-language` composer.
  * @param value The limit to apply.
  * @returns A `QueryPipeline` instance with the `LIMIT` command appended.
  */

--- a/src/platform/packages/shared/kbn-esql-composer/src/commands/rename.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/src/commands/rename.ts
@@ -13,6 +13,7 @@ import { append } from '../pipeline/append';
 /**
  * Appends an `RENAME` command to the ESQL composer pipeline.
  *
+ * @deprecated Migrate to `@kbn/esql-language` composer.
  * @param body The body of the `RENAME` command.
  * @param params The parameters to use in the `RENAME` command.
  * @returns A `QueryPipeline` instance with the `RENAME` command appended.

--- a/src/platform/packages/shared/kbn-esql-composer/src/commands/sort.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/src/commands/sort.ts
@@ -10,6 +10,9 @@
 import type { Params, QueryOperator } from '../types';
 import { append } from '../pipeline/append';
 
+/**
+ * @deprecated Migrate to `@kbn/esql-language` composer.
+ */
 export enum SortOrder {
   Asc = 'ASC',
   Desc = 'DESC',
@@ -22,6 +25,7 @@ type SortArgs = Sort | string | Array<Sort | string>;
 /**
  * Appends a `SORT` command to the ESQL composer pipeline.
  *
+ * @deprecated Migrate to `@kbn/esql-language` composer.
  * @param sorts The sort criteria.
  * @returns A `QueryPipeline` instance with the `SORT` command appended.
  */

--- a/src/platform/packages/shared/kbn-esql-composer/src/commands/stats.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/src/commands/stats.ts
@@ -13,6 +13,7 @@ import { append } from '../pipeline/append';
 /**
  * Appends a `STATS` command to the ESQL composer pipeline.
  *
+ * @deprecated Migrate to `@kbn/esql-language` composer.
  * @param body The body of the `STATS` command.
  * @param params The parameters to use in the `STATS` command.
  * @returns A `QueryPipeline` instance with the `STATS` command appended.

--- a/src/platform/packages/shared/kbn-esql-composer/src/commands/where.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/src/commands/where.ts
@@ -13,6 +13,7 @@ import { append } from '../pipeline/append';
 /**
  * Appends a `WHERE` command to the ESQL composer pipeline.
  *
+ * @deprecated Migrate to `@kbn/esql-language` composer.
  * @param body The body of the `WHERE` command.
  * @param params The parameters to use in the `WHERE` command.
  * @returns A `QueryPipeline` instance with the `WHERE` command appended.

--- a/src/platform/packages/shared/kbn-esql-composer/src/pipeline/replace_parameters.ts
+++ b/src/platform/packages/shared/kbn-esql-composer/src/pipeline/replace_parameters.ts
@@ -12,6 +12,9 @@ import { Walker } from '@kbn/esql-language';
 import { ParameterReplacer } from '../transformers/parameter_replacer';
 import type { Params } from '../types';
 
+/**
+ * @deprecated Migrate to `@kbn/esql-language` composer.
+ */
 export function replaceParameters(queryAst: ESQLAstQueryExpression, params?: Params) {
   const parameterReplacer = new ParameterReplacer(params);
   Walker.walk(queryAst, {


### PR DESCRIPTION
## Summary

Flags the o11y version of the ESQL composer tool as deprecated in favor of [platform's solution](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-esql-composer/README.md)



