### PR TITLE
[Fleet] Fix link Fleet doc serverless service account

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/developing_kibana_in_serverless.md
+++ b/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/developing_kibana_in_serverless.md
@@ -84,7 +84,7 @@ xpack.fleet.outputs:
 
 In serverless mode, Fleet Server runs in standalone mode. Unless you are [simultaneously developing Kibana and Fleet Server](./developing_kibana_and_fleet_server.mddeveloping_), it is easier to run Fleet Server as a Docker container.
 
-The Kibana's dev utils package defines a hard-coded [Fleet Server service token](ttps://github.com/elastic/kibana/blob/92b6fd64cd58fd62f69898c222e86409d5f15b60/src/platform/packages/shared/kbn-dev-utils/src/dev_service_account.ts#L21-L25) and fingerprint of the ca.crt certificate.
+The Kibana's dev utils package defines a hard-coded [Fleet Server service token](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-dev-utils/src/dev_service_account.ts#L21-L25) and fingerprint of the ca.crt certificate.
 
 Running a standalone Fleet Server:
 
@@ -154,7 +154,7 @@ xpack.fleet.outputs:
     is_internal: false
     hosts: ['https://<local_ip>:9200']
     ca_trusted_fingerprint: F71F73085975FD977339A1909EBFE2DF40DB255E0D5BB56FC37246BF383FFC84
-    config: 
+    config:
       ssl:
         verification_mode: none
 ```


### PR DESCRIPTION
## Summary

Fix link to service account for running fleet server in serverless locally 