### PR TITLE
[Streams] Do not surface temporary fields as modified in processing UI

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
@@ -173,15 +173,16 @@ export const simulateProcessing = async ({
   const otelStream = isOtelStream(stream);
 
   /* 4. Extract all the documents reports and processor metrics from the simulations */
-  const { docReports, processorsMetrics, finalDetectedFieldNames } = computePipelineSimulationResult(
-    pipelineSimulationResult.simulation,
-    ingestSimulationResult.simulation,
-    simulationData.docs,
-    params.body.processing,
-    Streams.WiredStream.Definition.is(stream),
-    otelStream,
-    streamFields
-  );
+  const { docReports, processorsMetrics, finalDetectedFieldNames } =
+    computePipelineSimulationResult(
+      pipelineSimulationResult.simulation,
+      ingestSimulationResult.simulation,
+      simulationData.docs,
+      params.body.processing,
+      Streams.WiredStream.Definition.is(stream),
+      otelStream,
+      streamFields
+    );
 
   /* 5. Extract valid detected fields with intelligent type suggestions from fieldsMetadataService */
   const detectedFields = await computeDetectedFields(


### PR DESCRIPTION
## Summary

Fixes #248968

Temporary fields that are created and later removed during stream processing are no longer treated as **modified** fields by the processing UI. The fix computes the diff between the initial input document and the final simulated output, filtering out fields that only exist as intermediate values.

## Problem

The `computeDetectedFields` function was aggregating detected fields from ALL processor steps:

```javascript
const fields = Object.values(processorsMetrics).flatMap((metrics) => metrics.detected_fields);
```

This included fields that were created by one processor but removed by a subsequent processor, causing temporary "helper" fields to incorrectly appear in the UI's "Modified fields" list.

## Changes

- Added `computeFinalDetectedFields` function to compute the set of field names that exist in the final output by comparing initial vs final document state
- Updated `computeDetectedFields` to use the final detected field names instead of aggregating from all processor metrics
- Per-processor `detected_fields` in `processorsMetrics` still track individual processor changes for stats purposes

## Test plan

Added 2 new integration tests to verify:
- Temporary fields don't appear in top-level `detected_fields` when created and then removed
- ECS-like fields that only exist as temporary fields are not auto-configured as mapped

All 16 tests pass (14 existing + 2 new).