### PR TITLE
[8.19] [APM] Fix incorrect dependencies stats (#249434)

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator.ts
@@ -22,6 +22,12 @@ const KEY_FIELDS: Array<keyof ApmFields> = [
   'service.target.type',
 ];
 
+/**
+ * Simulates multiple spans aggregated into a single service_destination metric document.
+ * Import this constant in tests to calculate expected values.
+ */
+export const SPANS_PER_DESTINATION_METRIC = 5;
+
 export function createSpanMetricsAggregator(flushInterval: string) {
   return createApmMetricAggregator(
     {
@@ -44,17 +50,17 @@ export function createSpanMetricsAggregator(flushInterval: string) {
           'processor.name': 'metric',
           'span.destination.service.response_time.count': 0,
           'span.destination.service.response_time.sum.us': 0,
+          _doc_count: 0,
         };
       },
     },
     (metric, event) => {
-      metric['span.destination.service.response_time.count'] += 1;
-      metric['span.destination.service.response_time.sum.us'] += event['span.duration.us']!;
+      metric['span.destination.service.response_time.count'] += SPANS_PER_DESTINATION_METRIC;
+      metric['span.destination.service.response_time.sum.us'] += event['span.duration.us']
+        ? event['span.duration.us'] * SPANS_PER_DESTINATION_METRIC
+        : 0;
+      metric._doc_count += 1;
     },
-    (metric) => {
-      // @ts-expect-error
-      metric._doc_count = metric['span.destination.service.response_time.count'];
-      return metric;
-    }
+    (metric) => metric
   );
 }

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/test/scenarios/03_span_destination_metrics.test.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/test/scenarios/03_span_destination_metrics.test.ts
@@ -10,9 +10,24 @@
 import { apm, timerange, ApmFields } from '@kbn/apm-synthtrace-client';
 import { sortBy } from 'lodash';
 import { Readable } from 'stream';
-import { createSpanMetricsAggregator } from '../../lib/apm/aggregators/create_span_metrics_aggregator';
+import {
+  createSpanMetricsAggregator,
+  SPANS_PER_DESTINATION_METRIC,
+} from '../../lib/apm/aggregators/create_span_metrics_aggregator';
 import { awaitStream } from '../../lib/utils/wait_until_stream_finished';
 import { ToolingLog } from '@kbn/tooling-log';
