### PR TITLE
[One Management] Update "Manage rules and connectors" link in Discover

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.test.tsx
@@ -20,6 +20,12 @@ import { dataViewWithNoTimefieldMock } from '../../../../../__mocks__/data_view_
 import { getDiscoverStateMock } from '../../../../../__mocks__/discover_state.mock';
 import type { AppMenuExtensionParams } from '../../../../../context_awareness';
 
+const mockGetIsExperimentalFeatureEnabled = jest.fn().mockReturnValue(false);
+
+jest.mock('@kbn/triggers-actions-ui-plugin/public', () => ({
+  getIsExperimentalFeatureEnabled: mockGetIsExperimentalFeatureEnabled,
+}));
+
 const mount = (
   dataView = dataViewMock,
   isEsqlMode = false,
@@ -107,6 +113,28 @@ describe('OpenAlertsPopover', () => {
     it('should render the manage rules and connectors link', () => {
       const component = mount();
       expect(findTestSubject(component, 'discoverManageAlertsButton').exists()).toBeTruthy();
+    });
+  });
+
+  describe('Manage rules and connectors link', () => {
+    beforeEach(() => {
+      mockGetIsExperimentalFeatureEnabled.mockClear();
+    });
+
+    it('should link to the unified rules page when unifiedRulesPage feature flag is enabled', () => {
+      mockGetIsExperimentalFeatureEnabled.mockReturnValue(true);
+      const component = mount();
+      const manageButton = findTestSubject(component, 'discoverManageAlertsButton');
+      expect(manageButton.prop('href')).toContain('/app/rules');
+    });
+
+    it('should link to the management page when unifiedRulesPage feature flag is disabled', () => {
+      mockGetIsExperimentalFeatureEnabled.mockReturnValue(false);
+      const component = mount();
+      const manageButton = findTestSubject(component, 'discoverManageAlertsButton');
+      expect(manageButton.prop('href')).toContain(
+        '/app/management/insightsAndAlerting/triggersActions/rules'
+      );
     });
   });
 });

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.test.tsx
@@ -20,12 +20,6 @@ import { dataViewWithNoTimefieldMock } from '../../../../../__mocks__/data_view_
 import { getDiscoverStateMock } from '../../../../../__mocks__/discover_state.mock';
 import type { AppMenuExtensionParams } from '../../../../../context_awareness';
 
