### PR TITLE
[9.3] [Streams][SigEvents] Fix query sync on save and add debounce for preview chart (#249833)

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/add_significant_event_flyout/manual_flow_form/manual_flow_form.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/add_significant_event_flyout/manual_flow_form/manual_flow_form.tsx
@@ -18,7 +18,8 @@ import {
 import { i18n } from '@kbn/i18n';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { StreamQueryKql, Streams, Feature } from '@kbn/streams-schema';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useDebounceFn } from '@kbn/react-hooks';
 import { UncontrolledStreamsAppSearchBar } from '../../../streams_app_search_bar/uncontrolled_streams_app_bar';
 import { PreviewDataSparkPlot } from '../common/preview_data_spark_plot';
 import { validateQuery } from '../common/validate_query';
@@ -35,6 +36,9 @@ interface Props {
   dataViews: DataView[];
 }
 
+const DEBOUNCE_DELAY_MS = 300;
+const DEBOUNCE_OPTIONS = { wait: DEBOUNCE_DELAY_MS };
+
 export function ManualFlowForm({
   definition,
   query,
@@ -50,6 +54,23 @@ export function ManualFlowForm({
     kql: false,
     severity: false,
   });
+
+  // Debounced KQL query for preview chart API calls
+  const [debouncedKqlQuery, setDebouncedKqlQuery] = useState(query.kql.query);
+
+  const { run: updateDebouncedKqlQuery } = useDebounceFn(
+    (kqlQuery: string) => setDebouncedKqlQuery(kqlQuery),
+    DEBOUNCE_OPTIONS
+  );
+
+  // Create a query object with debounced KQL for the preview chart
+  const debouncedQuery = useMemo(
+    (): StreamQueryKql => ({
+      ...query,
+      kql: { query: debouncedKqlQuery },
+    }),
+    [query, debouncedKqlQuery]
+  );
 
   const validation = validateQuery(query);
 
@@ -182,17 +203,15 @@ export function ManualFlowForm({
               showQueryInput
               showSubmitButton={false}
               isDisabled={isSubmitting}
-              onQueryChange={() => {
-                setTouched((prev) => ({ ...prev, kql: true }));
-              }}
-              onQuerySubmit={(next) => {
+              onQueryChange={(next) => {
+                // Immediately sync query state so it's always up-to-date for save
+                const nextKqlQuery = typeof next.query?.query === 'string' ? next.query.query : '';
                 setQuery({
                   ...query,
-                  kql: {
-                    query: typeof next.query?.query === 'string' ? next.query.query : '',
-                  },
+                  kql: { query: nextKqlQuery },
                 });
-
+                // Debounce the preview chart update
+                updateDebouncedKqlQuery(nextKqlQuery);
                 setTouched((prev) => ({ ...prev, kql: true }));
               }}
               placeholder={i18n.translate(
@@ -200,7 +219,6 @@ export function ManualFlowForm({
                 { defaultMessage: 'Enter query' }
               )}
               indexPatterns={dataViews}
-              submitOnBlur
             />
           </EuiFormRow>
         </EuiForm>
@@ -209,7 +227,7 @@ export function ManualFlowForm({
 
         <PreviewDataSparkPlot
           definition={definition}
-          query={query}
+          query={debouncedQuery}
           isQueryValid={!validation.kql.isInvalid}
         />
       </EuiFlexGroup>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Streams][SigEvents] Fix query sync on save and add debounce for preview chart (#249833)](https://github.com/elastic/kibana/pull/249833)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2026-01-21T11:50:20Z","message":"[Streams][SigEvents] Fix query sync on save and add debounce for preview chart (#249833)\n\n## Summary\n\n- Fix stale query value being used when saving significant events\nwithout blurring the query input field\n- Add debouncing to preview chart API calls to prevent excessive\nrequests with the new behavior\n\n## Problem\n\nWhen editing a significant event, the query input field only synced its\nvalue to the parent state on blur (via `submitOnBlur`). This meant that\nif a user edited the query and clicked \"Update event\" without first\nclicking outside the input, the old query value was saved instead of the\nnew one.\n\n## Solution\n\nUpdated `ManualFlowForm` to:\n\n1. **Sync query state immediately on change**: The `onQueryChange`\ncallback now updates the parent's query state on every keystroke,\nensuring the save button always has access to the latest value\n2. **Debounce preview chart updates**: Since the query state now updates\non every keystroke, added a 300ms debounce for the preview chart API\ncalls using `useDebounceFn` from `@kbn/react-hooks` to prevent excessive\nnetwork requests while typing\n\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/32d87e4f-eea1-43cf-a3d9-e16e7b4d684b\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/c4fedb32-20b9-4aa7-afaa-4afb2087eb5e","sha":"c5db71024a0d243ce1fbdddb3cb3317f8a61f3b0","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.4.0","author:actionable-obs","Feature:SigEvents","v9.3.1"],"title":"[Streams][SigEvents] Fix query sync on save and add debounce for preview chart","number":249833,"url":"https://github.com/elastic/kibana/pull/249833","mergeCommit":{"message":"[Streams][SigEvents] Fix query sync on save and add debounce for preview chart (#249833)\n\n## Summary\n\n- Fix stale query value being used when saving significant events\nwithout blurring the query input field\n- Add debouncing to preview chart API calls to prevent excessive\nrequests with the new behavior\n\n## Problem\n\nWhen editing a significant event, the query input field only synced its\nvalue to the parent state on blur (via `submitOnBlur`). This meant that\nif a user edited the query and clicked \"Update event\" without first\nclicking outside the input, the old query value was saved instead of the\nnew one.\n\n## Solution\n\nUpdated `ManualFlowForm` to:\n\n1. **Sync query state immediately on change**: The `onQueryChange`\ncallback now updates the parent's query state on every keystroke,\nensuring the save button always has access to the latest value\n2. **Debounce preview chart updates**: Since the query state now updates\non every keystroke, added a 300ms debounce for the preview chart API\ncalls using `useDebounceFn` from `@kbn/react-hooks` to prevent excessive\nnetwork requests while typing\n\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/32d87e4f-eea1-43cf-a3d9-e16e7b4d684b\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/c4fedb32-20b9-4aa7-afaa-4afb2087eb5e","sha":"c5db71024a0d243ce1fbdddb3cb3317f8a61f3b0"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249833","number":249833,"mergeCommit":{"message":"[Streams][SigEvents] Fix query sync on save and add debounce for preview chart (#249833)\n\n## Summary\n\n- Fix stale query value being used when saving significant events\nwithout blurring the query input field\n- Add debouncing to preview chart API calls to prevent excessive\nrequests with the new behavior\n\n## Problem\n\nWhen editing a significant event, the query input field only synced its\nvalue to the parent state on blur (via `submitOnBlur`). This meant that\nif a user edited the query and clicked \"Update event\" without first\nclicking outside the input, the old query value was saved instead of the\nnew one.\n\n## Solution\n\nUpdated `ManualFlowForm` to:\n\n1. **Sync query state immediately on change**: The `onQueryChange`\ncallback now updates the parent's query state on every keystroke,\nensuring the save button always has access to the latest value\n2. **Debounce preview chart updates**: Since the query state now updates\non every keystroke, added a 300ms debounce for the preview chart API\ncalls using `useDebounceFn` from `@kbn/react-hooks` to prevent excessive\nnetwork requests while typing\n\n\nBefore:\n\n\nhttps://github.com/user-attachments/assets/32d87e4f-eea1-43cf-a3d9-e16e7b4d684b\n\nAfter:\n\n\nhttps://github.com/user-attachments/assets/c4fedb32-20b9-4aa7-afaa-4afb2087eb5e","sha":"c5db71024a0d243ce1fbdddb3cb3317f8a61f3b0"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->