### PR TITLE
[Unified Rules] Update "Manage rules" link in Monitoring UI

### DIFF
--- a/x-pack/platform/plugins/private/monitoring/public/alerts/alerts_dropdown.tsx
+++ b/x-pack/platform/plugins/private/monitoring/public/alerts/alerts_dropdown.tsx
@@ -14,11 +14,13 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { MonitoringStartServices } from '../types';
 import { useAlertsModal } from '../application/hooks/use_alerts_modal';
 import { WatcherMigrationStep } from './enable_alerts_modal';
-
 export const AlertsDropdown: React.FC<{}> = () => {
   const [shouldShowModal, setShouldShowModal] = useState(false);
   const alertsEnableModalProvider = useAlertsModal();
-  const { navigateToApp } = useKibana<MonitoringStartServices>().services.application;
+  const { navigateToApp, isAppRegistered } =
+    useKibana<MonitoringStartServices>().services.application;
+
+  const unifiedRulesPageEnabled = isAppRegistered('rules');
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
@@ -65,7 +67,10 @@ export const AlertsDropdown: React.FC<{}> = () => {
         defaultMessage: 'Manage rules',
       }),
       icon: 'tableOfContents',
-      onClick: () => navigateToApp('rules'),
+      onClick: () =>
+        unifiedRulesPageEnabled
+          ? navigateToApp('rules')
+          : navigateToApp('management', { path: '/insightsAndAlerting/triggersActions/rules' }),
     },
   ];
 

--- a/x-pack/platform/plugins/private/monitoring/public/alerts/alerts_dropdown.tsx
+++ b/x-pack/platform/plugins/private/monitoring/public/alerts/alerts_dropdown.tsx
@@ -65,8 +65,7 @@ export const AlertsDropdown: React.FC<{}> = () => {
         defaultMessage: 'Manage rules',
       }),
       icon: 'tableOfContents',
-      onClick: () =>
-        navigateToApp('management', { path: '/insightsAndAlerting/triggersActions/rules' }),
+      onClick: () => navigateToApp('rules'),
     },
   ];
 


### PR DESCRIPTION
## Summary

Closes #239940

Updates the "Manage rules" link in the Monitoring application's Alerts dropdown to conditionally navigate to the new unified rule management page (`/app/rules`) when the unifiedRulesPage feature flag is enabled, with automatic fallback to the Stack Management URL when the feature flag is disabled.

## 🔬Testing

To test this change:
1. Enable the feature flag: `xpack.trigger_actions_ui.enableExperimental: ['unifiedRulesPage']`
2. Navigate to the Monitoring application
3. Click the "Alerts and rules" dropdown
4. Click "Manage rules"
5. Verify navigation goes to `/app/rules`