### PR TITLE
 [Security solution][Attacks][Take action] Assign attack from group panel

### DIFF
--- a/src/platform/packages/shared/kbn-grouping/src/components/accordion_panel/group_stats.test.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/accordion_panel/group_stats.test.tsx
@@ -27,7 +27,7 @@ const testProps = {
     { title: 'Rules:', badge: { value: 2 } },
     { title: 'Alerts:', badge: { value: 2, width: 50, color: '#a83632' } },
   ],
-  takeActionItems: () => (
+  actionItems: (
     <EuiContextMenu
       initialPanelId={0}
       panels={[
@@ -82,7 +82,7 @@ describe('Group stats', () => {
     const { queryByTestId } = render(
       <GroupStats
         {...testProps}
-        takeActionItems={() => (
+        actionItems={
           <EuiContextMenu
             initialPanelId={0}
             panels={[
@@ -92,14 +92,14 @@ describe('Group stats', () => {
               },
             ]}
           />
-        )}
+        }
       />
     );
     expect(queryByTestId('take-action-button')).toBeInTheDocument();
   });
 
   it('hides the Take Actions menu when no action item is provided', () => {
-    const { queryByTestId } = render(<GroupStats {...testProps} takeActionItems={undefined} />);
+    const { queryByTestId } = render(<GroupStats {...testProps} actionItems={undefined} />);
     expect(queryByTestId('take-action-button')).not.toBeInTheDocument();
   });
 });

--- a/src/platform/packages/shared/kbn-grouping/src/components/accordion_panel/group_stats.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/accordion_panel/group_stats.tsx
@@ -18,18 +18,15 @@ import {
   useEuiFontSize,
 } from '@elastic/eui';
 import React, { Fragment, useCallback, useMemo, useState } from 'react';
-import type { Filter } from '@kbn/es-query';
 import { css } from '@emotion/react';
 import type { GroupStatsItem } from '../types';
 import { TAKE_ACTION } from '../translations';
 
 interface GroupStatsProps<T> {
   bucketKey: string;
-  groupFilter: Filter[];
-  groupNumber: number;
   onTakeActionsOpen?: () => void;
   stats?: GroupStatsItem[];
-  takeActionItems?: (groupFilters: Filter[], groupNumber: number) => JSX.Element | undefined;
+  actionItems?: JSX.Element;
   /** Optional array of additional action buttons to display before the Take actions button */
   additionalActionButtons?: React.ReactElement[];
 }
@@ -51,20 +48,15 @@ const Separator = () => {
 
 const GroupStatsComponent = <T,>({
   bucketKey,
-  groupFilter,
-  groupNumber,
   onTakeActionsOpen,
   stats,
-  takeActionItems: getTakeActionItems,
+  actionItems,
   additionalActionButtons,
 }: GroupStatsProps<T>) => {
   const { euiTheme } = useEuiTheme();
   const xsFontSize = useEuiFontSize('xs').fontSize;
 
   const [isPopoverOpen, setPopover] = useState(false);
-  const takeActionItems = useMemo(() => {
-    return getTakeActionItems?.(groupFilter, groupNumber);
-  }, [getTakeActionItems, groupFilter, groupNumber]);
 
   const onButtonClick = useCallback(() => {
     return !isPopoverOpen && onTakeActionsOpen ? onTakeActionsOpen() : setPopover(!isPopoverOpen);
@@ -129,7 +121,7 @@ const GroupStatsComponent = <T,>({
 
   const takeActionMenu = useMemo(
     () =>
-      takeActionItems ? (
+      actionItems ? (
         <EuiFlexItem grow={false}>
           <EuiPopover
             anchorPosition="downLeft"
@@ -147,11 +139,11 @@ const GroupStatsComponent = <T,>({
             isOpen={isPopoverOpen}
             panelPaddingSize="none"
           >
-            {takeActionItems}
+            {actionItems}
           </EuiPopover>
         </EuiFlexItem>
       ) : null,
-    [isPopoverOpen, onButtonClick, takeActionItems]
+    [isPopoverOpen, onButtonClick, actionItems]
   );
 
   return (

--- a/src/platform/packages/shared/kbn-grouping/src/components/grouping.test.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/grouping.test.tsx
@@ -154,12 +154,47 @@ describe('Grouping', () => {
     );
     expect(screen.getByTestId('null-group-icon')).toBeInTheDocument();
 
-    let lastGroup = screen.getAllByTestId('grouping-accordion').at(-1);
+    const lastGroup = screen.getAllByTestId('grouping-accordion').at(-1);
     fireEvent.click(within(lastGroup!).getByTestId('take-action-button'));
 
-    expect(takeActionItems).toHaveBeenCalledWith(getNullGroupFilter('host.name'), 2);
+    expect((takeActionItems.mock.lastCall as any[])?.[0]).toEqual(getNullGroupFilter('host.name'));
+    expect((takeActionItems.mock.lastCall as any[])?.[1]).toEqual(2);
+    expect((takeActionItems.mock.lastCall as any[])?.[2]).toMatchInlineSnapshot(`
+      Object {
+        "alertsCount": Object {
+          "value": 11,
+        },
+        "doc_count": 11,
+        "hostTags": Object {
+          "buckets": Array [],
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+        },
+        "hostsCountAggregation": Object {
+          "value": 11,
+        },
+        "isNullGroup": true,
+        "key": Array [
+          "-",
+        ],
+        "key_as_string": "-",
+        "selectedGroup": "host.name",
+        "severitiesSubAggregation": Object {
+          "buckets": Array [
+            Object {
+              "doc_count": 11,
+              "key": "low",
+            },
+          ],
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+        },
+        "usersCountAggregation": Object {
+          "value": 11,
+        },
+      }
+    `);
 
-    lastGroup = screen.getAllByTestId('grouping-accordion').at(-1);
     fireEvent.click(within(lastGroup!).getByTestId('group-panel-toggle'));
 
     expect(renderChildComponent).toHaveBeenCalledWith(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -16,6 +16,7 @@ import type {
   DynamicGroupingProps,
   GroupChildComponentRenderer,
   GroupingSort,
+  GroupingBucket,
   ParsedGroupingAggregation,
 } from '@kbn/grouping/src';
 import { parseGroupingQuery } from '@kbn/grouping/src';
@@ -322,12 +323,17 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
   );
 
   const getTakeActionItems = useCallback(
-    (groupFilters: Filter[], groupNumber: number) => {
+    (
+      groupFilters: Filter[],
+      groupNumber: number,
+      groupBucket: GroupingBucket<AlertsGroupingAggregation>
+    ) => {
       const takeActionParams = {
         groupNumber,
         query: getGlobalQuery([...(defaultFilters ?? []), ...groupFilters])?.filterQuery,
         selectedGroup,
         tableId,
+        groupBucket,
       };
 
       return groupTakeActionItems?.(takeActionParams);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/types.ts
@@ -11,6 +11,7 @@ import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import type { AlertsTablePropsWithRef } from '@kbn/response-ops-alerts-table/types';
 import type { TableId } from '@kbn/securitysolution-data-table';
 import type { EuiContextMenuPanelItemDescriptor } from '@elastic/eui';
+import type { GroupingBucket } from '@kbn/grouping/src';
 import type { PageScope } from '../../../data_view_manager/constants';
 import type { AlertsUserProfilesData } from '../../configurations/security_solution_detections/fetch_page_context';
 import type { Status } from '../../../../common/api/detection_engine';
@@ -18,6 +19,7 @@ import type { Note } from '../../../../common/api/timeline';
 import type { DataProvider } from '../../../timelines/components/timeline/data_providers/data_provider';
 import type { TimelineModel } from '../../../timelines/store/model';
 import type { ControlColumnProps, RowRenderer } from '../../../../common/types';
+import type { AlertsGroupingAggregation } from './grouping_settings/types';
 
 export interface SetEventsLoadingProps {
   eventIds: string[];
@@ -99,4 +101,8 @@ export type GroupTakeActionItems = (props: {
    * Selected group to know which group is extended/visible. This is coming from the getLevel function in the detections alert grouping code.
    */
   selectedGroup: string;
+  /**
+   * Meta-data about the selected group
+   */
+  groupBucket: GroupingBucket<AlertsGroupingAggregation>;
 }) => JSX.Element | undefined;

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
+import { EuiContextMenu } from '@elastic/eui';
+import type { AttackDiscoveryAlert } from '@kbn/elastic-assistant-common';
+import React, { useCallback, useMemo } from 'react';
+import { useInvalidateFindAttackDiscoveries } from '../../../../attack_discovery/pages/use_find_attack_discoveries';
+import type { inputsModel } from '../../../../common/store';
+import { inputsSelectors } from '../../../../common/store';
+import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+import { useAttackAssigneesContextMenuItems } from '../../../hooks/attacks/bulk_actions/context_menu_items/use_attack_assignees_context_menu_items';
+
+interface AttacksGroupTakeActionItemsProps {
+  attack?: AttackDiscoveryAlert;
+}
+
+export function AttacksGroupTakeActionItems({ attack }: AttacksGroupTakeActionItemsProps) {
+  const invalidateAttackDiscoveriesCache = useInvalidateFindAttackDiscoveries();
+  const getGlobalQuerySelector = useMemo(() => inputsSelectors.globalQuery(), []);
+  const globalQueries = useDeepEqualSelector(getGlobalQuerySelector);
+  const refetchQuery = useCallback(() => {
+    globalQueries.forEach((q) => q.refetch && (q.refetch as inputsModel.Refetch)());
+  }, [globalQueries]);
+
+  const attacksWithAssignees = useMemo(() => {
+    if (attack?.id) {
+      return [
+        {
+          attackId: attack.id,
+          assignees: attack?.assignees,
+          relatedAlertIds: attack?.alertIds ?? [],
+        },
+      ];
+    }
+    return [];
+  }, [attack]);
+
+  const onAssignSuccess = useCallback(() => {
+    invalidateAttackDiscoveriesCache();
+    refetchQuery();
+  }, [invalidateAttackDiscoveriesCache, refetchQuery]);
+
+  const { items: assignItems, panels: assignPanels } = useAttackAssigneesContextMenuItems({
+    attacksWithAssignees,
+    onSuccess: onAssignSuccess,
+  });
+
+  const defaultPanel: EuiContextMenuPanelDescriptor = useMemo(
+    () => ({
+      id: 0,
+      items: [...assignItems],
+    }),
+    [assignItems]
+  );
+
+  const panels: EuiContextMenuPanelDescriptor[] = useMemo(
+    () => [defaultPanel, ...assignPanels],
+    [assignPanels, defaultPanel]
+  );
+
+  return <EuiContextMenu initialPanelId={defaultPanel.id} panels={panels} />;
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
@@ -31,8 +31,8 @@ export function AttacksGroupTakeActionItems({ attack }: AttacksGroupTakeActionIt
     return [
       {
         attackId: attack.id,
-        assignees: attack?.assignees,
-        relatedAlertIds: attack?.alertIds ?? [],
+        assignees: attack.assignees,
+        relatedAlertIds: attack.alertIds,
       },
     ];
   }, [attack]);

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attacks_group_take_action_items.tsx
@@ -16,7 +16,7 @@ import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { useAttackAssigneesContextMenuItems } from '../../../hooks/attacks/bulk_actions/context_menu_items/use_attack_assignees_context_menu_items';
 
 interface AttacksGroupTakeActionItemsProps {
-  attack?: AttackDiscoveryAlert;
+  attack: AttackDiscoveryAlert;
 }
 
 export function AttacksGroupTakeActionItems({ attack }: AttacksGroupTakeActionItemsProps) {
@@ -28,16 +28,13 @@ export function AttacksGroupTakeActionItems({ attack }: AttacksGroupTakeActionIt
   }, [globalQueries]);
 
   const attacksWithAssignees = useMemo(() => {
-    if (attack?.id) {
-      return [
-        {
-          attackId: attack.id,
-          assignees: attack?.assignees,
-          relatedAlertIds: attack?.alertIds ?? [],
-        },
-      ];
-    }
-    return [];
+    return [
+      {
+        attackId: attack.id,
+        assignees: attack?.assignees,
+        relatedAlertIds: attack?.alertIds ?? [],
+      },
+    ];
   }, [attack]);
 
   const onAssignSuccess = useCallback(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
@@ -17,7 +17,6 @@ import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { AttackDetailsRightPanelKey } from '../../../../flyout/attack_details/constants/panel_keys';
 import { ALERT_ATTACK_IDS } from '../../../../../common/field_maps/field_names';
 import { PageScope } from '../../../../data_view_manager/constants';
-import { useGroupTakeActionsItems } from '../../../hooks/alerts_table/use_group_take_action_items';
 import {
   defaultGroupStatsAggregations,
   defaultGroupStatsRenderer,
@@ -46,6 +45,8 @@ import { EmptyResultsPrompt } from './empty_results_prompt';
 import { groupingOptions, groupingSettings } from './grouping_configs';
 import * as i18n from './translations';
 import { buildConnectorIdFilter } from './filtering_configs';
+import type { GroupTakeActionItems } from '../../alerts_table/types';
+import { AttacksGroupTakeActionItems } from './attacks_group_take_action_items';
 
 export const TABLE_SECTION_TEST_ID = 'attacks-page-table-section';
 
@@ -104,7 +105,7 @@ export const TableSection = React.memo(
 
     const { to, from } = useGlobalTime();
 
-    const [{ loading: userInfoLoading, hasIndexWrite, hasIndexMaintenance }] = useUserData();
+    const [{ loading: userInfoLoading }] = useUserData();
 
     const { loading: listsConfigLoading } = useListsConfig();
 
@@ -230,10 +231,14 @@ export const TableSection = React.memo(
       [defaultFilters, getAttack, isLoading, showAnonymized]
     );
 
-    const groupTakeActionItems = useGroupTakeActionsItems({
-      currentStatus: statusFilter,
-      showAlertStatusActions: Boolean(hasIndexWrite) && Boolean(hasIndexMaintenance),
-    });
+    const groupTakeActionItems: GroupTakeActionItems = useCallback(
+      ({ selectedGroup, groupBucket }) => {
+        const attack = getAttack(selectedGroup, groupBucket);
+        if (!attack) return;
+        return <AttacksGroupTakeActionItems attack={attack} />;
+      },
+      [getAttack]
+    );
 
     const accordionExtraActionGroupStats = useMemo(
       () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alerts_table/use_group_take_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alerts_table/use_group_take_action_items.test.tsx
@@ -21,6 +21,12 @@ describe('useGroupTakeActionsItems', () => {
     tableId: 'mock-id',
     groupNumber: 0,
     selectedGroup: 'test',
+    groupBucket: {
+      key: ['bucket-test'],
+      key_as_string: 'bucket-test',
+      selectedGroup: 'test',
+      doc_count: 0,
+    },
   };
   it('returns all take actions items if showAlertStatusActions is true and currentStatus is undefined', async () => {
     const { result } = renderHook(


### PR DESCRIPTION
## Summary

Implement the "assign" and "un-assign" actions for the group panel in the new attack discovery page

> [!warning]
> If an attack is not assigned to anyone, but any of its alerts is assigned to the user the page is filtered for, the attack will be visible. Unfortunately, we do not have the list of users assigned to the underlying alerts, because it would require an ad-hoc query to retrieve that information.
>
> At present moment, other pages — like the alerts page — do not show a list of assignees if the selection of alerts exceeds the visible page.

## Screen-recording 🎬 

https://github.com/user-attachments/assets/3e1ab0bc-4ddd-4574-8f51-022f46c2aeea