+
+// Test parameters
+const SUCCESSFUL_RATE = 25;
+const FAILED_RATE = 50;
+const SUCCESSFUL_SPAN_DURATION = 1000;
+const FAILED_SPAN_DURATION = 500;
+
+// Expected values
+const SUCCESSFUL_TOTAL_COUNT = SUCCESSFUL_RATE * SPANS_PER_DESTINATION_METRIC;
+const FAILED_TOTAL_COUNT = FAILED_RATE * SPANS_PER_DESTINATION_METRIC;
+const SUCCESSFUL_TOTAL_DURATION = SUCCESSFUL_TOTAL_COUNT * SUCCESSFUL_SPAN_DURATION * 1000;
+const FAILED_TOTAL_DURATION = FAILED_TOTAL_COUNT * FAILED_SPAN_DURATION * 1000;
 
 describe('span destination metrics', () => {
   let events: Array<Record<string, any>>;
@@ -35,11 +50,11 @@ describe('span destination metrics', () => {
       ...Array.from(
         range
           .interval('1m')
-          .rate(25)
+          .rate(SUCCESSFUL_RATE)
           .generator((timestamp) =>
             javaInstance
               .transaction({ transactionName: 'GET /api/product/list' })
-              .duration(1000)
+              .duration(SUCCESSFUL_TOTAL_DURATION)
               .success()
               .timestamp(timestamp)
               .children(
@@ -50,7 +65,7 @@ describe('span destination metrics', () => {
                     spanSubtype: 'elasticsearch',
                   })
                   .timestamp(timestamp)
-                  .duration(1000)
+                  .duration(SUCCESSFUL_SPAN_DURATION)
                   .destination('elasticsearch')
                   .success()
               )
@@ -59,11 +74,11 @@ describe('span destination metrics', () => {
       ...Array.from(
         range
           .interval('1m')
-          .rate(50)
+          .rate(FAILED_RATE)
           .generator((timestamp) =>
             javaInstance
               .transaction({ transactionName: 'GET /api/product/list' })
-              .duration(1000)
+              .duration(SUCCESSFUL_SPAN_DURATION + FAILED_SPAN_DURATION)
               .failure()
               .timestamp(timestamp)
               .children(
@@ -74,13 +89,13 @@ describe('span destination metrics', () => {
                     spanSubtype: 'elasticsearch',
                   })
                   .timestamp(timestamp)
-                  .duration(1000)
+                  .duration(FAILED_SPAN_DURATION)
                   .destination('elasticsearch')
                   .failure(),
                 javaInstance
                   .span({ spanName: 'custom_operation', spanType: 'app' })
                   .timestamp(timestamp)
-                  .duration(500)
+                  .duration(SUCCESSFUL_SPAN_DURATION)
                   .success()
               )
           )
@@ -116,13 +131,15 @@ describe('span destination metrics', () => {
     expect(metricsSetsForSuccessfulExitSpans.length).toBe(15);
 
     metricsSetsForSuccessfulExitSpans.forEach((event) => {
-      expect(event['span.destination.service.response_time.count']).toEqual(25);
-      expect(event['span.destination.service.response_time.sum.us']).toEqual(25000000);
+      expect(event['span.destination.service.response_time.count']).toEqual(SUCCESSFUL_TOTAL_COUNT);
+      expect(event['span.destination.service.response_time.sum.us']).toEqual(
+        SUCCESSFUL_TOTAL_DURATION
+      );
     });
 
     metricsSetsForFailedExitSpans.forEach((event) => {
-      expect(event['span.destination.service.response_time.count']).toEqual(50);
-      expect(event['span.destination.service.response_time.sum.us']).toEqual(50000000);
+      expect(event['span.destination.service.response_time.count']).toEqual(FAILED_TOTAL_COUNT);
+      expect(event['span.destination.service.response_time.sum.us']).toEqual(FAILED_TOTAL_DURATION);
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/server/lib/connections/get_connection_stats/get_stats.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/connections/get_connection_stats/get_stats.ts
@@ -87,15 +87,17 @@ export const getStats = async ({
           type: NodeType.dependency as const,
         },
         value: {
-          count: bucket.doc_count ?? 0,
+          latency_count: bucket.total_latency_count.value ?? 0,
           latency_sum: bucket.total_latency_sum.value ?? 0,
           error_count: bucket.error_count.doc_count ?? 0,
+          success_count: bucket.success_count.doc_count ?? 0,
         },
         timeseries: bucket.timeseries?.buckets.map((dateBucket) => ({
           x: dateBucket.key + offsetInMs,
-          count: dateBucket.doc_count ?? 0,
+          latency_count: dateBucket.total_latency_count.value ?? 0,
           latency_sum: dateBucket.total_latency_sum.value ?? 0,
           error_count: dateBucket.error_count.doc_count ?? 0,
+          success_count: dateBucket.success_count.doc_count ?? 0,
         })),
       };
     }) ?? []
@@ -133,6 +135,13 @@ async function getConnectionStats({
     error_count: {
       filter: {
         bool: { filter: [{ terms: { [EVENT_OUTCOME]: [EventOutcome.failure] } }] },
+      },
+    },
+    success_count: {
+      filter: {
+        bool: {
+          filter: [{ terms: { [EVENT_OUTCOME]: [EventOutcome.success] } }],
+        },
       },
     },
   };

--- a/x-pack/solutions/observability/plugins/apm/server/lib/connections/get_connection_stats/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/connections/get_connection_stats/index.ts
@@ -83,26 +83,29 @@ export function getConnectionStats({
         (prev, current) => {
           return {
             value: {
-              count: prev.value.count + current.value.count,
+              latency_count: prev.value.latency_count + current.value.latency_count,
               latency_sum: prev.value.latency_sum + current.value.latency_sum,
               error_count: prev.value.error_count + current.value.error_count,
+              success_count: prev.value.success_count + current.value.success_count,
             },
             timeseries:
               prev.timeseries && current.timeseries
                 ? joinByKey([...prev.timeseries, ...current.timeseries], 'x', (a, b) => ({
                     x: a.x,
-                    count: a.count + b.count,
+                    latency_count: a.latency_count + b.latency_count,
                     latency_sum: a.latency_sum + b.latency_sum,
                     error_count: a.error_count + b.error_count,
+                    success_count: a.success_count + b.success_count,
                   }))
                 : undefined,
           };
         },
         {
           value: {
-            count: 0,
+            latency_count: 0,
             latency_sum: 0,
             error_count: 0,
+            success_count: 0,
           },
           timeseries: [],
         }
@@ -111,12 +114,12 @@ export function getConnectionStats({
       const destStats = {
         latency: {
           value:
-            mergedStats.value.count > 0
-              ? mergedStats.value.latency_sum / mergedStats.value.count
+            mergedStats.value.latency_count > 0
+              ? mergedStats.value.latency_sum / mergedStats.value.latency_count
               : null,
           timeseries: mergedStats.timeseries?.map((point) => ({
             x: point.x,
-            y: point.count > 0 ? point.latency_sum / point.count : null,
+            y: point.latency_count > 0 ? point.latency_sum / point.latency_count : null,
           })),
         },
         totalTime: {
@@ -128,33 +131,37 @@ export function getConnectionStats({
         },
         throughput: {
           value:
-            mergedStats.value.count > 0
+            mergedStats.value.latency_count > 0
               ? calculateThroughputWithRange({
                   start,
                   end,
-                  value: mergedStats.value.count,
+                  value: mergedStats.value.latency_count,
                 })
               : null,
           timeseries: mergedStats.timeseries?.map((point) => ({
             x: point.x,
             y:
-              point.count > 0
+              point.latency_count > 0
                 ? calculateThroughputWithRange({
                     start,
                     end,
-                    value: point.count,
+                    value: point.latency_count,
                   })
                 : null,
           })),
         },
         errorRate: {
           value:
-            mergedStats.value.count > 0
-              ? (mergedStats.value.error_count ?? 0) / mergedStats.value.count
+            mergedStats.value.error_count + mergedStats.value.success_count > 0
+              ? (mergedStats.value.error_count ?? 0) /
+                (mergedStats.value.error_count + mergedStats.value.success_count)
               : null,
           timeseries: mergedStats.timeseries?.map((point) => ({
             x: point.x,
-            y: point.count > 0 ? (point.error_count ?? 0) / point.count : null,
+            y:
+              mergedStats.value.error_count + mergedStats.value.success_count > 0
+                ? (point.error_count ?? 0) / (point.error_count + point.success_count)
+                : null,
           })),
         },
       };

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/dependencies/dependency_metrics.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/dependencies/dependency_metrics.spec.ts
@@ -10,7 +10,7 @@ import { isFiniteNumber } from '@kbn/apm-plugin/common/utils/is_finite_number';
 import { Coordinate } from '@kbn/apm-plugin/typings/timeseries';
 import { ENVIRONMENT_ALL } from '@kbn/apm-plugin/common/environment_filter_values';
 import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
-import { SPANS_PER_DESTINATION_METRIC } from '@kbn/synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
+import { SPANS_PER_DESTINATION_METRIC } from '@kbn/apm-synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
 import type { SupertestReturnType } from '../../../services/apm_api';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { roundNumber } from '../utils/common';

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/dependencies/dependency_metrics.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/dependencies/dependency_metrics.spec.ts
@@ -10,7 +10,8 @@ import { isFiniteNumber } from '@kbn/apm-plugin/common/utils/is_finite_number';
 import { Coordinate } from '@kbn/apm-plugin/typings/timeseries';
 import { ENVIRONMENT_ALL } from '@kbn/apm-plugin/common/environment_filter_values';
 import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
-import { SupertestReturnType } from '../../../services/apm_api';
+import { SPANS_PER_DESTINATION_METRIC } from '@kbn/synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
+import type { SupertestReturnType } from '../../../services/apm_api';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { roundNumber } from '../utils/common';
 import { generateOperationData, generateOperationDataConfig } from './generate_operation_data';
@@ -135,7 +136,9 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
               metric: 'throughput',
             });
 
-            expect(avg(response.body.currentTimeseries)).to.eql(REDIS_SET_RATE);
+            expect(avg(response.body.currentTimeseries)).to.eql(
+              REDIS_SET_RATE * SPANS_PER_DESTINATION_METRIC
+            );
           });
 
           it('returns the correct failure rate', async () => {
@@ -187,7 +190,9 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
             const searchRate = ES_SEARCH_UNKNOWN_RATE;
             const bulkRate = ES_BULK_RATE;
 
-            expect(avg(response.body.currentTimeseries)).to.eql(roundNumber(searchRate + bulkRate));
+            expect(avg(response.body.currentTimeseries)).to.eql(
+              roundNumber((searchRate + bulkRate) * SPANS_PER_DESTINATION_METRIC)
+            );
           });
 
           it('returns the correct failure rate', async () => {
@@ -238,7 +243,9 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
               ES_SEARCH_FAILURE_RATE + ES_SEARCH_SUCCESS_RATE + ES_SEARCH_UNKNOWN_RATE;
             const bulkRate = 0;
 
-            expect(avg(response.body.currentTimeseries)).to.eql(roundNumber(searchRate + bulkRate));
+            expect(avg(response.body.currentTimeseries)).to.eql(
+              roundNumber((searchRate + bulkRate) * SPANS_PER_DESTINATION_METRIC)
+            );
           });
 
           it('returns the correct failure rate', async () => {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/dependencies/top_dependencies.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/dependencies/top_dependencies.spec.ts
@@ -9,7 +9,7 @@ import type { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_
 import type { DependencyNode } from '@kbn/apm-plugin/common/connections';
 import { NodeType } from '@kbn/apm-plugin/common/connections';
 import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
-import { SPANS_PER_DESTINATION_METRIC } from '@kbn/synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
+import { SPANS_PER_DESTINATION_METRIC } from '@kbn/apm-synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { dataConfig, generateData } from './generate_data';
 import { roundNumber } from '../utils/common';

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/dependencies/top_dependencies.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/dependencies/top_dependencies.spec.ts
@@ -5,9 +5,11 @@
  * 2.0.
  */
 import expect from '@kbn/expect';
-import { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
-import { NodeType, DependencyNode } from '@kbn/apm-plugin/common/connections';
+import type { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
+import type { DependencyNode } from '@kbn/apm-plugin/common/connections';
+import { NodeType } from '@kbn/apm-plugin/common/connections';
 import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
+import { SPANS_PER_DESTINATION_METRIC } from '@kbn/synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { dataConfig, generateData } from './generate_data';
 import { roundNumber } from '../utils/common';
@@ -154,10 +156,12 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           } = dependencies;
           const { errorRate } = dataConfig;
           const totalRate = errorRate;
-          expect(roundNumber(throughput.value)).to.be(roundNumber(totalRate));
+          expect(roundNumber(throughput.value)).to.be(
+            roundNumber(totalRate * SPANS_PER_DESTINATION_METRIC)
+          );
           expect(
             topDependenciesStats.currentTimeseries[dataConfig.span.destination].throughput.every(
-              ({ y }) => roundNumber(y) === roundNumber(totalRate)
+              ({ y }) => roundNumber(y) === roundNumber(totalRate * SPANS_PER_DESTINATION_METRIC)
             )
           ).to.be(true);
         });
@@ -168,7 +172,8 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           } = dependencies;
           const { transaction, errorRate } = dataConfig;
 
-          const expectedValuePerBucket = errorRate * transaction.duration * 1000;
+          const expectedValuePerBucket =
+            errorRate * transaction.duration * SPANS_PER_DESTINATION_METRIC * 1000;
           expect(totalTime.value).to.be(expectedValuePerBucket * bucketSize);
         });
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/dependencies/top_operations.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/dependencies/top_operations.spec.ts
@@ -11,6 +11,7 @@ import { ValuesType } from 'utility-types';
 import { DependencyOperation } from '@kbn/apm-plugin/server/routes/dependencies/get_top_dependency_operations';
 import { meanBy } from 'lodash';
 import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
+import { SPANS_PER_DESTINATION_METRIC } from '@kbn/synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { roundNumber } from '../utils/common';
 import { generateOperationData, generateOperationDataConfig } from './generate_operation_data';
@@ -235,6 +236,19 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           }
           bulkOperationSpanEventsResponse = spanEventsResponse.find(findBulkOperation)!;
           bulkOperationSpanMetricsResponse = spanMetricsResponse.find(findBulkOperation)!;
+
+          /**
+           * The sum result of `span.destination.service.response_time.count` from service_destination metrics is synthetically
+           * multiplied by SPANS_PER_DESTINATION_METRIC to simulate muliple span for a single metric aggregation.
+           * We divide by SPANS_PER_DESTINATION_METRIC to get the comparable throughput.
+           **/
+          bulkOperationSpanMetricsResponse.timeseries.throughput =
+            bulkOperationSpanMetricsResponse.timeseries.throughput.map(({ y, x }) => ({
+              y: y === null ? null : y / SPANS_PER_DESTINATION_METRIC,
+              x,
+            }));
+          bulkOperationSpanMetricsResponse.throughput =
+            bulkOperationSpanMetricsResponse.throughput / SPANS_PER_DESTINATION_METRIC;
         });
 
         it('returns same latency', () => {
@@ -258,11 +272,11 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
             bulkOperationSpanMetricsResponse.throughput
           );
 
-          const meanSpanMetrics = meanBy(
+          const meanSpanEvents = meanBy(
             bulkOperationSpanEventsResponse.timeseries.throughput.filter(({ y }) => y !== 0),
             'y'
           );
-          const meanSpanEvents = meanBy(
+          const meanSpanMetrics = meanBy(
             bulkOperationSpanMetricsResponse.timeseries.throughput.filter(({ y }) => y !== 0),
             'y'
           );

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/dependencies/top_operations.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/dependencies/top_operations.spec.ts
@@ -11,7 +11,7 @@ import { ValuesType } from 'utility-types';
 import { DependencyOperation } from '@kbn/apm-plugin/server/routes/dependencies/get_top_dependency_operations';
 import { meanBy } from 'lodash';
 import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
-import { SPANS_PER_DESTINATION_METRIC } from '@kbn/synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
+import { SPANS_PER_DESTINATION_METRIC } from '@kbn/apm-synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { roundNumber } from '../utils/common';
 import { generateOperationData, generateOperationDataConfig } from './generate_operation_data';

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/service_overview/dependencies/index.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/service_overview/dependencies/index.spec.ts
@@ -9,6 +9,7 @@ import { DependencyNode } from '@kbn/apm-plugin/common/connections';
 import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
 import type { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
 import { NodeType } from '@kbn/apm-plugin/common/connections';
+import { SPANS_PER_DESTINATION_METRIC } from '@kbn/synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../../ftr_provider_context';
 import { roundNumber } from '../../utils/common';
 import { generateData, dataConfig } from './generate_data';
@@ -89,9 +90,12 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           currentStats: { latency },
         } = dependencies.serviceDependencies[0];
 
-        const { transaction } = dataConfig;
+        const { transaction, rate, errorRate } = dataConfig;
 
-        const expectedValue = transaction.duration * 1000;
+        // Example: ((20 successful + 5 errors) × span duration x 5 spans per metric x 1000 (convert to microseconds)) / ((20 successful + 5 errors) × 5 spans per metric) = 1000 ms
+        const expectedValue =
+          ((rate + errorRate) * transaction.duration * SPANS_PER_DESTINATION_METRIC * 1000) /
+          ((rate + errorRate) * SPANS_PER_DESTINATION_METRIC);
         expect(latency.value).to.be(expectedValue);
         expect(latency.timeseries?.every(({ y }) => y === expectedValue)).to.be(true);
       });
@@ -102,7 +106,8 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         } = dependencies.serviceDependencies[0];
         const { rate, errorRate } = dataConfig;
 
-        const expectedThroughput = rate + errorRate;
+        // Example: (20 successful + 5 errors) × 5 spans per metric = 125 spans per minute
+        const expectedThroughput = (rate + errorRate) * SPANS_PER_DESTINATION_METRIC;
         expect(roundNumber(throughput.value)).to.be(roundNumber(expectedThroughput));
         expect(
           throughput.timeseries?.every(
@@ -115,9 +120,11 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         const {
           currentStats: { totalTime },
         } = dependencies.serviceDependencies[0];
-        const { rate, transaction, errorRate } = dataConfig;
+        const { rate, errorRate, transaction } = dataConfig;
 
-        const expectedValuePerBucket = (rate + errorRate) * transaction.duration * 1000;
+        // Example: (20 successful + 5 errors) × 5 spans per metric × 1000 transaction duration × 1000 (convert to microseconds)  = 125.000.000 us
+        const expectedValuePerBucket =
+          (rate + errorRate) * SPANS_PER_DESTINATION_METRIC * transaction.duration * 1000;
         expect(totalTime.value).to.be(expectedValuePerBucket * bucketSize);
         expect(
           totalTime.timeseries?.every(

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/service_overview/dependencies/index.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/service_overview/dependencies/index.spec.ts
@@ -9,7 +9,7 @@ import { DependencyNode } from '@kbn/apm-plugin/common/connections';
 import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
 import type { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
 import { NodeType } from '@kbn/apm-plugin/common/connections';
-import { SPANS_PER_DESTINATION_METRIC } from '@kbn/synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
+import { SPANS_PER_DESTINATION_METRIC } from '@kbn/apm-synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../../ftr_provider_context';
 import { roundNumber } from '../../utils/common';
 import { generateData, dataConfig } from './generate_data';

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/throughput/dependencies_apis.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/throughput/dependencies_apis.spec.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { meanBy, sumBy } from 'lodash';
 import type { DependencyNode, ServiceNode } from '@kbn/apm-plugin/common/connections';
 import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
-import { SPANS_PER_DESTINATION_METRIC } from '@kbn/synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
+import { SPANS_PER_DESTINATION_METRIC } from '@kbn/apm-synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { roundNumber } from '../utils/common';
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/throughput/dependencies_apis.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/throughput/dependencies_apis.spec.ts
@@ -7,8 +7,9 @@
 import { apm, timerange } from '@kbn/apm-synthtrace-client';
 import expect from '@kbn/expect';
 import { meanBy, sumBy } from 'lodash';
-import { DependencyNode, ServiceNode } from '@kbn/apm-plugin/common/connections';
+import type { DependencyNode, ServiceNode } from '@kbn/apm-plugin/common/connections';
 import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
+import { SPANS_PER_DESTINATION_METRIC } from '@kbn/synthtrace/src/lib/apm/aggregators/create_span_metrics_aggregator';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import { roundNumber } from '../utils/common';
 
@@ -50,7 +51,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
             ...commonQuery,
             dependencyName: overrides?.dependencyName || 'elasticsearch',
             spanName: '',
-            searchServiceDestinationMetrics: false,
+            searchServiceDestinationMetrics: true,
             kuery: '',
           },
         },
@@ -187,9 +188,11 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           const { topDependencies } = throughputValues;
           const topDependenciesAsObj = Object.fromEntries(topDependencies);
           expect(topDependenciesAsObj.elasticsearch).to.equal(
-            roundNumber(JAVA_PROD_RATE + GO_PROD_RATE)
+            roundNumber((JAVA_PROD_RATE + GO_PROD_RATE) * SPANS_PER_DESTINATION_METRIC)
           );
-          expect(topDependenciesAsObj.postgresql).to.equal(roundNumber(GO_PROD_RATE));
+          expect(topDependenciesAsObj.postgresql).to.equal(
+            roundNumber(GO_PROD_RATE * SPANS_PER_DESTINATION_METRIC)
+          );
         });
       });
 
@@ -204,7 +207,9 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
             const topDependenciesAsObj = Object.fromEntries(topDependencies);
             const elasticsearchDependency = topDependenciesAsObj.elasticsearch;
             [elasticsearchDependency, dependencyThroughputChartMean].forEach((value) =>
-              expect(value).to.be.equal(roundNumber(JAVA_PROD_RATE + GO_PROD_RATE))
+              expect(value).to.be.equal(
+                roundNumber((JAVA_PROD_RATE + GO_PROD_RATE) * SPANS_PER_DESTINATION_METRIC)
+              )
             );
           });
 
@@ -216,7 +221,9 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
               sumBy(upstreamServicesThroughput, 'throughput')
             );
             [elasticsearchDependency, upstreamServiceThroughputSum].forEach((value) =>
-              expect(value).to.be.equal(roundNumber(JAVA_PROD_RATE + GO_PROD_RATE))
+              expect(value).to.be.equal(
+                roundNumber((JAVA_PROD_RATE + GO_PROD_RATE) * SPANS_PER_DESTINATION_METRIC)
+              )
             );
           });
         });
@@ -230,7 +237,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
             const topDependenciesAsObj = Object.fromEntries(topDependencies);
             const postgresqlDependency = topDependenciesAsObj.postgresql;
             [postgresqlDependency, dependencyThroughputChartMean].forEach((value) =>
-              expect(value).to.be.equal(roundNumber(GO_PROD_RATE))
+              expect(value).to.be.equal(roundNumber(GO_PROD_RATE * SPANS_PER_DESTINATION_METRIC))
             );
           });
 
