### PR TITLE
[Discover] Fix app menu focus when closing background search flyout

### DIFF
--- a/src/platform/plugins/shared/data/public/search/search_service.ts
+++ b/src/platform/plugins/shared/data/public/search/search_service.ts
@@ -242,7 +242,6 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
       fieldFormats,
       dataViews,
       inspector,
-      screenshotMode,
       scriptedFieldsEnabled,
       share,
       cps,

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.test.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.test.tsx
@@ -52,6 +52,7 @@ const setup = () => {
   render(
     <IntlProvider>
       <Flyout
+        flyoutId="test"
         onClose={onClose}
         api={api}
         config={mockConfig}
@@ -83,15 +84,6 @@ describe('<Flyout />', () => {
     setup();
     expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument();
-  });
-
-  describe('when the header close button is clicked', () => {
-    it('calls the onClose callback', async () => {
-      const { onClose, user } = setup();
-      const closeButton = screen.getByLabelText('Close this dialog');
-      await user.click(closeButton);
-      expect(onClose).toHaveBeenCalled();
-    });
   });
 
   describe('when the footer close button is clicked', () => {

--- a/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.tsx
+++ b/src/platform/plugins/shared/data/public/search/session/sessions_mgmt/flyout/flyout.tsx
@@ -11,12 +11,10 @@ import {
   EuiBetaBadge,
   EuiButtonEmpty,
   EuiFlexGroup,
-  EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiTitle,
-  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -28,11 +26,10 @@ import { SearchSessionsMgmtTable } from '../components/table';
 import type { SearchUsageCollector } from '../../../collectors';
 import type { BackgroundSearchOpenedHandler, LocatorsStart } from '../types';
 import { getColumns } from './get_columns';
-import { FLYOUT_WIDTH } from './constants';
 import type { ISearchSessionEBTManager } from '../../ebt_manager';
 
 export const Flyout = ({
-  onClose,
+  flyoutId,
   api,
   coreStart,
   usageCollector,
@@ -43,8 +40,9 @@ export const Flyout = ({
   appId,
   trackingProps,
   onBackgroundSearchOpened,
+  onClose,
 }: {
-  onClose: () => void;
+  flyoutId: string;
   api: SearchSessionsMgmtAPI;
   coreStart: CoreStart;
   usageCollector: SearchUsageCollector;
@@ -55,14 +53,14 @@ export const Flyout = ({
   appId?: string;
   trackingProps: { openedFrom: string };
   onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
+  onClose: () => void;
 }) => {
-  const flyoutId = useGeneratedHtmlId();
   const technicalPreviewLabel = i18n.translate('data.session_mgmt.technical_preview_label', {
     defaultMessage: 'Technical preview',
   });
 
   return (
-    <EuiFlyout size={FLYOUT_WIDTH} aria-labelledby={flyoutId} onClose={onClose}>
+    <>
       <EuiFlyoutHeader hasBorder>
         <EuiFlexGroup alignItems="center">
           <EuiTitle id={flyoutId} size="m">
@@ -98,6 +96,6 @@ export const Flyout = ({
           <FormattedMessage id="data.session_mgmt.close_flyout" defaultMessage="Close" />
         </EuiButtonEmpty>
       </EuiFlyoutFooter>
-    </EuiFlyout>
+    </>
   );
 };

--- a/src/platform/plugins/shared/data/public/search/types.ts
+++ b/src/platform/plugins/shared/data/public/search/types.ts
@@ -75,6 +75,7 @@ export interface ISearchStart {
     appId: string;
     trackingProps: { openedFrom: string };
     onBackgroundSearchOpened?: BackgroundSearchOpenedHandler;
+    onClose?: () => void;
   }) => void;
   /**
    * Feature flag value to make it easier to use in different plugins

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_background_search_flyout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_background_search_flyout.tsx
@@ -7,15 +7,15 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { AppMenuItemType } from '@kbn/core-chrome-app-menu-components';
+import type { DiscoverAppMenuItemType, DiscoverAppMenuRunAction } from '@kbn/discover-utils';
 import { AppMenuActionId } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
 
 export const getBackgroundSearchFlyout = ({
   onClick,
 }: {
-  onClick: () => void;
-}): AppMenuItemType => {
+  onClick: DiscoverAppMenuRunAction;
+}): DiscoverAppMenuItemType => {
   return {
     id: AppMenuActionId.backgroundsearch,
     order: 6,

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -139,7 +139,7 @@ export const useTopNavLinks = ({
       services.capabilities.discover_v2.storeSearchSession
     ) {
       const backgroundSearchFlyoutMenuItem = getBackgroundSearchFlyout({
-        onClick: () => {
+        onClick: ({ context: { onFinishAction } }) => {
           services.data.search.showSearchSessionsFlyout({
             appId,
             trackingProps: { openedFrom: 'background search button' },
@@ -147,6 +147,7 @@ export const useTopNavLinks = ({
               event?.preventDefault();
               dispatch(internalStateActions.openSearchSessionInNewTab({ searchSession: session }));
             },
+            onClose: onFinishAction,
           });
         },
       });


### PR DESCRIPTION
## Summary

Noticed while testing #246156. It looks like closing the background search flyout in Discover doesn't return focus to the correct app menu button. This PR fixes that.

It also fixes an issue where `EuiFlyout` was rendered twice for the background search flyout (caused by passing another `EuiFlyout` into `coreStart.overlays.openFlyout`). Afaict this didn't actually affect any functionality other than displaying a duplicate flyout backdrop overlay, but made the `onClose` callback misbehave, so I fixed it.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.