### PR TITLE
[ES|QL] Sometimes the KQL autocomplete appears while typing

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
@@ -139,26 +139,28 @@ export function QuickSearchVisor({
         <EuiFlexItem grow={false} css={styles.separator} />
         <EuiFlexItem css={styles.searchWrapper}>
           <div ref={kqlInputRef}>
-            <KQLComponent
-              iconType="search"
-              disableLanguageSwitcher={true}
-              indexPatterns={selectedSources.map((source) => source.label)}
-              bubbleSubmitEvent={false}
-              query={{
-                query: searchValue,
-                language: 'kuery',
-              }}
-              disableAutoFocus={false}
-              placeholder={searchPlaceholder}
-              onChange={(newQuery) => {
-                onKqlValueChange(newQuery.query as string);
-              }}
-              onSubmit={(newQuery) => {
-                onKqlSubmit(newQuery.query as string);
-              }}
-              appName="esqlEditorVisor"
-              dataTestSubj="esqlVisorKQLQueryInput"
-            />
+            {isVisible && (
+              <KQLComponent
+                iconType="search"
+                disableLanguageSwitcher={true}
+                indexPatterns={selectedSources.map((source) => source.label)}
+                bubbleSubmitEvent={false}
+                query={{
+                  query: searchValue,
+                  language: 'kuery',
+                }}
+                disableAutoFocus={false}
+                placeholder={searchPlaceholder}
+                onChange={(newQuery) => {
+                  onKqlValueChange(newQuery.query as string);
+                }}
+                onSubmit={(newQuery) => {
+                  onKqlSubmit(newQuery.query as string);
+                }}
+                appName="esqlEditorVisor"
+                dataTestSubj="esqlVisorKQLQueryInput"
+              />
+            )}
           </div>
         </EuiFlexItem>
       </EuiFlexGroup>


### PR DESCRIPTION
## Summary

It is difficult to replicate but sometimes while typing at the editor the autocomplete appears (although the visor is not visible). This is making sure that the KQL component is being rendered only when the visor is visible

<img width="1696" height="547" alt="image" src="https://github.com/user-attachments/assets/c38b614d-bb06-40ac-9eb1-ae070c715467" />





