### PR TITLE
[Entity Analytics] Fixing `security.entity` attachment format

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.test.ts
@@ -27,7 +27,7 @@ describe('createEntityAttachmentType', () => {
 
       expect(result.valid).toBe(true);
       if (result.valid) {
-        expect(result.data).toBe('identifier: hostname-1, identifierType: host');
+        expect(result.data).toEqual(input);
       }
     });
 
@@ -42,7 +42,7 @@ describe('createEntityAttachmentType', () => {
 
       expect(result.valid).toBe(true);
       if (result.valid) {
-        expect(result.data).toBe('identifier: username-1, identifierType: user');
+        expect(result.data).toEqual(input);
       }
     });
 
@@ -57,7 +57,7 @@ describe('createEntityAttachmentType', () => {
 
       expect(result.valid).toBe(true);
       if (result.valid) {
-        expect(result.data).toBe('identifier: service-1, identifierType: service');
+        expect(result.data).toEqual(input);
       }
     });
 
@@ -72,7 +72,7 @@ describe('createEntityAttachmentType', () => {
 
       expect(result.valid).toBe(true);
       if (result.valid) {
-        expect(result.data).toBe('identifier: generic-1, identifierType: generic');
+        expect(result.data).toEqual(input);
       }
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.ts
@@ -40,7 +40,7 @@ export const createEntityAttachmentType = (): AttachmentTypeDefinition => {
     validate: (input) => {
       const parseResult = riskEntityAttachmentDataSchema.safeParse(input);
       if (parseResult.success) {
-        return { valid: true, data: formatEntityRiskData(parseResult.data) };
+        return { valid: true, data: parseResult.data };
       } else {
         return { valid: false, error: parseResult.error.message };
       }
@@ -73,8 +73,4 @@ RISK ENTITY DATA:
       return description;
     },
   };
-};
-
-const formatEntityRiskData = (data: EntityRiskAttachmentData): string => {
-  return `identifier: ${data.identifier}, identifierType: ${data.identifierType}`;
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.ts
@@ -17,12 +17,6 @@ const riskEntityAttachmentDataSchema = securityAttachmentDataSchema.extend({
 });
 
 /**
- * Data for a risk entity attachment.
- * Note: After validation, the data is stored as a formatted string.
- */
-type EntityRiskAttachmentData = z.infer<typeof riskEntityAttachmentDataSchema>;
-
-/**
  * Type guard to check if data is a formatted risk entity string
  */
 const isEntityRiskFormattedData = (data: unknown): data is string => {


### PR DESCRIPTION
## Summary

After this [PR](https://github.com/elastic/kibana/pull/248979) merged, it looks like the `security.entity` attachment would throw a validation error because it's expecting an object and we're returning a string representation from the validate function. Removing this extra formatting fixes the issue.

## To Verify

1. Start ES and Kibana
2. Generate some alert data and then enable the risk scoring engine so the risk score task runs
3. Make sure you're using AI Agents (not Assistant)
4. From the Entity Analytics overview, click an entity to open the flyout then `Expand details`
5. From the expanded flyout, click `Add to chat` and then submit the conversation
6. You should see no validation errors and see a response from the agent.