### PR TITLE
[One Workflow] (fix): search step executions - set size to 10k, without it, it returns up to 10 results by default

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.ts
@@ -31,6 +31,7 @@ export class StepExecutionRepository {
         match: { workflowRunId: executionId },
       },
       sort: 'startedAt:desc',
+      size: 10000, // TODO: without it, it returns up to 10 results by default. We should improve this.
     });
 
     return response.hits.hits.map((hit) => hit._source as EsWorkflowStepExecution);


### PR DESCRIPTION
When does the issue happen?
* Only occurs in workflows that use a foreach step
* (AND) The loop contains a wait step with delay longer than 5s
* (AND) The long wait step is triggered after the 10th step execution
 (e.g., 5 loop iterations × 2 steps)

Why does it happen?
* `foreach` steps require the full step history to be loaded in memory to run correctly
* `wait` steps with delays longer than 5 seconds schedule a future `workflow:resume` task
* Resume tasks do not have step history in memory and instead load it from Elasticsearch (step execution index)
* Elasticsearch search queries return only the first 10 hits by default unless a size is explicitly provided
* The `searchStepExecutionsByExecutionId` query doesn't specify a size, so it falls back to the default of 10
* As a result, when workflows contain more than 10 steps, the resume task cannot fully reconstruct the workflow state

You can find more details [here](https://github.com/elastic/security-team/issues/15504)
**Note:** this is not the final approach. Pagination or an on-demand query for relevant steps should be implemented.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->