### PR TITLE
[8.19] [Graph] Limit drilldown URL capabilities (#248672)

### DIFF
--- a/x-pack/platform/plugins/private/graph/public/components/control_panel/control_panel.tsx
+++ b/x-pack/platform/plugins/private/graph/public/components/control_panel/control_panel.tsx
@@ -66,7 +66,7 @@ const ControlPanelComponent = ({
   const openUrlTemplate = (template: UrlTemplate) => {
     const url = template.url;
     const newUrl = url.replace(urlTemplateRegex, template.encoder.encode(workspace!));
-    window.open(newUrl, '_blank');
+    window.open(newUrl, '_blank', 'noopener,noreferrer');
   };
 
   const onSelectedFieldClick = (node: WorkspaceNode) => {

--- a/x-pack/platform/plugins/private/graph/public/components/control_panel/drill_downs.tsx
+++ b/x-pack/platform/plugins/private/graph/public/components/control_panel/drill_downs.tsx
@@ -7,8 +7,8 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiIcon } from '@elastic/eui';
-import { UrlTemplate } from '../../types';
+import { EuiIcon, EuiLink } from '@elastic/eui';
+import type { UrlTemplate } from '../../types';
 import { IconRenderer } from '../icon_renderer';
 import { gphSidebarHeaderStyles, gphSidebarPanelStyles, noUserSelectStyles } from '../../styles';
 
@@ -47,9 +47,7 @@ export const DrillDowns = ({ urlTemplates, openUrlTemplate }: DrillDownsProps) =
                     <IconRenderer icon={urlTemplate.icon} css={noUserSelectStyles} />{' '}
                   </>
                 )}
-                <a aria-hidden="true" onClick={onOpenUrlTemplate}>
-                  {urlTemplate.description}
-                </a>
+                <EuiLink onClick={onOpenUrlTemplate}>{urlTemplate.description}</EuiLink>
               </li>
             );
           })}

