### PR TITLE
[Security solution][Detections] Refactor `groupTakeActionItems` prop to use React components

### DIFF
--- a/src/platform/packages/shared/kbn-grouping/src/components/accordion_panel/group_stats.test.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/accordion_panel/group_stats.test.tsx
@@ -10,10 +10,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { GroupStats } from './group_stats';
-import type {
-  EuiContextMenuPanelDescriptor,
-  EuiContextMenuPanelItemDescriptor,
-} from '@elastic/eui';
+import { EuiContextMenu } from '@elastic/eui';
 
 const onTakeActionsOpen = jest.fn();
 const testProps = {
@@ -30,13 +27,20 @@ const testProps = {
     { title: 'Rules:', badge: { value: 2 } },
     { title: 'Alerts:', badge: { value: 2, width: 50, color: '#a83632' } },
   ],
-  takeActionItems: () => ({
-    items: [
-      { key: '1', 'data-test-subj': 'takeActionItem-1' },
-      { key: '2', 'data-test-subj': 'takeActionItem-2' },
-    ] as EuiContextMenuPanelItemDescriptor[],
-    panels: [] as EuiContextMenuPanelDescriptor[],
-  }),
+  takeActionItems: () => (
+    <EuiContextMenu
+      initialPanelId={0}
+      panels={[
+        {
+          id: 0,
+          items: [
+            { key: '1', 'data-test-subj': 'takeActionItem-1', name: '1' },
+            { key: '2', 'data-test-subj': 'takeActionItem-2', name: '2' },
+          ],
+        },
+      ]}
+    />
+  ),
 };
 describe('Group stats', () => {
   beforeEach(() => {
@@ -78,16 +82,24 @@ describe('Group stats', () => {
     const { queryByTestId } = render(
       <GroupStats
         {...testProps}
-        takeActionItems={() => ({ items: [{ name: 'test' }], panels: [] })}
+        takeActionItems={() => (
+          <EuiContextMenu
+            initialPanelId={0}
+            panels={[
+              {
+                id: 0,
+                items: [{ name: 'test' }],
+              },
+            ]}
+          />
+        )}
       />
     );
     expect(queryByTestId('take-action-button')).toBeInTheDocument();
   });
 
   it('hides the Take Actions menu when no action item is provided', () => {
-    const { queryByTestId } = render(
-      <GroupStats {...testProps} takeActionItems={() => ({ items: [], panels: [] })} />
-    );
+    const { queryByTestId } = render(<GroupStats {...testProps} takeActionItems={undefined} />);
     expect(queryByTestId('take-action-button')).not.toBeInTheDocument();
   });
 });

--- a/src/platform/packages/shared/kbn-grouping/src/components/accordion_panel/group_stats.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/accordion_panel/group_stats.tsx
@@ -7,10 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type {
-  EuiContextMenuPanelDescriptor,
-  EuiContextMenuPanelItemDescriptor,
-} from '@elastic/eui';
 import {
   EuiBadge,
   EuiButtonEmpty,
@@ -20,7 +16,6 @@ import {
   EuiToolTip,
   useEuiTheme,
   useEuiFontSize,
-  EuiContextMenu,
 } from '@elastic/eui';
 import React, { Fragment, useCallback, useMemo, useState } from 'react';
 import type { Filter } from '@kbn/es-query';
@@ -34,13 +29,7 @@ interface GroupStatsProps<T> {
   groupNumber: number;
   onTakeActionsOpen?: () => void;
   stats?: GroupStatsItem[];
-  takeActionItems?: (
-    groupFilters: Filter[],
-    groupNumber: number
-  ) => {
-    items: EuiContextMenuPanelItemDescriptor[];
-    panels: EuiContextMenuPanelDescriptor[];
-  };
+  takeActionItems?: (groupFilters: Filter[], groupNumber: number) => JSX.Element | undefined;
   /** Optional array of additional action buttons to display before the Take actions button */
   additionalActionButtons?: React.ReactElement[];
 }
@@ -73,20 +62,9 @@ const GroupStatsComponent = <T,>({
   const xsFontSize = useEuiFontSize('xs').fontSize;
 
   const [isPopoverOpen, setPopover] = useState(false);
-  const { items: takeActionItems, panels: takeActionPanels } = useMemo(() => {
-    return getTakeActionItems?.(groupFilter, groupNumber) ?? { items: [], panels: [] };
+  const takeActionItems = useMemo(() => {
+    return getTakeActionItems?.(groupFilter, groupNumber);
   }, [getTakeActionItems, groupFilter, groupNumber]);
-
-  const panels = useMemo(
-    () => [
-      {
-        id: 0,
-        items: takeActionItems,
-      } as EuiContextMenuPanelDescriptor,
-      ...takeActionPanels,
-    ],
-    [takeActionItems, takeActionPanels]
-  );
 
   const onButtonClick = useCallback(() => {
     return !isPopoverOpen && onTakeActionsOpen ? onTakeActionsOpen() : setPopover(!isPopoverOpen);
@@ -151,7 +129,7 @@ const GroupStatsComponent = <T,>({
 
   const takeActionMenu = useMemo(
     () =>
-      takeActionItems.length ? (
+      takeActionItems ? (
         <EuiFlexItem grow={false}>
           <EuiPopover
             anchorPosition="downLeft"
@@ -169,11 +147,11 @@ const GroupStatsComponent = <T,>({
             isOpen={isPopoverOpen}
             panelPaddingSize="none"
           >
-            <EuiContextMenu panels={panels} initialPanelId={0} />
+            {takeActionItems}
           </EuiPopover>
         </EuiFlexItem>
       ) : null,
-    [isPopoverOpen, onButtonClick, takeActionItems, panels]
+    [isPopoverOpen, onButtonClick, takeActionItems]
   );
 
   return (

--- a/src/platform/packages/shared/kbn-grouping/src/components/grouping.mock.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/grouping.mock.tsx
@@ -7,10 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type {
-  EuiContextMenuPanelDescriptor,
-  EuiContextMenuPanelItemDescriptor,
-} from '@elastic/eui';
+import { EuiContextMenu } from '@elastic/eui';
 import React from 'react';
 
 export const host1Name = 'nice-host';
@@ -135,12 +132,18 @@ export const mockGroupingProps = {
   renderChildComponent: () => <p>{'child component'}</p>,
   onGroupClose: () => {},
   selectedGroup: 'host.name',
-  takeActionItems: () => ({
-    items: [
-      { key: '1', name: 'Mark as acknowledged' },
-      { key: '1', name: 'Mark as closed' },
-    ] as EuiContextMenuPanelItemDescriptor[],
-    panels: [] as EuiContextMenuPanelDescriptor[],
-  }),
+  takeActionItems: () => (
+    <EuiContextMenu
+      panels={[
+        {
+          id: 0,
+          items: [
+            { key: '1', name: 'Mark as acknowledged' },
+            { key: '1', name: 'Mark as closed' },
+          ],
+        },
+      ]}
+    />
+  ),
   tracker: () => {},
 };

--- a/src/platform/packages/shared/kbn-grouping/src/components/grouping.test.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/grouping.test.tsx
@@ -18,6 +18,7 @@ import { getTelemetryEvent } from '../telemetry/const';
 
 import { mockGroupingProps, host1Name, host2Name } from './grouping.mock';
 import type { SetRequired } from 'type-fest';
+import { EuiContextMenu } from '@elastic/eui';
 
 const renderChildComponent = jest.fn();
 const takeActionItems = jest.fn(mockGroupingProps.takeActionItems);
@@ -135,7 +136,17 @@ describe('Grouping', () => {
   });
 
   it('Renders a null group and passes the correct filter to take actions and child component', () => {
-    takeActionItems.mockReturnValue({ items: [{ key: '1', name: '1' }], panels: [] });
+    takeActionItems.mockReturnValue(
+      <EuiContextMenu
+        initialPanelId={0}
+        panels={[
+          {
+            id: 0,
+            items: [{ key: '1', name: '1' }],
+          },
+        ]}
+      />
+    );
     render(
       <I18nProvider>
         <Grouping {...testProps} />

--- a/src/platform/packages/shared/kbn-grouping/src/components/grouping.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/grouping.tsx
@@ -7,10 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type {
-  EuiContextMenuPanelDescriptor,
-  EuiContextMenuPanelItemDescriptor,
-} from '@elastic/eui';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -61,13 +57,7 @@ export interface GroupingProps<T> {
   renderChildComponent: GroupChildComponentRenderer<T>;
   onGroupClose: () => void;
   selectedGroup: string;
-  takeActionItems?: (
-    groupFilters: Filter[],
-    groupNumber: number
-  ) => {
-    items: EuiContextMenuPanelItemDescriptor[];
-    panels: EuiContextMenuPanelDescriptor[];
-  };
+  takeActionItems?: (groupFilters: Filter[], groupNumber: number) => JSX.Element | undefined;
   tracker?: (
     type: UiCounterMetricType,
     event: string | string[],

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/grouping/group_wrapper.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/components/grouping/group_wrapper.tsx
@@ -38,7 +38,6 @@ export const GroupWrapperLoading = <T,>({
         renderChildComponent: () => <></>,
         onGroupClose: () => {},
         selectedGroup: '',
-        takeActionItems: () => ({ items: [], panels: [] }),
       })}
     </div>
   );
@@ -105,7 +104,6 @@ export const GroupWrapper = <T,>({
           onChangeGroupsPage,
           renderChildComponent,
           onGroupClose: () => {},
-          takeActionItems: () => ({ items: [], panels: [] }),
         })}
       </div>
     </div>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_grouping/cloud_security_grouping.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_grouping/cloud_security_grouping.tsx
@@ -49,7 +49,6 @@ export const CloudSecurityGroupingLoading = ({
         renderChildComponent: () => <></>,
         onGroupClose: () => {},
         selectedGroup: '',
-        takeActionItems: () => ({ items: [], panels: [] }),
       })}
     </div>
   );
@@ -113,7 +112,6 @@ export const CloudSecurityGrouping = ({
           onChangeGroupsPage,
           renderChildComponent,
           onGroupClose: () => {},
-          takeActionItems: () => ({ items: [], panels: [] }),
         })}
       </div>
     </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.test.tsx
@@ -200,7 +200,7 @@ describe('GroupedSubLevelComponent', () => {
   });
 
   it('processes groupTakeActionItems correctly', async () => {
-    const groupTakeActionItems = jest.fn(() => ({ items: [], panels: [] }));
+    const groupTakeActionItems = jest.fn(() => undefined);
     render(
       <TestProviders>
         <GroupedSubLevelComponent {...testProps} groupTakeActionItems={groupTakeActionItems} />

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -322,7 +322,7 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
         tableId,
       };
 
-      return groupTakeActionItems?.(takeActionParams) ?? { items: [], panels: [] };
+      return groupTakeActionItems?.(takeActionParams);
     },
     [defaultFilters, getGlobalQuery, groupTakeActionItems, selectedGroup, tableId]
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/types.ts
@@ -10,10 +10,7 @@ import type { Filter } from '@kbn/es-query';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import type { AlertsTablePropsWithRef } from '@kbn/response-ops-alerts-table/types';
 import type { TableId } from '@kbn/securitysolution-data-table';
-import type {
-  EuiContextMenuPanelDescriptor,
-  EuiContextMenuPanelItemDescriptor,
-} from '@elastic/eui';
+import type { EuiContextMenuPanelItemDescriptor } from '@elastic/eui';
 import type { PageScope } from '../../../data_view_manager/constants';
 import type { AlertsUserProfilesData } from '../../configurations/security_solution_detections/fetch_page_context';
 import type { Status } from '../../../../common/api/detection_engine';
@@ -102,7 +99,4 @@ export type GroupTakeActionItems = (props: {
    * Selected group to know which group is extended/visible. This is coming from the getLevel function in the detections alert grouping code.
    */
   selectedGroup: string;
-}) => {
-  items: EuiContextMenuPanelItemDescriptor[];
-  panels: EuiContextMenuPanelDescriptor[];
-};
+}) => JSX.Element | undefined;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alerts_table/use_group_take_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alerts_table/use_group_take_action_items.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { render, renderHook } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../common/mock';
 import { useGroupTakeActionsItems } from './use_group_take_action_items';
@@ -32,7 +32,11 @@ describe('useGroupTakeActionsItems', () => {
         wrapper: wrapperContainer,
       }
     );
-    await waitFor(() => expect(result.current(getActionItemsParams).items.length).toEqual(3));
+
+    const { queryAllByRole } = render(result.current(getActionItemsParams));
+    const buttons = await queryAllByRole('button');
+
+    expect(buttons.length).toBe(3);
   });
 
   it('returns all take actions items if currentStatus is []', async () => {
@@ -46,7 +50,10 @@ describe('useGroupTakeActionsItems', () => {
         wrapper: wrapperContainer,
       }
     );
-    await waitFor(() => expect(result.current(getActionItemsParams).items.length).toEqual(3));
+    const { queryAllByRole } = render(result.current(getActionItemsParams));
+    const buttons = await queryAllByRole('button');
+
+    expect(buttons.length).toBe(3);
   });
 
   it('returns all take actions items if currentStatus.length > 1', async () => {
@@ -60,7 +67,10 @@ describe('useGroupTakeActionsItems', () => {
         wrapper: wrapperContainer,
       }
     );
-    await waitFor(() => expect(result.current(getActionItemsParams).items.length).toEqual(3));
+    const { queryAllByRole } = render(result.current(getActionItemsParams));
+    const buttons = await queryAllByRole('button');
+
+    expect(buttons.length).toBe(3);
   });
 
   it('returns acknowledged & closed take actions items if currentStatus === ["open"]', async () => {
@@ -74,12 +84,13 @@ describe('useGroupTakeActionsItems', () => {
         wrapper: wrapperContainer,
       }
     );
-    await waitFor(() => {
-      const currentParams = result.current(getActionItemsParams);
-      expect(currentParams.items.length).toEqual(2);
-      expect(currentParams.items[0].key).toEqual('acknowledge');
-      expect(currentParams.items[1].key).toEqual('close-alert-with-reason');
-    });
+
+    const { queryAllByRole } = render(result.current(getActionItemsParams));
+    const buttons = await queryAllByRole('button');
+
+    expect(buttons.length).toBe(2);
+    expect(buttons[0].getAttribute('data-test-subj')).toBe('acknowledged-alert-status');
+    expect(buttons[1].getAttribute('data-test-subj')).toBe('alert-close-context-menu-item');
   });
 
   it('returns open & acknowledged take actions items if currentStatus === ["closed"]', async () => {
@@ -93,12 +104,13 @@ describe('useGroupTakeActionsItems', () => {
         wrapper: wrapperContainer,
       }
     );
-    await waitFor(() => {
-      const currentParams = result.current(getActionItemsParams);
-      expect(currentParams.items.length).toEqual(2);
-      expect(currentParams.items[0].key).toEqual('open');
-      expect(currentParams.items[1].key).toEqual('acknowledge');
-    });
+
+    const { queryAllByRole } = render(result.current(getActionItemsParams));
+    const buttons = await queryAllByRole('button');
+
+    expect(buttons.length).toBe(2);
+    expect(buttons[0].getAttribute('data-test-subj')).toBe('open-alert-status');
+    expect(buttons[1].getAttribute('data-test-subj')).toBe('acknowledged-alert-status');
   });
 
   it('returns open & closed take actions items if currentStatus === ["acknowledged"]', async () => {
@@ -112,12 +124,13 @@ describe('useGroupTakeActionsItems', () => {
         wrapper: wrapperContainer,
       }
     );
-    await waitFor(() => {
-      const currentParams = result.current(getActionItemsParams);
-      expect(currentParams.items.length).toEqual(2);
-      expect(currentParams.items[0].key).toEqual('open');
-      expect(currentParams.items[1].key).toEqual('close-alert-with-reason');
-    });
+
+    const { queryAllByRole } = render(result.current(getActionItemsParams));
+    const buttons = await queryAllByRole('button');
+
+    expect(buttons.length).toBe(2);
+    expect(buttons[0].getAttribute('data-test-subj')).toBe('open-alert-status');
+    expect(buttons[1].getAttribute('data-test-subj')).toBe('alert-close-context-menu-item');
   });
 
   it('returns empty take actions items if showAlertStatusActions is false', async () => {
@@ -130,7 +143,10 @@ describe('useGroupTakeActionsItems', () => {
         wrapper: wrapperContainer,
       }
     );
-    await waitFor(() => expect(result.current(getActionItemsParams).items.length).toEqual(0));
+    const { queryAllByRole } = render(result.current(getActionItemsParams));
+    const buttons = await queryAllByRole('button');
+
+    expect(buttons.length).toBe(0);
   });
 
   it('returns array take actions items if showAlertStatusActions is true', async () => {
@@ -143,6 +159,9 @@ describe('useGroupTakeActionsItems', () => {
         wrapper: wrapperContainer,
       }
     );
-    await waitFor(() => expect(result.current(getActionItemsParams).items.length).toEqual(3));
+    const { queryAllByRole } = render(result.current(getActionItemsParams));
+    const buttons = await queryAllByRole('button');
+
+    expect(buttons.length).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

As discussed in #249586 we need to refactor the `groupTakeActionItems` prop of the `kbn-grouping` package to allow the usage of React components instead of passing a static config.

## Status quo 🛑 

The current implementation accepts a function that returns and object with `items` and `panels` properties, compatible with the `EuiContextMenu`, which is what is used under the hood to render the action items.

```tsx

function MyComponent() {
  const groupTakeActionItems = useCallback(() => {
    return {
      items: [
        {
          name: 'My item',
          panel: 1,
        },
      ],
      panels: [
        {
          id: 1,
          items: [
            {
              name: 'Sub-item',
            },
          ],
        },
      ],
    };
  }, []);

  return <GroupedAlertsTable 
    /* ... */
    groupTakeActionItems={groupTakeActionItems} 
  />;
}
```

One key limitation with this, is that we cannot use hooks inside of `groupTakeActionitems`.

## Solution implemented in this PR ✅ 

In this contribution I am changing the signature of the prop in order to return a `JSX.Element` instead of a static config. The example above will now become something like this:
```tsx
function MyComponent() {
  const groupTakeActionItems = useCallback(() => {
    return (
      <EuiContextMenu
        initialPanelId={0}
        panels={[
          {
            id: 0,
            items: [
              {
                name: 'My item',
                panel: 1,
              },
            ],
          },
          {
            id: 1,
            items: [
              {
                name: 'Sub-item',
              },
            ],
          },
        ]}
      />
    );
  }, []);

  return (
    <GroupedAlertsTable
      /* ... */
      groupTakeActionItems={groupTakeActionItems}
    />
  );
}

```