### PR TITLE
[SharedUX] Enforce feedback enablement check for product intercept

### DIFF
--- a/x-pack/platform/plugins/private/intercepts/public/plugin.ts
+++ b/x-pack/platform/plugins/private/intercepts/public/plugin.ts
@@ -37,6 +37,7 @@ export class InterceptPublicPlugin implements Plugin {
       http: core.http,
       analytics: core.analytics,
       rendering: core.rendering,
+      isFeedbackEnabled: core.notifications.feedback.isEnabled(),
       targetDomElement: this.interceptsTargetDomElement,
     });
 

--- a/x-pack/platform/plugins/private/intercepts/public/plugin.ts
+++ b/x-pack/platform/plugins/private/intercepts/public/plugin.ts
@@ -37,7 +37,7 @@ export class InterceptPublicPlugin implements Plugin {
       http: core.http,
       analytics: core.analytics,
       rendering: core.rendering,
-      isFeedbackEnabled: core.notifications.feedback.isEnabled(),
+      userAllowsFeedback: core.notifications.feedback.isEnabled(),
       targetDomElement: this.interceptsTargetDomElement,
     });
 

--- a/x-pack/platform/plugins/private/intercepts/public/prompter/prompter.test.ts
+++ b/x-pack/platform/plugins/private/intercepts/public/prompter/prompter.test.ts
@@ -35,6 +35,8 @@ describe('ProductInterceptPrompter', () => {
     const http = httpServiceMock.createStartContract();
     const rendering = renderingServiceMock.create();
     const analytics = analyticsServiceMock.createAnalyticsServiceStart();
+    const notifications = notificationServiceMock.createStartContract();
+    const isFeedbackEnabled = notifications.feedback.isEnabled();
 
     const interceptDialogServiceStartFnSpy = jest.spyOn(InterceptDialogService.prototype, 'start');
     const userInterceptRunPersistenceServiceStartFnSpy = jest.spyOn(
@@ -62,6 +64,7 @@ describe('ProductInterceptPrompter', () => {
           rendering,
           analytics,
           targetDomElement: document.createElement('div'),
+          isFeedbackEnabled,
         })
       ).toEqual({
         registerIntercept: expect.any(Function),
@@ -135,6 +138,7 @@ describe('ProductInterceptPrompter', () => {
           rendering,
           analytics,
           targetDomElement: document.createElement('div'),
+          isFeedbackEnabled,
         }));
       });
 
@@ -155,6 +159,26 @@ describe('ProductInterceptPrompter', () => {
         });
 
         expect(intercept$).toBeInstanceOf(Rx.Observable);
+      });
+
+      it('skips intercept registration logic if feedback is disabled', () => {
+        const httpPostSpy = jest.spyOn(http, 'post');
+
+        ({ registerIntercept } = prompter.start({
+          http,
+          rendering,
+          analytics,
+          targetDomElement: document.createElement('div'),
+          isFeedbackEnabled: false,
+        }));
+
+        const intercept$ = registerIntercept({
+          id: intercept.id,
+          config: () => Promise.resolve(intercept),
+        });
+
+        expect(intercept$).toEqual(Rx.EMPTY);
+        expect(httpPostSpy).not.toHaveBeenCalled();
       });
 
       it('subscribing to the returned observable makes a request to the trigger info api endpoint', async () => {

--- a/x-pack/platform/plugins/private/intercepts/public/prompter/prompter.test.ts
+++ b/x-pack/platform/plugins/private/intercepts/public/prompter/prompter.test.ts
@@ -36,7 +36,7 @@ describe('ProductInterceptPrompter', () => {
     const rendering = renderingServiceMock.create();
     const analytics = analyticsServiceMock.createAnalyticsServiceStart();
     const notifications = notificationServiceMock.createStartContract();
-    const isFeedbackEnabled = notifications.feedback.isEnabled();
+    const userAllowsFeedback = notifications.feedback.isEnabled();
 
     const interceptDialogServiceStartFnSpy = jest.spyOn(InterceptDialogService.prototype, 'start');
     const userInterceptRunPersistenceServiceStartFnSpy = jest.spyOn(
@@ -64,7 +64,7 @@ describe('ProductInterceptPrompter', () => {
           rendering,
           analytics,
           targetDomElement: document.createElement('div'),
-          isFeedbackEnabled,
+          userAllowsFeedback,
         })
       ).toEqual({
         registerIntercept: expect.any(Function),
@@ -138,7 +138,7 @@ describe('ProductInterceptPrompter', () => {
           rendering,
           analytics,
           targetDomElement: document.createElement('div'),
-          isFeedbackEnabled,
+          userAllowsFeedback,
         }));
       });
 
@@ -169,7 +169,7 @@ describe('ProductInterceptPrompter', () => {
           rendering,
           analytics,
           targetDomElement: document.createElement('div'),
-          isFeedbackEnabled: false,
+          userAllowsFeedback: false,
         }));
 
         const intercept$ = registerIntercept({

--- a/x-pack/platform/plugins/private/intercepts/public/prompter/prompter.ts
+++ b/x-pack/platform/plugins/private/intercepts/public/prompter/prompter.ts
@@ -25,7 +25,7 @@ type ProductInterceptPrompterStartDeps = Omit<
   InterceptServiceStartDeps,
   'persistInterceptRunId' | 'staticAssetsHelper' | 'resetInterceptTimingRecord'
 > &
-  Pick<CoreStart, 'http'>;
+  Pick<CoreStart, 'http'> & { isFeedbackEnabled: boolean };
 
 export class InterceptPrompter {
   private userInterceptRunPersistenceService = new UserInterceptRunPersistenceService();
@@ -33,6 +33,7 @@ export class InterceptPrompter {
   private queueIntercept?: ReturnType<InterceptDialogService['start']>['add'];
   // observer for page visibility changes, shared across all intercepts
   private pageHidden$?: Rx.Observable<boolean>;
+  private isFeedbackEnabled?: boolean;
 
   // Registry for intercept timers, used to track activation of a particular intercept for each user
   private interceptTimerRegistry = new Proxy<Record<Intercept['id'], { timerStart: Date }>>(
@@ -72,7 +73,9 @@ export class InterceptPrompter {
     return {};
   }
 
-  start({ http, ...dialogServiceDeps }: ProductInterceptPrompterStartDeps) {
+  start({ http, isFeedbackEnabled, ...dialogServiceDeps }: ProductInterceptPrompterStartDeps) {
+    this.isFeedbackEnabled = isFeedbackEnabled;
+
     const { getUserTriggerData$, updateUserTriggerData } =
       this.userInterceptRunPersistenceService.start(http);
 
@@ -108,6 +111,8 @@ export class InterceptPrompter {
       config: () => Promise<Omit<Intercept, 'id'>>;
     }
   ) {
+    if (!this.isFeedbackEnabled) return Rx.EMPTY;
+
     return Rx.from(
       http.post<NonNullable<TriggerInfo>>(TRIGGER_INFO_API_ROUTE, {
         body: JSON.stringify({

--- a/x-pack/platform/plugins/private/intercepts/public/prompter/prompter.ts
+++ b/x-pack/platform/plugins/private/intercepts/public/prompter/prompter.ts
@@ -25,7 +25,7 @@ type ProductInterceptPrompterStartDeps = Omit<
   InterceptServiceStartDeps,
   'persistInterceptRunId' | 'staticAssetsHelper' | 'resetInterceptTimingRecord'
 > &
-  Pick<CoreStart, 'http'> & { isFeedbackEnabled: boolean };
+  Pick<CoreStart, 'http'> & { userAllowsFeedback: boolean };
 
 export class InterceptPrompter {
   private userInterceptRunPersistenceService = new UserInterceptRunPersistenceService();
@@ -33,7 +33,7 @@ export class InterceptPrompter {
   private queueIntercept?: ReturnType<InterceptDialogService['start']>['add'];
   // observer for page visibility changes, shared across all intercepts
   private pageHidden$?: Rx.Observable<boolean>;
-  private isFeedbackEnabled?: boolean;
+  private userAllowsFeedback?: boolean;
 
   // Registry for intercept timers, used to track activation of a particular intercept for each user
   private interceptTimerRegistry = new Proxy<Record<Intercept['id'], { timerStart: Date }>>(
@@ -73,8 +73,8 @@ export class InterceptPrompter {
     return {};
   }
 
-  start({ http, isFeedbackEnabled, ...dialogServiceDeps }: ProductInterceptPrompterStartDeps) {
-    this.isFeedbackEnabled = isFeedbackEnabled;
+  start({ http, userAllowsFeedback, ...dialogServiceDeps }: ProductInterceptPrompterStartDeps) {
+    this.userAllowsFeedback = userAllowsFeedback;
 
     const { getUserTriggerData$, updateUserTriggerData } =
       this.userInterceptRunPersistenceService.start(http);
@@ -111,7 +111,7 @@ export class InterceptPrompter {
       config: () => Promise<Omit<Intercept, 'id'>>;
     }
   ) {
-    if (!this.isFeedbackEnabled) return Rx.EMPTY;
+    if (!this.userAllowsFeedback) return Rx.EMPTY;
 
     return Rx.from(
       http.post<NonNullable<TriggerInfo>>(TRIGGER_INFO_API_ROUTE, {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/245629

## Summary

As part of [[Epic] Setting to disable feedback snippets, guided tours and announcements in Kibana](https://github.com/elastic/kibana/issues/234771) SharedUX has added two new `core.notifications` services for `feedback` and `tours`. Their `isEnabled()` API verifies if users should be shown that kind of elements by reading their preferences from global UI settings (`hideFeedback` and `hideAnnouncements`).

From now on, every feedback or tour component should call `isEnabled()` before rendering to honor user preferences. 

> [!IMPORTANT]
SharedUX will be opening PRs for existing occurrences per team. Each team should manually test their PR to verify toggling those settings results in the expected behavior. If your team owns more `feedback` or `tours` occurrences or are planning on doing so, this check needs to be added to honor user preferences.
>  

### Testing

**Feedback elements**
- This is a read-only setting, you need to override it via `kibana.dev.yml` with `uiSettings.globalOverrides.hideFeedback: true`.
- Verify changing the setting value hides/render the element as expected.

**Tours/announcements elements**
- Toggle either the deprecated `hideAnnouncements` space setting or the global one on the Stack Management > Advanced Settings UI.
- Verify toggling the setting hides/render the element as expected.

Related PR: [[SharedUX] Add feedback and tours to core notifications](https://github.com/elastic/kibana/pull/248248)
