### PR TITLE
[SharedUX] Enforce feedback enablement check for ML

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/components/feedback_button/feedback_button.test.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/feedback_button/feedback_button.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { FeedBackButton, getSurveyFeedbackURL } from './feedback_button';
+import { notificationServiceMock } from '@kbn/core/public/mocks';
 
 // Mock the required dependencies
 const mockUseMlKibana = jest.fn();
@@ -39,6 +40,7 @@ describe('FeedBackButton', () => {
     useMlKibana: {
       services: {
         kibanaVersion: '9.3.0',
+        notifications: notificationServiceMock.createStartContract(),
       },
     },
     useEnabledFeatures: {
@@ -67,6 +69,20 @@ describe('FeedBackButton', () => {
 
     it('does not render when no jobIds are provided', () => {
       render(<FeedBackButton jobIds={[]} />);
+
+      expect(screen.queryByTestId('mlFeatureFeedbackButton')).not.toBeInTheDocument();
+    });
+
+    it('does not render when feedback is not enabled', () => {
+      const notificationsMock = notificationServiceMock.createStartContract();
+      notificationsMock.feedback.isEnabled.mockReturnValue(false);
+      mockUseMlKibana.mockReturnValue({
+        services: {
+          kibanaVersion: '9.3.0',
+          notifications: notificationsMock,
+        },
+      });
+      render(<FeedBackButton jobIds={['test-job-1', 'test-job-2']} />);
 
       expect(screen.queryByTestId('mlFeatureFeedbackButton')).not.toBeInTheDocument();
     });
@@ -119,6 +135,7 @@ describe('FeedBackButton', () => {
       mockUseMlKibana.mockReturnValue({
         services: {
           kibanaVersion: undefined,
+          notifications: notificationServiceMock.createStartContract(),
         },
       });
 

--- a/x-pack/platform/plugins/shared/ml/public/application/components/feedback_button/feedback_button.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/feedback_button/feedback_button.tsx
@@ -70,7 +70,7 @@ export const getSurveyFeedbackURL = ({
 
 export const FeedBackButton: FC<Props> = ({ jobIds }) => {
   const {
-    services: { kibanaVersion },
+    services: { kibanaVersion, notifications },
   } = useMlKibana();
   const { isCloud: isCloudEnv } = useCloudCheck();
   // ML does not have an explicit isServerless flag,
@@ -79,6 +79,7 @@ export const FeedBackButton: FC<Props> = ({ jobIds }) => {
   // showNodeInfo will always be false in a serverless environment
   // and true in a non-serverless environment.
   const { showNodeInfo } = useEnabledFeatures();
+  const isFeedbackEnabled = notifications.feedback.isEnabled();
 
   const href = useMemo(() => {
     if (jobIds.length === 0) {
@@ -96,6 +97,8 @@ export const FeedBackButton: FC<Props> = ({ jobIds }) => {
   if (jobIds.length === 0) {
     return null;
   }
+
+  if (!isFeedbackEnabled) return null;
 
   return (
     <EuiButtonEmpty


### PR DESCRIPTION
## Summary

As part of [[Epic] Setting to disable feedback snippets, guided tours and announcements in Kibana](https://github.com/elastic/kibana/issues/234771) SharedUX has added two new `core.notifications` services for `feedback` and `tours`. Their `isEnabled()` API verifies if users should be shown that kind of elements by reading their preferences from global UI settings (`hideFeedback` and `hideAnnouncements`).

From now on, every feedback or tour component should call `isEnabled()` before rendering to honor user preferences. 

> [!IMPORTANT]
SharedUX will be opening PRs for existing occurrences per team. Each team should manually test their PR to verify toggling those settings results in the expected behavior. If your team owns more `feedback` or `tours` occurrences or are planning on doing so, this check needs to be added to honor user preferences.
>  

### Testing

**Feedback elements**
- This is a read-only setting, you need to override it via `kibana.dev.yml` with `uiSettings.globalOverrides.hideFeedback: true`.
- Verify changing the setting value hides/render the element as expected.

**Tours/announcements elements**
- Toggle either the deprecated `hideAnnouncements` space setting or the global one on the Stack Management > Advanced Settings UI.
- Verify toggling the setting hides/render the element as expected.

Related PR: [[SharedUX] Add feedback and tours to core notifications](https://github.com/elastic/kibana/pull/248248)