### PR TITLE
Account for flyouts in editor widget overflow container stacking

### DIFF
--- a/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
@@ -41,7 +41,8 @@ import {
 } from './mods';
 import { styles } from './editor.styles';
 
-export interface CodeEditorProps {
+export interface CodeEditorProps
+  extends Pick<ReactMonacoEditorProps, 'overflowWidgetsContainerZIndexOverride'> {
   /** Width of editor. Defaults to 100%. */
   width?: string | number;
 
@@ -204,7 +205,6 @@ export interface CodeEditorProps {
    */
   onFocus?: () => void;
   onBlur?: () => void;
-
   /**
    * Enables the suggestion widget repositioning. Enabled by default.
    * Disabled for cases like embedded console.
@@ -252,6 +252,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   onFocus,
   onBlur,
   enableSuggestWidgetRepositioning = true,
+  overflowWidgetsContainerZIndexOverride,
 }) => {
   const { euiTheme } = useEuiTheme();
   const { registerContextMenuActions, unregisterContextMenuActions } = useContextMenuUtils();
@@ -643,6 +644,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
             editorWillMount={_editorWillMount}
             editorDidMount={_editorDidMount}
             editorWillUnmount={_editorWillUnmount}
+            overflowWidgetsContainerZIndexOverride={overflowWidgetsContainerZIndexOverride}
             options={{
               padding: allowFullScreen || isCopyable ? { top: 24 } : {},
               renderLineHighlight: 'none',

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
@@ -243,7 +243,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   fitToContent,
   accessibilityOverlayEnabled = true,
   enableFindAction,
-  dataTestSubj,
+  dataTestSubj = 'kibanaCodeEditor',
   classNameCss,
   enableCustomContextMenu = false,
   customContextMenuActions = [],
@@ -607,7 +607,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
     <div
       css={styles.container}
       onKeyDown={onKeyDown}
-      data-test-subj={dataTestSubj ?? 'kibanaCodeEditor'}
+      data-test-subj={dataTestSubj}
       className="kibanaCodeEditor"
     >
       <Global styles={classNameCss} />

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -357,9 +357,12 @@ export function MonacoEditor({
       <EuiPortal portalRef={setOverflowWidgetsDomNode} />
       <Global
         styles={({ euiTheme: _euiTheme }) => ({
+          // by default display the overflow widgets below flyouts
           [`.${OVERFLOW_WIDGETS_CONTAINER_CLASS}`]: {
-            // ensure the overflow widgets are above headers and flyouts
-            // Fallback if euiTheme is not available
+            zIndex: Number(_euiTheme?.levels?.maskBelowHeader ?? 1000) - 2,
+          },
+          // When the editor is inside a flyout, ensure the overflow widgets are above the flyout
+          [`:has(.euiFlyout [class*="monaco-editor"]) .${OVERFLOW_WIDGETS_CONTAINER_CLASS}`]: {
             zIndex: _euiTheme?.levels?.menu ?? 2000,
           },
         })}

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -123,6 +123,10 @@ export interface MonacoEditorProps {
    * An event emitted when the content of the current model has changed.
    */
   onChange?: ChangeHandler;
+  /**
+   * Optional z-index to override the default z-index of the overflow widgets container.
+   */
+  overflowWidgetsContainerZIndexOverride?: number;
 }
 
 // initialize supported languages
@@ -130,6 +134,8 @@ initializeSupportedLanguages();
 
 export const OVERFLOW_WIDGETS_TEST_ID = 'kbnCodeEditorEditorOverflowWidgetsContainer';
 const OVERFLOW_WIDGETS_CONTAINER_CLASS = 'monaco-editor-overflowing-widgets-container';
+const OVERFLOW_WIDGETS_CONTAINER_STACKING_OVERRIDE_CLASS =
+  'monaco-editor-overflowing-widgets-container-stacking-override';
 
 export function MonacoEditor({
   width = '100%',
@@ -144,6 +150,7 @@ export function MonacoEditor({
   editorWillUnmount,
   onChange,
   className,
+  overflowWidgetsContainerZIndexOverride,
 }: MonacoEditorProps) {
   const containerElement = useRef<HTMLDivElement | null>(null);
   const overflowWidgetsDomNode = useRef<HTMLDivElement | null>(null);
@@ -369,11 +376,19 @@ export function MonacoEditor({
           [`.${OVERFLOW_WIDGETS_CONTAINER_CLASS}`]: {
             zIndex: Number(_euiTheme?.levels?.maskBelowHeader ?? 1000) - 2,
           },
-          // When the editor is inside a flyout, ensure the overflow widgets are above the flyout and modification is scoped to each instance
+          // When the editor is inside a flyout, ensure the overflow widgets are above the flyout and scoped to each instance
           [`:has(.euiFlyout [class*="monaco-editor"][id="${instanceId}"]) .${OVERFLOW_WIDGETS_CONTAINER_CLASS}[id="${instanceId}"]`]:
             {
               zIndex: _euiTheme?.levels?.menu ?? 2000,
             },
+          // Allow the overflow widgets container z-index to be overridden
+          ...(overflowWidgetsContainerZIndexOverride
+            ? {
+                [`.${OVERFLOW_WIDGETS_CONTAINER_STACKING_OVERRIDE_CLASS}[id="${instanceId}"]`]: {
+                  zIndex: overflowWidgetsContainerZIndexOverride,
+                },
+              }
+            : {}),
         })}
       />
     </>


### PR DESCRIPTION
## Summary

The most recent change to monaco split the widget container to render in the DOM separate from the confines of the monaco editor to resolve issues with the stacking context of the editor that would cause the widgets overflow container to render beneath the header resulted in couple of other issues.
We'd chose to render the widget a top all flyouts and didn't consider scenarios where an editor action triggers a flyout, in scenarios like this the editor action would render atop the flyout, the approach considered here renders the widget by default below flyouts, however when the editor is rendered in a flyout only then do we stack it above flyouts.

There's also an allowance to provide a custom override for the zIndex if needed with the new prop `overflowWidgetsContainerZIndexOverride`

### Visuals

#### Action triggering flyout opening

![ScreenRecording2026-01-21at11 32 38-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/0f2c3b42-1e2d-4dcd-b11a-a8889d29187a)

#### Editor within a flyout

<img width="750" height="832" alt="Screenshot 2026-01-21 at 11 33 40" src="https://github.com/user-attachments/assets/4b6b7cf0-4368-4569-a1fb-591d08fdab3b" />


<!--

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->

