### PR TITLE
[Global Search] validate the options.preference request parameter

### DIFF
--- a/x-pack/platform/plugins/shared/global_search/server/routes/find.ts
+++ b/x-pack/platform/plugins/shared/global_search/server/routes/find.ts
@@ -29,7 +29,7 @@ export const registerInternalFindRoute = (router: GlobalSearchRouter) => {
           }),
           options: schema.maybe(
             schema.object({
-              preference: schema.maybe(schema.string()),
+              preference: schema.maybe(schema.string({ maxLength: 64 })),
             })
           ),
         }),

--- a/x-pack/platform/plugins/shared/global_search/server/routes/integration_tests/find.test.ts
+++ b/x-pack/platform/plugins/shared/global_search/server/routes/integration_tests/find.test.ts
@@ -123,6 +123,35 @@ describe('POST /internal/global_search/find', () => {
     );
   });
 
+  it('allows requests with max length options.preference string', async () => {
+    const longPreference = 'a'.repeat(64); // maxLength is 64
+
+    const response = await supertest(server.listener)
+      .post('/internal/global_search/find')
+      .send({ params: { term: 'search' }, options: { preference: longPreference } })
+      .expect(200);
+
+    expect(response.body).toEqual({});
+  });
+
+  it('disallows requests with large options.preference string', async () => {
+    const longPreference = 'a'.repeat(65); // maxLength is 64
+
+    const response = await supertest(server.listener)
+      .post('/internal/global_search/find')
+      .send({ params: { term: 'search' }, options: { preference: longPreference } })
+      .expect(400);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        error: 'Bad Request',
+        message:
+          '[request body.options.preference]: value has length [65] but it must have a maximum length of [64].',
+        statusCode: 400,
+      })
+    );
+  });
+
   it('returns the default error when the observable throws any other error', async () => {
     globalSearchHandlerContext.find.mockReturnValue(throwError('any-error'));
 


### PR DESCRIPTION
## Summary

This PR improves the validation of the Global Search HTTP request handler.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- ~~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~
- ~~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
- ~~[ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
- ~~[ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~~
- [X] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [X] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- [X] The risk for adding validation to the HTTP request parameters for this route is low, since this is an internal route.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->