### PR TITLE
Exporting the isUiamCredential function to be used by consumers

### DIFF
--- a/x-pack/platform/plugins/shared/security/server/authentication/api_keys/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/api_keys/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { APIKeys, CreateApiKeyValidationError } from './api_keys';
+export { isUiamCredential } from './uiam';

--- a/x-pack/platform/plugins/shared/security/server/authentication/api_keys/uiam/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/api_keys/uiam/index.ts
@@ -5,5 +5,5 @@
  * 2.0.
  */
 
-export { UiamAPIKeys } from './uiam_api_keys';
+export { UiamAPIKeys, isUiamCredential } from './uiam_api_keys';
 export type { UiamAPIKeysOptions } from './uiam_api_keys';

--- a/x-pack/platform/plugins/shared/security/server/authentication/api_keys/uiam/uiam_api_keys.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/api_keys/uiam/uiam_api_keys.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@kbn/core/server/mocks';
 import type { Logger } from '@kbn/logging';
 
-import { UiamAPIKeys } from './uiam_api_keys';
+import { isUiamCredential, UiamAPIKeys } from './uiam_api_keys';
 import type { SecurityLicense } from '../../../../common';
 import { licenseMock } from '../../../../common/licensing/index.mock';
 import type { UiamServicePublic } from '../../../uiam';
@@ -331,7 +331,7 @@ describe('UiamAPIKeys', () => {
     it('returns true when credentials start with UIAM prefix', () => {
       const authorization = new HTTPAuthorizationHeader('ApiKey', 'essu_credential_123');
 
-      const result = UiamAPIKeys.isUiamCredential(authorization);
+      const result = isUiamCredential(authorization);
 
       expect(result).toBe(true);
     });
@@ -339,7 +339,7 @@ describe('UiamAPIKeys', () => {
     it('returns false when credentials do not start with UIAM prefix', () => {
       const authorization = new HTTPAuthorizationHeader('ApiKey', 'regular_credential_123');
 
-      const result = UiamAPIKeys.isUiamCredential(authorization);
+      const result = isUiamCredential(authorization);
 
       expect(result).toBe(false);
     });
@@ -347,7 +347,7 @@ describe('UiamAPIKeys', () => {
     it('returns false when credentials are empty', () => {
       const authorization = new HTTPAuthorizationHeader('ApiKey', '');
 
-      const result = UiamAPIKeys.isUiamCredential(authorization);
+      const result = isUiamCredential(authorization);
 
       expect(result).toBe(false);
     });

--- a/x-pack/platform/plugins/shared/security/server/authentication/api_keys/uiam/uiam_api_keys.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/api_keys/uiam/uiam_api_keys.ts
@@ -22,6 +22,16 @@ import { HTTPAuthorizationHeader } from '../../http_authentication';
 const UIAM_CREDENTIALS_PREFIX = 'essu_';
 
 /**
+ * Checks if the given authorization credentials are UIAM credentials.
+ *
+ * @param authorization The HTTP authorization header to check.
+ * @returns True if the credentials start with UIAM_CREDENTIALS_PREFIX, false otherwise.
+ */
+export function isUiamCredential(authorization: HTTPAuthorizationHeader) {
+  return authorization.credentials.startsWith(UIAM_CREDENTIALS_PREFIX);
+}
+
+/**
  * Options required to construct a UiamAPIKeys instance.
  */
 export interface UiamAPIKeysOptions {
@@ -72,7 +82,7 @@ export class UiamAPIKeys implements UiamAPIKeysType {
     let result: GrantAPIKeyResult;
 
     // Provided credential must be a UIAM credential with appropriate prefix
-    if (!UiamAPIKeys.isUiamCredential(authorization)) {
+    if (!isUiamCredential(authorization)) {
       const nonUiamCredentialError =
         'Cannot grant API key: provided credential is not compatible with UIAM';
       this.logger.error(nonUiamCredentialError);
@@ -118,7 +128,7 @@ export class UiamAPIKeys implements UiamAPIKeysType {
 
     this.logger.debug(`Trying to invalidate API key ${id}`);
 
-    if (!UiamAPIKeys.isUiamCredential(authorization)) {
+    if (!isUiamCredential(authorization)) {
       const uiamCredentialError = 'Cannot invalidate API key: not a UIAM API key';
       this.logger.error(uiamCredentialError);
       throw new Error(uiamCredentialError);
@@ -167,21 +177,9 @@ export class UiamAPIKeys implements UiamAPIKeysType {
     return this.clusterClient.asScoped({
       headers: {
         authorization: authorization.toString(),
-        ...(UiamAPIKeys.isUiamCredential(authorization)
-          ? this.uiam.getEsClientAuthenticationHeader()
-          : {}),
+        ...(isUiamCredential(authorization) ? this.uiam.getEsClientAuthenticationHeader() : {}),
       },
     });
-  }
-
-  /**
-   * Checks if the given authorization credentials are UIAM credentials.
-   *
-   * @param authorization The HTTP authorization header to check.
-   * @returns True if the credentials start with UIAM_CREDENTIALS_PREFIX, false otherwise.
-   */
-  static isUiamCredential(authorization: HTTPAuthorizationHeader) {
-    return authorization.credentials.startsWith(UIAM_CREDENTIALS_PREFIX);
   }
 
   /**

--- a/x-pack/platform/plugins/shared/security/server/authentication/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/index.ts
@@ -24,3 +24,4 @@ export {
   BasicHTTPAuthorizationHeaderCredentials,
   HTTPAuthorizationHeader,
 } from './http_authentication';
+export { isUiamCredential } from './api_keys';

--- a/x-pack/platform/plugins/shared/security/server/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/index.ts
@@ -20,7 +20,7 @@ import type { PluginSetupDependencies, SecurityPluginSetup } from './plugin';
 
 // These exports are part of public Security plugin contract, any change in signature of exported
 // functions or removal of exports should be considered as a breaking change.
-export { HTTPAuthorizationHeader } from './authentication';
+export { HTTPAuthorizationHeader, isUiamCredential } from './authentication';
 export type { CasesSupportedOperations } from './authorization';
 export type { SecurityPluginSetup, SecurityPluginStart };
 export type { AuthenticatedUser } from '../common';


### PR DESCRIPTION
## Summary

Consumers of UIAM APIKeys have stated that the would like a function to determine whether passed credentials are for the UIAM service

This PR exposes a utility function
