### PR TITLE
Upgrading tar from 7.5.2.to 7.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1447,7 +1447,7 @@
     "suricata-sid-db": "1.0.2",
     "swr": "2.3.3",
     "symbol-observable": "4.0.0",
-    "tar": "7.5.2",
+    "tar": "7.5.4",
     "textarea-caret": "3.1.0",
     "tree-dump": "1.1.0",
     "ts-easing": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32676,10 +32676,10 @@ tar-stream@^3.0.0, tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@7.5.2:
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.2.tgz#115c061495ec51ff3c6745ff8f6d0871c5b1dedc"
-  integrity sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==
+tar@7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.4.tgz#18b53b44f939a7e03ed874f1fafe17d29e306c81"
+  integrity sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
## Summary

Upgrading `tar` from `v7.5.2` to `v7.5.4`



<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->