### PR TITLE
[9.3] [Discover][Metrics] Add check to ensure ESQL is valid before matching Metrics profile (#248917)

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/metrics_data_source_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/metrics_data_source_profile/profile.test.ts
@@ -56,7 +56,8 @@ describe('metricsDataSourceProfileProvider', () => {
       'TS metrics-*',
       'TS metrics-* | LIMIT 10',
       'TS metrics-* | SORT @timestamp DESC',
-      'TS logs-* | LIMIT 5 | SORT @timestamp',
+      'TS metrics-* | WHERE host.name == "foo"',
+      'TS metrics-* | LIMIT 5 | SORT @timestamp',
     ])('when query contains only supported commands: %s', async (query) => {
       const result = await provider.resolve(
         createParams({
@@ -108,6 +109,53 @@ describe('metricsDataSourceProfileProvider', () => {
       'TS metrics-* | WHERE host.name="foo"',
       'TS metrics-* | STATS count() BY @timestamp',
     ])('when query contains commands that are not supported: %s', async (query) => {
+      const result = await provider.resolve(
+        createParams({
+          query: { esql: query },
+        })
+      );
+
+      expect(result).toEqual(RESOLUTION_MISMATCH);
+    });
+
+    it('when query contains ESQL that is not valid', async () => {
+      const query = `FROM logs-azure.auditlogs-*
+| WHERE @timestamp >= now() - 30d
+  AND event.action IN ("Update", "Create")
+| EVAL props_raw = COALESCE(azure.properties, properties)
+| EVAL props     = json_parse(props_raw)
+| EVAL settings  = COALESCE(json_get(props, "settings"), props)
+| MV_EXPAND setting = settings
+| WHERE LOWER(json_get(setting, "name")) == "enablenetworkprotection"
+| EVAL np_new_value = COALESCE(json_get(setting, "value"), json_get(setting, "Value"))
+| EVAL change_time  = @timestamp
+| KEEP change_time, event.action, user.name, target.resource.id, np_new_value
+| RENAME target.resource.id AS device_id
+
+/* JOIN endpoint flips observed within 6 hours of the change */
+| JOIN (
+    FROM logs-azure.auditlogs-* AS re
+    | WHERE @timestamp >= now() - 30d
+      AND event.action IN ("RegistryValueSet", "RegistryValueCreated")
+      AND (
+        registry.path LIKE "%SOFTWARE\\Policies\\Microsoft\\Windows Defender\\PolicyManager%"
+        OR registry.path LIKE "%SOFTWARE\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\Network Protection%"
+      )
+      AND registry.value.name == "EnableNetworkProtection"
+    | EVAL raw_value = COALESCE(registry.data.strings[0], registry.value.data, TO_STRING(registry.value))
+    | EVAL np_mode   = CASE(
+        raw_value == "0", "Off",
+        raw_value == "1", "Audit",
+        raw_value == "2", "Block",
+        "Unknown"
+      )
+    | EVAL flip_time = @timestamp
+    | KEEP host.name, host.id, np_mode, flip_time
+    | RENAME host.id AS device_id
+  )
+  ON ia.device_id == re.device_id
+| WHERE flip_time BETWEEN change_time AND change_time + INTERVAL 6 HOURS
+| SORT change_time DESC, flip_time DESC`;
       const result = await provider.resolve(
         createParams({
           query: { esql: query },

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/metrics_data_source_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/metrics_data_source_profile/profile.test.ts
@@ -56,7 +56,6 @@ describe('metricsDataSourceProfileProvider', () => {
       'TS metrics-*',
       'TS metrics-* | LIMIT 10',
       'TS metrics-* | SORT @timestamp DESC',
-      'TS metrics-* | WHERE host.name == "foo"',
       'TS metrics-* | LIMIT 5 | SORT @timestamp',
     ])('when query contains only supported commands: %s', async (query) => {
       const result = await provider.resolve(

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/metrics_data_source_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/metrics_data_source_profile/profile.ts
@@ -60,5 +60,8 @@ function isQuerySupported(query: AggregateQuery | Query | undefined): query is A
   }
 
   const parsed = Parser.parse(query.esql);
+  if (parsed.root.commands.length === 0 || parsed.errors.length > 0) {
+    return false;
+  }
   return parsed.root.commands.every((c) => SUPPORTED_ESQL_COMMANDS.has(c.name));
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Discover][Metrics] Add check to ensure ESQL is valid before matching Metrics profile (#248917)](https://github.com/elastic/kibana/pull/248917)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Chris Cowan","email":"chris@elastic.co"},"sourceCommit":{"committedDate":"2026-01-15T17:11:51Z","message":"[Discover][Metrics] Add check to ensure ESQL is valid before matching Metrics profile (#248917)\n\n## Summary\n\nThis PR fixes #248505 by introducing 2 check to ensure the ESQL query is\nvalid and returns commands we can use to determine the profile should be\nactivated.\n\n- If the AST returns any errors, return `false`\n- If the AST doesn't return any commands, return `false`\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"f08431dba371989bbc71cb308c3c466ba9b058f0","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","backport:all-open","Feature:Metrics in Discover","v9.4.0"],"title":"[Discover][Metrics] Add check to ensure ESQL is valid before matching Metrics profile","number":248917,"url":"https://github.com/elastic/kibana/pull/248917","mergeCommit":{"message":"[Discover][Metrics] Add check to ensure ESQL is valid before matching Metrics profile (#248917)\n\n## Summary\n\nThis PR fixes #248505 by introducing 2 check to ensure the ESQL query is\nvalid and returns commands we can use to determine the profile should be\nactivated.\n\n- If the AST returns any errors, return `false`\n- If the AST doesn't return any commands, return `false`\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"f08431dba371989bbc71cb308c3c466ba9b058f0"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248917","number":248917,"mergeCommit":{"message":"[Discover][Metrics] Add check to ensure ESQL is valid before matching Metrics profile (#248917)\n\n## Summary\n\nThis PR fixes #248505 by introducing 2 check to ensure the ESQL query is\nvalid and returns commands we can use to determine the profile should be\nactivated.\n\n- If the AST returns any errors, return `false`\n- If the AST doesn't return any commands, return `false`\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"f08431dba371989bbc71cb308c3c466ba9b058f0"}}]}] BACKPORT-->