### PR TITLE
[ObsPresentation] Synthtrace scenarios for kafka topics and messaging systems in service map

### DIFF
--- a/src/platform/packages/shared/kbn-synthtrace/src/scenarios/kafka_topics.ts
+++ b/src/platform/packages/shared/kbn-synthtrace/src/scenarios/kafka_topics.ts
@@ -1,0 +1,328 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Generates traces with spans targeting multiple Kafka topics to test service map grouping.
+
+import { Readable } from 'stream';
+import type { ApmFields, Serializable } from '@kbn/synthtrace-client';
+import { apm } from '@kbn/synthtrace-client';
+import type { Scenario } from '../cli/scenario';
+import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
+import { withClient } from '../lib/utils/with_client';
+
+const ENVIRONMENT = getSynthtraceEnvironment(__filename);
+
+const scenario: Scenario<ApmFields> = async () => {
+  return {
+    generate: ({ range, clients: { apmEsClient } }) => {
+      const producerService = apm
+        .service({ name: 'kafka-producer', environment: ENVIRONMENT, agentName: 'nodejs' })
+        .instance('kafka-producer-instance');
+
+      const consumerService = apm
+        .service({ name: 'kafka-consumer', environment: ENVIRONMENT, agentName: 'java' })
+        .instance('kafka-consumer-instance');
+
+      const orderProcessorService = apm
+        .service({ name: 'order-processor', environment: ENVIRONMENT, agentName: 'java' })
+        .instance('order-processor-instance');
+
+      const paymentProcessorService = apm
+        .service({ name: 'payment-processor', environment: ENVIRONMENT, agentName: 'java' })
+        .instance('payment-processor-instance');
+
+      const apiService = apm
+        .service({ name: 'api-service', environment: ENVIRONMENT, agentName: 'nodejs' })
+        .instance('api-service-instance');
+
+      const timestamps = range.ratePerMinute(6);
+
+      // Generate producer events FIRST to get Kafka span IDs for inbound span.links
+      const producerEvents = timestamps.generator((timestamp) =>
+        producerService
+          .transaction({ transactionName: 'POST /publish' })
+          .timestamp(timestamp)
+          .duration(200)
+          .success()
+          .children(
+            // Publish to orders topic
+            producerService
+              .span({
+                spanName: 'Publish to kafka/orders',
+                spanType: 'messaging',
+                spanSubtype: 'kafka',
+                'service.target.type': 'kafka',
+                'service.target.name': 'orders',
+                'span.destination.service.resource': 'kafka/orders',
+              })
+              .duration(30)
+              .success()
+              .timestamp(timestamp + 10),
+
+            // Publish to payments topic
+            producerService
+              .span({
+                spanName: 'Publish to kafka/payments',
+                spanType: 'messaging',
+                spanSubtype: 'kafka',
+                'service.target.type': 'kafka',
+                'service.target.name': 'payments',
+                'span.destination.service.resource': 'kafka/payments',
+              })
+              .duration(30)
+              .success()
+              .timestamp(timestamp + 50),
+
+            // Publish to notifications topic
+            producerService
+              .span({
+                spanName: 'Publish to kafka/notifications',
+                spanType: 'messaging',
+                spanSubtype: 'kafka',
+                'service.target.type': 'kafka',
+                'service.target.name': 'notifications',
+                'span.destination.service.resource': 'kafka/notifications',
+              })
+              .duration(30)
+              .success()
+              .timestamp(timestamp + 90),
+
+            // Publish to analytics topic
+            producerService
+              .span({
+                spanName: 'Publish to kafka/analytics',
+                spanType: 'messaging',
+                spanSubtype: 'kafka',
+                'service.target.type': 'kafka',
+                'service.target.name': 'analytics',
+                'span.destination.service.resource': 'kafka/analytics',
+              })
+              .duration(30)
+              .success()
+              .timestamp(timestamp + 130),
+
+            // Publish to events topic
+            producerService
+              .span({
+                spanName: 'Publish to kafka/events',
+                spanType: 'messaging',
+                spanSubtype: 'kafka',
+                'service.target.type': 'kafka',
+                'service.target.name': 'events',
+                'span.destination.service.resource': 'kafka/events',
+              })
+              .duration(30)
+              .success()
+              .timestamp(timestamp + 170),
+
+            // Publish to logs topic
+            producerService
+              .span({
+                spanName: 'Publish to kafka/logs',
+                spanType: 'messaging',
+                spanSubtype: 'kafka',
+                'service.target.type': 'kafka',
+                'service.target.name': 'logs',
+                'span.destination.service.resource': 'kafka/logs',
+              })
+              .duration(30)
+              .success()
+              .timestamp(timestamp + 210)
+          )
+      );
+
+      // Serialize producer events to get Kafka span IDs
+      const serializedProducerEvents = Array.from(producerEvents).flatMap((event) =>
+        event.serialize()
+      );
+
+      // Find the specific Kafka spans we want to link to
+      const ordersKafkaSpan = serializedProducerEvents.find(
+        (event) =>
+          event['processor.event'] === 'span' && event['span.name'] === 'Publish to kafka/orders'
+      );
+
+      const paymentsKafkaSpan = serializedProducerEvents.find(
+        (event) =>
+          event['processor.event'] === 'span' && event['span.name'] === 'Publish to kafka/payments'
+      );
+
+      // Create span.links from Kafka spans to consumer transactions (inbound links)
+      const ordersKafkaSpanLink =
+        ordersKafkaSpan && ordersKafkaSpan['span.id']
+          ? [
+              {
+                trace: { id: ordersKafkaSpan['trace.id']! },
+                span: { id: ordersKafkaSpan['span.id']! },
+              },
+            ]
+          : [];
+
+      const paymentsKafkaSpanLink =
+        paymentsKafkaSpan && paymentsKafkaSpan['span.id']
+          ? [
+              {
+                trace: { id: paymentsKafkaSpan['trace.id']! },
+                span: { id: paymentsKafkaSpan['span.id']! },
+              },
+            ]
+          : [];
+
+      // Create unserialized producer events
+      const unserializedProducerEvents = serializedProducerEvents.map((event) => ({
+        fields: event,
+        serialize: () => [event],
+      })) as Array<Serializable<ApmFields>>;
+
+      // NOW generate consumer transactions with inbound span.links to producer Kafka spans
+      const orderProcessorEvents = timestamps.generator((timestamp) =>
+        orderProcessorService
+          .transaction({ transactionName: 'Process Order from Kafka' })
+          .timestamp(timestamp + 300)
+          .duration(120)
+          .defaults({
+            'span.links': ordersKafkaSpanLink,
+          })
+          .success()
+          .children(
+            orderProcessorService
+              .span({
+                spanName: 'Receive from kafka/orders',
+                spanType: 'messaging',
+                spanSubtype: 'kafka',
+                'service.target.type': 'kafka',
+                'service.target.name': 'orders',
+                'span.destination.service.resource': 'kafka/orders',
+              })
+              .duration(20)
+              .success()
+              .timestamp(timestamp + 305)
+          )
+      );
+
+      const paymentProcessorEvents = timestamps.generator((timestamp) =>
+        paymentProcessorService
+          .transaction({ transactionName: 'Process Payment from Kafka' })
+          .timestamp(timestamp + 350)
+          .duration(100)
+          .defaults({
+            'span.links': paymentsKafkaSpanLink,
+          })
+          .success()
+          .children(
+            paymentProcessorService
+              .span({
+                spanName: 'Receive from kafka/payments',
+                spanType: 'messaging',
+                spanSubtype: 'kafka',
+                'service.target.type': 'kafka',
+                'service.target.name': 'payments',
+                'span.destination.service.resource': 'kafka/payments',
+              })
+              .duration(20)
+              .success()
+              .timestamp(timestamp + 355)
+          )
+      );
+
+      const serializedOrderProcessorEvents = Array.from(orderProcessorEvents).flatMap((event) =>
+        event.serialize()
+      );
+
+      const serializedPaymentProcessorEvents = Array.from(paymentProcessorEvents).flatMap((event) =>
+        event.serialize()
+      );
+
+      // Create unserialized wrappers for consumer events
+      const unserializedOrderProcessorEvents = serializedOrderProcessorEvents.map((event) => ({
+        fields: event,
+        serialize: () => [event],
+      })) as Array<Serializable<ApmFields>>;
+
+      const unserializedPaymentProcessorEvents = serializedPaymentProcessorEvents.map((event) => ({
+        fields: event,
+        serialize: () => [event],
+      })) as Array<Serializable<ApmFields>>;
+
+      // Generate other service events
+      const otherEvents = timestamps.generator((timestamp) => [
+        // API service that calls the producer
+        apiService
+          .transaction({ transactionName: 'POST /api/events' })
+          .timestamp(timestamp)
+          .duration(100)
+          .success()
+          .children(
+            apiService
+              .span({
+                spanName: 'Call Producer',
+                spanType: 'external',
+                spanSubtype: 'http',
+              })
+              .destination('kafka-producer:3000')
+              .timestamp(timestamp)
+              .duration(80)
+              .success()
+          ),
+
+        // Kafka consumer service that reads from orders topic
+        consumerService
+          .transaction({ transactionName: 'consume kafka/orders' })
+          .timestamp(timestamp + 500)
+          .duration(150)
+          .success()
+          .children(
+            // Read from orders topic
+            consumerService
+              .span({
+                spanName: 'Consume from kafka/orders',
+                spanType: 'messaging',
+                spanSubtype: 'kafka',
+                'service.target.type': 'kafka',
+                'service.target.name': 'orders',
+                'span.destination.service.resource': 'kafka/orders',
+              })
+              .duration(20)
+              .success()
+              .timestamp(timestamp + 510),
+
+            // Process the message
+            consumerService
+              .span({
+                spanName: 'Process order',
+                spanType: 'app',
+                spanSubtype: 'internal',
+              })
+              .duration(100)
+              .success()
+              .timestamp(timestamp + 540)
+          ),
+      ]);
+
+      const serializedOtherEvents = Array.from(otherEvents).flatMap((event) => event.serialize());
+
+      const unserializedOtherEvents = serializedOtherEvents.map((event) => ({
+        fields: event,
+        serialize: () => [event],
+      })) as Array<Serializable<ApmFields>>;
+
+      return withClient(
+        apmEsClient,
+        Readable.from([
+          ...unserializedProducerEvents,
+          ...unserializedOrderProcessorEvents,
+          ...unserializedPaymentProcessorEvents,
+          ...unserializedOtherEvents,
+        ])
+      );
+    },
+  };
+};
+
+export default scenario;

