### PR TITLE
[kbn/scout] temp skip ai_suggestions_*.spec.ts for ECH runs

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/config/create_config.ts
@@ -36,6 +36,8 @@ export function createPlaywrightConfig(options: ScoutPlaywrightOptions): Playwri
     },
     {
       name: 'ech',
+      // TODO: remove when AI suggestions are supported on ECH or when the new tagging system is in place
+      testIgnore: '**/ai_suggestions_*.spec.ts',
       use: { ...devices['Desktop Chrome'], configName: 'cloud_ech' },
     },
     {


### PR DESCRIPTION
## Summary

Workaround to stabilize Scout ECH pipeline before we get new tagging system in place.

Before:

```
*[main][~/github/kibana]$ npx playwright test --config=x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts --grep=@ess --project=ech

Running 200 tests using 1 worker
```

After: 

```
*[main][~/github/kibana]$ npx playwright test --config=x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts --grep=@ess --project=ech

Running 183 tests using 1 worker
```