### PR TITLE
Skipping Sec Solution basic license assertion tests for FIPS pipeline

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/basic_license_essentials_tier/api_feature_access.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/basic_license_essentials_tier/api_feature_access.ts
@@ -14,7 +14,8 @@ export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const privilegedUserMonitoringRoutes = privilegeMonitoringRouteHelpersFactory(supertest);
 
-  describe('@ess Basic License API Access', () => {
+  describe('@ess Basic License API Access', function () {
+    this.tags('skipFIPS');
     it('should not be able to access init engine api due to license', async () => {
       const response = await privilegedUserMonitoringRoutes.init(403);
       expect(response.body.message).toEqual(licenseMessage);


### PR DESCRIPTION
## Summary

Since FIPS Pipelines always run with a `trial` license, we need to skip these tests


