### PR TITLE
[One Workflow] remote JSON Schema reference support MVImpl with types registry API

### DIFF
--- a/remote_schema_architecture.md
+++ b/remote_schema_architecture.md
@@ -1,0 +1,249 @@
+# Remote JSON Schema Reference Architecture
+
+## Architecture Overview
+
+```mermaid
+graph TB
+    subgraph "Workflow Definition Layer"
+        A[Workflow YAML] -->|Defines inputs with $ref| B[Input Schema]
+        B -->|Supports multiple reference types| C{Reference Type}
+    end
+
+    subgraph "Reference Types Supported"
+        C -->|Local| D["#/definitions/User<br/>JSON Pointer"]
+        C -->|Remote HTTP| E["https://api.example.com/schemas/user.json<br/>Absolute URI"]
+        C -->|Remote with Fragment| F["https://api.example.com/schemas.json#/definitions/User<br/>URI + JSON Pointer"]
+        C -->|Local Repository| G["/api/workflows/types-registry.json#/definitions/User<br/>Internal API"]
+        C -->|Relative Path| H["./schemas/address.json<br/>Relative URI"]
+    end
+
+    subgraph "Schema Resolution Engine"
+        I[normalizeInputsToJsonSchemaAsync] -->|Detects refs| J{Has References?}
+        J -->|No| K[Return Schema As-Is]
+        J -->|Yes| L{Has Remote Refs?}
+        
+        L -->|Yes| M[resolveRemoteRefsInBrowser]
+        M -->|Fetch via HTTP| N[Remote Schema Registry]
+        M -->|Inline fetched schemas| O[Schema with Remote Refs Resolved]
+        
+        L -->|No| O
+        O -->|Check local refs| P{Has Local Refs?}
+        
+        P -->|Yes| Q[$RefParser.dereference]
+        Q -->|Resolve JSON Pointers| R[Fully Resolved Schema]
+        P -->|No| R
+    end
+
+    subgraph "Value Delivery Points"
+        R -->|Validated Schema| S[Workflow Execution Engine]
+        R -->|Type-safe Validation| T[Zod Validator]
+        R -->|IntelliSense| U[Monaco Editor Autocomplete]
+        R -->|Default Values| V[Input Form Pre-filling]
+        R -->|Schema Validation| W[YAML Validation]
+    end
+
+    subgraph "Benefits & Value"
+        X[Schema Reusability<br/>Share across workflows]
+        Y[Centralized Management<br/>Single source of truth]
+        Z[Type Safety<br/>Compile-time validation]
+        AA[Developer Experience<br/>Autocomplete & validation]
+        AB[Maintainability<br/>Update once, use everywhere]
+        AC[Standards Compliance<br/>JSON Schema spec compliant]
+    end
+
+    S --> X
+    T --> Z
+    U --> AA
+    V --> AA
+    W --> Y
+    R --> AB
+    R --> AC
+
+    style A fill:#e1f5ff
+    style R fill:#c8e6c9
+    style X fill:#fff9c4
+    style Y fill:#fff9c4
+    style Z fill:#fff9c4
+    style AA fill:#fff9c4
+    style AB fill:#fff9c4
+    style AC fill:#fff9c4
+```
+
+## Reference Resolution Flow
+
+```mermaid
+sequenceDiagram
+    participant WF as Workflow YAML
+    participant Normalize as normalizeInputsToJsonSchemaAsync
+    participant Resolver as resolveAllReferences
+    participant Remote as resolveRemoteRefsInBrowser
+    participant HTTP as HTTP Fetch
+    participant Local as $RefParser
+    participant Validator as Zod Validator
+    participant Editor as Monaco Editor
+    participant Exec as Execution Engine
+
+    WF->>Normalize: Input schema with $ref
+    Normalize->>Resolver: Check for references
+    
+    alt Remote Reference Detected
+        Resolver->>Remote: hasRemoteRefs() = true
+        Remote->>HTTP: Fetch remote schema
+        HTTP-->>Remote: JSON Schema response
+        Remote->>Remote: Inline remote refs
+        Remote-->>Resolver: Schema with remote refs resolved
+    end
+    
+    alt Local Reference Detected
+        Resolver->>Local: dereference() for local refs
+        Local->>Local: Resolve JSON Pointers (#/definitions/...)
+        Local-->>Resolver: Fully dereferenced schema
+    end
+    
+    Resolver-->>Normalize: Fully resolved schema
+    Normalize-->>Validator: Create Zod schema
+    Normalize-->>Editor: Provide for autocomplete
+    Normalize-->>Exec: Apply defaults & validate
+    
+    Validator->>Validator: Runtime validation
+    Editor->>Editor: IntelliSense suggestions
+    Exec->>Exec: Execute with validated inputs
+```
+
+## Reference Type Examples
+
+```mermaid
+graph LR
+    subgraph "Local Reference"
+        A1[Workflow YAML] -->|"$ref: '#/definitions/User'"| A2[Local definitions]
+        A2 -->|JSON Pointer| A3[Resolved inline]
+    end
+
+    subgraph "Remote HTTP"
+        B1[Workflow YAML] -->|"$ref: 'https://api.example.com/schemas/user.json'"| B2[HTTP Request]
+        B2 -->|Fetch| B3[Remote Schema]
+        B3 -->|Inline| B4[Resolved Schema]
+    end
+
+    subgraph "Remote with Fragment"
+        C1[Workflow YAML] -->|"$ref: 'https://api.example.com/schemas.json#/definitions/User'"| C2[HTTP Request]
+        C2 -->|Fetch| C3[Remote Schema]
+        C3 -->|Extract fragment| C4[JSON Pointer Resolution]
+        C4 -->|Inline specific definition| C5[Resolved Schema]
+    end
+
+    subgraph "Internal API"
+        D1[Workflow YAML] -->|"$ref: '/api/workflows/types-registry.json#/definitions/User'"| D2[Kibana API]
+        D2 -->|Internal fetch| D3[Types Registry]
+        D3 -->|Resolve & inline| D4[Resolved Schema]
+    end
+
+    style A3 fill:#c8e6c9
+    style B4 fill:#c8e6c9
+    style C5 fill:#c8e6c9
+    style D4 fill:#c8e6c9
+```
+
+## Integration Architecture
+
+```mermaid
+graph TB
+    subgraph "Frontend Integration"
+        FE1[Workflow YAML Editor] -->|Monaco Editor| FE2[Autocomplete Provider]
+        FE2 -->|resolveAllReferences| FE3[Schema Resolution]
+        FE3 -->|Property suggestions| FE4[IntelliSense]
+        
+        FE5[Run Workflow Modal] -->|normalizeInputsToJsonSchemaAsync| FE3
+        FE3 -->|Resolved schema| FE6[Zod Validator]
+        FE6 -->|Validation| FE7[Form with defaults]
+    end
+
+    subgraph "Backend Integration"
+        BE1[Workflow Execution] -->|buildWorkflowContext| BE2[normalizeInputsToJsonSchemaAsync]
+        BE2 -->|Resolved schema| BE3[applyInputDefaults]
+        BE3 -->|Validated inputs| BE4[Workflow Context]
+        BE4 -->|Runtime| BE5[Step Execution]
+    end
+
+    subgraph "Validation Integration"
+        VAL1[YAML Validation] -->|validateJsonSchemaDefaults| VAL2[normalizeInputsToJsonSchemaAsync]
+        VAL2 -->|Resolved schema| VAL3[Default validation]
+        VAL3 -->|Errors| VAL4[Editor markers]
+    end
+
+    FE3 -.->|Same resolution logic| BE2
+    BE2 -.->|Same resolution logic| VAL2
+
+    style FE4 fill:#fff9c4
+    style FE7 fill:#fff9c4
+    style BE4 fill:#c8e6c9
+    style VAL4 fill:#ffcdd2
+```
+
+## Value Proposition Matrix
+
+```mermaid
+graph TB
+    subgraph "Business Value"
+        BV1[Reduced Duplication<br/>DRY Principle]
+        BV2[Faster Development<br/>Reuse existing schemas]
+        BV3[Consistency<br/>Standardized types]
+        BV4[Maintainability<br/>Update once, propagate everywhere]
+    end
+
+    subgraph "Technical Value"
+        TV1[Type Safety<br/>Compile-time validation]
+        TV2[Standards Compliance<br/>JSON Schema spec]
+        TV3[Flexibility<br/>Multiple reference types]
+        TV4[Performance<br/>Lazy resolution, caching]
+    end
+
+    subgraph "Developer Experience"
+        DX1[Autocomplete<br/>IntelliSense in editor]
+        DX2[Validation<br/>Real-time error checking]
+        DX3[Documentation<br/>Schema descriptions]
+        DX4[Default Values<br/>Auto-populated forms]
+    end
+
+    BV1 -->|Enables| TV1
+    BV2 -->|Enables| DX1
+    BV3 -->|Enables| TV2
+    BV4 -->|Enables| TV4
+
+    TV1 -->|Provides| DX2
+    TV2 -->|Enables| DX3
+    TV3 -->|Enables| DX1
+    TV4 -->|Enables| DX4
+
+    style BV1 fill:#e3f2fd
+    style BV2 fill:#e3f2fd
+    style BV3 fill:#e3f2fd
+    style BV4 fill:#e3f2fd
+    style TV1 fill:#c8e6c9
+    style TV2 fill:#c8e6c9
+    style TV3 fill:#c8e6c9
+    style TV4 fill:#c8e6c9
+    style DX1 fill:#fff9c4
+    style DX2 fill:#fff9c4
+    style DX3 fill:#fff9c4
+    style DX4 fill:#fff9c4
+```
+
+## Reference Type Use Cases
+
+| Reference Type | Use Case | Example | Benefits |
+|---------------|----------|---------|----------|
+| **Local (`#/definitions/...`)** | Workflow-specific types | `$ref: "#/definitions/User"` | Simple, self-contained |
+| **Remote HTTP** | External schema registry | `$ref: "https://api.example.com/schemas/user.json"` | Centralized, versioned |
+| **Remote with Fragment** | Shared schema repository | `$ref: "https://api.example.com/schemas.json#/definitions/User"` | Efficient, selective |
+| **Internal API** | Kibana types registry | `$ref: "/api/workflows/types-registry.json#/definitions/User"` | Internal, controlled |
+| **Relative Path** | Local file system | `$ref: "./schemas/address.json"` | Organized, modular |
+
+## Architecture Principles
+
+1. **Lazy Resolution**: References are only resolved when needed
+2. **Graceful Degradation**: Falls back to original schema if resolution fails
+3. **Browser Compatibility**: Uses `fetch` API for cross-platform support
+4. **Security**: File system access disabled, HTTP-only for remote refs
+5. **Performance**: Early returns for schemas without references
+6. **Standards Compliance**: Full JSON Schema specification support

