### PR TITLE
[9.3] [Security Solution][Attack Discovery][Bug] Schedules fail to run due to internal Elastic Managed LLM connector changes (#249891)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/connectors/outdated_connectors.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/connectors/outdated_connectors.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  resolveConnectorId,
+  ELASTIC_MANAGED_LLM_CONNECTOR_ID,
+  GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID,
+  GENERAL_PURPOSE_LLM_V2_CONNECTOR_ID,
+  LATEST_ELASTIC_MANAGED_CONNECTOR_ID,
+} from './outdated_connectors';
+
+describe('outdated_connectors', () => {
+  describe('resolveConnectorId', () => {
+    it('resolves ELASTIC_MANAGED_LLM_CONNECTOR_ID to LATEST_ELASTIC_MANAGED_CONNECTOR_ID', () => {
+      expect(resolveConnectorId(ELASTIC_MANAGED_LLM_CONNECTOR_ID)).toBe(
+        LATEST_ELASTIC_MANAGED_CONNECTOR_ID
+      );
+    });
+
+    it('resolves GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID to LATEST_ELASTIC_MANAGED_CONNECTOR_ID', () => {
+      expect(resolveConnectorId(GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID)).toBe(
+        LATEST_ELASTIC_MANAGED_CONNECTOR_ID
+      );
+    });
+
+    it('does not resolve GENERAL_PURPOSE_LLM_V2_CONNECTOR_ID', () => {
+      expect(resolveConnectorId(GENERAL_PURPOSE_LLM_V2_CONNECTOR_ID)).toBe(
+        GENERAL_PURPOSE_LLM_V2_CONNECTOR_ID
+      );
+    });
+
+    it('returns the same connectorId if it is not outdated', () => {
+      const connectorId = 'some-other-connector-id';
+      expect(resolveConnectorId(connectorId)).toBe(connectorId);
+    });
+
+    it('returns LATEST_ELASTIC_MANAGED_CONNECTOR_ID if passed directly', () => {
+      expect(resolveConnectorId(LATEST_ELASTIC_MANAGED_CONNECTOR_ID)).toBe(
+        LATEST_ELASTIC_MANAGED_CONNECTOR_ID
+      );
+    });
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/connectors/outdated_connectors.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/connectors/outdated_connectors.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const ELASTIC_MANAGED_LLM_CONNECTOR_ID = 'Elastic-Managed-LLM';
+export const GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID = 'General-Purpose-LLM-v1';
+export const GENERAL_PURPOSE_LLM_V2_CONNECTOR_ID = 'General-Purpose-LLM-v2';
+export const ANTHROPIC_CLAUDE_SONNET_4_5_CONNECTOR_ID = 'Anthropic-Claude-Sonnet-4-5';
+
+export const OUTDATED_ELASTIC_MANAGED_CONNECTOR_IDS = [
+  ELASTIC_MANAGED_LLM_CONNECTOR_ID,
+  GENERAL_PURPOSE_LLM_V1_CONNECTOR_ID,
+];
+
+export const LATEST_ELASTIC_MANAGED_CONNECTOR_ID = ANTHROPIC_CLAUDE_SONNET_4_5_CONNECTOR_ID;
+
+export const resolveConnectorId = (connectorId: string) => {
+  if (OUTDATED_ELASTIC_MANAGED_CONNECTOR_IDS.includes(connectorId)) {
+    return LATEST_ELASTIC_MANAGED_CONNECTOR_ID;
+  }
+  return connectorId;
+};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/index.ts
@@ -98,6 +98,8 @@ export {
 export { transformAttackDiscoveryAlertFromApi } from './impl/utils/transform_attack_discovery_alert_from_api';
 export { transformAttackDiscoveryAlertToApi } from './impl/utils/transform_attack_discovery_alert_to_api';
 export { transformAttackDiscoveryScheduleFromApi } from './impl/utils/transform_attack_discovery_schedule_from_api';
+
+export * from './impl/connectors/outdated_connectors';
 export { transformAttackDiscoveryScheduleToApi } from './impl/utils/transform_attack_discovery_schedule_to_api';
 export { transformAttackDiscoveryScheduleCreatePropsToApi } from './impl/utils/transform_attack_discovery_schedule_create_props_to_api';
 export { transformAttackDiscoveryScheduleUpdatePropsToApi } from './impl/utils/transform_attack_discovery_schedule_update_props_to_api';

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transform.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transform.test.ts
@@ -7,6 +7,11 @@
 
 import type { estypes } from '@elastic/elasticsearch';
 import {
+  ELASTIC_MANAGED_LLM_CONNECTOR_ID,
+  LATEST_ELASTIC_MANAGED_CONNECTOR_ID,
+} from '@kbn/elastic-assistant-common';
+
+import {
   transformESToConversation,
   transformESSearchToConversations,
   transformESToConversations,
@@ -115,6 +120,32 @@ describe('transforms', () => {
   });
 
   describe('transformESToConversation', () => {
+    it('should correctly transform ES conversation with mapped connector ID', () => {
+      const esConversation = getEsConversationMock();
+
+      const message = transformESToConversation({
+        ...esConversation,
+        api_config: {
+          ...esConversation.api_config,
+          connector_id: ELASTIC_MANAGED_LLM_CONNECTOR_ID,
+        } as EsConversationSchema['api_config'],
+      });
+      expect(message.apiConfig?.connectorId).toBe(LATEST_ELASTIC_MANAGED_CONNECTOR_ID);
+    });
+
+    it('should correctly transform ES conversation with unmapped connector ID', () => {
+      const esConversation = getEsConversationMock();
+
+      const message = transformESToConversation({
+        ...esConversation,
+        api_config: {
+          ...esConversation.api_config,
+          connector_id: 'some-other-id',
+        } as EsConversationSchema['api_config'],
+      });
+      expect(message.apiConfig?.connectorId).toBe('some-other-id');
+    });
+
     it('should correctly transform ES conversation', () => {
       const esConversation = getEsConversationMock();
       const conversation = transformESToConversation(esConversation);

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transforms.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transforms.ts
@@ -7,7 +7,10 @@
 
 import type { estypes } from '@elastic/elasticsearch';
 import type { ConversationResponse, Replacements } from '@kbn/elastic-assistant-common';
-import { replaceOriginalValuesWithUuidValues } from '@kbn/elastic-assistant-common';
+import {
+  replaceOriginalValuesWithUuidValues,
+  resolveConnectorId,
+} from '@kbn/elastic-assistant-common';
 import _ from 'lodash';
 import type { EsConversationSchema } from './types';
 
@@ -32,8 +35,11 @@ export const transformESToConversation = (
     ...(conversationSchema.api_config
       ? {
           apiConfig: {
+            // Resolve potentially outdated Elastic managed connector ID to the new one.
+            // This provides backward compatibility for existing conversations that reference
+            // "Elastic-Managed-LLM" or "General-Purpose-LLM-v1".
+            connectorId: resolveConnectorId(conversationSchema.api_config.connector_id),
             actionTypeId: conversationSchema.api_config.action_type_id,
-            connectorId: conversationSchema.api_config.connector_id,
             defaultSystemPromptId: conversationSchema.api_config.default_system_prompt_id,
             model: conversationSchema.api_config.model,
             provider: conversationSchema.api_config.provider,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.ts
@@ -8,7 +8,10 @@
 import moment from 'moment';
 import type { AnalyticsServiceSetup, Logger } from '@kbn/core/server';
 import { AlertsClientError } from '@kbn/alerting-plugin/server';
-import { getAttackDiscoveryMarkdownFields } from '@kbn/elastic-assistant-common';
+import {
+  getAttackDiscoveryMarkdownFields,
+  resolveConnectorId,
+} from '@kbn/elastic-assistant-common';
 import { ALERT_URL } from '@kbn/rule-data-utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
 
@@ -52,6 +55,13 @@ export const attackDiscoveryScheduleExecutor = async ({
   }
   if (!actionsClient) {
     throw new Error('Expected actionsClient not to be null!');
+  }
+
+  if (params.apiConfig?.connectorId) {
+    // Resolve potentially outdated Elastic managed connector ID to the new one.
+    // This provides backward compatibility for existing schedules that reference
+    // "Elastic-Managed-LLM" or "General-Purpose-LLM-v1".
+    params.apiConfig.connectorId = resolveConnectorId(params.apiConfig.connectorId);
   }
 
   const esClient = scopedClusterClient.asCurrentUser;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Security Solution][Attack Discovery][Bug] Schedules fail to run due to internal Elastic Managed LLM connector changes (#249891)](https://github.com/elastic/kibana/pull/249891)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2026-01-21T20:36:20Z","message":"[Security Solution][Attack Discovery][Bug] Schedules fail to run due to internal Elastic Managed LLM connector changes (#249891)\n\n## Summary\n\nThis PR addresses an issue where schedules and conversations referencing\noutdated Elastic managed LLM connector IDs fail to execute or display\ncorrectly. The outdated connector IDs `Elastic-Managed-LLM` and\n`General-Purpose-LLM-v1` have been replaced by\n`Anthropic-Claude-Sonnet-4-5`.\n\nThis change implements a backward compatibility layer that automatically\nresolves these outdated connector IDs to the new one at runtime.\n\n### Testing\n\n1. **Setup EIS Locally**: Follow [this\nguide](https://docs.elastic.dev/search-team/teams/inference/faq#how-can-i-use-eis-locally-in-kibana)\nto setup EIS locally.\n\n2. **Configure Old Connector**: In an older version (or before applying\nthese changes), add a predefined connector referencing EIS in your\n`kibana.dev.yml`:\n\n    ```yaml\n    xpack.actions.preconfigured:\n      Elastic-Managed-LLM:\n        name: Elastic Managed LLM\n        actionTypeId: .inference\n        exposeConfig: true\n        config:\n          provider: 'elastic'\n          taskType: 'chat_completion'\n          inferenceId: '.rainbow-sprinkles-elastic'\n          providerConfig:\n            model_id: 'rainbow-sprinkles'\n    ```\n\n3. **Create Data**:\n    - Create an **Attack Discovery Schedule** using this connector.\n    - Start an **AI Assistant Conversation** using this connector.\n\n4. **Update Connector Configuration**: Replace the previous\n`Elastic-Managed-LLM` connector configuration with the new one:\n\n   ```yaml\n    xpack.actions.preconfigured:\n      Anthropic-Claude-Sonnet-4-5:\n        name: Anthropic Claude Sonnet 4.5\n       provider: 'elastic'\n       taskType: 'chat_completion'\n       inferenceId: '.rainbow-sprinkles-elastic'\n       providerConfig:\n         model_id: 'rainbow-sprinkles'\n   ```\n\n5. **Verify**: Restart Kibana and verify that:\n- The existing Attack Discovery Schedule continues to run successfully.\n- The existing AI Assistant Conversation loads correctly and allows\ncontinuing the chat using the new connector.","sha":"b6a8dbb64d576dcf1a9f495445b8dd2268bab0c3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team: SecuritySolution","Team:Security Generative AI","backport:version","v9.3.0","v9.4.0"],"title":"[Security Solution][Attack Discovery][Bug] Schedules fail to run due to internal Elastic Managed LLM connector changes","number":249891,"url":"https://github.com/elastic/kibana/pull/249891","mergeCommit":{"message":"[Security Solution][Attack Discovery][Bug] Schedules fail to run due to internal Elastic Managed LLM connector changes (#249891)\n\n## Summary\n\nThis PR addresses an issue where schedules and conversations referencing\noutdated Elastic managed LLM connector IDs fail to execute or display\ncorrectly. The outdated connector IDs `Elastic-Managed-LLM` and\n`General-Purpose-LLM-v1` have been replaced by\n`Anthropic-Claude-Sonnet-4-5`.\n\nThis change implements a backward compatibility layer that automatically\nresolves these outdated connector IDs to the new one at runtime.\n\n### Testing\n\n1. **Setup EIS Locally**: Follow [this\nguide](https://docs.elastic.dev/search-team/teams/inference/faq#how-can-i-use-eis-locally-in-kibana)\nto setup EIS locally.\n\n2. **Configure Old Connector**: In an older version (or before applying\nthese changes), add a predefined connector referencing EIS in your\n`kibana.dev.yml`:\n\n    ```yaml\n    xpack.actions.preconfigured:\n      Elastic-Managed-LLM:\n        name: Elastic Managed LLM\n        actionTypeId: .inference\n        exposeConfig: true\n        config:\n          provider: 'elastic'\n          taskType: 'chat_completion'\n          inferenceId: '.rainbow-sprinkles-elastic'\n          providerConfig:\n            model_id: 'rainbow-sprinkles'\n    ```\n\n3. **Create Data**:\n    - Create an **Attack Discovery Schedule** using this connector.\n    - Start an **AI Assistant Conversation** using this connector.\n\n4. **Update Connector Configuration**: Replace the previous\n`Elastic-Managed-LLM` connector configuration with the new one:\n\n   ```yaml\n    xpack.actions.preconfigured:\n      Anthropic-Claude-Sonnet-4-5:\n        name: Anthropic Claude Sonnet 4.5\n       provider: 'elastic'\n       taskType: 'chat_completion'\n       inferenceId: '.rainbow-sprinkles-elastic'\n       providerConfig:\n         model_id: 'rainbow-sprinkles'\n   ```\n\n5. **Verify**: Restart Kibana and verify that:\n- The existing Attack Discovery Schedule continues to run successfully.\n- The existing AI Assistant Conversation loads correctly and allows\ncontinuing the chat using the new connector.","sha":"b6a8dbb64d576dcf1a9f495445b8dd2268bab0c3"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249891","number":249891,"mergeCommit":{"message":"[Security Solution][Attack Discovery][Bug] Schedules fail to run due to internal Elastic Managed LLM connector changes (#249891)\n\n## Summary\n\nThis PR addresses an issue where schedules and conversations referencing\noutdated Elastic managed LLM connector IDs fail to execute or display\ncorrectly. The outdated connector IDs `Elastic-Managed-LLM` and\n`General-Purpose-LLM-v1` have been replaced by\n`Anthropic-Claude-Sonnet-4-5`.\n\nThis change implements a backward compatibility layer that automatically\nresolves these outdated connector IDs to the new one at runtime.\n\n### Testing\n\n1. **Setup EIS Locally**: Follow [this\nguide](https://docs.elastic.dev/search-team/teams/inference/faq#how-can-i-use-eis-locally-in-kibana)\nto setup EIS locally.\n\n2. **Configure Old Connector**: In an older version (or before applying\nthese changes), add a predefined connector referencing EIS in your\n`kibana.dev.yml`:\n\n    ```yaml\n    xpack.actions.preconfigured:\n      Elastic-Managed-LLM:\n        name: Elastic Managed LLM\n        actionTypeId: .inference\n        exposeConfig: true\n        config:\n          provider: 'elastic'\n          taskType: 'chat_completion'\n          inferenceId: '.rainbow-sprinkles-elastic'\n          providerConfig:\n            model_id: 'rainbow-sprinkles'\n    ```\n\n3. **Create Data**:\n    - Create an **Attack Discovery Schedule** using this connector.\n    - Start an **AI Assistant Conversation** using this connector.\n\n4. **Update Connector Configuration**: Replace the previous\n`Elastic-Managed-LLM` connector configuration with the new one:\n\n   ```yaml\n    xpack.actions.preconfigured:\n      Anthropic-Claude-Sonnet-4-5:\n        name: Anthropic Claude Sonnet 4.5\n       provider: 'elastic'\n       taskType: 'chat_completion'\n       inferenceId: '.rainbow-sprinkles-elastic'\n       providerConfig:\n         model_id: 'rainbow-sprinkles'\n   ```\n\n5. **Verify**: Restart Kibana and verify that:\n- The existing Attack Discovery Schedule continues to run successfully.\n- The existing AI Assistant Conversation loads correctly and allows\ncontinuing the chat using the new connector.","sha":"b6a8dbb64d576dcf1a9f495445b8dd2268bab0c3"}}]}] BACKPORT-->