### PR TITLE
[APM] Migrate Infra home page tests to Scout - Part III - Alerts & Saved Views

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/saved_views/manage_views_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/saved_views/manage_views_flyout.tsx
@@ -93,9 +93,11 @@ export function ManageViewsFlyout<TSavedViewState extends SavedViewItem>({
           defaultMessage: 'Mark as default',
         })}
         key={item.id}
-        data-test-subj={`infraRenderMakeDefaultActionButton-${
-          item.attributes.isDefault ? 'filled' : 'empty'
-        }`}
+        data-test-subj={
+          item.attributes.isDefault
+            ? 'infraRenderMakeDefaultActionButton-filled'
+            : 'infraRenderMakeDefaultActionButton-empty'
+        }
         iconType={item.attributes.isDefault ? 'starFilled' : 'starEmpty'}
         size="s"
         onClick={() => {

--- a/x-pack/solutions/observability/plugins/infra/public/components/saved_views/manage_views_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/saved_views/manage_views_flyout.tsx
@@ -163,7 +163,9 @@ export function ManageViewsFlyout<TSavedViewState extends SavedViewItem>({
             search={searchConfig}
             pagination={true}
             sorting={true}
-            tableCaption="Saved views"
+            tableCaption={i18n.translate('xpack.infra.openView.table.tableCaption', {
+              defaultMessage: 'Saved views',
+            })}
             data-test-subj="savedViews-viewsTable"
           />
         </EuiFlyoutBody>

--- a/x-pack/solutions/observability/plugins/infra/public/components/saved_views/manage_views_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/saved_views/manage_views_flyout.tsx
@@ -93,7 +93,9 @@ export function ManageViewsFlyout<TSavedViewState extends SavedViewItem>({
           defaultMessage: 'Mark as default',
         })}
         key={item.id}
-        data-test-subj="infraRenderMakeDefaultActionButton"
+        data-test-subj={`infraRenderMakeDefaultActionButton-${
+          item.attributes.isDefault ? 'filled' : 'empty'
+        }`}
         iconType={item.attributes.isDefault ? 'starFilled' : 'starEmpty'}
         size="s"
         onClick={() => {
@@ -161,6 +163,8 @@ export function ManageViewsFlyout<TSavedViewState extends SavedViewItem>({
             search={searchConfig}
             pagination={true}
             sorting={true}
+            tableCaption="Saved views"
+            data-test-subj="savedViews-viewsTable"
           />
         </EuiFlyoutBody>
         <EuiModalFooter>
@@ -212,7 +216,7 @@ const DeleteConfimation = ({ isDisabled, onConfirm }: DeleteConfimationProps) =>
       aria-label={i18n.translate('xpack.infra.deleteConfimation.deleteButton.ariaLabel', {
         defaultMessage: 'Delete',
       })}
-      data-test-subj="infraDeleteConfimationButton"
+      data-test-subj="infraDeleteConfirmationButton"
       iconType="trash"
       color="danger"
       size="s"

--- a/x-pack/solutions/observability/plugins/infra/public/components/saved_views/upsert_modal.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/saved_views/upsert_modal.tsx
@@ -84,6 +84,7 @@ export const UpsertViewModal = ({
         <EuiSpacer size="xl" />
         <EuiSwitch
           id={'saved-view-save-time-checkbox'}
+          data-test-subj="savedViews-includeTimeCheckbox"
           label={
             <FormattedMessage
               defaultMessage="Store time with view"

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -27,6 +27,12 @@ export const LOG_LEVELS = [
   { message: 'Error with certificate: "ca_trusted_fingerprint"', level: 'error' },
 ];
 
+export const HOST_LOGS = [
+  { message: 'A simple log', level: 'info' },
+  { message: 'Yet another debug log', level: 'debug' },
+  { message: 'Error with certificate: "ca_trusted_fingerprint"', level: 'error' },
+];
+
 export const HOST_NAME_WITH_SERVICES = HOST1_NAME;
 export const SERVICE_PER_HOST_COUNT = 3;
 

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -27,12 +27,6 @@ export const LOG_LEVELS = [
   { message: 'Error with certificate: "ca_trusted_fingerprint"', level: 'error' },
 ];
 
-export const HOST_LOGS = [
-  { message: 'A simple log', level: 'info' },
-  { message: 'Yet another debug log', level: 'debug' },
-  { message: 'Error with certificate: "ca_trusted_fingerprint"', level: 'error' },
-];
-
 export const HOST_NAME_WITH_SERVICES = HOST1_NAME;
 export const SERVICE_PER_HOST_COUNT = 3;
 

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -113,6 +113,7 @@ export const EXTENDED_TIMEOUT = 45000; // 45 seconds
 
 export const KUBERNETES_TOUR_STORAGE_KEY = 'isKubernetesTourSeen';
 export const KUBERNETES_CARD_DISMISSED_STORAGE_KEY = 'infra.inventory.k8sCardDismissed';
+export const KUBERNETES_TOAST_STORAGE_KEY = 'kubernetesToastKey';
 
 export const BASE_DEFAULT_INVENTORY_VIEW_ATTRIBUTES: Omit<
   CreateInventoryViewAttributes,

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/index.ts
@@ -23,12 +23,14 @@ import { InventoryPage } from './page_objects/inventory';
 import { AssetDetailsPage } from './page_objects/asset_details/asset_details';
 import { getInventoryViewsApiService, type InventoryViewApiService } from './apis/inventory_views';
 import { NodeDetailsPage } from './page_objects/node_details/node_details';
+import { SavedViews } from './page_objects/saved_views';
 
 export interface ExtendedScoutTestFixtures extends ObltTestFixtures {
   pageObjects: ObltPageObjects & {
     inventoryPage: InventoryPage;
     assetDetailsPage: AssetDetailsPage;
     nodeDetailsPage: NodeDetailsPage;
+    savedViews: SavedViews;
   };
 }
 
@@ -44,11 +46,14 @@ export const test = base.extend<ExtendedScoutTestFixtures, ExtendedScoutWorkerFi
     { pageObjects, page, kbnUrl },
     use: (pageObjects: ExtendedScoutTestFixtures['pageObjects']) => Promise<void>
   ) => {
+    const savedViews = createLazyPageObject(SavedViews, page);
+
     const extendedPageObjects = {
       ...pageObjects,
-      inventoryPage: createLazyPageObject(InventoryPage, page, kbnUrl),
+      inventoryPage: createLazyPageObject(InventoryPage, page, kbnUrl, savedViews),
       assetDetailsPage: createLazyPageObject(AssetDetailsPage, page, kbnUrl),
       nodeDetailsPage: createLazyPageObject(NodeDetailsPage, page, kbnUrl),
+      savedViews,
     };
 
     await use(extendedPageObjects);

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -125,7 +125,7 @@ export class InventoryPage {
     );
   }
 
-  private async waitForNodesToLoad() {
+  public async waitForNodesToLoad() {
     await this.page
       .getByTestId('infraNodesOverviewLoadingPanel')
       .waitFor({ state: 'hidden', timeout: EXTENDED_TIMEOUT });

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -42,6 +42,21 @@ export class InventoryPage {
 
   public readonly k8sPodWaffleContextMenu: Locator;
 
+  public readonly alertsHeaderButton: Locator;
+  public readonly alertsMenu: Locator;
+
+  public readonly inventoryAlertsMenuOption: Locator;
+  public readonly createInventoryRuleButton: Locator;
+
+  public readonly metricsAlertsMenuOption: Locator;
+  public readonly createMetricsThresholdRuleButton: Locator;
+
+  public readonly customThresholdAlertMenuOption: Locator;
+
+  public readonly alertsFlyout: Locator;
+  public readonly alertsFlyoutRuleDefinitionSection: Locator;
+  public readonly alertsFlyoutRuleTypeName: Locator;
+
   constructor(private readonly page: ScoutPage, private readonly kbnUrl: KibanaUrl) {
     this.feedbackLink = this.page.getByTestId('infraInventoryFeedbackLink');
     this.k8sFeedbackLink = this.page.getByTestId('infra-kubernetes-feedback-link');
@@ -73,6 +88,29 @@ export class InventoryPage {
     this.k8sPodWaffleContextMenu = this.page
       .getByRole('dialog')
       .filter({ hasText: 'Kubernetes Pod details' });
+
+    this.alertsHeaderButton = this.page.getByTestId('infrastructure-alerts-and-rules');
+    this.alertsMenu = this.page.getByTestId('metrics-alert-menu');
+
+    this.inventoryAlertsMenuOption = this.alertsMenu.getByTestId('inventory-alerts-menu-option');
+    this.createInventoryRuleButton = this.alertsMenu.getByTestId('inventory-alerts-create-rule');
+
+    this.metricsAlertsMenuOption = this.alertsMenu.getByTestId(
+      'metrics-threshold-alerts-menu-option'
+    );
+    this.createMetricsThresholdRuleButton = this.alertsMenu.getByTestId(
+      'metrics-threshold-alerts-create-rule'
+    );
+
+    this.customThresholdAlertMenuOption = this.alertsMenu.getByTestId(
+      'custom-threshold-alerts-menu-option'
+    );
+
+    this.alertsFlyout = this.page.getByRole('dialog').filter({ hasText: 'Create rule' });
+    this.alertsFlyoutRuleDefinitionSection = this.alertsFlyout.getByTestId('ruleDefinition');
+    this.alertsFlyoutRuleTypeName = this.alertsFlyout.getByTestId(
+      'ruleDefinitionHeaderRuleTypeName'
+    );
   }
 
   private async waitForNodesToLoad() {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/saved_views.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/saved_views.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Locator, ScoutPage } from '@kbn/scout-oblt';
+
+export class SavedViews {
+  public readonly selector: Locator;
+  public readonly manageViewsButton: Locator;
+  public readonly updateViewButton: Locator;
+  public readonly saveNewViewButton: Locator;
+
+  public readonly upsertModal: Locator;
+  public readonly viewNameInput: Locator;
+  public readonly includeTimeCheckbox: Locator;
+  public readonly cancelUpsertButton: Locator;
+  public readonly confirmUpsertButton: Locator;
+
+  public readonly manageViewsFlyout: Locator;
+  public readonly manageViewsFilterInput: Locator;
+  public readonly manageViewsTable: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.selector = this.page.getByTestId('savedViews-openPopover-loaded');
+    this.manageViewsButton = this.page.getByTestId('savedViews-manageViews');
+    this.updateViewButton = this.page.getByTestId('savedViews-updateView');
+    this.saveNewViewButton = this.page.getByTestId('savedViews-saveNewView');
+
+    this.upsertModal = this.page.getByTestId('savedViews-upsertModal');
+    this.viewNameInput = this.upsertModal.getByTestId('savedViewName');
+    this.includeTimeCheckbox = this.upsertModal.getByTestId('savedViews-includeTimeCheckbox');
+    this.cancelUpsertButton = this.upsertModal.getByTestId('infraSavedViewCreateModalCancelButton');
+    this.confirmUpsertButton = this.upsertModal.getByTestId('createSavedViewButton');
+
+    this.manageViewsFlyout = this.page.getByTestId('loadViewsFlyout');
+    this.manageViewsFilterInput = this.manageViewsFlyout.getByRole('searchbox');
+    this.manageViewsTable = this.manageViewsFlyout.getByTestId('savedViews-viewsTable');
+  }
+
+  public async waitForViewsToLoad() {
+    await this.selector.waitFor();
+  }
+
+  public async createView(viewName: string, opts: { saveTime?: boolean } = {}) {
+    await this.selector.click();
+    await this.saveNewViewButton.click();
+    await this.viewNameInput.fill(viewName);
+
+    if (opts.saveTime) {
+      await this.includeTimeCheckbox.click();
+    }
+
+    await this.confirmUpsertButton.click();
+    await this.upsertModal.waitFor({ state: 'hidden' });
+  }
+
+  public async saveCurrentView(newName?: string) {
+    await this.selector.click();
+    await this.updateViewButton.click();
+
+    if (newName) {
+      await this.viewNameInput.clear();
+      await this.viewNameInput.fill(newName);
+    }
+
+    await this.confirmUpsertButton.click();
+    await this.upsertModal.waitFor({ state: 'hidden' });
+  }
+}

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/alerts_flyouts.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/alerts_flyouts.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-oblt';
+import { test } from '../../fixtures';
+
+test.describe('Infrastructure Inventory - Alerts Flyout', { tag: ['@ess', '@svlOblt'] }, () => {
+  test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
+    await browserAuth.loginAsPrivilegedUser();
+    await inventoryPage.addDismissK8sTourInitScript();
+    await inventoryPage.goToPage();
+  });
+
+  test('Should open inventory rule flyout', async ({ pageObjects: { inventoryPage } }) => {
+    await test.step('open alerts menu', async () => {
+      await inventoryPage.alertsHeaderButton.click();
+      await expect(inventoryPage.alertsMenu).toBeVisible();
+    });
+
+    await test.step('open infrastructure rules submenu', async () => {
+      await inventoryPage.inventoryAlertsMenuOption.click();
+      await expect(inventoryPage.alertsMenu).toContainText('Infrastructure rules');
+    });
+
+    await test.step('open inventory rule flyout', async () => {
+      await inventoryPage.createInventoryRuleButton.click();
+      await expect(inventoryPage.alertsFlyout).toBeVisible();
+      await expect(inventoryPage.alertsFlyoutRuleDefinitionSection).toBeVisible();
+      await expect(inventoryPage.alertsFlyoutRuleTypeName).toHaveText('Inventory');
+    });
+  });
+
+  test('Should open metrics threshold rule flyout', async ({ pageObjects: { inventoryPage } }) => {
+    await test.step('open alerts menu', async () => {
+      await inventoryPage.alertsHeaderButton.click();
+      await expect(inventoryPage.alertsMenu).toBeVisible();
+    });
+
+    await test.step('open metrics rules submenu', async () => {
+      await inventoryPage.metricsAlertsMenuOption.click();
+      await expect(inventoryPage.alertsMenu).toContainText('Metrics rules');
+    });
+
+    await test.step('open metrics threshold rule flyout', async () => {
+      await inventoryPage.createMetricsThresholdRuleButton.click();
+      await expect(inventoryPage.alertsFlyout).toBeVisible();
+      await expect(inventoryPage.alertsFlyoutRuleDefinitionSection).toBeVisible();
+      await expect(inventoryPage.alertsFlyoutRuleTypeName).toHaveText('Metric threshold');
+    });
+  });
+
+  test('Should not have option to create custom threshold rule', async ({
+    pageObjects: { inventoryPage },
+  }) => {
+    await test.step('open alerts menu', async () => {
+      await inventoryPage.alertsHeaderButton.click();
+      await expect(inventoryPage.alertsMenu).toBeVisible();
+    });
+
+    await test.step('verify custom threshold alert menu option is not visible', async () => {
+      await expect(inventoryPage.customThresholdAlertMenuOption).toBeHidden();
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/alerts_flyouts.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/alerts_flyouts.spec.ts
@@ -8,31 +8,35 @@
 import { expect } from '@kbn/scout-oblt';
 import { test } from '../../fixtures';
 
-test.describe('Infrastructure Inventory - Alerts Flyout', { tag: ['@ess', '@svlOblt'] }, () => {
+test.describe('Infrastructure Inventory - Alerts Flyout', { tag: ['@ess'] }, () => {
   test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
     await browserAuth.loginAsPrivilegedUser();
     await inventoryPage.addDismissK8sTourInitScript();
     await inventoryPage.goToPage();
   });
 
-  test('Should open inventory rule flyout', async ({ pageObjects: { inventoryPage } }) => {
-    await test.step('open alerts menu', async () => {
-      await inventoryPage.alertsHeaderButton.click();
-      await expect(inventoryPage.alertsMenu).toBeVisible();
-    });
+  test(
+    'Should open inventory rule flyout',
+    { tag: ['@svlOblt'] },
+    async ({ pageObjects: { inventoryPage } }) => {
+      await test.step('open alerts menu', async () => {
+        await inventoryPage.alertsHeaderButton.click();
+        await expect(inventoryPage.alertsMenu).toBeVisible();
+      });
 
-    await test.step('open infrastructure rules submenu', async () => {
-      await inventoryPage.inventoryAlertsMenuOption.click();
-      await expect(inventoryPage.alertsMenu).toContainText('Infrastructure rules');
-    });
+      await test.step('open infrastructure rules submenu', async () => {
+        await inventoryPage.inventoryAlertsMenuOption.click();
+        await expect(inventoryPage.alertsMenu).toContainText('Infrastructure rules');
+      });
 
-    await test.step('open inventory rule flyout', async () => {
-      await inventoryPage.createInventoryRuleButton.click();
-      await expect(inventoryPage.alertsFlyout).toBeVisible();
-      await expect(inventoryPage.alertsFlyoutRuleDefinitionSection).toBeVisible();
-      await expect(inventoryPage.alertsFlyoutRuleTypeName).toHaveText('Inventory');
-    });
-  });
+      await test.step('open inventory rule flyout', async () => {
+        await inventoryPage.createInventoryRuleButton.click();
+        await expect(inventoryPage.alertsFlyout).toBeVisible();
+        await expect(inventoryPage.alertsFlyoutRuleDefinitionSection).toBeVisible();
+        await expect(inventoryPage.alertsFlyoutRuleTypeName).toHaveText('Inventory');
+      });
+    }
+  );
 
   test('Should open metrics threshold rule flyout', async ({ pageObjects: { inventoryPage } }) => {
     await test.step('open alerts menu', async () => {
@@ -53,16 +57,18 @@ test.describe('Infrastructure Inventory - Alerts Flyout', { tag: ['@ess', '@svlO
     });
   });
 
-  test('Should not have option to create custom threshold rule', async ({
-    pageObjects: { inventoryPage },
-  }) => {
-    await test.step('open alerts menu', async () => {
-      await inventoryPage.alertsHeaderButton.click();
-      await expect(inventoryPage.alertsMenu).toBeVisible();
-    });
+  test(
+    'Should not have option to create custom threshold rule',
+    { tag: ['@svlOblt'] },
+    async ({ pageObjects: { inventoryPage } }) => {
+      await test.step('open alerts menu', async () => {
+        await inventoryPage.alertsHeaderButton.click();
+        await expect(inventoryPage.alertsMenu).toBeVisible();
+      });
 
-    await test.step('verify custom threshold alert menu option is not visible', async () => {
-      await expect(inventoryPage.customThresholdAlertMenuOption).toBeHidden();
-    });
-  });
+      await test.step('verify custom threshold alert menu option is not visible', async () => {
+        await expect(inventoryPage.customThresholdAlertMenuOption).toBeHidden();
+      });
+    }
+  );
 });

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/container_asset_details_flyout.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/container_asset_details_flyout.spec.ts
@@ -54,7 +54,7 @@ test.describe(
     });
 
     test.afterAll(async ({ apiServices: { inventoryViews } }) => {
-      await inventoryViews.deleteOne(savedViewId);
+      await inventoryViews.deleteById(savedViewId);
     });
 
     test('Overview Tab', async ({ pageObjects: { assetDetailsPage } }) => {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/host_asset_details_flyout.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/host_asset_details_flyout.spec.ts
@@ -404,34 +404,5 @@ test.describe(
         await expect(assetDetailsPage.metadataTab.table).toBeVisible();
       });
     });
-
-    test('Open as page and return to flyout', async ({
-      page,
-      pageObjects: { assetDetailsPage },
-    }) => {
-      await test.step('go to metadata tab', async () => {
-        await assetDetailsPage.metadataTab.clickTab();
-        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
-      });
-
-      await test.step('open asset details as page keeping the selected tab', async () => {
-        await assetDetailsPage.openAsPageButton.click();
-        const url = new URL(page.url());
-        expect(url.pathname).toBe(`/app/metrics/detail/host/${encodeURIComponent(HOST1_NAME)}`);
-        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
-        await expect(assetDetailsPage.metadataTab.searchBar).toBeVisible();
-        await expect(assetDetailsPage.metadataTab.table).toBeVisible();
-      });
-
-      await test.step('return to flyout from asset details page', async () => {
-        await assetDetailsPage.returnButton.click();
-        await expect(
-          page.getByRole('dialog').getByRole('heading', { name: HOST1_NAME })
-        ).toBeVisible();
-        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
-        await expect(assetDetailsPage.metadataTab.searchBar).toBeVisible();
-        await expect(assetDetailsPage.metadataTab.table).toBeVisible();
-      });
-    });
   }
 );

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/host_asset_details_flyout.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/host_asset_details_flyout.spec.ts
@@ -404,5 +404,34 @@ test.describe(
         await expect(assetDetailsPage.metadataTab.table).toBeVisible();
       });
     });
+
+    test('Open as page and return to flyout', async ({
+      page,
+      pageObjects: { assetDetailsPage },
+    }) => {
+      await test.step('go to metadata tab', async () => {
+        await assetDetailsPage.metadataTab.clickTab();
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+      });
+
+      await test.step('open asset details as page keeping the selected tab', async () => {
+        await assetDetailsPage.openAsPageButton.click();
+        const url = new URL(page.url());
+        expect(url.pathname).toBe(`/app/metrics/detail/host/${encodeURIComponent(HOST1_NAME)}`);
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+        await expect(assetDetailsPage.metadataTab.searchBar).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.table).toBeVisible();
+      });
+
+      await test.step('return to flyout from asset details page', async () => {
+        await assetDetailsPage.returnButton.click();
+        await expect(
+          page.getByRole('dialog').getByRole('heading', { name: HOST1_NAME })
+        ).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.tab).toHaveAttribute('aria-selected', 'true');
+        await expect(assetDetailsPage.metadataTab.searchBar).toBeVisible();
+        await expect(assetDetailsPage.metadataTab.table).toBeVisible();
+      });
+    });
   }
 );

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/host_asset_details_flyout.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/host_asset_details_flyout.spec.ts
@@ -49,7 +49,7 @@ test.describe(
     });
 
     test.afterAll(async ({ apiServices: { inventoryViews } }) => {
-      await inventoryViews.deleteOne(savedViewId);
+      await inventoryViews.deleteById(savedViewId);
     });
 
     test('Overview Tab', async ({ pageObjects: { assetDetailsPage } }) => {

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/saved_views.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/saved_views.spec.ts
@@ -1,0 +1,342 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-oblt';
+import { test } from '../../fixtures';
+import {
+  DATE_WITH_DOCKER_DATA,
+  DATE_WITH_DOCKER_DATA_TIMESTAMP,
+  DATE_WITH_POD_DATA,
+} from '../../fixtures/constants';
+
+test.use({
+  timezoneId: 'GMT',
+});
+
+test.describe('Infrastructure Inventory - Saved Views', { tag: ['@ess', '@svlOblt'] }, () => {
+  let preloadedViewId = '';
+
+  test.beforeAll(async ({ apiServices: { inventoryViews } }) => {
+    const response = await inventoryViews.create({
+      name: 'Preloaded View',
+      nodeType: 'container',
+      metric: { type: 'memory' },
+      groupBy: [],
+      view: 'table',
+      customOptions: [],
+      customMetrics: [],
+      boundsOverride: {
+        max: 1,
+        min: 0,
+      },
+      autoBounds: true,
+      accountId: '',
+      region: '',
+      legend: {
+        palette: 'cool',
+        reverseColors: false,
+        steps: 10,
+      },
+      sort: {
+        by: 'name',
+        direction: 'desc',
+      },
+      timelineOpen: false,
+      autoReload: false,
+      filterQuery: {
+        expression: '',
+        kind: 'kuery',
+      },
+      preferredSchema: 'ecs',
+      time: DATE_WITH_DOCKER_DATA_TIMESTAMP,
+    });
+
+    preloadedViewId = response.id;
+  });
+
+  test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
+    await browserAuth.loginAsPrivilegedUser();
+    await inventoryPage.addDismissK8sTourInitScript();
+    await inventoryPage.addDismissK8sToastInitScript();
+  });
+
+  test.afterEach(async ({ apiServices: { inventoryViews } }) => {
+    await inventoryViews.deleteByName([
+      'View without time',
+      'View with time',
+      'View to delete',
+      'View to update',
+      'View updated',
+    ]);
+    await inventoryViews.makeDefault('0'); // Reset to default view whose id is fixed to '0'
+  });
+
+  test.afterAll(async ({ apiServices: { inventoryViews } }) => {
+    await inventoryViews.deleteById(preloadedViewId);
+  });
+
+  test("Load the 'Default view' when no saved view is selected", async ({
+    pageObjects: { savedViews, inventoryPage },
+  }) => {
+    await test.step("load 'Default View' on page load", async () => {
+      await inventoryPage.goToPage();
+      await expect(savedViews.selector).toHaveText('Default view');
+    });
+
+    await test.step("verify 'Default View' cannot be updated", async () => {
+      await savedViews.selector.click();
+      await expect(savedViews.updateViewButton).toBeDisabled();
+    });
+
+    await test.step("verify 'Default View' is marked as default in manage views flyout", async () => {
+      await savedViews.manageViewsButton.click();
+      await savedViews.manageViewsFilterInput.pressSequentially('Default view');
+      await expect(savedViews.manageViewsTable.getByTestId('infraRenderNameButton')).toContainText(
+        'Default view'
+      );
+      await expect(
+        savedViews.manageViewsTable.getByTestId('infraRenderMakeDefaultActionButton-filled')
+      ).toBeVisible();
+    });
+  });
+
+  test('Apply an existing saved view when it is selected in the URL', async ({
+    pageObjects: { savedViews, inventoryPage },
+  }) => {
+    await inventoryPage.goToPageWithSavedView(preloadedViewId);
+    await expect(savedViews.selector).toHaveText('Preloaded View');
+    await expect(inventoryPage.datePickerInput).toHaveValue(DATE_WITH_DOCKER_DATA);
+    await expect(inventoryPage.tableViewButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(inventoryPage.nodesOverviewTable).toBeVisible();
+    await expect(inventoryPage.inventorySwitcherButton).toHaveText('Docker Containers');
+    await expect(inventoryPage.metricSwitcherButton).toHaveText('Memory usage');
+  });
+
+  test('Create a new saved view from the current inventory state without saving the time', async ({
+    page,
+    pageObjects: { inventoryPage, savedViews },
+  }) => {
+    await test.step('configure some inventory state', async () => {
+      await inventoryPage.goToPage();
+      await inventoryPage.goToTime(DATE_WITH_POD_DATA);
+      await inventoryPage.showPods();
+      await inventoryPage.selectMetric('Inbound traffic');
+      await inventoryPage.toggleTimeline();
+    });
+
+    await test.step('create a new saved view without saving the time', async () => {
+      await savedViews.createView('View without time', { saveTime: false });
+      await expect(savedViews.selector).toHaveText('View without time');
+
+      const url = new URL(page.url());
+      const inventoryViewId = url.searchParams.get('inventoryViewId')?.replace(/'/g, '');
+      expect(inventoryViewId).toBeDefined();
+      expect(inventoryViewId).not.toBe(0);
+
+      // The saved time doesn't match the one we set before creating the view as time wasn't saved
+      await expect(inventoryPage.datePickerInput).not.toHaveValue(DATE_WITH_POD_DATA);
+    });
+  });
+
+  test('Create a new saved view from the current inventory state saving the time', async ({
+    page,
+    pageObjects: { inventoryPage, savedViews },
+  }) => {
+    await test.step('configure some inventory state', async () => {
+      await inventoryPage.goToPage();
+      await inventoryPage.goToTime(DATE_WITH_DOCKER_DATA);
+      await inventoryPage.showContainers();
+      await inventoryPage.selectMetric('Outbound traffic');
+    });
+
+    await test.step('create a new saved view saving the time', async () => {
+      await savedViews.createView('View with time', { saveTime: true });
+      await expect(savedViews.selector).toHaveText('View with time');
+
+      const url = new URL(page.url());
+      const inventoryViewId = url.searchParams.get('inventoryViewId')?.replace(/'/g, '');
+      expect(inventoryViewId).toBeDefined();
+      expect(inventoryViewId).not.toBe(0);
+
+      // The saved time should match the one we set before creating the view
+      await expect(inventoryPage.datePickerInput).toHaveValue(DATE_WITH_DOCKER_DATA);
+      await expect(inventoryPage.waffleMap).toBeVisible();
+    });
+  });
+
+  test('Select and load an existing saved view from the manage views flyout', async ({
+    pageObjects: { inventoryPage, savedViews },
+  }) => {
+    await test.step('land on inventory page loading the default view', async () => {
+      await inventoryPage.goToPage();
+      await expect(savedViews.selector).toHaveText('Default view');
+    });
+
+    await test.step('open manage views flyout', async () => {
+      await savedViews.selector.click();
+      await savedViews.manageViewsButton.click();
+      await expect(savedViews.manageViewsFlyout).toBeVisible();
+    });
+
+    await test.step("filter views table and select 'Preloaded View'", async () => {
+      await savedViews.manageViewsFilterInput.pressSequentially('Preloaded View');
+      const viewLocator = savedViews.manageViewsTable.getByTestId('infraRenderNameButton');
+      await expect(viewLocator).toContainText('Preloaded View');
+      await viewLocator.click();
+      await savedViews.waitForViewsToLoad();
+      await inventoryPage.waitForNodesToLoad();
+    });
+
+    await test.step("verify 'Preloaded View' is applied", async () => {
+      await expect(savedViews.manageViewsFlyout).toBeHidden();
+      await expect(savedViews.selector).toHaveText('Preloaded View');
+      await expect(inventoryPage.datePickerInput).toHaveValue(DATE_WITH_DOCKER_DATA);
+      await expect(inventoryPage.tableViewButton).toHaveAttribute('aria-pressed', 'true');
+      await expect(inventoryPage.nodesOverviewTable).toBeVisible();
+      await expect(inventoryPage.inventorySwitcherButton).toHaveText('Docker Containers');
+      await expect(inventoryPage.metricSwitcherButton).toHaveText('Memory usage');
+    });
+  });
+
+  test('Can make a saved view the default view from the manage views flyout', async ({
+    pageObjects: { inventoryPage, savedViews, toasts },
+  }) => {
+    await test.step('land on inventory page loading the default view', async () => {
+      await inventoryPage.goToPage();
+      await expect(savedViews.selector).toHaveText('Default view');
+    });
+
+    await test.step('open manage views flyout', async () => {
+      await savedViews.selector.click();
+      await savedViews.manageViewsButton.click();
+      await expect(savedViews.manageViewsFlyout).toBeVisible();
+    });
+
+    await test.step("filter views table and make 'Preloaded View' the default view", async () => {
+      await savedViews.manageViewsFilterInput.pressSequentially('Preloaded View');
+      const makeDefaultButton = savedViews.manageViewsTable.getByTestId(
+        'infraRenderMakeDefaultActionButton-empty'
+      );
+      await expect(makeDefaultButton).toBeVisible();
+      await makeDefaultButton.click();
+      await toasts.waitFor();
+      expect(await toasts.getHeaderText()).toBe('Metrics settings successfully updated');
+    });
+
+    await test.step("navigate page without saved view and verify 'Preloaded View' is applied", async () => {
+      await inventoryPage.goToPage();
+      await expect(savedViews.selector).toHaveText('Preloaded View');
+    });
+  });
+
+  test('Delete a saved view from the manage views flyout', async ({
+    apiServices: { inventoryViews },
+    pageObjects: { inventoryPage, savedViews },
+  }) => {
+    await inventoryViews.create({
+      name: 'View to delete',
+      nodeType: 'container',
+      metric: { type: 'memory' },
+      groupBy: [],
+      view: 'table',
+      customOptions: [],
+      customMetrics: [],
+      boundsOverride: {
+        max: 1,
+        min: 0,
+      },
+      autoBounds: true,
+      accountId: '',
+      region: '',
+      legend: {
+        palette: 'cool',
+        reverseColors: false,
+        steps: 10,
+      },
+      sort: {
+        by: 'name',
+        direction: 'desc',
+      },
+      timelineOpen: false,
+      autoReload: false,
+      filterQuery: {
+        expression: '',
+        kind: 'kuery',
+      },
+      preferredSchema: 'ecs',
+    });
+
+    await test.step('navigate page and open manage views flyout', async () => {
+      await inventoryPage.goToPage();
+      await savedViews.selector.click();
+      await savedViews.manageViewsButton.click();
+      await expect(savedViews.manageViewsFlyout).toBeVisible();
+    });
+
+    await test.step("filter views table and delete 'View to delete'", async () => {
+      await savedViews.manageViewsFilterInput.pressSequentially('View to delete');
+      const nameLocator = savedViews.manageViewsTable
+        .getByTestId('infraRenderNameButton')
+        .filter({ hasText: 'View to delete' });
+      await expect(nameLocator).toBeVisible();
+      await savedViews.manageViewsTable.getByTestId('infraDeleteConfirmationButton').click();
+      await savedViews.manageViewsTable.getByTestId('showConfirm').click();
+      await expect(nameLocator).toBeHidden();
+    });
+  });
+
+  test('Update a saved view from the manage views flyout', async ({
+    apiServices: { inventoryViews },
+    pageObjects: { inventoryPage, savedViews },
+  }) => {
+    const response = await inventoryViews.create({
+      name: 'View to update',
+      nodeType: 'container',
+      metric: { type: 'memory' },
+      groupBy: [],
+      view: 'table',
+      customOptions: [],
+      customMetrics: [],
+      boundsOverride: {
+        max: 1,
+        min: 0,
+      },
+      autoBounds: true,
+      accountId: '',
+      region: '',
+      legend: {
+        palette: 'cool',
+        reverseColors: false,
+        steps: 10,
+      },
+      sort: {
+        by: 'name',
+        direction: 'desc',
+      },
+      timelineOpen: false,
+      autoReload: false,
+      filterQuery: {
+        expression: '',
+        kind: 'kuery',
+      },
+      preferredSchema: 'ecs',
+    });
+    const viewId = response.id;
+
+    await test.step('navigate page with preloaded view', async () => {
+      await inventoryPage.goToPageWithSavedView(viewId);
+      await expect(savedViews.selector).toHaveText('View to update');
+    });
+
+    await test.step('change inventory state and update view', async () => {
+      await inventoryPage.showHosts();
+      await savedViews.saveCurrentView('View updated');
+      await expect(savedViews.selector).toHaveText('View updated');
+      await expect(inventoryPage.inventorySwitcherButton).toHaveText('Hosts');
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/saved_views.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/saved_views.spec.ts
@@ -225,11 +225,9 @@ test.describe('Infrastructure Inventory - Saved Views', { tag: ['@ess', '@svlObl
       await makeDefaultButton.click();
       await toasts.waitFor();
       expect(await toasts.getHeaderText()).toBe('Metrics settings successfully updated');
-    });
-
-    await test.step("navigate page without saved view and verify 'Preloaded View' is applied", async () => {
-      await inventoryPage.goToPage();
-      await expect(savedViews.selector).toHaveText('Preloaded View');
+      await expect(
+        savedViews.manageViewsTable.getByTestId('infraRenderMakeDefaultActionButton-filled')
+      ).toBeVisible();
     });
   });
 


### PR DESCRIPTION
## Summary
Part of #246428

This PR is part III of the test migration effort to port infra home page tests from FTR to Scout. The original FTR file contains lots of tests that I believe could be split into multiple separate suites following the recommended approach of keeping 1 describe block per test file. The migration will consist of these steps:

- [x] Infra home page (this PR). Includes most of the standalone `it` tests inside the outter most describe block in the original FTR suite. It tests the main home page contents, without opening any flyout pr navigating away.
- [x] **Asset details flyout**. Will cover the asset details flyout that opens up after clicking a node in the waffle map. Will in turn be split into 2 separate files to cover the 2 distinct FTR describe blocks, one for hosts and another for containers. This will also cover the "Redirect to Node Details page" block as the redirection occurs within the flyout.
- [x] Alert flyouts. Will cover the equivalent describe block around alerts from the infra home page
- [x] Saved views. Will cover the block around saved views functionality
- [ ] React component test for waffle map. Will cover the outstanding `it` tests focused around waffle map functionality. As already specified in the FTR file, this are better suited as unit tests

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->