### PR TITLE
[ResponseOps] Add API key info to relevant authentication error messages

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/lib/errors/es_error_parser.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/errors/es_error_parser.ts
@@ -13,6 +13,11 @@ const getEsCause = (
 ): string[] => {
   const updated = [...causes];
 
+  const authMessage = obj.additional_unsuccessful_credentials;
+  if (typeof authMessage === 'string') {
+    updated.push(authMessage);
+  }
+
   if (obj.caused_by) {
     if (obj.caused_by?.reason) {
       updated.push(obj.caused_by?.reason);

--- a/x-pack/platform/plugins/shared/alerting/server/lib/errors/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/errors/types.ts
@@ -18,6 +18,7 @@ export interface ElasticsearchErrorCausedByObject {
       caused_by?: ElasticsearchErrorCausedByObject;
     };
   }>;
+  additional_unsuccessful_credentials?: string;
 }
 
 interface ElasticsearchErrorMeta {


### PR DESCRIPTION
When an authentication error is logged, because of an invalidated API key, no information is provided in the log message.  Even the fact that it's an invalidated API key is not provided.

This PR adds the `additional_unsuccessful_credentials` property to relevant error messages, which indicates the keys are invalid, and also provides the API key id.

The API key id can be logged, but it should not be presented in a UX, so should not written to the event log, alerts, etc.

The message logged today is:

    Executing Rule default:.<type>:<id> has resulted in Error: security_exception
    Root causes:
    security_exception: unable to authenticate with provided credentials
    and anonymous access is not allowed for this request

With this PR, the message will be as follows, basically, adding the final line, everything else is the same:

    Executing Rule default:.<type>:<id> has resulted in Error: security_exception
    Root causes:
    security_exception: unable to authenticate with provided credentials
    and anonymous access is not allowed for this request,
    caused by: "API key: api key [uydIypsBsFtA59dS1JcM] has been invalidated"

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



