### PR TITLE
[Security Solution][Attacks/Alerts][Attacks page][Table section] Design updates to the group component (#250119)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/index.test.tsx
@@ -16,6 +16,7 @@ import {
   ATTACK_GROUP_TEST_ID_SUFFIX,
   ATTACK_STATUS_TEST_ID_SUFFIX,
   ATTACK_SPARKLES_ICON_TEST_ID_SUFFIX,
+  EXPAND_ATTACK_BUTTON_TEST_ID,
 } from '.';
 
 jest.mock(
@@ -36,7 +37,11 @@ const mockAttack = getMockAttackDiscoveryAlerts()[0];
 describe('AttackGroupContent', () => {
   it('should render component with attack details', () => {
     const { getByTestId } = render(
-      <AttackGroupContent attack={mockAttack} dataTestSubj="test_id" />
+      <AttackGroupContent
+        attack={mockAttack}
+        dataTestSubj="test_id"
+        openAttackDetailsFlyout={jest.fn()}
+      />
     );
 
     expect(getByTestId(`test_id${ATTACK_GROUP_TEST_ID_SUFFIX}`)).toBeInTheDocument();
@@ -52,10 +57,32 @@ describe('AttackGroupContent', () => {
     expect(getByTestId('mock-subtitle')).toBeInTheDocument();
   });
 
+  it('should call openAttackDetailsFlyout when "Open attack details" button is clicked', () => {
+    const openAttackDetailsFlyoutMock = jest.fn();
+    const { getByTestId } = render(
+      <AttackGroupContent
+        attack={mockAttack}
+        dataTestSubj="test_id"
+        openAttackDetailsFlyout={openAttackDetailsFlyoutMock}
+      />
+    );
+
+    const button = getByTestId(EXPAND_ATTACK_BUTTON_TEST_ID);
+    expect(button).toBeInTheDocument();
+
+    button.click();
+
+    expect(openAttackDetailsFlyoutMock).toHaveBeenCalledTimes(1);
+  });
+
   it('should render an empty state when the attack title is empty', () => {
     const attackWithEmptyTitle = { ...mockAttack, title: '' };
     const { getByTestId } = render(
-      <AttackGroupContent attack={attackWithEmptyTitle} dataTestSubj="test_id" />
+      <AttackGroupContent
+        attack={attackWithEmptyTitle}
+        dataTestSubj="test_id"
+        openAttackDetailsFlyout={jest.fn()}
+      />
     );
 
     expect(getByTestId(`test_id${ATTACK_TITLE_TEST_ID_SUFFIX}`)).toBeEmptyDOMElement();
@@ -63,7 +90,12 @@ describe('AttackGroupContent', () => {
 
   it('should show anonymized values in title when showAnonymized is true', () => {
     const { getByTestId } = render(
-      <AttackGroupContent attack={mockAttack} dataTestSubj="test_id" showAnonymized />
+      <AttackGroupContent
+        attack={mockAttack}
+        dataTestSubj="test_id"
+        showAnonymized
+        openAttackDetailsFlyout={jest.fn()}
+      />
     );
 
     expect(getByTestId(`test_id${ATTACK_TITLE_TEST_ID_SUFFIX}`)).toHaveTextContent(
@@ -73,7 +105,12 @@ describe('AttackGroupContent', () => {
 
   it('should show original values in title when showAnonymized is false', () => {
     const { getByTestId } = render(
-      <AttackGroupContent attack={mockAttack} dataTestSubj="test_id" showAnonymized={false} />
+      <AttackGroupContent
+        attack={mockAttack}
+        dataTestSubj="test_id"
+        showAnonymized={false}
+        openAttackDetailsFlyout={jest.fn()}
+      />
     );
 
     expect(getByTestId(`test_id${ATTACK_TITLE_TEST_ID_SUFFIX}`)).toHaveTextContent(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/index.tsx
@@ -6,71 +6,109 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import {
   replaceAnonymizedValuesWithOriginalValues,
   type AttackDiscoveryAlert,
 } from '@kbn/elastic-assistant-common';
+import { i18n } from '@kbn/i18n';
 
 import { IconSparkles } from '../../../../../common/icons/sparkles';
 import { RuleStatus } from '../../../../../timelines/components/timeline/body/renderers/rule_status';
 import { Subtitle } from './subtitle';
+
+export const EXPAND_BUTTON_ARIAL_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.attacks.tableSection.expandButtonArialLabel',
+  {
+    defaultMessage: 'Open attack details',
+  }
+);
 
 export const ATTACK_GROUP_TEST_ID_SUFFIX = '-group-renderer' as const;
 export const ATTACK_TITLE_TEST_ID_SUFFIX = '-title' as const;
 export const ATTACK_DESCRIPTION_TEST_ID_SUFFIX = '-description' as const;
 export const ATTACK_STATUS_TEST_ID_SUFFIX = '-status' as const;
 export const ATTACK_SPARKLES_ICON_TEST_ID_SUFFIX = '-sparkles-icon' as const;
+export const EXPAND_ATTACK_BUTTON_TEST_ID = 'expand-attack-button';
 
-export const AttackGroupContent = React.memo<{
+export interface AttackGroupContentProps {
+  /** The attack alert object to display */
   attack: AttackDiscoveryAlert;
+  /** Optional data-test-subj prefix for testing */
   dataTestSubj?: string;
+  /** Whether to show anonymized values in the title and description */
   showAnonymized?: boolean;
-}>(({ attack, dataTestSubj, showAnonymized = false }) => {
-  const title = useMemo(
-    () =>
-      showAnonymized
-        ? attack.title
-        : replaceAnonymizedValuesWithOriginalValues({
-            messageContent: attack.title,
-            replacements: attack.replacements,
-          }),
-    [attack.replacements, attack.title, showAnonymized]
-  );
+  /** Callback to open the attack details flyout */
+  openAttackDetailsFlyout: () => void;
+}
 
-  return (
-    <EuiFlexGroup
-      data-test-subj={`${dataTestSubj}${ATTACK_GROUP_TEST_ID_SUFFIX}`}
-      direction="column"
-      gutterSize="s"
-    >
-      <EuiFlexItem grow={false}>
-        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
-          <EuiFlexItem grow={false}>
-            <EuiTitle data-test-subj={`${dataTestSubj}${ATTACK_TITLE_TEST_ID_SUFFIX}`} size="xs">
-              <h5>{title}</h5>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <IconSparkles
-              data-test-subj={`${dataTestSubj}${ATTACK_SPARKLES_ICON_TEST_ID_SUFFIX}`}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            data-test-subj={`${dataTestSubj}${ATTACK_STATUS_TEST_ID_SUFFIX}`}
+export const AttackGroupContent = React.memo<AttackGroupContentProps>(
+  ({ attack, dataTestSubj, showAnonymized = false, openAttackDetailsFlyout }) => {
+    const title = useMemo(
+      () =>
+        showAnonymized
+          ? attack.title
+          : replaceAnonymizedValuesWithOriginalValues({
+              messageContent: attack.title,
+              replacements: attack.replacements,
+            }),
+      [attack.replacements, attack.title, showAnonymized]
+    );
+
+    return (
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            aria-label={EXPAND_BUTTON_ARIAL_LABEL}
+            color="text"
+            data-test-subj={EXPAND_ATTACK_BUTTON_TEST_ID}
+            iconType="expand"
+            onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+              event.stopPropagation();
+              openAttackDetailsFlyout();
+            }}
+            size="s"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFlexGroup
+            data-test-subj={`${dataTestSubj}${ATTACK_GROUP_TEST_ID_SUFFIX}`}
+            direction="column"
+            gutterSize="s"
           >
-            <RuleStatus value={attack.alertWorkflowStatus} />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
-        data-test-subj={`${dataTestSubj}${ATTACK_DESCRIPTION_TEST_ID_SUFFIX}`}
-      >
-        <Subtitle attack={attack} showAnonymized={showAnonymized} />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  );
-});
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiTitle
+                    data-test-subj={`${dataTestSubj}${ATTACK_TITLE_TEST_ID_SUFFIX}`}
+                    size="xs"
+                  >
+                    <h5>{title}</h5>
+                  </EuiTitle>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <IconSparkles
+                    data-test-subj={`${dataTestSubj}${ATTACK_SPARKLES_ICON_TEST_ID_SUFFIX}`}
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                  data-test-subj={`${dataTestSubj}${ATTACK_STATUS_TEST_ID_SUFFIX}`}
+                >
+                  <RuleStatus value={attack.alertWorkflowStatus} />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem
+              grow={false}
+              data-test-subj={`${dataTestSubj}${ATTACK_DESCRIPTION_TEST_ID_SUFFIX}`}
+            >
+              <Subtitle attack={attack} showAnonymized={showAnonymized} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+);
 AttackGroupContent.displayName = 'AttackGroupContent';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.test.tsx
@@ -13,7 +13,7 @@ import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 
 import { TestProviders } from '../../../../common/mock';
 import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
-import { EXPAND_ATTACK_BUTTON_TEST_ID, TABLE_SECTION_TEST_ID, TableSection } from './table_section';
+import { TABLE_SECTION_TEST_ID, TableSection } from './table_section';
 import { useUserData } from '../../user_info';
 import { useListsConfig } from '../../../containers/detection_engine/lists/use_lists_config';
 import { useGetDefaultGroupTitleRenderers } from '../../../hooks/attacks/use_get_default_group_title_renderers';
@@ -21,7 +21,6 @@ import { useAttackGroupHandler } from '../../../hooks/attacks/use_attack_group_h
 import { GroupedAlertsTable } from '../../alerts_table/alerts_grouping';
 import type { AlertsGroupingAggregation } from '../../alerts_table/grouping_settings/types';
 import { ALERT_ATTACK_IDS } from '../../../../../common/field_maps/field_names';
-import { AttackDetailsRightPanelKey } from '../../../../flyout/attack_details/constants/panel_keys';
 import { groupingOptions, groupingSettings } from './grouping_configs';
 import { EmptyResultsPrompt } from './empty_results_prompt';
 
@@ -378,6 +377,7 @@ describe('<TableSection />', () => {
           getAttack: expect.any(Function),
           showAnonymized: false,
           isLoading: false,
+          openAttackDetailsFlyout: expect.any(Function),
         });
       });
     });
@@ -394,6 +394,7 @@ describe('<TableSection />', () => {
           getAttack: expect.any(Function),
           showAnonymized: false,
           isLoading: false,
+          openAttackDetailsFlyout: expect.any(Function),
         });
       });
 
@@ -410,6 +411,7 @@ describe('<TableSection />', () => {
           getAttack: expect.any(Function),
           showAnonymized: true,
           isLoading: false,
+          openAttackDetailsFlyout: expect.any(Function),
         });
       });
     });
@@ -435,6 +437,7 @@ describe('<TableSection />', () => {
           getAttack: expect.any(Function),
           showAnonymized: true,
           isLoading: false,
+          openAttackDetailsFlyout: expect.any(Function),
         });
       });
 
@@ -448,6 +451,7 @@ describe('<TableSection />', () => {
           getAttack: expect.any(Function),
           showAnonymized: false,
           isLoading: false,
+          openAttackDetailsFlyout: expect.any(Function),
         });
       });
     });
@@ -470,218 +474,6 @@ describe('<TableSection />', () => {
           hideOptionsTitle: true,
           enforcedGroups: [ALERT_ATTACK_IDS],
         });
-      });
-    });
-  });
-
-  describe('getAdditionalActionButtons', () => {
-    it('should return an empty array for null group buckets', async () => {
-      render(
-        <TestProviders>
-          <TableSection {...defaultProps} />
-        </TestProviders>
-      );
-
-      await waitFor(() => {
-        expect(GroupedAlertsTable).toHaveBeenCalled();
-      });
-
-      const [props] = (GroupedAlertsTable as unknown as jest.Mock).mock.calls[0];
-      const { getAdditionalActionButtons } = props;
-
-      const groupingBucket = {
-        key: ['some-key'],
-        doc_count: 10,
-        selectedGroup: 'some-group',
-        key_as_string: 'some-key',
-        isNullGroup: true,
-      };
-
-      expect(getAdditionalActionButtons('some-key', groupingBucket)).toEqual([]);
-    });
-
-    it('should return an expand button for non-null grouping buckets', async () => {
-      render(
-        <TestProviders>
-          <TableSection {...defaultProps} />
-        </TestProviders>
-      );
-
-      await waitFor(() => {
-        expect(GroupedAlertsTable).toHaveBeenCalled();
-      });
-
-      const [props] = (GroupedAlertsTable as unknown as jest.Mock).mock.calls[0];
-      const { getAdditionalActionButtons } = props;
-
-      const groupingBucket = {
-        key: ['some-key'],
-        doc_count: 10,
-        selectedGroup: 'some-group',
-        key_as_string: 'some-key',
-        isNullGroup: false,
-      };
-
-      const buttons = getAdditionalActionButtons('some-key', groupingBucket);
-      expect(buttons).toHaveLength(1);
-      expect(buttons[0].props['data-test-subj']).toBe(EXPAND_ATTACK_BUTTON_TEST_ID);
-    });
-
-    it('should return an empty array for non-grouping buckets', async () => {
-      render(
-        <TestProviders>
-          <TableSection {...defaultProps} />
-        </TestProviders>
-      );
-
-      await waitFor(() => {
-        expect(GroupedAlertsTable).toHaveBeenCalled();
-      });
-
-      const [props] = (GroupedAlertsTable as unknown as jest.Mock).mock.calls[0];
-      const { getAdditionalActionButtons } = props;
-
-      // Case 1: Not a grouping bucket (missing selectedGroup or key is not array)
-      const bucket1 = { key: 'k', doc_count: 1 };
-      const buttons1 = getAdditionalActionButtons('k', bucket1);
-      expect(buttons1).toEqual([]);
-    });
-
-    it('should call getAttack when expand button is clicked', async () => {
-      const getAttackMock = jest.fn();
-      mockUseAttackGroupHandler.mockReturnValue({
-        getAttack: getAttackMock,
-        isLoading: false,
-      });
-
-      render(
-        <TestProviders>
-          <TableSection {...defaultProps} />
-        </TestProviders>
-      );
-
-      await waitFor(() => {
-        expect(GroupedAlertsTable).toHaveBeenCalled();
-      });
-
-      const [props] = (GroupedAlertsTable as unknown as jest.Mock).mock.calls[0];
-      const { getAdditionalActionButtons } = props;
-
-      const groupingBucket = {
-        key: ['some-key'],
-        doc_count: 10,
-        selectedGroup: 'some-group',
-        key_as_string: 'some-key',
-        isNullGroup: false,
-      };
-
-      const buttons = getAdditionalActionButtons('some-key', groupingBucket);
-      const { getByTestId } = render(<div>{buttons}</div>);
-
-      const button = getByTestId(EXPAND_ATTACK_BUTTON_TEST_ID);
-      await act(async () => {
-        button.click();
-      });
-
-      expect(getAttackMock).toHaveBeenCalledWith('some-key', groupingBucket);
-    });
-
-    describe('openAttackDetailsFlyout', () => {
-      it('should call openFlyout with correct parameters when attack exists', async () => {
-        const openFlyoutMock = jest.fn();
-        mockUseExpandableFlyoutApi.mockReturnValue({
-          openFlyout: openFlyoutMock,
-        });
-
-        const mockAttack = { id: 'attack-123' };
-        const getAttackMock = jest.fn().mockReturnValue(mockAttack);
-        mockUseAttackGroupHandler.mockReturnValue({
-          getAttack: getAttackMock,
-          isLoading: false,
-        });
-
-        render(
-          <TestProviders>
-            <TableSection {...defaultProps} />
-          </TestProviders>
-        );
-
-        await waitFor(() => {
-          expect(GroupedAlertsTable).toHaveBeenCalled();
-        });
-
-        const [props] = (GroupedAlertsTable as unknown as jest.Mock).mock.calls[0];
-        const { getAdditionalActionButtons } = props;
-
-        const groupingBucket = {
-          key: ['attack-123'],
-          doc_count: 10,
-          selectedGroup: 'some-group',
-          key_as_string: 'attack-123',
-          isNullGroup: false,
-        };
-
-        const buttons = getAdditionalActionButtons('attack-123', groupingBucket);
-        const { getByTestId } = render(<div>{buttons}</div>);
-
-        const button = getByTestId(EXPAND_ATTACK_BUTTON_TEST_ID);
-        await act(async () => {
-          button.click();
-        });
-
-        expect(openFlyoutMock).toHaveBeenCalledWith({
-          right: {
-            id: AttackDetailsRightPanelKey,
-            params: {
-              attackId: 'attack-123',
-              indexName: dataView.getIndexPattern(),
-            },
-          },
-        });
-      });
-
-      it('should not call openFlyout when attack does not exist', async () => {
-        const openFlyoutMock = jest.fn();
-        mockUseExpandableFlyoutApi.mockReturnValue({
-          openFlyout: openFlyoutMock,
-        });
-
-        const getAttackMock = jest.fn().mockReturnValue(undefined);
-        mockUseAttackGroupHandler.mockReturnValue({
-          getAttack: getAttackMock,
-          isLoading: false,
-        });
-
-        render(
-          <TestProviders>
-            <TableSection {...defaultProps} />
-          </TestProviders>
-        );
-
-        await waitFor(() => {
-          expect(GroupedAlertsTable).toHaveBeenCalled();
-        });
-
-        const [props] = (GroupedAlertsTable as unknown as jest.Mock).mock.calls[0];
-        const { getAdditionalActionButtons } = props;
-
-        const groupingBucket = {
-          key: ['unknown-key'],
-          doc_count: 10,
-          selectedGroup: 'some-group',
-          key_as_string: 'unknown-key',
-          isNullGroup: false,
-        };
-
-        const buttons = getAdditionalActionButtons('unknown-key', groupingBucket);
-        const { getByTestId } = render(<div>{buttons}</div>);
-
-        const button = getByTestId(EXPAND_ATTACK_BUTTON_TEST_ID);
-        await act(async () => {
-          button.click();
-        });
-
-        expect(openFlyoutMock).not.toHaveBeenCalled();
       });
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/table_section.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { EuiButtonIcon, EuiSwitch } from '@elastic/eui';
+import { EuiSwitch } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { DataView } from '@kbn/data-views-plugin/common';
@@ -48,7 +48,6 @@ import * as i18n from './translations';
 import { buildConnectorIdFilter } from './filtering_configs';
 
 export const TABLE_SECTION_TEST_ID = 'attacks-page-table-section';
-export const EXPAND_ATTACK_BUTTON_TEST_ID = 'expand-attack-button';
 
 export interface TableSectionProps {
   /**
@@ -131,10 +130,31 @@ export const TableSection = React.memo(
 
     const [attackIds, setAttackIds] = useState<string[] | undefined>(undefined);
     const { getAttack, isLoading: isAttacksLoading } = useAttackGroupHandler({ attackIds });
+
+    const { openFlyout } = useExpandableFlyoutApi();
+    const openAttackDetailsFlyout = useCallback(
+      (selectedGroup: string, bucket: RawBucket<AlertsGroupingAggregation>) => {
+        const attack = getAttack(selectedGroup, bucket);
+        if (attack) {
+          openFlyout({
+            right: {
+              id: AttackDetailsRightPanelKey,
+              params: {
+                attackId: attack.id,
+                indexName: dataView.getIndexPattern(),
+              },
+            },
+          });
+        }
+      },
+      [dataView, getAttack, openFlyout]
+    );
+
     const { defaultGroupTitleRenderers } = useGetDefaultGroupTitleRenderers({
       getAttack,
       showAnonymized,
       isLoading: isAttacksLoading,
+      openAttackDetailsFlyout,
     });
 
     const onAggregationsChange = useCallback(
@@ -227,44 +247,6 @@ export const TableSection = React.memo(
       return dataView.toSpec(true);
     }, [dataView]);
 
-    const { openFlyout } = useExpandableFlyoutApi();
-    const openAttackDetailsFlyout = useCallback(
-      (selectedGroup: string, bucket: RawBucket<AlertsGroupingAggregation>) => {
-        const attack = getAttack(selectedGroup, bucket);
-        if (attack) {
-          openFlyout({
-            right: {
-              id: AttackDetailsRightPanelKey,
-              params: {
-                attackId: attack.id,
-                indexName: dataView.getIndexPattern(),
-              },
-            },
-          });
-        }
-      },
-      [dataView, getAttack, openFlyout]
-    );
-
-    const getAdditionalActionButtons = useCallback(
-      (selectedGroup: string, fieldBucket: RawBucket<AlertsGroupingAggregation>) => {
-        return !isGroupingBucket(fieldBucket) || fieldBucket.isNullGroup
-          ? []
-          : [
-              <EuiButtonIcon
-                key="expand-attack-button"
-                aria-label={i18n.EXPAND_BUTTON_ARIAL_LABEL}
-                data-test-subj={EXPAND_ATTACK_BUTTON_TEST_ID}
-                iconType="expand"
-                onClick={() => openAttackDetailsFlyout(selectedGroup, fieldBucket)}
-                size="s"
-                color="text"
-              />,
-            ];
-      },
-      [openAttackDetailsFlyout]
-    );
-
     const emptyGroupingComponent = useMemo(
       () => <EmptyResultsPrompt openSchedulesFlyout={openSchedulesFlyout} />,
       [openSchedulesFlyout]
@@ -291,7 +273,6 @@ export const TableSection = React.memo(
           additionalToolbarControls={[showAnonymizedSwitch]}
           pageScope={PageScope.attacks} // allow filtering and grouping by attack fields
           settings={groupingSettings}
-          getAdditionalActionButtons={getAdditionalActionButtons}
           emptyGroupingComponent={emptyGroupingComponent}
         />
       </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/translations.ts
@@ -14,13 +14,6 @@ export const SHOW_ANONYMIZED_LABEL = i18n.translate(
   }
 );
 
-export const EXPAND_BUTTON_ARIAL_LABEL = i18n.translate(
-  'xpack.securitySolution.detectionEngine.attacks.tableSection.expandButtonArialLabel',
-  {
-    defaultMessage: 'Open attack details',
-  }
-);
-
 export const LEARN_MORE = i18n.translate(
   'xpack.securitySolution.detectionEngine.attacks.emptyResults.learnMoreLink',
   {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/use_get_default_group_title_renderers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/use_get_default_group_title_renderers.test.tsx
@@ -15,7 +15,10 @@ import {
   ATTACK_GROUP_LOADING_SPINNER_TEST_ID,
   useGetDefaultGroupTitleRenderers,
 } from './use_get_default_group_title_renderers';
-import { ATTACK_TITLE_TEST_ID_SUFFIX } from '../../components/attacks/table/attack_group_content';
+import {
+  ATTACK_TITLE_TEST_ID_SUFFIX,
+  EXPAND_ATTACK_BUTTON_TEST_ID,
+} from '../../components/attacks/table/attack_group_content';
 
 jest.mock('@kbn/elastic-assistant', () => ({
   useAssistantContext: jest.fn(),
@@ -55,7 +58,10 @@ describe('useGetDefaultGroupTitleRenderers', () => {
     mockGetAttack.mockReturnValue(mockAttacks[0]);
 
     const { result } = renderHook(() =>
-      useGetDefaultGroupTitleRenderers({ getAttack: mockGetAttack })
+      useGetDefaultGroupTitleRenderers({
+        getAttack: mockGetAttack,
+        openAttackDetailsFlyout: jest.fn(),
+      })
     );
 
     const renderer = result.current.defaultGroupTitleRenderers;
@@ -74,7 +80,10 @@ describe('useGetDefaultGroupTitleRenderers', () => {
     mockGetAttack.mockReturnValue(undefined);
 
     const { result } = renderHook(() =>
-      useGetDefaultGroupTitleRenderers({ getAttack: mockGetAttack })
+      useGetDefaultGroupTitleRenderers({
+        getAttack: mockGetAttack,
+        openAttackDetailsFlyout: jest.fn(),
+      })
     );
 
     const renderer = result.current.defaultGroupTitleRenderers;
@@ -93,6 +102,7 @@ describe('useGetDefaultGroupTitleRenderers', () => {
         useGetDefaultGroupTitleRenderers({
           getAttack: mockGetAttack,
           showAnonymized: true,
+          openAttackDetailsFlyout: jest.fn(),
         })
       );
 
@@ -114,6 +124,7 @@ describe('useGetDefaultGroupTitleRenderers', () => {
         useGetDefaultGroupTitleRenderers({
           getAttack: mockGetAttack,
           showAnonymized: false,
+          openAttackDetailsFlyout: jest.fn(),
         })
       );
 
@@ -131,7 +142,10 @@ describe('useGetDefaultGroupTitleRenderers', () => {
       mockGetAttack.mockReturnValue(mockAttacks[0]);
 
       const { result } = renderHook(() =>
-        useGetDefaultGroupTitleRenderers({ getAttack: mockGetAttack })
+        useGetDefaultGroupTitleRenderers({
+          getAttack: mockGetAttack,
+          openAttackDetailsFlyout: jest.fn(),
+        })
       );
 
       const renderer = result.current.defaultGroupTitleRenderers;
@@ -151,6 +165,7 @@ describe('useGetDefaultGroupTitleRenderers', () => {
         useGetDefaultGroupTitleRenderers({
           getAttack: mockGetAttack,
           isLoading: true,
+          openAttackDetailsFlyout: jest.fn(),
         })
       );
 
@@ -168,6 +183,7 @@ describe('useGetDefaultGroupTitleRenderers', () => {
         useGetDefaultGroupTitleRenderers({
           getAttack: mockGetAttack,
           isLoading: false,
+          openAttackDetailsFlyout: jest.fn(),
         })
       );
 
@@ -186,6 +202,7 @@ describe('useGetDefaultGroupTitleRenderers', () => {
         useGetDefaultGroupTitleRenderers({
           getAttack: mockGetAttack,
           isLoading: true,
+          openAttackDetailsFlyout: jest.fn(),
         })
       );
 
@@ -195,6 +212,33 @@ describe('useGetDefaultGroupTitleRenderers', () => {
 
       const { getByTestId } = render(rendered as React.ReactElement);
       expect(getByTestId(ATTACK_GROUP_LOADING_SPINNER_TEST_ID)).toBeInTheDocument();
+    });
+  });
+
+  describe('openAttackDetailsFlyout prop', () => {
+    it('should be called when the attack title button is clicked', () => {
+      mockGetAttack.mockReturnValue(mockAttacks[0]);
+      const openAttackDetailsFlyout = jest.fn();
+
+      const { result } = renderHook(() =>
+        useGetDefaultGroupTitleRenderers({
+          getAttack: mockGetAttack,
+          openAttackDetailsFlyout,
+        })
+      );
+
+      const renderer = result.current.defaultGroupTitleRenderers;
+      const bucket = { key: [mockAttacks[0].id], doc_count: 1 };
+      const rendered = renderer(ALERT_ATTACK_IDS, bucket);
+
+      // We need to render the output to simulate the click on the AttackGroupContent
+      const { getByTestId } = render(rendered as React.ReactElement);
+
+      // The button ID is defined in attack_group_content/index.tsx
+      const button = getByTestId(EXPAND_ATTACK_BUTTON_TEST_ID);
+      button.click();
+
+      expect(openAttackDetailsFlyout).toHaveBeenCalledWith(ALERT_ATTACK_IDS, bucket);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/use_get_default_group_title_renderers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/use_get_default_group_title_renderers.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback } from 'react';
 import { EuiSkeletonLoading, EuiSkeletonRectangle, EuiSpacer } from '@elastic/eui';
-import type { GroupPanelRenderer } from '@kbn/grouping/src';
+import type { GroupPanelRenderer, RawBucket } from '@kbn/grouping/src';
 
 import type { AlertsGroupingAggregation } from '../../components/alerts_table/grouping_settings/types';
 import { AttackGroupContent } from '../../components/attacks/table/attack_group_content';
@@ -27,6 +27,12 @@ export interface UseGetDefaultGroupTitleRenderersProps {
 
   /** Indicates if the attack data is currently loading */
   isLoading?: boolean;
+
+  /** Helper function to open the flyout */
+  openAttackDetailsFlyout: (
+    selectedGroup: string,
+    bucket: RawBucket<AlertsGroupingAggregation>
+  ) => void;
 }
 
 /**
@@ -38,12 +44,14 @@ export interface UseGetDefaultGroupTitleRenderersProps {
  * @param props.getAttack - Helper function to retrieve attack details
  * @param props.showAnonymized - When true, displays anonymized values; when false, displays original values
  * @param props.isLoading - Indicates if the attack data is currently loading
+ * @param props.openAttackDetailsFlyout - Helper function to open the flyout
  * @returns An object containing the defaultGroupTitleRenderers function for rendering group titles
  */
 export const useGetDefaultGroupTitleRenderers = ({
   getAttack,
   showAnonymized,
   isLoading = false,
+  openAttackDetailsFlyout,
 }: UseGetDefaultGroupTitleRenderersProps) => {
   const defaultGroupTitleRenderers: GroupPanelRenderer<AlertsGroupingAggregation> = useCallback(
     (selectedGroup, bucket) => {
@@ -72,6 +80,7 @@ export const useGetDefaultGroupTitleRenderers = ({
                   attack={attack}
                   dataTestSubj="attack"
                   showAnonymized={showAnonymized}
+                  openAttackDetailsFlyout={() => openAttackDetailsFlyout(selectedGroup, bucket)}
                 />
               )}
             </>
@@ -79,7 +88,7 @@ export const useGetDefaultGroupTitleRenderers = ({
         />
       );
     },
-    [getAttack, showAnonymized, isLoading]
+    [getAttack, showAnonymized, isLoading, openAttackDetailsFlyout]
   );
 
   return { defaultGroupTitleRenderers };


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/250119

This PR updates the layout of the `AttackGroupContent` component by relocating the "Open Details" button. The button was previously injected via `getAdditionalActionButtons` but is now positioned directly in front of the title section, aligning with the updated design mockups.

**Updated mockups**:

<img width="3552" height="2232" alt="image (1)" src="https://github.com/user-attachments/assets/14ace06b-73b2-49ae-8785-239de8161528" />

## Screenshots

<img width="1885" height="1349" alt="Screenshot 2026-01-26 at 10 35 44" src="https://github.com/user-attachments/assets/3aca8d68-091b-47e8-9e41-2e51e7411469" />

## Feature Flag

> [!NOTE]
> The feature is hidden behind the feature flag (in `kibana.dev.yml`):

```
feature_flags.overrides:
  securitySolution.attacksAlertsAlignment: true
```
