### PR TITLE
[Security Solution][Attack Discovery][Bug] Schedules fail to run due to internal Elastic Managed LLM connector changes

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/connectors/outdated_connectors.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/connectors/outdated_connectors.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  resolveConnectorId,
+  ELASTIC_MANAGED_LLM_CONNECTOR_ID,
+  GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID,
+  GENERAL_PURPOSE_LLM_V2_CONNECTOR_ID,
+  ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID,
+} from './outdated_connectors';
+
+describe('outdated_connectors', () => {
+  describe('resolveConnectorId', () => {
+    it('resolves ELASTIC_MANAGED_LLM_CONNECTOR_ID to ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID', () => {
+      expect(resolveConnectorId(ELASTIC_MANAGED_LLM_CONNECTOR_ID)).toBe(
+        ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID
+      );
+    });
+
+    it('resolves GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID to ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID', () => {
+      expect(resolveConnectorId(GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID)).toBe(
+        ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID
+      );
+    });
+
+    it('does not resolve GENERAL_PURPOSE_LLM_V2_CONNECTOR_ID', () => {
+      expect(resolveConnectorId(GENERAL_PURPOSE_LLM_V2_CONNECTOR_ID)).toBe(
+        GENERAL_PURPOSE_LLM_V2_CONNECTOR_ID
+      );
+    });
+
+    it('returns the same connectorId if it is not outdated', () => {
+      const connectorId = 'some-other-connector-id';
+      expect(resolveConnectorId(connectorId)).toBe(connectorId);
+    });
+
+    it('returns ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID if passed directly', () => {
+      expect(resolveConnectorId(ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID)).toBe(
+        ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID
+      );
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/connectors/outdated_connectors.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/connectors/outdated_connectors.test.ts
@@ -10,20 +10,20 @@ import {
   ELASTIC_MANAGED_LLM_CONNECTOR_ID,
   GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID,
   GENERAL_PURPOSE_LLM_V2_CONNECTOR_ID,
-  ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID,
+  LATEST_ELASTIC_MANAGED_CONNECTOR_ID,
 } from './outdated_connectors';
 
 describe('outdated_connectors', () => {
   describe('resolveConnectorId', () => {
-    it('resolves ELASTIC_MANAGED_LLM_CONNECTOR_ID to ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID', () => {
+    it('resolves ELASTIC_MANAGED_LLM_CONNECTOR_ID to LATEST_ELASTIC_MANAGED_CONNECTOR_ID', () => {
       expect(resolveConnectorId(ELASTIC_MANAGED_LLM_CONNECTOR_ID)).toBe(
-        ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID
+        LATEST_ELASTIC_MANAGED_CONNECTOR_ID
       );
     });
 
-    it('resolves GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID to ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID', () => {
+    it('resolves GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID to LATEST_ELASTIC_MANAGED_CONNECTOR_ID', () => {
       expect(resolveConnectorId(GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID)).toBe(
-        ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID
+        LATEST_ELASTIC_MANAGED_CONNECTOR_ID
       );
     });
 
@@ -38,9 +38,9 @@ describe('outdated_connectors', () => {
       expect(resolveConnectorId(connectorId)).toBe(connectorId);
     });
 
-    it('returns ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID if passed directly', () => {
-      expect(resolveConnectorId(ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID)).toBe(
-        ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID
+    it('returns LATEST_ELASTIC_MANAGED_CONNECTOR_ID if passed directly', () => {
+      expect(resolveConnectorId(LATEST_ELASTIC_MANAGED_CONNECTOR_ID)).toBe(
+        LATEST_ELASTIC_MANAGED_CONNECTOR_ID
       );
     });
   });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/connectors/outdated_connectors.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/connectors/outdated_connectors.ts
@@ -8,17 +8,18 @@
 export const ELASTIC_MANAGED_LLM_CONNECTOR_ID = 'Elastic-Managed-LLM';
 export const GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID = 'General-Purpose-LLM-v1';
 export const GENERAL_PURPOSE_LLM_V2_CONNECTOR_ID = 'General-Purpose-LLM-v2';
+export const ANTHROPIC_CLAUDE_SONNET_4_5_CONNECTOR_ID = 'Anthropic-Claude-Sonnet-4-5';
 
 export const OUTDATED_ELASTIC_MANAGED_CONNECTOR_IDS = [
   ELASTIC_MANAGED_LLM_CONNECTOR_ID,
   GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID,
 ];
 
-export const ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID = 'Anthropic-Claude-Sonnet-3-7';
+export const LATEST_ELASTIC_MANAGED_CONNECTOR_ID = ANTHROPIC_CLAUDE_SONNET_4_5_CONNECTOR_ID;
 
 export const resolveConnectorId = (connectorId: string) => {
   if (OUTDATED_ELASTIC_MANAGED_CONNECTOR_IDS.includes(connectorId)) {
-    return ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID;
+    return LATEST_ELASTIC_MANAGED_CONNECTOR_ID;
   }
   return connectorId;
 };

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/connectors/outdated_connectors.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/connectors/outdated_connectors.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const ELASTIC_MANAGED_LLM_CONNECTOR_ID = 'Elastic-Managed-LLM';
+export const GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID = 'General-Purpose-LLM-v1';
+export const GENERAL_PURPOSE_LLM_V2_CONNECTOR_ID = 'General-Purpose-LLM-v2';
+
+export const OUTDATED_ELASTIC_MANAGED_CONNECTOR_IDS = [
+  ELASTIC_MANAGED_LLM_CONNECTOR_ID,
+  GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID,
+];
+
+export const ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID = 'Anthropic-Claude-Sonnet-3-7';
+
+export const resolveConnectorId = (connectorId: string) => {
+  if (OUTDATED_ELASTIC_MANAGED_CONNECTOR_IDS.includes(connectorId)) {
+    return ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID;
+  }
+  return connectorId;
+};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/index.ts
@@ -98,6 +98,8 @@ export {
 export { transformAttackDiscoveryAlertFromApi } from './impl/utils/transform_attack_discovery_alert_from_api';
 export { transformAttackDiscoveryAlertToApi } from './impl/utils/transform_attack_discovery_alert_to_api';
 export { transformAttackDiscoveryScheduleFromApi } from './impl/utils/transform_attack_discovery_schedule_from_api';
+
+export * from './impl/connectors/outdated_connectors';
 export { transformAttackDiscoveryScheduleToApi } from './impl/utils/transform_attack_discovery_schedule_to_api';
 export { transformAttackDiscoveryScheduleCreatePropsToApi } from './impl/utils/transform_attack_discovery_schedule_create_props_to_api';
 export { transformAttackDiscoveryScheduleUpdatePropsToApi } from './impl/utils/transform_attack_discovery_schedule_update_props_to_api';

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transform.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transform.test.ts
@@ -8,7 +8,7 @@
 import type { estypes } from '@elastic/elasticsearch';
 import {
   ELASTIC_MANAGED_LLM_CONNECTOR_ID,
-  ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID,
+  LATEST_ELASTIC_MANAGED_CONNECTOR_ID,
 } from '@kbn/elastic-assistant-common';
 
 import {
@@ -130,7 +130,7 @@ describe('transforms', () => {
           connector_id: ELASTIC_MANAGED_LLM_CONNECTOR_ID,
         } as EsConversationSchema['api_config'],
       });
-      expect(message.apiConfig?.connectorId).toBe(ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID);
+      expect(message.apiConfig?.connectorId).toBe(LATEST_ELASTIC_MANAGED_CONNECTOR_ID);
     });
 
     it('should correctly transform ES conversation with unmapped connector ID', () => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transform.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transform.test.ts
@@ -7,6 +7,11 @@
 
 import type { estypes } from '@elastic/elasticsearch';
 import {
+  ELASTIC_MANAGED_LLM_CONNECTOR_ID,
+  ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID,
+} from '@kbn/elastic-assistant-common';
+
+import {
   transformESToConversation,
   transformESSearchToConversations,
   transformESToConversations,
@@ -115,6 +120,32 @@ describe('transforms', () => {
   });
 
   describe('transformESToConversation', () => {
+    it('should correctly transform ES conversation with mapped connector ID', () => {
+      const esConversation = getEsConversationMock();
+
+      const message = transformESToConversation({
+        ...esConversation,
+        api_config: {
+          ...esConversation.api_config,
+          connector_id: ELASTIC_MANAGED_LLM_CONNECTOR_ID,
+        } as EsConversationSchema['api_config'],
+      });
+      expect(message.apiConfig?.connectorId).toBe(ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID);
+    });
+
+    it('should correctly transform ES conversation with unmapped connector ID', () => {
+      const esConversation = getEsConversationMock();
+
+      const message = transformESToConversation({
+        ...esConversation,
+        api_config: {
+          ...esConversation.api_config,
+          connector_id: 'some-other-id',
+        } as EsConversationSchema['api_config'],
+      });
+      expect(message.apiConfig?.connectorId).toBe('some-other-id');
+    });
+
     it('should correctly transform ES conversation', () => {
       const esConversation = getEsConversationMock();
       const conversation = transformESToConversation(esConversation);

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transforms.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transforms.ts
@@ -7,7 +7,10 @@
 
 import type { estypes } from '@elastic/elasticsearch';
 import type { ConversationResponse, Replacements } from '@kbn/elastic-assistant-common';
-import { replaceOriginalValuesWithUuidValues } from '@kbn/elastic-assistant-common';
+import {
+  replaceOriginalValuesWithUuidValues,
+  resolveConnectorId,
+} from '@kbn/elastic-assistant-common';
 import _ from 'lodash';
 import type { EsConversationSchema } from './types';
 
@@ -32,8 +35,11 @@ export const transformESToConversation = (
     ...(conversationSchema.api_config
       ? {
           apiConfig: {
+            // Resolve potentially outdated Elastic managed connector ID to the new one.
+            // This provides backward compatibility for existing conversations that reference
+            // "Elastic-Managed-LLM" or "General-Purpose-LLM-v1".
+            connectorId: resolveConnectorId(conversationSchema.api_config.connector_id),
             actionTypeId: conversationSchema.api_config.action_type_id,
-            connectorId: conversationSchema.api_config.connector_id,
             defaultSystemPromptId: conversationSchema.api_config.default_system_prompt_id,
             model: conversationSchema.api_config.model,
             provider: conversationSchema.api_config.provider,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
@@ -13,6 +13,10 @@ import { AlertsClientError } from '@kbn/alerting-plugin/server';
 import { alertsMock } from '@kbn/alerting-plugin/server/mocks';
 import { analyticsServiceMock } from '@kbn/core/server/mocks';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
+import {
+  ELASTIC_MANAGED_LLM_CONNECTOR_ID,
+  ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID,
+} from '@kbn/elastic-assistant-common';
 
 import { attackDiscoveryScheduleExecutor } from './executor';
 import { findDocuments } from '../../../../ai_assistant_data_clients/find';
@@ -603,5 +607,35 @@ describe('attackDiscoveryScheduleExecutor', () => {
     );
 
     expect(createTaskRunError).toHaveBeenCalledWith(error, TaskErrorSource.USER);
+  });
+
+  it('should resolve outdated connector ID to the new one before generating discoveries', async () => {
+    const options = {
+      ...executorOptions,
+      params: {
+        ...params,
+        apiConfig: {
+          ...params.apiConfig,
+          connectorId: ELASTIC_MANAGED_LLM_CONNECTOR_ID,
+        },
+      },
+    } as unknown as RuleExecutorOptions;
+
+    await attackDiscoveryScheduleExecutor({
+      options,
+      logger: mockLogger,
+      publicBaseUrl: undefined,
+      telemetry: mockTelemetry,
+    });
+
+    expect(generateAttackDiscoveries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          apiConfig: expect.objectContaining({
+            connectorId: ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID,
+          }),
+        }),
+      })
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
@@ -15,7 +15,7 @@ import { analyticsServiceMock } from '@kbn/core/server/mocks';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import {
   ELASTIC_MANAGED_LLM_CONNECTOR_ID,
-  ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID,
+  LATEST_ELASTIC_MANAGED_CONNECTOR_ID,
 } from '@kbn/elastic-assistant-common';
 
 import { attackDiscoveryScheduleExecutor } from './executor';
@@ -632,7 +632,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
       expect.objectContaining({
         config: expect.objectContaining({
           apiConfig: expect.objectContaining({
-            connectorId: ANTHROPIC_CLAUDE_SONNET_3_7_CONNECTOR_ID,
+            connectorId: LATEST_ELASTIC_MANAGED_CONNECTOR_ID,
           }),
         }),
       })


### PR DESCRIPTION
## Summary

This PR addresses an issue where schedules and conversations referencing outdated Elastic managed LLM connector IDs fail to execute or display correctly. The outdated connector IDs `Elastic-Managed-LLM` and `General-Purpose-LLM-v1` have been replaced by `Anthropic-Claude-Sonnet-4-5`.

This change implements a backward compatibility layer that automatically resolves these outdated connector IDs to the new one at runtime.

### Testing

1. **Setup EIS Locally**: Follow [this guide](https://docs.elastic.dev/search-team/teams/inference/faq#how-can-i-use-eis-locally-in-kibana) to setup EIS locally.

2. **Configure Old Connector**: In an older version (or before applying these changes), add a predefined connector referencing EIS in your `kibana.dev.yml`:

    ```yaml
    xpack.actions.preconfigured:
      Elastic-Managed-LLM:
        name: Elastic Managed LLM
        actionTypeId: .inference
        exposeConfig: true
        config:
          provider: 'elastic'
          taskType: 'chat_completion'
          inferenceId: '.rainbow-sprinkles-elastic'
          providerConfig:
            model_id: 'rainbow-sprinkles'
    ```

3. **Create Data**:
    - Create an **Attack Discovery Schedule** using this connector.
    - Start an **AI Assistant Conversation** using this connector.

4. **Update Connector Configuration**: Replace the previous `Elastic-Managed-LLM` connector configuration with the new one:

   ```yaml
    xpack.actions.preconfigured:
      Anthropic-Claude-Sonnet-4-5:
        name: Anthropic Claude Sonnet 4.5
       provider: 'elastic'
       taskType: 'chat_completion'
       inferenceId: '.rainbow-sprinkles-elastic'
       providerConfig:
         model_id: 'rainbow-sprinkles'
   ```

5. **Verify**: Restart Kibana and verify that:
    - The existing Attack Discovery Schedule continues to run successfully.
    - The existing AI Assistant Conversation loads correctly and allows continuing the chat using the new connector.


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->