### PR TITLE
[8.19] [Dataset quality] configuring dockerized package registry in tests (#250040)

### DIFF
--- a/src/platform/packages/shared/kbn-test/index.ts
+++ b/src/platform/packages/shared/kbn-test/index.ts
@@ -80,9 +80,8 @@ export * from './src/find_test_plugin_paths';
 
 export { getDockerFileMountPath } from '@kbn/es';
 
-// Docker image to use for Fleet API integration tests.
-// This image comes from the latest successful build of https://buildkite.com/elastic/kibana-package-registry-promote
-// which is promoted after acceptance tests succeed against docker.elastic.co/package-registry/distribution:lite
-export const fleetPackageRegistryDockerImage =
-  process.env.FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE ||
-  'docker.elastic.co/kibana-ci/package-registry-distribution:lite';
+export {
+  fleetPackageRegistryDockerImage,
+  packageRegistryDocker,
+  dockerRegistryPort,
+} from './src/functional_test_runner';

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/docker_servers/index.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/docker_servers/index.ts
@@ -9,3 +9,4 @@
 
 export * from './docker_servers_service';
 export * from './define_docker_servers_config';
+export * from './package_registry';

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/docker_servers/package_registry/index.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/docker_servers/package_registry/index.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { join } from 'path';
+
+// Docker image to use for Fleet API integration tests.
+// This image comes from the latest successful build of https://buildkite.com/elastic/kibana-package-registry-promote
+// which is promoted after acceptance tests succeed against docker.elastic.co/package-registry/distribution:lite
+export const fleetPackageRegistryDockerImage =
+  process.env.FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE ||
+  'docker.elastic.co/kibana-ci/package-registry-distribution:lite';
+
+const packageRegistryConfig = join(__dirname, './package_registry_config.yml');
+const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
+
+/**
+ * This is used by CI to set the docker registry port
+ * you can also define this environment variable locally when running tests which
+ * will spin up a local docker package registry locally for you
+ * if this is defined it takes precedence over the `packageRegistryOverride` variable
+ */
+export const dockerRegistryPort: string | undefined = process.env.FLEET_PACKAGE_REGISTRY_PORT;
+
+export const packageRegistryDocker = {
+  enabled: !!dockerRegistryPort,
+  image: fleetPackageRegistryDockerImage,
+  portInContainer: 8080,
+  port: dockerRegistryPort,
+  args: dockerArgs,
+  waitForLogLine: 'package manifests loaded',
+  waitForLogLineTimeoutMs: 60 * 4 * 1000, // 4 minutes
+  preferCached: true,
+};

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/docker_servers/package_registry/package_registry_config.yml
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/docker_servers/package_registry/package_registry_config.yml
@@ -1,0 +1,2 @@
+package_paths:
+  - /packages/package-storage

--- a/x-pack/platform/plugins/shared/dataset_quality/README.md
+++ b/x-pack/platform/plugins/shared/dataset_quality/README.md
@@ -78,7 +78,7 @@ node x-pack/platform/plugins/shared/dataset_quality/scripts/api --runner --grep-
 
 For tests using package registry we have enabled a configuration that uses a dockerized lite version to execute the tests in the CI, this will reduce the flakyness of them when calling the real endpoint.
 
-To be able to run this version locally you must have a docker daemon running in your systema and set `FLEET_PACKAGE_REGISTRY_PORT` env var. In order to set this variable execute
+To be able to run this version locally you must have a docker daemon running in your system and set `FLEET_PACKAGE_REGISTRY_PORT` env var. In order to set this variable execute
 
 ```
 export set FLEET_PACKAGE_REGISTRY_PORT=12345

--- a/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/feature_flag.serverless.config.base.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/feature_flag.serverless.config.base.ts
@@ -4,17 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import {
-  fleetPackageRegistryDockerImage,
-  FtrConfigProviderContext,
-  Config,
-  defineDockerServersConfig,
-} from '@kbn/test';
+import type { FtrConfigProviderContext, Config } from '@kbn/test';
+import { defineDockerServersConfig, packageRegistryDocker, dockerRegistryPort } from '@kbn/test';
 
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
-import { ServerlessProjectType } from '@kbn/es';
-import path from 'path';
-import { DeploymentAgnosticCommonServices, services } from '../services';
+import type { ServerlessProjectType } from '@kbn/es';
+import type { DeploymentAgnosticCommonServices } from '../services';
+import { services } from '../services';
 import { updateKbnServerArguments } from './helpers';
 
 interface CreateTestConfigOptions<T> {
@@ -64,21 +60,11 @@ export function createServerlessFeatureFlagTestConfig<T extends DeploymentAgnost
   options: CreateTestConfigOptions<T>
 ) {
   return async ({ readConfigFile }: FtrConfigProviderContext): Promise<Config> => {
-    const packageRegistryConfig = path.join(__dirname, './fixtures/package_registry_config.yml');
-    const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
     let kbnServerArgs: string[] = [];
 
     if (options.kbnServerArgs) {
       kbnServerArgs = await updateKbnServerArguments(options.kbnServerArgs);
     }
-
-    /**
-     * This is used by CI to set the docker registry port
-     * you can also define this environment variable locally when running tests which
-     * will spin up a local docker package registry locally for you
-     * if this is defined it takes precedence over the `packageRegistryOverride` variable
-     */
-    const dockerRegistryPort: string | undefined = process.env.FLEET_PACKAGE_REGISTRY_PORT;
 
     const svlSharedConfig = await readConfigFile(
       require.resolve('../../serverless/shared/config.base.ts')
@@ -93,16 +79,7 @@ export function createServerlessFeatureFlagTestConfig<T extends DeploymentAgnost
         ...(options.services || services),
       },
       dockerServers: defineDockerServersConfig({
-        registry: {
-          enabled: !!dockerRegistryPort,
-          image: fleetPackageRegistryDockerImage,
-          portInContainer: 8080,
-          port: dockerRegistryPort,
-          args: dockerArgs,
-          waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes,
-          preferCached: true,
-        },
+        registry: packageRegistryDocker,
       }),
       esTestCluster: {
         ...svlSharedConfig.get('esTestCluster'),

--- a/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/feature_flag.stateful.config.base.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/feature_flag.stateful.config.base.ts
@@ -13,12 +13,13 @@ import {
   MOCK_IDP_ATTRIBUTE_NAME,
 } from '@kbn/mock-idp-utils';
 import {
-  fleetPackageRegistryDockerImage,
   esTestConfig,
   kbnTestConfig,
   systemIndicesSuperuser,
   FtrConfigProviderContext,
   defineDockerServersConfig,
+  packageRegistryDocker,
+  dockerRegistryPort,
 } from '@kbn/test';
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 import path from 'path';
@@ -44,21 +45,11 @@ export function createStatefulFeatureFlagTestConfig<T extends DeploymentAgnostic
     // if config is executed on CI or locally
     const isRunOnCI = process.env.CI;
 
-    const packageRegistryConfig = path.join(__dirname, './fixtures/package_registry_config.yml');
-    const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
     let kbnServerArgs: string[] = [];
 
     if (options.kbnServerArgs) {
       kbnServerArgs = await updateKbnServerArguments(options.kbnServerArgs);
     }
-
-    /**
-     * This is used by CI to set the docker registry port
-     * you can also define this environment variable locally when running tests which
-     * will spin up a local docker package registry locally for you
-     * if this is defined it takes precedence over the `packageRegistryOverride` variable
-     */
-    const dockerRegistryPort: string | undefined = process.env.FLEET_PACKAGE_REGISTRY_PORT;
 
     const xPackAPITestsConfig = await readConfigFile(
       require.resolve('../../api_integration/config.ts')
@@ -90,16 +81,7 @@ export function createStatefulFeatureFlagTestConfig<T extends DeploymentAgnostic
       servers,
       testConfigCategory: ScoutTestRunConfigCategory.API_TEST,
       dockerServers: defineDockerServersConfig({
-        registry: {
-          enabled: !!dockerRegistryPort,
-          image: fleetPackageRegistryDockerImage,
-          portInContainer: 8080,
-          port: dockerRegistryPort,
-          args: dockerArgs,
-          waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes,
-          preferCached: true,
-        },
+        registry: packageRegistryDocker,
       }),
       testFiles: options.testFiles,
       security: { disableTestUser: true },

--- a/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/fixtures/package_registry_config.yml
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/fixtures/package_registry_config.yml
@@ -1,2 +1,0 @@
-package_paths:
-  - /packages/package-storage

--- a/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/serverless.config.base.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/serverless.config.base.ts
@@ -4,17 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import {
-  fleetPackageRegistryDockerImage,
-  FtrConfigProviderContext,
-  Config,
-  defineDockerServersConfig,
-} from '@kbn/test';
+import type { FtrConfigProviderContext, Config } from '@kbn/test';
+import { defineDockerServersConfig, packageRegistryDocker, dockerRegistryPort } from '@kbn/test';
 
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
-import { ServerlessProjectType } from '@kbn/es';
-import path from 'path';
-import { DeploymentAgnosticCommonServices, services } from '../services';
+import type { ServerlessProjectType } from '@kbn/es';
+import type { DeploymentAgnosticCommonServices } from '../services';
+import { services } from '../services';
 
 interface CreateTestConfigOptions<T> {
   serverlessProject: ServerlessProjectType;
@@ -69,17 +65,6 @@ export function createServerlessTestConfig<T extends DeploymentAgnosticCommonSer
       );
     }
 
-    const packageRegistryConfig = path.join(__dirname, './fixtures/package_registry_config.yml');
-    const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
-
-    /**
-     * This is used by CI to set the docker registry port
-     * you can also define this environment variable locally when running tests which
-     * will spin up a local docker package registry locally for you
-     * if this is defined it takes precedence over the `packageRegistryOverride` variable
-     */
-    const dockerRegistryPort: string | undefined = process.env.FLEET_PACKAGE_REGISTRY_PORT;
-
     const svlSharedConfig = await readConfigFile(
       require.resolve('../../serverless/shared/config.base.ts')
     );
@@ -93,16 +78,7 @@ export function createServerlessTestConfig<T extends DeploymentAgnosticCommonSer
         ...(options.services || services),
       },
       dockerServers: defineDockerServersConfig({
-        registry: {
-          enabled: !!dockerRegistryPort,
-          image: fleetPackageRegistryDockerImage,
-          portInContainer: 8080,
-          port: dockerRegistryPort,
-          args: dockerArgs,
-          waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes,
-          preferCached: true,
-        },
+        registry: packageRegistryDocker,
       }),
       esTestCluster: {
         ...svlSharedConfig.get('esTestCluster'),

--- a/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/stateful.config.base.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/default_configs/stateful.config.base.ts
@@ -13,12 +13,13 @@ import {
   MOCK_IDP_ATTRIBUTE_NAME,
 } from '@kbn/mock-idp-utils';
 import {
-  fleetPackageRegistryDockerImage,
   esTestConfig,
   kbnTestConfig,
   systemIndicesSuperuser,
   FtrConfigProviderContext,
   defineDockerServersConfig,
+  dockerRegistryPort,
+  packageRegistryDocker,
 } from '@kbn/test';
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 import path from 'path';
@@ -50,17 +51,6 @@ export function createStatefulTestConfig<T extends DeploymentAgnosticCommonServi
     // if config is executed on CI or locally
     const isRunOnCI = process.env.CI;
 
-    const packageRegistryConfig = path.join(__dirname, './fixtures/package_registry_config.yml');
-    const dockerArgs: string[] = ['-v', `${packageRegistryConfig}:/package-registry/config.yml`];
-
-    /**
-     * This is used by CI to set the docker registry port
-     * you can also define this environment variable locally when running tests which
-     * will spin up a local docker package registry locally for you
-     * if this is defined it takes precedence over the `packageRegistryOverride` variable
-     */
-    const dockerRegistryPort: string | undefined = process.env.FLEET_PACKAGE_REGISTRY_PORT;
-
     const xPackAPITestsConfig = await readConfigFile(
       require.resolve('../../api_integration/config.ts')
     );
@@ -91,16 +81,7 @@ export function createStatefulTestConfig<T extends DeploymentAgnosticCommonServi
       servers,
       testConfigCategory: ScoutTestRunConfigCategory.API_TEST,
       dockerServers: defineDockerServersConfig({
-        registry: {
-          enabled: !!dockerRegistryPort,
-          image: fleetPackageRegistryDockerImage,
-          portInContainer: 8080,
-          port: dockerRegistryPort,
-          args: dockerArgs,
-          waitForLogLine: 'package manifests loaded',
-          waitForLogLineTimeoutMs: 60 * 6 * 1000, // 6 minutes,
-          preferCached: true,
-        },
+        registry: packageRegistryDocker,
       }),
       testFiles: options.testFiles,
       security: { disableTestUser: true },

--- a/x-pack/solutions/observability/test/functional/apps/dataset_quality/dataset_quality_details.ts
+++ b/x-pack/solutions/observability/test/functional/apps/dataset_quality/dataset_quality_details.ts
@@ -48,11 +48,11 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
     version: '1.14.0',
   };
 
-  const bitbucketDatasetName = 'atlassian_bitbucket.audit';
-  const bitbucketAuditDataStreamName = `logs-${bitbucketDatasetName}-${defaultNamespace}`;
-  const bitbucketPkg = {
-    name: 'atlassian_bitbucket',
-    version: '1.14.0',
+  const fleetServerDatasetName = 'fleet_server.output_health';
+  const fleetServerOutputHealthDataStreamName = `logs-${fleetServerDatasetName}-${defaultNamespace}`;
+  const fleetServerPkg = {
+    name: 'fleet_server',
+    version: '1.6.0',
   };
 
   const regularDatasetName = datasetNames[0];
@@ -67,8 +67,8 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       // Install Apache Integration and ingest logs for it
       await PageObjects.observabilityLogsExplorer.installPackage(apachePkg);
 
-      // Install Bitbucket Integration (package which does not has Dashboards) and ingest logs for it
-      await PageObjects.observabilityLogsExplorer.installPackage(bitbucketPkg);
+      // Install fleet server Integration (package which does not has Dashboards) and ingest logs for it
+      await PageObjects.observabilityLogsExplorer.installPackage(fleetServerPkg);
 
       await synthtrace.createCustomPipeline(processors, 'synth.2@pipeline');
       await synthtrace.createComponentTemplate({
@@ -106,7 +106,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
           isMalformed: true,
         }),
         // Index logs for Bitbucket integration
-        getLogsForDataset({ to, count: 10, dataset: bitbucketDatasetName }),
+        getLogsForDataset({ to, count: 10, dataset: fleetServerDatasetName }),
         createFailedLogRecord({
           to: new Date().toISOString(),
           count: 2,
@@ -122,7 +122,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
     after(async () => {
       await PageObjects.observabilityLogsExplorer.uninstallPackage(apachePkg);
-      await PageObjects.observabilityLogsExplorer.uninstallPackage(bitbucketPkg);
+      await PageObjects.observabilityLogsExplorer.uninstallPackage(fleetServerPkg);
       await synthtrace.clean();
       await synthtrace.deleteIndexTemplate(IndexTemplateName.Synht2);
       await synthtrace.deleteComponentTemplate('synth.2@custom');
@@ -355,7 +355,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
       it('should hide integration dashboard for integrations without dashboards', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
-          dataStream: bitbucketAuditDataStreamName,
+          dataStream: fleetServerOutputHealthDataStreamName,
         });
 
         await PageObjects.datasetQuality.openIntegrationActionsMenu();
@@ -369,7 +369,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
       it('should navigate to integration overview page on clicking integration overview action', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
-          dataStream: bitbucketAuditDataStreamName,
+          dataStream: fleetServerOutputHealthDataStreamName,
         });
         await PageObjects.datasetQuality.openIntegrationActionsMenu();
 
@@ -383,7 +383,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
           const currentUrl = await browser.getCurrentUrl();
           const parsedUrl = new URL(currentUrl);
 
-          expect(parsedUrl.pathname).to.contain('/app/integrations/detail/atlassian_bitbucket');
+          expect(parsedUrl.pathname).to.contain('/app/integrations/detail/fleet_server');
         });
       });
 

--- a/x-pack/solutions/observability/test/functional/apps/observability_logs_explorer/data_source_selector.ts
+++ b/x-pack/solutions/observability/test/functional/apps/observability_logs_explorer/data_source_selector.ts
@@ -10,7 +10,6 @@ import { FtrProviderContext } from './config';
 
 const initialPackageMap = {
   apache: 'Apache HTTP Server',
-  aws: 'AWS',
   system: 'System',
 };
 const initialPackagesTexts = Object.values(initialPackageMap);
@@ -256,7 +255,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
           await retry.try(async () => {
             const { integrations } = await PageObjects.observabilityLogsExplorer.getIntegrations();
-            expect(integrations).to.eql([initialPackageMap.apache, initialPackageMap.aws]);
+            expect(integrations).to.eql([initialPackageMap.apache]);
           });
         });
 

--- a/x-pack/solutions/observability/test/functional/apps/observability_logs_explorer/data_source_selector.ts
+++ b/x-pack/solutions/observability/test/functional/apps/observability_logs_explorer/data_source_selector.ts
@@ -214,7 +214,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         it('should display a list of installed integrations', async () => {
           const { integrations } = await PageObjects.observabilityLogsExplorer.getIntegrations();
 
-          expect(integrations.length).to.be(3);
+          expect(integrations.length).to.be(2);
           expect(integrations).to.eql(initialPackagesTexts);
         });
 

--- a/x-pack/solutions/observability/test/functional/config.base.ts
+++ b/x-pack/solutions/observability/test/functional/config.base.ts
@@ -6,9 +6,10 @@
  */
 
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
-import { FtrConfigProviderContext } from '@kbn/test';
-import { services } from './services';
+import type { FtrConfigProviderContext } from '@kbn/test';
+import { defineDockerServersConfig, dockerRegistryPort, packageRegistryDocker } from '@kbn/test';
 import { pageObjects } from './page_objects';
+import { services } from './services';
 
 export async function getFunctionalConfig({ readConfigFile }: FtrConfigProviderContext) {
   const xPackPlatformFunctionalTestsConfig = await readConfigFile(
@@ -21,13 +22,21 @@ export async function getFunctionalConfig({ readConfigFile }: FtrConfigProviderC
     pageObjects,
     testConfigCategory: ScoutTestRunConfigCategory.UI_TEST,
     servers: xPackPlatformFunctionalTestsConfig.get('servers'),
+    dockerServers: defineDockerServersConfig({
+      registry: packageRegistryDocker,
+    }),
     security: xPackPlatformFunctionalTestsConfig.get('security'),
     junit: {
       reportName: 'X-Pack Observability Functional UI Tests',
     },
     kbnTestServer: {
       ...xPackPlatformFunctionalTestsConfig.get('kbnTestServer'),
-      serverArgs: [...xPackPlatformFunctionalTestsConfig.get('kbnTestServer.serverArgs')],
+      serverArgs: [
+        ...xPackPlatformFunctionalTestsConfig.get('kbnTestServer.serverArgs'),
+        ...(dockerRegistryPort
+          ? [`--xpack.fleet.registryUrl=http://localhost:${dockerRegistryPort}`]
+          : []),
+      ],
     },
     esTestCluster: {
       ...xPackPlatformFunctionalTestsConfig.get('esTestCluster'),

--- a/x-pack/solutions/observability/test/functional/page_objects/observability_logs_explorer.ts
+++ b/x-pack/solutions/observability/test/functional/page_objects/observability_logs_explorer.ts
@@ -25,7 +25,7 @@ const packages: IntegrationPackage[] = [
     version: '1.14.0',
   },
   {
-    name: 'aws',
+    name: 'aws', // not available in the dockerized package registry
     version: '1.51.0',
   },
   {

--- a/x-pack/solutions/observability/test/observability_ai_assistant_functional/common/config.ts
+++ b/x-pack/solutions/observability/test/observability_ai_assistant_functional/common/config.ts
@@ -65,7 +65,12 @@ async function getTestConfig({
   kibanaConfig: Record<string, any> | undefined;
   readConfigFile: FtrConfigProviderContext['readConfigFile'];
 }) {
-  const testConfig = await readConfigFile(require.resolve('../../functional/config.base.ts'));
+  // This has been changed from the original config.base.ts
+  // to avoid the usage of the dockerized package registry
+  // problem is apmSynthtraceKibanaClient initialization happens before the docker container is started
+  const testConfig = await readConfigFile(
+    require.resolve('@kbn/test-suites-xpack-platform/functional/config.base')
+  );
 
   const getScopedApiClientForUsername = (username: string) =>
     getScopedApiClient(kibanaServer, username);
@@ -110,8 +115,8 @@ async function getTestConfig({
         ...testConfig.get('kbnTestServer.serverArgs'),
         ...(kibanaConfig
           ? Object.entries(kibanaConfig).map(([key, value]) =>
-              Array.isArray(value) ? `--${key}=${JSON.stringify(value)}` : `--${key}=${value}`
-            )
+            Array.isArray(value) ? `--${key}=${JSON.stringify(value)}` : `--${key}=${value}`
+          )
           : []),
       ],
     },

--- a/x-pack/solutions/observability/test/observability_ai_assistant_functional/common/config.ts
+++ b/x-pack/solutions/observability/test/observability_ai_assistant_functional/common/config.ts
@@ -115,8 +115,8 @@ async function getTestConfig({
         ...testConfig.get('kbnTestServer.serverArgs'),
         ...(kibanaConfig
           ? Object.entries(kibanaConfig).map(([key, value]) =>
-            Array.isArray(value) ? `--${key}=${JSON.stringify(value)}` : `--${key}=${value}`
-          )
+              Array.isArray(value) ? `--${key}=${JSON.stringify(value)}` : `--${key}=${value}`
+            )
           : []),
       ],
     },

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/dataset_quality_details.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/dataset_quality_details.ts
@@ -46,11 +46,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     version: '1.14.0',
   };
 
