### PR TITLE
[8.19] [Security Solution][Detections] Improve getDocLinks usage (#249406)

### DIFF
--- a/x-pack/solutions/security/packages/kbn-securitysolution-autocomplete/kibana.jsonc
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-autocomplete/kibana.jsonc
@@ -1,5 +1,5 @@
 {
-  "type": "shared-common",
+  "type": "shared-browser",
   "id": "@kbn/securitysolution-autocomplete",
   "owner": [
     "@elastic/security-detection-engine"

--- a/x-pack/solutions/security/packages/kbn-securitysolution-autocomplete/moon.yml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-autocomplete/moon.yml
@@ -24,10 +24,10 @@ dependsOn:
   - '@kbn/securitysolution-io-ts-list-types'
   - '@kbn/securitysolution-list-hooks'
   - '@kbn/securitysolution-list-utils'
-  - '@kbn/doc-links'
   - '@kbn/securitysolution-utils'
+  - '@kbn/kibana-react-plugin'
 tags:
-  - shared-common
+  - shared-browser
   - package
   - prod
   - group-security

--- a/x-pack/solutions/security/packages/kbn-securitysolution-autocomplete/src/field_value_lists/index.tsx
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-autocomplete/src/field_value_lists/index.tsx
@@ -10,7 +10,7 @@ import { EuiComboBox, EuiComboBoxOptionOption, EuiFormRow, EuiLink, EuiText } fr
 import type { ListSchema } from '@kbn/securitysolution-io-ts-list-types';
 import { useFindListsBySize } from '@kbn/securitysolution-list-hooks';
 import { DataViewFieldBase } from '@kbn/es-query';
-import { getDocLinks } from '@kbn/doc-links';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 
 import { filterFieldToList } from '../filter_field_to_list';
 import { getGenericComboBoxProps } from '../get_generic_combo_box_props';
@@ -58,6 +58,8 @@ export const AutocompleteFieldListsComponent: React.FC<AutocompleteFieldListsPro
   'aria-label': ariaLabel,
   showValueListModal,
 }): JSX.Element => {
+  const { docLinks } = useKibana().services;
+
   const [error, setError] = useState<string | undefined>(undefined);
   const [listData, setListData] = useState<AutocompleteListsData>({
     smallLists: [],
@@ -136,12 +138,7 @@ export const AutocompleteFieldListsComponent: React.FC<AutocompleteFieldListsPro
             <EuiLink
               external
               target="_blank"
-              href={
-                getDocLinks({
-                  kibanaBranch: 'main',
-                  buildFlavor: 'traditional',
-                }).securitySolution.exceptions.value_lists
-              }
+              href={docLinks?.links.securitySolution.exceptions.value_lists}
             >
               {i18n.SEE_DOCUMENTATION}
             </EuiLink>
@@ -149,7 +146,8 @@ export const AutocompleteFieldListsComponent: React.FC<AutocompleteFieldListsPro
         )}
       </>
     );
-  }, [allowLargeValueLists, selectedValue, ShowValueListModal]);
+  }, [allowLargeValueLists, selectedValue, ShowValueListModal, docLinks]);
+
   return (
     <EuiFormRow
       label={rowLabel}

--- a/x-pack/solutions/security/packages/kbn-securitysolution-autocomplete/tsconfig.json
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-autocomplete/tsconfig.json
@@ -15,8 +15,8 @@
     "@kbn/securitysolution-io-ts-list-types",
     "@kbn/securitysolution-list-hooks",
     "@kbn/securitysolution-list-utils",
-    "@kbn/doc-links",
     "@kbn/securitysolution-utils",
+    "@kbn/kibana-react-plugin",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exception-list-components/kibana.jsonc
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exception-list-components/kibana.jsonc
@@ -1,5 +1,5 @@
 {
-  "type": "shared-common",
+  "type": "shared-browser",
   "id": "@kbn/securitysolution-exception-list-components",
   "owner": [
     "@elastic/security-detection-engine"

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exception-list-components/moon.yml
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exception-list-components/moon.yml
@@ -24,7 +24,7 @@ dependsOn:
   - '@kbn/i18n'
   - '@kbn/i18n-react'
 tags:
-  - shared-common
+  - shared-browser
   - package
   - prod
   - group-security

--- a/x-pack/solutions/security/plugins/lists/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/lists/kibana.jsonc
@@ -18,6 +18,9 @@
       "spaces",
       "security"
     ],
+    "requiredBundles": [
+      "kibanaReact",
+    ],
     "extraPublicDirs": [
       "common"
     ]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution][Detections] Improve getDocLinks usage (#249406)](https://github.com/elastic/kibana/pull/249406)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hannah Brooks","email":"hannah.brooks@elastic.co"},"sourceCommit":{"committedDate":"2026-01-21T17:33:20Z","message":"[Security Solution][Detections] Improve getDocLinks usage (#249406)\n\n## Summary\n\nPreviously, `getDocLinks` was being called on each render. We have\nrefactored the `AutocompleteFieldListsComponent` to consume the\n`useKibana` hook in order to access the doc links service and create a\nstable reference.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"48c5af09b8bc52c9a1669265f148dec908e8da9a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detection Engine","backport:version","v9.3.0","v9.4.0","v9.2.5","v8.19.11","v9.3.1"],"title":"[Security Solution][Detections] Improve getDocLinks usage","number":249406,"url":"https://github.com/elastic/kibana/pull/249406","mergeCommit":{"message":"[Security Solution][Detections] Improve getDocLinks usage (#249406)\n\n## Summary\n\nPreviously, `getDocLinks` was being called on each render. We have\nrefactored the `AutocompleteFieldListsComponent` to consume the\n`useKibana` hook in order to access the doc links service and create a\nstable reference.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"48c5af09b8bc52c9a1669265f148dec908e8da9a"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/249934","number":249934,"state":"MERGED","mergeCommit":{"sha":"15485f60745d928a0ab2805fef13a657a8ba908e","message":"[9.3] [Security Solution][Detections] Improve getDocLinks usage (#249406) (#249934)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Security Solution][Detections] Improve getDocLinks usage\n(#249406)](https://github.com/elastic/kibana/pull/249406)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Hannah Brooks <hannah.brooks@elastic.co>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249406","number":249406,"mergeCommit":{"message":"[Security Solution][Detections] Improve getDocLinks usage (#249406)\n\n## Summary\n\nPreviously, `getDocLinks` was being called on each render. We have\nrefactored the `AutocompleteFieldListsComponent` to consume the\n`useKibana` hook in order to access the doc links service and create a\nstable reference.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"48c5af09b8bc52c9a1669265f148dec908e8da9a"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/249933","number":249933,"state":"MERGED","mergeCommit":{"sha":"0be7216bc552f604f502fcd7a6d64d15f5f1725b","message":"[9.2] [Security Solution][Detections] Improve getDocLinks usage (#249406) (#249933)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Security Solution][Detections] Improve getDocLinks usage\n(#249406)](https://github.com/elastic/kibana/pull/249406)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Hannah Brooks <hannah.brooks@elastic.co>"}},{"branch":"8.19","label":"v8.19.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->