### PR TITLE
alertingv2/streaming esql

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/query_service/query_service.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/services/query_service/query_service.ts
@@ -11,8 +11,11 @@ import type { ESQLSearchParams, ESQLSearchResponse } from '@kbn/es-types';
 import type { IKibanaSearchRequest, IKibanaSearchResponse } from '@kbn/search-types';
 import { catchError, filter as rxFilter, lastValueFrom, map, throwError } from 'rxjs';
 import { inject, injectable } from 'inversify';
+import type { RecordBatch } from 'apache-arrow';
+import type { ElasticsearchClient } from '@kbn/core/server';
 import type { LoggerServiceContract } from '../logger_service/logger_service';
 import { LoggerServiceToken } from '../logger_service/logger_service';
+import { EsServiceScopedToken } from '../es_service/tokens';
 
 interface ExecuteQueryParams {
   query: ESQLSearchParams['query'];
@@ -21,16 +24,27 @@ interface ExecuteQueryParams {
   abortSignal?: AbortSignal;
 }
 
+interface ExecuteQueryStreamingParams {
+  query: string;
+  dropNullColumns?: boolean;
+  allowPartialResults?: boolean;
+  abortSignal?: AbortSignal;
+}
+
 export interface QueryServiceContract {
   executeQuery(params: ExecuteQueryParams): Promise<ESQLSearchResponse>;
   queryResponseToRecords<T extends Record<string, any>>(response: ESQLSearchResponse): T[];
+  executeQueryStreaming(
+    params: ExecuteQueryStreamingParams
+  ): AsyncIterable<Record<string, unknown>>;
 }
 
 @injectable()
 export class QueryService implements QueryServiceContract {
   constructor(
     private readonly searchClient: IScopedSearchClient,
-    @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract
+    @inject(LoggerServiceToken) private readonly logger: LoggerServiceContract,
+    @inject(EsServiceScopedToken) private readonly esClient: ElasticsearchClient
   ) {}
 
   async executeQuery({
@@ -91,6 +105,90 @@ export class QueryService implements QueryServiceContract {
 
       throw error;
     }
+  }
+
+  async *executeQueryStreaming({
+    query,
+    dropNullColumns = false,
+    allowPartialResults = true,
+    abortSignal,
+  }: ExecuteQueryStreamingParams): AsyncIterable<Record<string, unknown>> {
+    try {
+      this.logger.debug({
+        message: () =>
+          `QueryService: Starting streaming query - ${JSON.stringify({
+            query,
+            dropNullColumns,
+            allowPartialResults,
+          })}`,
+      });
+
+      // Use helpers.esql() for Arrow streaming support
+      const esqlHelper = this.esClient.helpers.esql({
+        query,
+        drop_null_columns: dropNullColumns,
+        allow_partial_results: allowPartialResults,
+        ...(abortSignal ? { signal: abortSignal } : {}),
+      });
+
+      // Get Arrow reader for streaming record batches
+      const reader = await esqlHelper.toArrowReader();
+
+      let columnNames: string[] = [];
+
+      // Process record batches and yield row objects
+      for await (const recordBatch of reader) {
+        // Extract column names from the first batch
+        if (columnNames.length === 0 && recordBatch.schema.fields.length > 0) {
+          columnNames = recordBatch.schema.fields.map((field) => field.name);
+        }
+
+        // Convert batch to row objects and yield them individually
+        const rows = this.recordBatchToRecords(recordBatch, columnNames);
+        for (const row of rows) {
+          yield row;
+        }
+      }
+
+      this.logger.debug({
+        message: 'QueryService: Streaming query completed successfully',
+      });
+    } catch (error) {
+      this.logger.error({
+        error,
+        code: 'ESQL_STREAMING_QUERY_ERROR',
+        type: 'QueryServiceError',
+      });
+
+      throw error;
+    }
+  }
+
+  private recordBatchToRecords(
+    recordBatch: RecordBatch,
+    columnNames: string[]
+  ): Record<string, unknown>[] {
+    const rows: Record<string, unknown>[] = [];
+
+    // Process each row in the batch
+    for (let rowIndex = 0; rowIndex < recordBatch.numRows; rowIndex++) {
+      const rowObject: Record<string, unknown> = {};
+
+      // Extract values for each column in this row
+      for (let colIndex = 0; colIndex < recordBatch.numCols; colIndex++) {
+        const column = recordBatch.getChildAt(colIndex);
+        if (column) {
+          const columnName = columnNames[colIndex] || `column_${colIndex}`;
+          // Get the value at the current row index
+          const value = column.get(rowIndex);
+          rowObject[columnName] = value;
+        }
+      }
+
+      rows.push(rowObject);
+    }
+
+    return rows;
   }
 
   public queryResponseToRecords<T extends Record<string, any>>(response: ESQLSearchResponse): T[] {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/poc_streaming.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/poc_streaming.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import type { TypeOf } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
+import { Request, Response } from '@kbn/core-di-server';
+import type { KibanaRequest, KibanaResponseFactory, RouteSecurity } from '@kbn/core-http-server';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { inject, injectable } from 'inversify';
+import type { Logger as KibanaLogger } from '@kbn/logging';
+import { Logger } from '@kbn/core-di';
+import type { RecordBatch } from 'apache-arrow';
+import { ALERTING_V2_API_PRIVILEGES } from '../lib/security/privileges';
+import { EsServiceInternalToken } from '../lib/services/es_service/tokens';
+
+const getRuleParamsSchema = schema.object({
+  id: schema.string(),
+});
+
+@injectable()
+export class GetStreamingRoute {
+  static method = 'get' as const;
+  static path = `/internal/alerting/v2/streaming`;
+  static security: RouteSecurity = {
+    authz: {
+      requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.rules.read],
+    },
+  };
+  static options = { access: 'internal' } as const;
+  static validate = {} as const;
+
+  constructor(
+    @inject(Logger) private readonly logger: KibanaLogger,
+    @inject(Request)
+    private readonly request: KibanaRequest<TypeOf<typeof getRuleParamsSchema>, unknown, unknown>,
+    @inject(Response) private readonly response: KibanaResponseFactory,
+    @inject(EsServiceInternalToken) private readonly esClient: ElasticsearchClient
+  ) {}
+
+  async handle() {
+    try {
+      // Use helpers.esql() for Arrow streaming support
+      const esqlHelper = this.esClient.helpers.esql({
+        query: 'FROM .alerts-events*',
+        drop_null_columns: false,
+        allow_partial_results: true,
+      });
+
+      // Get Arrow reader for streaming record batches (returns a Promise)
+      const reader = await esqlHelper.toArrowReader();
+
+      let rowCount = 0;
+      const columnNames: string[] = [];
+
+      // Process record batches as they arrive (true streaming)
+      for await (const recordBatch of reader) {
+        // Extract column names from the first batch
+        if (columnNames.length === 0 && recordBatch.schema.fields.length > 0) {
+          columnNames.push(...recordBatch.schema.fields.map((field) => field.name));
+        }
+
+        // Process each row in the batch
+        for (let rowIndex = 0; rowIndex < recordBatch.numRows; rowIndex++) {
+          const rowObject: Record<string, unknown> = {};
+
+          // Extract values for each column in this row
+          for (let colIndex = 0; colIndex < recordBatch.numCols; colIndex++) {
+            const column = recordBatch.getChildAt(colIndex);
+            if (column) {
+              const columnName = columnNames[colIndex] || `column_${colIndex}`;
+              // Get the value at the current row index
+              const value = column.get(rowIndex);
+              rowObject[columnName] = value;
+            }
+          }
+
+          // Log each row as it becomes available
+          this.logger.info(`ESQL Row Result: ${JSON.stringify(rowObject)}`);
+          rowCount++;
+        }
+      }
+
+      return this.response.ok({
+        body: { message: 'Streaming completed', rowCount },
+      });
+    } catch (e) {
+      const boom = Boom.isBoom(e) ? e : Boom.boomify(e);
+      return this.response.customError({
+        statusCode: boom.output.statusCode,
+        body: boom.output.payload,
+      });
+    }
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_routes.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_routes.ts
@@ -12,6 +12,7 @@ import { UpdateRuleRoute } from '../routes/update_rule_route';
 import { GetRulesRoute } from '../routes/get_rules_route';
 import { GetRuleRoute } from '../routes/get_rule_route';
 import { DeleteRuleRoute } from '../routes/delete_rule_route';
+import { GetStreamingRoute } from '../routes/poc_streaming';
 
 export function bindRoutes({ bind }: ContainerModuleLoadOptions) {
   bind(Route).toConstantValue(CreateRuleRoute);
@@ -19,4 +20,5 @@ export function bindRoutes({ bind }: ContainerModuleLoadOptions) {
   bind(Route).toConstantValue(GetRulesRoute);
   bind(Route).toConstantValue(GetRuleRoute);
   bind(Route).toConstantValue(DeleteRuleRoute);
+  bind(Route).toConstantValue(GetStreamingRoute);
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/setup/bind_services.ts
@@ -62,8 +62,9 @@ export function bindServices({ bind }: ContainerModuleLoadOptions) {
       const request = get(Request);
       const data = get(PluginStart<AlertingServerStartDependencies['data']>('data'));
       const loggerService = get(LoggerServiceToken);
+      const esClient = get(EsServiceScopedToken);
       const searchClient = data.search.asScoped(request);
-      return new QueryService(searchClient, loggerService);
+      return new QueryService(searchClient, loggerService, esClient);
     })
     .inRequestScope();
 


### PR DESCRIPTION
- **[ResponseOps][Alerting] Init alerting v2 plugin (#247283)**
- **[ResponseOps][Alerting] Add the alerting v2 feature privileges (#247452)**
- **Changes from node scripts/regenerate_moon_projects.js --update**
- **[ResponseOps][Alerting] Add alerting v2 Rule Executor  (#247472)**
- **Fix yarn.lock**
- **[ResponseOps][Alerting] Alerting v2 rule HTTP APIs (#248285)**
- **[ResponseOps][Alerting] Alerting v2: Create basic services (#248306)**
- **Changes from node scripts/regenerate_moon_projects.js --update**
- **[ResponseOps] Alerting v2:  Initialize all resources (#248696)**
- **Changes from node scripts/regenerate_moon_projects.js --update**
- **[ResponseOps] Update task runner to use core services  (#248866)**
- **esql streaming results**
