### PR TITLE
[8.19] [ES|QL visualizations] Send `render_lens_esql_chart` event when an ES|QL visualization is rendered in the dashboard (#247396)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/esql_layer/text_based_languages.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/esql_layer/text_based_languages.test.ts
@@ -1031,4 +1031,32 @@ describe('Textbased Data Source', () => {
       ]);
     });
   });
+
+  describe('#getRenderEventCounters', () => {
+    it('should return correct counter for esql query', () => {
+      const state = {
+        layers: {
+          a: {
+            columns: [
+              {
+                columnId: 'col1',
+                fieldName: 'Test 1',
+                meta: {
+                  type: 'number',
+                },
+              },
+            ],
+            query: { esql: 'FROM foo' },
+            index: 'foo',
+          },
+        },
+      } as unknown as TextBasedPrivateState;
+
+      const counters =
+        TextBasedDatasource.getRenderEventCounters &&
+        TextBasedDatasource.getRenderEventCounters(state);
+
+      expect(counters).toEqual(['esql_chart']);
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/esql_layer/text_based_languages.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/esql_layer/text_based_languages.tsx
@@ -10,13 +10,13 @@ import React from 'react';
 import { CoreStart } from '@kbn/core/public';
 import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import { getESQLAdHocDataview } from '@kbn/esql-utils';
-import { AggregateQuery, isOfAggregateQueryType, getAggregateQueryMode } from '@kbn/es-query';
+import { AggregateQuery, isOfAggregateQueryType } from '@kbn/es-query';
 import type { SavedObjectReference } from '@kbn/core/public';
 import type { ExpressionsStart, DatatableColumn } from '@kbn/expressions-plugin/public';
 import type { DataViewsPublicPluginStart, DataView } from '@kbn/data-views-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import memoizeOne from 'memoize-one';
-import { isEqual } from 'lodash';
+import { flatten, isEqual } from 'lodash';
 import { TextBasedDataPanel } from './components/datapanel';
 import { TextBasedDimensionEditor } from './components/dimension_editor';
 import { TextBasedDimensionTrigger } from './components/dimension_trigger';
@@ -498,13 +498,15 @@ export function getTextBasedDatasource({
     },
 
     getRenderEventCounters(state: TextBasedPrivateState): string[] {
-      const context = state?.initialContext;
-      if (context && 'query' in context && context.query && isOfAggregateQueryType(context.query)) {
-        const language = getAggregateQueryMode(context.query);
-        // it will eventually log render_lens_esql_chart
-        return [`${language}_chart`];
-      }
-      return [];
+      const counters = flatten(
+        Object.values(state?.layers ?? {}).map((layer) => {
+          if (isOfAggregateQueryType(layer.query)) {
+            return ['esql_chart'];
+          }
+          return [];
+        })
+      );
+      return counters;
     },
 
     DimensionEditorComponent: (props: DatasourceDimensionEditorProps<TextBasedPrivateState>) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ES|QL visualizations] Send `render_lens_esql_chart` event when an ES|QL visualization is rendered in the dashboard (#247396)](https://github.com/elastic/kibana/pull/247396)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maria Iriarte","email":"106958839+mariairiartef@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-12T16:53:18Z","message":"[ES|QL visualizations] Send `render_lens_esql_chart` event when an ES|QL visualization is rendered in the dashboard (#247396)\n\n## Summary\n\nfix https://github.com/elastic/kibana/issues/241423\n\nUpdates text based `getRenderEventCounters` method to use `state.layers`\ninstead of `state.initialContext`.\n\n#### Expected behavior\n\nThe `render_lens_esql_chart` event should be sent every time an ES|QL\nvisualization is rendered in the dashboard.\n\n\n\n## Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Resources\n\n\n[kibana-ui-counters](https://stack-telemetry.elastic.dev/s/kibana-analytics/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_tab=(tabId:'8e794483-0b69-4b4c-ae68-ecfa546e4085')&_a=(columns:!(),dataSource:(dataViewId:'533babe8-28cc-56f6-b71a-f087aef783ec',type:dataView),filters:!(),interval:auto,query:(language:kuery,query:''),sort:!(!(timestamp,desc))))","sha":"68f6db5839ea183cc1709f9700b7882b9f123080","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Team:Visualizations","release_note:skip","backport:skip","telemetry","v9.3.0","v9.4.0"],"title":"[ES|QL visualizations] Send `render_lens_esql_chart` event when an ES|QL visualization is rendered in the dashboard","number":247396,"url":"https://github.com/elastic/kibana/pull/247396","mergeCommit":{"message":"[ES|QL visualizations] Send `render_lens_esql_chart` event when an ES|QL visualization is rendered in the dashboard (#247396)\n\n## Summary\n\nfix https://github.com/elastic/kibana/issues/241423\n\nUpdates text based `getRenderEventCounters` method to use `state.layers`\ninstead of `state.initialContext`.\n\n#### Expected behavior\n\nThe `render_lens_esql_chart` event should be sent every time an ES|QL\nvisualization is rendered in the dashboard.\n\n\n\n## Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Resources\n\n\n[kibana-ui-counters](https://stack-telemetry.elastic.dev/s/kibana-analytics/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_tab=(tabId:'8e794483-0b69-4b4c-ae68-ecfa546e4085')&_a=(columns:!(),dataSource:(dataViewId:'533babe8-28cc-56f6-b71a-f087aef783ec',type:dataView),filters:!(),interval:auto,query:(language:kuery,query:''),sort:!(!(timestamp,desc))))","sha":"68f6db5839ea183cc1709f9700b7882b9f123080"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247396","number":247396,"mergeCommit":{"message":"[ES|QL visualizations] Send `render_lens_esql_chart` event when an ES|QL visualization is rendered in the dashboard (#247396)\n\n## Summary\n\nfix https://github.com/elastic/kibana/issues/241423\n\nUpdates text based `getRenderEventCounters` method to use `state.layers`\ninstead of `state.initialContext`.\n\n#### Expected behavior\n\nThe `render_lens_esql_chart` event should be sent every time an ES|QL\nvisualization is rendered in the dashboard.\n\n\n\n## Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n## Resources\n\n\n[kibana-ui-counters](https://stack-telemetry.elastic.dev/s/kibana-analytics/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_tab=(tabId:'8e794483-0b69-4b4c-ae68-ecfa546e4085')&_a=(columns:!(),dataSource:(dataViewId:'533babe8-28cc-56f6-b71a-f087aef783ec',type:dataView),filters:!(),interval:auto,query:(language:kuery,query:''),sort:!(!(timestamp,desc))))","sha":"68f6db5839ea183cc1709f9700b7882b9f123080"}}]}] BACKPORT-->