### PR TITLE
[ES|QL] Fix circular deps. in suggestForExpression

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/index.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/index.ts
@@ -8,5 +8,5 @@
  */
 
 export { suggestForExpression } from './suggestion_engine';
-export { getPosition as getExpressionPosition, type ExpressionPosition } from './position';
+export type { ExpressionPosition } from './types';
 export { buildExpressionFunctionParameterContext } from './utils';

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/position.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/position.ts
@@ -14,14 +14,7 @@ import type { ESQLColumnData } from '../../../../registry/types';
 import { isNullCheckOperator } from './utils';
 import { checkFunctionInvocationComplete } from '../../functions';
 import { getExpressionType } from '../../expressions';
-
-export type ExpressionPosition =
-  | 'in_function'
-  | 'after_not'
-  | 'after_operator'
-  | 'after_complete'
-  | 'after_cast'
-  | 'empty_expression';
+import type { ExpressionPosition } from './types';
 
 /** Matches " not" at end of string (case insensitive) */
 const NOT_PATTERN = / not$/i;

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/after_cast.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/after_cast.ts
@@ -8,13 +8,13 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { SupportedDataType } from '../../../../..';
+import type { SupportedDataType } from '../../../../types';
 import type { ESQLInlineCast } from '../../../../../../types';
 import { Walker, within } from '../../../../../../ast';
 import type { ISuggestionItem } from '../../../../../registry/types';
 import { getFunctionDefinition } from '../../../functions';
 import type { ExpressionContext } from '../types';
-import { getExpressionType } from '../../..';
+import { getExpressionType } from '../../../expressions';
 import { inlineCastsMapping } from '../../../../generated/inline_casts_mapping';
 import { getMatchingSignatures } from '../../../expressions';
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/after_complete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/after_complete.ts
@@ -183,7 +183,7 @@ export async function suggestAfterComplete(ctx: ExpressionContext): Promise<ISug
       hasMoreParams: paramState.hasMoreParams,
       isVariadic: paramState.isVariadic,
       isAmbiguousPosition: signatureAnalysis?.isAmbiguousPosition,
-      functionSignatures: signatureAnalysis?.getValidSignatures(),
+      isExpressionHeavy: signatureAnalysis?.acceptsArbitraryExpressions,
       expressionType,
       isCursorFollowedByComma: options.isCursorFollowedByComma,
     });

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/after_operator.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/after_operator.ts
@@ -173,7 +173,7 @@ function handleCompleteOperator(
         hasMoreParams: analyzer.hasMoreParams,
         isVariadic: analyzer.isVariadic,
         hasMoreMandatoryArgs: analyzer.getHasMoreMandatoryArgs(),
-        functionSignatures: analyzer.getValidSignatures(),
+        isExpressionHeavy: analyzer.acceptsArbitraryExpressions,
         isCursorFollowedByComma: false,
       });
     }

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/dispatcher.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/dispatcher.ts
@@ -8,8 +8,7 @@
  */
 
 import type { ISuggestionItem } from '../../../../../registry/types';
-import type { ExpressionPosition } from '../position';
-import type { ExpressionContext } from '../types';
+import type { ExpressionContext, ExpressionPosition } from '../types';
 import { suggestAfterCast } from './after_cast';
 import { suggestAfterComplete } from './after_complete';
 import { suggestAfterNot } from './after_not';

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/empty_expression.ts
@@ -75,7 +75,11 @@ async function handleFunctionParameterContext(
   }
 
   // Try exclusive suggestions first (COUNT(*), enum values)
