### PR TITLE
[Discover] Fix readonly badge for new app menu

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/ui/header/header_breadcrumbs_badges.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header_breadcrumbs_badges.tsx
@@ -34,6 +34,7 @@ export const HeaderBreadcrumbsBadges = ({
       data-test-subj="header-breadcrumbs-badge-group"
       css={css`
         margin-left: ${isFirst ? euiTheme.size.xs : 0};
+        align-items: center;
       `}
     >
       {badges.map(createBadge)}

--- a/src/platform/plugins/shared/discover/public/application/discover_router.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/discover_router.test.tsx
@@ -6,13 +6,14 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
+
 import React from 'react';
 import { createMemoryHistory } from 'history';
-
-// Mock dependencies to avoid issues with external modules like monaco
-jest.mock('@kbn/kibana-react-plugin/public', () => ({
-  KibanaContextProvider: ({ children }: { children: React.ReactNode }) => children,
-}));
+import { render, screen } from '@testing-library/react';
+import { DiscoverRouter } from './discover_router';
+import { mockCustomizationContext } from '../customizations/__mocks__/customization_context';
+import { createDiscoverServicesMock } from '../__mocks__/services';
+import type { HistoryLocationState } from '../build_services';
 
 // Mock the component dependencies
 jest.mock('./context', () => ({
@@ -35,20 +36,19 @@ jest.mock('./not_found', () => ({
   NotFoundRoute: () => <div data-test-subj="not-found-route" />,
 }));
 
-// Import testing utilities after mocks
-import { render, screen } from '@testing-library/react';
-import { Router } from '@kbn/shared-ux-router';
-import { DiscoverRoutes } from './discover_router';
-import { mockCustomizationContext } from '../customizations/__mocks__/customization_context';
+const services = createDiscoverServicesMock();
 
 const renderWithRouter = (path: string) => {
-  const history = createMemoryHistory({
+  const history = createMemoryHistory<HistoryLocationState>({
     initialEntries: [path],
   });
+
   render(
-    <Router history={history}>
-      <DiscoverRoutes onAppLeave={jest.fn()} customizationContext={mockCustomizationContext} />
-    </Router>
+    <DiscoverRouter
+      services={{ ...services, history }}
+      onAppLeave={jest.fn()}
+      customizationContext={mockCustomizationContext}
+    />
   );
 
   return history;

--- a/src/platform/plugins/shared/discover/public/application/discover_router.tsx
+++ b/src/platform/plugins/shared/discover/public/application/discover_router.tsx
@@ -7,13 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { RouteProps } from 'react-router-dom';
 import { Redirect } from 'react-router-dom';
 import { Router, Routes, Route } from '@kbn/shared-ux-router';
-import React from 'react';
-import { EuiErrorBoundary } from '@elastic/eui';
+import type { PropsWithChildren } from 'react';
+import React, { useEffect } from 'react';
+import { EuiBetaBadge, EuiErrorBoundary } from '@elastic/eui';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
-import type { AppMountParameters } from '@kbn/core/public';
+import type { AppMountParameters, Capabilities } from '@kbn/core/public';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
+import type { ChromeBreadcrumbsBadge } from '@kbn/core-chrome-browser';
+import { i18n } from '@kbn/i18n';
 import { ContextAppRoute } from './context';
 import { SingleDocRoute } from './doc';
 import { NotFoundRoute } from './not_found';
@@ -21,6 +25,7 @@ import type { DiscoverServices } from '../build_services';
 import { ViewAlertRoute } from './view_alert';
 import type { DiscoverCustomizationContext } from '../customizations';
 import { DiscoverMainRoute } from './main';
+import { useDiscoverServices } from '../hooks/use_discover_services';
 
 export interface DiscoverRouterProps {
   services: DiscoverServices;
@@ -52,28 +57,73 @@ export const DiscoverRoutes = ({
 }: Pick<DiscoverRouterProps, 'customizationContext' | 'onAppLeave'>) => {
   return (
     <Routes>
-      <Route path="/context/:dataViewId/:id">
+      <DiscoverRoute path="/context/:dataViewId/:id">
         <ContextAppRoute />
-      </Route>
-      <Route
+      </DiscoverRoute>
+      <DiscoverRoute
         path="/doc/:dataView/:index/:type"
         render={(props) => (
           <Redirect to={`/doc/${props.match.params.dataView}/${props.match.params.index}`} />
         )}
       />
-      <Route path="/doc/:dataViewId/:index">
+      <DiscoverRoute path="/doc/:dataViewId/:index">
         <SingleDocRoute />
-      </Route>
-      <Route path="/viewAlert/:id">
+      </DiscoverRoute>
+      <DiscoverRoute path="/viewAlert/:id">
         <ViewAlertRoute />
-      </Route>
-      <Route path="/view/:id">
+      </DiscoverRoute>
+      <DiscoverRoute path="/view/:id">
         <DiscoverMainRoute {...routeProps} />
-      </Route>
-      <Route path="/" exact>
+      </DiscoverRoute>
+      <DiscoverRoute path="/" exact>
         <DiscoverMainRoute {...routeProps} />
-      </Route>
+      </DiscoverRoute>
       <NotFoundRoute />
     </Routes>
   );
 };
+
+const DiscoverRoute = ({ children, ...props }: PropsWithChildren<RouteProps>) => {
+  const { chrome, capabilities } = useDiscoverServices();
+
+  useEffect(() => {
+    const readOnlyBadge = getReadOnlyBadge({ capabilities });
+
+    if (readOnlyBadge) {
+      chrome.setBreadcrumbsBadges([readOnlyBadge]);
+    }
+
+    return () => {
+      chrome.setBreadcrumbsBadges([]);
+    };
+  }, [capabilities, chrome, props.path]);
+
+  return <Route {...props}>{children}</Route>;
+};
+
+export const getReadOnlyBadge = ({
+  capabilities,
+}: {
+  capabilities: Capabilities;
+}): ChromeBreadcrumbsBadge | undefined =>
+  capabilities.discover_v2.save
+    ? undefined
+    : {
+        badgeText: i18n.translate('discover.badge.readOnly.text', {
+          defaultMessage: 'Read only',
+        }),
+        renderCustomBadge: ({ badgeText }) => {
+          return (
+            <EuiBetaBadge
+              label={badgeText}
+              tooltipContent={i18n.translate('discover.badge.readOnly.tooltip', {
+                defaultMessage: 'Unable to save Discover sessions',
+              })}
+              color="hollow"
+              iconType="glasses"
+              data-test-subj="discover-readonly-badge"
+              css={{ display: 'block' }}
+            />
+          );
+        },
+      };

--- a/src/platform/plugins/shared/discover/public/application/discover_router.tsx
+++ b/src/platform/plugins/shared/discover/public/application/discover_router.tsx
@@ -51,8 +51,7 @@ export const DiscoverRouter = ({ services, ...routeProps }: DiscoverRouterProps)
   );
 };
 
-// this exists as a separate component to allow the tests to gather the routes
-export const DiscoverRoutes = ({
+const DiscoverRoutes = ({
   ...routeProps
 }: Pick<DiscoverRouterProps, 'customizationContext' | 'onAppLeave'>) => {
   return (

--- a/src/platform/plugins/shared/discover/public/application/index.tsx
+++ b/src/platform/plugins/shared/discover/public/application/index.tsx
@@ -8,7 +8,6 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import type { AppMountParameters } from '@kbn/core/public';
 import { DiscoverRouter } from './discover_router';
@@ -28,19 +27,7 @@ export const renderApp = ({
   services,
   customizationContext,
 }: RenderAppProps) => {
-  const { capabilities, chrome, data, core } = services;
-
-  if (!capabilities.discover_v2.save) {
-    chrome.setBadge({
-      text: i18n.translate('discover.badge.readOnly.text', {
-        defaultMessage: 'Read only',
-      }),
-      tooltip: i18n.translate('discover.badge.readOnly.tooltip', {
-        defaultMessage: 'Unable to save Discover sessions',
-      }),
-      iconType: 'glasses',
-    });
-  }
+  const { data, core } = services;
 
   const unmount = toMountPoint(
     <DiscoverRouter

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav_menu.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav_menu.tsx
@@ -23,6 +23,7 @@ import useObservable from 'react-use/lib/useObservable';
 import type { useDiscoverTopNav } from './use_discover_topnav';
 import type { DiscoverCustomizationContext } from '../../../../customizations';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
+import { getReadOnlyBadge } from '../../../discover_router';
 
 /**
  * We handle the top nav menu this way because we need to render it higher in the tree than
@@ -46,7 +47,7 @@ export const DiscoverTopNavMenuProvider = ({
   customizationContext,
   children,
 }: PropsWithChildren<{ customizationContext: DiscoverCustomizationContext }>) => {
-  const { chrome } = useDiscoverServices();
+  const { chrome, capabilities } = useDiscoverServices();
   const [topNavMenuContext] = useState<DiscoverTopNavMenuContext>(() => createTopNavMenuContext());
 
   const topNavBadges = useObservable(
@@ -59,12 +60,15 @@ export const DiscoverTopNavMenuProvider = ({
       return;
     }
 
-    chrome.setBreadcrumbsBadges(topNavBadges ?? []);
+    const readOnlyBadge = getReadOnlyBadge({ capabilities });
+    const badges = readOnlyBadge ? [readOnlyBadge] : [];
 
-    return () => {
-      chrome.setBreadcrumbsBadges([]);
-    };
-  }, [chrome, customizationContext.displayMode, topNavBadges]);
+    if (topNavBadges) {
+      badges.push(...topNavBadges);
+    }
+
+    chrome.setBreadcrumbsBadges(badges);
+  }, [capabilities, chrome, customizationContext.displayMode, topNavBadges]);
 
   useUnmount(() => {
     topNavMenuContext.topNavBadges$.next(undefined);

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
@@ -31,17 +31,6 @@ export const getTopNavBadges = ({
 
   const isManaged = stateContainer.savedSearchState.getState().managed;
 
-  if (services.spaces && !isMobile) {
-    entries.push({
-      badgeText: i18n.translate('discover.topNav.solutionViewTitle', {
-        defaultMessage: 'Check out context-aware Discover',
-      }),
-      renderCustomBadge: ({ badgeText }) => (
-        <SolutionsViewBadge badgeText={badgeText} services={services} />
-      ),
-    });
-  }
-
   if (isManaged) {
     entries.push(
       getManagedContentBadge(
@@ -51,6 +40,17 @@ export const getTopNavBadges = ({
         })
       )
     );
+  }
+
+  if (services.spaces && !isMobile) {
+    entries.push({
+      badgeText: i18n.translate('discover.topNav.solutionViewTitle', {
+        defaultMessage: 'Check out context-aware Discover',
+      }),
+      renderCustomBadge: ({ badgeText }) => (
+        <SolutionsViewBadge badgeText={badgeText} services={services} />
+      ),
+    });
   }
 
   return entries;

--- a/x-pack/platform/test/functional/apps/discover/group2/feature_controls/discover_security.ts
+++ b/x-pack/platform/test/functional/apps/discover/group2/feature_controls/discover_security.ts
@@ -183,6 +183,8 @@ export default function (ctx: FtrProviderContext) {
           full_name: 'test user',
         });
 
+        await security.forceLogout();
+
         await security.login('global_discover_read_user', 'global_discover_read_user-password', {
           expectSpaceSelector: true,
         });

--- a/x-pack/platform/test/functional/apps/discover/group2/feature_controls/discover_security.ts
+++ b/x-pack/platform/test/functional/apps/discover/group2/feature_controls/discover_security.ts
@@ -157,12 +157,6 @@ export default function (ctx: FtrProviderContext) {
 
     describe('global discover read-only privileges', () => {
       before(async () => {
-        await spaces.create({
-          id: 'readonly-solution-space',
-          name: 'Readonly Solution Space',
-          solution: 'oblt',
-        });
-
         await securityService.role.create('global_discover_read_role', {
           elasticsearch: {
             indices: [{ names: ['logstash-*'], privileges: ['read', 'view_index_metadata'] }],
@@ -183,13 +177,15 @@ export default function (ctx: FtrProviderContext) {
           full_name: 'test user',
         });
 
-        await security.forceLogout();
-
         await security.login('global_discover_read_user', 'global_discover_read_user-password', {
-          expectSpaceSelector: true,
+          expectSpaceSelector: false,
         });
 
-        await spaceSelector.clickSpaceCard('default');
+        await spaces.create({
+          id: 'readonly-solution-space',
+          name: 'Readonly Solution Space',
+          solution: 'oblt',
+        });
       });
 
       after(async () => {

--- a/x-pack/platform/test/functional/apps/discover/group2/feature_controls/discover_security.ts
+++ b/x-pack/platform/test/functional/apps/discover/group2/feature_controls/discover_security.ts
@@ -32,7 +32,6 @@ export default function (ctx: FtrProviderContext) {
     header,
     unifiedFieldList,
     exports,
-    spaceSelector,
   } = getPageObjects([
     'common',
     'error',
@@ -43,7 +42,6 @@ export default function (ctx: FtrProviderContext) {
     'header',
     'unifiedFieldList',
     'exports',
-    'spaceSelector',
   ]);
   const testSubjects = getService('testSubjects');
   const appsMenu = getService('appsMenu');

--- a/x-pack/platform/test/functional/apps/saved_query_management/feature_controls/create_security_tests.ts
+++ b/x-pack/platform/test/functional/apps/saved_query_management/feature_controls/create_security_tests.ts
@@ -33,6 +33,8 @@ export function createSecurityTests(
     const esArchiver = getService('esArchiver');
     const securityService = getService('security');
     const globalNav = getService('globalNav');
+    const kibanaServer = getService('kibanaServer');
+    const testSubjects = getService('testSubjects');
     const { common, discover, security, dashboard, maps, visualize, spaceSelector } =
       getPageObjects([
         'common',
@@ -43,7 +45,6 @@ export function createSecurityTests(
         'visualize',
         'spaceSelector',
       ]);
-    const kibanaServer = getService('kibanaServer');
 
     async function login(
       featureName: FeatureName,
@@ -107,6 +108,26 @@ export function createSecurityTests(
       }
     }
 
+    async function assertReadOnlyBadgeExists(appName: FeatureApp) {
+      switch (appName) {
+        case 'discover':
+          await testSubjects.existOrFail('discover-readonly-badge');
+          break;
+        default:
+          await globalNav.badgeExistsOrFail('Read only');
+      }
+    }
+
+    async function assertReadOnlyBadgeMissing(appName: FeatureApp) {
+      switch (appName) {
+        case 'discover':
+          await testSubjects.missingOrFail('discover-readonly-badge');
+          break;
+        default:
+          await globalNav.badgeMissingOrFail();
+      }
+    }
+
     describe('Security', () => {
       describe('App vs Global privilege', () => {
         featureConfigs.forEach(({ feature, app, hasImplicitSaveQueryManagement }) => {
@@ -149,7 +170,7 @@ export function createSecurityTests(
             });
 
             it('shows read-only badge', async () => {
-              await globalNav.badgeExistsOrFail('Read only');
+              await assertReadOnlyBadgeExists(app);
             });
 
             savedQuerySecurityUtils.shouldAllowSavingQueries();
@@ -167,7 +188,7 @@ export function createSecurityTests(
             });
 
             it('shows read-only badge', async () => {
-              await globalNav.badgeExistsOrFail('Read only');
+              await assertReadOnlyBadgeExists(app);
             });
 
             savedQuerySecurityUtils.shouldDisallowSavingButAllowLoadingSavedQueries();
@@ -184,7 +205,7 @@ export function createSecurityTests(
             });
 
             it('shows read-only badge', async () => {
-              await globalNav.badgeExistsOrFail('Read only');
+              await assertReadOnlyBadgeExists(app);
             });
 
             if (hasImplicitSaveQueryManagement) {
@@ -205,7 +226,7 @@ export function createSecurityTests(
             });
 
             it("doesn't show read-only badge", async () => {
-              await globalNav.badgeMissingOrFail();
+              await assertReadOnlyBadgeMissing(app);
             });
 
             savedQuerySecurityUtils.shouldAllowSavingQueries();
@@ -222,7 +243,7 @@ export function createSecurityTests(
             });
 
             it("doesn't show read-only badge", async () => {
-              await globalNav.badgeMissingOrFail();
+              await assertReadOnlyBadgeMissing(app);
             });
 
             if (hasImplicitSaveQueryManagement) {
@@ -243,7 +264,7 @@ export function createSecurityTests(
             });
 
             it("doesn't show read-only badge", async () => {
-              await globalNav.badgeMissingOrFail();
+              await assertReadOnlyBadgeMissing(app);
             });
 
             if (hasImplicitSaveQueryManagement) {


### PR DESCRIPTION
## Summary

Followup to #246156. This PR fixes the readonly badge in Discover, which was not showing in solution views after the new app menu changes. Since the `chrome.setBadge` API previously used doesn't work now that Discover's app menu is in the tabs bar, the code has been updated to use the same `chrome.setBreadcrumbsBadges` API that the managed and context awareness badges use.

The readonly badge should appear in the same circumstances as before but directly next to the breadcrumbs (always the first badge), whether in classic or solution view. It should remain there while in the main app, surrounding docs, or single doc, and be removed when leaving Discover. I've also reordered the managed badge to appear next to the readonly badge when both are visible.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

Closes: https://github.com/elastic/kibana-team/issues/2713