### PR TITLE
[Agent Builder] fix bounded tools

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/default/run_chat_agent.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/default/run_chat_agent.ts
@@ -109,6 +109,7 @@ export const runDefaultAgentMode: RunChatAgentFn = async (
     agentConfiguration,
     attachmentsService: attachments,
     request,
+    spaceId: context.spaceId,
     runner: context.runner,
   });
 


### PR DESCRIPTION
## Summary

resolves bug where bounded tools were not properly propagated to the LLM due to select_tools.ts not being properly integrated with the new attachments system.