-  const bitbucketDatasetName = 'atlassian_bitbucket.audit';
-  const bitbucketAuditDataStreamName = `logs-${bitbucketDatasetName}-${defaultNamespace}`;
-  const bitbucketPkg = {
-    name: 'atlassian_bitbucket',
-    version: '1.14.0',
+  const fleetServerDatasetName = 'fleet_server.output_health';
+  const fleetServerOutputHealthDataStreamName = `logs-${fleetServerDatasetName}-${defaultNamespace}`;
+  const fleetServerPkg = {
+    name: 'fleet_server',
+    version: '1.6.0',
   };
 
   const regularDatasetName = datasetNames[0];
@@ -63,8 +63,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       // Install Apache Integration and ingest logs for it
       await PageObjects.observabilityLogsExplorer.installPackage(apachePkg);
 
-      // Install Bitbucket Integration (package which does not has Dashboards) and ingest logs for it
-      await PageObjects.observabilityLogsExplorer.installPackage(bitbucketPkg);
+      // Install fleet server Integration (package which does not has Dashboards) and ingest logs for it
+      await PageObjects.observabilityLogsExplorer.installPackage(fleetServerPkg);
 
       await synthtrace.index([
         // Ingest basic logs
@@ -91,7 +91,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           isMalformed: true,
         }),
         // Index logs for Bitbucket integration
-        getLogsForDataset({ to, count: 10, dataset: bitbucketDatasetName }),
+        getLogsForDataset({ to, count: 10, dataset: fleetServerDatasetName }),
       ]);
 
       await PageObjects.svlCommonPage.loginAsViewer();
