### PR TITLE
[9.3] fix issue with eui flyouts not rendering appropriately in new layout (#248921)

### DIFF
--- a/src/core/packages/chrome/layout/core-chrome-layout/layouts/grid/grid_global_app_style.tsx
+++ b/src/core/packages/chrome/layout/core-chrome-layout/layouts/grid/grid_global_app_style.tsx
@@ -92,19 +92,28 @@ const globalTempHackStyles = (euiTheme: UseEuiTheme['euiTheme']) => css`
   }
 
   .kbnBody {
-    // adjust position of all the right flyouts relative to the application area, except the ones that are "above the header"
-    .euiFlyout[class*='right']:not(.euiOverlayMask[class*='aboveHeader'] .euiFlyout) {
-      ${logicalCSS('top', layoutVar('application.top', '0px'))};
-      ${logicalCSS('bottom', layoutVar('application.bottom', '0px'))};
-      ${logicalCSS('right', layoutVar('application.right', '0px'))};
-    }
-
     // overlay mask "belowHeader" should only cover the application area
-    .euiOverlayMask[class*='belowHeader'] {
+    .euiOverlayMask[data-relative-to-header='below'] {
       ${logicalCSS('top', layoutVar('application.top', '0px'))};
       ${logicalCSS('left', layoutVar('application.left', '0px'))};
       ${logicalCSS('right', layoutVar('application.right', '0px'))};
       ${logicalCSS('bottom', layoutVar('application.bottom', '0px'))};
+    }
+
+    // adjust position of all the right flyouts relative to the application area
+    .euiFlyout[class*='right'] {
+      ${logicalCSS('top', layoutVar('application.top', '0px'))};
+      ${logicalCSS('right', layoutVar('application.right', '0px'))};
+      ${logicalCSS('bottom', layoutVar('application.bottom', '0px'))};
+    }
+
+    // if the overlay mask exists that is above the header, set the top, right and bottom of the right flyouts to 0
+    .euiOverlayMask[data-relative-to-header='above']
+      + [data-euiportal='true']
+      .euiFlyout[class*='right'] {
+      ${logicalCSS('top', 0)};
+      ${logicalCSS('right', 0)};
+      ${logicalCSS('bottom', 0)};
     }
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [fix issue with eui flyouts not rendering appropriately in new layout (#248921)](https://github.com/elastic/kibana/pull/248921)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-19T09:54:13Z","message":"fix issue with eui flyouts not rendering appropriately in new layout (#248921)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/245851 for export flyouts\n\n<img width=\"717\" height=\"883\" alt=\"Screenshot 2026-01-13 at 22 38 35\"\nsrc=\"https://github.com/user-attachments/assets/a9056904-3f78-4cae-8ce2-9ec8fd526a9b\"\n/>\n\nAlso accounts for when the below header option is selected in eui\nflyouts;\n\n<img width=\"499\" height=\"832\" alt=\"Screenshot 2026-01-13 at 22 39 46\"\nsrc=\"https://github.com/user-attachments/assets/0585998f-dd9c-447a-a7ff-12d32deda9d9\"\n/>\n\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"ff53b808731b8020b8962141bb4f78613b079374","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:SharedUX","v9.4.0","backport:9.3"],"title":"fix issue with eui flyouts not rendering appropriately in new layout","number":248921,"url":"https://github.com/elastic/kibana/pull/248921","mergeCommit":{"message":"fix issue with eui flyouts not rendering appropriately in new layout (#248921)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/245851 for export flyouts\n\n<img width=\"717\" height=\"883\" alt=\"Screenshot 2026-01-13 at 22 38 35\"\nsrc=\"https://github.com/user-attachments/assets/a9056904-3f78-4cae-8ce2-9ec8fd526a9b\"\n/>\n\nAlso accounts for when the below header option is selected in eui\nflyouts;\n\n<img width=\"499\" height=\"832\" alt=\"Screenshot 2026-01-13 at 22 39 46\"\nsrc=\"https://github.com/user-attachments/assets/0585998f-dd9c-447a-a7ff-12d32deda9d9\"\n/>\n\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"ff53b808731b8020b8962141bb4f78613b079374"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248921","number":248921,"mergeCommit":{"message":"fix issue with eui flyouts not rendering appropriately in new layout (#248921)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/245851 for export flyouts\n\n<img width=\"717\" height=\"883\" alt=\"Screenshot 2026-01-13 at 22 38 35\"\nsrc=\"https://github.com/user-attachments/assets/a9056904-3f78-4cae-8ce2-9ec8fd526a9b\"\n/>\n\nAlso accounts for when the below header option is selected in eui\nflyouts;\n\n<img width=\"499\" height=\"832\" alt=\"Screenshot 2026-01-13 at 22 39 46\"\nsrc=\"https://github.com/user-attachments/assets/0585998f-dd9c-447a-a7ff-12d32deda9d9\"\n/>\n\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"ff53b808731b8020b8962141bb4f78613b079374"}}]}] BACKPORT-->