### PR TITLE
[Obs AI] Update AI Insight UI description

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/ai_insight/ai_insight.tsx
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/ai_insight/ai_insight.tsx
@@ -131,7 +131,7 @@ export function AiInsight({ title, fetchInsight, buildAttachments }: AiInsightPr
               <EuiText size="s" css={{ color: euiTheme.colors.textSubdued }}>
                 <span>
                   {i18n.translate('xpack.observabilityAgentBuilder.aiInsight.description', {
-                    defaultMessage: 'Get helpful insights from our Elastic AI Agent',
+                    defaultMessage: 'Get helpful insights from our Observability Agent',
                   })}
                 </span>
               </EuiText>


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-team/issues/480

## Summary

AI Insights use the Observability Agent with the merge of https://github.com/elastic/kibana/pull/249776

This PR updates the AI Insight subtitle copy to say `Observability Agent` instead of `Elastic AI Agent` .

<img width="1344" height="96" alt="Screenshot 2026-01-22 at 7 37 39 PM" src="https://github.com/user-attachments/assets/a6e5e669-ac8d-4008-9f49-316c677b1de9" />

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->