### PR TITLE
[9.1] Upgrading tar from 7.5.2.to 7.5.4 (#249767)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1346,7 +1346,7 @@
     "suricata-sid-db": "^1.0.2",
     "swr": "^2.3.3",
     "symbol-observable": "^4.0.0",
-    "tar": "^7.5.2",
+    "tar": "7.5.4",
     "textarea-caret": "^3.1.0",
     "ts-easing": "^0.2.0",
     "tslib": "^2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -31636,10 +31636,10 @@ tar-stream@^3.0.0, tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@^7.5.2:
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.2.tgz#115c061495ec51ff3c6745ff8f6d0871c5b1dedc"
-  integrity sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==
+tar@7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.4.tgz#18b53b44f939a7e03ed874f1fafe17d29e306c81"
+  integrity sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Upgrading tar from 7.5.2.to 7.5.4 (#249767)](https://github.com/elastic/kibana/pull/249767)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kurt","email":"kc13greiner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-20T20:35:15Z","message":"Upgrading tar from 7.5.2.to 7.5.4 (#249767)\n\n## Summary\n\nUpgrading `tar` from `v7.5.2` to `v7.5.4`","sha":"72fb78fd8396c056cacbe9fdb95f212c12c6b0d0","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:all-open","v9.4.0"],"title":"Upgrading tar from 7.5.2.to 7.5.4","number":249767,"url":"https://github.com/elastic/kibana/pull/249767","mergeCommit":{"message":"Upgrading tar from 7.5.2.to 7.5.4 (#249767)\n\n## Summary\n\nUpgrading `tar` from `v7.5.2` to `v7.5.4`","sha":"72fb78fd8396c056cacbe9fdb95f212c12c6b0d0"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249767","number":249767,"mergeCommit":{"message":"Upgrading tar from 7.5.2.to 7.5.4 (#249767)\n\n## Summary\n\nUpgrading `tar` from `v7.5.2` to `v7.5.4`","sha":"72fb78fd8396c056cacbe9fdb95f212c12c6b0d0"}}]}] BACKPORT-->