### PR TITLE
[9.2] Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-data-discovery` files (#246176)

### DIFF
--- a/examples/data_view_field_editor_example/moon.yml
+++ b/examples/data_view_field_editor_example/moon.yml
@@ -23,6 +23,7 @@ dependsOn:
   - '@kbn/data-views-plugin'
   - '@kbn/data-view-field-editor-plugin'
   - '@kbn/developer-examples-plugin'
+  - '@kbn/i18n'
 tags:
   - plugin
   - prod

--- a/examples/data_view_field_editor_example/public/app.tsx
+++ b/examples/data_view_field_editor_example/public/app.tsx
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { i18n } from '@kbn/i18n';
 import type { DefaultItemAction } from '@elastic/eui';
 import {
   EuiProvider,
@@ -129,6 +130,10 @@ const DataViewFieldEditorExample = ({ dataView, dataViewFieldEditor }: Props) =>
             direction: 'asc',
           },
         }}
+        tableCaption={i18n.translate('dataViewFieldEditorExample.fieldsTable.caption', {
+          defaultMessage: 'Fields in {dataViewTitle}',
+          values: { dataViewTitle: dataView.title },
+        })}
       />
     </>
   ) : (

--- a/examples/data_view_field_editor_example/tsconfig.json
+++ b/examples/data_view_field_editor_example/tsconfig.json
@@ -18,5 +18,6 @@
     "@kbn/data-views-plugin",
     "@kbn/data-view-field-editor-plugin",
     "@kbn/developer-examples-plugin",
+    "@kbn/i18n",
   ]
 }

--- a/examples/field_formats_example/moon.yml
+++ b/examples/field_formats_example/moon.yml
@@ -24,6 +24,7 @@ dependsOn:
   - '@kbn/data-plugin'
   - '@kbn/data-view-field-editor-plugin'
   - '@kbn/field-types'
+  - '@kbn/i18n'
 tags:
   - plugin
   - prod

--- a/examples/field_formats_example/public/app.tsx
+++ b/examples/field_formats_example/public/app.tsx
@@ -8,6 +8,7 @@
  */
 
 import React from 'react';
+import { i18n } from '@kbn/i18n';
 import {
   EuiBasicTable,
   EuiCallOut,
@@ -62,6 +63,9 @@ const UsingAnExistingFieldFormatExample: React.FC<{ deps: Deps }> = (props) => {
       <EuiSpacer size={'s'} />
       <EuiBasicTable
         data-test-subj={'example1 sample table'}
+        tableCaption={i18n.translate('fieldFormatsExamples.existingFieldFormatSampleTableCaption', {
+          defaultMessage: 'Sample values formatted with the existing field format.',
+        })}
         items={sample}
         columns={[
           {
@@ -102,6 +106,9 @@ const CreatingCustomFieldFormat: React.FC<{ deps: Deps }> = (props) => {
       <EuiBasicTable
         items={sample}
         data-test-subj={'example2 sample table'}
+        tableCaption={i18n.translate('fieldFormatsExamples.customFieldFormatSampleTableCaption', {
+          defaultMessage: 'Sample values formatted with the custom field format.',
+        })}
         columns={[
           {
             field: 'raw',

--- a/examples/field_formats_example/tsconfig.json
+++ b/examples/field_formats_example/tsconfig.json
@@ -21,5 +21,6 @@
     "@kbn/data-plugin",
     "@kbn/data-view-field-editor-plugin",
     "@kbn/field-types",
+    "@kbn/i18n",
   ]
 }

--- a/examples/partial_results_example/moon.yml
+++ b/examples/partial_results_example/moon.yml
@@ -21,6 +21,7 @@ dependsOn:
   - '@kbn/core'
   - '@kbn/developer-examples-plugin'
   - '@kbn/expressions-plugin'
+  - '@kbn/i18n'
 tags:
   - plugin
   - prod

--- a/examples/partial_results_example/public/app/app.tsx
+++ b/examples/partial_results_example/public/app/app.tsx
@@ -19,6 +19,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 import type { Datatable } from '@kbn/expressions-plugin/common';
+import { i18n } from '@kbn/i18n';
 import { ExpressionsContext } from './expressions_context';
 
 const expression = `getEvents