--- a/src/platform/packages/shared/kbn-synthtrace/src/scenarios/messaging_systems_mixed.ts
+++ b/src/platform/packages/shared/kbn-synthtrace/src/scenarios/messaging_systems_mixed.ts
@@ -1,0 +1,367 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Mixed Messaging Systems Scenario
+ *
+ * This scenario creates multiple services producing to different messaging systems
+ * to test service map grouping behavior with Kafka, RabbitMQ, and SQS.
+ *
+ * Test cases covered:
+ * 1. kafka-producer → 5 Kafka topics (should group - exceeds minimum of 4)
+ * 2. multi-messaging → 4 Kafka + 4 RabbitMQ + 4 SQS (tests separate grouping by spanSubtype)
+ * 3. rabbitmq-producer → 4 RabbitMQ queues (should group - meets minimum of 4)
+ *
+ * Expected service map:
+ * - kafka-producer → kafka (5 resources) grouped node
+ * - multi-messaging → kafka (4 resources) grouped node
+ * - multi-messaging → rabbitmq (4 resources) grouped node
+ * - multi-messaging → sqs (4 resources) grouped node
+ * - rabbitmq-producer → rabbitmq (4 resources) grouped node
+ *
+ * Run: node scripts/synthtrace messaging_systems_mixed.ts --clean
+ * Then check APM → Service Map
+ */
+
+import type { ApmFields } from '@kbn/synthtrace-client';
+import { apm } from '@kbn/synthtrace-client';
+import type { Scenario } from '../cli/scenario';
+import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
+import { withClient } from '../lib/utils/with_client';
+
+const ENVIRONMENT = getSynthtraceEnvironment(__filename);
+
+const scenario: Scenario<ApmFields> = async () => {
+  return {
+    generate: ({ range, clients: { apmEsClient } }) => {
+      const kafkaProducerService = apm
+        .service({ name: 'kafka-producer', environment: ENVIRONMENT, agentName: 'nodejs' })
+        .instance('kafka-producer-instance');
+
+      const multiMessagingService = apm
+        .service({ name: 'multi-messaging', environment: ENVIRONMENT, agentName: 'java' })
+        .instance('multi-messaging-instance');
+
+      const rabbitmqProducerService = apm
+        .service({ name: 'rabbitmq-producer', environment: ENVIRONMENT, agentName: 'python' })
+        .instance('rabbitmq-producer-instance');
+
+      const successfulTimestamps = range.ratePerMinute(6);
+
+      return withClient(
+        apmEsClient,
+        successfulTimestamps.generator((timestamp) => {
+          return [
+            // Scenario 1: kafka-producer → 5 Kafka topics
+            kafkaProducerService
+              .transaction({ transactionName: 'POST /produce/kafka' })
+              .timestamp(timestamp)
+              .duration(300)
+              .success()
+              .children(
+                kafkaProducerService
+                  .span({
+                    spanName: 'Produce kafka/orders',
+                    spanType: 'messaging',
+                    spanSubtype: 'kafka',
+                    'service.target.type': 'kafka',
+                    'service.target.name': 'orders',
+                    'span.destination.service.resource': 'kafka/orders',
+                  })
+                  .duration(40)
+                  .success()
+                  .timestamp(timestamp + 10),
+
+                kafkaProducerService
+                  .span({
+                    spanName: 'Produce kafka/payments',
+                    spanType: 'messaging',
+                    spanSubtype: 'kafka',
+                    'service.target.type': 'kafka',
+                    'service.target.name': 'payments',
+                    'span.destination.service.resource': 'kafka/payments',
+                  })
+                  .duration(40)
+                  .success()
+                  .timestamp(timestamp + 60),
+
+                kafkaProducerService
+                  .span({
+                    spanName: 'Produce kafka/inventory',
+                    spanType: 'messaging',
+                    spanSubtype: 'kafka',
+                    'service.target.type': 'kafka',
+                    'service.target.name': 'inventory',
+                    'span.destination.service.resource': 'kafka/inventory',
+                  })
+                  .duration(40)
+                  .success()
+                  .timestamp(timestamp + 110),
+
+                kafkaProducerService
+                  .span({
+                    spanName: 'Produce kafka/notifications',
+                    spanType: 'messaging',
+                    spanSubtype: 'kafka',
+                    'service.target.type': 'kafka',
+                    'service.target.name': 'notifications',
+                    'span.destination.service.resource': 'kafka/notifications',
+                  })
+                  .duration(40)
+                  .success()
+                  .timestamp(timestamp + 160),
+
+                kafkaProducerService
+                  .span({
+                    spanName: 'Produce kafka/analytics',
+                    spanType: 'messaging',
+                    spanSubtype: 'kafka',
+                    'service.target.type': 'kafka',
+                    'service.target.name': 'analytics',
+                    'span.destination.service.resource': 'kafka/analytics',
+                  })
+                  .duration(40)
+                  .success()
+                  .timestamp(timestamp + 210)
+              ),
+
+            // Scenario 2: multi-messaging → 4 Kafka + 4 RabbitMQ + 4 SQS (tests separate grouping)
+            multiMessagingService
+              .transaction({ transactionName: 'POST /produce/mixed' })
+              .timestamp(timestamp)
+              .duration(600)
+              .success()
+              .children(
+                // Kafka (4 resources)
+                multiMessagingService
+                  .span({
+                    spanName: 'Produce kafka/events',
+                    spanType: 'messaging',
+                    spanSubtype: 'kafka',
+                    'service.target.type': 'kafka',
+                    'service.target.name': 'events',
+                    'span.destination.service.resource': 'kafka/events',
+                  })
+                  .duration(40)
+                  .success()
+                  .timestamp(timestamp + 10),
+
+                multiMessagingService
+                  .span({
+                    spanName: 'Produce kafka/metrics',
+                    spanType: 'messaging',
+                    spanSubtype: 'kafka',
+                    'service.target.type': 'kafka',
+                    'service.target.name': 'metrics',
+                    'span.destination.service.resource': 'kafka/metrics',
+                  })
+                  .duration(40)
+                  .success()
+                  .timestamp(timestamp + 60),
+
+                multiMessagingService
+                  .span({
+                    spanName: 'Produce kafka/traces',
+                    spanType: 'messaging',
+                    spanSubtype: 'kafka',
+                    'service.target.type': 'kafka',
+                    'service.target.name': 'traces',
+                    'span.destination.service.resource': 'kafka/traces',
+                  })
+                  .duration(40)
+                  .success()
+                  .timestamp(timestamp + 110),
+
+                multiMessagingService
+                  .span({
+                    spanName: 'Produce kafka/logs',
+                    spanType: 'messaging',
+                    spanSubtype: 'kafka',
+                    'service.target.type': 'kafka',
+                    'service.target.name': 'logs',
+                    'span.destination.service.resource': 'kafka/logs',
+                  })
+                  .duration(40)
+                  .success()
+                  .timestamp(timestamp + 160),
+
+                // RabbitMQ (4 resources)
+                multiMessagingService
+                  .span({
+                    spanName: 'Publish rabbitmq/tasks',
+                    spanType: 'messaging',
+                    spanSubtype: 'rabbitmq',
+                    'service.target.type': 'rabbitmq',
+                    'service.target.name': 'tasks',
+                    'span.destination.service.resource': 'rabbitmq/tasks',
+                  })
+                  .duration(30)
+                  .success()
+                  .timestamp(timestamp + 210),
+
+                multiMessagingService
+                  .span({
+                    spanName: 'Publish rabbitmq/emails',
+                    spanType: 'messaging',
+                    spanSubtype: 'rabbitmq',
+                    'service.target.type': 'rabbitmq',
+                    'service.target.name': 'emails',
+                    'span.destination.service.resource': 'rabbitmq/emails',
+                  })
+                  .duration(30)
+                  .success()
+                  .timestamp(timestamp + 250),
+
+                multiMessagingService
+                  .span({
+                    spanName: 'Publish rabbitmq/notifications',
+                    spanType: 'messaging',
+                    spanSubtype: 'rabbitmq',
+                    'service.target.type': 'rabbitmq',
+                    'service.target.name': 'notifications',
+                    'span.destination.service.resource': 'rabbitmq/notifications',
+                  })
+                  .duration(30)
+                  .success()
+                  .timestamp(timestamp + 290),
+
+                multiMessagingService
+                  .span({
+                    spanName: 'Publish rabbitmq/reports',
+                    spanType: 'messaging',
+                    spanSubtype: 'rabbitmq',
+                    'service.target.type': 'rabbitmq',
+                    'service.target.name': 'reports',
+                    'span.destination.service.resource': 'rabbitmq/reports',
+                  })
+                  .duration(30)
+                  .success()
+                  .timestamp(timestamp + 330),
+
+                // SQS (4 resources)
+                multiMessagingService
+                  .span({
+                    spanName: 'Send sqs/alerts',
+                    spanType: 'messaging',
+                    spanSubtype: 'sqs',
+                    'service.target.type': 'sqs',
+                    'service.target.name': 'alerts',
+                    'span.destination.service.resource': 'sqs/alerts',
+                  })
+                  .duration(50)
+                  .success()
+                  .timestamp(timestamp + 370),
+
+                multiMessagingService
+                  .span({
+                    spanName: 'Send sqs/logs',
+                    spanType: 'messaging',
+                    spanSubtype: 'sqs',
+                    'service.target.type': 'sqs',
+                    'service.target.name': 'logs',
+                    'span.destination.service.resource': 'sqs/logs',
+                  })
+                  .duration(50)
+                  .success()
+                  .timestamp(timestamp + 430),
+
+                multiMessagingService
+                  .span({
+                    spanName: 'Send sqs/backups',
+                    spanType: 'messaging',
+                    spanSubtype: 'sqs',
+                    'service.target.type': 'sqs',
+                    'service.target.name': 'backups',
+                    'span.destination.service.resource': 'sqs/backups',
+                  })
+                  .duration(50)
+                  .success()
+                  .timestamp(timestamp + 490),
+
+                multiMessagingService
+                  .span({
+                    spanName: 'Send sqs/archives',
+                    spanType: 'messaging',
+                    spanSubtype: 'sqs',
+                    'service.target.type': 'sqs',
+                    'service.target.name': 'archives',
+                    'span.destination.service.resource': 'sqs/archives',
+                  })
+                  .duration(50)
+                  .success()
+                  .timestamp(timestamp + 550)
+              ),
+
+            // Scenario 3: rabbitmq-producer → 4 RabbitMQ queues
+            rabbitmqProducerService
+              .transaction({ transactionName: 'POST /produce/rabbitmq' })
+              .timestamp(timestamp)
+              .duration(250)
+              .success()
+              .children(
+                rabbitmqProducerService
+                  .span({
+                    spanName: 'Publish rabbitmq/orders',
+                    spanType: 'messaging',
+                    spanSubtype: 'rabbitmq',
+                    'service.target.type': 'rabbitmq',
+                    'service.target.name': 'orders',
+                    'span.destination.service.resource': 'rabbitmq/orders',
+                  })
+                  .duration(30)
+                  .success()
+                  .timestamp(timestamp + 10),
+
+                rabbitmqProducerService
+                  .span({
+                    spanName: 'Publish rabbitmq/shipping',
+                    spanType: 'messaging',
+                    spanSubtype: 'rabbitmq',
+                    'service.target.type': 'rabbitmq',
+                    'service.target.name': 'shipping',
+                    'span.destination.service.resource': 'rabbitmq/shipping',
+                  })
+                  .duration(30)
+                  .success()
+                  .timestamp(timestamp + 50),
+
+                rabbitmqProducerService
+                  .span({
+                    spanName: 'Publish rabbitmq/returns',
+                    spanType: 'messaging',
+                    spanSubtype: 'rabbitmq',
+                    'service.target.type': 'rabbitmq',
+                    'service.target.name': 'returns',
+                    'span.destination.service.resource': 'rabbitmq/returns',
+                  })
+                  .duration(30)
+                  .success()
+                  .timestamp(timestamp + 90),
+
+                rabbitmqProducerService
+                  .span({
+                    spanName: 'Publish rabbitmq/inventory',
+                    spanType: 'messaging',
+                    spanSubtype: 'rabbitmq',
+                    'service.target.type': 'rabbitmq',
+                    'service.target.name': 'inventory',
+                    'span.destination.service.resource': 'rabbitmq/inventory',
+                  })
+                  .duration(30)
+                  .success()
+                  .timestamp(timestamp + 130)
+              ),
+          ];
+        })
+      );
+    },
+  };
+};
+
+export default scenario;


### PR DESCRIPTION
## Summary

Adds two new synthtrace scenarios to test service map span grouping functionality with messaging systems (Kafka, RabbitMQ, and SQS).

These scenarios specifically test the service map's span grouping feature, which automatically collapses 4+ external resources (messaging queues, topics, etc.) with identical upstream services into a single grouped node. This reduces visual clutter in the service map when dealing with microservices that connect to many similar resources.

## Files Added

### 📄 `src/platform/packages/shared/kbn-synthtrace/src/scenarios/kafka_topics.ts`
A scenario that generates APM data for testing Kafka topic grouping with multiple consumer patterns.

**Usage:**
`node scripts/synthtrace kafka_topics --clean`

### 📄 `src/platform/packages/shared/kbn-synthtrace/src/scenarios/messaging_systems_mixed.ts`
A comprehensive scenario testing grouping behavior across different messaging system types.

**Usage:**
`node scripts/synthtrace messaging_systems_mixed --clean
`
