### PR TITLE
[Fleet] Fix copy integration policy test

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/agent_policy_multi_select.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/agent_policy_multi_select.tsx
@@ -51,7 +51,7 @@ export const AgentPolicyMultiSelect: React.FunctionComponent<Props> = ({
   return (
     <EuiComboBox
       aria-label="Select Multiple Agent Policies"
-      data-test-subj="agentPolicyMultiSelect"
+      data-test-subj={isLoading ? 'agentPolicyMultiSelectLoading' : 'agentPolicyMultiSelect'}
       placeholder={i18n.translate(
         'xpack.fleet.createPackagePolicy.StepSelectPolicy.agentPolicyMultiPlaceholderText',
         {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/agent_policy_multi_select.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/agent_policy_multi_select.tsx
@@ -51,7 +51,7 @@ export const AgentPolicyMultiSelect: React.FunctionComponent<Props> = ({
   return (
     <EuiComboBox
       aria-label="Select Multiple Agent Policies"
-      data-test-subj={isLoading ? 'agentPolicyMultiSelectLoading' : 'agentPolicyMultiSelect'}
+      data-test-subj="agentPolicyMultiSelect"
       placeholder={i18n.translate(
         'xpack.fleet.createPackagePolicy.StepSelectPolicy.agentPolicyMultiPlaceholderText',
         {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/copy_integration_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/copy_integration_page.ts
@@ -30,6 +30,10 @@ export class CopyIntegrationPage {
     return this.page.testSubj.locator('agentPolicyMultiSelect');
   }
 
+  getAgentPolicySelectOption() {
+    return this.getAgentPolicySelect().getByTestId('comboBoxInput');
+  }
+
   async fillPackagePolicyName(name: string) {
     const input = this.getPackagePolicyNameInput();
     await input.clear();

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/copy_integration_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/copy_integration_page.ts
@@ -30,8 +30,8 @@ export class CopyIntegrationPage {
     return this.page.testSubj.locator('agentPolicyMultiSelect');
   }
 
-  getAgentPolicySelectOption() {
-    return this.getAgentPolicySelect().getByTestId('comboBoxInput');
+  getAgentPolicySelectIsLoading() {
+    return this.getAgentPolicySelect().getByRole('progressbar');
   }
 
   async fillPackagePolicyName(name: string) {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/copy_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/copy_integration.spec.ts
@@ -141,6 +141,8 @@ test.describe('Copy integration', { tag: ['@ess'] }, () => {
     const nameInput = copyIntegration.getPackagePolicyNameInput();
     await expect(nameInput).toBeVisible();
 
+    await expect(copyIntegration.getAgentPolicySelectOption()).toBeVisible();
+
     await expect(nameInput).toHaveValue(`copy-${packagePolicyName}`);
 
     const pathsInput = copyIntegration.getMultiTextInputRow('nginx.access', 'paths');

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/copy_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/copy_integration.spec.ts
@@ -141,7 +141,9 @@ test.describe('Copy integration', { tag: ['@ess'] }, () => {
     const nameInput = copyIntegration.getPackagePolicyNameInput();
     await expect(nameInput).toBeVisible();
 
-    await expect(copyIntegration.getAgentPolicySelectOption()).toBeVisible();
+    // Ensure agent policy select is loaded
+    await expect(copyIntegration.getAgentPolicySelect()).toBeVisible();
+    await expect(copyIntegration.getAgentPolicySelectIsLoading()).toBeHidden();
 
     await expect(nameInput).toHaveValue(`copy-${packagePolicyName}`);
 


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/249893 

Fix some flakyness in copy integration test, the test need the agent policy select to be fully loaded.

A more future proof fix, will be to refactor the package policy editor, so loading agent policies do not happens in a child element and trigger side and the submit button will only clickable when agent policies are loaded but it seems a big and risky refacto,