### PR TITLE
[9.2] [Global Search] validate the options.preference request parameter (#249787)

### DIFF
--- a/x-pack/platform/plugins/shared/global_search/server/routes/find.ts
+++ b/x-pack/platform/plugins/shared/global_search/server/routes/find.ts
@@ -29,7 +29,7 @@ export const registerInternalFindRoute = (router: GlobalSearchRouter) => {
           }),
           options: schema.maybe(
             schema.object({
-              preference: schema.maybe(schema.string()),
+              preference: schema.maybe(schema.string({ maxLength: 64 })),
             })
           ),
         }),

--- a/x-pack/platform/plugins/shared/global_search/server/routes/integration_tests/find.test.ts
+++ b/x-pack/platform/plugins/shared/global_search/server/routes/integration_tests/find.test.ts
@@ -123,6 +123,35 @@ describe('POST /internal/global_search/find', () => {
     );
   });
 
+  it('allows requests with max length options.preference string', async () => {
+    const longPreference = 'a'.repeat(64); // maxLength is 64
+
+    const response = await supertest(server.listener)
+      .post('/internal/global_search/find')
+      .send({ params: { term: 'search' }, options: { preference: longPreference } })
+      .expect(200);
+
+    expect(response.body).toEqual({});
+  });
+
+  it('disallows requests with large options.preference string', async () => {
+    const longPreference = 'a'.repeat(65); // maxLength is 64
+
+    const response = await supertest(server.listener)
+      .post('/internal/global_search/find')
+      .send({ params: { term: 'search' }, options: { preference: longPreference } })
+      .expect(400);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        error: 'Bad Request',
+        message:
+          '[request body.options.preference]: value has length [65] but it must have a maximum length of [64].',
+        statusCode: 400,
+      })
+    );
+  });
+
   it('returns the default error when the observable throws any other error', async () => {
     globalSearchHandlerContext.find.mockReturnValue(throwError('any-error'));
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Global Search] validate the options.preference request parameter (#249787)](https://github.com/elastic/kibana/pull/249787)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tim Sullivan","email":"tsullivan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-21T15:34:26Z","message":"[Global Search] validate the options.preference request parameter (#249787)\n\n## Summary\n\nThis PR improves the validation of the Global Search HTTP request\nhandler.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- ~~[ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- ~~[ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- ~~[ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- ~~[ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- ~~[ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- [X] The risk for adding validation to the HTTP request parameters for\nthis route is low, since this is an internal route.","sha":"9b6a80be062735832fce2dea508080e703aa68ad","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.4.0","backport:9.2","v9.2.5","v8.19.11","backport:9.3","v9.3.1"],"title":"[Global Search] validate the options.preference request parameter","number":249787,"url":"https://github.com/elastic/kibana/pull/249787","mergeCommit":{"message":"[Global Search] validate the options.preference request parameter (#249787)\n\n## Summary\n\nThis PR improves the validation of the Global Search HTTP request\nhandler.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- ~~[ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- ~~[ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- ~~[ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- ~~[ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- ~~[ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- [X] The risk for adding validation to the HTTP request parameters for\nthis route is low, since this is an internal route.","sha":"9b6a80be062735832fce2dea508080e703aa68ad"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249787","number":249787,"mergeCommit":{"message":"[Global Search] validate the options.preference request parameter (#249787)\n\n## Summary\n\nThis PR improves the validation of the Global Search HTTP request\nhandler.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- ~~[ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- ~~[ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- ~~[ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- ~~[ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- ~~[ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [X] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\n- [X] The risk for adding validation to the HTTP request parameters for\nthis route is low, since this is an internal route.","sha":"9b6a80be062735832fce2dea508080e703aa68ad"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/249905","number":249905,"state":"OPEN"},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/249918","number":249918,"state":"OPEN"}]}] BACKPORT-->