### PR TITLE
[Flyout System] Allow full set of flyoutMenuProps in openSystemFlyout options

### DIFF
--- a/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.test.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.test.tsx
@@ -88,6 +88,35 @@ describe('SystemFlyoutService', () => {
       expect(renderedElement).toBeDefined();
     });
 
+    it('renders flyoutMenuProps with custom properties', () => {
+      const expectedFlyoutMenuProps = {
+        title: 'Visible Title',
+        'data-test-subj': 'test-menu',
+        hideTitle: false,
+      };
+
+      systemFlyouts.open(<div>System flyout content</div>, {
+        flyoutMenuProps: expectedFlyoutMenuProps,
+      });
+      expect(mockReactDomRender).toHaveBeenCalledTimes(1);
+
+      // Navigate to the actual EuiFlyout component to check its props
+      const renderedElement = mockReactDomRender.mock.calls[0][0];
+      // The structure is: KibanaRenderContextProvider > EuiFlyout
+      const euiFlyoutElement = renderedElement.props.children;
+      expect(euiFlyoutElement.props.flyoutMenuProps).toEqual(expectedFlyoutMenuProps);
+    });
+
+    it('does not allow title in both top-level and flyoutMenuProps', () => {
+      // TypeScript should prevent this at compile time.
+      // This test is just to document the behavior.
+      systemFlyouts.open(<div>System flyout content</div>, {
+        title: 'Top Level Title',
+        // @ts-expect-error - Title can not be in both places
+        flyoutMenuProps: { title: 'Menu Title', 'data-test-subj': 'test-menu' },
+      });
+    });
+
     it('applies additional EuiFlyout options', () => {
       systemFlyouts.open(<div>System flyout content</div>, {
         size: 'l',

--- a/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.test.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.test.tsx
@@ -77,15 +77,16 @@ describe('SystemFlyoutService', () => {
       expect(container.querySelector('[data-eui="EuiFlyout"]')).toBeTruthy();
     });
 
-    it('renders with custom title in flyoutMenuProps', () => {
+    it('renders with custom title at the top level', () => {
       systemFlyouts.open(<div>System flyout content</div>, {
-        title: 'Custom Title',
+        title: 'Top Level Title',
       });
       expect(mockReactDomRender).toHaveBeenCalledTimes(1);
 
-      // Verify render was called
-      const [renderedElement] = mockReactDomRender.mock.calls[0];
-      expect(renderedElement).toBeDefined();
+      // Verify the title was passed through
+      const renderedElement = mockReactDomRender.mock.calls[0][0];
+      const euiFlyoutElement = renderedElement.props.children;
+      expect(euiFlyoutElement.props.flyoutMenuProps.title).toBe('Top Level Title');
     });
 
     it('renders flyoutMenuProps with custom properties', () => {
@@ -107,14 +108,17 @@ describe('SystemFlyoutService', () => {
       expect(euiFlyoutElement.props.flyoutMenuProps).toEqual(expectedFlyoutMenuProps);
     });
 
-    it('does not allow title in both top-level and flyoutMenuProps', () => {
-      // TypeScript should prevent this at compile time.
-      // This test is just to document the behavior.
+    it('gives precedence to flyoutMenuProps.title over top-level title', () => {
       systemFlyouts.open(<div>System flyout content</div>, {
         title: 'Top Level Title',
-        // @ts-expect-error - Title can not be in both places
         flyoutMenuProps: { title: 'Menu Title', 'data-test-subj': 'test-menu' },
       });
+      expect(mockReactDomRender).toHaveBeenCalledTimes(1);
+
+      // Verify that flyoutMenuProps.title takes precedence
+      const renderedElement = mockReactDomRender.mock.calls[0][0];
+      const euiFlyoutElement = renderedElement.props.children;
+      expect(euiFlyoutElement.props.flyoutMenuProps.title).toBe('Menu Title');
     });
 
     it('applies additional EuiFlyout options', () => {

--- a/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.tsx
@@ -53,6 +53,7 @@ export class SystemFlyoutService {
         content: React.ReactElement,
         { session = 'start', title, ...options }: OverlaySystemFlyoutOpenOptions = {}
       ): OverlayRef => {
+        const { flyoutMenuProps } = options;
         const flyoutId = `system-flyout-${uuidV4()}`;
 
         // Create a container for this flyout within the main React tree
@@ -75,6 +76,9 @@ export class SystemFlyoutService {
           flyoutRef.close();
         };
 
+        // Merge top-level title into flyoutMenuProps
+        const mergedFlyoutMenuProps = title ? { ...flyoutMenuProps, title } : flyoutMenuProps;
+
         // Render the flyout content using EuiFlyout with session="start"
         // This ensures full EUI Flyout System integration as a new MAIN flyout.
         render(
@@ -86,7 +90,7 @@ export class SystemFlyoutService {
           >
             <EuiFlyout
               {...options}
-              flyoutMenuProps={{ title }}
+              flyoutMenuProps={mergedFlyoutMenuProps}
               session={session}
               onClose={onCloseFlyout}
               aria-label={options['aria-label']}

--- a/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.tsx
@@ -20,7 +20,7 @@ import type {
   OverlaySystemFlyoutStart,
 } from '@kbn/core-overlays-browser';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
-import { EuiFlyout } from '@elastic/eui';
+import { EuiFlyout, type EuiFlyoutMenuProps } from '@elastic/eui';
 import { SystemFlyoutRef } from './system_flyout_ref';
 
 interface SystemFlyoutStartDeps {
@@ -76,8 +76,11 @@ export class SystemFlyoutService {
           flyoutRef.close();
         };
 
-        // Merge top-level title into flyoutMenuProps
-        const mergedFlyoutMenuProps = title ? { ...flyoutMenuProps, title } : flyoutMenuProps;
+        // title and other flyoutMenuProps: flyoutMenuProps.title takes precedence over top-level title
+        let mergedFlyoutMenuProps: EuiFlyoutMenuProps | undefined;
+        if (title || flyoutMenuProps) {
+          mergedFlyoutMenuProps = { title, ...flyoutMenuProps };
+        }
 
         // Render the flyout content using EuiFlyout with session="start"
         // This ensures full EUI Flyout System integration as a new MAIN flyout.

--- a/src/core/packages/overlays/browser/README.md
+++ b/src/core/packages/overlays/browser/README.md
@@ -149,6 +149,43 @@ const flyoutRef = openMySystemFlyout(overlays);
 flyoutRef.close();
 ```
 
+#### Title Configuration
+
+The `title` option is used by the EUI Flyout Manager for history navigation and creates the flyout menu header. You can provide the title in two ways:
+
+1. **Top-level `title` option**:
+```typescript
+overlays.openSystemFlyout(<MyContent />, {
+  title: 'My Flyout Title',
+  // ... other options
+});
+```
+
+2. **Within `flyoutMenuProps.title`**:
+```typescript
+overlays.openSystemFlyout(<MyContent />, {
+  flyoutMenuProps: {
+    title: 'My Flyout Title',
+    hideTitle: false,
+    'data-test-subj': 'myFlyout',
+    // ... other flyout menu props
+  },
+  // ... other options
+});
+```
+
+**Precedence behavior:** If you provide `title` in both places, `flyoutMenuProps.title` takes precedence over the top-level `title`.
+
+```typescript
+// Example: flyoutMenuProps.title takes precedence
+overlays.openSystemFlyout(<MyContent />, {
+  title: 'Default Title',  // This will be ignored
+  flyoutMenuProps: {
+    title: 'Override Title',  // This will be used
+  },
+});
+```
+
 ### Key Differences
 
 - **`openFlyout`**: Traditional method that requires `toMountPoint`. Opens flyouts with `session="never"`. Content should include `EuiFlyoutHeader` and `EuiFlyoutBody`. Optionally include `EuiFlyoutFooter`.

--- a/src/core/packages/overlays/browser/src/system_flyout.ts
+++ b/src/core/packages/overlays/browser/src/system_flyout.ts
@@ -11,13 +11,59 @@ import type { OverlayRef } from '@kbn/core-mount-utils-browser';
 import type { EuiFlyoutProps } from '@elastic/eui';
 import type { OverlayFlyoutOpenOptions } from './flyout';
 
-export type OverlaySystemFlyoutOpenOptions = Omit<OverlayFlyoutOpenOptions, 'session'> & {
-  /**
-   * Control the flyout session behavior. See {@link EuiFlyoutProps.session}
-   * @default "start"
-   */
-  session?: EuiFlyoutProps['session'];
-};
+/**
+ * Options for opening a system flyout. Title can be provided either at the top level
+ * or within flyoutMenuProps, but not both.
+ */
+export type OverlaySystemFlyoutOpenOptions =
+  | (Omit<OverlayFlyoutOpenOptions, 'session' | 'flyoutMenuProps' | 'title'> & {
+      /**
+       * Control the flyout session behavior. See {@link EuiFlyoutProps.session}
+       * @default "start"
+       */
+      session?: EuiFlyoutProps['session'];
+      /**
+       * Title for the flyout (for flyout system managed history). When provided at the top level,
+       * do not provide title in flyoutMenuProps.
+       */
+      title: string;
+      /**
+       * Props for the flyout menu. Title should not be provided here when using top-level title.
+       */
+      flyoutMenuProps?: Omit<NonNullable<EuiFlyoutProps['flyoutMenuProps']>, 'title'>;
+    })
+  | (Omit<OverlayFlyoutOpenOptions, 'session' | 'flyoutMenuProps' | 'title'> & {
+      /**
+       * Control the flyout session behavior. See {@link EuiFlyoutProps.session}
+       * @default "start"
+       */
+      session?: EuiFlyoutProps['session'];
+      /**
+       * Title for the flyout. When providing title in flyoutMenuProps, do not use top-level title.
+       */
+      title?: never;
+      /**
+       * Props for the flyout menu with title.
+       */
+      flyoutMenuProps: Omit<NonNullable<EuiFlyoutProps['flyoutMenuProps']>, 'title'> & {
+        title: string;
+      };
+    })
+  | (Omit<OverlayFlyoutOpenOptions, 'session' | 'flyoutMenuProps' | 'title'> & {
+      /**
+       * Control the flyout session behavior. See {@link EuiFlyoutProps.session}
+       * @default "start"
+       */
+      session?: EuiFlyoutProps['session'];
+      /**
+       * Title for the flyout (for accessibility).
+       */
+      title?: never;
+      /**
+       * Props for the flyout menu.
+       */
+      flyoutMenuProps?: Omit<NonNullable<EuiFlyoutProps['flyoutMenuProps']>, 'title'>;
+    });
 
 /**
  * APIs to open and manage fly-out dialogs.

--- a/src/core/packages/overlays/browser/src/system_flyout.ts
+++ b/src/core/packages/overlays/browser/src/system_flyout.ts
@@ -12,58 +12,24 @@ import type { EuiFlyoutProps } from '@elastic/eui';
 import type { OverlayFlyoutOpenOptions } from './flyout';
 
 /**
- * Options for opening a system flyout. Title can be provided either at the top level
- * or within flyoutMenuProps, but not both.
+ * Options for opening a system flyout.
  */
-export type OverlaySystemFlyoutOpenOptions =
-  | (Omit<OverlayFlyoutOpenOptions, 'session' | 'flyoutMenuProps' | 'title'> & {
-      /**
-       * Control the flyout session behavior. See {@link EuiFlyoutProps.session}
-       * @default "start"
-       */
-      session?: EuiFlyoutProps['session'];
-      /**
-       * Title for the flyout (for flyout system managed history). When provided at the top level,
-       * do not provide title in flyoutMenuProps.
-       */
-      title: string;
-      /**
-       * Props for the flyout menu. Title should not be provided here when using top-level title.
-       */
-      flyoutMenuProps?: Omit<NonNullable<EuiFlyoutProps['flyoutMenuProps']>, 'title'>;
-    })
-  | (Omit<OverlayFlyoutOpenOptions, 'session' | 'flyoutMenuProps' | 'title'> & {
-      /**
-       * Control the flyout session behavior. See {@link EuiFlyoutProps.session}
-       * @default "start"
-       */
-      session?: EuiFlyoutProps['session'];
-      /**
-       * Title for the flyout. When providing title in flyoutMenuProps, do not use top-level title.
-       */
-      title?: never;
-      /**
-       * Props for the flyout menu with title.
-       */
-      flyoutMenuProps: Omit<NonNullable<EuiFlyoutProps['flyoutMenuProps']>, 'title'> & {
-        title: string;
-      };
-    })
-  | (Omit<OverlayFlyoutOpenOptions, 'session' | 'flyoutMenuProps' | 'title'> & {
-      /**
-       * Control the flyout session behavior. See {@link EuiFlyoutProps.session}
-       * @default "start"
-       */
-      session?: EuiFlyoutProps['session'];
-      /**
-       * Title for the flyout (for accessibility).
-       */
-      title?: never;
-      /**
-       * Props for the flyout menu.
-       */
-      flyoutMenuProps?: Omit<NonNullable<EuiFlyoutProps['flyoutMenuProps']>, 'title'>;
-    });
+export type OverlaySystemFlyoutOpenOptions = Omit<OverlayFlyoutOpenOptions, 'session'> & {
+  /**
+   * Control the flyout session behavior. See {@link EuiFlyoutProps.session}
+   * @default "start"
+   */
+  session?: EuiFlyoutProps['session'];
+  /**
+   * Title for the flyout (for flyout system managed history).
+   */
+  title?: string;
+  /**
+   * Props for the flyout menu.
+   * If `title` is provided here, it takes precedence over the top-level `title`.
+   */
+  flyoutMenuProps?: EuiFlyoutProps['flyoutMenuProps'];
+};
 
 /**
  * APIs to open and manage fly-out dialogs.


### PR DESCRIPTION
This change allows you to use the full set of `flyoutMenuProps`, not just `title`:

```
    flyoutRef.current = core.overlays.openSystemFlyout(
      <FlyoutContent />,
      {
        flyoutMenuProps: {
          title,
          hideTitle: false,
          ['data-test-subj']: `flyoutMenu-${title}`,
        },
      }
    );

```

NOTE: `title` can be provided at the top level of the `OverlaySystemFlyoutOpenOptions`, or can be provided in the `flyoutMenuProps` (as in the example above). If provided in both places, the menu props title will take precedence. This choice was made to keep the type declaration of the options simple and readable.

## Summary

Fix an issue where the `OverlaySystemFlyoutOpenOptions` interface, used in `core.overlays.openSystemFlyout`, would not honor `flyoutMenuProps` such as `hideTitle`.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- ~~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~
- ~~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
- ~~[ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
- ~~[ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
