### PR TITLE
[inference] handle array type without items property

### DIFF
--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/tool_schema.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/tool_schema.ts
@@ -37,7 +37,7 @@ interface ToolSchemaTypeNumber extends ToolSchemaFragmentBase {
 
 interface ToolSchemaTypeArray extends ToolSchemaFragmentBase {
   type: 'array';
-  items: Exclude<ToolSchemaType, ToolSchemaTypeArray>;
+  items?: Exclude<ToolSchemaType, ToolSchemaTypeArray>;
 }
 
 /**
@@ -64,9 +64,10 @@ type FromToolSchemaObject<TToolSchemaObject extends ToolSchemaTypeObject> =
       >
     : never;
 
-type FromToolSchemaArray<TToolSchemaObject extends ToolSchemaTypeArray> = Array<
-  FromToolSchema<TToolSchemaObject['items']>
->;
+type FromToolSchemaArray<TToolSchemaObject extends ToolSchemaTypeArray> =
+  TToolSchemaObject['items'] extends Exclude<ToolSchemaType, ToolSchemaTypeArray>
+    ? Array<FromToolSchema<TToolSchemaObject['items']>>
+    : unknown[];
 
 type FromToolSchemaString<TToolSchemaString extends ToolSchemaTypeString> =
   TToolSchemaString extends { const: string }

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/convert_tools.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/convert_tools.ts
@@ -94,7 +94,7 @@ export function fixSchemaArrayProperties<T extends ToolSchemaType>(schemaPart: T
       description: schemaPart.description
         ? `${schemaPart.description}. Must be provided as a JSON array`
         : 'Must be provided as a JSON array',
-      items: schemaPart.items ? fixSchemaArrayProperties(schemaPart.items) : undefined,
+      items: schemaPart.items ? fixSchemaArrayProperties(schemaPart.items) : {},
     };
   }
 

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/convert_tools.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/convert_tools.ts
@@ -94,7 +94,7 @@ export function fixSchemaArrayProperties<T extends ToolSchemaType>(schemaPart: T
       description: schemaPart.description
         ? `${schemaPart.description}. Must be provided as a JSON array`
         : 'Must be provided as a JSON array',
-      items: fixSchemaArrayProperties(schemaPart.items),
+      items: schemaPart.items ? fixSchemaArrayProperties(schemaPart.items) : undefined,
     };
   }
 

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/gemini/gemini_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/gemini/gemini_adapter.ts
@@ -134,7 +134,8 @@ function toolSchemaToGemini({ schema }: { schema: ToolSchema }): Gemini.Function
         return {
           type: Gemini.SchemaType.ARRAY,
           description: def.description,
-          items: convertSchemaType({ def: def.items }),
+          // @ts-expect-error - items is optional (empty object means any)
+          items: def.items ? convertSchemaType({ def: def.items }) : {},
         };
       case 'object':
         return {


### PR DESCRIPTION
## Summary

Fix a bug which was causing a runtime error when using tools with `array` schema without an `items` property (which is somewhat valid JSON schema but somehow getting away in the schema types we use for inference)






<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->