### PR TITLE
[Entity Analytics] Adding event based telemetry for entity highlights API usage

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/entity_analytics/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/entity_analytics/constants.ts
@@ -7,7 +7,7 @@
 
 // INTERNAL
 const INTERNAL_URL = `/internal/entity_details` as const;
-export const ENTITY_DETAILS_HIGHLIGH_INTERNAL_URL = `${INTERNAL_URL}/highlights` as const;
+export const ENTITY_DETAILS_HIGHLIGHT_INTERNAL_URL = `${INTERNAL_URL}/highlights` as const;
 
 // PUBLIC
 export const PUBLIC_URL = `/api/entity_details` as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
@@ -8,7 +8,7 @@
 import { useMemo } from 'react';
 import type { AnonymizationFieldResponse } from '@kbn/elastic-assistant-common';
 import type { EntityDetailsHighlightsResponse } from '../../../common/api/entity_analytics/entity_details/highlights.gen';
-import { ENTITY_DETAILS_HIGHLIGH_INTERNAL_URL } from '../../../common/entity_analytics/entity_analytics/constants';
+import { ENTITY_DETAILS_HIGHLIGHT_INTERNAL_URL } from '../../../common/entity_analytics/entity_analytics/constants';
 import type {
   AssetCriticalityRecord,
   CreateEntitySourceResponse,
@@ -461,7 +461,7 @@ export const useEntityAnalyticsRoutes = () => {
       },
       signal?: AbortSignal
     ): Promise<EntityDetailsHighlightsResponse> =>
-      http.fetch(ENTITY_DETAILS_HIGHLIGH_INTERNAL_URL, {
+      http.fetch(ENTITY_DETAILS_HIGHLIGHT_INTERNAL_URL, {
         version: API_VERSIONS.internal.v1,
         method: 'POST',
         body: JSON.stringify(params),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_details/routes/entity_details_highlight.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_details/routes/entity_details_highlight.ts
@@ -15,12 +15,13 @@ import {
 import { getPrompt } from '@kbn/elastic-assistant-plugin/server/lib/prompt/get_prompt';
 import type { EntityDetailsHighlightsResponse } from '../../../../../common/api/entity_analytics/entity_details/highlights.gen';
 import { EntityDetailsHighlightsRequestBody } from '../../../../../common/api/entity_analytics/entity_details/highlights.gen';
-import { ENTITY_DETAILS_HIGHLIGH_INTERNAL_URL } from '../../../../../common/entity_analytics/entity_analytics/constants';
+import { ENTITY_DETAILS_HIGHLIGHT_INTERNAL_URL } from '../../../../../common/entity_analytics/entity_analytics/constants';
 import { EntityTypeToIdentifierField } from '../../../../../common/entity_analytics/types';
 import { APP_ID, API_VERSIONS } from '../../../../../common/constants';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
 import { entityDetailsHighlightsServiceFactory } from '../entity_details_highlights_service';
 import { withLicense } from '../../../siem_migrations/common/api/util/with_license';
+import { ENTITY_HIGHLIGHTS_USAGE_EVENT } from '../../../telemetry/event_based/events';
 
 export const entityDetailsHighlightsRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -31,7 +32,7 @@ export const entityDetailsHighlightsRoute = (
   router.versioned
     .post({
       access: 'internal',
-      path: ENTITY_DETAILS_HIGHLIGH_INTERNAL_URL,
+      path: ENTITY_DETAILS_HIGHLIGHT_INTERNAL_URL,
       security: {
         authz: {
           requiredPrivileges: ['securitySolution', `${APP_ID}-entity-analytics`],
@@ -73,6 +74,12 @@ export const entityDetailsHighlightsRoute = (
             const soClient = coreContext.savedObjects.client;
             const riskEngineClient = securitySolution.getRiskEngineDataClient();
             const assetCriticalityClient = securitySolution.getAssetCriticalityDataClient();
+
+            const telemetry = securitySolution.getAnalytics();
+            telemetry.reportEvent(ENTITY_HIGHLIGHTS_USAGE_EVENT.eventType, {
+              entityType,
+              spaceId,
+            });
 
             const {
               getRiskScoreData,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
@@ -645,6 +645,27 @@ export const ENTITY_ENGINE_DELETION_EVENT: EventTypeOpts<{
   },
 };
 
+export const ENTITY_HIGHLIGHTS_USAGE_EVENT: EventTypeOpts<{
+  entityType: string;
+  spaceId: string;
+}> = {
+  eventType: 'entity_highlights_usage',
+  schema: {
+    entityType: {
+      type: 'keyword',
+      _meta: {
+        description: 'Type of entity highlights have been request for  (e.g. "host")',
+      },
+    },
+    spaceId: {
+      type: 'keyword',
+      _meta: {
+        description: 'Space where the highlight request originated (e.g. "default")',
+      },
+    },
+  },
+};
+
 export const ENTITY_STORE_USAGE_EVENT: EventTypeOpts<{
   storeSize: number;
   entityType: string;
@@ -1715,6 +1736,7 @@ export const events = [
   ENTITY_ENGINE_INITIALIZATION_EVENT,
   ENTITY_ENGINE_DELETION_EVENT,
   ENTITY_STORE_USAGE_EVENT,
+  ENTITY_HIGHLIGHTS_USAGE_EVENT,
   PRIVMON_ENGINE_INITIALIZATION_EVENT,
   PRIVMON_ENGINE_RESOURCE_INIT_FAILURE_EVENT,
   TELEMETRY_DATA_STREAM_EVENT,


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/249234

## Summary

Adds call to report event when entity details highlight API is called.

## To Verify
1. Add `telemetry.localShipper: true` to your Kibana config
2. Start ES and Kibana
3. Generate some entity data
4. For each entity, open the flyout and generate a summary
5. Repeat for a few different entities
6. In Dev Tools, perform the following query

```
GET ebt-kibana-server/_search
{
    "query": {
        "bool": {
            "filter": [
              {
                "term": {
                  "event_type": "entity_highlights_usage"
                }
              }
            ]
        }
    }
}
```

7. You should see a document for each time you generated a summary with the entity type and space ID properties populated correctly

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->