### PR TITLE
[One Management] Update rules URL in Stack Management Alerts

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_page/hooks/use_rule_stats.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_page/hooks/use_rule_stats.tsx
@@ -31,6 +31,7 @@ export const useRuleStats = ({ ruleTypeIds, consumers }: Props = {}) => {
   const {
     http,
     notifications: { toasts },
+    application: { isAppRegistered },
   } = useKibana().services;
   const [loading, setLoading] = useState<boolean>(false);
   const [stats, setStats] = useState({
@@ -40,9 +41,14 @@ export const useRuleStats = ({ ruleTypeIds, consumers }: Props = {}) => {
     error: 0,
     snoozed: 0,
   });
+
+  const unifiedRulesPageEnabled = isAppRegistered('rules');
   const manageRulesHref = useMemo(
-    () => http.basePath.prepend('/app/management/insightsAndAlerting/triggersActions/rules'),
-    [http.basePath]
+    () =>
+      unifiedRulesPageEnabled
+        ? http.basePath.prepend('/app/rules')
+        : http.basePath.prepend('/app/management/insightsAndAlerting/triggersActions/rules'),
+    [http.basePath, unifiedRulesPageEnabled]
   );
 
   const loadRuleStats = useCallback(async () => {


### PR DESCRIPTION
## Summary

Closes #239788

Updates the "Manage rules" link in the Stack Alerts page header to conditionally navigate to the new unified rule management page (`/app/rules`) when the unified rules app is registered, with automatic fallback to the Stack Management URL (`/app/management/insightsAndAlerting/triggersActions/rules`) when the feature is disabled.

## 🔬 Testing

To test this change:

**With unified rules enabled:**
1. Enable the feature flag: `xpack.trigger_actions_ui.enableExperimental: ['unifiedRulesPage']`
2. Navigate to the Stack Alerts page (`/app/management/insightsAndAlerting/triggersActions/alerts`)
3. Click "Manage Rules" in the page header
4. Verify navigation goes to `/app/rules`

**With unified rules disabled (default):**
1. Ensure the feature flag is not set
2. Navigate to the Stack Alerts page
3. Click "Manage Rules" in the page header
4. Verify navigation goes to `/app/management/insightsAndAlerting/triggersActions/rules`