### PR TITLE
[Dataset Quality] Should gracefully handle failed aggregations

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/get_data_stream_details.test.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/get_data_stream_details.test.ts
@@ -116,6 +116,14 @@ describe('getDataStreamDetails', () => {
         },
       },
     } as any);
+
+    mockESClient.fieldCaps.mockResolvedValue({
+      fields: {
+        'host.name': {
+          keyword: { type: 'keyword', aggregatable: true },
+        },
+      },
+    } as any);
   });
 
   afterEach(() => {

--- a/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/index.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/routes/data_streams/get_data_stream_details/index.ts
@@ -128,11 +128,17 @@ const entityFields = [
   'aws.sqs.queue.name',
 ];
 
-// Gather host terms like 'host', 'pod', 'container'
-const hostsAgg: TermAggregation = entityFields.reduce(
-  (acc, idField) => ({ ...acc, [idField]: { terms: { field: idField, size: MAX_HOSTS } } }),
-  {} as TermAggregation
-);
+function isFieldAggregatable(
+  fieldCapsResponse: Awaited<ReturnType<ElasticsearchClient['fieldCaps']>>,
+  fieldName: string
+): boolean {
+  const fieldCaps = fieldCapsResponse.fields[fieldName];
+  if (!fieldCaps) {
+    return false;
+  }
+
+  return Object.values(fieldCaps).every((caps) => caps.aggregatable === true);
+}
 
 async function getDataStreamSummaryStats(
   esClient: ElasticsearchClient,
@@ -146,6 +152,22 @@ async function getDataStreamSummaryStats(
   hosts: Record<string, string[]>;
 }> {
   const datasetQualityESClient = createDatasetQualityESClient(esClient);
+
+  const fieldCapsResponse = await esClient.fieldCaps({
+    index: dataStream,
+    fields: ['*'],
+    include_unmapped: false,
+  });
+
+  const aggregatableFields = entityFields.filter((field) =>
+    isFieldAggregatable(fieldCapsResponse, field)
+  );
+
+  // Gather host terms like 'host', 'pod', 'container'
+  const hostsAgg = aggregatableFields.reduce(
+    (acc, idField) => ({ ...acc, [idField]: { terms: { field: idField, size: MAX_HOSTS } } }),
+    {} as TermAggregation
+  );
 
   const response = await datasetQualityESClient.search({
     index: dataStream,


### PR DESCRIPTION
## Summary

Closes #240406

This PR adds pre-checking field capabilities to only aggregate on keyword/numeric fields.

**Before**
<img width="1920" height="873" alt="Screenshot 2026-01-23 at 11 21 46" src="https://github.com/user-attachments/assets/6e939513-b0e8-4ff7-b571-82d58ac7fff0" />

**After**
<img width="1920" height="873" alt="Screenshot 2026-01-23 at 11 17 12" src="https://github.com/user-attachments/assets/023a8f5a-67bb-4c05-aeee-7a255b692d23" />





<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->