### PR TITLE
[9.3] [Timelion] Limit timelion run expression execution to 100 (#248450)

### DIFF
--- a/src/platform/plugins/private/vis_types/timelion/server/routes/run.ts
+++ b/src/platform/plugins/private/vis_types/timelion/server/routes/run.ts
@@ -48,7 +48,7 @@ export function runRoute(
       },
       validate: {
         body: schema.object({
-          sheet: schema.arrayOf(schema.string()),
+          sheet: schema.arrayOf(schema.string(), { maxSize: 1 }),
           extended: schema.maybe(
             schema.object({
               es: schema.object({

--- a/src/platform/plugins/private/vis_types/timelion/server/series_functions/fixtures/series_list.js
+++ b/src/platform/plugins/private/vis_types/timelion/server/series_functions/fixtures/series_list.js
@@ -11,12 +11,14 @@ import buckets from './bucket_list';
 import getSeries from '../test_helpers/get_series';
 import getSeriesList from '../test_helpers/get_series_list';
 
+const seriesList = getSeriesList([
+  getSeries('Negative', buckets, [-51, 17, 82, 20]),
+  getSeries('Nice', buckets, [100, 50, 50, 20]),
+  getSeries('All the same', buckets, [1, 1, 1, 1]),
+  getSeries('Decimals', buckets, [3.1415926535, 2, 1.439, 0.3424235]),
+  getSeries('PowerOfTen', buckets, [10, 100, 10, 1]),
+]);
+
 export default function () {
-  return getSeriesList([
-    getSeries('Negative', buckets, [-51, 17, 82, 20]),
-    getSeries('Nice', buckets, [100, 50, 50, 20]),
-    getSeries('All the same', buckets, [1, 1, 1, 1]),
-    getSeries('Decimals', buckets, [3.1415926535, 2, 1.439, 0.3424235]),
-    getSeries('PowerOfTen', buckets, [10, 100, 10, 1]),
-  ]);
+  return structuredClone(seriesList);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Timelion] Limit timelion run expression execution to 100 (#248450)](https://github.com/elastic/kibana/pull/248450)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2026-01-19T15:24:36Z","message":"[Timelion] Limit timelion run expression execution to 100 (#248450)\n\n## Summary\n\nThis PR limits the actual possible execution runs of Timelion to a max\nof 100 expression at the same time.\nThis value should be enough to cover the current use cases and extra\nedge cases, providing a limit to the actual maximum number of execution\nthat can run at the same time,","sha":"a9984abf2df27138e44fa21ab3da0016d32ba133","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","backport missing","backport:all-open","v9.4.0"],"title":"[Timelion] Limit timelion run expression execution to 100","number":248450,"url":"https://github.com/elastic/kibana/pull/248450","mergeCommit":{"message":"[Timelion] Limit timelion run expression execution to 100 (#248450)\n\n## Summary\n\nThis PR limits the actual possible execution runs of Timelion to a max\nof 100 expression at the same time.\nThis value should be enough to cover the current use cases and extra\nedge cases, providing a limit to the actual maximum number of execution\nthat can run at the same time,","sha":"a9984abf2df27138e44fa21ab3da0016d32ba133"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248450","number":248450,"mergeCommit":{"message":"[Timelion] Limit timelion run expression execution to 100 (#248450)\n\n## Summary\n\nThis PR limits the actual possible execution runs of Timelion to a max\nof 100 expression at the same time.\nThis value should be enough to cover the current use cases and extra\nedge cases, providing a limit to the actual maximum number of execution\nthat can run at the same time,","sha":"a9984abf2df27138e44fa21ab3da0016d32ba133"}}]}] BACKPORT-->