### PR TITLE
[Inspect Component] Fix inspect component flyout zIndex regression

### DIFF
--- a/src/platform/plugins/private/inspect_component/public/components/inspect/flyout/inspect_flyout.tsx
+++ b/src/platform/plugins/private/inspect_component/public/components/inspect/flyout/inspect_flyout.tsx
@@ -63,9 +63,10 @@ export const InspectFlyout = ({ componentData, target, branch }: Props) => {
     const flyoutElement = document.getElementById(INSPECT_FLYOUT_ID);
     const portalParent = flyoutElement?.closest(EUI_PORTAL_ATTRIBUTE);
 
-    if (portalParent instanceof HTMLElement) {
+    if (portalParent instanceof HTMLElement && flyoutElement instanceof HTMLElement) {
       requestAnimationFrame(() => {
         portalParent.style.zIndex = (toastZIndex + 2).toString();
+        flyoutElement.style.zIndex = (toastZIndex + 2).toString();
       });
     }
   }, [toastZIndex]);


### PR DESCRIPTION
## Summary

Some unidentified regression made it so the inspect component highlighted item would render above the flyout. This PR fixes it by adjusting z-index not only for the portal but also for the flyout.



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.2"]} ONMERGE-->