@@ -57,6 +58,9 @@ export function App() {
           <EuiSpacer size={'m'} />
           {datatable ? (
             <EuiBasicTable
+              tableCaption={i18n.translate('partialResultsDemo.tableCaption', {
+                defaultMessage: 'Partial expression results',
+              })}
               data-test-subj={'example-table'}
               columns={datatable.columns?.map(({ id: field, name }) => ({
                 field,

--- a/examples/partial_results_example/tsconfig.json
+++ b/examples/partial_results_example/tsconfig.json
@@ -16,5 +16,6 @@
     "@kbn/core",
     "@kbn/developer-examples-plugin",
     "@kbn/expressions-plugin",
+    "@kbn/i18n",
   ]
 }

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/static_lookup/__snapshots__/static_lookup.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/static_lookup/__snapshots__/static_lookup.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`StaticLookupFormatEditor should render multiple lookup entries and unkn
         },
       ]
     }
+    tableCaption="Static lookup entries"
   />
   <EuiSpacer
     size="m"
@@ -141,6 +142,7 @@ exports[`StaticLookupFormatEditor should render normally 1`] = `
         },
       ]
     }
+    tableCaption="Static lookup entries"
   />
   <EuiSpacer
     size="m"

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/static_lookup/static_lookup.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/editors/static_lookup/static_lookup.tsx
@@ -154,7 +154,14 @@ export class StaticLookupFormatEditor extends DefaultFormatEditor<StaticLookupFo
 
     return (
       <Fragment>
-        <EuiBasicTable items={items} columns={columns} css={{ maxWidth: '400px' }} />
+        <EuiBasicTable
+          items={items}
+          columns={columns}
+          css={{ maxWidth: '400px' }}
+          tableCaption={i18n.translate('indexPatternFieldEditor.staticLookup.tableCaption', {
+            defaultMessage: 'Static lookup entries',
+          })}
+        />
         <EuiSpacer size="m" />
         <EuiButton
           iconType="plusInCircle"

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/samples/samples.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/field_format_editor/samples/samples.tsx
@@ -72,6 +72,9 @@ export class FormatEditorSamples extends PureComponent<FormatEditorSamplesProps>
           compressed={true}
           items={samples}
           columns={columns}
+          tableCaption={i18n.translate('indexPatternFieldEditor.samples.tableCaption', {
+            defaultMessage: 'Sample input and output values',
+          })}
         />
       </EuiFormRow>
     ) : null;

--- a/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/delete_data_view_flyout/delete_data_view_flyout_content.tsx
@@ -46,6 +46,13 @@ const tableTitle = i18n.translate('indexPatternManagement.dataViewTable.tableTit
   defaultMessage: 'Data views selected for deletion',
 });
 
+const relationshipsTableCaption = i18n.translate(
+  'indexPatternManagement.dataViewTable.relationshipsTableCaption',
+  {
+    defaultMessage: 'Kibana objects using this data view',
+  }
+);
+
 export const spacesWarningText = i18n.translate(
   'indexPatternManagement.dataViewTable.deleteWarning',
   {
@@ -124,7 +131,11 @@ export const DeleteModalContent: React.FC<ModalProps> = ({
               <EuiSpacer size="xs" />
             </>
           )}
-          <EuiBasicTable items={relationships[id]} columns={relationsColumns} />
+          <EuiBasicTable
+            tableCaption={relationshipsTableCaption}
+            items={relationships[id]}
+            columns={relationsColumns}
+          />
         </div>
       );
       itemIdToExpandedRowMapValues[id] = relationsTable;

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/indexed_fields_table/components/table/__snapshots__/table.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/indexed_fields_table/components/table/__snapshots__/table.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`Table render conflict summary modal  1`] = `
           />
         }
         rowHeader="firstName"
-        tableCaption="Demo of EuiBasicTable"
+        tableCaption="Field type conflicts across indices"
         tableLayout="auto"
       />
     </EuiText>
@@ -306,6 +306,7 @@ exports[`Table should render normally 1`] = `
       },
     }
   }
