### PR TITLE
[9.3] [Serverless] Preconfigured Connectors: adds new connectors (#249379)

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -137,6 +137,16 @@ xpack.actions.preconfigured:
       inferenceId: ".gp-llm-v2-chat_completion"
       providerConfig:
         model_id: "gp-llm-v2"
+  Anthropic-Claude-Opus-4-5:
+    name: Anthropic Claude Opus 4.5
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".anthropic-claude-4.5-opus-chat_completion"
+      providerConfig:
+        model_id: "anthropic-claude-4.5-opus"
   OpenAI-GPT-OSS-120B:
     name: OpenAI GPT-OSS 120B
     actionTypeId: .inference
@@ -147,3 +157,103 @@ xpack.actions.preconfigured:
       inferenceId: ".openai-gpt-oss-120b-chat_completion"
       providerConfig:
         model_id: "openai-gpt-oss-120b"
+  OpenAI-GPT-4-1:
+    name: OpenAI GPT-4.1
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-4.1-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-4.1"
+  OpenAI-GPT-4-1-Mini:
+    name: OpenAI GPT-4.1 Mini
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-4.1-mini-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-4.1-mini"
+  OpenAI-GPT-5-2:
+    name: OpenAI GPT-5.2
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.2-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.2"
+  OpenAI-GPT-OSS-20B:
+    name: OpenAI GPT-OSS 20B
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-oss-20b-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-oss-20b"
+  OpenAI-o4:
+    name: OpenAI o4
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-o4-chat_completion"
+      providerConfig:
+        model_id: "openai-o4"
+  OpenAI-o4-Mini:
+    name: OpenAI o4 Mini
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-o4-mini-chat_completion"
+      providerConfig:
+        model_id: "openai-o4-mini"
+  Google-Gemini-2-5-Pro:
+    name: Google Gemini 2.5 Pro
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-2.5-pro-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-2.5-pro"
+  Google-Gemini-2-5-Flash:
+    name: Google Gemini 2.5 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-2.5-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-2.5-flash"
+  Google-Gemini-3-0-Pro:
+    name: Google Gemini 3.0 Pro
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.0-pro-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.0-pro"
+  Google-Gemini-3-0-Flash:
+    name: Google Gemini 3.0 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.0-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.0-flash"

--- a/config/serverless.oblt.complete.yml
+++ b/config/serverless.oblt.complete.yml
@@ -45,6 +45,16 @@ xpack.actions.preconfigured:
       inferenceId: ".gp-llm-v2-chat_completion"
       providerConfig:
         model_id: "gp-llm-v2"
+  Anthropic-Claude-Opus-4-5:
+    name: Anthropic Claude Opus 4.5
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".anthropic-claude-4.5-opus-chat_completion"
+      providerConfig:
+        model_id: "anthropic-claude-4.5-opus"
   OpenAI-GPT-OSS-120B:
     name: OpenAI GPT-OSS 120B
     actionTypeId: .inference
@@ -55,4 +65,103 @@ xpack.actions.preconfigured:
       inferenceId: ".openai-gpt-oss-120b-chat_completion"
       providerConfig:
         model_id: "openai-gpt-oss-120b"
-
+  OpenAI-GPT-4-1:
+    name: OpenAI GPT-4.1
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-4.1-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-4.1"
+  OpenAI-GPT-4-1-Mini:
+    name: OpenAI GPT-4.1 Mini
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-4.1-mini-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-4.1-mini"
+  OpenAI-GPT-5-2:
+    name: OpenAI GPT-5.2
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.2-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.2"
+  OpenAI-GPT-OSS-20B:
+    name: OpenAI GPT-OSS 20B
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-oss-20b-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-oss-20b"
+  OpenAI-o4:
+    name: OpenAI o4
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-o4-chat_completion"
+      providerConfig:
+        model_id: "openai-o4"
+  OpenAI-o4-Mini:
+    name: OpenAI o4 Mini
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-o4-mini-chat_completion"
+      providerConfig:
+        model_id: "openai-o4-mini"
+  Google-Gemini-2-5-Pro:
+    name: Google Gemini 2.5 Pro
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-2.5-pro-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-2.5-pro"
+  Google-Gemini-2-5-Flash:
+    name: Google Gemini 2.5 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-2.5-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-2.5-flash"
+  Google-Gemini-3-0-Pro:
+    name: Google Gemini 3.0 Pro
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.0-pro-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.0-pro"
+  Google-Gemini-3-0-Flash:
+    name: Google Gemini 3.0 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.0-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.0-flash"

--- a/config/serverless.security.complete.yml
+++ b/config/serverless.security.complete.yml
@@ -29,6 +29,16 @@ xpack.actions.preconfigured:
       inferenceId: ".gp-llm-v2-chat_completion"
       providerConfig:
         model_id: "gp-llm-v2"
+  Anthropic-Claude-Opus-4-5:
+    name: Anthropic Claude Opus 4.5
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".anthropic-claude-4.5-opus-chat_completion"
+      providerConfig:
+        model_id: "anthropic-claude-4.5-opus"
   OpenAI-GPT-OSS-120B:
     name: OpenAI GPT-OSS 120B
     actionTypeId: .inference
@@ -39,3 +49,103 @@ xpack.actions.preconfigured:
       inferenceId: ".openai-gpt-oss-120b-chat_completion"
       providerConfig:
         model_id: "openai-gpt-oss-120b"
+  OpenAI-GPT-4-1:
+    name: OpenAI GPT-4.1
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-4.1-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-4.1"
+  OpenAI-GPT-4-1-Mini:
+    name: OpenAI GPT-4.1 Mini
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-4.1-mini-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-4.1-mini"
+  OpenAI-GPT-5-2:
+    name: OpenAI GPT-5.2
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.2-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.2"
+  OpenAI-GPT-OSS-20B:
+    name: OpenAI GPT-OSS 20B
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-oss-20b-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-oss-20b"
+  OpenAI-o4:
+    name: OpenAI o4
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-o4-chat_completion"
+      providerConfig:
+        model_id: "openai-o4"
+  OpenAI-o4-Mini:
+    name: OpenAI o4 Mini
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-o4-mini-chat_completion"
+      providerConfig:
+        model_id: "openai-o4-mini"
+  Google-Gemini-2-5-Pro:
+    name: Google Gemini 2.5 Pro
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-2.5-pro-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-2.5-pro"
+  Google-Gemini-2-5-Flash:
+    name: Google Gemini 2.5 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-2.5-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-2.5-flash"
+  Google-Gemini-3-0-Pro:
+    name: Google Gemini 3.0 Pro
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.0-pro-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.0-pro"
+  Google-Gemini-3-0-Flash:
+    name: Google Gemini 3.0 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.0-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.0-flash"

--- a/config/serverless.security.search_ai_lake.yml
+++ b/config/serverless.security.search_ai_lake.yml
@@ -131,6 +131,16 @@ xpack.actions.preconfigured:
       inferenceId: ".gp-llm-v2-chat_completion"
       providerConfig:
         model_id: "gp-llm-v2"
+  Anthropic-Claude-Opus-4-5:
+    name: Anthropic Claude Opus 4.5
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".anthropic-claude-4.5-opus-chat_completion"
+      providerConfig:
+        model_id: "anthropic-claude-4.5-opus"
   OpenAI-GPT-OSS-120B:
     name: OpenAI GPT-OSS 120B
     actionTypeId: .inference
@@ -141,3 +151,103 @@ xpack.actions.preconfigured:
       inferenceId: ".openai-gpt-oss-120b-chat_completion"
       providerConfig:
         model_id: "openai-gpt-oss-120b"
+  OpenAI-GPT-4-1:
+    name: OpenAI GPT-4.1
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-4.1-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-4.1"
+  OpenAI-GPT-4-1-Mini:
+    name: OpenAI GPT-4.1 Mini
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-4.1-mini-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-4.1-mini"
+  OpenAI-GPT-5-2:
+    name: OpenAI GPT-5.2
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.2-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.2"
+  OpenAI-GPT-OSS-20B:
+    name: OpenAI GPT-OSS 20B
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-oss-20b-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-oss-20b"
+  OpenAI-o4:
+    name: OpenAI o4
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-o4-chat_completion"
+      providerConfig:
+        model_id: "openai-o4"
+  OpenAI-o4-Mini:
+    name: OpenAI o4 Mini
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-o4-mini-chat_completion"
+      providerConfig:
+        model_id: "openai-o4-mini"
+  Google-Gemini-2-5-Pro:
+    name: Google Gemini 2.5 Pro
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-2.5-pro-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-2.5-pro"
+  Google-Gemini-2-5-Flash:
+    name: Google Gemini 2.5 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-2.5-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-2.5-flash"
+  Google-Gemini-3-0-Pro:
+    name: Google Gemini 3.0 Pro
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.0-pro-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.0-pro"
+  Google-Gemini-3-0-Flash:
+    name: Google Gemini 3.0 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.0-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.0-flash"

--- a/config/serverless.workplaceai.yml
+++ b/config/serverless.workplaceai.yml
@@ -51,6 +51,16 @@ xpack.actions.preconfigured:
       inferenceId: ".gp-llm-v2-chat_completion"
       providerConfig:
         model_id: "gp-llm-v2"
+  Anthropic-Claude-Opus-4-5:
+    name: Anthropic Claude Opus 4.5
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".anthropic-claude-4.5-opus-chat_completion"
+      providerConfig:
+        model_id: "anthropic-claude-4.5-opus"
   OpenAI-GPT-OSS-120B:
     name: OpenAI GPT-OSS 120B
     actionTypeId: .inference
@@ -61,3 +71,103 @@ xpack.actions.preconfigured:
       inferenceId: ".openai-gpt-oss-120b-chat_completion"
       providerConfig:
         model_id: "openai-gpt-oss-120b"
+  OpenAI-GPT-4-1:
+    name: OpenAI GPT-4.1
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-4.1-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-4.1"
+  OpenAI-GPT-4-1-Mini:
+    name: OpenAI GPT-4.1 Mini
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-4.1-mini-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-4.1-mini"
+  OpenAI-GPT-5-2:
+    name: OpenAI GPT-5.2
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.2-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.2"
+  OpenAI-GPT-OSS-20B:
+    name: OpenAI GPT-OSS 20B
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-oss-20b-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-oss-20b"
+  OpenAI-o4:
+    name: OpenAI o4
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-o4-chat_completion"
+      providerConfig:
+        model_id: "openai-o4"
+  OpenAI-o4-Mini:
+    name: OpenAI o4 Mini
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-o4-mini-chat_completion"
+      providerConfig:
+        model_id: "openai-o4-mini"
+  Google-Gemini-2-5-Pro:
+    name: Google Gemini 2.5 Pro
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-2.5-pro-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-2.5-pro"
+  Google-Gemini-2-5-Flash:
+    name: Google Gemini 2.5 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-2.5-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-2.5-flash"
+  Google-Gemini-3-0-Pro:
+    name: Google Gemini 3.0 Pro
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.0-pro-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.0-pro"
+  Google-Gemini-3-0-Flash:
+    name: Google Gemini 3.0 Flash
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".google-gemini-3.0-flash-chat_completion"
+      providerConfig:
+        model_id: "google-gemini-3.0-flash"

--- a/x-pack/platform/plugins/shared/fleet/cypress/tasks/api_calls/connectors.ts
+++ b/x-pack/platform/plugins/shared/fleet/cypress/tasks/api_calls/connectors.ts
@@ -29,7 +29,18 @@ export const INTERNAL_INFERENCE_CONNECTORS = [
   'Elastic-Managed-LLM',
   'Anthropic-Claude-Sonnet-3-7',
   'Anthropic-Claude-Sonnet-4-5',
+  'Anthropic-Claude-Opus-4-5',
   'OpenAI-GPT-OSS-120B',
+  'OpenAI-GPT-4-1',
+  'OpenAI-GPT-4-1-Mini',
+  'OpenAI-GPT-5-2',
+  'OpenAI-GPT-OSS-20B',
+  'OpenAI-o4',
+  'OpenAI-o4-Mini',
+  'Google-Gemini-2-5-Pro',
+  'Google-Gemini-2-5-Flash',
+  'Google-Gemini-3-0-Pro',
+  'Google-Gemini-3-0-Flash',
 ];
 export const INTERNAL_CLOUD_CONNECTORS = ['Elastic-Cloud-SMTP'];
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
@@ -21,7 +21,18 @@ const INTERNAL_INFERENCE_CONNECTORS = [
   'Elastic-Managed-LLM',
   'Anthropic-Claude-Sonnet-3-7',
   'Anthropic-Claude-Sonnet-4-5',
+  'Anthropic-Claude-Opus-4-5',
   'OpenAI-GPT-OSS-120B',
+  'OpenAI-GPT-4-1',
+  'OpenAI-GPT-4-1-Mini',
+  'OpenAI-GPT-5-2',
+  'OpenAI-GPT-OSS-20B',
+  'OpenAI-o4',
+  'OpenAI-o4-Mini',
+  'Google-Gemini-2-5-Pro',
+  'Google-Gemini-2-5-Flash',
+  'Google-Gemini-3-0-Pro',
+  'Google-Gemini-3-0-Flash',
 ];
 const INTERNAL_CONNECTORS = [...INTERNAL_CLOUD_CONNECTORS, ...INTERNAL_INFERENCE_CONNECTORS];
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Serverless] Preconfigured Connectors: adds new connectors (#249379)](https://github.com/elastic/kibana/pull/249379)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Melissa Alvarez","email":"melissa.alvarez@elastic.co"},"sourceCommit":{"committedDate":"2026-01-20T22:41:15Z","message":"[Serverless] Preconfigured Connectors: adds new connectors (#249379)\n\n## Summary\n\nRelated issue https://github.com/elastic/kibana/issues/249272\n\nAdds preconfigured connector configs for the following:\n\n\n-------------------------------------------------------------------------------------------------\n| Display Name | Model Name | Inference Endpoint |\n\n---------------|--------------|--------------------------------------------------------------------\n| Google Gemini 3.0 Pro | google-gemini-3.0-pro |\n.google-gemini-3.0-pro-chat_completion |\n| Google Gemini 3.0 Flash | google-gemini-3.0-flash |\n.google-gemini-3.0-flash-chat_completion |\n| OpenAI GPT-4.1 | openai-gpt-4.1 | .openai-gpt-4.1-chat_completion |\n| OpenAI GPT-4.1 Mini | openai-gpt-4.1-mini |\n.openai-gpt-4.1-mini-chat_completion |\n| OpenAI GPT-5.2 | openai-gpt-5.2 | .openai-gpt-5.2-chat_completion |\n| OpenAI GPT-OSS 20B | openai-gpt-oss-20b |\n.openai-gpt-oss-20b-chat_completion |\n\n--------------------------------------------------------------------------------------------------\n\n**EDIT: Additional models**\n\nNote - these were added after the PR was raised but still need to be\nincluded in the code before it's merged.\n\n[Model sheet is the source of\ntruth](https://docs.google.com/spreadsheets/d/1R1svJ72mGiK7NMtn19WMa5MnM-uLp68ySvHJHpdXizg/edit?gid=0#gid=0)\n\n\n---------------------------------------------------------------------------------------------------------\n| Display Name | Model Name | Inference Endpoint |\n\n---------------|--------------|---------------------------------------------------------------------------\n| Google Gemini 2.5 Pro | google-gemini-2.5-pro |\n.google-gemini-2.5-pro-chat_completion |\n| Google Gemini 2.5 Flash | google-gemini-2.5-flash |\n.google-gemini-2.5-flash-chat_completion |\n| OpenAI o4 | openai-o4 | .openai-o4-chat_completion |\n| OpenAI o4 Mini | openai-o4-mini | .openai-o4-mini-chat_completion |\n| Anthropic Claude Opus 4.5 | anthropic-claude-4.5-opus |\n.anthropic-claude-4.5-opus-chat_completion |\n\n----------------------------------------------------------------------------------------------------------\n\nThis PR also updates the places in kibana that check for internal\nconnectors.\nThis logic will be improved with the work to make this process dynamic.\nDue to the time sensitive nature of this change, adding in manually.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Saikat Sarkar <saikat.sarkar@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"75dc39e9df93fcfcce1a19a8f97fbcca8368fd26","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement",":ml","Team:Fleet","ci:project-deploy-elasticsearch","ci:project-deploy-observability","ci:project-deploy-security","Team:AI Infra","Feature:Inference UI","v9.3.0","v9.4.0"],"title":"[Serverless] Preconfigured Connectors: adds new connectors","number":249379,"url":"https://github.com/elastic/kibana/pull/249379","mergeCommit":{"message":"[Serverless] Preconfigured Connectors: adds new connectors (#249379)\n\n## Summary\n\nRelated issue https://github.com/elastic/kibana/issues/249272\n\nAdds preconfigured connector configs for the following:\n\n\n-------------------------------------------------------------------------------------------------\n| Display Name | Model Name | Inference Endpoint |\n\n---------------|--------------|--------------------------------------------------------------------\n| Google Gemini 3.0 Pro | google-gemini-3.0-pro |\n.google-gemini-3.0-pro-chat_completion |\n| Google Gemini 3.0 Flash | google-gemini-3.0-flash |\n.google-gemini-3.0-flash-chat_completion |\n| OpenAI GPT-4.1 | openai-gpt-4.1 | .openai-gpt-4.1-chat_completion |\n| OpenAI GPT-4.1 Mini | openai-gpt-4.1-mini |\n.openai-gpt-4.1-mini-chat_completion |\n| OpenAI GPT-5.2 | openai-gpt-5.2 | .openai-gpt-5.2-chat_completion |\n| OpenAI GPT-OSS 20B | openai-gpt-oss-20b |\n.openai-gpt-oss-20b-chat_completion |\n\n--------------------------------------------------------------------------------------------------\n\n**EDIT: Additional models**\n\nNote - these were added after the PR was raised but still need to be\nincluded in the code before it's merged.\n\n[Model sheet is the source of\ntruth](https://docs.google.com/spreadsheets/d/1R1svJ72mGiK7NMtn19WMa5MnM-uLp68ySvHJHpdXizg/edit?gid=0#gid=0)\n\n\n---------------------------------------------------------------------------------------------------------\n| Display Name | Model Name | Inference Endpoint |\n\n---------------|--------------|---------------------------------------------------------------------------\n| Google Gemini 2.5 Pro | google-gemini-2.5-pro |\n.google-gemini-2.5-pro-chat_completion |\n| Google Gemini 2.5 Flash | google-gemini-2.5-flash |\n.google-gemini-2.5-flash-chat_completion |\n| OpenAI o4 | openai-o4 | .openai-o4-chat_completion |\n| OpenAI o4 Mini | openai-o4-mini | .openai-o4-mini-chat_completion |\n| Anthropic Claude Opus 4.5 | anthropic-claude-4.5-opus |\n.anthropic-claude-4.5-opus-chat_completion |\n\n----------------------------------------------------------------------------------------------------------\n\nThis PR also updates the places in kibana that check for internal\nconnectors.\nThis logic will be improved with the work to make this process dynamic.\nDue to the time sensitive nature of this change, adding in manually.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Saikat Sarkar <saikat.sarkar@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"75dc39e9df93fcfcce1a19a8f97fbcca8368fd26"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249379","number":249379,"mergeCommit":{"message":"[Serverless] Preconfigured Connectors: adds new connectors (#249379)\n\n## Summary\n\nRelated issue https://github.com/elastic/kibana/issues/249272\n\nAdds preconfigured connector configs for the following:\n\n\n-------------------------------------------------------------------------------------------------\n| Display Name | Model Name | Inference Endpoint |\n\n---------------|--------------|--------------------------------------------------------------------\n| Google Gemini 3.0 Pro | google-gemini-3.0-pro |\n.google-gemini-3.0-pro-chat_completion |\n| Google Gemini 3.0 Flash | google-gemini-3.0-flash |\n.google-gemini-3.0-flash-chat_completion |\n| OpenAI GPT-4.1 | openai-gpt-4.1 | .openai-gpt-4.1-chat_completion |\n| OpenAI GPT-4.1 Mini | openai-gpt-4.1-mini |\n.openai-gpt-4.1-mini-chat_completion |\n| OpenAI GPT-5.2 | openai-gpt-5.2 | .openai-gpt-5.2-chat_completion |\n| OpenAI GPT-OSS 20B | openai-gpt-oss-20b |\n.openai-gpt-oss-20b-chat_completion |\n\n--------------------------------------------------------------------------------------------------\n\n**EDIT: Additional models**\n\nNote - these were added after the PR was raised but still need to be\nincluded in the code before it's merged.\n\n[Model sheet is the source of\ntruth](https://docs.google.com/spreadsheets/d/1R1svJ72mGiK7NMtn19WMa5MnM-uLp68ySvHJHpdXizg/edit?gid=0#gid=0)\n\n\n---------------------------------------------------------------------------------------------------------\n| Display Name | Model Name | Inference Endpoint |\n\n---------------|--------------|---------------------------------------------------------------------------\n| Google Gemini 2.5 Pro | google-gemini-2.5-pro |\n.google-gemini-2.5-pro-chat_completion |\n| Google Gemini 2.5 Flash | google-gemini-2.5-flash |\n.google-gemini-2.5-flash-chat_completion |\n| OpenAI o4 | openai-o4 | .openai-o4-chat_completion |\n| OpenAI o4 Mini | openai-o4-mini | .openai-o4-mini-chat_completion |\n| Anthropic Claude Opus 4.5 | anthropic-claude-4.5-opus |\n.anthropic-claude-4.5-opus-chat_completion |\n\n----------------------------------------------------------------------------------------------------------\n\nThis PR also updates the places in kibana that check for internal\nconnectors.\nThis logic will be improved with the work to make this process dynamic.\nDue to the time sensitive nature of this change, adding in manually.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Saikat Sarkar <saikat.sarkar@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"75dc39e9df93fcfcce1a19a8f97fbcca8368fd26"}}]}] BACKPORT-->