### PR TITLE
[Entity Analytics][Watchlists] Add a new saved object for watchlists

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/constants.ts
@@ -32,3 +32,5 @@ export const PRE_EXCLUDE_INDICES: string[] = [
 
 // Indices that are excludes from the search result (This patterns can't be excluded from the search)
 export const POST_EXCLUDE_INDICES = ['.']; // internal indices
+
+export const PRIVILEGED_USERS_RISK_MODIFIER = 1.5;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/engine/initialisation_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/engine/initialisation_service.ts
@@ -63,6 +63,7 @@ export const createInitialisationService = (
       'Initializing privilege monitoring engine'
     );
     const descriptor = await descriptorClient.init();
+
     dataClient.log('info', `Initialized privileged monitoring engine saved object`);
 
     // upsert index AND integration sources

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/saved_objects/watchlist_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/saved_objects/watchlist_config.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsFindResponse, SavedObjectsClientContract } from '@kbn/core/server';
+import { watchlistConfigTypeName } from './watchlist_config_type';
+
+export const MAX_PER_PAGE = 10_000;
+interface WatchlistConfigAttributes {
+  name: string;
+  description?: string;
+  riskModifier?: number;
+  createdAt: string;
+  modifiedAt: string;
+}
+
+interface WatchlistConfigClientDeps {
+  soClient: SavedObjectsClientContract;
+  namespace: string;
+}
+
+export class WatchlistConfigClient {
+  constructor(private readonly deps: WatchlistConfigClientDeps) {}
+
+  getSavedObjectId(name: string) {
+    // Use name as unique identifier within namespace
+    return `watchlist-config-${this.deps.namespace}-${name}`;
+  }
+
+  async create(attrs: Omit<WatchlistConfigAttributes, 'createdAt' | 'modifiedAt'>) {
+    const now = new Date().toISOString();
+    const id = this.getSavedObjectId(attrs.name);
+    const { attributes } = await this.deps.soClient.create<WatchlistConfigAttributes>(
+      watchlistConfigTypeName,
+      {
+        ...attrs,
+        createdAt: now,
+        modifiedAt: now,
+      },
+      { id, refresh: 'wait_for' }
+    );
+    return attributes;
+  }
+
+  async update(
+    name: string,
+    attrs: Partial<Omit<WatchlistConfigAttributes, 'createdAt' | 'modifiedAt' | 'name'>>
+  ) {
+    const id = this.getSavedObjectId(name);
+    const now = new Date().toISOString();
+
+    const existing = await this.get(name);
+    const update = {
+      ...existing,
+      ...attrs,
+      modifiedAt: now,
+    };
+    const { attributes } = await this.deps.soClient.update<WatchlistConfigAttributes>(
+      watchlistConfigTypeName,
+      id,
+      update,
+      { refresh: 'wait_for' }
+    );
+    return attributes;
+  }
+
+  async find(): Promise<SavedObjectsFindResponse<WatchlistConfigAttributes>> {
+    return this.deps.soClient.find<WatchlistConfigAttributes>({
+      type: watchlistConfigTypeName,
+      namespaces: [this.deps.namespace],
+      perPage: MAX_PER_PAGE,
+    });
+  }
+
+  async get(name: string) {
+    const id = this.getSavedObjectId(name);
+    try {
+      const so = await this.deps.soClient.get<WatchlistConfigAttributes>(
+        watchlistConfigTypeName,
+        id
+      );
+      return so.attributes;
+    } catch (e) {
+      if (e.output && e.output.statusCode === 404) {
+        throw new Error(`Watchlist config '${name}' not found`);
+      }
+      throw e;
+    }
+  }
+
+  async delete(name: string) {
+    const id = this.getSavedObjectId(name);
+    return this.deps.soClient.delete(watchlistConfigTypeName, id, { refresh: 'wait_for' });
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/saved_objects/watchlist_config_type.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/saved_objects/watchlist_config_type.ts
@@ -22,12 +22,8 @@ export const watchlistConfigTypeNameMappings: SavedObjectsType['mappings'] = {
     riskModifier: {
       type: 'float',
     },
-
-    createdAt: {
-      type: 'date',
-    },
-    modifiedAt: {
-      type: 'date',
+    managed: {
+      type: 'boolean',
     },
   },
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/saved_objects/watchlist_config_type.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/privilege_monitoring/saved_objects/watchlist_config_type.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SECURITY_SOLUTION_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import type { SavedObjectsType } from '@kbn/core/server';
+
+export const watchlistConfigTypeName = 'watchlist-config';
+
+export const watchlistConfigTypeNameMappings: SavedObjectsType['mappings'] = {
+  dynamic: false,
+  properties: {
+    name: {
+      type: 'keyword',
+    },
+    description: {
+      type: 'text',
+    },
+    riskModifier: {
+      type: 'float',
+    },
+
+    createdAt: {
+      type: 'date',
+    },
+    modifiedAt: {
+      type: 'date',
+    },
+  },
+};
+
+export const watchlistConfigType: SavedObjectsType = {
+  name: watchlistConfigTypeName,
+  indexPattern: SECURITY_SOLUTION_SAVED_OBJECT_INDEX,
+  hidden: false,
+  namespaceType: 'multiple-isolated',
+  mappings: watchlistConfigTypeNameMappings,
+  modelVersions: {},
+};


### PR DESCRIPTION
## Summary

This pull request introduces a new "watchlist config" saved object for privileged user monitoring in the entity analytics privilege monitoring subsystem.

**Watchlist configuration:**

* Added a new `WatchlistConfigClient` to handle creation, updating, retrieval, and deletion of watchlist SOs

Schema:
```ts
{
  name: string,          // unique name per watchlist
  description: string,
  riskModifier: float,   // the risk engine will look this up to apply modifiers to the score
  
  createdAt: timestamp,
  modifiedAt: timestamp,
}
```

This saved object is not initialised anywhere. This is merely scaffolding for upcoming work.