@@ -242,7 +249,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
               sumBy(upstreamServicesThroughput, 'throughput')
             );
             [postgresqlDependency, upstreamServiceThroughputSum].forEach((value) =>
-              expect(value).to.be.equal(roundNumber(GO_PROD_RATE))
+              expect(value).to.be.equal(roundNumber(GO_PROD_RATE * SPANS_PER_DESTINATION_METRIC))
             );
           });
         });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM] Fix incorrect dependencies stats (#249434)](https://github.com/elastic/kibana/pull/249434)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miłosz Marcinkowski","email":"38698566+miloszmarcinkowski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-26T09:57:51Z","message":"[APM] Fix incorrect dependencies stats (#249434)\n\nCloses #249609\n\n## Summary\n\nWe used the incorrect formula to calculate throughput and latency in the\ndependency stats. Instead of using the total number of spans,\nrepresented by\n[`span.destination.service.response_time.count`](https://www.elastic.co/docs/solutions/observability/apm/metrics#_service_destination_metrics),\nwe used the total number of docs. The affected pages are:\n- Dependencies on the Service page,\n- Upstream dependencies on the Dependency page,\n- Top dependencies page.\n\n|-|Before|After|\n|-|-|-|\n\n|Throughput|`span.destination.service.response_time.sum.us`/`doc_count`|`span.destination.service.response_time.sum.us`/`span.destination.service.response_time.count`|\n|Latency|`doc_count`/`number of\nminutes`|`span.destination.service.response_time.count`/`number of\nminutes`|\n|-|<img width=\"2560\" height=\"1250\" alt=\"Screenshot 2026-01-16 at 17 11\n55\"\nsrc=\"https://github.com/user-attachments/assets/c114be12-8872-4645-b19f-1ac5aba477d1\"\n/>|<img width=\"2559\" height=\"1291\" alt=\"Screenshot 2026-01-16 at 17 47\n45\"\nsrc=\"https://github.com/user-attachments/assets/c0357dbb-102a-47dc-9c3c-0f7cf2d4815d\"\n/>|\n\n### How to test\nThe issue is easily visible when comparing the Service Map connection\nstats (the feature is being implemented in #248646) with Dependencies\nstats on the Service page.","sha":"837744b10ee782719ffb6637bd2a2e88a89f2f8f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:all-open","v9.4.0","Team:obs-presentation"],"title":"[APM] Fix incorrect dependencies stats","number":249434,"url":"https://github.com/elastic/kibana/pull/249434","mergeCommit":{"message":"[APM] Fix incorrect dependencies stats (#249434)\n\nCloses #249609\n\n## Summary\n\nWe used the incorrect formula to calculate throughput and latency in the\ndependency stats. Instead of using the total number of spans,\nrepresented by\n[`span.destination.service.response_time.count`](https://www.elastic.co/docs/solutions/observability/apm/metrics#_service_destination_metrics),\nwe used the total number of docs. The affected pages are:\n- Dependencies on the Service page,\n- Upstream dependencies on the Dependency page,\n- Top dependencies page.\n\n|-|Before|After|\n|-|-|-|\n\n|Throughput|`span.destination.service.response_time.sum.us`/`doc_count`|`span.destination.service.response_time.sum.us`/`span.destination.service.response_time.count`|\n|Latency|`doc_count`/`number of\nminutes`|`span.destination.service.response_time.count`/`number of\nminutes`|\n|-|<img width=\"2560\" height=\"1250\" alt=\"Screenshot 2026-01-16 at 17 11\n55\"\nsrc=\"https://github.com/user-attachments/assets/c114be12-8872-4645-b19f-1ac5aba477d1\"\n/>|<img width=\"2559\" height=\"1291\" alt=\"Screenshot 2026-01-16 at 17 47\n45\"\nsrc=\"https://github.com/user-attachments/assets/c0357dbb-102a-47dc-9c3c-0f7cf2d4815d\"\n/>|\n\n### How to test\nThe issue is easily visible when comparing the Service Map connection\nstats (the feature is being implemented in #248646) with Dependencies\nstats on the Service page.","sha":"837744b10ee782719ffb6637bd2a2e88a89f2f8f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249434","number":249434,"mergeCommit":{"message":"[APM] Fix incorrect dependencies stats (#249434)\n\nCloses #249609\n\n## Summary\n\nWe used the incorrect formula to calculate throughput and latency in the\ndependency stats. Instead of using the total number of spans,\nrepresented by\n[`span.destination.service.response_time.count`](https://www.elastic.co/docs/solutions/observability/apm/metrics#_service_destination_metrics),\nwe used the total number of docs. The affected pages are:\n- Dependencies on the Service page,\n- Upstream dependencies on the Dependency page,\n- Top dependencies page.\n\n|-|Before|After|\n|-|-|-|\n\n|Throughput|`span.destination.service.response_time.sum.us`/`doc_count`|`span.destination.service.response_time.sum.us`/`span.destination.service.response_time.count`|\n|Latency|`doc_count`/`number of\nminutes`|`span.destination.service.response_time.count`/`number of\nminutes`|\n|-|<img width=\"2560\" height=\"1250\" alt=\"Screenshot 2026-01-16 at 17 11\n55\"\nsrc=\"https://github.com/user-attachments/assets/c114be12-8872-4645-b19f-1ac5aba477d1\"\n/>|<img width=\"2559\" height=\"1291\" alt=\"Screenshot 2026-01-16 at 17 47\n45\"\nsrc=\"https://github.com/user-attachments/assets/c0357dbb-102a-47dc-9c3c-0f7cf2d4815d\"\n/>|\n\n### How to test\nThe issue is easily visible when comparing the Service Map connection\nstats (the feature is being implemented in #248646) with Dependencies\nstats on the Service page.","sha":"837744b10ee782719ffb6637bd2a2e88a89f2f8f"}},{"url":"https://github.com/elastic/kibana/pull/250367","number":250367,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->