### PR TITLE
Add Storybook checkbox to elasticmachine draft comment

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-storybooks-from-pr.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-storybooks-from-pr.yml
@@ -1,0 +1,33 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: bk-kibana-deploy-storybooks-from-pr
+  description: 'Build Storybooks from a PR'
+  links:
+    - url: 'https://buildkite.com/elastic/kibana-storybooks-from-pr'
+      title: Pipeline link
+spec:
+  type: buildkite-pipeline
+  system: buildkite
+  owner: 'group:appex-sharedux'
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: kibana / storybooks from PR
+      description: 'Builds Storybooks from a PR.'
+    spec:
+      pipeline_file: .buildkite/pipelines/storybooks_from_pr.yml
+      provider_settings:
+        build_pull_requests: true
+        prefix_pull_request_fork_branch_names: false
+        skip_pull_request_builds_for_existing_commits: true
+        trigger_mode: none
+      cancel_intermediate_builds: true
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'
+      teams:
+        platform-ui:
+          access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-storybooks-from-pr.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-storybooks-from-pr.yml
@@ -17,6 +17,7 @@ spec:
       name: kibana / storybooks from PR
       description: 'Builds Storybooks from a PR.'
     spec:
+      repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/storybooks_from_pr.yml
       provider_settings:
         build_pull_requests: true

--- a/.buildkite/pipeline-resource-definitions/kibana-storybooks-from-pr.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-storybooks-from-pr.yml
@@ -27,7 +27,11 @@ spec:
       env:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'
       teams:
-        platform-ui:
+        appex-sharedux:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: BUILD_AND_READ
+        kibana-operations:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana

--- a/.buildkite/pipeline-resource-definitions/locations.yml
+++ b/.buildkite/pipeline-resource-definitions/locations.yml
@@ -49,6 +49,7 @@ spec:
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
+    - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-storybooks-from-pr.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/scalability_testing-daily.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/security-solution-ess/gen-ai-evals.yml

--- a/.buildkite/pipelines/storybooks_from_pr.yml
+++ b/.buildkite/pipelines/storybooks_from_pr.yml
@@ -1,0 +1,21 @@
+steps:
+  - label: "Build Storybooks"
+    command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
+    agents:
+      machineType: n2-standard-8
+      preemptible: true
+    timeout_in_minutes: 80
+
+  - label: "Comment Storybooks URL"
+    command: |
+      STORYBOOK_URL=$(buildkite-agent meta-data get pr_comment:storybooks:head)
+      ts-node .buildkite/scripts/lifecycle/comment_on_pr.ts \
+        --message "$STORYBOOK_URL" \
+        --context "kibana-deploy-storybooks-from-pr" \
+        --clear-previous
+    agents:
+      provider: gcp
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      machineType: n2-standard-2
+    timeout_in_minutes: 5

--- a/.buildkite/pipelines/storybooks_from_pr.yml
+++ b/.buildkite/pipelines/storybooks_from_pr.yml
@@ -1,21 +1,9 @@
 steps:
   - label: "Build Storybooks"
-    command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
-    agents:
-      machineType: n2-standard-8
-      preemptible: true
-    timeout_in_minutes: 80
-
-  - label: "Comment Storybooks URL"
-    command: |
-      STORYBOOK_URL=$(buildkite-agent meta-data get pr_comment:storybooks:head)
-      ts-node .buildkite/scripts/lifecycle/comment_on_pr.ts \
-        --message "$STORYBOOK_URL" \
+    commands:
+      - .buildkite/scripts/steps/storybooks/build_and_upload.sh
+      - export STORYBOOK_URL=$(buildkite-agent meta-data get pr_comment:storybooks:head)
+      - ts-node .buildkite/scripts/lifecycle/comment_on_pr.ts \
+        --message "Storybook deployment $STORYBOOK_URL" \
         --context "kibana-deploy-storybooks-from-pr" \
         --clear-previous
-    agents:
-      provider: gcp
-      image: family/kibana-ubuntu-2404
-      imageProject: elastic-images-prod
-      machineType: n2-standard-2
-    timeout_in_minutes: 5

--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -132,6 +132,27 @@
     {
       "repoOwner": "elastic",
       "repoName": "kibana",
+      "pipelineSlug": "kibana-deploy-storybooks-from-pr",
+      "enabled": true,
+      "allow_org_users": true,
+      "allowed_repo_permissions": [
+        "admin",
+        "write"
+      ],
+      "allowed_list": [
+        "elastic-vault-github-plugin-prod[bot]"
+      ],
+      "set_commit_status": true,
+      "commit_status_context": "kibana-deploy-storybooks-from-pr",
+      "build_on_commit": false,
+      "build_on_comment": true,
+      "build_drafts": false,
+      "enable_trigger_checkbox": true,
+      "kibana_versions_check": true
+    },
+    {
+      "repoOwner": "elastic",
+      "repoName": "kibana",
       "pipelineSlug": "kibana-renovate-helper",
       "skip_ci_labels": [],
       "enabled": true,

--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -145,7 +145,6 @@
       "set_commit_status": true,
       "commit_status_context": "kibana-deploy-storybooks-from-pr",
       "build_on_commit": false,
-      "build_on_comment": true,
       "build_drafts": false,
       "enable_trigger_checkbox": true,
       "kibana_versions_check": true


### PR DESCRIPTION
## Summary

This PR adds a way to run `Build and deploy Storybooks` job from the comment elasticmachine leaves on draft PRs.



