### PR TITLE
Add a way to run storybooks pipeline only

### DIFF
--- a/.buildkite/pipelines/pull_request/storybooks_only.yml
+++ b/.buildkite/pipelines/pull_request/storybooks_only.yml
@@ -1,0 +1,9 @@
+steps:
+  - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
+    label: 'Build Storybooks Only'
+    agents:
+      machineType: n2-standard-8
+      preemptible: true
+    key: storybooks-only
+    timeout_in_minutes: 80
+    if: build.pull_request.draft == true && build.pull_request.labels includes "ci:build-storybooks-only"

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -376,6 +376,12 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/security_solution/explore.yml'));
     }
 
+    if (GITHUB_PR_LABELS.includes('ci:build-storybooks-only')) {
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/storybooks.yml', false));
+      emitPipeline(pipeline);
+      return;
+    }
+
     if (
       (await doAnyChangesMatch([
         /^package.json/,

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -376,8 +376,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/security_solution/explore.yml'));
     }
 
-    if (GITHUB_PR_LABELS.includes('ci:build-storybooks-only')) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/storybooks.yml', false));
+    // If the only label is "ci:build-storybooks-only", run just that pipeline
+    if (GITHUB_PR_LABELS === 'ci:build-storybooks-only') {
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/storybooks_only.yml', false));
       emitPipeline(pipeline);
       return;
     }

--- a/dev_docs/tutorials/ci.mdx
+++ b/dev_docs/tutorials/ci.mdx
@@ -122,3 +122,7 @@ Prevents an existing deployment from being shutdown due to inactivity.
 #### `ci:security-genai-run-evals`
 
 Run evaluations for the GenAI security evaluation suite.
+
+### `ci:build-storybooks-only`
+
+Build and upload storybooks, skipping unrelated CI steps.


### PR DESCRIPTION
## Summary

This PR adds a way to trigger a pipeline that only runs the `storybooks` pipeline by adding new `ci:build-storybooks-only` label to a pull request.

## Concerns

Adding this label should not allow to skip other CI steps and allow for merging. 


