### PR TITLE
[CI] OAS Snapshots: make snapshot file writing default

### DIFF
--- a/.buildkite/scripts/steps/checks/capture_oas_snapshot.sh
+++ b/.buildkite/scripts/steps/checks/capture_oas_snapshot.sh
@@ -8,7 +8,7 @@ source .buildkite/scripts/common/util.sh
 .buildkite/scripts/setup_es_snapshot_cache.sh
 
 echo --- Capture OAS snapshot
-cmd="node scripts/capture_oas_snapshot \
+cmd="node scripts/capture_oas_snapshot\
   --include-path /api/status \
   --include-path /api/alerting/rule/ \
   --include-path /api/alerting/rules \
@@ -21,9 +21,6 @@ cmd="node scripts/capture_oas_snapshot \
   --include-path /api/saved_objects/_export \
   --include-path /api/maintenance_window \
   --include-path /api/agent_builder"
-if is_pr && ! is_auto_commit_disabled; then
-  cmd="$cmd --update"
-fi
 
 if [[ $BUILDKITE_PULL_REQUEST != "false" && "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" != "main" ]] || [[ $BUILDKITE_PULL_REQUEST == "false" && "$BUILDKITE_BRANCH" != "main" ]]; then
   cmd="$cmd --no-serverless"
@@ -40,4 +37,8 @@ retry 5 15 run_check
 
 node ./scripts/validate_oas_docs.js --assert-no-error-increase --skip-printing-issues --update-baseline
 
-check_for_changed_files "capture_oas_snapshot.sh" true
+if is_pr && ! is_auto_commit_disabled; then
+  check_for_changed_files "capture_oas_snapshot.sh" true
+else
+  check_for_changed_files "capture_oas_snapshot.sh" false
+fi

--- a/packages/kbn-capture-oas-snapshot-cli/src/capture_oas_snapshot.ts
+++ b/packages/kbn-capture-oas-snapshot-cli/src/capture_oas_snapshot.ts
@@ -20,7 +20,6 @@ interface CaptureOasSnapshotArgs {
   log: ToolingLog;
   buildFlavour: 'serverless' | 'traditional';
   outputFile: string;
-  update: boolean;
   filters?: {
     pathStartsWith?: string[];
     excludePathsMatching?: string[];
@@ -34,7 +33,6 @@ export async function captureOasSnapshot({
   log,
   filters = {},
   buildFlavour,
-  update,
   outputFile,
 }: CaptureOasSnapshotArgs): Promise<void> {
   const { excludePathsMatching = [], pathStartsWith } = filters;
@@ -84,17 +82,9 @@ export async function captureOasSnapshot({
     });
 
     log.info(`Recieved OAS, writing to ${outputFile}...`);
-    if (update) {
-      await fs.writeFile(outputFile, sortAndPrettyPrint(currentOas));
-      const { size: sizeBytes } = await fs.stat(outputFile);
-      log.success(`OAS written to ${outputFile}. File size ~${twoDeci(sizeBytes / MB)} MB.`);
-    } else {
-      log.success(
-        `OAS recieved, not writing to file. Got OAS for ${
-          Object.keys(currentOas.paths).length
-        } paths.`
-      );
-    }
+    await fs.writeFile(outputFile, sortAndPrettyPrint(currentOas));
+    const { size: sizeBytes } = await fs.stat(outputFile);
+    log.success(`OAS written to ${outputFile}. File size ~${twoDeci(sizeBytes / MB)} MB.`);
   } catch (err) {
     log.error(`Failed to capture OAS: ${err}`);
     throw err;

--- a/packages/kbn-capture-oas-snapshot-cli/src/run_capture_oas_snapshot_cli.ts
+++ b/packages/kbn-capture-oas-snapshot-cli/src/run_capture_oas_snapshot_cli.ts
@@ -10,7 +10,6 @@
 import path from 'node:path';
 import { run } from '@kbn/dev-cli-runner';
 import { REPO_ROOT } from '@kbn/repo-info';
-import chalk from 'chalk';
 import { captureOasSnapshot } from './capture_oas_snapshot';
 
 export const sortAndPrettyPrint = (object: object) => {
@@ -35,7 +34,6 @@ run(
       process.exit(1);
     }
 
-    const update = flagsReader.boolean('update');
     const pathStartsWith = flagsReader.arrayOfStrings('include-path');
     const excludePathsMatching = flagsReader.arrayOfStrings('exclude-path') ?? [];
 
@@ -46,7 +44,6 @@ run(
         buildFlavour: 'traditional',
         outputFile: path.resolve(OAS_OUTPUT_DIR, 'bundle.json'),
         filters: { pathStartsWith, excludePathsMatching },
-        update,
       });
       log.success('Captured OAS for traditional Kibana.');
     }
@@ -58,7 +55,6 @@ run(
         buildFlavour: 'serverless',
         outputFile: path.resolve(OAS_OUTPUT_DIR, 'bundle.serverless.json'),
         filters: { pathStartsWith, excludePathsMatching },
-        update,
       });
       log.success('Captured OAS for serverless Kibana.');
     }
@@ -78,7 +74,6 @@ run(
       help: `
         --include-path            Path to include. Path must start with provided value. Can be passed multiple times.
         --exclude-path            Path to exclude. Path must NOT start with provided value. Can be passed multiple times.
-        --update                  Write the current OAS bundles to ${chalk.cyan(OAS_OUTPUT_DIR)}.
         --no-serverless           Whether to skip OAS for serverless Kibana. Defaults to false.
         --no-traditional          Whether to skip OAS for traditional Kibana. Defaults to false.
       `,


### PR DESCRIPTION
## Summary
https://github.com/elastic/kibana/pull/249907 removes the intermediary files for the OAS snapshot validation, however, in the `on-merge` pipeline, the files are not generated, so the merging fails.

This PR makes generation default, so we pass this stage in the on-merges.