### PR TITLE
Add missing optional dependency towards `timelines`

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/osquery/kibana.jsonc
@@ -31,7 +31,8 @@
       "lens",
       "telemetry",
       "cases",
-      "spaces"
+      "spaces",
+      "timelines"
     ],
     "requiredBundles": [
       "esUiShared",


### PR DESCRIPTION
## Summary

The dependency was expected but not present in the manifest.