### PR TITLE
[Infra][Scout] Add test for the k8s dashboard/integration links

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/constants.ts
@@ -112,6 +112,7 @@ export const DATE_WITHOUT_DATA = '04/01/2024 6:20:59 PM';
 export const EXTENDED_TIMEOUT = 45000; // 45 seconds
 
 export const KUBERNETES_TOUR_STORAGE_KEY = 'isKubernetesTourSeen';
+export const KUBERNETES_CARD_DISMISSED_STORAGE_KEY = 'infra.inventory.k8sCardDismissed';
 
 export const BASE_DEFAULT_INVENTORY_VIEW_ATTRIBUTES: Omit<
   CreateInventoryViewAttributes,

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/fixtures/page_objects/inventory.ts
@@ -6,7 +6,11 @@
  */
 
 import { type KibanaUrl, type Locator, type ScoutPage } from '@kbn/scout-oblt';
-import { EXTENDED_TIMEOUT, KUBERNETES_TOUR_STORAGE_KEY } from '../constants';
+import {
+  EXTENDED_TIMEOUT,
+  KUBERNETES_TOUR_STORAGE_KEY,
+  KUBERNETES_CARD_DISMISSED_STORAGE_KEY,
+} from '../constants';
 
 export class InventoryPage {
   public readonly feedbackLink: Locator;
@@ -155,6 +159,16 @@ export class InventoryPage {
         window.localStorage.setItem(k8sTourStorageKey, 'true');
       },
       [KUBERNETES_TOUR_STORAGE_KEY]
+    );
+  }
+
+  public async addClearK8sCardDismissedInitScript() {
+    // Clear the K8s dashboard promotion card dismissed state to ensure cards are visible
+    await this.page.addInitScript(
+      ([k8sCardDismissedKey]) => {
+        window.localStorage.removeItem(k8sCardDismissedKey);
+      },
+      [KUBERNETES_CARD_DISMISSED_STORAGE_KEY]
     );
   }
 

--- a/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory_k8s_integration_links.spec.ts
+++ b/x-pack/solutions/observability/plugins/infra/test/scout/ui/parallel_tests/inventory/inventory_k8s_integration_links.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-oblt';
+import { test } from '../../fixtures';
+import { DATE_WITH_POD_DATA } from '../../fixtures/constants';
+
+const KUBERNETES_PACKAGE_NAME = 'kubernetes';
+
+test.describe.serial(
+  'Infrastructure Inventory - K8s Integration Links Navigation',
+  { tag: ['@ess', '@svlOblt'] },
+  () => {
+    test.beforeAll(async ({ log, apiServices }) => {
+      // Start with a clean state - ensure kubernetes is NOT installed
+      log.info(`Ensuring ${KUBERNETES_PACKAGE_NAME} integration is not installed...`);
+      await apiServices.fleet.integration.delete(KUBERNETES_PACKAGE_NAME);
+    });
+
+    test.beforeEach(async ({ browserAuth, pageObjects: { inventoryPage } }) => {
+      await browserAuth.loginAsViewer();
+      await inventoryPage.addDismissK8sTourInitScript();
+      await inventoryPage.addClearK8sCardDismissedInitScript();
+      await inventoryPage.goToPage();
+    });
+
+    test.afterAll(async ({ log, apiServices }) => {
+      // Cleanup - remove kubernetes integration
+      log.info(`Cleaning up ${KUBERNETES_PACKAGE_NAME} integration...`);
+      await apiServices.fleet.integration.delete(KUBERNETES_PACKAGE_NAME);
+    });
+
+    test('K8s integration link navigates to integrations detail page', async ({
+      pageObjects: { inventoryPage },
+      page,
+    }) => {
+      await test.step('switch to K8s pods view', async () => {
+        await inventoryPage.goToTime(DATE_WITH_POD_DATA);
+        await inventoryPage.showPods();
+        await expect(inventoryPage.inventorySwitcherButton).toContainText('Kubernetes Pods');
+      });
+
+      await test.step('click integration link and verify navigation', async () => {
+        const installLink = page.getByTestId('infraKubernetesDashboardCardInstallLink');
+        await expect(installLink).toBeVisible();
+        await installLink.click();
+
+        // Should navigate to integrations detail page for kubernetes
+        await expect(page).toHaveURL(/integrations.*kubernetes/);
+      });
+    });
+
+    test('K8s dashboards link navigates to dashboards with tag filter', async ({
+      pageObjects: { inventoryPage },
+      page,
+      kbnClient,
+      log,
+    }) => {
+      await test.step('install kubernetes integration from registry', async () => {
+        log.info(`Installing ${KUBERNETES_PACKAGE_NAME} integration package from registry...`);
+        await kbnClient.request({
+          method: 'POST',
+          path: `/api/fleet/epm/packages/${KUBERNETES_PACKAGE_NAME}`,
+          body: { force: true },
+        });
+        log.info(`${KUBERNETES_PACKAGE_NAME} integration package installed`);
+      });
+
+      await test.step('switch to K8s pods view', async () => {
+        await inventoryPage.goToTime(DATE_WITH_POD_DATA);
+        await inventoryPage.showPods();
+        await expect(inventoryPage.inventorySwitcherButton).toContainText('Kubernetes Pods');
+      });
+
+      await test.step('click dashboards link and verify navigation', async () => {
+        const dashboardLink = page.getByTestId('infraKubernetesDashboardCardLink');
+        await expect(dashboardLink).toBeVisible();
+        await dashboardLink.click();
+
+        // Should navigate to dashboards app with Kubernetes tag filter
+        await expect(page).toHaveURL(/dashboards.*tag:\(Kubernetes\)/);
+      });
+    });
+  }
+);


### PR DESCRIPTION
closes [246138](https://github.com/elastic/kibana/issues/246138)
## Summary

Create integration tests for the recently introduced k8s dashboard/integration links in the Inventor UI


