### PR TITLE
[OAS] `@kbn/config-schema` pass `meta.id` to underlying Joi schema

### DIFF
--- a/src/platform/packages/shared/kbn-config-schema/src/types/array_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/array_type.ts
@@ -39,6 +39,10 @@ export class ArrayType<T> extends Type<T[]> {
       schema = schema.options({ stripUnknown: { objects: unknowns === 'ignore' } });
     }
 
+    if (options.meta?.id) {
+      schema = schema.id(options.meta.id);
+    }
+
     super(schema, options);
     this.arrayType = type;
     this.arrayOptions = options;

--- a/src/platform/packages/shared/kbn-config-schema/src/types/union_type.ts
+++ b/src/platform/packages/shared/kbn-config-schema/src/types/union_type.ts
@@ -11,18 +11,20 @@ import typeDetect from 'type-detect';
 import { SchemaTypeError, SchemaTypesError } from '../errors';
 import { internals } from '../internals';
 import type { ExtendsDeepOptions } from './type';
-import { Type, type TypeOptions, type TypeMeta } from './type';
+import { Type, type TypeOptions } from './type';
 
-export type UnionTypeOptions<T> = TypeOptions<T> & {
-  meta?: Omit<TypeMeta, 'id'>;
-};
+export type UnionTypeOptions<T> = TypeOptions<T>;
 
 export class UnionType<RTS extends Array<Type<any>>, T> extends Type<T> {
   private readonly unionTypes: RTS;
   private readonly typeOptions?: UnionTypeOptions<T>;
 
   constructor(types: RTS, options?: UnionTypeOptions<T>) {
-    const schema = internals.alternatives(types.map((type) => type.getSchema())).match('any');
+    let schema = internals.alternatives(types.map((type) => type.getSchema())).match('any');
+
+    if (options?.meta?.id) {
+      schema = schema.id(options.meta.id);
+    }
 
     super(schema, options);
     this.unionTypes = types;

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
@@ -102,7 +102,37 @@ Object {
 exports[`generateOpenApiDocument @kbn/config-schema generates the expected OpenAPI document 1`] = `
 Object {
   "components": Object {
-    "schemas": Object {},
+    "schemas": Object {
+      "myArray": Object {
+        "items": Object {
+          "additionalProperties": false,
+          "properties": Object {
+            "foo": Object {
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "foo",
+          ],
+          "type": "object",
+        },
+        "type": "array",
+      },
+      "myUnion": Object {
+        "anyOf": Array [
+          Object {
+            "description": "Union string",
+            "maxLength": 1,
+            "type": "string",
+          },
+          Object {
+            "description": "Union number",
+            "minimum": 0,
+            "type": "number",
+          },
+        ],
+      },
+    },
     "securitySchemes": Object {
       "apiKeyAuth": Object {
         "in": "header",
@@ -253,6 +283,24 @@ Object {
                 "additionalProperties": false,
                 "properties": Object {
                   "any": Object {},
+                  "array": Object {
+                    "items": Object {
+                      "additionalProperties": false,
+                      "properties": Object {
+                        "foo": Object {
+                          "type": "string",
+                        },
+                      },
+                      "required": Array [
+                        "foo",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "arrayWithId": Object {
+                    "$ref": "#/components/schemas/myArray",
+                  },
                   "booleanDefault": Object {
                     "default": true,
                     "description": "defaults to to true",
@@ -304,6 +352,9 @@ Object {
                       },
                     ],
                   },
+                  "unionWithId": Object {
+                    "$ref": "#/components/schemas/myUnion",
+                  },
                   "uri": Object {
                     "default": "prototest://something",
                     "format": "uri",
@@ -317,6 +368,9 @@ Object {
                   "map",
                   "record",
                   "union",
+                  "unionWithId",
+                  "array",
+                  "arrayWithId",
                   "any",
                 ],
                 "type": "object",
@@ -397,6 +451,24 @@ Object {
                 "additionalProperties": false,
                 "properties": Object {
                   "any": Object {},
+                  "array": Object {
+                    "items": Object {
+                      "additionalProperties": false,
+                      "properties": Object {
+                        "foo": Object {
+                          "type": "string",
+                        },
+                      },
+                      "required": Array [
+                        "foo",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "arrayWithId": Object {
+                    "$ref": "#/components/schemas/myArray",
+                  },
                   "booleanDefault": Object {
                     "default": true,
                     "description": "defaults to to true",
@@ -448,6 +520,9 @@ Object {
                       },
                     ],
                   },
+                  "unionWithId": Object {
+                    "$ref": "#/components/schemas/myUnion",
+                  },
                   "uri": Object {
                     "default": "prototest://something",
                     "format": "uri",
@@ -461,6 +536,9 @@ Object {
                   "map",
                   "record",
                   "union",
+                  "unionWithId",
+                  "array",
+                  "arrayWithId",
                   "any",
                 ],
                 "type": "object",

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/kbn_config_schema/lib.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/kbn_config_schema/lib.test.ts
@@ -26,6 +26,22 @@ describe('convert', () => {
         additionalProperties: false,
         properties: {
           any: {},
+          array: {
+            items: {
+              additionalProperties: false,
+              properties: {
+                foo: {
+                  type: 'string',
+                },
+              },
+              required: ['foo'],
+              type: 'object',
+            },
+            type: 'array',
+          },
+          arrayWithId: {
+            $ref: '#/components/schemas/myArray',
+          },
           booleanDefault: {
             default: true,
             description: 'defaults to to true',
@@ -75,16 +91,56 @@ describe('convert', () => {
               },
             ],
           },
+          unionWithId: {
+            $ref: '#/components/schemas/myUnion',
+          },
           uri: {
             default: 'prototest://something',
             format: 'uri',
             type: 'string',
           },
         },
-        required: ['string', 'ipType', 'literalType', 'map', 'record', 'union', 'any'],
+        required: [
+          'string',
+          'ipType',
+          'literalType',
+          'map',
+          'record',
+          'union',
+          'unionWithId',
+          'array',
+          'arrayWithId',
+          'any',
+        ],
         type: 'object',
       },
-      shared: {},
+      shared: {
+        myArray: {
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              foo: { type: 'string' },
+            },
+            required: ['foo'],
+          },
+          type: 'array',
+        },
+        myUnion: {
+          anyOf: [
+            {
+              description: 'Union string',
+              maxLength: 1,
+              type: 'string',
+            },
+            {
+              description: 'Union number',
+              minimum: 0,
+              type: 'number',
+            },
+          ],
+        },
+      },
     });
   });
 

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/kbn_config_schema/lib.test.util.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/kbn_config_schema/lib.test.util.ts
@@ -28,6 +28,17 @@ export function createLargeSchema() {
       schema.string({ maxLength: 1, meta: { description: 'Union string' } }),
       schema.number({ min: 0, meta: { description: 'Union number' } }),
     ]),
+    unionWithId: schema.oneOf(
+      [
+        schema.string({ maxLength: 1, meta: { description: 'Union string' } }),
+        schema.number({ min: 0, meta: { description: 'Union number' } }),
+      ],
+      { meta: { id: 'myUnion' } }
+    ),
+    array: schema.arrayOf(schema.object({ foo: schema.string() })),
+    arrayWithId: schema.arrayOf(schema.object({ foo: schema.string() }), {
+      meta: { id: 'myArray' },
+    }),
     uri: schema.uri({
       scheme: ['prototest'],
       defaultValue: () => 'prototest://something',


### PR DESCRIPTION
## Summary
Close: https://github.com/elastic/kibana/issues/249766
Related https://github.com/elastic/kibana/issues/249889

Enable the following types to set `schema.id` on underlying Joi schema so that OAS can be refactored to references for the types:

- `schema.oneOf`
- `schema.arrayOf`