### PR TITLE
[Alerting][Custom Threshold Rule] Update custom_threshold_rule schema and test snapshot

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_params/custom_threshold/v1.ts
+++ b/src/platform/packages/shared/response-ops/rule_params/custom_threshold/v1.ts
@@ -58,7 +58,11 @@ const customCriterion = schema.object({
         name: schema.string(),
         aggType: oneOfLiterals(allowedAggregators),
         field: schema.string(),
-        filter: schema.never(),
+        filter: schema.maybe(
+          schema.string({
+            validate: validateKQLStringFilter,
+          })
+        ),
       }),
       schema.object({
         name: schema.string(),

--- a/x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap
+++ b/x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap
@@ -3200,10 +3200,30 @@ Object {
                           },
                           "filter": Object {
                             "flags": Object {
+                              "default": [Function],
                               "error": [Function],
-                              "presence": "forbidden",
+                              "presence": "optional",
                             },
-                            "type": "any",
+                            "metas": Array [
+                              Object {
+                                "x-oas-optional": true,
+                              },
+                            ],
+                            "rules": Array [
+                              Object {
+                                "args": Object {
+                                  "method": [Function],
+                                },
+                                "name": "custom",
+                              },
+                              Object {
+                                "args": Object {
+                                  "method": [Function],
+                                },
+                                "name": "custom",
+                              },
+                            ],
+                            "type": "string",
                           },
                           "name": Object {
                             "flags": Object {


### PR DESCRIPTION
## Summary

This PR is for an intermediate release for #248845 .

* Update the Custom Threshold Rule schema to accept an optional KQL string filter as part of the `metrics` items : schema changed from `never` to `optional string` 

## Test
I tested it manually and verified that Custom Threshold Rules with the new schema in place are executed without issues in current Kibana version in `main` 



