### PR TITLE
[agent builder] telemetry updates + docs

### DIFF
--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_platform.json
@@ -496,96 +496,7 @@
             }
           }
         },
-        "time_to_last_token": {
-          "properties": {
-            "p50": {
-              "type": "long",
-              "_meta": {
-                "description": "50th percentile time-to-last-token in milliseconds"
-              }
-            },
-            "p75": {
-              "type": "long",
-              "_meta": {
-                "description": "75th percentile time-to-last-token in milliseconds"
-              }
-            },
-            "p90": {
-              "type": "long",
-              "_meta": {
-                "description": "90th percentile time-to-last-token in milliseconds"
-              }
-            },
-            "p95": {
-              "type": "long",
-              "_meta": {
-                "description": "95th percentile time-to-last-token in milliseconds"
-              }
-            },
-            "p99": {
-              "type": "long",
-              "_meta": {
-                "description": "99th percentile time-to-last-token in milliseconds"
-              }
-            },
-            "mean": {
-              "type": "long",
-              "_meta": {
-                "description": "Mean time-to-last-token in milliseconds"
-              }
-            },
-            "total_samples": {
-              "type": "long",
-              "_meta": {
-                "description": "Total number of TTLT samples"
-              }
-            }
-          }
-        },
-        "latency_by_model": {
-          "type": "array",
-          "items": {
-            "properties": {
-              "model": {
-                "type": "keyword",
-                "_meta": {
-                  "description": "Model identifier (e.g., gpt-4o, claude-3-sonnet)"
-                }
-              },
-              "ttft_p50": {
-                "type": "long",
-                "_meta": {
-                  "description": "50th percentile TTFT for this model"
-                }
-              },
-              "ttft_p95": {
-                "type": "long",
-                "_meta": {
-                  "description": "95th percentile TTFT for this model"
-                }
-              },
-              "ttlt_p50": {
-                "type": "long",
-                "_meta": {
-                  "description": "50th percentile TTLT for this model"
-                }
-              },
-              "ttlt_p95": {
-                "type": "long",
-                "_meta": {
-                  "description": "95th percentile TTLT for this model"
-                }
-              },
-              "sample_count": {
-                "type": "long",
-                "_meta": {
-                  "description": "Number of samples for this model"
-                }
-              }
-            }
-          }
-        },
-        "latency_by_agent_type": {
+        "query_to_result_time_by_agent_type": {
           "type": "array",
           "items": {
             "properties": {
@@ -595,29 +506,26 @@
                   "description": "Agent ID"
                 }
               },
-              "ttft_p50": {
-                "type": "long",
-                "_meta": {
-                  "description": "50th percentile TTFT for this agent"
-                }
+              "p50": {
+                "type": "long"
               },
-              "ttft_p95": {
-                "type": "long",
-                "_meta": {
-                  "description": "95th percentile TTFT for this agent"
-                }
+              "p75": {
+                "type": "long"
               },
-              "ttlt_p50": {
-                "type": "long",
-                "_meta": {
-                  "description": "50th percentile TTLT for this agent"
-                }
+              "p90": {
+                "type": "long"
               },
-              "ttlt_p95": {
-                "type": "long",
-                "_meta": {
-                  "description": "95th percentile TTLT for this agent"
-                }
+              "p95": {
+                "type": "long"
+              },
+              "p99": {
+                "type": "long"
+              },
+              "mean": {
+                "type": "long"
+              },
+              "total_samples": {
+                "type": "long"
               },
               "sample_count": {
                 "type": "long",

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/agent_builder_telemetry.md
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/agent_builder_telemetry.md
@@ -156,8 +156,6 @@ period configured by Kibana (defaults to several days).
   - Count of tool calls triggered via direct API calls.
 - `agent_builder_tool_call_a2a`
   - Count of tool calls triggered by agent-to-agent communication.
-  - These counters are tracked for usage purposes but are not currently reported in the
-    snapshot telemetry payload.
 
 ### LLM usage counters
 - `agent_builder_llm_provider_{provider}`

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/agent_builder_telemetry.md
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/agent_builder_telemetry.md
@@ -1,0 +1,194 @@
+# Agent Builder Telemetry
+
+This document describes the telemetry payload reported by the Agent Builder collector and the
+usage counters used to build parts of that payload.
+
+## Snapshot telemetry
+
+The collector registers a single snapshot payload named `agent_builder`. The payload shape is
+defined in `telemetry_collector.ts` as `AgentBuilderTelemetry` and is assembled in the `fetch`
+function. The telemetry document is written under the `agent-builder` root in the
+`agent-builder-telemetry` index (time field: `timestamp`). Below is a field-by-field description
+of what is reported and how it is calculated.
+
+### Platform metadata fields
+
+In addition to the `agent-builder.*` payload, Kibana attaches standard metadata fields to the
+telemetry document. These are not computed by the Agent Builder collector, but by the telemetry
+pipeline. They include:
+- Cluster and version metadata: `cluster_uuid`, `cluster-name`, `version`, `version-major-minor`.
+- Cloud metadata: `cloud.*` (account ID, trial status, deployment flags, kbn UUID).
+- ECE metadata: `ece.*` (account ID, kbn UUID).
+- License metadata: `license.*` (UID, type, status, issue/start/expiry dates, max nodes/RUs).
+- Serverless metadata: `serverless.*` (project ID, type, tier).
+
+### custom_tools
+- `custom_tools.total`
+  - What it is: Total number of user-created tools (excluding built-in tools).
+  - How we count: ES aggregation on the tools system index, filtering out `type: builtin`, then
+    summing bucket doc counts. 
+- `custom_tools.by_type[]`
+  - What it is: Breakdown of custom tools by `type` (e.g., `esql`, `index_search`, `workflow`).
+  - How we count: ES terms aggregation on `type`, excluding `builtin`.
+
+### custom_agents
+- `custom_agents.total`
+  - What it is: Total number of custom agents created.
+  - How we count: ES `count` on the agents system index.
+
+### conversations
+- `conversations.total`
+  - What it is: Total number of conversations.
+  - How we count: ES `hits.total` on the conversations index.
+- `conversations.rounds_distribution[]`
+  - What it is: Distribution of conversations by number of rounds.
+  - How we count: ES scripted terms aggregation using `conversation_rounds` (or `rounds` fallback)
+    and bucket labels `1-5`, `6-10`, `11-20`, `21-50`, `51+`.
+- `conversations.total_rounds`
+  - What it is: Approximate total number of rounds across all conversations.
+  - How we count: Derived from `rounds_distribution` buckets by multiplying each bucket count by
+    a midpoint (3, 8, 15, 35, 75) and summing.
+- `conversations.avg_rounds_per_conversation`
+  - What it is: Average rounds per conversation.
+  - How we count: `total_rounds / total`, rounded to two decimals.
+- `conversations.tokens_used`
+  - What it is: Total tokens used across all conversation rounds.
+  - How we count: ES scripted sum aggregation over `conversation_rounds[*].model_usage`
+    (`input_tokens + output_tokens`).
+- `conversations.average_tokens_per_conversation`
+  - What it is: Average tokens per conversation.
+  - How we count: `tokens_used / total`, rounded to two decimals.
+
+### tokens_by_model[]
+- `tokens_by_model[].model`
+  - What it is: LLM model identifier.
+- `tokens_by_model[].total_tokens`
+  - What it is: Total input + output tokens consumed by that model.
+  - How we count: ES nested terms aggregation on model with sum of input and output tokens.
+- `tokens_by_model[].avg_tokens_per_round`
+  - What it is: Average tokens per round for that model.
+  - How we count: `total_tokens / sample_count`, rounded to two decimals.
+- `tokens_by_model[].sample_count`
+  - What it is: Number of rounds that contributed to the model bucket.
+
+### query_to_result_time
+- `query_to_result_time.p50|p75|p90|p95|p99|mean`
+  - What it is: Percentiles and mean of query-to-result latency.
+  - How we count: Computed from the conversations index using nested percentiles/avg on
+    `conversation_rounds.time_to_last_token`. This represents the end-to-end time to last token
+    for completed rounds.
+
+### query_to_result_time_by_model[]
+- `query_to_result_time_by_model[].model`
+  - What it is: LLM model identifier.
+- `query_to_result_time_by_model[].p50|p75|p90|p95|p99|mean|total_samples|sample_count`
+  - What it is: TTLT percentiles/mean and sample counts per model.
+  - How we count: ES nested terms aggregation on model with percentiles/avg/count of
+    `conversation_rounds.time_to_last_token`.
+
+### query_to_result_time_by_agent_type[]
+- `query_to_result_time_by_agent_type[].agent_id`
+  - What it is: Agent identifier stored on the conversation.
+- `query_to_result_time_by_agent_type[].p50|p75|p90|p95|p99|mean|total_samples|sample_count`
+  - What it is: Per-agent TTLT percentiles/mean with sample counts.
+  - How we count: ES terms aggregation on `agent_id`, then nested percentiles/avg/count over
+    `conversation_rounds.time_to_last_token`.
+
+### time_to_first_token
+- `time_to_first_token.p50|p75|p90|p95|p99|mean|total_samples`
+  - What it is: TTFT percentiles/mean and sample count.
+  - How we count: ES nested aggregation on `conversation_rounds.time_to_first_token`.
+
+### tool_calls
+- `tool_calls.total`
+  - What it is: Total tool calls across all sources.
+  - How we count: Sum of per-source usage counters (see usage counters section).
+- `tool_calls.by_source.default_agent|custom_agent|mcp|api|a2a`
+  - What it is: Tool calls grouped by origin.
+  - How we count: Individual usage counters per source.
+
+### tool_calls_by_model[]
+- `tool_calls_by_model[].model`
+  - What it is: LLM model identifier from each round.
+- `tool_calls_by_model[].count`
+  - What it is: Total number of tool-call steps for that model across all rounds.
+  - How we count: ES scripted metric that iterates each round and counts steps where
+    `step.type == 'tool_call'`, then aggregates per model.
+
+### llm_usage
+- `llm_usage.by_provider[]`
+  - What it is: Count of LLM invocations per provider.
+  - How we count: Usage counters named `agent_builder_llm_provider_{provider}`.
+    Provider names are sanitized for counter safety.
+- `llm_usage.by_model[]`
+  - What it is: Count of LLM invocations per model.
+  - How we count: Usage counters named `agent_builder_llm_model_{model}`.
+    Model names are sanitized for counter safety.
+
+### errors
+- `errors.total`
+  - What it is: Total errors surfaced to users.
+  - How we count: Usage counter `agent_builder_error_total`.
+- `errors.total_conversations_with_errors`
+  - What it is: Count of unique conversations that experienced an error.
+  - How we count: Usage counter `agent_builder_error_conversations_with_errors`.
+- `errors.avg_errors_per_conversation`
+  - What it is: Average number of errors per conversation that had at least one error.
+  - How we count: `errors.total / errors.total_conversations_with_errors` (0 if none).
+- `errors.by_type[]`
+  - What it is: Error counts grouped by normalized error type/code.
+  - How we count: Usage counters prefixed with `agent_builder_error_by_type_`.
+
+## Usage counters
+
+All usage counters are stored under the domain `agent_builder` using the Usage Counters
+service. Counters are persisted as daily saved objects (`usage-counter`) with a retention
+period configured by Kibana (defaults to several days).
+
+### Tool call counters
+- `agent_builder_tool_call_default_agent`
+  - Count of tool calls triggered by default agents.
+- `agent_builder_tool_call_custom_agent`
+  - Count of tool calls triggered by custom agents.
+- `agent_builder_tool_call_mcp`
+  - Count of tool calls triggered by MCP clients.
+- `agent_builder_tool_call_api`
+  - Count of tool calls triggered via direct API calls.
+- `agent_builder_tool_call_a2a`
+  - Count of tool calls triggered by agent-to-agent communication.
+  - These counters are tracked for usage purposes but are not currently reported in the
+    snapshot telemetry payload.
+
+### LLM usage counters
+- `agent_builder_llm_provider_{provider}`
+  - Count of LLM invocations for a provider (sanitized string).
+- `agent_builder_llm_model_{model}`
+  - Count of LLM invocations for a model (sanitized string).
+
+### Error counters
+- `agent_builder_error_total`
+  - Count of all errors surfaced to users.
+- `agent_builder_error_conversations_with_errors`
+  - Count of unique conversations that had at least one error.
+- `agent_builder_error_by_type_{error_type}`
+  - Count of errors by normalized error type/code.
+  - For agent execution errors, the type is prefixed with
+    `agentExecutionError_{code}` after normalization.
+
+### Conversation round counters
+- `agent_builder_rounds_1-5`
+- `agent_builder_rounds_6-10`
+- `agent_builder_rounds_11-20`
+- `agent_builder_rounds_21-50`
+- `agent_builder_rounds_51+`
+  - Count of conversation rounds bucketed by current round number.
+
+### Query-to-result time counters
+- `agent_builder_query_to_result_time_<1s`
+- `agent_builder_query_to_result_time_1-5s`
+- `agent_builder_query_to_result_time_5-10s`
+- `agent_builder_query_to_result_time_10-30s`
+- `agent_builder_query_to_result_time_30s+`
+  - Count of query-to-result durations bucketed by latency. These buckets are
+    currently tracked for usage counters but are not used in the snapshot payload.
+

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/query_utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/query_utils.ts
@@ -580,23 +580,26 @@ export class QueryUtils {
   }
 
   /**
-   * Get latency breakdown by agent
-   * Returns TTFT and TTLT p50/p95 for each agent_id
+   * Get query-to-result time (TTLT) grouped by agent
+   * Returns TTLT percentiles/mean for each agent_id
    */
-  async getLatencyByAgentType(): Promise<
+  async getQueryToResultTimeByAgentType(): Promise<
     Array<{
       agent_id: string;
-      ttft_p50: number;
-      ttft_p95: number;
-      ttlt_p50: number;
-      ttlt_p95: number;
+      p50: number;
+      p75: number;
+      p90: number;
+      p95: number;
+      p99: number;
+      mean: number;
+      total_samples: number;
       sample_count: number;
     }>
   > {
     try {
       const conversationIndexName = chatSystemIndex('conversations');
 
-      // Get latency metrics grouped by agent_id
+      // Get TTLT metrics grouped by agent_id
       const response = await this.esClient.search({
         index: conversationIndexName,
         size: 0,
@@ -612,23 +615,14 @@ export class QueryUtils {
                   path: 'conversation_rounds',
                 },
                 aggs: {
-                  ttft_percentiles: {
-                    percentiles: {
-                      field: 'conversation_rounds.time_to_first_token',
-                      percents: [50, 95],
-                    },
-                  },
-                  ttlt_percentiles: {
+                  ttl_percentiles: {
                     percentiles: {
                       field: 'conversation_rounds.time_to_last_token',
-                      percents: [50, 95],
+                      percents: [50, 75, 90, 95, 99],
                     },
                   },
-                  count: {
-                    value_count: {
-                      field: 'conversation_rounds.time_to_first_token',
-                    },
-                  },
+                  ttl_avg: { avg: { field: 'conversation_rounds.time_to_last_token' } },
+                  ttl_count: { value_count: { field: 'conversation_rounds.time_to_last_token' } },
                 },
               },
             },
@@ -640,18 +634,23 @@ export class QueryUtils {
 
       return buckets.map((bucket: any) => {
         const roundsAggs = bucket.all_rounds;
+        const percentiles = roundsAggs?.ttl_percentiles?.values || {};
+        const totalSamples = roundsAggs?.ttl_count?.value || 0;
         return {
           agent_id: bucket.key,
-          ttft_p50: Math.round(roundsAggs?.ttft_percentiles?.values?.['50.0'] || 0),
-          ttft_p95: Math.round(roundsAggs?.ttft_percentiles?.values?.['95.0'] || 0),
-          ttlt_p50: Math.round(roundsAggs?.ttlt_percentiles?.values?.['50.0'] || 0),
-          ttlt_p95: Math.round(roundsAggs?.ttlt_percentiles?.values?.['95.0'] || 0),
-          sample_count: roundsAggs?.count?.value || 0,
+          p50: Math.round(percentiles['50.0'] || 0),
+          p75: Math.round(percentiles['75.0'] || 0),
+          p90: Math.round(percentiles['90.0'] || 0),
+          p95: Math.round(percentiles['95.0'] || 0),
+          p99: Math.round(percentiles['99.0'] || 0),
+          mean: Math.round(roundsAggs?.ttl_avg?.value || 0),
+          total_samples: totalSamples,
+          sample_count: totalSamples,
         };
       });
     } catch (error) {
       if (!isIndexNotFoundError(error)) {
-        this.logger.warn(`Failed to fetch latency by agent: ${error.message}`);
+        this.logger.warn(`Failed to fetch query-to-result time by agent: ${error.message}`);
       }
       return [];
     }

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/telemetry_collector.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/telemetry_collector.test.ts
@@ -22,10 +22,9 @@ jest.mock('./query_utils', () => ({
     calculatePercentilesFromBuckets: jest.fn(),
     getTTFTMetrics: jest.fn(),
     getTTLTMetrics: jest.fn(),
-    getLatencyByModel: jest.fn(),
-    getLatencyByAgentType: jest.fn(),
     getTokensByModel: jest.fn(),
     getQueryToResultTimeByModel: jest.fn(),
+    getQueryToResultTimeByAgentType: jest.fn(),
     getToolCallsByModel: jest.fn(),
   })),
   isIndexNotFoundError: jest.fn(),
@@ -199,26 +198,6 @@ describe('telemetry_collector', () => {
           mean: 1500,
           total_samples: 1000,
         }),
-        getLatencyByModel: jest.fn().mockResolvedValue([
-          {
-            model: 'gpt-4',
-            ttft_p50: 100,
-            ttft_p95: 500,
-            ttlt_p50: 1000,
-            ttlt_p95: 5000,
-            sample_count: 500,
-          },
-        ]),
-        getLatencyByAgentType: jest.fn().mockResolvedValue([
-          {
-            agent_id: 'default',
-            ttft_p50: 120,
-            ttft_p95: 550,
-            ttlt_p50: 1100,
-            ttlt_p95: 5500,
-            sample_count: 300,
-          },
-        ]),
         getTokensByModel: jest.fn().mockResolvedValue([
           {
             model: 'gpt-4',
@@ -238,6 +217,19 @@ describe('telemetry_collector', () => {
             mean: 1100,
             total_samples: 100,
             sample_count: 100,
+          },
+        ]),
+        getQueryToResultTimeByAgentType: jest.fn().mockResolvedValue([
+          {
+            agent_id: 'default',
+            p50: 1000,
+            p75: 2000,
+            p90: 4000,
+            p95: 6000,
+            p99: 8000,
+            mean: 1500,
+            total_samples: 300,
+            sample_count: 300,
           },
         ]),
         getToolCallsByModel: jest.fn().mockResolvedValue([
@@ -336,7 +328,7 @@ describe('telemetry_collector', () => {
       });
 
       expect(result.query_to_result_time).toEqual({
-        p50: 500,
+        p50: 1000,
         p75: 2000,
         p90: 4000,
         p95: 6000,
@@ -364,6 +356,20 @@ describe('telemetry_collector', () => {
           mean: 1100,
           total_samples: 100,
           sample_count: 100,
+        },
+      ]);
+
+      expect(result.query_to_result_time_by_agent_type).toEqual([
+        {
+          agent_id: 'default',
+          p50: 1000,
+          p75: 2000,
+          p90: 4000,
+          p95: 6000,
+          p99: 8000,
+          mean: 1500,
+          total_samples: 300,
+          sample_count: 300,
         },
       ]);
 
@@ -441,19 +447,9 @@ describe('telemetry_collector', () => {
           mean: 0,
           total_samples: 0,
         },
-        time_to_last_token: {
-          p50: 0,
-          p75: 0,
-          p90: 0,
-          p95: 0,
-          p99: 0,
-          mean: 0,
-          total_samples: 0,
-        },
-        latency_by_model: [],
-        latency_by_agent_type: [],
         tokens_by_model: [],
         query_to_result_time_by_model: [],
+        query_to_result_time_by_agent_type: [],
         tool_calls_by_model: [],
         tool_calls: {
           total: 0,
@@ -586,29 +582,5 @@ describe('telemetry_collector', () => {
       expect(result.errors.avg_errors_per_conversation).toBe(0);
     });
 
-    it('handles missing tool_call counters with default 0', async () => {
-      mockQueryUtils.getCountersByPrefix.mockImplementation((domain: string, prefix: string) => {
-        if (prefix === `${AGENTBUILDER_USAGE_DOMAIN}_tool_call_`) {
-          return Promise.resolve(
-            new Map([
-              [`${AGENTBUILDER_USAGE_DOMAIN}_tool_call_default_agent`, 10],
-              // Missing other sources
-            ])
-          );
-        }
-        return Promise.resolve(new Map());
-      });
-
-      const result: AgentBuilderTelemetry = await registeredCollector.fetch(mockContext);
-
-      expect(result.tool_calls.by_source).toEqual({
-        default_agent: 10,
-        custom_agent: 0,
-        mcp: 0,
-        api: 0,
-        a2a: 0,
-      });
-      expect(result.tool_calls.total).toBe(10);
-    });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/telemetry/telemetry_collector.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/telemetry/telemetry_collector.test.ts
@@ -581,6 +581,5 @@ describe('telemetry_collector', () => {
 
       expect(result.errors.avg_errors_per_conversation).toBe(0);
     });
-
   });
 });


### PR DESCRIPTION
## Summary

resolves https://github.com/elastic/search-team/issues/12508

also:
- removes `time_to_last_token` (duplicate of `query_to_result_time`)
- removes `latency_by_model` (duplicate of `query_to_result_time_by_model`)
- renames `latency_by_type` to `query_to_result_time_by_agent_type`


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->