+  tableCaption="Indexed fields"
   tableLayout="fixed"
 />
 `;

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/indexed_fields_table/components/table/table.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/indexed_fields_table/components/table/table.tsx
@@ -333,7 +333,10 @@ export const getConflictModalContent = ({
           />
         </p>
         <EuiBasicTable
-          tableCaption="Demo of EuiBasicTable"
+          tableCaption={i18n.translate(
+            'indexPatternManagement.editIndexPattern.fields.conflictModal.tableCaption',
+            { defaultMessage: 'Field type conflicts across indices' }
+          )}
           items={getItems(conflictDescriptions)}
           rowHeader="firstName"
           columns={conflictColumns}
@@ -521,6 +524,10 @@ class TableClass extends PureComponent<
 
     return (
       <EuiInMemoryTable
+        tableCaption={i18n.translate(
+          'indexPatternManagement.editIndexPattern.fields.table.tableCaption',
+          { defaultMessage: 'Indexed fields' }
+        )}
         items={items}
         columns={columns}
         pagination={pagination}

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/relationships_table/i18n.ts
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/relationships_table/i18n.ts
@@ -37,3 +37,10 @@ export const filterTitle = i18n.translate(
   'indexPatternManagement.objectsTable.relationships.search.filters.type.name',
   { defaultMessage: 'Type' }
 );
+
+export const relationshipsTableCaption = i18n.translate(
+  'indexPatternManagement.relationshipsTable.tableCaption',
+  {
+    defaultMessage: 'Saved object relationships',
+  }
+);

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/relationships_table/relationships_table.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/relationships_table/relationships_table.tsx
@@ -30,6 +30,7 @@ import {
   titleFieldName,
   titleFieldDescription,
   filterTitle,
+  relationshipsTableCaption,
 } from './i18n';
 
 const canGoInApp = (
@@ -148,6 +149,7 @@ export const RelationshipsTable = ({
       <EuiInMemoryTable<SavedObjectRelation>
         items={relationships}
         columns={columns}
+        tableCaption={relationshipsTableCaption}
         pagination={{
           pageSize,
         }}

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/scripted_fields_table/components/table/__snapshots__/table.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/scripted_fields_table/components/table/__snapshots__/table.test.tsx.snap
@@ -96,6 +96,7 @@ exports[`Table should render normally 1`] = `
       },
     }
   }
+  tableCaption="Scripted fields"
   tableLayout="fixed"
 />
 `;

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/scripted_fields_table/components/table/table.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/scripted_fields_table/components/table/table.tsx
@@ -157,6 +157,10 @@ class TableClass extends PureComponent<
         pagination={pagination}
         sorting={sorting}
         onTableChange={onTableChange}
+        tableCaption={i18n.translate(
+          'indexPatternManagement.editIndexPattern.scripted.table.caption',
+          { defaultMessage: 'Scripted fields' }
+        )}
       />
     );
   }

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/source_filters_table/components/table/__snapshots__/table.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/source_filters_table/components/table/__snapshots__/table.test.tsx.snap
@@ -100,6 +100,7 @@ exports[`Table should render normally 1`] = `
       },
     }
   }
+  tableCaption="Source filters"
   tableLayout="fixed"
 />
 `;

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/source_filters_table/components/table/table.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/source_filters_table/components/table/table.tsx
@@ -46,6 +46,13 @@ const matchesDescription = i18n.translate(
   { defaultMessage: 'Language used for the field' }
 );
 
+const tableCaption = i18n.translate(
+  'indexPatternManagement.editIndexPattern.source.table.caption',
+  {
+    defaultMessage: 'Source filters',
+  }
+);
+
 const editAria = i18n.translate('indexPatternManagement.editIndexPattern.source.table.editAria', {
   defaultMessage: 'Edit',
 });
@@ -250,6 +257,7 @@ class TableClass extends Component<
         pagination={pagination}
         sorting={sorting}
         onTableChange={onTableChange}
+        tableCaption={tableCaption}
       />
     );
   }

--- a/src/platform/plugins/shared/data_view_management/public/components/field_editor/__snapshots__/field_editor.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_management/public/components/field_editor/__snapshots__/field_editor.test.tsx.snap
@@ -1307,6 +1307,7 @@ exports[`FieldEditor should show multiple type field warning with a table contai
             },
           ]
         }
+        tableCaption="Indices listed by conflicting field type"
       />
       <eui-spacer
         size="m"

--- a/src/platform/plugins/shared/data_view_management/public/components/field_editor/field_editor.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/field_editor/field_editor.tsx
@@ -491,7 +491,13 @@ export class FieldEditor extends PureComponent<FieldEdiorProps, FieldEditorState
           />
         </EuiCallOut>
         <EuiSpacer size="m" />
-        <EuiBasicTable items={items} columns={columns} />
+        <EuiBasicTable
+          items={items}
+          columns={columns}
+          tableCaption={i18n.translate('indexPatternManagement.fieldTypeConflictTableCaption', {
+            defaultMessage: 'Indices listed by conflicting field type',
+          })}
+        />
         <EuiSpacer size="m" />
       </div>
     );

