### PR TITLE
[Obs AI] elasticsearch tools from OpenAPI specs

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -30,6 +30,7 @@ export const AGENT_BUILDER_BUILTIN_TOOLS: string[] = [
   `${internalNamespaces.observability}.get_metric_change_points`,
   `${internalNamespaces.observability}.get_index_info`,
   `${internalNamespaces.observability}.get_trace_change_points`,
+  `${internalNamespaces.observability}.elasticsearch`,
 
   // Dashboards
   'platform.dashboard.create_dashboard',

--- a/x-pack/platform/packages/shared/ai-infra/product-doc-common/index.ts
+++ b/x-pack/platform/packages/shared/ai-infra/product-doc-common/index.ts
@@ -24,5 +24,8 @@ export {
   securityLabsIndexPrefix,
   securityLabsIndexPattern,
   getSecurityLabsIndexName,
+  openApiSpecIndexPrefix,
+  openApiSpecIndexPattern,
+  getOpenApiSpecIndexName,
 } from './src/indices';
 export type { ProductDocumentationAttributes } from './src/documents';

--- a/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/indices.ts
+++ b/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/indices.ts
@@ -36,3 +36,23 @@ export const getSecurityLabsIndexName = (inferenceId?: string): string => {
     !isImpliedDefaultElserInferenceId(inferenceId) ? `-${inferenceId}` : ''
   }`;
 };
+
+/**
+ * Index name prefix for OpenAPI Spec content.
+ */
+export const openApiSpecIndexPrefix = '.kibana_ai_openapi_spec';
+
+/**
+ * Index pattern for OpenAPI Spec content.
+ */
+export const openApiSpecIndexPattern = `${openApiSpecIndexPrefix}*`;
+
+/**
+ * Returns the index name for OpenAPI Spec content.
+ * Format: .kibana_ai_openapi_spec[-{inferenceId}]
+ */
+export const getOpenApiSpecIndexName = (inferenceId?: string): string => {
+  return `${openApiSpecIndexPrefix}${
+    !isImpliedDefaultElserInferenceId(inferenceId) ? `-${inferenceId}` : ''
+  }`;
+};

--- a/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/resource_type.ts
+++ b/x-pack/platform/packages/shared/ai-infra/product-doc-common/src/resource_type.ts
@@ -10,9 +10,10 @@
  * - `product_doc`: Elastic product documentation (Kibana, Elasticsearch, etc.)
  * - `security_labs`: Elastic Security Labs content
  */
-export type ResourceType = 'product_doc' | 'security_labs';
+export type ResourceType = 'product_doc' | 'security_labs' | 'openapi_spec';
 
 export const ResourceTypes = {
   productDoc: 'product_doc',
   securityLabs: 'security_labs',
+  openapiSpec: 'openapi_spec',
 } as const;

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/README.md
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/README.md
@@ -13,14 +13,16 @@ All APIs accept an optional `resourceType` parameter. When omitted, it defaults 
 
 ### Resource Types
 
-| Resource Type | Description | Versioning |
-|---------------|-------------|------------|
-| `product_doc` | Elastic product documentation | Kibana version (e.g., 8.18) |
+| Resource Type   | Description                   | Versioning                    |
+| --------------- | ----------------------------- | ----------------------------- |
+| `product_doc`   | Elastic product documentation | Kibana version (e.g., 8.18)   |
 | `security_labs` | Elastic Security Labs content | Date-based (e.g., 2024.12.11) |
+| `openapi_spec`  | Elastic open api spec         |                               |
 
 ### To install
 
 **Product Documentation (default):**
+
 ```
 POST kbn://internal/product_doc_base/install
 {
@@ -29,6 +31,7 @@ POST kbn://internal/product_doc_base/install
 ```
 
 **Security Labs:**
+
 ```
 POST kbn://internal/product_doc_base/install
 {
@@ -44,6 +47,7 @@ Passing `forceUpdate: true` will uninstall and install the product docs to the l
 Because the operation is expensive, by default, `forceUpdate` is set to false unless user explicitly wants to do that with the API.
 
 To force update all previously installed Inference IDs:
+
 ```
 POST kbn://internal/product_doc_base/update_all
 {
@@ -53,6 +57,7 @@ POST kbn://internal/product_doc_base/update_all
 ```
 
 Optionally, you can specify specific Inference IDs to update:
+
 ```
 POST kbn://internal/product_doc_base/update_all
 {
@@ -63,7 +68,9 @@ POST kbn://internal/product_doc_base/update_all
   ]
 }
 ```
+
 Omit `inferenceIds` if you want to update all previously installed docs, regardless of which Inference ID.
+
 - If ELSER was installed, but not E5 → ELSER docs will be updated
 - If E5 was installed, but not ELSER → E5 docs will be updated
 - If ELSER was installed, E5 was installed → ELSER & E5 docs will be updated
@@ -71,6 +78,7 @@ Omit `inferenceIds` if you want to update all previously installed docs, regardl
 ### To uninstall
 
 **Product Documentation (default):**
+
 ```
 POST kbn://internal/product_doc_base/uninstall
 {
@@ -79,6 +87,7 @@ POST kbn://internal/product_doc_base/uninstall
 ```
 
 **Security Labs:**
+
 ```
 POST kbn://internal/product_doc_base/uninstall
 {
@@ -90,11 +99,13 @@ POST kbn://internal/product_doc_base/uninstall
 ### To check status
 
 **Product Documentation (default):**
+
 ```
 GET kbn://internal/product_doc_base/status?inferenceId=.elser-2-elasticsearch
 ```
 
 **Security Labs:**
+
 ```
 GET kbn://internal/product_doc_base/status?inferenceId=.elser-2-elasticsearch&resourceType=security_labs
 ```
@@ -104,20 +115,24 @@ GET kbn://internal/product_doc_base/status?inferenceId=.elser-2-elasticsearch&re
 Both product documentation and Security Labs artifacts are hosted on the same CDN. The repository URL is configurable via:
 
 ```yaml
-xpack.productDocBase.artifactRepositoryUrl: "https://kibana-knowledge-base-artifacts.elastic.co"
+xpack.productDocBase.artifactRepositoryUrl: 'https://kibana-knowledge-base-artifacts.elastic.co'
 ```
 
 Artifact naming conventions:
+
 - Product docs: `kb-product-doc-{product}-{version}.zip`
 - Security Labs: `security-labs-{YYYY.MM.DD}.zip`
 
 ## Run tests
 
 Set up test server
+
 ```
 node scripts/functional_tests_server.js --config x-pack/platform/test/functional_gen_ai/inference/config.ts
 ```
+
 Run tests on different terminal
+
 ```
 node scripts/functional_tests_server.js --config x-pack/platform/test/functional_gen_ai/inference/config.ts --grep='product docs base'
 ```

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/routes/installation.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/routes/installation.ts
@@ -29,7 +29,11 @@ import type { InternalServices } from '../types';
  * Schema for resourceType parameter validation.
  */
 const resourceTypeSchema = schema.oneOf(
-  [schema.literal(ResourceTypes.productDoc), schema.literal(ResourceTypes.securityLabs)],
+  [
+    schema.literal(ResourceTypes.productDoc),
+    schema.literal(ResourceTypes.securityLabs),
+    schema.literal(ResourceTypes.openapiSpec),
+  ],
   { defaultValue: ResourceTypes.productDoc }
 );
 
@@ -142,6 +146,28 @@ export const registerInstallationRoutes = ({
             installed: securityLabsStatus.status === 'installed',
             ...(securityLabsStatus.failureReason
               ? { failureReason: securityLabsStatus.failureReason }
+              : {}),
+          },
+        });
+      }
+
+      // Handle OpenAPI Spec installation
+      if (resourceType === ResourceTypes.openapiSpec) {
+        await documentationManager.installOpenApiSpec({
+          request: req,
+          wait: true,
+          inferenceId,
+        });
+
+        const openApiSpecStatus = await documentationManager.getOpenApiSpecStatus({
+          inferenceId,
+        });
+
+        return res.ok<PerformInstallResponse>({
+          body: {
+            installed: openApiSpecStatus.status === 'installed',
+            ...(openApiSpecStatus.failureReason
+              ? { failureReason: openApiSpecStatus.failureReason }
               : {}),
           },
         });

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/product_doc_install_service.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/doc_install_status/product_doc_install_service.ts
@@ -277,6 +277,100 @@ export class ProductDocInstallClient {
       }
     }
   }
+
+  // OpenAPI spec status helpers (stored in the same SO type but a different object id to avoid collisions)
+
+  async getOpenapiSpecInstallationStatus({
+    inferenceId,
+  }: {
+    inferenceId: string;
+  }): Promise<SecurityLabsStatusResponse> {
+    const objectId = getSecurityLabsObjectId(inferenceId);
+    try {
+      const so = await this.soClient.get<TypeAttributes>(typeName, objectId);
+      return {
+        status: so.attributes.installation_status,
+        version: so.attributes.product_version,
+        ...(so.attributes.last_installation_failure_reason
+          ? { failureReason: so.attributes.last_installation_failure_reason }
+          : {}),
+      };
+    } catch (e) {
+      if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
+        return { status: 'uninstalled' };
+      }
+      throw e;
+    }
+  }
+
+  async setOpenapiSpecInstallationStarted(fields: {
+    productName: 'kibana' | 'elasticsearch';
+    inferenceId: string;
+  }) {
+    const { productName, inferenceId } = fields;
+    const objectId = getSecurityLabsObjectId(inferenceId);
+    const attributes: TypeAttributes = {
+      product_name: productName,
+      product_version: 'latest', // to be included later
+      installation_status: 'installing',
+      last_installation_failure_reason: '',
+      inference_id: inferenceId,
+      resource_type: ResourceTypes.openapiSpec,
+    };
+    await this.soClient.update<TypeAttributes>(typeName, objectId, attributes, {
+      upsert: attributes,
+    });
+  }
+
+  async setOpenapiSpecInstallationSuccessful(fields: {
+    productName: 'kibana' | 'elasticsearch';
+    indexName: string;
+    inferenceId: string;
+  }) {
+    const { productName, indexName, inferenceId } = fields;
+    const objectId = getSecurityLabsObjectId(inferenceId);
+    await this.soClient.update<TypeAttributes>(typeName, objectId, {
+      product_name: productName,
+      product_version: 'latest', // to be included later
+      installation_status: 'installed',
+      index_name: indexName,
+      inference_id: inferenceId,
+      resource_type: ResourceTypes.openapiSpec,
+    });
+  }
+
+  async setOpenapiSpecInstallationFailed(fields: {
+    productName: 'kibana' | 'elasticsearch';
+    failureReason: string;
+    inferenceId: string;
+  }) {
+    const { productName, failureReason, inferenceId } = fields;
+    const objectId = getSecurityLabsObjectId(inferenceId);
+    await this.soClient.update<TypeAttributes>(typeName, objectId, {
+      installation_status: 'error',
+      last_installation_failure_reason: failureReason,
+      inference_id: inferenceId,
+      resource_type: ResourceTypes.openapiSpec,
+      product_name: productName,
+      product_version: 'latest', // to be included later
+    });
+  }
+
+  async setOpenapiSpecUninstalled(inferenceId: string) {
+    const objectId = getSecurityLabsObjectId(inferenceId);
+    try {
+      await this.soClient.update<TypeAttributes>(typeName, objectId, {
+        installation_status: 'uninstalled',
+        last_installation_failure_reason: '',
+        inference_id: inferenceId,
+        resource_type: ResourceTypes.openapiSpec,
+      });
+    } catch (e) {
+      if (!SavedObjectsErrorHelpers.isNotFoundError(e)) {
+        throw e;
+      }
+    }
+  }
 }
 
 const getObjectIdFromProductName = (productName: ProductName, inferenceId: string | undefined) => {

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/index.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/index.ts
@@ -13,3 +13,4 @@ export {
   ensureInferenceDeployed,
 } from './ensure_default_elser_deployed';
 export { isLegacySemanticTextVersion } from './manifest_versions';
+export { ingestOpenApiSpec } from './ingest_openapi_spec';

--- a/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/ingest_openapi_spec.ts
+++ b/x-pack/platform/plugins/shared/ai_infra/product_doc_base/server/services/package_installer/utils/ingest_openapi_spec.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { OpenAPIV3 } from 'openapi-types';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
+
+interface Document {
+  path: string;
+  method: string;
+  description: string | undefined;
+  summary: string | undefined;
+  parameters: (OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject)[] | undefined;
+  response: OpenAPIV3.ReferenceObject | OpenAPIV3.ResponseObject;
+  example: unknown;
+  tags?: string[];
+  externalDocs?: OpenAPIV3.ExternalDocumentationObject;
+  operationId?: string;
+  requestBody?: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject;
+  responses?: OpenAPIV3.ResponsesObject;
+  callbacks?: { [callback: string]: OpenAPIV3.ReferenceObject | OpenAPIV3.CallbackObject };
+  deprecated?: boolean;
+  security?: OpenAPIV3.SecurityRequirementObject[];
+  servers?: OpenAPIV3.ServerObject[];
+}
+
+function generateDocuments(openApiSpec: OpenAPIV3.Document): Document[] {
+  const documents = Object.entries(openApiSpec.paths)
+    .map(([path, methods]) => {
+      if (!methods) {
+        return [];
+      }
+
+      // ignore paths that contant _cat -> https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-cat
+      if (path.includes('/_cat/')) {
+        return [];
+      }
+
+      return Object.entries(methods).map(([method, operation]) => {
+        if (!operation || typeof operation === 'string' || !('operationId' in operation)) {
+          throw new Error(`Invalid operation for path ${path} and method ${method}`);
+        }
+        const parameters = operation.parameters?.map((param) => {
+          if ('$ref' in param) {
+            const ref = param.$ref as string;
+            const refName = ref.replace('#/components/parameters/', '');
+            const resolvedParam = openApiSpec.components?.parameters?.[refName];
+            return resolvedParam || param;
+          }
+          if ('$ref' in param && (!('schema' in param) || !param.schema)) {
+            return param;
+          }
+
+          const { schema } = param as { schema: OpenAPIV3.SchemaObject };
+
+          if (schema && '$ref' in schema) {
+            const ref = schema.$ref as string;
+            const refName = ref.replace('#/components/schemas/', '');
+            const resolvedSchema = openApiSpec.components?.schemas?.[refName];
+            return { ...param, schema: resolvedSchema || schema };
+          }
+
+          return param;
+        });
+
+        let response = operation.responses?.['200'];
+
+        if ('$ref' in response) {
+          const ref = response.$ref as string;
+          const refName = ref.replace('#/components/responses/', '');
+          const resolvedResponse = openApiSpec.components?.responses?.[refName];
+          response = resolvedResponse || response;
+        }
+        if (
+          response &&
+          typeof response === 'object' &&
+          'content' in response &&
+          response.content &&
+          response.content['application/json']
+        ) {
+          const { schema } = response.content['application/json'] as {
+            schema: OpenAPIV3.SchemaObject;
+          };
+          if (schema && '$ref' in schema) {
+            const ref = schema.$ref as string;
+            const refName = ref.replace('#/components/schemas/', '');
+            const resolvedSchema = openApiSpec.components?.schemas?.[refName];
+            response.content['application/json'].schema = resolvedSchema || schema;
+          }
+        }
+
+        return {
+          ...operation,
+          path,
+          method,
+          description: operation.description,
+          summary: operation.summary,
+          parameters,
+          response,
+          example: (operation as Record<string, unknown>)['x-codeSamples'],
+        };
+      });
+    })
+    .flat();
+  return documents;
+}
+
+async function ingestDoc(
+  indexName: string,
+  documents: Document[],
+  esClient: ElasticsearchClient,
+  logger: Logger
+) {
+  logger.info(`Total documents in file: ${documents.length}`);
+
+  const exists = await esClient.indices.exists({ index: indexName });
+  if (exists) {
+    logger.info(`Index ${indexName} already exists. Deleting...`);
+    await esClient.indices.delete({ index: indexName });
+    logger.info(`Index ${indexName} deleted.`);
+  }
+
+  logger.info(`Creating index ${indexName}...`);
+  await esClient.indices.create({
+    index: indexName,
+    settings: {
+      'index.mapping.total_fields.limit': 2000,
+    },
+    mappings: {
+      properties: {
+        // Semantic text fields for semantic search
+        description: {
+          type: 'semantic_text',
+          inference_id: '.multilingual-e5-small-elasticsearch',
+        },
+        endpoint: {
+          type: 'semantic_text',
+          inference_id: '.multilingual-e5-small-elasticsearch',
+        },
+        summary: {
+          type: 'semantic_text',
+          inference_id: '.multilingual-e5-small-elasticsearch',
+        },
+        // Text fields for lexical search
+        description_text: { type: 'text' },
+        summary_text: { type: 'text' },
+        operationId: { type: 'text' },
+        // Keyword fields for exact and prefix matching
+        method: { type: 'keyword' },
+        path: {
+          type: 'text',
+          fields: {
+            keyword: { type: 'keyword' },
+          },
+        },
+        tags: { type: 'keyword' },
+        // Nested and other fields
+        parameters: {
+          type: 'object',
+          enabled: false,
+        },
+        responses: {
+          type: 'object',
+          enabled: false,
+        },
+        example: {
+          type: 'object',
+          enabled: false,
+        },
+      },
+    },
+  });
+  logger.info(`Index ${indexName} created successfully.`);
+
+  // Prepare bulk operations only with the needed fields
+  logger.info('Preparing bulk operations...');
+  const operations = documents.flatMap((doc) => {
+    const payload: Record<string, any> = {
+      // Search fields
+      description: doc.description ?? '',
+      summary: doc.summary ?? '',
+      operationId: doc.operationId ?? '',
+      method: doc.method ?? '',
+      path: doc.path ?? '',
+      tags: doc.tags ?? [],
+      // Text versions for lexical search
+      description_text: doc.description ?? '',
+      summary_text: doc.summary ?? '',
+      // Store complete data for tool generation (but don't index deeply)
+      parameters: doc.parameters ?? [],
+      responses: doc.responses ?? {},
+      example: doc.example ?? [],
+    };
+    if (doc.method && doc.path) {
+      payload.endpoint = `${doc.method.toUpperCase()} ${doc.path}`;
+    }
+
+    return [{ index: { _index: indexName } }, payload];
+  });
+
+  logger.info(`Bulk operations prepared: ${operations.length / 2} documents`);
+  logger.info('Starting bulk indexing...');
+
+  const response = await esClient.bulk({
+    refresh: true,
+    operations: operations as any,
+  });
+
+  if (response.errors) {
+    const errorItems = response.items.filter((item) => item.index?.error);
+    logger.error(`Bulk indexing had ${errorItems.length} errors:`);
+    errorItems.slice(0, 5).forEach((item) => {
+      logger.error(JSON.stringify(item.index?.error, null, 2));
+    });
+    throw new Error(
+      `Error indexing documents: ${errorItems.length} failed out of ${response.items.length}`
+    );
+  }
+
+  logger.info(`Successfully indexed ${response.items.length} documents!`);
+  logger.info(`Took: ${response.took}ms`);
+}
+
+export async function ingestOpenApiSpec({
+  indexName,
+  esClient,
+  openApiSpec,
+  logger,
+}: {
+  indexName: string;
+  openApiSpec: OpenAPIV3.Document;
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}) {
+  const documents = generateDocuments(openApiSpec);
+  await ingestDoc(indexName, documents, esClient, logger);
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/kibana.jsonc
@@ -21,7 +21,7 @@
       "discoverShared",
       "licensing"
     ],
-    "optionalPlugins": ["ml", "spaces"],
+    "optionalPlugins": ["ml", "spaces", "llmTasks"],
     "requiredBundles": ["kibanaReact"],
     "extraPublicDirs": []
   }

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/graph.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/graph.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { StateGraph, Annotation } from '@langchain/langgraph';
+import { type Tool, tool as toTool } from '@langchain/core/tools';
+import type { BaseMessage } from '@langchain/core/messages';
+import { messagesStateReducer } from '@langchain/langgraph';
+import { ToolNode } from '@langchain/langgraph/prebuilt';
+import type { KibanaRequest } from '@kbn/core/server';
+import type { ModelProvider, ToolEventEmitter } from '@kbn/agent-builder-server';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
+import type { IScopedClusterClient } from '@kbn/core/server';
+import { getElasticsearchPrompt } from './prompts';
+import { progressMessages } from './i18n';
+import type { ObservabilityAgentBuilderCoreSetup } from '../../types';
+import { OpenAPIToolSet } from '../../utils/openapi_tool_set';
+
+const StateAnnotation = Annotation.Root({
+  // inputs
+  nlQuery: Annotation<string>(),
+  query: Annotation<string>(),
+  // inner
+  toolsValid: Annotation<boolean>(),
+  tools: Annotation<Tool[]>(),
+  messages: Annotation<BaseMessage[]>({
+    reducer: messagesStateReducer,
+    default: () => [],
+  }),
+  // outputs
+  error: Annotation<string>(),
+  results: Annotation<{ content: unknown }[]>({
+    reducer: (a, b) => [...a, ...b],
+    default: () => [],
+  }),
+});
+
+export type StateType = typeof StateAnnotation.State;
+
+export const createElasticsearchToolGraph = async ({
+  core,
+  modelProvider,
+  esClient,
+  events,
+  request,
+}: {
+  core: ObservabilityAgentBuilderCoreSetup;
+  modelProvider: ModelProvider;
+  esClient: IScopedClusterClient;
+  events: ToolEventEmitter;
+  request: KibanaRequest;
+}) => {
+  // TODO make this configurable, we need a platform level setting for the embedding model
+  const inferenceId = defaultInferenceEndpoints.ELSER;
+  // Create a closure that will resolve llmTasks when the handler is called
+  const getLlmTasks = async () => {
+    const [, plugins] = await core.getStartServices();
+    return plugins.llmTasks;
+  };
+  const model = await modelProvider.getDefaultModel();
+
+  const generateTools = async (state: StateType) => {
+    events?.reportProgress(progressMessages.generatingTools());
+    const llmTasks = await getLlmTasks();
+    if (!llmTasks) {
+      return {
+        toolsValid: false,
+        error: 'LLM Tasks plugin is not available',
+      };
+    }
+    const connector = model.connector;
+    // Retrieve documentation
+    const result = await llmTasks.retrieveDocumentation({
+      searchTerm: state.query,
+      products: ['elasticsearch'],
+      resourceTypes: ['openapi_spec'],
+      max: 5,
+      connectorId: connector.connectorId,
+      request,
+      inferenceId,
+    });
+
+    const openapiSpecs = result.documents.map((doc) => JSON.parse(doc.content));
+
+    const openApiToolSet = new OpenAPIToolSet({ operations: openapiSpecs });
+
+    const tools = openApiToolSet.getTools();
+
+    // TODO: validate tools
+    if (tools.length > 0) {
+      return {
+        toolsValid: true,
+        tools: tools.map((tool) =>
+          toTool(async (args) => tool.handler(args, esClient), {
+            name: tool.name,
+            description: tool.description,
+            schema: tool.schema,
+          })
+        ),
+      };
+    } else {
+      return {
+        toolsValid: false,
+        error: `Could not dynamically generate tools`,
+      };
+    }
+  };
+
+  const terminateIfInvalidTools = async (state: StateType) => {
+    return state.toolsValid ? 'agent' : '__end__';
+  };
+
+  const callElasticsearchAgent = async (state: StateType) => {
+    events?.reportProgress(progressMessages.callingElasticsearchAgent());
+    const searchModel = model.chatModel.bindTools(state.tools).withConfig({
+      tags: ['observability-elasticsearch-tool'],
+    });
+    const response = await searchModel.invoke(
+      getElasticsearchPrompt({ nlQuery: state.nlQuery, tools: state.tools })
+    );
+    return {
+      messages: [response],
+    };
+  };
+
+  const decideContinueOrEnd = async (state: StateType) => {
+    // only one call for now
+    return '__end__';
+  };
+
+  const executeTool = async (state: StateType) => {
+    events?.reportProgress(progressMessages.performingElasticsearchTool());
+    const toolNode = new ToolNode<typeof StateAnnotation.State.messages>(state.tools);
+    const toolNodeResult = await toolNode.invoke(state.messages);
+    const toolMessage = toolNodeResult[toolNodeResult.length - 1];
+    return {
+      results: [
+        {
+          name: toolMessage.name!,
+          content: JSON.parse(toolMessage.content as string),
+        },
+      ],
+    };
+  };
+
+  const graph = new StateGraph(StateAnnotation)
+    // nodes
+    .addNode('generate_tools', generateTools)
+    .addNode('agent', callElasticsearchAgent)
+    .addNode('execute_tool', executeTool)
+    // edges
+    .addEdge('__start__', 'generate_tools')
+    .addConditionalEdges('generate_tools', terminateIfInvalidTools, {
+      agent: 'agent',
+      __end__: '__end__',
+    })
+    .addEdge('agent', 'execute_tool')
+    .addConditionalEdges('execute_tool', decideContinueOrEnd, {
+      agent: 'agent',
+      __end__: '__end__',
+    })
+    .compile();
+
+  return graph;
+};

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/graph.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/graph.ts
@@ -22,7 +22,6 @@ import { OpenAPIToolSet } from '../../utils/openapi_tool_set';
 const StateAnnotation = Annotation.Root({
   // inputs
   nlQuery: Annotation<string>(),
-  query: Annotation<string>(),
   // inner
   toolsValid: Annotation<boolean>(),
   tools: Annotation<Tool[]>(),
@@ -74,7 +73,7 @@ export const createElasticsearchToolGraph = async ({
     const connector = model.connector;
     // Retrieve documentation
     const result = await llmTasks.retrieveDocumentation({
-      searchTerm: state.query,
+      searchTerm: state.nlQuery,
       products: ['elasticsearch'],
       resourceTypes: ['openapi_spec'],
       max: 5,

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/handler.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/handler.ts
@@ -15,7 +15,6 @@ import { createElasticsearchToolGraph } from './graph';
 export const getToolHandler = async ({
   core,
   nlQuery,
-  query,
   modelProvider,
   esClient,
   events,
@@ -23,7 +22,6 @@ export const getToolHandler = async ({
 }: {
   core: ObservabilityAgentBuilderCoreSetup;
   nlQuery: string;
-  query: string;
   modelProvider: ModelProvider;
   esClient: IScopedClusterClient;
   events: ToolEventEmitter;
@@ -46,7 +44,7 @@ export const getToolHandler = async ({
     },
     async () => {
       const outState = await toolGraph.invoke(
-        { nlQuery, query },
+        { nlQuery },
         { tags: ['elasticsearch_tool'], metadata: { graphName: 'elasticsearch_tool' } }
       );
 

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/handler.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/handler.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import { withActiveInferenceSpan, ElasticGenAIAttributes } from '@kbn/inference-tracing';
+import type { ModelProvider, ToolEventEmitter } from '@kbn/agent-builder-server';
+import type { IScopedClusterClient } from '@kbn/core/server';
+import type { ObservabilityAgentBuilderCoreSetup } from '../../types';
+import { createElasticsearchToolGraph } from './graph';
+
+export const getToolHandler = async ({
+  core,
+  nlQuery,
+  query,
+  modelProvider,
+  esClient,
+  events,
+  request,
+}: {
+  core: ObservabilityAgentBuilderCoreSetup;
+  nlQuery: string;
+  query: string;
+  modelProvider: ModelProvider;
+  esClient: IScopedClusterClient;
+  events: ToolEventEmitter;
+  request: KibanaRequest;
+}) => {
+  const toolGraph = await createElasticsearchToolGraph({
+    core,
+    modelProvider,
+    esClient,
+    events,
+    request,
+  });
+
+  return withActiveInferenceSpan(
+    'ElasticsearchToolGraph',
+    {
+      attributes: {
+        [ElasticGenAIAttributes.InferenceSpanKind]: 'CHAIN',
+      },
+    },
+    async () => {
+      const outState = await toolGraph.invoke(
+        { nlQuery, query },
+        { tags: ['elasticsearch_tool'], metadata: { graphName: 'elasticsearch_tool' } }
+      );
+
+      if (outState.error) {
+        throw new Error(outState.error);
+      }
+
+      return outState.results[0];
+    }
+  );
+};

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/i18n.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/i18n.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const progressMessages = {
+  generatingTools: () => {
+    return i18n.translate(
+      'xpack.observability.agent.tools.elasticsearch.progress.generatingTools',
+      {
+        defaultMessage: 'Dynamically generating tools based on the user query',
+      }
+    );
+  },
+  callingElasticsearchAgent: () => {
+    return i18n.translate(
+      'xpack.observability.agent.tools.elasticsearch.progress.callingElasticsearchAgent',
+      {
+        defaultMessage: 'Choosing the most appropriate Elasticsearch API',
+      }
+    );
+  },
+  performingElasticsearchTool: () => {
+    return i18n.translate(
+      'xpack.observability.agent.tools.elasticsearch.progress.performingElasticsearchTool',
+      {
+        defaultMessage: 'Executing the Elasticsearch tool',
+      }
+    );
+  },
+};

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/prompts.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/prompts.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BaseMessageLike } from '@langchain/core/messages';
+import type { Tool } from '@langchain/core/tools';
+
+export const getElasticsearchPrompt = ({
+  nlQuery,
+  tools,
+}: {
+  nlQuery: string;
+  tools: Tool[];
+}): BaseMessageLike[] => {
+  const systemPrompt = `You are an expert Elasticsearch tool caller. Your sole task is to analyze a user's request and call the single most appropriate tool to answer it.
+You **must** call **one** of the available tools. Do not answer the user directly or ask clarifying questions.
+
+## Available Tools
+
+${tools.map((tool) => `### ${tool.name} (${tool.description})`).join('\n')}
+
+`;
+
+  const userPrompt = `Execute the following user query: "${nlQuery}"`;
+
+  return [
+    ['system', systemPrompt],
+    ['user', userPrompt],
+  ];
+};

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/tool.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import { ToolType } from '@kbn/agent-builder-common';
+import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
+import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
+import type { Logger } from '@kbn/core/server';
+import type {
+  ObservabilityAgentBuilderCoreSetup,
+  ObservabilityAgentBuilderPluginSetupDependencies,
+} from '../../types';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import { getToolHandler } from './handler';
+export const OBSERVABILITY_ELASTICSEARCH_TOOL_ID = 'observability.elasticsearch';
+
+const ElasticsearchSchema = z.object({
+  query: z.string().describe('a query to search documents in Elasticsearch OpenAPI index.'),
+  nlQuery: z
+    .string()
+    .describe('A natural language query to describe the Elasticsearch operation to perform.'),
+});
+
+export function createElasticsearchTool({
+  core,
+  plugins,
+  logger,
+}: {
+  core: ObservabilityAgentBuilderCoreSetup;
+  plugins: ObservabilityAgentBuilderPluginSetupDependencies;
+  logger: Logger;
+}) {
+  const toolDefinition: BuiltinToolDefinition<typeof ElasticsearchSchema> = {
+    id: OBSERVABILITY_ELASTICSEARCH_TOOL_ID,
+    type: ToolType.builtin,
+    description:
+      'Executes Elasticsearch API calls by searching the Elasticsearch API documentation index for relevant endpoints based on a natural language query, then dynamically selecting and calling the most appropriate API.',
+    schema: ElasticsearchSchema,
+    tags: ['observability', 'elasticsearch'],
+    availability: {
+      cacheMode: 'space',
+      handler: async ({ request }) => {
+        return getAgentBuilderResourceAvailability({ core, request, logger });
+      },
+    },
+    handler: async ({ query, nlQuery }, { modelProvider, esClient, events, request }) => {
+      try {
+        const data = await getToolHandler({
+          core,
+          nlQuery,
+          query,
+          modelProvider,
+          esClient,
+          events,
+          request,
+        });
+
+        return {
+          results: [
+            {
+              type: ToolResultType.other,
+              data,
+            },
+          ],
+        };
+      } catch (error) {
+        logger.error(`Error executing Elasticsearch tool: ${error.message}`);
+        logger.debug(error);
+        return {
+          results: [
+            {
+              type: ToolResultType.error,
+              data: {
+                message: `Error executing Elasticsearch tool: ${error.message}`,
+                stack: error.stack,
+              },
+            },
+          ],
+        };
+      }
+    },
+  };
+
+  return toolDefinition;
+}

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/tool.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/elasticsearch/tool.ts
@@ -19,7 +19,6 @@ import { getToolHandler } from './handler';
 export const OBSERVABILITY_ELASTICSEARCH_TOOL_ID = 'observability.elasticsearch';
 
 const ElasticsearchSchema = z.object({
-  query: z.string().describe('a query to search documents in Elasticsearch OpenAPI index.'),
   nlQuery: z
     .string()
     .describe('A natural language query to describe the Elasticsearch operation to perform.'),
@@ -47,12 +46,11 @@ export function createElasticsearchTool({
         return getAgentBuilderResourceAvailability({ core, request, logger });
       },
     },
-    handler: async ({ query, nlQuery }, { modelProvider, esClient, events, request }) => {
+    handler: async ({ nlQuery }, { modelProvider, esClient, events, request }) => {
       try {
         const data = await getToolHandler({
           core,
           nlQuery,
-          query,
           modelProvider,
           esClient,
           events,

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/register_tools.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/tools/register_tools.ts
@@ -53,6 +53,7 @@ import {
   createGetTraceChangePointsTool,
 } from './get_trace_change_points/tool';
 import { OBSERVABILITY_GET_INDEX_INFO_TOOL_ID, createGetIndexInfoTool } from './get_index_info';
+import { OBSERVABILITY_ELASTICSEARCH_TOOL_ID, createElasticsearchTool } from './elasticsearch/tool';
 
 const PLATFORM_TOOL_IDS = [
   platformCoreTools.listIndices,
@@ -75,6 +76,7 @@ const OBSERVABILITY_TOOL_IDS = [
   OBSERVABILITY_GET_METRIC_CHANGE_POINTS_TOOL_ID,
   OBSERVABILITY_GET_TRACE_CHANGE_POINTS_TOOL_ID,
   OBSERVABILITY_GET_INDEX_INFO_TOOL_ID,
+  OBSERVABILITY_ELASTICSEARCH_TOOL_ID,
 ];
 
 export const OBSERVABILITY_AGENT_TOOL_IDS = [...PLATFORM_TOOL_IDS, ...OBSERVABILITY_TOOL_IDS];
@@ -104,6 +106,7 @@ export async function registerTools({
     createGetMetricChangePointsTool({ core, plugins, logger }),
     createGetTraceChangePointsTool({ core, plugins, logger }),
     createGetIndexInfoTool({ core, plugins, logger }),
+    createElasticsearchTool({ core, plugins, logger }),
   ];
 
   for (const tool of observabilityTools) {

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/types.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/types.ts
@@ -27,6 +27,7 @@ import type { RuleRegistryPluginStartContract } from '@kbn/rule-registry-plugin/
 import type { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
 import type { MlPluginSetup, MlPluginStart } from '@kbn/ml-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { LlmTasksPluginStart } from '@kbn/llm-tasks-plugin/server';
 import type { InferenceServerSetup, InferenceServerStart } from '@kbn/inference-plugin/server';
 import type { ObservabilityAgentBuilderDataRegistry } from './data_registry/data_registry';
 
@@ -57,6 +58,7 @@ export interface ObservabilityAgentBuilderPluginStartDependencies {
   inference: InferenceServerStart;
   ml?: MlPluginStart;
   spaces?: SpacesPluginStart;
+  llmTasks?: LlmTasksPluginStart;
 }
 
 export type ObservabilityAgentBuilderCoreSetup = CoreSetup<

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/utils/openapi_tool_set.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/utils/openapi_tool_set.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* eslint-disable max-classes-per-file */
+import type { OpenAPIV3 } from 'openapi-types';
+import type {
+  ToolDefinitions,
+  ToolDefinition,
+} from '@kbn/inference-common/src/chat_complete/tools';
+import type { ToolSchema } from '@kbn/inference-common/src/chat_complete/tool_schema';
+import type { IScopedClusterClient } from '@kbn/core/server';
+
+export type OperationObject = OpenAPIV3.OperationObject<{
+  path: string;
+  method: OpenAPIV3.HttpMethods;
+  endpoint: string;
+}>;
+
+type ToolHandler = (
+  args: any,
+  esClient: IScopedClusterClient
+) => Promise<{ response?: any; console_command: string; error?: string }>;
+
+class RestApiTool {
+  private readonly operation: OperationObject;
+  private readonly name: string;
+  private readonly description: string;
+  private readonly schema: ToolSchema;
+  private readonly handler: ToolHandler;
+  constructor(operation: OperationObject) {
+    this.operation = operation;
+    this.name = this.getOperationName(operation);
+    this.description = this.getOperationDescription(operation);
+    this.schema = this.getOperationSchema(operation);
+    this.handler = this.getOperationHandler(operation);
+  }
+  getOperationHandler(operation: OperationObject): ToolHandler {
+    return async (args, esClient) => {
+      let path = operation.path;
+      const parameters = operation.parameters as OpenAPIV3.ParameterObject[];
+      const pathParams = parameters.filter((p) => p.in === 'path');
+      for (const p of pathParams) {
+        if (!args[p.name] && p.required) {
+          throw new Error(`Missing required path param: ${p.name}`);
+        }
+        path = path.replace(`{${p.name}}`, encodeURIComponent(args[p.name]));
+      }
+
+      const queryParams = parameters.filter((p) => p.in === 'query');
+      const query: Record<string, string> = {};
+      for (const p of queryParams) {
+        if (args[p.name] != null) query[p.name] = args[p.name];
+      }
+
+      // equivalent command for debugging
+      const consoleCommand = `${operation.method.toUpperCase()} ${path}${
+        Object.keys(query).length
+          ? '?' +
+            Object.entries(query)
+              .map(([k, v]) => `${k}=${v}`)
+              .join('&')
+          : ''
+      }`;
+
+      try {
+        const response = await esClient.asCurrentUser.transport.request({
+          method: operation.method,
+          path,
+          querystring: Object.keys(query).length ? query : undefined,
+        });
+
+        return {
+          response,
+          console_command: consoleCommand,
+        };
+      } catch (error) {
+        return { error: error.message, console_command: consoleCommand };
+      }
+    };
+  }
+
+  getOperationName(operation: OperationObject): string {
+    if (operation.operationId) {
+      return operation.operationId;
+    }
+    return `${operation.method.toLowerCase()}_${operation.path}`;
+  }
+  getOperationDescription(operation: OperationObject): string {
+    return `${operation.method.toUpperCase()} ${operation.path} - ${operation.description} - ${
+      operation.summary
+    }`;
+  }
+  getOperationSchema(operation: OperationObject): ToolSchema {
+    const properties: Record<string, any> = {};
+    const required: string[] = [];
+    const parameters = operation.parameters as OpenAPIV3.ParameterObject[];
+    for (const param of parameters) {
+      const schema = param.schema as OpenAPIV3.SchemaObject;
+      if (schema.type === 'array') {
+        properties[param.name] = {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        };
+      } else {
+        properties[param.name] = {
+          type: schema.type,
+          description: param.description,
+        };
+      }
+      if (param.required) required.push(param.name);
+    }
+    const schema: ToolSchema = {
+      type: 'object',
+      properties,
+      required,
+    };
+    return schema;
+  }
+
+  getToolDefinition(): ToolDefinition {
+    return {
+      description: this.description,
+      schema: this.schema,
+    };
+  }
+
+  getOperation(): OperationObject {
+    return this.operation;
+  }
+
+  getName(): string {
+    return this.name;
+  }
+  getHandler(): ToolHandler {
+    return this.handler;
+  }
+  getTool() {
+    return {
+      handler: this.handler,
+      name: this.name,
+      description: this.description,
+      schema: this.schema,
+    };
+  }
+}
+
+export class OpenAPIToolSet {
+  private readonly operations: OperationObject[];
+  private readonly tools: RestApiTool[];
+  constructor({ operations }: { operations: OperationObject[] }) {
+    this.operations = operations;
+    this.tools = this.parse(operations);
+  }
+
+  private parse(operations: OperationObject[]): RestApiTool[] {
+    const tools: RestApiTool[] = [];
+    for (const operation of operations) {
+      tools.push(new RestApiTool(operation));
+    }
+    return tools;
+  }
+
+  getTools() {
+    return this.tools.map((tool) => tool.getTool());
+  }
+
+  getToolDefinitions(): ToolDefinitions {
+    return this.tools.reduce<ToolDefinitions>((acc: ToolDefinitions, tool: RestApiTool) => {
+      acc[tool.getName()] = tool.getToolDefinition();
+      return acc;
+    }, {});
+  }
+
+  getTool(operationId: string): RestApiTool | undefined {
+    return this.tools.find((tool) => tool.getName() === operationId);
+  }
+
+  getToolHandler(operationId: string): ToolHandler | undefined {
+    return this.tools.find((tool) => tool.getName() === operationId)?.getHandler();
+  }
+
+  getToolOperation(operationId: string): OperationObject | undefined {
+    return this.tools.find((tool) => tool.getName() === operationId)?.getOperation();
+  }
+
+  getToolName(operationId: string): string | undefined {
+    return this.tools.find((tool) => tool.getName() === operationId)?.getName();
+  }
+}


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-team/issues/472
## Summary

This PR add a Elasticsearch Tool (NL-to-elasticsearch API tool based on Elasticsearch OpenAPI docs) that enables the Obs Agent to execute Elasticsearch APIs from natural language using dynamic tool generation. 

The tool searches indexed Elasticsearch OpenAPI documentation, generates tools dynamically from matching API definitions, and executes the selected API. 


Example:
Before:

https://github.com/user-attachments/assets/a3ffb0f0-d31e-4054-8092-f8eeca12451c

trace: https://oblt-apps.elastic.dev/phoenix-ai/projects/UHJvamVjdDoyOTMz/spans/242f58fad201f855f9812e1f43d786d0?selectedSpanNodeId=U3BhbjozNzM5OTI=

Current:

https://github.com/user-attachments/assets/b2bbfc1a-d1ef-45c8-b6a1-137adb13d1d0

trace: https://oblt-apps.elastic.dev/phoenix-ai/projects/UHJvamVjdDoyOTMz/spans/03b4cfea17ef0c6257281c86cb8c2316?selectedSpanNodeId=U3BhbjozNzQwMjg=