### PR TITLE
POC: Suggest loading unmapped fields on unknown field errors

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/errors_warnings_popover.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/errors_warnings_popover.tsx
@@ -8,6 +8,7 @@
  */
 
 import {
+  EuiButton,
   EuiButtonEmpty,
   EuiDescriptionList,
   EuiDescriptionListDescription,
@@ -64,10 +65,12 @@ function ErrorsWarningsContent({
   items,
   type,
   onErrorClick,
+  onQuickFixClick,
 }: {
   items: MonacoMessage[];
   type: 'error' | 'warning';
   onErrorClick: (error: MonacoMessage) => void;
+  onQuickFixClick?: (error: MonacoMessage) => void;
 }) {
   const { euiTheme } = useEuiTheme();
   const { color } = getConstsByType(type, items.length);
@@ -123,6 +126,32 @@ function ErrorsWarningsContent({
                   {item.message}
                 </EuiFlexItem>
               </EuiFlexGroup>
+              {onQuickFixClick &&
+                (item.code === 'unknownColumn' ||
+                  item.code === 'unmappedColumnWarning' ||
+                  (item.code === 'errorFromES' && item.message.includes('Unknown column'))) && (
+                  <EuiFlexGroup
+                    gutterSize="s"
+                    alignItems="center"
+                    css={{ marginTop: euiTheme.size.xs }}
+                  >
+                    <EuiFlexItem grow={false}>
+                      <EuiButton
+                        size="s"
+                        color="primary"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onQuickFixClick(item);
+                        }}
+                        data-test-subj="ESQLEditor-quickfix-unmapped-fields"
+                      >
+                        {i18n.translate('esqlEditor.query.addUnmappedFieldsQuickFix', {
+                          defaultMessage: 'Load unmapped fields',
+                        })}
+                      </EuiButton>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                )}
             </EuiDescriptionListDescription>
           );
         })}
@@ -182,6 +211,7 @@ export function ErrorsWarningsFooterPopover({
   onErrorClick,
   isSpaceReduced,
   dataErrorsControl,
+  onQuickFixClick,
 }: {
   isPopoverOpen: boolean;
   items: MonacoMessage[];
@@ -190,6 +220,7 @@ export function ErrorsWarningsFooterPopover({
   onErrorClick: (error: MonacoMessage) => void;
   isSpaceReduced?: boolean;
   dataErrorsControl?: DataErrorsControl;
+  onQuickFixClick?: (error: MonacoMessage) => void;
 }) {
   // Visible items may be 0 if dataErrorsControl is enabled and there are only data errors.
   // In this case, we still want to show the popover with the switch, so the user can disable it to see the errors.
@@ -230,7 +261,12 @@ export function ErrorsWarningsFooterPopover({
           closePopover={closePopover}
         >
           {visibleItems.length > 0 && (
-            <ErrorsWarningsContent items={visibleItems} type={type} onErrorClick={onErrorClick} />
+            <ErrorsWarningsContent
+              items={visibleItems}
+              type={type}
+              onErrorClick={onErrorClick}
+              onQuickFixClick={onQuickFixClick}
+            />
           )}
           {dataErrorsControl && (
             <ErrorsWarningsFooter

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/index.tsx
@@ -67,6 +67,7 @@ interface EditorFooterProps {
   displayDocumentationAsFlyout?: boolean;
   dataErrorsControl?: DataErrorsControl;
   toggleVisor: () => void;
+  onAddUnmappedFieldsSetting?: () => void;
 }
 
 export const EditorFooter = memo(function EditorFooter({
@@ -95,6 +96,7 @@ export const EditorFooter = memo(function EditorFooter({
   code,
   dataErrorsControl,
   toggleVisor,
+  onAddUnmappedFieldsSetting,
 }: EditorFooterProps) {
   const kibana = useKibana<ESQLEditorDeps>();
   const { docLinks } = kibana.services;
@@ -112,6 +114,21 @@ export const EditorFooter = memo(function EditorFooter({
   }, [isLanguageComponentOpen, setIsHistoryOpen, setIsLanguageComponentOpen]);
 
   const limit = useMemo(() => getLimitFromESQLQuery(code), [code]);
+  const handleQuickFix = useCallback(
+    (error: MonacoMessage) => {
+      if (
+        (error.code === 'unknownColumn' ||
+          error.code === 'unmappedColumnWarning' ||
+          (error.code === 'errorFromES' && error.message.includes('Unknown column'))) &&
+        onAddUnmappedFieldsSetting
+      ) {
+        onAddUnmappedFieldsSetting();
+        setIsErrorPopoverOpen(false);
+        setIsWarningPopoverOpen(false);
+      }
+    },
+    [onAddUnmappedFieldsSetting]
+  );
 
   return (
     <EuiFlexGroup
@@ -205,6 +222,7 @@ export const EditorFooter = memo(function EditorFooter({
                   }}
                   onErrorClick={onErrorClick}
                   dataErrorsControl={dataErrorsControl}
+                  onQuickFixClick={handleQuickFix}
                 />
               )}
               {warnings && warnings.length > 0 && (
@@ -219,6 +237,7 @@ export const EditorFooter = memo(function EditorFooter({
                     setIsWarningPopoverOpen(isOpen);
                   }}
                   onErrorClick={onErrorClick}
+                  onQuickFixClick={handleQuickFix}
                 />
               )}
             </EuiFlexGroup>

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -238,6 +238,16 @@ const ESQLEditorInternal = function ESQLEditor({
     [onTextLangQueryChange]
   );
 
+  const onAddUnmappedFieldsSetting = useCallback(() => {
+    const currentQuery = editorRef.current?.getValue() || code;
+    // Check if the query already has SET unmapped_fields
+    if (/SET\s+unmapped_fields\s*=/i.test(currentQuery)) {
+      return; // Already has the setting, don't add it
+    }
+    const newQuery = `SET unmapped_fields = "LOAD";\n${currentQuery}`;
+    onQueryUpdate(newQuery);
+  }, [code, onQueryUpdate]);
+
   const { onSuggestionsReady, resetSuggestionsTracking } = useSuggestionsLatencyTracking({
     telemetryService,
     sessionIdRef,
@@ -1323,6 +1333,7 @@ const ESQLEditorInternal = function ESQLEditor({
         dataErrorsControl={dataErrorsControl}
         toggleVisor={() => setIsVisorOpen(!isVisorOpen)}
         hideQuickSearch={hideQuickSearch}
+        onAddUnmappedFieldsSetting={onAddUnmappedFieldsSetting}
       />
       {createPortal(
         Object.keys(popoverPosition).length !== 0 && popoverPosition.constructor === Object && (


### PR DESCRIPTION
# Just a vibe-coded POC, don't worry about the code, worry about the functionality

Soon, there will be a "load" strategy for unmapped fields. To make this feature more discoverable, I think it would be great to tell the user this exists and make it easily available.

This PR adds a button to "fix" a query if you know the field exists but is just unmapped:
<img width="870" height="303" alt="Screenshot 2026-01-23 at 10 52 36" src="https://github.com/user-attachments/assets/e9906d23-aeaf-434a-adcd-0a858db84b38" />

When clicking you get this:
<img width="1058" height="223" alt="Screenshot 2026-01-23 at 10 53 10" src="https://github.com/user-attachments/assets/3c92c7e7-dc12-4af5-b796-21523ade8e07" />
