### PR TITLE
PoC: Add alert details app section for failed transaction rate threshold rule

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/alerting/rule_types/register_apm_rule_types.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/alerting/rule_types/register_apm_rule_types.ts
@@ -115,6 +115,10 @@ export function registerApmRuleTypes(observabilityRuleTypeRegistry: Observabilit
     validate: () => ({
       errors: [],
     }),
+    alertDetailsAppSection: lazy(
+      () =>
+        import('../ui_components/alert_details_app_section/transaction_error_rate_alert_details')
+    ),
     requiresAppContext: false,
     defaultActionMessage: transactionErrorRateMessage,
     defaultRecoveryMessage: transactionErrorRateRecoveryMessage,

--- a/x-pack/solutions/observability/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/apm_alerts_charts_section.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/apm_alerts_charts_section.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+
+interface Props {
+  mainChart: React.ReactNode;
+  secondaryCharts: React.ReactNode[];
+}
+
+export function ApmAlertsChartsSection({ mainChart, secondaryCharts }: Props) {
+  return (
+    <EuiFlexItem>
+      {mainChart}
+      <EuiSpacer size="s" />
+      <EuiFlexGroup direction="row" gutterSize="s">
+        {secondaryCharts.map((chart, index) => (
+          <EuiFlexItem key={index}>{chart}</EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  );
+}

--- a/x-pack/solutions/observability/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/transaction_error_rate_alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/alerting/ui_components/alert_details_app_section/transaction_error_rate_alert_details.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { AlertDetailsAppSection } from '.';
+import type { AlertDetailsAppSectionProps } from './types';
+
+export function TransactionErrorRateAlertDetails({
+  rule,
+  alert,
+  timeZone,
+}: AlertDetailsAppSectionProps) {
+  return (
+    <AlertDetailsAppSection
+      rule={rule}
+      alert={alert}
+      timeZone={timeZone}
+      mainChart="FailedTransactionChart"
+    />
+  );
+}
+
+// eslint-disable-next-line import/no-default-export
+export default TransactionErrorRateAlertDetails;

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/alerting/alerting_failed_transactions_chart/chart.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/alerting/alerting_failed_transactions_chart/chart.tsx
@@ -53,6 +53,7 @@ export function APMAlertingFailedTransactionsChart({
 
   return (
     <FailedTransactionChart
+      alert={alert}
       transactionType={currentTransactionType}
       transactionTypes={transactionTypes}
       setTransactionType={setTransactionType}

--- a/x-pack/solutions/observability/plugins/observability/public/utils/is_alert_details_enabled.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/utils/is_alert_details_enabled.ts
@@ -18,6 +18,7 @@ import type { TopAlert } from '../typings/alerts';
 
 const ALLOWED_RULE_TYPES = [
   ApmRuleType.TransactionDuration,
+  ApmRuleType.TransactionErrorRate,
   LOG_THRESHOLD_ALERT_TYPE_ID,
   METRIC_THRESHOLD_ALERT_TYPE_ID,
   OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
@@ -39,6 +40,8 @@ export const isAlertDetailsEnabledPerApp = (
 ): boolean => {
   if (!alert) return false;
   const ruleTypeId = alert.fields[ALERT_RULE_TYPE_ID];
+  console.log('ruleTypeId:', ruleTypeId);
+  console.log('ALLOWED_RULE_TYPES:', ALLOWED_RULE_TYPES);
 
   // The feature flags for alertDetails are not specific enough so we need to check
   // the specific rule types to see if they should be blocked or not.


### PR DESCRIPTION
## Summary

A PoC to add alert details app section for the failed transaction rate threshold rule.

<img width="1512" height="864" alt="image" src="https://github.com/user-attachments/assets/074b45d3-56f3-4f26-975c-bfb37d8adc8b" />
<img width="1507" height="659" alt="image" src="https://github.com/user-attachments/assets/8fd5c7c2-de41-42e5-93b5-58e45f015c56" />


### Tasks
- [ ] Better structure/naming for the files in alert_details_app_section
    - [ ] Moving components to one folder
    - [ ] exposing different app sections at the top level + types 
- [ ] Add test
- [ ] Showing threshold annotation correctly
- [ ] Removing unnecessary props from the FailedTransaction and Latency charts (such as alertStart, alertEnd, ... relying on alert object instead)