### PR TITLE
[Discover][Traces] Remove custom top style for doc details

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/moon.yml
+++ b/src/platform/plugins/shared/unified_doc_viewer/moon.yml
@@ -63,7 +63,6 @@ dependsOn:
   - '@kbn/esql-composer'
   - '@kbn/deeplinks-analytics'
   - '@kbn/lens-embeddable-utils'
-  - '@kbn/core-chrome-layout-constants'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/waterfall_flyout/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/waterfall_flyout/index.tsx
@@ -22,7 +22,6 @@ import {
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
 import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
-import { layoutVar } from '@kbn/core-chrome-layout-constants';
 import { css } from '@emotion/react';
 import React, { useState } from 'react';
 import DocViewerSource from '../../../../../doc_viewer_source';
@@ -100,7 +99,6 @@ export function WaterfallFlyout({
       // TODO: Remove this once we migrate to the new flyout system: https://github.com/elastic/observability-dev/issues/4980
       css={css`
         z-index: ${(euiTheme.levels.mask as number) + 1} !important;
-        margin-top: calc(-1 * ${layoutVar('header.height', '0px')});
       `}
       onClose={onCloseFlyout}
       aria-labelledby={flyoutId}

--- a/src/platform/plugins/shared/unified_doc_viewer/tsconfig.json
+++ b/src/platform/plugins/shared/unified_doc_viewer/tsconfig.json
@@ -56,8 +56,7 @@
     "@kbn/storybook",
     "@kbn/esql-composer",
     "@kbn/deeplinks-analytics",
-    "@kbn/lens-embeddable-utils",
-    "@kbn/core-chrome-layout-constants"
+    "@kbn/lens-embeddable-utils"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/249732

A custom fix introduced in [this PR](https://github.com/elastic/kibana/pull/244983) is no longer needed for the span/transaction/log details flyout to be positioned correctly. In fact, it’s now causing the flyout to be positioned incorrectly.

Checked if the change was needed in 9.3.0 and it is, so backporting.

|Before|After|
|-|-|
|<img width="1463" height="969" alt="Screenshot 2026-01-20 at 16 10 52" src="https://github.com/user-attachments/assets/bc8b2821-39e1-4553-b98a-28cd25ca9827" />|<img width="1464" height="968" alt="Screenshot 2026-01-20 at 16 04 43" src="https://github.com/user-attachments/assets/95e84a2d-46e1-48af-84fa-38d2977e7144" />|





<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->