### PR TITLE
[Streams] Do not surface temporary fields as modified in processing UI

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
@@ -173,7 +173,7 @@ export const simulateProcessing = async ({
   const otelStream = isOtelStream(stream);
 
   /* 4. Extract all the documents reports and processor metrics from the simulations */
-  const { docReports, processorsMetrics } = computePipelineSimulationResult(
+  const { docReports, processorsMetrics, finalDetectedFieldNames } = computePipelineSimulationResult(
     pipelineSimulationResult.simulation,
     ingestSimulationResult.simulation,
     simulationData.docs,
@@ -185,7 +185,7 @@ export const simulateProcessing = async ({
 
   /* 5. Extract valid detected fields with intelligent type suggestions from fieldsMetadataService */
   const detectedFields = await computeDetectedFields(
-    processorsMetrics,
+    finalDetectedFieldNames,
     params,
     streamFields,
     streamIndexFieldCaps,
@@ -512,6 +512,7 @@ const computePipelineSimulationResult = (
 ): {
   docReports: SimulationDocReport[];
   processorsMetrics: Record<string, ProcessorMetrics>;
+  finalDetectedFieldNames: string[];
 } => {
   const transpiledProcessors = transpileIngestPipeline(processing, {
     ignoreMalformed: true,
@@ -583,7 +584,11 @@ const computePipelineSimulationResult = (
     sampleSize: docReports.length,
   });
 
-  return { docReports, processorsMetrics };
+  // Compute the final detected fields by diffing the initial input with the final output
+  // This ensures temporary fields that are created and then removed don't appear as modified
+  const finalDetectedFieldNames = computeFinalDetectedFields(sampleDocs, docReports);
+
+  return { docReports, processorsMetrics, finalDetectedFieldNames };
 };
 
 const initProcessorMetricsMap = (
@@ -644,6 +649,32 @@ const extractProcessorMetrics = ({
       dropped_rate: parseFloat(droppedRate.toFixed(3)),
     };
   });
+};
+
+/**
+ * Computes the final detected fields by comparing the initial input documents
+ * with the final simulated output documents. This ensures that temporary fields
+ * (created by one processor and removed by another) are not surfaced as modified.
+ */
+const computeFinalDetectedFields = (
+  sampleDocs: Array<{ _source: FlattenRecord }>,
+  docReports: SimulationDocReport[]
+): string[] => {
+  const allFinalFields = new Set<string>();
+
+  docReports.forEach((report, id) => {
+    const initialDoc = flattenObjectNestedLast(sampleDocs[id]._source);
+    const finalDoc = report.value;
+
+    const { added, updated } = calculateObjectDiff(initialDoc, finalDoc);
+
+    const addedFields = Object.keys(flattenObjectNestedLast(added));
+    const updatedFields = Object.keys(flattenObjectNestedLast(updated));
+
+    [...addedFields, ...updatedFields].forEach((field) => allFinalFields.add(field));
+  });
+
+  return Array.from(allFinalFields).sort();
 };
 
 const getDocumentStatus = (
@@ -916,17 +947,17 @@ const getStreamFields = async (
 
 /**
  * In case new fields have been detected, we want to tell the user which ones are inherited and already mapped.
+ * Uses the final detected field names (diff between initial input and final output) to ensure
+ * temporary fields that are created and then removed don't appear as modified.
  */
 const computeDetectedFields = async (
-  processorsMetrics: Record<string, ProcessorMetrics>,
+  finalDetectedFieldNames: string[],
   params: ProcessingSimulationParams,
   streamFields: FieldDefinition,
   streamFieldCaps: FieldCapsResponse['fields'],
   fieldsMetadataClient: IFieldsMetadataClient
 ): Promise<DetectedField[]> => {
-  const fields = Object.values(processorsMetrics).flatMap((metrics) => metrics.detected_fields);
-
-  const uniqueFields = uniq(fields);
+  const uniqueFields = finalDetectedFieldNames;
 
   // Short-circuit to avoid fetching streams fields if none is detected
   if (isEmpty(uniqueFields)) {

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
@@ -173,15 +173,16 @@ export const simulateProcessing = async ({
   const otelStream = isOtelStream(stream);
 
   /* 4. Extract all the documents reports and processor metrics from the simulations */
-  const { docReports, processorsMetrics, finalDetectedFieldNames } = computePipelineSimulationResult(
-    pipelineSimulationResult.simulation,
-    ingestSimulationResult.simulation,
-    simulationData.docs,
-    params.body.processing,
-    Streams.WiredStream.Definition.is(stream),
-    otelStream,
-    streamFields
-  );
+  const { docReports, processorsMetrics, finalDetectedFieldNames } =
+    computePipelineSimulationResult(
+      pipelineSimulationResult.simulation,
+      ingestSimulationResult.simulation,
+      simulationData.docs,
+      params.body.processing,
+      Streams.WiredStream.Definition.is(stream),
+      otelStream,
+      streamFields
+    );
 
   /* 5. Extract valid detected fields with intelligent type suggestions from fieldsMetadataService */
   const detectedFields = await computeDetectedFields(


### PR DESCRIPTION
## Summary

Fixes #248968

Temporary fields that are created and later removed during stream processing were incorrectly appearing in the "Modified fields" list. This happened because `computeDetectedFields` aggregated detected fields from ALL processor steps, including fields that were created by one processor but removed by a subsequent one.

## Changes

- Added `computeFinalDetectedFields` function that computes detected fields by comparing the initial input document with the final simulation output
- Modified `computeDetectedFields` to use the final-only detected fields instead of aggregating from all processor metrics
- Per-processor detection still works for individual processor stats display
- Added unit tests for temporary field scenarios

## How it works

Instead of aggregating detected fields from all processor steps:
```javascript
// Before: aggregated from all processors
const fields = Object.values(processorsMetrics).flatMap((metrics) => metrics.detected_fields);
```

The fix computes detected fields by comparing the initial input with the final output:
```javascript
// After: compare initial input vs final output
const initialFields = Object.keys(initialDoc._source);
const finalFields = Object.keys(finalDoc.value);
// ... compute added/removed/changed fields
```

## Testing

- Added automated tests for temporary field handling in `processing_simulate.ts`
- Manually verified in the UI:
  1. Created a SET processor to add `temp_field`
  2. Created a REMOVE processor to delete `temp_field`
  3. Confirmed `temp_field` does NOT appear in "Modified fields" tab
  4. Confirmed per-processor stats still show the field was detected

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Release Note

Fix temporary fields appearing in "Modified fields" list during stream processing simulation.