-  const exclusiveSuggestions = tryExclusiveSuggestions(functionParamContext, ctx);
+  const exclusiveSuggestions = tryExclusiveSuggestions(
+    functionParamContext,
+    ctx,
+    analyzer.acceptsArbitraryExpressions
+  );
 
   if (exclusiveSuggestions.length > 0) {
     return exclusiveSuggestions;
@@ -88,7 +92,8 @@ async function handleFunctionParameterContext(
 /** Try suggestions that are exclusive (if present, return only these) */
 function tryExclusiveSuggestions(
   functionParamContext: FunctionParamContext,
-  ctx: ExpressionContext
+  ctx: ExpressionContext,
+  isExpressionHeavy: boolean
 ): ISuggestionItem[] {
   const { functionDefinition, paramDefinitions } = functionParamContext;
   const { options } = ctx;
@@ -98,7 +103,8 @@ function tryExclusiveSuggestions(
     paramDefinitions,
     functionDefinition!,
     Boolean(functionParamContext.hasMoreMandatoryArgs),
-    options.isCursorFollowedByComma ?? false
+    options.isCursorFollowedByComma ?? false,
+    isExpressionHeavy
   );
   if (enumItems.length > 0) {
     return enumItems;
@@ -340,7 +346,7 @@ function getParamSuggestionConfig(
     hasMoreMandatoryArgs,
     functionType: functionDefinition!.type,
     isCursorFollowedByComma,
-    functionSignatures: functionDefinition!.signatures,
+    isExpressionHeavy: analyzer.acceptsArbitraryExpressions,
   };
 
   const shouldAddComma = shouldSuggestComma(commaContext);
@@ -358,7 +364,8 @@ function buildEnumValueSuggestions(
   paramDefinitions: FunctionParameter[],
   functionDefinition: FunctionDefinition,
   hasMoreMandatoryArgs: boolean,
-  isCursorFollowedByComma: boolean
+  isCursorFollowedByComma: boolean,
+  isExpressionHeavy: boolean
 ): ISuggestionItem[] {
   const values = collectSuggestedValues(paramDefinitions);
 
@@ -371,7 +378,7 @@ function buildEnumValueSuggestions(
     hasMoreMandatoryArgs,
     functionType: functionDefinition.type,
     isCursorFollowedByComma,
-    functionSignatures: functionDefinition.signatures,
+    isExpressionHeavy,
   };
 
   const shouldAddComma = shouldSuggestComma(commaContext);

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/in_function.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/positions/in_function.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { suggestForExpression } from '../suggestion_engine';
 import type { ExpressionContext, FunctionParameterContext } from '../types';
 import { getFunctionDefinition } from '../../../functions';
 import type { ISuggestionItem } from '../../../../../registry/types';
@@ -53,7 +52,7 @@ export async function suggestInFunction(ctx: ExpressionContext): Promise<ISugges
     ? existing
     : [...existing, functionExpression.name];
 
-  const { suggestions } = await suggestForExpression({
+  const { suggestions } = await ctx.recursiveSuggest({
     query,
     command,
     cursorPosition,

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/suggestion_engine.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/suggestion_engine.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getExpressionType, getFunctionDefinition } from '../..';
+import { getFunctionDefinition } from '../../functions';
+import { getExpressionType } from '../../expressions';
 import { isFunctionExpression } from '../../../../../ast/is';
 import { within } from '../../../../../ast/location';
 import { buildMapValueCompleteItem } from '../../../../registry/complete_items';
@@ -17,7 +18,7 @@ import { isExpressionComplete } from '../../expressions';
 import { getOverlapRange } from '../../shared';
 import { dispatchPartialOperators } from './operators/partial/dispatcher';
 import { detectIn, detectLike, detectNullCheck } from './operators/partial/utils';
-import { getPosition, type ExpressionPosition } from './position';
+import { getPosition } from './position';
 import { dispatchStates } from './positions/dispatcher';
 import type { MapParameters } from '../map_expression';
 import { DOUBLE_QUOTED_STRING_REGEX, getCommandMapExpressionSuggestions } from '../map_expression';
@@ -26,6 +27,7 @@ import type {
   ExpressionComputedMetadata,
   ExpressionContext,
   ExpressionContextOptions,
+  ExpressionPosition,
   SuggestForExpressionParams,
   SuggestForExpressionResult,
 } from './types';
@@ -147,6 +149,7 @@ function buildContext(params: SuggestForExpressionParams): ExpressionContext {
     context: params.context,
     callbacks: params.callbacks,
     options,
+    recursiveSuggest: suggestForExpression,
   };
 }
 

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/types.ts
@@ -23,7 +23,14 @@ import type {
   Signature,
   SupportedDataType,
 } from '../../../types';
-import type { ExpressionPosition } from './position';
+
+export type ExpressionPosition =
+  | 'in_function'
+  | 'after_not'
+  | 'after_operator'
+  | 'after_complete'
+  | 'after_cast'
+  | 'empty_expression';
 
 export interface SuggestForExpressionParams {
   query: string;
@@ -47,6 +54,8 @@ export interface ExpressionContext {
   context?: ICommandContext;
   callbacks?: ICommandCallbacks;
   options: ExpressionContextOptions;
+  /** Callback to recursively suggest for nested expressions (e.g., inside functions) */
+  recursiveSuggest: (params: SuggestForExpressionParams) => Promise<SuggestForExpressionResult>;
 }
 
 export interface ExpressionContextOptions {

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/autocomplete/expressions/utils.ts
@@ -11,40 +11,13 @@ import type { ESQLFunction } from '../../../../../types';
 import { nullCheckOperators, inOperators } from '../../../all_operators';
 import type { ExpressionContext, FunctionParameterContext } from './types';
 import type { ICommandContext, ISuggestionItem } from '../../../../registry/types';
-import { getFunctionDefinition } from '../..';
+import { getFunctionDefinition } from '../../functions';
 import { SignatureAnalyzer } from './signature_analyzer';
-import type { Signature } from '../../../types';
 
 export type SpecialFunctionName = 'case' | 'count' | 'bucket';
 
 /** IN, NOT IN, IS NULL, IS NOT NULL operators requiring special autocomplete handling */
 export const specialOperators = [...inOperators, ...nullCheckOperators];
-
-/**
- * Detects if function signatures accept arbitrary/complex expressions in parameters.
- *
- * This pattern indicates functions where parameters can contain complex expressions
- * (not just simple values), characterized by:
- * - Variadic with multiple parameters (minParams >= 2)
- * - Unknown return type (depends on arguments)
- * - Mixed parameter types (boolean + any)
- *
- * Examples: CASE(condition1, value1, condition2, value2, ..., default)
- */
-export function acceptsArbitraryExpressions(signatures: Signature[]): boolean {
-  if (!signatures || signatures.length === 0) {
-    return false;
-  }
-
-  return signatures.some((sig) => {
-    const isVariadicWithMultipleParams = sig.minParams != null && sig.minParams >= 2;
-    const hasUnknownReturn = sig.returnType === 'unknown';
-    const hasMixedBooleanAndAny =
-      sig.params.some(({ type }) => type === 'boolean') && sig.params.some((p) => p.type === 'any');
-
-    return isVariadicWithMultipleParams && hasUnknownReturn && hasMixedBooleanAndAny;
-  });
-}
 
 /** Checks if operator is a NULL check (IS NULL, IS NOT NULL) */
 export function isNullCheckOperator(name: string) {


### PR DESCRIPTION
## Summary
part of https://github.com/elastic/kibana/issues/250232

` npx madge --circular --extensions ts --exclude '^\.\.' src/platform/packages/shared/kbn-esql-language/src/commands `

- acceptsArbitraryExpressions - function to detect if a function (e.g., CASE) accepts complex expressions in its parameters
- ExpressionPosition - type defining cursor positions within an expression (in_function, after_operator, etc.)
- suggestForExpression - recursive function for generating suggestions in nested expressions (e.g., functions inside

Before 

<img width="2167" height="634" alt="ggg" src="https://github.com/user-attachments/assets/5df91d52-65d9-43be-9d65-a32d0ffcd4d8" />

After 

<img width="1968" height="219" alt="de" src="https://github.com/user-attachments/assets/15a085b6-4bbd-4d4e-a3ad-d218677ae3ad" />
