### PR TITLE
[Streams] Do not surface temporary fields as modified in processing UI

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
@@ -173,15 +173,16 @@ export const simulateProcessing = async ({
   const otelStream = isOtelStream(stream);
 
   /* 4. Extract all the documents reports and processor metrics from the simulations */
-  const { docReports, processorsMetrics, finalDetectedFieldNames } = computePipelineSimulationResult(
-    pipelineSimulationResult.simulation,
-    ingestSimulationResult.simulation,
-    simulationData.docs,
-    params.body.processing,
-    Streams.WiredStream.Definition.is(stream),
-    otelStream,
-    streamFields
-  );
+  const { docReports, processorsMetrics, finalDetectedFieldNames } =
+    computePipelineSimulationResult(
+      pipelineSimulationResult.simulation,
+      ingestSimulationResult.simulation,
+      simulationData.docs,
+      params.body.processing,
+      Streams.WiredStream.Definition.is(stream),
+      otelStream,
+      streamFields
+    );
 
   /* 5. Extract valid detected fields with intelligent type suggestions from fieldsMetadataService */
   const detectedFields = await computeDetectedFields(


### PR DESCRIPTION
## 🍒 Summary

Fixes #248968

Temporary fields that are created and later removed during stream processing were being incorrectly shown in the "modified fields" tab of the processing UI. This happened because the code aggregated detected fields from ALL processor steps, including fields that were only transiently present during intermediate processing steps.

This change computes modified fields from the diff between the initial input document and the final simulated output only, ensuring temporary fields don't appear in the UI while preserving per-processor detection stats.

## 🛠️ Changes

- Add `computeFinalDetectedFields` function that compares initial input with final output for each document to identify fields that actually exist in the final state
- Update `computePipelineSimulationResult` to compute and return `finalDetectedFieldNames`
- Update `computeDetectedFields` to use final detected fields instead of aggregating from all processors' `detected_fields`
- Add API integration tests:
  - Test that temporary fields created and removed don't appear in top-level `detected_fields`
  - Test that ECS fields that only exist temporarily are not auto-configured

## 🎙️ Prompts

- Fix issue #248968: temporary fields surfaced in modified fields UI
- Compute detected fields from diff between initial and final document only

🤖 This pull request was assisted by Cursor