--- a/src/platform/plugins/shared/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -392,6 +392,7 @@ export const IndexPatternTable = ({ history, canSave, setShowCreateDialog, title
           onTableChange={onTableChange}
           search={search}
           selection={dataViews.getCanSaveSync() ? selection : undefined}
+          tableCaption={title}
         />
       </ContextWrapper>
       {flyoutOpen && (

--- a/src/platform/plugins/shared/saved_objects_finder/public/finder/saved_object_finder.tsx
+++ b/src/platform/plugins/shared/saved_objects_finder/public/finder/saved_object_finder.tsx
@@ -407,6 +407,9 @@ class SavedObjectFinderUiClass extends React.Component<
             columns={columns}
             data-test-subj="savedObjectsFinderTable"
             message={this.props.noItemsMessage}
+            tableCaption={i18n.translate('savedObjectsFinder.tableCaption', {
+              defaultMessage: 'Saved objects search results',
+            })}
             search={search}
             pagination={pagination}
             sorting={!!this.state.query?.text ? undefined : sorting}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-data-discovery` files (#246176)](https://github.com/elastic/kibana/pull/246176)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexey Antonov","email":"alexwizp@gmail.com"},"sourceCommit":{"committedDate":"2026-01-21T08:06:10Z","message":"Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-data-discovery` files (#246176)\n\n> [!CAUTION]\n> ⚠️ **Changes / translations were made by GenAI**. I’ve reviewed them\ncarefully, but your code owners’ expert eyes will ensure they’re 100%\nright.\n\n## Summary\nThis PR applies the auto-fix for the newly introduced\n`@elastic/eui/require-table-caption`.\nThis rule ensure `EuiInMemoryTable`, `EuiBasicTable` have a\n`tableCaption` prop for accessibility.\n\n## Changes\n\n1. 🎯 Added missing `tableCaption` attributes to elements flagged by\n`@elastic/eui/require-table-caption` — accessibility leveled up!\n\n## Related\n- https://github.com/elastic/eui/pull/9168\n\nThis time, to avoid annoying approvals collection, we've broken files\ndown by teams. Now, we are waiting a review only from your team!","sha":"4d43ef8b17904ce299122784e2e391f7c1b2bfda","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport:version","v9.3.0","v9.4.0","v9.2.5"],"title":"Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-data-discovery` files","number":246176,"url":"https://github.com/elastic/kibana/pull/246176","mergeCommit":{"message":"Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-data-discovery` files (#246176)\n\n> [!CAUTION]\n> ⚠️ **Changes / translations were made by GenAI**. I’ve reviewed them\ncarefully, but your code owners’ expert eyes will ensure they’re 100%\nright.\n\n## Summary\nThis PR applies the auto-fix for the newly introduced\n`@elastic/eui/require-table-caption`.\nThis rule ensure `EuiInMemoryTable`, `EuiBasicTable` have a\n`tableCaption` prop for accessibility.\n\n## Changes\n\n1. 🎯 Added missing `tableCaption` attributes to elements flagged by\n`@elastic/eui/require-table-caption` — accessibility leveled up!\n\n## Related\n- https://github.com/elastic/eui/pull/9168\n\nThis time, to avoid annoying approvals collection, we've broken files\ndown by teams. Now, we are waiting a review only from your team!","sha":"4d43ef8b17904ce299122784e2e391f7c1b2bfda"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/249828","number":249828,"state":"MERGED","mergeCommit":{"sha":"971b328e5332d14c05978af1fcbbedd7ad1f3867","message":"[9.3] Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-data-discovery` files (#246176) (#249828)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [Address `@elastic/eui/require-table-caption` lint violations across\n`@elastic/kibana-data-discovery` files\n(#246176)](https://github.com/elastic/kibana/pull/246176)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/246176","number":246176,"mergeCommit":{"message":"Address `@elastic/eui/require-table-caption` lint violations across `@elastic/kibana-data-discovery` files (#246176)\n\n> [!CAUTION]\n> ⚠️ **Changes / translations were made by GenAI**. I’ve reviewed them\ncarefully, but your code owners’ expert eyes will ensure they’re 100%\nright.\n\n## Summary\nThis PR applies the auto-fix for the newly introduced\n`@elastic/eui/require-table-caption`.\nThis rule ensure `EuiInMemoryTable`, `EuiBasicTable` have a\n`tableCaption` prop for accessibility.\n\n## Changes\n\n1. 🎯 Added missing `tableCaption` attributes to elements flagged by\n`@elastic/eui/require-table-caption` — accessibility leveled up!\n\n## Related\n- https://github.com/elastic/eui/pull/9168\n\nThis time, to avoid annoying approvals collection, we've broken files\ndown by teams. Now, we are waiting a review only from your team!","sha":"4d43ef8b17904ce299122784e2e391f7c1b2bfda"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->