### PR TITLE
[Streams][SigEvents] Prevent editing feature of significant event queries

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/utils/assert_feature_not_changed.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/utils/assert_feature_not_changed.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isEqual } from 'lodash';
+import type { StreamQueryKql } from '@kbn/streams-schema';
+import type { QueryClient } from '../../lib/streams/assets/query/query_client';
+import { StatusError } from '../../lib/streams/errors/status_error';
+
+/**
+ * Validates that the feature field has not changed for existing queries.
+ * Throws a StatusError (400) if attempting to modify the feature of an existing query.
+ */
+export async function assertFeatureNotChanged({
+  queryClient,
+  streamName,
+  queries,
+}: {
+  queryClient: QueryClient;
+  streamName: string;
+  queries: Array<{ id: string; feature: StreamQueryKql['feature'] }>;
+}): Promise<void> {
+  if (queries.length === 0) return;
+
+  const queryIds = queries.map((q) => q.id);
+  const existingQueries = await queryClient.bulkGetByIds(streamName, queryIds);
+  const existingQueryMap = new Map(existingQueries.map((q) => [q.query.id, q.query]));
+
+  for (const query of queries) {
+    const existing = existingQueryMap.get(query.id);
+    if (existing && !isEqual(existing.feature, query.feature)) {
+      throw new StatusError(
+        `Cannot modify feature of existing significant event query [${query.id}]`,
+        400
+      );
+    }
+  }
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/add_significant_event_flyout/add_significant_event_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/add_significant_event_flyout/add_significant_event_flyout.tsx
@@ -288,6 +288,7 @@ export function AddSignificantEventFlyout({
                       <EuiSpacer size="m" />
                       <ManualFlowForm
                         isSubmitting={isSubmitting}
+                        isEditMode={isEditMode}
                         setQuery={(next: StreamQueryKql) => setQueries([next])}
                         query={queries[0]}
                         setCanSave={(next: boolean) => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/add_significant_event_flyout/manual_flow_form/manual_flow_form.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/add_significant_event_flyout/manual_flow_form/manual_flow_form.tsx
@@ -29,6 +29,7 @@ interface Props {
   definition: Streams.all.Definition;
   query: StreamQueryKql;
   isSubmitting: boolean;
+  isEditMode: boolean;
   setQuery: (query: StreamQueryKql) => void;
   setCanSave: (canSave: boolean) => void;
   features: System[];
@@ -41,6 +42,7 @@ export function ManualFlowForm({
   setQuery,
   setCanSave,
   isSubmitting,
+  isEditMode,
   features,
   dataViews,
 }: Props) {
@@ -144,7 +146,7 @@ export function ManualFlowForm({
                 'xpack.streams.addSignificantEventFlyout.manualFlow.featurePlaceholder',
                 { defaultMessage: 'Select feature' }
               )}
-              disabled={isSubmitting || features.length === 0}
+              disabled={isSubmitting || features.length === 0 || isEditMode}
               onBlur={() => {
                 setTouched((prev) => ({ ...prev, feature: true }));
               }}

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/queries.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/queries.ts
@@ -229,6 +229,92 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         expect(updatedRules.body.data[0].name).to.eql('updated title');
         expect(updatedRules.body.data[0].id).to.eql(initialRules.body.data[0].id);
       });
+
+      it('returns 400 when attempting to change the feature of an existing query', async () => {
+        const initialFeature = {
+          name: 'initial-feature',
+          filter: { field: 'host.name', operator: 'eq' as const, value: 'host1' },
+          type: 'system' as const,
+        };
+        const query = {
+          id: 'feature-query',
+          title: 'query with feature',
+          kql: { query: 'test query' },
+          feature: initialFeature,
+        };
+        await putStream(apiClient, STREAM_NAME, {
+          stream,
+          ...emptyAssets,
+          queries: [query],
+        });
+
+        const updatedFeature = {
+          name: 'updated-feature',
+          filter: { field: 'host.name', operator: 'eq' as const, value: 'host2' },
+          type: 'system' as const,
+        };
+
+        await apiClient
+          .fetch('PUT /api/streams/{name}/queries/{queryId} 2023-10-31', {
+            params: {
+              path: { name: STREAM_NAME, queryId: query.id },
+              body: {
+                title: query.title,
+                kql: query.kql,
+                feature: updatedFeature,
+              },
+            },
+          })
+          .expect(400);
+
+        // Verify the query was not updated
+        const getQueriesResponse = await getQueries(apiClient, STREAM_NAME);
+        expect(getQueriesResponse.queries).to.eql([query]);
+      });
+
+      it('allows updating a query when the feature remains unchanged', async () => {
+        const feature = {
+          name: 'test-feature',
+          filter: { field: 'host.name', operator: 'eq' as const, value: 'host1' },
+          type: 'system' as const,
+        };
+        const query = {
+          id: 'feature-query',
+          title: 'initial title',
+          kql: { query: 'initial query' },
+          feature,
+        };
+        await putStream(apiClient, STREAM_NAME, {
+          stream,
+          ...emptyAssets,
+          queries: [query],
+        });
+
+        const upsertQueryResponse = await apiClient
+          .fetch('PUT /api/streams/{name}/queries/{queryId} 2023-10-31', {
+            params: {
+              path: { name: STREAM_NAME, queryId: query.id },
+              body: {
+                title: 'updated title',
+                kql: { query: 'updated query' },
+                feature,
+              },
+            },
+          })
+          .expect(200)
+          .then((res) => res.body);
+        expect(upsertQueryResponse.acknowledged).to.be(true);
+
+        const getQueriesResponse = await getQueries(apiClient, STREAM_NAME);
+        expect(getQueriesResponse.queries).to.eql([
+          {
+            id: query.id,
+            title: 'updated title',
+            kql: { query: 'updated query' },
+            feature,
+          },
+        ]);
+      });
     });
 
     it('deletes an existing query and the associated rule successfully', async () => {
@@ -349,6 +435,53 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       expect(initialThirdRuleId).not.to.eql(
         updatedRules.body.data.find((rule: any) => rule.name === updateThirdQuery.title).id
       );
+    });
+
+    it('returns 400 when bulk operation attempts to change the feature of an existing query', async () => {
+      const initialFeature = {
+        name: 'initial-feature',
+        filter: { field: 'host.name', operator: 'eq' as const, value: 'host1' },
+        type: 'system' as const,
+      };
+      const queryWithFeature = {
+        id: 'feature-query',
+        title: 'query with feature',
+        kql: { query: 'test query' },
+        feature: initialFeature,
+      };
+      await putStream(apiClient, STREAM_NAME, {
+        stream,
+        ...emptyAssets,
+        queries: [queryWithFeature],
+      });
+
+      const updatedFeature = {
+        name: 'updated-feature',
+        filter: { field: 'host.name', operator: 'eq' as const, value: 'host2' },
+        type: 'system' as const,
+      };
+
+      await apiClient
+        .fetch('POST /api/streams/{name}/queries/_bulk 2023-10-31', {
+          params: {
+            path: { name: STREAM_NAME },
+            body: {
+              operations: [
+                {
+                  index: {
+                    ...queryWithFeature,
+                    feature: updatedFeature,
+                  },
+                },
+              ],
+            },
+          },
+        })
+        .expect(400);
+
+      // Verify the query was not updated
+      const getQueriesResponse = await getQueries(apiClient, STREAM_NAME);
+      expect(getQueriesResponse.queries).to.eql([queryWithFeature]);
     });
   });
 }


### PR DESCRIPTION
### Summary

This PR prevents modifying the `feature` field of existing significant event queries in both the UI and API. Feature selection remains available when **creating** new significant events, but becomes read-only when **editing** existing ones.

### Background

When creating a significant event, a detection rule is created combining the KQL query with the feature condition. The rule ID is generated from the `ASSET_UUID` and `kql.query` only - it does not include the `feature` field. When the feature changes, the rule ID stays the same, causing alerts from the previous rule configuration to still appear.

Since features are being removed from significant events, this is a temporary fix to prevent the bug from occurring.

Before:

https://github.com/user-attachments/assets/bf5e21ea-c55e-487c-9f32-163d767b13ad

After:

https://github.com/user-attachments/assets/268f4e65-1861-4a46-b07b-9473238995df



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->