### PR TITLE
Fix monitoring breadcrumbs for solution view

### DIFF
--- a/x-pack/platform/plugins/private/monitoring/public/application/hooks/use_breadcrumbs.ts
+++ b/x-pack/platform/plugins/private/monitoring/public/application/hooks/use_breadcrumbs.ts
@@ -267,7 +267,13 @@ export const useBreadcrumbs = ({ history }: { history: History }) => {
         }
         delete breadcrumb.ignoreGlobalState;
       });
-      chrome.setBreadcrumbs(bcrumbs.slice(0));
+      bcrumbs = bcrumbs.slice(0);
+      // set the breadcrumbs for both classic and project navigation
+      chrome.setBreadcrumbs(bcrumbs, {
+        project: {
+          value: bcrumbs,
+        },
+      });
     },
     [chrome]
   );


### PR DESCRIPTION
## Summary

Fixes monitoring app breadcrumbs display when in solution view

<img width="2027" height="1081" alt="Screenshot 2026-01-20 at 17 03 46" src="https://github.com/user-attachments/assets/445f5489-002a-45c0-8b62-ea0df0cae3a0" />




<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->