### PR TITLE
[CPS] Do not reset the CPS setting when navigating between apps

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -494,20 +494,6 @@ const createMiddleware = (options: InternalStateDependencies) => {
     },
   });
 
-  startListening({
-    actionCreator: initializeTabs.fulfilled,
-    effect: (action, listenerApi) => {
-      const { services } = listenerApi.extra;
-
-      // Initialize CPS manager with session-level projectRouting after state is updated
-      if (services.cps?.cpsManager) {
-        services.cps.cpsManager.setProjectRouting(
-          services.cps.cpsManager.getDefaultProjectRouting()
-        );
-      }
-    },
-  });
-
   return listenerMiddleware.middleware;
 };
 

--- a/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
@@ -115,43 +115,6 @@ type PreloadedState = Omit<
   'resolvedDateRange' | 'searchSessionId' | 'isLinkedToOriginatingApp'
 >;
 
-/**
- * Initialize project routing in CPS Manager
- * Determines whether to preserve or reset the project routing based on the context
- */
-function initProjectRoutingState({
-  cps,
-  lens,
-  initialInput,
-  isLinkedToOriginatingApp = false,
-}: {
-  cps: LensAppServices['cps'];
-  lens: LensAppState;
-  initialInput?: LensSerializedState;
-  isLinkedToOriginatingApp?: boolean;
-}) {
-  if (!cps?.cpsManager) {
-    return;
-  }
-  const cpsManager = cps.cpsManager;
-
-  // Check if dataSources have been initialized already to detect save/save-as scenarios
-  const hasActiveLensSession = !Object.values(lens.datasourceStates).every(
-    (ds) => ds.state === null
-  );
-
-  // Reset when: NOT linked to originating app, NOT active session, NOT embeddable
-  const shouldReset = !isLinkedToOriginatingApp && !hasActiveLensSession && !initialInput;
-
-  if (shouldReset) {
-    const defaultRouting = cpsManager.getDefaultProjectRouting();
-    cpsManager.setProjectRouting(defaultRouting);
-    return defaultRouting;
-  } else {
-    return cpsManager.getProjectRouting();
-  }
-}
-
 async function loadFromLocatorState(
   store: MiddlewareAPI,
   initialState: NonNullable<LensStoreDeps['initialStateFromLocator']>,
@@ -384,12 +347,7 @@ export async function loadInitial(
   const { notifications, data, cps } = lensServices;
   const { lens } = store.getState();
 
-  const projectRouting = initProjectRoutingState({
-    cps,
-    lens,
-    initialInput,
-    isLinkedToOriginatingApp,
-  });
+  const projectRouting = cps?.cpsManager?.getProjectRouting();
 
   const loaderSharedArgs: LoaderSharedArgs = {
     visualizationMap,


### PR DESCRIPTION
## Summary

Changes the CPS behavior to persist when navigating between Analyst Experience apps (=== do nothing), rather than resetting to space defaults.
 
### Background

The initial CPS design assumed we should reset the setting when navigating between AnalystExp apps. However, after analysis, this doesn't align with user workflows for the following reasons:

  1. Intertwined workflows: Interactions between apps are often dependent on each other, making silent resets disruptive
  2. Consistency with time range: Users expect persistence similar to how time range behaves across apps
  3. User feedback first: Rather than assuming reset behavior is desired, let's gather real-world feedback in Tech preview/GA phase

### Behavior to analyze

When persistence scenarios make sense (setting is maintained):

  - Discover to Lens - from histogram or field statistics
  - Discover to Dashboard - when saving and navigating directly to Dashboard
  - Dashboard workflows:
    - Creating a new panel for the dashboard
    - Editing existing panels
  - Lens/Vega/Maps:
    - Save to Dashboard
    - Inspect in Discover

When reset scenarios might make more sense:

  - Page reload (does not persist) - it works like this at the moment
  - Direct navigation via search bar or navigation menu (for future consideration - maybe users actually expect to persist)

**Alternative reset mechanism**

  To help users reset to space defaults without automatic resets, the "revert to space defaults" feature (initially designed for GA, not TP, but I think it makes sense to have it here) has been implemented in #250000.