### PR TITLE
[Streams][SigEvents] Fix query sync on save and add debounce for preview chart

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/add_significant_event_flyout/manual_flow_form/manual_flow_form.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/add_significant_event_flyout/manual_flow_form/manual_flow_form.tsx
@@ -18,7 +18,8 @@ import {
 import { i18n } from '@kbn/i18n';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { StreamQueryKql, Streams, System } from '@kbn/streams-schema';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useDebounceFn } from '@kbn/react-hooks';
 import { UncontrolledStreamsAppSearchBar } from '../../../streams_app_search_bar/uncontrolled_streams_app_bar';
 import { PreviewDataSparkPlot } from '../common/preview_data_spark_plot';
 import { validateQuery } from '../common/validate_query';
@@ -35,6 +36,8 @@ interface Props {
   dataViews: DataView[];
 }
 
+const DEBOUNCE_DELAY_MS = 300;
+
 export function ManualFlowForm({
   definition,
   query,
@@ -50,6 +53,25 @@ export function ManualFlowForm({
     kql: false,
     severity: false,
   });
+
+  // Debounced KQL query for preview chart API calls
+  const [debouncedKqlQuery, setDebouncedKqlQuery] = useState(query.kql.query);
+
+  const { run: updateDebouncedKqlQuery } = useDebounceFn(
+    (kqlQuery: string) => {
+      setDebouncedKqlQuery(kqlQuery);
+    },
+    { wait: DEBOUNCE_DELAY_MS }
+  );
+
+  // Create a query object with debounced KQL for the preview chart
+  const debouncedQuery = useMemo(
+    (): StreamQueryKql => ({
+      ...query,
+      kql: { query: debouncedKqlQuery },
+    }),
+    [query, debouncedKqlQuery]
+  );
 
   const validation = validateQuery(query);
 
@@ -182,17 +204,15 @@ export function ManualFlowForm({
               showQueryInput
               showSubmitButton={false}
               isDisabled={isSubmitting}
-              onQueryChange={() => {
-                setTouched((prev) => ({ ...prev, kql: true }));
-              }}
-              onQuerySubmit={(next) => {
+              onQueryChange={(next) => {
+                // Immediately sync query state so it's always up-to-date for save
+                const nextKqlQuery = typeof next.query?.query === 'string' ? next.query.query : '';
                 setQuery({
                   ...query,
-                  kql: {
-                    query: typeof next.query?.query === 'string' ? next.query.query : '',
-                  },
+                  kql: { query: nextKqlQuery },
                 });
-
+                // Debounce the preview chart update
+                updateDebouncedKqlQuery(nextKqlQuery);
                 setTouched((prev) => ({ ...prev, kql: true }));
               }}
               placeholder={i18n.translate(
@@ -200,7 +220,6 @@ export function ManualFlowForm({
                 { defaultMessage: 'Enter query' }
               )}
               indexPatterns={dataViews}
-              submitOnBlur
             />
           </EuiFormRow>
         </EuiForm>
@@ -209,7 +228,7 @@ export function ManualFlowForm({
 
         <PreviewDataSparkPlot
           definition={definition}
-          query={query}
+          query={debouncedQuery}
           isQueryValid={!validation.kql.isInvalid}
         />
       </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/add_significant_event_flyout/manual_flow_form/manual_flow_form.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/add_significant_event_flyout/manual_flow_form/manual_flow_form.tsx
@@ -37,6 +37,7 @@ interface Props {
 }
 
 const DEBOUNCE_DELAY_MS = 300;
+const DEBOUNCE_OPTIONS = { wait: DEBOUNCE_DELAY_MS };
 
 export function ManualFlowForm({
   definition,
@@ -58,10 +59,8 @@ export function ManualFlowForm({
   const [debouncedKqlQuery, setDebouncedKqlQuery] = useState(query.kql.query);
 
   const { run: updateDebouncedKqlQuery } = useDebounceFn(
-    (kqlQuery: string) => {
-      setDebouncedKqlQuery(kqlQuery);
-    },
-    { wait: DEBOUNCE_DELAY_MS }
+    (kqlQuery: string) => setDebouncedKqlQuery(kqlQuery),
+    DEBOUNCE_OPTIONS
   );
 
   // Create a query object with debounced KQL for the preview chart


### PR DESCRIPTION
## Summary

- Fix stale query value being used when saving significant events without blurring the query input field
- Add debouncing to preview chart API calls to prevent excessive requests with the new behavior

## Problem

When editing a significant event, the query input field only synced its value to the parent state on blur (via `submitOnBlur`). This meant that if a user edited the query and clicked "Update event" without first clicking outside the input, the old query value was saved instead of the new one.

## Solution

Updated `ManualFlowForm` to:

1. **Sync query state immediately on change**: The `onQueryChange` callback now updates the parent's query state on every keystroke, ensuring the save button always has access to the latest value
2. **Debounce preview chart updates**: Since the query state now updates on every keystroke, added a 300ms debounce for the preview chart API calls using `useDebounceFn` from `@kbn/react-hooks` to prevent excessive network requests while typing


Before:

https://github.com/user-attachments/assets/32d87e4f-eea1-43cf-a3d9-e16e7b4d684b

After:

https://github.com/user-attachments/assets/c4fedb32-20b9-4aa7-afaa-4afb2087eb5e



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->