### PR TITLE
Fix code editor widget and flyout stacking issue

### DIFF
--- a/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
@@ -41,7 +41,8 @@ import {
 } from './mods';
 import { styles } from './editor.styles';
 
-export interface CodeEditorProps {
+export interface CodeEditorProps
+  extends Pick<ReactMonacoEditorProps, 'overflowWidgetsContainerZIndexOverride'> {
   /** Width of editor. Defaults to 100%. */
   width?: string | number;
 
@@ -204,7 +205,6 @@ export interface CodeEditorProps {
    */
   onFocus?: () => void;
   onBlur?: () => void;
-
   /**
    * Enables the suggestion widget repositioning. Enabled by default.
    * Disabled for cases like embedded console.
@@ -252,6 +252,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   onFocus,
   onBlur,
   enableSuggestWidgetRepositioning = true,
+  overflowWidgetsContainerZIndexOverride,
 }) => {
   const { euiTheme } = useEuiTheme();
   const { registerContextMenuActions, unregisterContextMenuActions } = useContextMenuUtils();
@@ -643,6 +644,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
             editorWillMount={_editorWillMount}
             editorDidMount={_editorDidMount}
             editorWillUnmount={_editorWillUnmount}
+            overflowWidgetsContainerZIndexOverride={overflowWidgetsContainerZIndexOverride}
             options={{
               padding: allowFullScreen || isCopyable ? { top: 24 } : {},
               renderLineHighlight: 'none',

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
@@ -243,7 +243,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   fitToContent,
   accessibilityOverlayEnabled = true,
   enableFindAction,
-  dataTestSubj,
+  dataTestSubj = 'kibanaCodeEditor',
   classNameCss,
   enableCustomContextMenu = false,
   customContextMenuActions = [],
@@ -607,7 +607,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
     <div
       css={styles.container}
       onKeyDown={onKeyDown}
-      data-test-subj={dataTestSubj ?? 'kibanaCodeEditor'}
+      data-test-subj={dataTestSubj}
       className="kibanaCodeEditor"
     >
       <Global styles={classNameCss} />

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -227,8 +227,10 @@ export function MonacoEditor({
 
       // handle special case of editor being rendered inside an EUI flyout,
       // in which case we want to ensure the overflow widgets appear above the flyout z-index
-      const isInsideFlyout = containerElement.current!.closest('.euiFlyout') !== null;
-
+      const isInsideFlyout =
+        containerElement.current!.closest('.euiFlyout') !== null || // covers both overlay and push flyouts
+        containerElement.current!.closest('[data-euiportal="true"]') !== null; // covers custom portals, like security timeline overlay
+      // by default we cover only a single flyout (1000), more specific edge cases can use the z-index override prop
       const defaultZIndex = isInsideFlyout
         ? OVERFLOW_WIDGETS_Z_INDEX_ABOVE_EUI_FLYOUT
         : OVERFLOW_WIDGETS_Z_INDEX_BELOW_EUI_FLYOUT;

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -357,9 +357,12 @@ export function MonacoEditor({
       <EuiPortal portalRef={setOverflowWidgetsDomNode} />
       <Global
         styles={({ euiTheme: _euiTheme }) => ({
+          // by default display the overflow widgets below flyouts
           [`.${OVERFLOW_WIDGETS_CONTAINER_CLASS}`]: {
-            // ensure the overflow widgets are above headers and flyouts
-            // Fallback if euiTheme is not available
+            zIndex: Number(_euiTheme?.levels?.maskBelowHeader ?? 1000) - 2,
+          },
+          // When the editor is inside a flyout, ensure the overflow widgets are above the flyout
+          [`:has(.euiFlyout [class*="monaco-editor"]) .${OVERFLOW_WIDGETS_CONTAINER_CLASS}`]: {
             zIndex: _euiTheme?.levels?.menu ?? 2000,
           },
         })}

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -123,6 +123,10 @@ export interface MonacoEditorProps {
    * An event emitted when the content of the current model has changed.
    */
   onChange?: ChangeHandler;
+  /**
+   * Optional z-index to override the default z-index of the overflow widgets container.
+   */
+  overflowWidgetsContainerZIndexOverride?: number;
 }
 
 // initialize supported languages
@@ -130,6 +134,8 @@ initializeSupportedLanguages();
 
 export const OVERFLOW_WIDGETS_TEST_ID = 'kbnCodeEditorEditorOverflowWidgetsContainer';
 const OVERFLOW_WIDGETS_CONTAINER_CLASS = 'monaco-editor-overflowing-widgets-container';
+const OVERFLOW_WIDGETS_CONTAINER_STACKING_OVERRIDE_CLASS =
+  'monaco-editor-overflowing-widgets-container-stacking-override';
 
 export function MonacoEditor({
   width = '100%',
@@ -144,6 +150,7 @@ export function MonacoEditor({
   editorWillUnmount,
   onChange,
   className,
+  overflowWidgetsContainerZIndexOverride,
 }: MonacoEditorProps) {
   const containerElement = useRef<HTMLDivElement | null>(null);
   const overflowWidgetsDomNode = useRef<HTMLDivElement | null>(null);
@@ -369,11 +376,19 @@ export function MonacoEditor({
           [`.${OVERFLOW_WIDGETS_CONTAINER_CLASS}`]: {
             zIndex: Number(_euiTheme?.levels?.maskBelowHeader ?? 1000) - 2,
           },
-          // When the editor is inside a flyout, ensure the overflow widgets are above the flyout and modification is scoped to each instance
+          // When the editor is inside a flyout, ensure the overflow widgets are above the flyout and scoped to each instance
           [`:has(.euiFlyout [class*="monaco-editor"][id="${instanceId}"]) .${OVERFLOW_WIDGETS_CONTAINER_CLASS}[id="${instanceId}"]`]:
             {
               zIndex: _euiTheme?.levels?.menu ?? 2000,
             },
+          // Allow the overflow widgets container z-index to be overridden
+          ...(overflowWidgetsContainerZIndexOverride
+            ? {
+                [`.${OVERFLOW_WIDGETS_CONTAINER_STACKING_OVERRIDE_CLASS}[id="${instanceId}"]`]: {
+                  zIndex: overflowWidgetsContainerZIndexOverride,
+                },
+              }
+            : {}),
         })}
       />
     </>

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -225,13 +225,13 @@ export function MonacoEditor({
       overflowWidgetsDomNode.current?.classList.add(OVERFLOW_WIDGETS_CONTAINER_CLASS);
       overflowWidgetsDomNode.current?.setAttribute('data-test-subj', OVERFLOW_WIDGETS_TEST_ID);
 
-      // handle special case of editor being rendered inside an EUI flyout,
-      // in which case we want to ensure the overflow widgets appear above the flyout z-index
-      const isInsideFlyout =
+      // handle special case of editor being rendered inside a container with a high z-index, like an EUI flyout
+      // if this is the case by default we will just raise the overflow widgets container z-index above the flyout (1000)
+      // more specific edge cases can use the z-index override prop
+      const isInsideStackedContainer =
         containerElement.current!.closest('.euiFlyout') !== null || // covers both overlay and push flyouts
         containerElement.current!.closest('[data-euiportal="true"]') !== null; // covers custom portals, like security timeline overlay
-      // by default we cover only a single flyout (1000), more specific edge cases can use the z-index override prop
-      const defaultZIndex = isInsideFlyout
+      const defaultZIndex = isInsideStackedContainer
         ? OVERFLOW_WIDGETS_Z_INDEX_ABOVE_EUI_FLYOUT
         : OVERFLOW_WIDGETS_Z_INDEX_BELOW_EUI_FLYOUT;
 


### PR DESCRIPTION
## Summary

Alternative to https://github.com/elastic/kibana/pull/249145, https://github.com/elastic/kibana/pull/249845

## Summary

The most recent change to Monaco split the widget container to render in the DOM separately from the Monaco editor. This resolved issues with the stacking context of the editor that would cause the widgets overflow container to render beneath the header. However, this change resulted in a couple of other issues.

We chose to render the widget on top of all flyouts and didn't consider scenarios where an editor action triggers a flyout. In these scenarios, the editor action would render on top of the flyout. The approach considered here renders the widget below flyouts by default. However, when the editor is rendered in a flyout, we stack it above flyouts instead.

There's also an allowance to provide a custom override for the zIndex if needed with the new prop `overflowWidgetsContainerZIndexOverride`

### Visuals

#### Action triggering flyout opening

![ScreenRecording2026-01-21at11 32 38-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/0f2c3b42-1e2d-4dcd-b11a-a8889d29187a)

#### Editor within a flyout

<img width="750" height="832" alt="Screenshot 2026-01-21 at 11 33 40" src="https://github.com/user-attachments/assets/4b6b7cf0-4368-4569-a1fb-591d08fdab3b" />


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->