--- a/remote_schema_architecture_single.md
+++ b/remote_schema_architecture_single.md
@@ -1,0 +1,263 @@
+# Remote JSON Schema Reference Architecture
+
+```mermaid
+graph TB
+    subgraph "Workflow Input Definition"
+        A[Workflow YAML] -->|Defines inputs| B[Input Schema with $ref]
+    end
+
+    subgraph "Reference Types & Sources"
+        B --> C{Reference Type}
+        C -->|Local| D["#/definitions/User<br/>JSON Pointer<br/>Self-contained"]
+        C -->|Remote HTTP| E["https://api.example.com/schemas/user.json<br/>External Registry<br/>Versioned & Centralized"]
+        C -->|Remote Fragment| F["https://api.example.com/schemas.json#/definitions/User<br/>Shared Repository<br/>Selective Resolution"]
+        C -->|Internal API| G["/api/workflows/types-registry.json#/definitions/User<br/>Kibana Registry<br/>Controlled & Internal"]
+        C -->|Relative Path| H["./schemas/address.json<br/>Local Files<br/>Modular Organization"]
+    end
+
+    subgraph "Schema Resolution Pipeline"
+        I[normalizeInputsToJsonSchemaAsync] -->|Parse & Detect| J{Has References?}
+        J -->|No| K[Return Schema As-Is<br/>No Processing Needed]
+        J -->|Yes| L{Remote Refs?}
+        
+        L -->|Yes| M[resolveRemoteRefsInBrowser]
+        M -->|HTTP Fetch| N[Remote Schema Sources]
+        N -->|E1: External API| O1[External Schema Registry]
+        N -->|E2: Internal API| O2[Kibana Types Registry]
+        M -->|Inline & Resolve Fragments| P[Schema with Remote Refs Resolved]
+        
+        L -->|No| P
+        P -->|Check Local| Q{Local Refs?}
+        
+        Q -->|Yes| R[$RefParser.dereference<br/>JSON Pointer Resolution]
+        R -->|Resolve #/definitions| S[Fully Resolved Schema<br/>All Refs Inlined]
+        Q -->|No| S
+    end
+
+    subgraph "Value Delivery & Integration"
+        S -->|Type-Safe Schema| T1[Zod Validator<br/>Runtime Validation]
+        S -->|Schema Structure| T2[Monaco Editor<br/>IntelliSense & Autocomplete]
+        S -->|Default Values| T3[Input Forms<br/>Auto-populated Fields]
+        S -->|Validated Inputs| T4[Workflow Execution<br/>Context Building]
+        S -->|Schema Validation| T5[YAML Validation<br/>Error Detection]
+    end
+
+    subgraph "AI Agent Tool Integration"
+        AG1[AI Agent] -->|Discovers Workflows| AG2[Workflow Tool Registry]
+        AG2 -->|getSchema| AG3[generateSchema]
+        AG3 -->|normalizeInputsToJsonSchemaAsync| I
+        S -->|Resolved Input Schema| AG4[Zod Schema for AI]
+        AG4 -->|Tool Definition| AG5[LangChain StructuredTool]
+        AG5 -->|Function Calling| AG6[AI Model]
+        AG6 -->|Validated Parameters| AG7[Workflow Execution]
+        
+        AG8[Workflow Output Schema] -->|outputSchema property| AG9[AI Structured Output]
+        AG9 -->|Expected Response Format| AG6
+        AG7 -->|Validated Results| AG10[AI Agent Response]
+    end
+
+    subgraph "Business Value"
+        V1[🔄 Schema Reusability<br/>DRY Principle<br/>Share across workflows]
+        V2[📦 Centralized Management<br/>Single Source of Truth<br/>Update once, propagate everywhere]
+        V3[🛡️ Type Safety<br/>Compile-time & Runtime<br/>Validation at multiple layers]
+        V4[⚡ Developer Experience<br/>Autocomplete, Validation<br/>Real-time feedback]
+        V5[📋 Standards Compliance<br/>JSON Schema Spec<br/>Industry-standard approach]
+        V6[🔧 Maintainability<br/>Version Control<br/>Schema evolution support]
+        V7[🤖 AI Agent Integration<br/>Dynamic Tool Discovery<br/>Type-safe AI workflows]
+        V8[🔍 Schema Discovery<br/>Remote Registry Access<br/>Self-documenting APIs]
+    end
+
+    T1 --> V3
+    T2 --> V4
+    T3 --> V4
+    T4 --> V1
+    T5 --> V2
+    S --> V5
+    S --> V6
+    AG4 --> V7
+    AG9 --> V7
+    AG2 --> V8
+    O1 --> V8
+    O2 --> V8
+
+    D -.->|Example| I
+    E -.->|Example| I
+    F -.->|Example| I
+    G -.->|Example| I
+    H -.->|Example| I
+
+    style A fill:#4a90e2,stroke:#1e3a8a,stroke-width:2px
+    style S fill:#10b981,stroke:#065f46,stroke-width:3px
+    style V1 fill:#fbbf24,stroke:#92400e,stroke-width:2px
+    style V2 fill:#fbbf24,stroke:#92400e,stroke-width:2px
+    style V3 fill:#fbbf24,stroke:#92400e,stroke-width:2px
+    style V4 fill:#fbbf24,stroke:#92400e,stroke-width:2px
+    style V5 fill:#fbbf24,stroke:#92400e,stroke-width:2px
+    style V6 fill:#fbbf24,stroke:#92400e,stroke-width:2px
+    style V7 fill:#a78bfa,stroke:#5b21b6,stroke-width:2px
+    style V8 fill:#a78bfa,stroke:#5b21b6,stroke-width:2px
+    style AG1 fill:#c084fc,stroke:#6b21a8,stroke-width:2px
+    style AG6 fill:#c084fc,stroke:#6b21a8,stroke-width:2px
+    style AG10 fill:#c084fc,stroke:#6b21a8,stroke-width:2px
+    style O1 fill:#fb923c,stroke:#9a3412,stroke-width:2px
+    style O2 fill:#fb923c,stroke:#9a3412,stroke-width:2px
+```
+
+## Key Architecture Components
+
+### 1. **Reference Resolution Engine**
+- **Entry Point**: `normalizeInputsToJsonSchemaAsync()`
+- **Remote Resolution**: `resolveRemoteRefsInBrowser()` - Uses `fetch` API for cross-platform compatibility
+- **Local Resolution**: `$RefParser.dereference()` - Handles JSON Pointer resolution
+- **Optimization**: Early returns for schemas without references
+
+### 2. **Supported Reference Types**
+
+| Type | Pattern | Use Case | Example |
+|------|---------|----------|---------|
+| **Local** | `#/definitions/...` | Workflow-specific types | `$ref: "#/definitions/User"` |
+| **Remote HTTP** | `https://...` | External schema registry | `$ref: "https://api.example.com/schemas/user.json"` |
+| **Remote Fragment** | `https://...#/...` | Shared repository | `$ref: "https://api.example.com/schemas.json#/definitions/User"` |
+| **Internal API** | `/api/...` | Kibana types registry | `$ref: "/api/workflows/types-registry.json#/definitions/User"` |
+| **Relative** | `./...` or `../...` | Local file system | `$ref: "./schemas/address.json"` |
+
+### 3. **Integration Points**
+
+- **Frontend**: Monaco Editor autocomplete, form validation, default value pre-filling
+- **Backend**: Workflow execution context building, input validation
+- **Validation**: YAML schema validation, default value validation
+
+### 4. **AI Agent Tool Integration**
+
+When workflows are used as tools for AI agents, remote schema references provide critical capabilities:
+
+#### **Input Schema Discovery**
+- **Dynamic Tool Registration**: AI agents discover available workflows and their input requirements
+- **Schema Resolution**: Remote schemas are resolved to generate Zod schemas that AI models understand
+- **Type-Safe Parameters**: AI agents receive structured input schemas, ensuring correct parameter types
+- **Example Flow**:
+  ```typescript
+  // AI Agent discovers workflow tool
+  workflowTool.getSchema() 
+    → normalizeInputsToJsonSchemaAsync(workflow.inputs)
+    → resolveAllReferences() // Resolves remote $ref
+    → generateSchema() // Converts to Zod
+    → LangChain StructuredTool // AI can use it
+  ```
+
+#### **Output Schema Validation**
+- **Structured Output**: Workflows can define `outputSchema` to specify expected response format
+- **AI Model Compliance**: AI models use output schemas to generate structured responses
+- **Validation**: Output is validated against the schema before returning to the agent
+- **Example**:
+  ```yaml
+  - name: extract_data
+    type: ai_prompt
+    with:
+      prompt: "Extract information from {{ inputs.text }}"
+      outputSchema:
+        type: object
+        properties:
+          summary: { type: string }
+          key_points: { type: array, items: { type: string } }
+  ```
+
+#### **Benefits for AI Agents**
+- **Self-Documenting**: Remote schemas provide up-to-date documentation for AI agents
+- **Version Control**: Schema changes propagate automatically to all workflows using them
+- **Consistency**: Shared schemas ensure consistent data structures across workflows
+- **Discovery**: AI agents can query remote schema registries to discover available types
+- **Type Safety**: Prevents runtime errors by validating inputs/outputs at schema level
+
+### 5. **Value Propositions**
+
+- **Reusability**: Define once, use everywhere across workflows
+- **Centralization**: Single source of truth for type definitions
+- **Type Safety**: Multi-layer validation (compile-time + runtime)
+- **Developer Experience**: IntelliSense, autocomplete, real-time validation
+- **Standards Compliance**: Full JSON Schema specification support
+- **Maintainability**: Update schemas in one place, propagate automatically
+- **AI Agent Integration**: Dynamic tool discovery with type-safe schemas
+- **Schema Discovery**: Remote registry access enables self-documenting APIs
+
+## AI Agent Use Case Examples
+
+### Example 1: Workflow as AI Tool with Remote Input Schema
+
+```yaml
+# Workflow Definition
+name: Process User Data
+inputs:
+  properties:
+    user:
+      $ref: "https://api.example.com/schemas/v1/user.json"
+    address:
+      $ref: "/api/workflows/types-registry.json#/definitions/Address"
+```
+
+**AI Agent Flow**:
+1. Agent discovers workflow tool via registry
+2. Calls `getSchema()` which resolves remote `$ref` references
+3. Receives fully resolved Zod schema with all type information
+4. Uses schema to generate correct function call parameters
+5. Executes workflow with validated inputs
+
+### Example 2: Workflow with Structured Output Schema
+
+```yaml
+# Workflow with AI step that has output schema
+steps:
+  - name: analyze_sentiment
+    type: ai_prompt
+    with:
+      connectorId: "my-ai-connector"
+      prompt: "Analyze sentiment of: {{ inputs.text }}"
+      outputSchema:
+        $ref: "https://api.example.com/schemas/v1/sentiment-analysis.json"
+```
+
+**Benefits**:
+- AI model receives output schema from remote registry
+- Ensures consistent response format across all workflows
+- Schema updates automatically propagate to all workflows
+- AI agents can validate responses against expected schema
+
+### Example 3: Centralized Type Registry for AI Tools
+
+```yaml
+# Multiple workflows sharing the same schema
+# Workflow 1
+inputs:
+  properties:
+    incident:
+      $ref: "/api/workflows/types-registry.json#/definitions/Incident"
+
+# Workflow 2  
+inputs:
+  properties:
+    ticket:
+      $ref: "/api/workflows/types-registry.json#/definitions/Incident"
+```
+
+**AI Agent Benefits**:
+- Single source of truth for `Incident` type
+- AI agents learn consistent structure across all workflows
+- Schema changes update all workflows automatically
+- Reduces confusion from inconsistent type definitions
+
+### Example 4: Dynamic Schema Discovery
+
+```typescript
+// AI Agent discovers available schemas
+const schemaRegistry = await fetch('/api/workflows/types-registry.json');
+const availableTypes = schemaRegistry.definitions;
+
+// Agent can now understand what types are available
+// and suggest appropriate workflows to users
+```
+
+**Value**:
+- AI agents can query schema registry dynamically
+- Enables intelligent workflow recommendations
+- Supports schema evolution without breaking changes
+- Provides self-documenting API for AI systems