--- a/x-pack/platform/plugins/private/graph/public/components/settings/url_template_form.tsx
+++ b/x-pack/platform/plugins/private/graph/public/components/settings/url_template_form.tsx
@@ -213,7 +213,8 @@ export function UrlTemplateForm(props: UrlTemplateFormProps) {
             urlPlaceholderMissing
               ? [
                   i18n.translate('xpack.graph.settings.drillDowns.invalidUrlWarningText', {
-                    defaultMessage: 'The URL must contain a {placeholder} string.',
+                    defaultMessage:
+                      'The URL is invalid and/or must contain a {placeholder} string.',
                     values: { placeholder: '{{gquery}}' },
                   }),
                 ]

--- a/x-pack/platform/plugins/private/graph/public/helpers/url_template.test.ts
+++ b/x-pack/platform/plugins/private/graph/public/helpers/url_template.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isUrlTemplateValid, urlTemplatePlaceholder } from './url_template';
+
+describe('isUrlTemplateValid', () => {
+  it('accepts http URLs that contain the placeholder', () => {
+    expect(isUrlTemplateValid(`http://elastic.co/${urlTemplatePlaceholder}`)).toBe(true);
+  });
+
+  it('accepts mailto URLs that contain the placeholder', () => {
+    const mailtoTemplate = `mailto:test@elastic.co?subject=${urlTemplatePlaceholder}`;
+    expect(isUrlTemplateValid(mailtoTemplate)).toBe(true);
+  });
+
+  it('accepts https URLs that contain the placeholder', () => {
+    expect(isUrlTemplateValid(`https://elastic.co/${urlTemplatePlaceholder}`)).toBe(true);
+  });
+
+  it('accepts relative URLs by resolving against the current origin', () => {
+    const relativeUrl = `/app/discover/${urlTemplatePlaceholder}`;
+    expect(isUrlTemplateValid(relativeUrl)).toBe(true);
+  });
+
+  it('rejects URLs using unsupported protocols even with the placeholder', () => {
+    const ftpUrl = `ftp://elastic.co/${urlTemplatePlaceholder}`;
+    expect(isUrlTemplateValid(ftpUrl)).toBe(false);
+  });
+
+  it('rejects URLs that do not contain the placeholder', () => {
+    const missingPlaceholder = 'https://elastic.co/app/discover';
+    expect(isUrlTemplateValid(missingPlaceholder)).toBe(false);
+  });
+
+  it('rejects URLs that cannot be parsed', () => {
+    const unparsableUrl = `//`;
+    expect(isUrlTemplateValid(unparsableUrl)).toBe(false);
+  });
+
+  it('rejects javascript URLs to prevent script execution', () => {
+    const javascriptUrl = `javascript:alert(${urlTemplatePlaceholder})`;
+    expect(isUrlTemplateValid(javascriptUrl)).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/private/graph/public/helpers/url_template.ts
+++ b/x-pack/platform/plugins/private/graph/public/helpers/url_template.ts
@@ -8,6 +8,7 @@
 export const urlTemplatePlaceholder = '{{gquery}}';
 export const urlTemplateRegex = /\{\{gquery\}\}/g;
 const defaultKibanaQuery = /,query:\(language:kuery,query:'.*?'\)/g;
+const ALLOWED_PROTOCOLS = ['http:', 'https:', 'mailto:'];
 
 /**
  * Checks whether a given string is a url template. This is the
@@ -15,7 +16,10 @@ const defaultKibanaQuery = /,query:\(language:kuery,query:'.*?'\)/g;
  * @param url The url to check
  */
 export function isUrlTemplateValid(url: string) {
-  return url.search(urlTemplateRegex) > -1;
+  // with window.location.origin we can also handle also relative paths correctly
+  const parsedUrl = URL.parse(url, window.location.origin);
+  if (!parsedUrl) return false;
+  return ALLOWED_PROTOCOLS.includes(parsedUrl.protocol) && url.includes(urlTemplatePlaceholder);
 }
 
 /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Graph] Limit drilldown URL capabilities (#248672)](https://github.com/elastic/kibana/pull/248672)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2026-01-26T09:39:10Z","message":"[Graph] Limit drilldown URL capabilities (#248672)\n\n## Summary\n\nThis pull request improves the security, accessibility, and validation\nof URL templates in the Graph plugin, and enhances the user interface\nfor drill-down links. The main changes include stricter URL validation\nto prevent unsafe protocols, improved warning messages, and UI updates\nto use consistent components.\n\n**Security and Validation Improvements:**\n\n* The `isUrlTemplateValid` function now only allows `http:`, `https:`,\nand `mailto:` protocols, and requires the `{{gquery}}` placeholder. This\nprevents unsafe protocols like `javascript:` and `ftp:` from being used,\nand ensures URLs are valid and parseable.\n* Added comprehensive unit tests for `isUrlTemplateValid` to cover\nsupported protocols, placeholder presence, and invalid cases.\n\n**User Interface Enhancements:**\n\n* Updated the drill-down links in the control panel to use the `EuiLink`\ncomponent from Elastic UI, improving accessibility and consistency (on\nhover the cursor wasn't changing to a pointer)\n* Enhanced the warning message in the URL Template Form to indicate when\na URL is invalid and/or missing the required placeholder.\n\n**Security Best Practices:**\n\n* Updated the `window.open` call to include `'noopener,noreferrer'` for\nnewly opened URLs, mitigating security risks such as reverse tabnabbing.\n\n**Component Imports:**\n\n* Added the `EuiLink` import to the drill-downs component to support the\nnew UI changes.","sha":"977d56e136fde1bb40516d91c106e44eb60846a4","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Graph","Team:Visualizations","release_note:skip","backport:all-open","v9.4.0"],"title":"[Graph] Limit drilldown URL capabilities","number":248672,"url":"https://github.com/elastic/kibana/pull/248672","mergeCommit":{"message":"[Graph] Limit drilldown URL capabilities (#248672)\n\n## Summary\n\nThis pull request improves the security, accessibility, and validation\nof URL templates in the Graph plugin, and enhances the user interface\nfor drill-down links. The main changes include stricter URL validation\nto prevent unsafe protocols, improved warning messages, and UI updates\nto use consistent components.\n\n**Security and Validation Improvements:**\n\n* The `isUrlTemplateValid` function now only allows `http:`, `https:`,\nand `mailto:` protocols, and requires the `{{gquery}}` placeholder. This\nprevents unsafe protocols like `javascript:` and `ftp:` from being used,\nand ensures URLs are valid and parseable.\n* Added comprehensive unit tests for `isUrlTemplateValid` to cover\nsupported protocols, placeholder presence, and invalid cases.\n\n**User Interface Enhancements:**\n\n* Updated the drill-down links in the control panel to use the `EuiLink`\ncomponent from Elastic UI, improving accessibility and consistency (on\nhover the cursor wasn't changing to a pointer)\n* Enhanced the warning message in the URL Template Form to indicate when\na URL is invalid and/or missing the required placeholder.\n\n**Security Best Practices:**\n\n* Updated the `window.open` call to include `'noopener,noreferrer'` for\nnewly opened URLs, mitigating security risks such as reverse tabnabbing.\n\n**Component Imports:**\n\n* Added the `EuiLink` import to the drill-downs component to support the\nnew UI changes.","sha":"977d56e136fde1bb40516d91c106e44eb60846a4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/248672","number":248672,"mergeCommit":{"message":"[Graph] Limit drilldown URL capabilities (#248672)\n\n## Summary\n\nThis pull request improves the security, accessibility, and validation\nof URL templates in the Graph plugin, and enhances the user interface\nfor drill-down links. The main changes include stricter URL validation\nto prevent unsafe protocols, improved warning messages, and UI updates\nto use consistent components.\n\n**Security and Validation Improvements:**\n\n* The `isUrlTemplateValid` function now only allows `http:`, `https:`,\nand `mailto:` protocols, and requires the `{{gquery}}` placeholder. This\nprevents unsafe protocols like `javascript:` and `ftp:` from being used,\nand ensures URLs are valid and parseable.\n* Added comprehensive unit tests for `isUrlTemplateValid` to cover\nsupported protocols, placeholder presence, and invalid cases.\n\n**User Interface Enhancements:**\n\n* Updated the drill-down links in the control panel to use the `EuiLink`\ncomponent from Elastic UI, improving accessibility and consistency (on\nhover the cursor wasn't changing to a pointer)\n* Enhanced the warning message in the URL Template Form to indicate when\na URL is invalid and/or missing the required placeholder.\n\n**Security Best Practices:**\n\n* Updated the `window.open` call to include `'noopener,noreferrer'` for\nnewly opened URLs, mitigating security risks such as reverse tabnabbing.\n\n**Component Imports:**\n\n* Added the `EuiLink` import to the drill-downs component to support the\nnew UI changes.","sha":"977d56e136fde1bb40516d91c106e44eb60846a4"}},{"url":"https://github.com/elastic/kibana/pull/250360","number":250360,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/250361","number":250361,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->