### PR TITLE
[CPS] Added Revert to space defaults setting to a CPS picker and convert `project_tags` route from `GET` to `POST` 

### DIFF
--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker.tsx
@@ -33,6 +33,7 @@ export interface ProjectPickerProps {
   onProjectRoutingChange: (projectRouting: ProjectRouting) => void;
   fetchProjects: () => Promise<ProjectsData | null>;
   isReadonly?: boolean;
+  settingsComponent?: React.ReactNode;
 }
 
 export const ProjectPicker = ({
@@ -40,6 +41,7 @@ export const ProjectPicker = ({
   onProjectRoutingChange,
   fetchProjects,
   isReadonly = false,
+  settingsComponent,
 }: ProjectPickerProps) => {
   const [showPopover, setShowPopover] = useState(false);
   const styles = useMemoCss(projectPickerStyles);
@@ -112,12 +114,14 @@ export const ProjectPicker = ({
         ownFocus
         panelPaddingSize="none"
         panelProps={{ css: styles.popover }}
+        hasArrow
       >
         <ProjectPickerContent
           projectRouting={projectRouting}
           onProjectRoutingChange={onProjectRoutingChange}
           fetchProjects={fetchProjects}
           isReadonly={isReadonly}
+          settingsComponent={settingsComponent}
         />
       </EuiPopover>
     </EuiTourStep>

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_container.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_container.tsx
@@ -13,6 +13,7 @@ import type { ProjectRouting } from '@kbn/es-query';
 import type { ICPSManager } from '../types';
 import { ProjectRoutingAccess } from '../types';
 import { DisabledProjectPicker, ProjectPicker } from './project_picker';
+import { ProjectPickerSettings } from './project_picker_settings';
 
 interface ProjectPickerContainerProps {
   cpsManager: ICPSManager;
@@ -31,6 +32,10 @@ export const ProjectPickerContainer: React.FC<ProjectPickerContainerProps> = ({ 
     return cpsManager.fetchProjects();
   }, [cpsManager]);
 
+  const resetProjectPicker = useCallback(() => {
+    updateProjectRouting(cpsManager.getDefaultProjectRouting());
+  }, [cpsManager, updateProjectRouting]);
+
   if (access === ProjectRoutingAccess.DISABLED) {
     return <DisabledProjectPicker />;
   }
@@ -41,6 +46,7 @@ export const ProjectPickerContainer: React.FC<ProjectPickerContainerProps> = ({ 
       onProjectRoutingChange={updateProjectRouting}
       fetchProjects={fetchProjects}
       isReadonly={access === ProjectRoutingAccess.READONLY}
+      settingsComponent={<ProjectPickerSettings onResetToDefaults={resetProjectPicker} />}
     />
   );
 };

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_content.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_content.tsx
@@ -34,6 +34,7 @@ export interface ProjectPickerContentProps {
   onProjectRoutingChange: (projectRouting: ProjectRouting) => void;
   fetchProjects: () => Promise<ProjectsData | null>;
   isReadonly?: boolean;
+  settingsComponent?: React.ReactNode;
 }
 
 const projectPickerOptions = [
@@ -54,6 +55,7 @@ export const ProjectPickerContent = ({
   onProjectRoutingChange,
   fetchProjects,
   isReadonly = false,
+  settingsComponent,
 }: ProjectPickerContentProps) => {
   const styles = useMemoCss(projectPickerContentStyles);
   const { originProject, linkedProjects } = useFetchProjects(fetchProjects);
@@ -72,30 +74,13 @@ export const ProjectPickerContent = ({
     <EuiFlexGroup gutterSize="none" direction="column" responsive={false} css={styles.container}>
       <EuiFlexItem grow={false}>
         <EuiPopoverTitle paddingSize="s">
-          <EuiFlexGroup responsive={false} justifyContent="spaceBetween">
+          <EuiFlexGroup responsive={false} justifyContent="spaceBetween" alignItems="center">
             <EuiFlexItem>
               <EuiTitle size="xxs">
                 <h5>{strings.getProjectPickerPopoverTitle()}</h5>
               </EuiTitle>
             </EuiFlexItem>
-            {/* TODO: Add settings button when cps management is available
-            <EuiFlexItem grow={false}>
-              <EuiToolTip content={strings.getManageCrossProjectSearchLabel()} repositionOnScroll>
-                <EuiButtonIcon
-                  display="empty"
-                  iconType="gear"
-                  aria-label={i18n.translate('cpsUtils.projectPicker.settingsButtonLabel', {
-                    defaultMessage: 'Manage cross-project search',
-                  })}
-                  onClick={() => {
-                    // TODO: redirect to the correct project settings page
-                  }}
-                  isDisabled={true}
-                  size="xs"
-                  color="text"
-                />
-              </EuiToolTip>
-            </EuiFlexItem> */}
+            {settingsComponent && <EuiFlexItem grow={false}>{settingsComponent}</EuiFlexItem>}
           </EuiFlexGroup>
         </EuiPopoverTitle>
         {isReadonly && (

--- a/src/platform/packages/shared/kbn-cps-utils/components/project_picker_settings.tsx
+++ b/src/platform/packages/shared/kbn-cps-utils/components/project_picker_settings.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useState } from 'react';
+import { EuiButtonIcon, EuiPopover, EuiContextMenu } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { strings } from './strings';
+
+export interface ProjectPickerSettingsProps {
+  onResetToDefaults: () => void;
+}
+
+export const ProjectPickerSettings = ({ onResetToDefaults }: ProjectPickerSettingsProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const closePopover = () => setIsOpen(false);
+
+  const panels = [
+    {
+      id: 0,
+      items: [
+        {
+          name: i18n.translate('cpsUtils.projectPicker.revertToSpaceDefaultsLabel', {
+            defaultMessage: 'Revert to space defaults',
+          }),
+          icon: 'clockCounter',
+          'data-test-subj': 'projectPickerRevertToSpaceDefaultsMenuItem',
+          onClick: () => {
+            onResetToDefaults();
+            closePopover();
+          },
+        },
+        {
+          isSeparator: true as const,
+        },
+        {
+          name: strings.getManageCrossProjectSearchLabel(),
+          icon: 'gear',
+          'data-test-subj': 'projectPickerManageSettingsMenuItem',
+          onClick: closePopover, // TODO: redirect to CPS management - UI not ready yet
+        },
+      ],
+    },
+  ];
+
+  return (
+    <EuiPopover
+      button={
+        <EuiButtonIcon
+          display="empty"
+          iconType="ellipsis"
+          aria-label={i18n.translate('cpsUtils.projectPicker.settingsButtonLabel', {
+            defaultMessage: 'Manage cross-project search',
+          })}
+          onClick={() => setIsOpen(!isOpen)}
+          size="s"
+          color="text"
+        />
+      }
+      isOpen={isOpen}
+      closePopover={closePopover}
+      repositionOnScroll
+      anchorPosition="rightCenter"
+      ownFocus
+      panelPaddingSize="none"
+    >
+      <EuiContextMenu initialPanelId={0} panels={panels} />
+    </EuiPopover>
+  );
+};

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/set_instructions_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/set_instructions_helpers.test.ts
@@ -26,10 +26,10 @@ describe('set instructions helpers', () => {
     });
 
     describe('when project_routing is set', () => {
-      it('should return the correct project routing for "_alias: *"', () => {
-        const queryString = 'SET project_routing = "_alias: *"; FROM my_index';
+      it('should return the correct project routing for "_alias:*"', () => {
+        const queryString = 'SET project_routing = "_alias:*"; FROM my_index';
         const result = getProjectRoutingFromEsqlQuery(queryString);
-        expect(result).toBe('_alias: *');
+        expect(result).toBe('_alias:*');
       });
 
       it('should return the correct project routing for "_alias:_origin"', () => {

--- a/src/platform/plugins/private/presentation_panel/public/panel_actions/customize_panel_action/cps_usage_overrides_badge.test.ts
+++ b/src/platform/plugins/private/presentation_panel/public/panel_actions/customize_panel_action/cps_usage_overrides_badge.test.ts
@@ -33,7 +33,7 @@ describe('CPS usage overrides badge action', () => {
   });
 
   it('is compatible when embeddable has project routing overrides', async () => {
-    updateOverrides([{ value: '_alias: *' }]);
+    updateOverrides([{ value: '_alias:*' }]);
     expect(await action.isCompatible(context)).toBe(true);
   });
 
@@ -64,7 +64,7 @@ describe('CPS usage overrides badge action', () => {
 
   describe('getOverrideValues', () => {
     it('returns override values array for single override', async () => {
-      updateOverrides([{ value: '_alias: *' }]);
+      updateOverrides([{ value: '_alias:*' }]);
       expect(await action.isCompatible(context)).toBe(true);
     });
 

--- a/src/platform/plugins/shared/cps/README.md
+++ b/src/platform/plugins/shared/cps/README.md
@@ -4,14 +4,18 @@
 
 ### API Routes
 
-#### GET /internal/cps/projects_tags
+#### POST /internal/cps/projects_tags
 
 Retrieves project tags from Elasticsearch using the `/_project/tags` endpoint.
 
 **Route Details:**
+
 - **Path:** `/internal/cps/projects_tags`
+- **Body (optional):**
+  - `project_routing` (optional): String parameter for project routing
 - **Authorization:** Handled by the scoped Elasticsearch client
 - **Response Format:**
+
 ```typescript
 {
   [key: string]: Record<string, string>;

--- a/src/platform/plugins/shared/cps/public/services/cps_manager.test.ts
+++ b/src/platform/plugins/shared/cps/public/services/cps_manager.test.ts
@@ -57,7 +57,7 @@ describe('CPSManager', () => {
 
   beforeEach(() => {
     mockHttp = {
-      get: jest.fn().mockResolvedValue(mockResponse),
+      post: jest.fn().mockResolvedValue(mockResponse),
     } as unknown as jest.Mocked<HttpSetup>;
 
     mockApplication = {
@@ -80,7 +80,7 @@ describe('CPSManager', () => {
     it('should fetch and store projects successfully', async () => {
       const result = await cpsManager.fetchProjects();
 
-      expect(mockHttp.get).toHaveBeenCalledWith('/internal/cps/projects_tags');
+      expect(mockHttp.post).toHaveBeenCalledWith('/internal/cps/projects_tags');
       expect(result).toEqual({
         origin: mockOriginProject,
         linkedProjects: [mockLinkedProjects[1], mockLinkedProjects[0]], // sorted by alias
@@ -99,16 +99,16 @@ describe('CPSManager', () => {
     it('should cache results and not refetch on subsequent calls', async () => {
       // First fetch
       await cpsManager.fetchProjects();
-      expect(mockHttp.get).toHaveBeenCalledTimes(1);
+      expect(mockHttp.post).toHaveBeenCalledTimes(1);
 
       // Second fetch should return cached data without calling HTTP
       await cpsManager.fetchProjects();
-      expect(mockHttp.get).toHaveBeenCalledTimes(1);
+      expect(mockHttp.post).toHaveBeenCalledTimes(1);
     });
 
     it('should not cache failed requests', async () => {
       jest.useFakeTimers();
-      mockHttp.get.mockRejectedValue(new Error('Network error'));
+      mockHttp.post.mockRejectedValue(new Error('Network error'));
 
       // First fetch fails - run all timers to completion
       const promise = cpsManager.fetchProjects();
@@ -116,7 +116,7 @@ describe('CPSManager', () => {
 
       await expect(Promise.all([promise, timerPromise])).rejects.toThrow('Network error');
 
-      expect(mockHttp.get).toHaveBeenCalledTimes(3); // initial + 2 retries
+      expect(mockHttp.post).toHaveBeenCalledTimes(3); // initial + 2 retries
 
       jest.useRealTimers();
     });
@@ -124,15 +124,15 @@ describe('CPSManager', () => {
 
   describe('refresh', () => {
     it('should refetch data when refresh is called', async () => {
-      mockHttp.get.mockResolvedValue(mockResponse);
+      mockHttp.post.mockResolvedValue(mockResponse);
 
       // First fetch
       await cpsManager.fetchProjects();
-      expect(mockHttp.get).toHaveBeenCalledTimes(1);
+      expect(mockHttp.post).toHaveBeenCalledTimes(1);
 
       // Refresh should call HTTP again
       await cpsManager.refresh();
-      expect(mockHttp.get).toHaveBeenCalledTimes(2);
+      expect(mockHttp.post).toHaveBeenCalledTimes(2);
     });
 
     it('should update cached data after refresh', async () => {
@@ -145,8 +145,8 @@ describe('CPSManager', () => {
         linked_projects: mockResponse.linked_projects,
       };
 
-      mockHttp.get.mockResolvedValueOnce(mockResponse);
-      mockHttp.get.mockResolvedValueOnce(updatedResponse);
+      mockHttp.post.mockResolvedValueOnce(mockResponse);
+      mockHttp.post.mockResolvedValueOnce(updatedResponse);
 
       // First fetch
       const result1 = await cpsManager.fetchProjects();
@@ -159,14 +159,14 @@ describe('CPSManager', () => {
       // Subsequent fetch should return updated cached data
       const result3 = await cpsManager.fetchProjects();
       expect(result3!.origin?._alias).toBe('Updated Project');
-      expect(mockHttp.get).toHaveBeenCalledTimes(2); // Only 2 calls, third was from cache
+      expect(mockHttp.post).toHaveBeenCalledTimes(2); // Only 2 calls, third was from cache
     });
   });
 
   describe('retry logic', () => {
     it('should retry on failure with exponential backoff', async () => {
       jest.useFakeTimers();
-      mockHttp.get
+      mockHttp.post
         .mockRejectedValueOnce(new Error('Error 1'))
         .mockRejectedValueOnce(new Error('Error 2'))
         .mockResolvedValueOnce(mockResponse);
@@ -176,7 +176,7 @@ describe('CPSManager', () => {
 
       const result = await promise;
 
-      expect(mockHttp.get).toHaveBeenCalledTimes(3); // initial + 2 retries
+      expect(mockHttp.post).toHaveBeenCalledTimes(3); // initial + 2 retries
       expect(result!.origin).toEqual(mockOriginProject);
 
       jest.useRealTimers();
@@ -184,21 +184,21 @@ describe('CPSManager', () => {
 
     it('should throw error after max retries exceeded', async () => {
       jest.useFakeTimers();
-      mockHttp.get.mockRejectedValue(new Error('Persistent error'));
+      mockHttp.post.mockRejectedValue(new Error('Persistent error'));
 
       const promise = cpsManager.fetchProjects();
       const timerPromise = jest.runAllTimersAsync();
 
       await expect(Promise.all([promise, timerPromise])).rejects.toThrow('Persistent error');
 
-      expect(mockHttp.get).toHaveBeenCalledTimes(3); // initial + 2 retries
+      expect(mockHttp.post).toHaveBeenCalledTimes(3); // initial + 2 retries
 
       jest.useRealTimers();
     });
 
     it('should throw error on final failure', async () => {
       jest.useFakeTimers();
-      mockHttp.get.mockRejectedValue(new Error('Error'));
+      mockHttp.post.mockRejectedValue(new Error('Error'));
 
       const promise = cpsManager.fetchProjects();
       const timerPromise = jest.runAllTimersAsync();

--- a/src/platform/plugins/shared/cps/public/services/project_fetcher.ts
+++ b/src/platform/plugins/shared/cps/public/services/project_fetcher.ts
@@ -31,7 +31,7 @@ export function createProjectFetcher(http: HttpSetup, logger: Logger): ProjectFe
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
-        const response = await http.get<ProjectTagsResponse>('/internal/cps/projects_tags');
+        const response = await http.post<ProjectTagsResponse>('/internal/cps/projects_tags');
         const originValues = response.origin ? Object.values(response.origin) : [];
 
         return {

--- a/src/platform/plugins/shared/cps/server/routes/get_projects_tags.ts
+++ b/src/platform/plugins/shared/cps/server/routes/get_projects_tags.ts
@@ -11,17 +11,16 @@ import { schema } from '@kbn/config-schema';
 import type { IRouter, PluginInitializerContext } from '@kbn/core/server';
 import type { ProjectTagsResponse } from '@kbn/cps-utils';
 
-export const registerGetProjectTagsRoute = (
-  router: IRouter,
-  { logger }: PluginInitializerContext
-) => {
-  router.get(
+export const registerProjectTagsRoute = (router: IRouter, { logger }: PluginInitializerContext) => {
+  router.post(
     {
       path: '/internal/cps/projects_tags',
       validate: {
-        query: schema.object({
-          project_routing: schema.maybe(schema.string()),
-        }),
+        body: schema.nullable(
+          schema.object({
+            project_routing: schema.maybe(schema.string()),
+          })
+        ),
       },
       security: {
         authz: {
@@ -33,13 +32,13 @@ export const registerGetProjectTagsRoute = (
     async (requestHandlerContext, request, response) => {
       try {
         const core = await requestHandlerContext.core;
-        const { project_routing } = request.query;
+        const { project_routing } = request.body ?? {};
 
         const result: ProjectTagsResponse =
           await core.elasticsearch.client.asCurrentUser.transport.request({
-            method: 'GET',
+            method: 'POST',
             path: `/_project/tags`,
-            querystring: project_routing ? { project_routing } : undefined,
+            body: project_routing ? { project_routing } : {},
           });
 
         return response.ok({

--- a/src/platform/plugins/shared/cps/server/routes/index.ts
+++ b/src/platform/plugins/shared/cps/server/routes/index.ts
@@ -8,10 +8,10 @@
  */
 
 import type { CoreSetup, PluginInitializerContext } from '@kbn/core/server';
-import { registerGetProjectTagsRoute } from './get_projects_tags';
+import { registerProjectTagsRoute } from './get_projects_tags';
 
 export const registerRoutes = (setup: CoreSetup, initContext: PluginInitializerContext) => {
   const router = setup.http.createRouter();
 
-  registerGetProjectTagsRoute(router, initContext);
+  registerProjectTagsRoute(router, initContext);
 };

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/project_routing_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/project_routing_manager.ts
@@ -29,10 +29,10 @@ export function initializeProjectRoutingManager(
 
   const projectRouting$ = new BehaviorSubject<ProjectRouting>(initialState.project_routing);
 
-  // pass the initial state to CPS manager from dashboard state or just reset to default on dashboard init
-  cpsManager.setProjectRouting(
-    initialState.project_routing ?? cpsManager.getDefaultProjectRouting()
-  );
+  // pass the initial state to CPS manager from dashboard state if set
+  if (initialState.project_routing) {
+    cpsManager.setProjectRouting(initialState.project_routing);
+  }
 
   function setProjectRouting(projectRouting: ProjectRouting) {
     if (projectRouting !== projectRouting$.value) {


### PR DESCRIPTION
## Summary

 This PR makes two main changes to the CPS  functionality:

  1. **Convert `/_project/tags` route from GET to POST**: The Elasticsearch `/_project/tags` endpoint now requires a request body to pass `project_routing` (see elastic/elasticsearch#141048), so we need to call it as a POST request.

  2. **Added settings popover to the CPS project picker UI.**
  
  - Added "Revert to space defaults" setting to CPS project picker
  - Note: "Manage cross-project search" setting is visible but not yet functional - will be completed before CPS release

  ## Screenshot

<img width="821" height="262" alt="Screenshot 2026-01-22 at 11 01 28" src="https://github.com/user-attachments/assets/520a557d-ba04-4683-b394-0199ecda432e" />

  ## Related