--- a/src/platform/packages/shared/kbn-workflows/spec/examples/example_remote_format_reference.yml
+++ b/src/platform/packages/shared/kbn-workflows/spec/examples/example_remote_format_reference.yml
@@ -1,0 +1,76 @@
+name: Remote Types Registry Reference Example
+description: Demonstrates remote JSON Schema reference using the local types registry
+enabled: true
+
+triggers:
+  - type: manual
+
+inputs:
+  properties:
+    # Example 1: Reference a type definition from the local types registry
+    # The registry is served at: http://localhost:5601/hdz/api/workflows/types-registry.json
+    # Note: Replace /hdz with your actual base path if different
+    user:
+      $ref: "http://localhost:5601/hdz/api/workflows/types-registry.json#/definitions/User"
+    
+    # Example 2: Reference another type from the registry
+    address:
+      $ref: "http://localhost:5601/hdz/api/workflows/types-registry.json#/definitions/Address"
+    
+    # Example 3: Reference contact information type
+    contact:
+      $ref: "http://localhost:5601/hdz/api/workflows/types-registry.json#/definitions/ContactInfo"
+    
+    # Example 4: Reference simple types
+    createdAt:
+      $ref: "http://localhost:5601/hdz/api/workflows/types-registry.json#/definitions/Timestamp"
+    
+    incidentId:
+      $ref: "http://localhost:5601/hdz/api/workflows/types-registry.json#/definitions/UUID"
+    
+    severity:
+      $ref: "http://localhost:5601/hdz/api/workflows/types-registry.json#/definitions/Severity"
+    
+    priority:
+      $ref: "http://localhost:5601/hdz/api/workflows/types-registry.json#/definitions/Priority"
+    
+    status:
+      $ref: "http://localhost:5601/hdz/api/workflows/types-registry.json#/definitions/Status"
+    
+    # Local reference example (still works alongside remote references)
+    localConfig:
+      $ref: "#/definitions/LocalConfig"
+  
+  definitions:
+    LocalConfig:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: true
+        timeout:
+          type: number
+          default: 30
+      required:
+        - enabled
+
+steps:
+  - name: print-user-info
+    type: console
+    with:
+      message: "User: {{ inputs.user.name }} ({{ inputs.user.email }}) - Role: {{ inputs.user.role }}"
+  
+  - name: print-address
+    type: console
+    with:
+      message: "Address: {{ inputs.address.street }}, {{ inputs.address.city }}, {{ inputs.address.state }} {{ inputs.address.zipCode }}"
+  
+  - name: print-contact
+    type: console
+    with:
+      message: "Contact: {{ inputs.contact.email }} - Website: {{ inputs.contact.website }}"
+  
+  - name: print-metadata
+    type: console
+    with:
+      message: "Incident ID: {{ inputs.incidentId }}, Severity: {{ inputs.severity }}, Priority: {{ inputs.priority }}, Status: {{ inputs.status }}, Created: {{ inputs.createdAt }}"

