### PR TITLE
[ES|QL] Add support for null type in Discover

### DIFF
--- a/src/platform/packages/shared/kbn-field-types/src/kbn_field_types.test.ts
+++ b/src/platform/packages/shared/kbn-field-types/src/kbn_field_types.test.ts
@@ -85,6 +85,7 @@ describe('utils/kbn_field_types', () => {
         KBN_FIELD_TYPES.IP_RANGE,
         KBN_FIELD_TYPES.MURMUR3,
         KBN_FIELD_TYPES.NESTED,
+        KBN_FIELD_TYPES.NULL,
         KBN_FIELD_TYPES.NUMBER,
         KBN_FIELD_TYPES.NUMBER_RANGE,
         KBN_FIELD_TYPES.OBJECT,

--- a/src/platform/packages/shared/kbn-field-types/src/kbn_field_types_factory.ts
+++ b/src/platform/packages/shared/kbn-field-types/src/kbn_field_types_factory.ts
@@ -132,7 +132,8 @@ export const createKbnFieldTypes = (): KbnFieldType[] => [
     esTypes: [ES_FIELD_TYPES.TDIGEST],
   }),
   new KbnFieldType({
-    name: KBN_FIELD_TYPES.CONFLICT,
+    name: KBN_FIELD_TYPES.NULL,
+    esTypes: [ES_FIELD_TYPES.NULL],
   }),
   kbnFieldTypeUnknown,
 ];

--- a/src/platform/packages/shared/kbn-field-types/src/kbn_field_types_factory.ts
+++ b/src/platform/packages/shared/kbn-field-types/src/kbn_field_types_factory.ts
@@ -132,6 +132,9 @@ export const createKbnFieldTypes = (): KbnFieldType[] => [
     esTypes: [ES_FIELD_TYPES.TDIGEST],
   }),
   new KbnFieldType({
+    name: KBN_FIELD_TYPES.CONFLICT,
+  }),
+  new KbnFieldType({
     name: KBN_FIELD_TYPES.NULL,
     esTypes: [ES_FIELD_TYPES.NULL],
   }),

--- a/src/platform/packages/shared/kbn-field-types/src/types.ts
+++ b/src/platform/packages/shared/kbn-field-types/src/types.ts
@@ -65,6 +65,8 @@ export enum ES_FIELD_TYPES {
   HISTOGRAM = 'histogram',
   EXPONENTIAL_HISTOGRAM = 'exponential_histogram',
   TDIGEST = 'tdigest',
+
+  NULL = 'null',
 }
 
 /** @public **/
@@ -90,4 +92,5 @@ export enum KBN_FIELD_TYPES {
   EXPONENTIAL_HISTOGRAM = 'exponential_histogram',
   TDIGEST = 'tdigest',
   MISSING = 'missing',
+  NULL = 'null',
 }

--- a/src/platform/packages/shared/kbn-field-utils/src/utils/field_types.ts
+++ b/src/platform/packages/shared/kbn-field-utils/src/utils/field_types.ts
@@ -44,6 +44,7 @@ export enum KNOWN_FIELD_TYPES {
   STRING = 'string',
   TEXT = 'text',
   VERSION = 'version',
+  NULL = 'null',
 }
 
 export const KNOWN_FIELD_TYPE_LIST: string[] = Object.values(KNOWN_FIELD_TYPES);

--- a/src/platform/packages/shared/kbn-field-utils/src/utils/get_field_type_description.ts
+++ b/src/platform/packages/shared/kbn-field-utils/src/utils/get_field_type_description.ts
@@ -156,6 +156,10 @@ export function getFieldTypeDescription(type?: string) {
       return i18n.translate('fieldUtils.fieldNameDescription.versionField', {
         defaultMessage: 'Software versions. Supports "Semantic Versioning" precedence rules.',
       });
+    case KNOWN_FIELD_TYPES.NULL:
+      return i18n.translate('fieldUtils.fieldNameDescription.nullField', {
+        defaultMessage: 'Field with null values.',
+      });
     default:
       // If you see a typescript error here, that's a sign that there are missing switch cases ^^
       const _exhaustiveCheck: never = knownType;

--- a/src/platform/packages/shared/kbn-field-utils/src/utils/get_field_type_name.ts
+++ b/src/platform/packages/shared/kbn-field-utils/src/utils/get_field_type_name.ts
@@ -160,6 +160,10 @@ export function getFieldTypeName(type?: string) {
       return i18n.translate('fieldUtils.fieldNameIcons.versionFieldAriaLabel', {
         defaultMessage: 'Version',
       });
+    case KNOWN_FIELD_TYPES.NULL:
+      return i18n.translate('fieldUtils.fieldNameIcons.nullFieldAriaLabel', {
+        defaultMessage: 'Null',
+      });
     default:
       // If you see a typescript error here, that's a sign that there are missing switch cases ^^
       const _exhaustiveCheck: never = knownType;

--- a/src/platform/packages/shared/kbn-react-field/src/field_icon/__snapshots__/field_icon.test.tsx.snap
+++ b/src/platform/packages/shared/kbn-react-field/src/field_icon/__snapshots__/field_icon.test.tsx.snap
@@ -295,6 +295,16 @@ exports[`FieldIcon renders known field types nested is rendered 1`] = `
 />
 `;
 
+exports[`FieldIcon renders known field types null is rendered 1`] = `
+<EuiToken
+  aria-label="null"
+  className="kbnFieldIcon"
+  iconType="tokenNull"
+  size="s"
+  title="null"
+/>
+`;
+
 exports[`FieldIcon renders known field types number is rendered 1`] = `
 <EuiToken
   aria-label="number"

--- a/src/platform/packages/shared/kbn-react-field/src/field_icon/field_icon.tsx
+++ b/src/platform/packages/shared/kbn-react-field/src/field_icon/field_icon.tsx
@@ -64,6 +64,7 @@ export const typeToEuiIconMap = {
   nested: { iconType: 'tokenNested' },
   version: { iconType: 'tokenTag' },
   percolator: { iconType: 'tokenPercolator' },
+  null: { iconType: 'tokenNull' },
 } as const;
 
 type AllowedIconType = keyof typeof typeToEuiIconMap;

--- a/src/platform/plugins/shared/data_view_management/public/components/field_editor/__snapshots__/field_editor.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_management/public/components/field_editor/__snapshots__/field_editor.test.tsx.snap
@@ -972,6 +972,10 @@ exports[`FieldEditor should show deprecated lang warning 1`] = `
               "value": "conflict",
             },
             Object {
+              "text": "null",
+              "value": "null",
+            },
+            Object {
               "text": "unknown",
               "value": "unknown",
             },


### PR DESCRIPTION
## Summary
The `null` type always existed but it was not common to be found, as the only way of generating it was with custom (no-sense) querys. I.E: `FROM index | EVAL col0 = null`

But now with the introduction of `SET unmapped_fields = "NULLIFY";` setting, this type is going to be more common in the query results.

This PR adds support for visualising correctly fields with `null` type.

### Before
<img width="1395" height="631" alt="image" src="https://github.com/user-attachments/assets/b81c3c21-9161-461b-820b-bfc664e79e9d" />

### After
<img width="1723" height="543" alt="image" src="https://github.com/user-attachments/assets/91a557bb-2e82-400a-82ce-cf353a6e80c6" />



