### PR TITLE
[apm][scout] disable solution tour to stabilise tests on ECH

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/global.setup.ts
@@ -22,8 +22,13 @@ globalSetupHook.setTimeout(2 * 60 * 1000); // 2 minutes
 globalSetupHook(
   'Ingest data to Elasticsearch',
   { tag: ['@ess', '@svlOblt'] },
-  async ({ apmSynthtraceEsClient, apiServices, log, config, esClient }) => {
+  async ({ apmSynthtraceEsClient, apiServices, log, config, esClient, kbnClient }) => {
     const startTime = Date.now();
+
+    // disable solution tour on ECH
+    if (config.isCloud && !config.serverless) {
+      await kbnClient.uiSettings.update({ showSpaceSolutionTour: false });
+    }
     if (!config.isCloud) {
       await apiServices.fleet.internal.setup();
       log.info('Fleet infrastructure setup completed');


### PR DESCRIPTION
## Summary

Fixes test failure on ECH:

```
Error: locator.waitFor: Error: strict mode violation: getByRole('dialog') resolved to 2 elements:
    1) <div role="dialog" aria-modal="true" aria-live="assertive" aria-labelledby=":r16:" data-popover-open="true" data-popover-panel="true" data-test-subj="spaceSolutionTour" class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel euiTour css-1x5r2xi-euiPanel-grow-m-m-plain-euiPopover__panel-light-isOpen-hasTransform-bottom-euiTour">…</div> aka getByTestId('spaceSolutionTour')
    2) <div tabindex="0" role="dialog" aria-modal="true" data-autofocus="true" aria-describedby=":r1v:" aria-labelledby="flyoutTitle" class="euiFlyout css-e7ttjf-euiFlyout-l-noMaxWidth-overlay-right-right">…</div> aka getByRole('dialog', { name: 'Create rule' })

Call log:
  - waiting for getByRole('dialog') to be hidden

    at AddRuleFlyout.saveRule (x-pack/solutions/observability/plugins/apm/test/scout/ui/fixtures/page_objects/alerts_controls/add_rule_flyout.ts:59:23)
    at x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/alerts/error_count.spec.ts:51:7
    at x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/alerts/error_count.spec.ts:49:5
```

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/03998680-3b5d-4d86-bcca-f0216c87712a" />


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->