--- a/src/platform/packages/shared/kbn-workflows/spec/lib/input_conversion.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/input_conversion.test.ts
@@ -12,11 +12,12 @@ import {
   applyInputDefaults,
   convertLegacyInputsToJsonSchema,
   normalizeInputsToJsonSchema,
+  normalizeInputsToJsonSchemaAsync,
 } from './input_conversion';
 import type { WorkflowInputSchema } from '../schema';
 
 describe('convertLegacyInputsToJsonSchema', () => {
-  it('should convert array of legacy inputs to JSON Schema object format', () => {
+  it('should convert array of legacy inputs to JSON Schema object format', async () => {
     const legacyInputs = [
       {
         name: 'username',
@@ -53,7 +54,7 @@ describe('convertLegacyInputsToJsonSchema', () => {
     });
   });
 
-  it('should convert choice input to enum', () => {
+  it('should convert choice input to enum', async () => {
     const legacyInputs = [
       {
         name: 'status',
@@ -74,7 +75,7 @@ describe('convertLegacyInputsToJsonSchema', () => {
     expect(result.required).toEqual(['status']);
   });
 
-  it('should convert array input with constraints', () => {
+  it('should convert array input with constraints', async () => {
     const legacyInputs = [
       {
         name: 'tags',
@@ -98,7 +99,7 @@ describe('convertLegacyInputsToJsonSchema', () => {
     });
   });
 
-  it('should handle empty array', () => {
+  it('should handle empty array', async () => {
     const result = convertLegacyInputsToJsonSchema([]);
     expect(result).toEqual({
       properties: {},
@@ -106,7 +107,7 @@ describe('convertLegacyInputsToJsonSchema', () => {
     });
   });
 
-  it('should not include required array if no inputs are required', () => {
+  it('should not include required array if no inputs are required', async () => {
     const legacyInputs = [
       {
         name: 'optional',
@@ -122,7 +123,7 @@ describe('convertLegacyInputsToJsonSchema', () => {
     expect(result.required).toBeUndefined();
   });
 
-  it('should handle array with null items (partial YAML parsing)', () => {
+  it('should handle array with null items (partial YAML parsing)', async () => {
     const legacyInputs = [
       {
         name: 'username',
@@ -148,7 +149,7 @@ describe('convertLegacyInputsToJsonSchema', () => {
 });
 
 describe('normalizeInputsToJsonSchema', () => {
-  it('should return new format inputs as-is', () => {
+  it('should return new format inputs as-is', async () => {
     const inputs = {
       properties: {
         username: {
@@ -160,11 +161,11 @@ describe('normalizeInputsToJsonSchema', () => {
       additionalProperties: false,
     };
 
-    const result = normalizeInputsToJsonSchema(inputs);
+    const result = await normalizeInputsToJsonSchema(inputs);
     expect(result).toEqual(inputs);
   });
 
-  it('should convert legacy array format to new format', () => {
+  it('should convert legacy array format to new format', async () => {
     const legacyInputs = [
       {
         name: 'username',
@@ -173,7 +174,7 @@ describe('normalizeInputsToJsonSchema', () => {
       },
     ];
 
-    const result = normalizeInputsToJsonSchema(legacyInputs as any);
+    const result = await normalizeInputsToJsonSchema(legacyInputs as any);
 
     expect(result?.properties?.username).toEqual({
       type: 'string',
@@ -181,61 +182,61 @@ describe('normalizeInputsToJsonSchema', () => {
     expect(result?.required).toEqual(['username']);
   });
 
-  it('should return undefined for undefined input', () => {
-    const result = normalizeInputsToJsonSchema(undefined);
+  it('should return undefined for undefined input', async () => {
+    const result = await normalizeInputsToJsonSchema(undefined);
     expect(result).toBeUndefined();
   });
 
   describe('edge cases - partially parsed YAML (defensive checks)', () => {
-    it('should handle string input (partially typed "properties")', () => {
+    it('should handle string input (partially typed "properties")', async () => {
       // Simulates user typing "properties:" in YAML editor
-      const result = normalizeInputsToJsonSchema('properties' as any);
+      const result = await normalizeInputsToJsonSchema('properties' as any);
       expect(result).toBeUndefined();
     });
 
-    it('should handle number input', () => {
-      const result = normalizeInputsToJsonSchema(123 as any);
+    it('should handle number input', async () => {
+      const result = await normalizeInputsToJsonSchema(123 as any);
       expect(result).toBeUndefined();
     });
 
-    it('should handle boolean input', () => {
-      const result = normalizeInputsToJsonSchema(true as any);
+    it('should handle boolean input', async () => {
+      const result = await normalizeInputsToJsonSchema(true as any);
       expect(result).toBeUndefined();
     });
 
-    it('should handle null input', () => {
-      const result = normalizeInputsToJsonSchema(null as any);
+    it('should handle null input', async () => {
+      const result = await normalizeInputsToJsonSchema(null as any);
       expect(result).toBeUndefined();
     });
 
-    it('should handle empty string input', () => {
+    it('should handle empty string input', async () => {
       const result = normalizeInputsToJsonSchema('' as any);
       expect(result).toBeUndefined();
     });
 
-    it('should handle object without properties key', () => {
+    it('should handle object without properties key', async () => {
       const result = normalizeInputsToJsonSchema({ foo: 'bar' } as any);
       expect(result).toBeUndefined();
     });
 
-    it('should handle object with null properties', () => {
-      const result = normalizeInputsToJsonSchema({ properties: null } as any);
+    it('should handle object with null properties', async () => {
+      const result = await normalizeInputsToJsonSchema({ properties: null } as any);
       expect(result).toBeUndefined();
     });
 
-    it('should handle object with string properties', () => {
-      const result = normalizeInputsToJsonSchema({ properties: 'invalid' } as any);
+    it('should handle object with string properties', async () => {
+      const result = await normalizeInputsToJsonSchema({ properties: 'invalid' } as any);
       expect(result).toBeUndefined();
     });
 
-    it('should handle object with array properties (invalid)', () => {
-      const result = normalizeInputsToJsonSchema({ properties: [] } as any);
+    it('should handle object with array properties (invalid)', async () => {
+      const result = await normalizeInputsToJsonSchema({ properties: [] } as any);
       // Should return undefined or handle gracefully (array is not valid properties)
       expect(result).toBeUndefined();
     });
 
-    it('should handle object with properties containing null values', () => {
-      const result = normalizeInputsToJsonSchema({
+    it('should handle object with properties containing null values', async () => {
+      const result = await normalizeInputsToJsonSchema({
         properties: {
           name: null,
           age: { type: 'number' },
@@ -246,8 +247,8 @@ describe('normalizeInputsToJsonSchema', () => {
       expect(result?.properties?.age).toEqual({ type: 'number' });
     });
 
-    it('should handle object with properties containing string values (invalid schema)', () => {
-      const result = normalizeInputsToJsonSchema({
+    it('should handle object with properties containing string values (invalid schema)', async () => {
+      const result = await normalizeInputsToJsonSchema({
         properties: {
           name: 'invalid string schema',
           age: { type: 'number' },
@@ -257,8 +258,8 @@ describe('normalizeInputsToJsonSchema', () => {
       expect(result).toBeDefined();
     });
 
-    it('should handle deeply nested null values', () => {
-      const result = normalizeInputsToJsonSchema({
+    it('should handle deeply nested null values', async () => {
+      const result = await normalizeInputsToJsonSchema({
         properties: {
           user: {
             type: 'object',
@@ -274,7 +275,7 @@ describe('normalizeInputsToJsonSchema', () => {
     });
   });
 
-  it('should handle nested object example from requirements', () => {
+  it('should handle nested object example from requirements', async () => {
     const inputs = {
       properties: {
         customer: {
@@ -302,14 +303,14 @@ describe('normalizeInputsToJsonSchema', () => {
       additionalProperties: false,
     };
 
-    const result = normalizeInputsToJsonSchema(inputs);
+    const result = await normalizeInputsToJsonSchema(inputs);
     expect(result).toEqual(inputs);
   });
 });
 
 describe('applyInputDefaults', () => {
-  it('should apply defaults when inputs are undefined', () => {
-    const inputsSchema = normalizeInputsToJsonSchema({
+  it('should apply defaults when inputs are undefined', async () => {
+    const inputsSchema = await normalizeInputsToJsonSchema({
       properties: {
         name: { type: 'string', default: 'Default Name' },
         age: { type: 'number', default: 25 },
@@ -325,8 +326,8 @@ describe('applyInputDefaults', () => {
     });
   });
 
-  it('should apply defaults for missing properties', () => {
-    const inputsSchema = normalizeInputsToJsonSchema({
+  it('should apply defaults for missing properties', async () => {
+    const inputsSchema = await normalizeInputsToJsonSchema({
       properties: {
         name: { type: 'string', default: 'Default Name' },
         age: { type: 'number', default: 25 },
@@ -342,8 +343,8 @@ describe('applyInputDefaults', () => {
     });
   });
 
-  it('should apply defaults for nested objects', () => {
-    const inputsSchema = normalizeInputsToJsonSchema({
+  it('should apply defaults for nested objects', async () => {
+    const inputsSchema = await normalizeInputsToJsonSchema({
       properties: {
         analyst: {
           type: 'object',
@@ -370,8 +371,8 @@ describe('applyInputDefaults', () => {
     });
   });
 
-  it('should apply defaults for partial nested objects', () => {
-    const inputsSchema = normalizeInputsToJsonSchema({
+  it('should apply defaults for partial nested objects', async () => {
+    const inputsSchema = await normalizeInputsToJsonSchema({
       properties: {
         analyst: {
           type: 'object',
@@ -398,8 +399,8 @@ describe('applyInputDefaults', () => {
     });
   });
 
-  it('should apply defaults for arrays', () => {
-    const inputsSchema = normalizeInputsToJsonSchema({
+  it('should apply defaults for arrays', async () => {
+    const inputsSchema = await normalizeInputsToJsonSchema({
       properties: {
         notifyTeams: {
           type: 'array',
@@ -416,8 +417,8 @@ describe('applyInputDefaults', () => {
     });
   });
 
-  it('should apply defaults for $ref references', () => {
-    const inputsSchema = normalizeInputsToJsonSchema({
+  it('should apply defaults for $ref references', async () => {
+    const inputsSchema = await normalizeInputsToJsonSchema({
       properties: {
         user: {
           $ref: '#/definitions/UserSchema',
@@ -459,8 +460,8 @@ describe('applyInputDefaults', () => {
     });
   });
 
-  it('should pre-fill Threat Intelligence Enrichment workflow with all defaults', () => {
-    const inputsSchema = normalizeInputsToJsonSchema({
+  it('should pre-fill Threat Intelligence Enrichment workflow with all defaults', async () => {
+    const inputsSchema = await normalizeInputsToJsonSchema({
       properties: {
         analyst: {
           type: 'object',
@@ -634,8 +635,8 @@ describe('applyInputDefaults', () => {
     expect(result?.priority).toBe('P2');
   });
 
-  it('should handle the security workflow example with all defaults', () => {
-    const inputsSchema = normalizeInputsToJsonSchema({
+  it('should handle the security workflow example with all defaults', async () => {
+    const inputsSchema = await normalizeInputsToJsonSchema({
       properties: {
         analyst: {
           type: 'object',
@@ -708,6 +709,37 @@ describe('applyInputDefaults', () => {
         createTicket: true,
         notifyTeams: ['SOC', 'Management'],
       },
+    });
+  });
+
+  it('should work with simple legacy inputs workflow - regression test', async () => {
+    // Test the exact workflow scenario: legacy inputs with default
+    const legacyInputs = [
+      {
+        name: 'message',
+        type: 'string' as const,
+        default: 'hello world',
+      },
+    ];
+
+    // Step 1: Normalize legacy inputs to JSON Schema (async to resolve refs)
+    const normalizedSchema = await normalizeInputsToJsonSchemaAsync(
+      legacyInputs as Array<z.infer<typeof WorkflowInputSchema>>
+    );
+
+    expect(normalizedSchema).toBeDefined();
+    expect(normalizedSchema?.properties?.message).toEqual({
+      type: 'string',
+      default: 'hello world',
+    });
+
+    // Step 2: Apply defaults when no inputs provided
+    const inputsWithDefaults = applyInputDefaults(undefined, normalizedSchema);
+
+    // Debug: log what we got
+
+    expect(inputsWithDefaults).toEqual({
+      message: 'hello world',
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.ts
@@ -35,7 +35,7 @@ export class ConnectorStepImpl extends BaseAtomicNodeImplementation<ConnectorSte
     super(step, stepExecutionRuntime, connectorExecutor, workflowState);
   }
 
-  public getInput() {
+  public async getInput() {
     return this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(
       this.step.with || {}
     );
@@ -74,7 +74,7 @@ export class ConnectorStepImpl extends BaseAtomicNodeImplementation<ConnectorSte
         : withInputs;
 
       const connectorIdRendered =
-        this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(
+        await this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(
           step['connector-id']
         );
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/custom_step_impl.ts
@@ -45,7 +45,7 @@ export class CustomStepImpl extends BaseAtomicNodeImplementation<BaseStep> {
   /**
    * Get and validate the input for this step
    */
-  public override getInput(): unknown {
+  public override async getInput(): Promise<unknown> {
     const withData = this.node.configuration.with || {};
     return this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(withData);
   }
@@ -84,7 +84,7 @@ export class CustomStepImpl extends BaseAtomicNodeImplementation<BaseStep> {
         getScopedEsClient: () => {
           return this.stepExecutionRuntime.contextManager.getEsClientAsUser();
         },
-        renderInputTemplate: (value, additionalContext) => {
+        renderInputTemplate: async (value, additionalContext) => {
           return this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(
             value,
             additionalContext

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/data_set_step/data_set_step_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/data_set_step/data_set_step_impl.ts
@@ -35,7 +35,7 @@ export class DataSetStepImpl extends BaseAtomicNodeImplementation<DataSetStep> {
     super(dataSetStep, stepExecutionRuntime, undefined, workflowRuntime);
   }
 
-  public override getInput(): unknown {
+  public override async getInput(): Promise<unknown> {
     const withData = this.node.configuration.with || {};
     return this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(withData);
   }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/elasticsearch_action_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/elasticsearch_action_step.ts
@@ -33,7 +33,7 @@ export class ElasticsearchActionStepImpl extends BaseAtomicNodeImplementation<El
     super(step, contextManager, undefined, workflowRuntime);
   }
 
-  public getInput() {
+  public async getInput() {
     // Render inputs from 'with' - support both direct step.with and step.configuration.with
     const stepWith = this.step.with || (this.step as any).configuration?.with || {};
     return this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(stepWith);

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/enter_foreach_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/foreach_step/enter_foreach_node_impl.ts
@@ -35,7 +35,7 @@ export class EnterForeachNodeImpl implements NodeImplementation {
     this.stepExecutionRuntime.setInput({
       foreach: this.node.configuration.foreach,
     });
-    const evaluatedItems = this.getItems();
+    const evaluatedItems = await this.getItems();
 
     if (evaluatedItems.length === 0) {
       this.workflowLogger.logDebug(
@@ -96,9 +96,9 @@ export class EnterForeachNodeImpl implements NodeImplementation {
     this.wfExecutionRuntimeManager.navigateToNextNode();
   }
 
-  private getItems(): unknown[] {
+  private async getItems(): Promise<unknown[]> {
     const expression = this.node.configuration.foreach;
-    let resolvedValue = this.processForeachConfiguration();
+    let resolvedValue = await this.processForeachConfiguration();
 
     if (typeof resolvedValue === 'string') {
       try {
@@ -126,7 +126,7 @@ export class EnterForeachNodeImpl implements NodeImplementation {
     return resolvedValue;
   }
 
-  private processForeachConfiguration(): unknown {
+  private async processForeachConfiguration(): Promise<unknown> {
     const expression = this.node.configuration.foreach;
 
     if (!expression) {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/http_step/http_step_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/http_step/http_step_impl.ts
@@ -67,7 +67,7 @@ export class HttpStepImpl extends BaseAtomicNodeImplementation<HttpStep> {
     );
   }
 
-  public getInput() {
+  public async getInput() {
     const { url, method = 'GET', headers = {}, body, fetcher } = this.step.with;
 
     return this.stepExecutionRuntime.contextManager.renderValueAccordingToContext({
@@ -81,7 +81,7 @@ export class HttpStepImpl extends BaseAtomicNodeImplementation<HttpStep> {
 
   protected async _run(input: any): Promise<RunStepResult> {
     try {
-      return await this.executeHttpRequest(input);
+      return this.executeHttpRequest(input);
     } catch (error) {
       return this.handleFailure(input, error);
     }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/enter_if_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/if_step/enter_if_node_impl.ts
@@ -49,7 +49,9 @@ export class EnterIfNodeImpl implements NodeImplementation {
       (node) => !Object.hasOwn(node, 'condition')
     ) as EnterConditionBranchNode;
     const renderedCondition =
-      this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(thenNode.condition);
+      await this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(
+        thenNode.condition
+      );
     const evaluatedConditionResult = this.evaluateCondition(renderedCondition);
     this.stepExecutionRuntime.setInput({
       condition: renderedCondition,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/kibana_action_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/kibana_action_step.ts
@@ -45,7 +45,7 @@ export class KibanaActionStepImpl extends BaseAtomicNodeImplementation<KibanaAct
     super(step, stepExecutionRuntime, undefined, workflowRuntime);
   }
 
-  public getInput() {
+  public async getInput() {
     // Render inputs from 'with' - support both direct step.with and step.configuration.with
     const stepWith = this.step.with || (this.step as any).configuration?.with || {};
     return this.stepExecutionRuntime.contextManager.renderValueAccordingToContext(stepWith);

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
@@ -98,7 +98,7 @@ export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep>
     return this.step.name;
   }
 
-  public getInput(): any {
+  public async getInput(): Promise<any> {
     return {};
   }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/continue_step/enter_continue_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/continue_step/enter_continue_node_impl.ts
@@ -24,8 +24,8 @@ export class EnterContinueNodeImpl implements NodeImplementation, NodeWithErrorC
     this.workflowRuntime.navigateToNextNode();
   }
 
-  public catchError(failedContext: StepExecutionRuntime): void {
-    const shouldContinue = failedContext.contextManager.evaluateBooleanExpressionInContext(
+  public async catchError(failedContext: StepExecutionRuntime): Promise<void> {
+    const shouldContinue = await failedContext.contextManager.evaluateBooleanExpressionInContext(
       this.node.configuration.condition,
       {
         error: failedContext.stepExecution?.error,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/retry_step/enter_retry_node_impl.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/on_failure/retry_step/enter_retry_node_impl.ts
@@ -32,8 +32,8 @@ export class EnterRetryNodeImpl implements NodeImplementation, NodeWithErrorCatc
     this.advanceRetryAttempt();
   }
 
-  public catchError(failedContext: StepExecutionRuntime): void {
-    const shouldRetry = failedContext.contextManager.evaluateBooleanExpressionInContext(
+  public async catchError(failedContext: StepExecutionRuntime): Promise<void> {
+    const shouldRetry = await failedContext.contextManager.evaluateBooleanExpressionInContext(
       this.node.configuration.condition || true,
       {
         error: failedContext.getCurrentStepResult()?.error,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/build_workflow_context.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/build_workflow_context.test.ts
@@ -51,7 +51,7 @@ describe('buildWorkflowContext', () => {
   };
 
   describe('input default values', () => {
-    it('should merge default input values when inputs are not provided', () => {
+    it('should merge default input values when inputs are not provided', async () => {
       const workflowDefinition: WorkflowYaml = {
         name: 'Merge inputs into ctx',
         version: '1',
@@ -76,14 +76,14 @@ describe('buildWorkflowContext', () => {
         },
       };
 
-      const context = buildWorkflowContext(execution, undefined, dependencies);
+      const context = await buildWorkflowContext(execution, undefined, dependencies);
 
       expect(context.inputs).toEqual({
         inputWithDefault: 'defaultValue',
       });
     });
 
-    it('should override default values with provided inputs', () => {
+    it('should override default values with provided inputs', async () => {
       const workflowDefinition: WorkflowYaml = {
         name: 'Merge inputs into ctx',
         version: '1',
@@ -110,14 +110,14 @@ describe('buildWorkflowContext', () => {
         },
       };
 
-      const context = buildWorkflowContext(execution, undefined, dependencies);
+      const context = await buildWorkflowContext(execution, undefined, dependencies);
 
       expect(context.inputs).toEqual({
         inputWithDefault: 'customValue',
       });
     });
 
-    it('should apply defaults for missing inputs while preserving provided ones', () => {
+    it('should apply defaults for missing inputs while preserving provided ones', async () => {
       const workflowDefinition: WorkflowYaml = {
         name: 'Merge inputs into ctx',
         version: '1',
@@ -150,12 +150,63 @@ describe('buildWorkflowContext', () => {
         },
       };
 
-      const context = buildWorkflowContext(execution, undefined, dependencies);
+      const context = await buildWorkflowContext(execution, undefined, dependencies);
 
       expect(context.inputs).toEqual({
         inputWithDefault: 'customValue',
         anotherInput: 'anotherDefault',
       });
+    });
+
+    it('should apply defaults for simple legacy inputs workflow - regression test', async () => {
+      const workflowDefinition: WorkflowYaml = {
+        name: 'New workflow',
+        version: '1',
+        enabled: false,
+        description: 'This is a new workflow',
+        inputs: [
+          {
+            name: 'message',
+            type: 'string',
+            default: 'hello world',
+          },
+        ] as any,
+        consts: {},
+        triggers: [{ type: 'manual' }],
+        steps: [
+          {
+            name: 'hello_world_step',
+            type: 'console',
+            with: {
+              message: '{{ inputs.message }}',
+            },
+          } as any,
+        ],
+      };
+
+      const execution: EsWorkflowExecution = {
+        ...baseExecution,
+        workflowDefinition,
+        context: {
+          // No inputs provided - should use defaults
+        },
+      };
+
+      const context = await buildWorkflowContext(execution, undefined, dependencies);
+
+      // Verify inputs have default applied
+      expect(context.inputs).toEqual({
+        message: 'hello world',
+      });
+
+      // Verify the context can be used for template rendering
+      // This simulates what the console step does
+      const { WorkflowTemplatingEngine } = await import('../../templating_engine');
+      const templatingEngine = new WorkflowTemplatingEngine();
+      const renderedMessage = templatingEngine.render('{{ inputs.message }}', context);
+
+      // This is what the console step should receive
+      expect(renderedMessage).toBe('hello world');
     });
 
     it('should handle workflows without input defaults', () => {
@@ -185,14 +236,14 @@ describe('buildWorkflowContext', () => {
         },
       };
 
-      const context = buildWorkflowContext(execution, undefined, dependencies);
+      const context = await buildWorkflowContext(execution, undefined, dependencies);
 
       expect(context.inputs).toEqual({
         inputWithDefault: 'providedValue',
       });
     });
 
-    it('should return undefined inputs when there are no defaults and no provided inputs (backwards compatible)', () => {
+    it('should return undefined inputs when there are no defaults and no provided inputs (backwards compatible)', async () => {
       const workflowDefinition: WorkflowYaml = {
         name: 'Merge inputs into ctx',
         version: '1',
@@ -217,13 +268,13 @@ describe('buildWorkflowContext', () => {
         },
       };
 
-      const context = buildWorkflowContext(execution, undefined, dependencies);
+      const context = await buildWorkflowContext(execution, undefined, dependencies);
 
       // Backwards compatible: should return undefined when no defaults and no provided inputs
       expect(context.inputs).toBeUndefined();
     });
 
-    it('should handle empty inputs context', () => {
+    it('should handle empty inputs context', async () => {
       const workflowDefinition: WorkflowYaml = {
         name: 'Merge inputs into ctx',
         version: '1',
@@ -248,14 +299,14 @@ describe('buildWorkflowContext', () => {
         },
       };
 
-      const context = buildWorkflowContext(execution, undefined, dependencies);
+      const context = await buildWorkflowContext(execution, undefined, dependencies);
 
       expect(context.inputs).toEqual({
         inputWithDefault: 'defaultValue',
       });
     });
 
-    it('should handle different input types with defaults', () => {
+    it('should handle different input types with defaults', async () => {
       const workflowDefinition: WorkflowYaml = {
         name: 'Test Workflow',
         version: '1',
@@ -293,7 +344,7 @@ describe('buildWorkflowContext', () => {
         },
       };
 
-      const context = buildWorkflowContext(execution, undefined, dependencies);
+      const context = await buildWorkflowContext(execution, undefined, dependencies);
 
       expect(context.inputs).toEqual({
         count: 42,
@@ -302,7 +353,7 @@ describe('buildWorkflowContext', () => {
       });
     });
 
-    it('should handle empty provided inputs object (not undefined)', () => {
+    it('should handle empty provided inputs object (not undefined)', async () => {
       const workflowDefinition: WorkflowYaml = {
         name: 'Merge inputs into ctx',
         version: '1',
@@ -327,7 +378,7 @@ describe('buildWorkflowContext', () => {
         },
       };
 
-      const context = buildWorkflowContext(execution, undefined, dependencies);
+      const context = await buildWorkflowContext(execution, undefined, dependencies);
 
       // Should still apply defaults when providedInputs is empty object
       expect(context.inputs).toEqual({
@@ -335,7 +386,7 @@ describe('buildWorkflowContext', () => {
       });
     });
 
-    it('should handle workflow definition with undefined name and enabled', () => {
+    it('should handle workflow definition with undefined name and enabled', async () => {
       const execution: EsWorkflowExecution = {
         ...baseExecution,
         workflowDefinition: {
@@ -350,14 +401,14 @@ describe('buildWorkflowContext', () => {
         context: {},
       };
 
-      const context = buildWorkflowContext(execution, undefined, dependencies);
+      const context = await buildWorkflowContext(execution, undefined, dependencies);
 
       // Should use default values for undefined name and enabled
       expect(context.workflow.name).toBe('');
       expect(context.workflow.enabled).toBe(false);
     });
 
-    it('should handle workflow definition with undefined consts', () => {
+    it('should handle workflow definition with undefined consts', async () => {
       const execution: EsWorkflowExecution = {
         ...baseExecution,
         workflowDefinition: {
@@ -372,13 +423,13 @@ describe('buildWorkflowContext', () => {
         context: {},
       };
 
-      const context = buildWorkflowContext(execution, undefined, dependencies);
+      const context = await buildWorkflowContext(execution, undefined, dependencies);
 
       // Should use empty object for undefined consts
       expect(context.consts).toEqual({});
     });
 
-    it('should handle when workflowInputs parameter is undefined (uses default)', () => {
+    it('should handle when workflowInputs parameter is undefined (uses default)', async () => {
       const execution: EsWorkflowExecution = {
         ...baseExecution,
         workflowDefinition: {
@@ -397,7 +448,7 @@ describe('buildWorkflowContext', () => {
         },
       };
 
-      const context = buildWorkflowContext(execution, undefined, dependencies);
+      const context = await buildWorkflowContext(execution, undefined, dependencies);
 
       // Should handle undefined inputs array (uses default empty array)
       expect(context.inputs).toEqual({

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_runtime_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_runtime_manager.ts
@@ -400,7 +400,7 @@ export class WorkflowExecutionRuntimeManager {
       const finishDate = new Date();
       workflowExecutionUpdate.finishedAt = finishDate.toISOString();
       workflowExecutionUpdate.duration = finishDate.getTime() - startedAt.getTime();
-      workflowExecutionUpdate.context = buildWorkflowContext(
+      workflowExecutionUpdate.context = await buildWorkflowContext(
         this.workflowExecution,
         this.coreStart,
         this.dependencies

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/use_yaml_validation.ts
@@ -135,7 +135,7 @@ export function useYamlValidation(
             workflowDefinition,
             yamlDocument
           ),
-          ...validateJsonSchemaDefaults(yamlDocument, workflowDefinition, model)
+          ...(await validateJsonSchemaDefaults(yamlDocument, workflowDefinition, model))
         );
       }
 

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_json_schema_defaults.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_json_schema_defaults.ts
@@ -12,19 +12,23 @@ import type { Document } from 'yaml';
 import { isPair, isScalar, visit } from 'yaml';
 import type { monaco } from '@kbn/monaco';
 import type { WorkflowYaml } from '@kbn/workflows';
-import { normalizeInputsToJsonSchema, resolveRef } from '@kbn/workflows/spec/lib/input_conversion';
+import {
+  normalizeInputsToJsonSchemaAsync,
+  resolveRef,
+} from '@kbn/workflows/spec/lib/input_conversion';
 import { convertJsonSchemaToZod } from '../../../../common/lib/json_schema_to_zod';
 import { getPathFromAncestors } from '../../../../common/lib/yaml';
 import type { YamlValidationResult } from '../model/types';
 
 /**
  * Validates that default values in JSON Schema inputs match their property constraints
+ * Resolves remote $ref references for validation
  */
-export function validateJsonSchemaDefaults(
+export async function validateJsonSchemaDefaults(
   yamlDocument: Document | null,
   workflowDefinition: WorkflowYaml,
   model?: monaco.editor.ITextModel
-): YamlValidationResult[] {
+): Promise<YamlValidationResult[]> {
   const errors: YamlValidationResult[] = [];
 
   if (!yamlDocument) {
@@ -51,8 +55,8 @@ export function validateJsonSchemaDefaults(
     return errors;
   }
 
-  // Normalize inputs to JSON Schema format
-  const normalizedInputs = normalizeInputsToJsonSchema(inputs);
+  // Normalize inputs to JSON Schema format and resolve remote references
+  const normalizedInputs = await normalizeInputsToJsonSchemaAsync(inputs);
   // Defensive check: ensure normalizedInputs has valid properties object
   if (
     !normalizedInputs ||

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/use_context_override_data.ts
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/use_context_override_data.ts
@@ -32,7 +32,7 @@ export function useContextOverrideData() {
   const yamlString = useSelector(selectYamlString);
 
   const getContextOverrideData = useCallback(
-    (stepId: string): ContextOverrideData | null => {
+    async (stepId: string): Promise<ContextOverrideData | null> => {
       if (!workflowGraph || !workflowDefinition || !spaceId) {
         return null;
       }

--- a/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/workflow_detail/ui/workflow_detail_editor.tsx
@@ -109,7 +109,7 @@ export const WorkflowDetailEditor = React.memo<WorkflowDetailEditorProps>(({ hig
         return;
       }
 
-      const contextOverrideData = getContextOverrideData(params.stepId);
+      const contextOverrideData = await getContextOverrideData(params.stepId);
       if (!contextOverrideData) {
         return;
       }

--- a/src/platform/plugins/shared/workflows_management/public/shared/utils/build_step_context_override/build_step_context_override.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/utils/build_step_context_override/build_step_context_override.test.ts
@@ -22,7 +22,7 @@ describe('buildContextOverride', () => {
   };
 
   describe('with simple workflow', () => {
-    it('should return empty context when no inputs are found in graph', () => {
+    it('should return empty context when no inputs are found in graph', async () => {
       const simpleWorkflow = {
         version: '1' as const,
         name: 'test-workflow',
@@ -45,13 +45,13 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(simpleWorkflow);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       expect(result.stepContext).toEqual({});
       expect(result.schema).toBeDefined();
     });
 
-    it('should build context for step references', () => {
+    it('should build context for step references', async () => {
       const workflowWithStepReferences = {
         version: '1' as const,
         name: 'test-workflow',
@@ -81,7 +81,7 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithStepReferences);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       expect(result.stepContext).toEqual({
         steps: {
@@ -95,7 +95,7 @@ describe('buildContextOverride', () => {
       expect(result.schema).toBeDefined();
     });
 
-    it('should build context for nested step output references', () => {
+    it('should build context for nested step output references', async () => {
       const workflowWithNestedReferences = {
         version: '1' as const,
         name: 'test-workflow',
@@ -126,7 +126,7 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithNestedReferences);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       expect(result.stepContext).toEqual({
         steps: {
@@ -149,7 +149,7 @@ describe('buildContextOverride', () => {
       expect(result.schema).toBeDefined();
     });
 
-    it('should build context for foreach references', () => {
+    it('should build context for foreach references', async () => {
       const workflowWithForeach = {
         version: '1' as const,
         name: 'test-workflow',
@@ -181,7 +181,7 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithForeach);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       // The foreach step should extract inputs from the template expression
       expect(result.stepContext).toEqual({
@@ -196,7 +196,7 @@ describe('buildContextOverride', () => {
       expect(result.schema).toBeDefined();
     });
 
-    it('should build context for foreach variables when used in non-foreach steps', () => {
+    it('should build context for foreach variables when used in non-foreach steps', async () => {
       const workflowWithForeachUsage = {
         version: '1' as const,
         name: 'test-workflow',
@@ -220,7 +220,7 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithForeachUsage);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       expect(result.stepContext).toEqual({
         foreach: {
@@ -233,7 +233,7 @@ describe('buildContextOverride', () => {
       expect(result.schema).toBeDefined();
     });
 
-    it('should build context for workflow execution references', () => {
+    it('should build context for workflow execution references', async () => {
       const workflowWithExecutionRefs = {
         version: '1' as const,
         name: 'test-workflow',
@@ -257,7 +257,7 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithExecutionRefs);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       expect(result.stepContext).toEqual({
         execution: {
@@ -270,7 +270,7 @@ describe('buildContextOverride', () => {
       expect(result.schema).toBeDefined();
     });
 
-    it('should build context for mixed references', () => {
+    it('should build context for mixed references', async () => {
       const workflowWithMixedRefs = {
         version: '1' as const,
         name: 'test-workflow',
@@ -296,7 +296,7 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithMixedRefs);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       expect(result.stepContext).toEqual({
         steps: {
@@ -323,7 +323,7 @@ describe('buildContextOverride', () => {
       expect(result.schema).toBeDefined();
     });
 
-    it('should use input default values when inputsDefinition is provided', () => {
+    it('should use input default values when inputsDefinition is provided', async () => {
       const workflowWithInputs = {
         version: '1' as const,
         name: 'test-workflow',
@@ -356,7 +356,7 @@ describe('buildContextOverride', () => {
           { name: 'flag', type: 'boolean' as const, default: true },
         ],
       };
-      const result = buildContextOverride(workflowGraph, staticDataWithInputs);
+      const result = await buildContextOverride(workflowGraph, staticDataWithInputs);
 
       expect(result.stepContext).toEqual({
         inputs: {
@@ -368,7 +368,7 @@ describe('buildContextOverride', () => {
       expect(result.schema).toBeDefined();
     });
 
-    it('should fall back to placeholder for inputs without defaults', () => {
+    it('should fall back to placeholder for inputs without defaults', async () => {
       const workflowWithInputs = {
         version: '1' as const,
         name: 'test-workflow',
@@ -399,7 +399,7 @@ describe('buildContextOverride', () => {
           { name: 'messageWithoutDefault', type: 'string' as const },
         ],
       };
-      const result = buildContextOverride(workflowGraph, staticDataWithInputs);
+      const result = await buildContextOverride(workflowGraph, staticDataWithInputs);
 
       expect(result.stepContext).toEqual({
         inputs: {
@@ -410,7 +410,7 @@ describe('buildContextOverride', () => {
       expect(result.schema).toBeDefined();
     });
 
-    it('should handle array input defaults', () => {
+    it('should handle array input defaults', async () => {
       const workflowWithArrayInput = {
         version: '1' as const,
         name: 'test-workflow',
@@ -439,7 +439,7 @@ describe('buildContextOverride', () => {
           { name: 'tags', type: 'array' as const, default: ['tag1', 'tag2', 'tag3'] },
         ],
       };
-      const result = buildContextOverride(workflowGraph, staticDataWithInputs);
+      const result = await buildContextOverride(workflowGraph, staticDataWithInputs);
 
       expect(result.stepContext).toEqual({
         inputs: {
@@ -449,7 +449,7 @@ describe('buildContextOverride', () => {
       expect(result.schema).toBeDefined();
     });
 
-    it('should handle choice input defaults', () => {
+    it('should handle choice input defaults', async () => {
       const workflowWithChoiceInput = {
         version: '1' as const,
         name: 'test-workflow',
@@ -483,7 +483,7 @@ describe('buildContextOverride', () => {
           },
         ],
       };
-      const result = buildContextOverride(workflowGraph, staticDataWithInputs);
+      const result = await buildContextOverride(workflowGraph, staticDataWithInputs);
 
       expect(result.stepContext).toEqual({
         inputs: {
@@ -493,7 +493,7 @@ describe('buildContextOverride', () => {
       expect(result.schema).toBeDefined();
     });
 
-    it('should use input default values when inputsDefinition is provided in JSON Schema format', () => {
+    it('should use input default values when inputsDefinition is provided in JSON Schema format', async () => {
       const workflowWithInputs = {
         version: '1' as const,
         name: 'test-workflow',
@@ -538,7 +538,7 @@ describe('buildContextOverride', () => {
           additionalProperties: false,
         },
       };
-      const result = buildContextOverride(workflowGraph, staticDataWithInputs);
+      const result = await buildContextOverride(workflowGraph, staticDataWithInputs);
 
       expect(result.stepContext).toEqual({
         inputs: {
@@ -550,7 +550,7 @@ describe('buildContextOverride', () => {
       expect(result.schema).toBeDefined();
     });
 
-    it('should fall back to placeholder for JSON Schema inputs without defaults', () => {
+    it('should fall back to placeholder for JSON Schema inputs without defaults', async () => {
       const workflowWithInputs = {
         version: '1' as const,
         name: 'test-workflow',
@@ -589,7 +589,7 @@ describe('buildContextOverride', () => {
           additionalProperties: false,
         },
       };
-      const result = buildContextOverride(workflowGraph, staticDataWithInputs);
+      const result = await buildContextOverride(workflowGraph, staticDataWithInputs);
 
       expect(result.stepContext).toEqual({
         inputs: {
@@ -600,7 +600,7 @@ describe('buildContextOverride', () => {
       expect(result.schema).toBeDefined();
     });
 
-    it('should handle nested object defaults in JSON Schema format', () => {
+    it('should handle nested object defaults in JSON Schema format', async () => {
       const workflowWithNestedInputs = {
         version: '1' as const,
         name: 'test-workflow',
@@ -648,7 +648,7 @@ describe('buildContextOverride', () => {
           additionalProperties: false,
         },
       };
-      const result = buildContextOverride(workflowGraph, staticDataWithInputs);
+      const result = await buildContextOverride(workflowGraph, staticDataWithInputs);
 
       // Nested object defaults are now extracted using applyInputDefaults (same as exec modal)
       expect(result.stepContext).toEqual({
@@ -664,7 +664,7 @@ describe('buildContextOverride', () => {
   });
 
   describe('schema generation', () => {
-    it('should generate a valid zod schema that validates the mock data', () => {
+    it('should generate a valid zod schema that validates the mock data', async () => {
       const workflow = {
         version: '1' as const,
         name: 'test-workflow',
@@ -688,13 +688,13 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflow);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       // The schema should successfully parse the mock data
       expect(() => result.schema.parse(result.stepContext)).not.toThrow();
     });
 
-    it('should generate schema for array structures', () => {
+    it('should generate schema for array structures', async () => {
       const workflow = {
         version: '1' as const,
         name: 'test-workflow',
@@ -717,7 +717,7 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflow);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       expect(result.stepContext).toEqual({
         steps: {
@@ -739,7 +739,7 @@ describe('buildContextOverride', () => {
   });
 
   describe('edge cases', () => {
-    it('should handle empty workflow gracefully', () => {
+    it('should handle empty workflow gracefully', async () => {
       const emptyWorkflow = {
         version: '1' as const,
         name: 'empty-workflow',
@@ -749,14 +749,14 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(emptyWorkflow);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       expect(result.stepContext).toEqual({});
       expect(result.schema).toBeDefined();
       expect(() => result.schema.parse(result.stepContext)).not.toThrow();
     });
 
-    it('should handle duplicate step references', () => {
+    it('should handle duplicate step references', async () => {
       const workflowWithDuplicates = {
         version: '1' as const,
         name: 'test-workflow',
@@ -781,7 +781,7 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithDuplicates);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       expect(result.stepContext).toEqual({
         steps: {
@@ -795,7 +795,7 @@ describe('buildContextOverride', () => {
       });
     });
 
-    it('should handle deeply nested property paths', () => {
+    it('should handle deeply nested property paths', async () => {
       const workflowWithDeepNesting = {
         version: '1' as const,
         name: 'test-workflow',
@@ -818,7 +818,7 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithDeepNesting);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       expect(result.stepContext).toEqual({
         steps: {
@@ -841,7 +841,7 @@ describe('buildContextOverride', () => {
       });
     });
 
-    it('should handle multiple array indices', () => {
+    it('should handle multiple array indices', async () => {
       const workflowWithMultipleArrays = {
         version: '1' as const,
         name: 'test-workflow',
@@ -865,7 +865,7 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithMultipleArrays);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       expect(result.stepContext).toEqual({
         steps: {
@@ -889,7 +889,7 @@ describe('buildContextOverride', () => {
       });
     });
 
-    it('should handle complex property access with mixed notation', () => {
+    it('should handle complex property access with mixed notation', async () => {
       const workflowWithMixedNotation = {
         version: '1' as const,
         name: 'test-workflow',
@@ -912,7 +912,7 @@ describe('buildContextOverride', () => {
       };
 
       const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowWithMixedNotation);
-      const result = buildContextOverride(workflowGraph, mockStaticData);
+      const result = await buildContextOverride(workflowGraph, mockStaticData);
 
       expect(result.stepContext).toEqual({
         steps: {

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/get_suggestions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/get_suggestions.ts
@@ -24,6 +24,7 @@ import { getVariableSuggestions } from './variable/get_variable_suggestions';
 import { getPropertyHandler } from '../../../../../../common/schema';
 import type { ExtendedAutocompleteContext } from '../context/autocomplete.types';
 
+// eslint-disable-next-line complexity
 export async function getSuggestions(
   autocompleteContext: ExtendedAutocompleteContext
 ): Promise<monaco.languages.CompletionItem[]> {
@@ -160,7 +161,7 @@ export async function getSuggestions(
   //       enum: |<- (suggest enum values from schema)
   // This should be checked BEFORE other type completions to avoid conflicts
   // but AFTER variable/connector completions which are more specific
-  const jsonSchemaSuggestions = getJsonSchemaSuggestions(autocompleteContext);
+  const jsonSchemaSuggestions = await getJsonSchemaSuggestions(autocompleteContext);
   if (jsonSchemaSuggestions.length > 0) {
     return jsonSchemaSuggestions;
   }

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/json_schema/get_json_schema_suggestions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/lib/autocomplete/suggestions/json_schema/get_json_schema_suggestions.test.ts
@@ -53,13 +53,13 @@ describe('getJsonSchemaSuggestions', () => {
   };
 
   describe('property key suggestions', () => {
-    it('should provide property key suggestions on empty line after property definition', () => {
+    it('should provide property key suggestions on empty line after property definition', async () => {
       const context = createMockContext(
         ['inputs', 'properties'],
         '      ' // 6 spaces - empty line after property
       );
 
-      const suggestions = getJsonSchemaSuggestions(context);
+      const suggestions = await getJsonSchemaSuggestions(context);
 
       expect(suggestions.length).toBeGreaterThan(0);
       expect(suggestions.some((s) => s.label === 'type')).toBe(true);
@@ -67,25 +67,25 @@ describe('getJsonSchemaSuggestions', () => {
       expect(suggestions.some((s) => s.label === 'format')).toBe(true);
     });
 
-    it('should provide property key suggestions when typing property key', () => {
+    it('should provide property key suggestions when typing property key', async () => {
       const context = createMockContext(
         ['inputs', 'properties', 'x'],
         '      type' // typing "type"
       );
 
-      const suggestions = getJsonSchemaSuggestions(context);
+      const suggestions = await getJsonSchemaSuggestions(context);
 
       expect(suggestions.length).toBeGreaterThan(0);
       expect(suggestions.some((s) => s.label === 'type')).toBe(true);
     });
 
-    it('should NOT provide property key suggestions when line has property key with colon', () => {
+    it('should NOT provide property key suggestions when line has property key with colon', async () => {
       const context = createMockContext(
         ['inputs', 'properties'],
         '      type: ' // property key with colon - should show value suggestions instead
       );
 
-      const suggestions = getJsonSchemaSuggestions(context);
+      const suggestions = await getJsonSchemaSuggestions(context);
 
       // Should not have property key suggestions when we have "type: "
       expect(suggestions.some((s) => s.insertText === 'type: ')).toBe(false);
@@ -93,7 +93,7 @@ describe('getJsonSchemaSuggestions', () => {
   });
 
   describe('type value suggestions', () => {
-    it('should provide type value suggestions when typing after "type:"', () => {
+    it('should provide type value suggestions when typing after "type:"', async () => {
       const lineUpToCursor = '      type: ';
       const typeMatch = lineUpToCursor.match(/^(?<prefix>\s*-?\s*type:)\s*(?<value>.*)$/);
       const context = createMockContext(
@@ -110,7 +110,7 @@ describe('getJsonSchemaSuggestions', () => {
           : null
       );
 
-      const suggestions = getJsonSchemaSuggestions(context);
+      const suggestions = await getJsonSchemaSuggestions(context);
 
       expect(suggestions.length).toBeGreaterThan(0);
       expect(suggestions.some((s) => s.label === 'string')).toBe(true);
@@ -120,10 +120,10 @@ describe('getJsonSchemaSuggestions', () => {
   });
 
   describe('format value suggestions', () => {
-    it('should provide format value suggestions when typing after "format:"', () => {
+    it('should provide format value suggestions when typing after "format:"', async () => {
       const context = createMockContext(['inputs', 'properties', 'x'], '      format: ');
 
-      const suggestions = getJsonSchemaSuggestions(context);
+      const suggestions = await getJsonSchemaSuggestions(context);
 
       expect(suggestions.length).toBeGreaterThan(0);
       expect(suggestions.some((s) => s.label === 'email')).toBe(true);
@@ -133,7 +133,7 @@ describe('getJsonSchemaSuggestions', () => {
   });
 
   describe('empty path inference', () => {
-    it('should infer path from indentation when path is empty on empty line after property', () => {
+    it('should infer path from indentation when path is empty on empty line after property', async () => {
       const mockModel = {
         getLineContent: (lineNum: number) => {
           if (lineNum === 1) return '    x:';
@@ -146,14 +146,14 @@ describe('getJsonSchemaSuggestions', () => {
       context.model = mockModel;
       context.position = { lineNumber: 2, column: 7 } as any;
 
-      const suggestions = getJsonSchemaSuggestions(context);
+      const suggestions = await getJsonSchemaSuggestions(context);
 
       expect(suggestions.length).toBeGreaterThan(0);
       expect(suggestions.some((s) => s.label === 'type')).toBe(true);
       expect(suggestions.some((s) => s.label === 'default')).toBe(true);
     });
 
-    it('should infer path from properties line when path is empty', () => {
+    it('should infer path from properties line when path is empty', async () => {
       const mockModel = {
         getLineContent: (lineNum: number) => {
           if (lineNum === 1) return '  properties:';
@@ -166,26 +166,26 @@ describe('getJsonSchemaSuggestions', () => {
       context.model = mockModel;
       context.position = { lineNumber: 2, column: 7 } as any;
 
-      const suggestions = getJsonSchemaSuggestions(context);
+      const suggestions = await getJsonSchemaSuggestions(context);
 
       expect(suggestions.length).toBeGreaterThan(0);
     });
   });
 
   describe('context validation', () => {
-    it('should return empty array when not in inputs.properties context', () => {
+    it('should return empty array when not in inputs.properties context', async () => {
       const context = createMockContext(['steps'], '      ');
 
-      const suggestions = getJsonSchemaSuggestions(context);
+      const suggestions = await getJsonSchemaSuggestions(context);
 
       expect(suggestions).toEqual([]);
     });
 
-    it('should return empty array when in triggers context', () => {
+    it('should return empty array when in triggers context', async () => {
       const context = createMockContext(['inputs', 'properties', 'x'], '      type');
       context.isInTriggersContext = true;
 
-      const suggestions = getJsonSchemaSuggestions(context);
+      const suggestions = await getJsonSchemaSuggestions(context);
 
       expect(suggestions).toEqual([]);
     });

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_types_registry.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_types_registry.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { WORKFLOW_ROUTE_OPTIONS } from './route_constants';
+import { handleRouteError } from './route_error_handlers';
+import type { RouteDependencies } from './types';
+import { typesRegistry } from './types_registry_schema';
+
+/**
+ * Registers a route to serve the workflow types registry JSON Schema.
+ * This allows workflows to reference common type definitions via $ref.
+ *
+ * Example usage in workflow YAML:
+ * ```yaml
+ * inputs:
+ *   properties:
+ *     user:
+ *       $ref: "http://localhost:5601/hdz/api/workflows/types-registry.json#/definitions/User"
+ * ```
+ * Note: Replace /hdz with your actual base path if different
+ */
+export function registerGetTypesRegistryRoute({ router, logger }: RouteDependencies) {
+  logger.debug('Registering types registry route');
+  router.get(
+    {
+      path: '/api/workflows/types-registry.json',
+      options: {
+        ...WORKFLOW_ROUTE_OPTIONS,
+        tags: ['api', 'access:workflows-read'],
+        access: 'public', // Public route for schema resolution
+        httpResource: true, // Serves static JSON Schema resource
+        excludeFromRateLimiter: true,
+      },
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'Public read-only schema registry - no authorization required',
+        },
+        authc: {
+          enabled: false,
+          reason: 'Public read-only schema registry for JSON Schema reference resolution',
+        },
+      },
+      validate: false,
+    },
+    async (context, request, response) => {
+      try {
+        logger.debug('Serving types registry');
+        // Set proper content type for JSON Schema
+        return response.ok({
+          body: typesRegistry,
+          headers: {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'public, max-age=3600', // Cache for 1 hour
+            'Access-Control-Allow-Origin': '*', // Allow CORS for ref resolution
+          },
+        });
+      } catch (error) {
+        logger.error('Error serving types registry:', error);
+        return handleRouteError(response, error);
+      }
+    }
+  );
+}

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/index.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/index.ts
@@ -15,6 +15,7 @@ import { registerDeleteWorkflowByIdRoute } from './delete_workflow_by_id';
 import { registerDeleteWorkflowsBulkRoute } from './delete_workflows_bulk';
 import { registerGetConnectorsRoute } from './get_connectors';
 import { registerGetStepExecutionRoute } from './get_step_execution';
+import { registerGetTypesRegistryRoute } from './get_types_registry';
 import { registerGetWorkflowAggsRoute } from './get_workflow_aggs';
 import { registerGetWorkflowByIdRoute } from './get_workflow_by_id';
 import { registerGetWorkflowExecutionByIdRoute } from './get_workflow_execution_by_id';
@@ -62,4 +63,5 @@ export function defineRoutes(
   registerGetWorkflowExecutionLogsRoute(deps);
   registerGetStepExecutionRoute(deps);
   registerGetWorkflowJsonSchemaRoute(deps);
+  registerGetTypesRegistryRoute(deps);
 }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/types_registry_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/types_registry_schema.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { JSONSchema7 } from 'json-schema';
+
+/**
+ * Workflow Types Registry
+ *
+ * A centralized registry of reusable JSON Schema type definitions for workflows.
+ * This allows workflows to reference common types via $ref, promoting consistency
+ * and reducing duplication.
+ *
+ * Usage in workflow YAML:
+ * ```yaml
+ * inputs:
+ *   properties:
+ *     user:
+ *       $ref: "http://localhost:5601/hdz/api/workflows/types-registry.json#/definitions/User"
+ *     address:
+ *       $ref: "http://localhost:5601/hdz/api/workflows/types-registry.json#/definitions/Address"
+ * ```
+ * Note: Replace /hdz with your actual base path if different
+ *
+ * Best Practices:
+ * - Keep definitions focused and reusable
+ * - Use descriptive names
+ * - Include defaults where appropriate
+ * - Document with descriptions
+ * - Version the registry if breaking changes are needed
+ */
+export const typesRegistry: JSONSchema7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'http://localhost:5601/api/workflows/types-registry.json',
+  title: 'Workflow Types Registry',
+  description: 'Centralized registry of reusable JSON Schema type definitions for workflows',
+  definitions: {
+    User: {
+      type: 'object',
+      title: 'User',
+      description: 'A user with contact information',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Full name of the user',
+          default: 'John Doe',
+          minLength: 1,
+          maxLength: 100,
+        },
+        email: {
+          type: 'string',
+          format: 'email',
+          description: 'Email address (validated per RFC5321)',
+          default: 'user@example.com',
+        },
+        role: {
+          type: 'string',
+          enum: ['admin', 'user', 'viewer', 'editor'],
+          description: 'User role',
+          default: 'user',
+        },
+      },
+      required: ['name', 'email'],
+      additionalProperties: false,
+    },
+    Address: {
+      type: 'object',
+      title: 'Address',
+      description: 'Physical address information',
+      properties: {
+        street: {
+          type: 'string',
+          description: 'Street address',
+          default: '123 Main St',
+          minLength: 1,
+        },
+        city: {
+          type: 'string',
+          description: 'City name',
+          default: 'San Francisco',
+          minLength: 1,
+        },
+        state: {
+          type: 'string',
+          description: 'State or province',
+          default: 'CA',
+          minLength: 2,
+          maxLength: 2,
+        },
+        zipCode: {
+          type: 'string',
+          description: 'ZIP or postal code',
+          default: '94102',
+          pattern: '^\\d{5}(-\\d{4})?$',
+        },
+        country: {
+          type: 'string',
+          description: 'Country code (ISO 3166-1 alpha-2)',
+          default: 'US',
+          pattern: '^[A-Z]{2}$',
+        },
+      },
+      required: ['street', 'city', 'state', 'zipCode', 'country'],
+      additionalProperties: false,
+    },
+    ContactInfo: {
+      type: 'object',
+      title: 'Contact Information',
+      description: 'Contact details for a person or organization',
+      properties: {
+        email: {
+          type: 'string',
+          format: 'email',
+          description: 'Email address',
+          default: 'contact@example.com',
+        },
+        phone: {
+          type: 'string',
+          description: 'Phone number',
+          pattern: '^\\+?[1-9]\\d{1,14}$',
+        },
+        website: {
+          type: 'string',
+          format: 'uri',
+          description: 'Website URL',
+          default: 'https://example.com',
+        },
+      },
+      required: ['email'],
+      additionalProperties: false,
+    },
+    Timestamp: {
+      type: 'string',
+      format: 'date-time',
+      description: 'ISO 8601 timestamp (RFC3339)',
+      default: '2024-01-01T00:00:00Z',
+    },
+    UUID: {
+      type: 'string',
+      format: 'uuid',
+      description: 'Universally Unique Identifier (RFC4122)',
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+    },
+    Severity: {
+      type: 'string',
+      enum: ['low', 'medium', 'high', 'critical'],
+      description: 'Severity level',
+      default: 'medium',
+    },
+    Priority: {
+      type: 'string',
+      enum: ['P1', 'P2', 'P3', 'P4'],
+      description: 'Priority level (P1=Critical, P4=Low)',
+      default: 'P4',
+    },
+    Status: {
+      type: 'string',
+      enum: ['open', 'in-progress', 'resolved', 'closed'],
+      description: 'Status of an item',
+      default: 'open',
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Implements MVP support for remote JSON Schema references in workflow inputs, enabling schema reuse across workflows and integration with external schema registries. This feature allows workflows to reference schemas from remote URLs, internal APIs, and local definitions, following the JSON Schema specification.

## What's Changed

### Core Features
- ✅ Remote HTTP reference resolution (`https://api.example.com/schemas/user.json`)
- ✅ Remote fragment references (`https://api.example.com/schemas.json#/definitions/User`)
- ✅ Internal types registry API (`/api/workflows/types-registry.json#/definitions/User`)
- ✅ Local reference support (backward compatible with `#/definitions/User`)
- ✅ Async schema resolution with graceful error handling
- ✅ Monaco editor autocomplete for remote schema properties
- ✅ Zod validation with resolved schemas
- ✅ Default value application from remote schemas

### Technical Implementation

**Schema Resolution Pipeline:**
- Added `normalizeInputsToJsonSchemaAsync()` for async schema normalization
- Implemented `resolveRemoteRefsInBrowser()` using `fetch` API for cross-platform compatibility
- Enhanced `resolveAllReferences()` to handle both remote and local references
- Updated `buildWorkflowContext()` to use async resolution

**Types Registry:**
- New API endpoint: `GET /api/workflows/types-registry.json`
- Comprehensive schema definitions (User, Address, ContactInfo, Timestamp, UUID, Severity, Priority, Status)
- Serves as centralized schema repository for Kibana workflows

**Editor Integration:**
- Enhanced Monaco autocomplete to resolve remote `$ref` for property suggestions
- Updated variable suggestions to support remote schema properties
- Real-time schema resolution in editor context

**Validation:**
- Updated YAML validation to handle remote schema references
- Default value validation with resolved schemas
- Error handling for failed remote fetches

### Files Changed
- `input_conversion.ts` - Core resolution logic (354 lines added)
- `build_workflow_context.ts` - Async context building
- `workflow_execute_manual_form.tsx` - Form validation with resolved schemas
- `get_json_schema_suggestions.ts` - Autocomplete enhancements
- `get_types_registry.ts` - New API route
- `types_registry_schema.ts` - Schema definitions
- Test files updated with remote reference test cases

### Documentation
- Architecture diagram (`remote-schema-architecture-single.md`)
- AI agent integration use cases
- Example workflow (`example_remote_format_reference.yml`)

## Supported Reference Types

| Type | Pattern | Example |
|------|---------|---------|
| **Local** | `#/definitions/...` | `$ref: "#/definitions/User"` |
| **Remote HTTP** | `https://...` | `$ref: "https://api.example.com/schemas/user.json"` |
| **Remote Fragment** | `https://...#/...` | `$ref: "https://api.example.com/schemas.json#/definitions/User"` |
| **Internal API** | `/api/...` | `$ref: "/api/workflows/types-registry.json#/definitions/User"` |

## Testing

- ✅ Unit tests for remote reference resolution
- ✅ Test cases for HTTP fetch and fragment resolution
- ✅ Error handling tests for network failures
- ✅ Backward compatibility tests for local references
- ✅ Autocomplete tests for remote schema properties
- ✅ Validation tests with resolved schemas

## Breaking Changes

**None** - Fully backward compatible with existing local `#/definitions/...` references.

## Example Usage

inputs:
  properties:
    user:
      $ref: "/api/workflows/types-registry.json#/definitions/User"
    address:
      $ref: "/api/workflows/types-registry.json#/definitions/Address"
    contact:
      $ref: "/api/workflows/types-registry.json#/definitions/ContactInfo"