-const mockGetIsExperimentalFeatureEnabled = jest.fn().mockReturnValue(false);
-
-jest.mock('@kbn/triggers-actions-ui-plugin/public', () => ({
-  getIsExperimentalFeatureEnabled: mockGetIsExperimentalFeatureEnabled,
-}));
-
 const mount = (
   dataView = dataViewMock,
   isEsqlMode = false,
@@ -117,19 +111,15 @@ describe('OpenAlertsPopover', () => {
   });
 
   describe('Manage rules and connectors link', () => {
-    beforeEach(() => {
-      mockGetIsExperimentalFeatureEnabled.mockClear();
-    });
-
-    it('should link to the unified rules page when unifiedRulesPage feature flag is enabled', () => {
-      mockGetIsExperimentalFeatureEnabled.mockReturnValue(true);
+    it('should link to the unified rules page when rules app is registered', () => {
+      (discoverServiceMock.application.isAppRegistered as jest.Mock).mockReturnValue(true);
       const component = mount();
       const manageButton = findTestSubject(component, 'discoverManageAlertsButton');
       expect(manageButton.prop('href')).toContain('/app/rules');
     });
 
-    it('should link to the management page when unifiedRulesPage feature flag is disabled', () => {
-      mockGetIsExperimentalFeatureEnabled.mockReturnValue(false);
+    it('should link to the management page when rules app is not registered', () => {
+      (discoverServiceMock.application.isAppRegistered as jest.Mock).mockReturnValue(false);
       const component = mount();
       const manageButton = findTestSubject(component, 'discoverManageAlertsButton');
       expect(manageButton.prop('href')).toContain(

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.test.tsx
@@ -113,6 +113,9 @@ describe('OpenAlertsPopover', () => {
   describe('Manage rules and connectors link', () => {
     it('should link to the unified rules page when rules app is registered', () => {
       (discoverServiceMock.application.isAppRegistered as jest.Mock).mockReturnValue(true);
+      (discoverServiceMock.application.getUrlForApp as jest.Mock).mockImplementation(
+        (appId: string) => `/app/${appId}`
+      );
       const component = mount();
       const manageButton = findTestSubject(component, 'discoverManageAlertsButton');
       expect(manageButton.prop('href')).toContain('/app/rules');
@@ -120,6 +123,9 @@ describe('OpenAlertsPopover', () => {
 
     it('should link to the management page when rules app is not registered', () => {
       (discoverServiceMock.application.isAppRegistered as jest.Mock).mockReturnValue(false);
+      (discoverServiceMock.application.getUrlForApp as jest.Mock).mockImplementation(
+        (appId: string) => `/app/${appId}`
+      );
       const component = mount();
       const manageButton = findTestSubject(component, 'discoverManageAlertsButton');
       expect(manageButton.prop('href')).toContain(

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.tsx
@@ -20,7 +20,6 @@ import { AlertConsumers, ES_QUERY_ID, STACK_ALERTS_FEATURE_ID } from '@kbn/rule-
 import type { RuleTypeMetaData } from '@kbn/alerting-plugin/common';
 import { RuleFormFlyout } from '@kbn/response-ops-rule-form/flyout';
 import { isValidRuleFormPlugins } from '@kbn/response-ops-rule-form/lib';
-import { getIsExperimentalFeatureEnabled } from '@kbn/triggers-actions-ui-plugin/public';
 import type { DiscoverStateContainer } from '../../../state_management/discover_state';
 import type { AppMenuDiscoverParams } from './types';
 import type { DiscoverServices } from '../../../../../build_services';
@@ -187,7 +186,7 @@ export const getAlertsAppMenuItem = ({
               iconType: 'tableOfContents',
               testId: 'discoverManageAlertsButton',
               href: services.application.getUrlForApp(
-                getIsExperimentalFeatureEnabled('unifiedRulesPage')
+                services.application.isAppRegistered?.('rules')
                   ? 'rules'
                   : 'management/insightsAndAlerting/triggersActions/rules'
               ),

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.tsx
@@ -20,6 +20,7 @@ import { AlertConsumers, ES_QUERY_ID, STACK_ALERTS_FEATURE_ID } from '@kbn/rule-
 import type { RuleTypeMetaData } from '@kbn/alerting-plugin/common';
 import { RuleFormFlyout } from '@kbn/response-ops-rule-form/flyout';
 import { isValidRuleFormPlugins } from '@kbn/response-ops-rule-form/lib';
+import { getIsExperimentalFeatureEnabled } from '@kbn/triggers-actions-ui-plugin/public';
 import type { DiscoverStateContainer } from '../../../state_management/discover_state';
 import type { AppMenuDiscoverParams } from './types';
 import type { DiscoverServices } from '../../../../../build_services';
@@ -186,7 +187,9 @@ export const getAlertsAppMenuItem = ({
               iconType: 'tableOfContents',
               testId: 'discoverManageAlertsButton',
               href: services.application.getUrlForApp(
-                'management/insightsAndAlerting/triggersActions/rules'
+                getIsExperimentalFeatureEnabled('unifiedRulesPage')
+                  ? 'rules'
+                  : 'management/insightsAndAlerting/triggersActions/rules'
               ),
               onClick: undefined,
             },

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_alerts.tsx
@@ -186,7 +186,7 @@ export const getAlertsAppMenuItem = ({
               iconType: 'tableOfContents',
               testId: 'discoverManageAlertsButton',
               href: services.application.getUrlForApp(
-                services.application.isAppRegistered?.('rules')
+                services.application.isAppRegistered('rules')
                   ? 'rules'
                   : 'management/insightsAndAlerting/triggersActions/rules'
               ),

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/index.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/index.ts
@@ -126,3 +126,5 @@ export { transformRule } from './application/lib/rule_api/common_transformations
 export { validateActionFilterQuery } from './application/lib/value_validators';
 
 export { RULE_PREBUILD_DESCRIPTION_FIELDS } from './application/sections/rule_details/components/rule_detail_description_type';
+
+export { getIsExperimentalFeatureEnabled } from './common/get_experimental_features';

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/index.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/index.ts
@@ -126,5 +126,3 @@ export { transformRule } from './application/lib/rule_api/common_transformations
 export { validateActionFilterQuery } from './application/lib/value_validators';
 
 export { RULE_PREBUILD_DESCRIPTION_FIELDS } from './application/sections/rule_details/components/rule_detail_description_type';
-
-export { getIsExperimentalFeatureEnabled } from './common/get_experimental_features';


### PR DESCRIPTION
Resolves #239936 

Updates the "Manage rules and connectors" link in Discover, in Alerts dropdown to navigate to the new unified rule management page (/app/rules) instead of the Stack Management URL.

**Changes**

- Updated the href logic to conditionally use either:
  1. '`rules`' when `isAppRegistered ` contains 'rules'
  2. '`management/insightsAndAlerting/triggersActions/rules`' when it's disabled
  
**Testing**

To test this change:

1. Enable the feature flag: `xpack.trigger_actions_ui.enableExperimental: ['unifiedRulesPage']`
2. Navigate to the Discover
3. Click the "Alerts" dropdown
4. Click "Manage rules and connectors"
5. Verify navigation goes to `/app/rules`