@@ -99,7 +99,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await PageObjects.observabilityLogsExplorer.uninstallPackage(apachePkg);
-      await PageObjects.observabilityLogsExplorer.uninstallPackage(bitbucketPkg);
+      await PageObjects.observabilityLogsExplorer.uninstallPackage(fleetServerPkg);
       await synthtrace.clean();
     });
 
@@ -227,7 +227,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should hide integration dashboard for integrations without dashboards', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
-          dataStream: bitbucketAuditDataStreamName,
+          dataStream: fleetServerOutputHealthDataStreamName,
         });
 
         await PageObjects.datasetQuality.openIntegrationActionsMenu();
@@ -241,7 +241,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('Should navigate to integration overview page on clicking integration overview action', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
-          dataStream: bitbucketAuditDataStreamName,
+          dataStream: fleetServerOutputHealthDataStreamName,
         });
         await PageObjects.datasetQuality.openIntegrationActionsMenu();
 
@@ -254,8 +254,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await retry.tryForTime(5000, async () => {
           const currentUrl = await browser.getCurrentUrl();
           const parsedUrl = new URL(currentUrl);
-
-          expect(parsedUrl.pathname).to.contain('/app/integrations/detail/atlassian_bitbucket');
+          expect(parsedUrl.pathname).to.contain('/app/integrations/detail/fleet_server');
         });
       });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Dataset quality] configuring dockerized package registry in tests (#250040)](https://github.com/elastic/kibana/pull/250040)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"mohamedhamed-ahmed","email":"mohamed.ahmed@elastic.co"},"sourceCommit":{"committedDate":"2026-01-23T23:19:17Z","message":"[Dataset quality] configuring dockerized package registry in tests (#250040)\n\n## Summary\n\nWe have been dealing with a lot of flakiness in our tests due to package\nregistry not being available, this PR changes the package registery\nbeing used to the dockerized one in Dataset Quality. As well as\ncentralizing its usage in kbn-test package so that it can later on be\nused from a central place by other teams instead of duplicating it in\nevery test suite.\n\nThis is work continuation for [[Dataset quality] configuring dockerized\npackage registry in\ntests](https://github.com/elastic/kibana/pull/234891).","sha":"890247929ccd1b7d40d2e88eccd14ea9267af063","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.1.0","v8.19.0","v9.2.0","v9.3.0","v9.4.0","v9.2.5"],"title":"[Dataset quality] configuring dockerized package registry in tests","number":250040,"url":"https://github.com/elastic/kibana/pull/250040","mergeCommit":{"message":"[Dataset quality] configuring dockerized package registry in tests (#250040)\n\n## Summary\n\nWe have been dealing with a lot of flakiness in our tests due to package\nregistry not being available, this PR changes the package registery\nbeing used to the dockerized one in Dataset Quality. As well as\ncentralizing its usage in kbn-test package so that it can later on be\nused from a central place by other teams instead of duplicating it in\nevery test suite.\n\nThis is work continuation for [[Dataset quality] configuring dockerized\npackage registry in\ntests](https://github.com/elastic/kibana/pull/234891).","sha":"890247929ccd1b7d40d2e88eccd14ea9267af063"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","8.19"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/250291","number":250291,"state":"MERGED","mergeCommit":{"sha":"2bb2422a3ccd11ac0f2b31e2df501b8f4c8e098b","message":"[9.2] [Dataset quality] configuring dockerized package registry in tests (#250040) (#250291)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Dataset quality] configuring dockerized package registry in tests\n(#250040)](https://github.com/elastic/kibana/pull/250040)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: mohamedhamed-ahmed <mohamed.ahmed@elastic.co>"}},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/250292","number":250292,"state":"MERGED","mergeCommit":{"sha":"06fa3a8dffffb243b20b57aece5f7cf5c253abf8","message":"[9.3] [Dataset quality] configuring dockerized package registry in tests (#250040) (#250292)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Dataset quality] configuring dockerized package registry in tests\n(#250040)](https://github.com/elastic/kibana/pull/250040)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: mohamedhamed-ahmed <mohamed.ahmed@elastic.co>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250040","number":250040,"mergeCommit":{"message":"[Dataset quality] configuring dockerized package registry in tests (#250040)\n\n## Summary\n\nWe have been dealing with a lot of flakiness in our tests due to package\nregistry not being available, this PR changes the package registery\nbeing used to the dockerized one in Dataset Quality. As well as\ncentralizing its usage in kbn-test package so that it can later on be\nused from a central place by other teams instead of duplicating it in\nevery test suite.\n\nThis is work continuation for [[Dataset quality] configuring dockerized\npackage registry in\ntests](https://github.com/elastic/kibana/pull/234891).","sha":"890247929ccd1b7d40d2e88eccd14ea9267af063"}}]}] BACKPORT-->