### PR TITLE
[Streams] Use TS source command for time-series data streams

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -117,6 +117,11 @@ export {
 } from './src/models/ingest/settings';
 
 export {
+  type IngestStreamIndexMode,
+  ingestStreamIndexModeSchema,
+} from './src/models/ingest/index_mode';
+
+export {
   type FailureStore,
   type EffectiveFailureStore,
   type WiredIngestStreamEffectiveFailureStore,

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/base.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/base.ts
@@ -19,6 +19,8 @@ import { failureStoreSchema } from './failure_store';
 import type { IngestStreamProcessing } from './processing';
 import { ingestStreamProcessingSchema } from './processing';
 import type { StrictOmit } from '../core';
+import type { IngestStreamIndexMode } from './index_mode';
+import { ingestStreamIndexModeSchema } from './index_mode';
 
 interface IngestStreamPrivileges {
   // User can change everything about the stream
@@ -127,6 +129,7 @@ export namespace IngestBaseStream {
     TDefinition extends IngestBaseStream.Definition = IngestBaseStream.Definition
   > extends BaseStream.GetResponse<TDefinition> {
     privileges: IngestStreamPrivileges;
+    index_mode?: IngestStreamIndexMode;
   }
 
   export type UpsertRequest<
@@ -148,6 +151,7 @@ const IngestBaseStreamSchema = {
   }),
   GetResponse: z.object({
     privileges: ingestStreamPrivilegesSchema,
+    index_mode: z.optional(ingestStreamIndexModeSchema),
   }),
   UpsertRequest: z.object({}),
 };

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/index.ts
@@ -13,6 +13,8 @@ import type { Validation } from '../validation/validation';
 import { validation } from '../validation/validation';
 import { ClassicIngest, ClassicIngestUpsertRequest, ClassicStream } from './classic';
 import { WiredIngest, WiredIngestUpsertRequest, WiredStream } from './wired';
+export type { IngestStreamIndexMode } from './index_mode';
+export { ingestStreamIndexModeSchema } from './index_mode';
 
 /* eslint-disable @typescript-eslint/no-namespace */
 export namespace IngestStream {

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/index_mode.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/index_mode.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { z } from '@kbn/zod';
+
+/**
+ * Index mode values returned by Elasticsearch for data streams.
+ * - standard: Default index mode
+ * - time_series: Time series data stream (TSDB)
+ * - logsdb: Logs data stream
+ * - lookup: Lookup index mode
+ */
+export type IngestStreamIndexMode = 'standard' | 'time_series' | 'logsdb' | 'lookup';
+
+export const ingestStreamIndexModeSchema: z.Schema<IngestStreamIndexMode> = z.enum([
+  'standard',
+  'time_series',
+  'logsdb',
+  'lookup',
+]);

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/crud/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/crud/route.ts
@@ -8,7 +8,10 @@
 import type { SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
 import { z } from '@kbn/zod';
 import type { estypes } from '@elastic/elasticsearch';
-import type { ClassicIngestStreamEffectiveLifecycle } from '@kbn/streams-schema';
+import type {
+  ClassicIngestStreamEffectiveLifecycle,
+  IngestStreamIndexMode,
+} from '@kbn/streams-schema';
 import type { Streams } from '@kbn/streams-schema';
 import { processAsyncInChunks } from '../../../../utils/process_async_in_chunks';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
@@ -19,6 +22,7 @@ export interface ListStreamDetail {
   stream: Streams.all.Definition;
   effective_lifecycle?: ClassicIngestStreamEffectiveLifecycle;
   data_stream?: estypes.IndicesDataStream;
+  index_mode?: IngestStreamIndexMode;
 }
 
 export const listStreamsRoute = createServerRoute({
@@ -65,6 +69,7 @@ export const listStreamsRoute = createServerRoute({
         stream,
         effective_lifecycle: getDataStreamLifecycle(match ?? null),
         data_stream: match,
+        index_mode: match?.index_mode as IngestStreamIndexMode | undefined,
       });
       return acc;
     }, []);

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/read_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/read_stream.ts
@@ -107,6 +107,7 @@ export async function readStream({
       effective_failure_store: getFailureStore({
         dataStream: dataStream as DataStreamWithFailureStore,
       }),
+      index_mode: dataStream?.index_mode,
     } satisfies Streams.ClassicStream.GetResponse;
   }
 
@@ -134,6 +135,7 @@ export async function readStream({
     effective_settings: getInheritedSettings([...ancestors, streamDefinition]),
     inherited_fields: inheritedFields,
     effective_failure_store: effectiveFailureStore,
+    index_mode: dataStream?.index_mode,
   };
   return body;
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_badges/index.tsx
@@ -24,6 +24,7 @@ import { css } from '@emotion/react';
 import { useKibana } from '../../hooks/use_kibana';
 
 import { truncateText } from '../../util/truncate_text';
+import { getEsqlSourceCommand } from '../../util/esql_source_command';
 
 const DataRetentionTooltip: React.FC<{ children: React.ReactElement }> = ({ children }) => (
   <EuiToolTip
@@ -179,8 +180,9 @@ export function DiscoverBadgeButton({
   const dataStreamExists =
     Streams.WiredStream.GetResponse.is(definition) || definition.data_stream_exists;
   const indexPatterns = getIndexPatternsForStream(definition.stream);
+  const sourceCommand = getEsqlSourceCommand(definition.index_mode);
   const esqlQuery = indexPatterns
-    ? `FROM ${indexPatterns.join(', ')}${isWiredStream ? ' METADATA _source' : ''}`
+    ? `${sourceCommand} ${indexPatterns.join(', ')}${isWiredStream ? ' METADATA _source' : ''}`
     : undefined;
   const useUrl = share.url.locators.useUrl;
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/child_stream_list.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/child_stream_list.tsx
@@ -24,7 +24,7 @@ export function ChildStreamList({ definition }: { definition?: Streams.ingest.al
     if (!definition) {
       return [];
     }
-    return wiredStreams?.filter((d) => isDescendantOf(definition.stream.name, d.name));
+    return wiredStreams?.filter((d) => isDescendantOf(definition.stream.name, d.stream.name));
   }, [definition, wiredStreams]);
 
   if (definition && childrenStreams?.length === 0) {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/components/stream_chart_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/components/stream_chart_panel.tsx
@@ -25,6 +25,7 @@ import { StreamsAppSearchBar } from '../../streams_app_search_bar';
 import { useStreamsAppFetch } from '../../../hooks/use_streams_app_fetch';
 import { useTimefilter } from '../../../hooks/use_timefilter';
 import { executeEsqlQuery } from '../../../hooks/use_execute_esql_query';
+import { getEsqlSourceCommand } from '../../../util/esql_source_command';
 
 interface StreamChartPanelProps {
   definition: Streams.ingest.all.GetResponse;
@@ -59,7 +60,8 @@ export function StreamChartPanel({ definition }: StreamChartPanelProps) {
       return undefined;
     }
 
-    const baseQuery = `FROM ${indexPatterns.join(', ')}`;
+    const sourceCommand = getEsqlSourceCommand(definition.index_mode);
+    const baseQuery = `${sourceCommand} ${indexPatterns.join(', ')}`;
 
     const histogramQuery = `${baseQuery} | STATS metric = COUNT(*) BY @timestamp = BUCKET(@timestamp, ${bucketSize})`;
 
@@ -67,7 +69,7 @@ export function StreamChartPanel({ definition }: StreamChartPanelProps) {
       baseQuery,
       histogramQuery,
     };
-  }, [bucketSize, indexPatterns]);
+  }, [bucketSize, definition.index_mode, indexPatterns]);
 
   const discoverLink = useMemo(() => {
     if (!discoverLocator || !queries?.baseQuery) {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
@@ -498,6 +498,7 @@ export function StreamsTreeTable({
                 {
                   stream: item.stream,
                   data_stream_exists: !!item.data_stream,
+                  index_mode: item.index_mode,
                 } as Streams.ingest.all.GetResponse
               }
               isWiredStream={item.type === 'wired'}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.ts
@@ -188,6 +188,7 @@ export const enrichStream = (node: StreamTree | ListStreamDetail): EnrichedStrea
     stream: node.stream,
     effective_lifecycle: node.effective_lifecycle,
     data_stream: node.data_stream,
+    index_mode: node.index_mode,
     nameSortKey,
     documentsCount: 0,
     retentionMs,

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_wired_streams.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_wired_streams.ts
@@ -6,6 +6,7 @@
  */
 
 import { Streams } from '@kbn/streams-schema';
+import type { ListStreamDetail } from '@kbn/streams-plugin/server/routes/internal/streams/crud/route';
 import { useKibana } from './use_kibana';
 import { useStreamsAppFetch } from './use_streams_app_fetch';
 
@@ -19,12 +20,14 @@ export const useWiredStreams = () => {
   } = useKibana();
 
   const result = useStreamsAppFetch(
-    async ({ signal }) => streamsRepositoryClient.fetch('GET /api/streams 2023-10-31', { signal }),
+    async ({ signal }) => streamsRepositoryClient.fetch('GET /internal/streams', { signal }),
     [streamsRepositoryClient]
   );
 
   return {
-    wiredStreams: result.value?.streams.filter(Streams.WiredStream.Definition.is),
+    wiredStreams: result.value?.streams.filter((s): s is ListStreamDetail =>
+      Streams.WiredStream.Definition.is(s.stream)
+    ),
     isLoading: result.loading,
   };
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/util/esql_source_command.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/util/esql_source_command.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IngestStreamIndexMode } from '@kbn/streams-schema';
+import { getEsqlSourceCommand } from './esql_source_command';
+
+describe('getEsqlSourceCommand', () => {
+  it('returns "TS" for time_series index mode', () => {
+    const indexMode: IngestStreamIndexMode = 'time_series';
+    expect(getEsqlSourceCommand(indexMode)).toBe('TS');
+  });
+
+  it('returns "FROM" for standard index mode', () => {
+    const indexMode: IngestStreamIndexMode = 'standard';
+    expect(getEsqlSourceCommand(indexMode)).toBe('FROM');
+  });
+
+  it('returns "FROM" for logsdb index mode', () => {
+    const indexMode: IngestStreamIndexMode = 'logsdb';
+    expect(getEsqlSourceCommand(indexMode)).toBe('FROM');
+  });
+
+  it('returns "FROM" for lookup index mode', () => {
+    const indexMode: IngestStreamIndexMode = 'lookup';
+    expect(getEsqlSourceCommand(indexMode)).toBe('FROM');
+  });
+
+  it('returns "FROM" when index mode is undefined', () => {
+    expect(getEsqlSourceCommand(undefined)).toBe('FROM');
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/util/esql_source_command.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/util/esql_source_command.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IngestStreamIndexMode } from '@kbn/streams-schema';
+
+/**
+ * Determines the ES|QL source command to use based on the stream's index mode.
+ * - For time_series index mode (TSDB), returns 'TS'
+ * - For all other index modes (standard, logsdb, lookup) or when index_mode is undefined, returns 'FROM'
+ *
+ * @param indexMode - The index mode of the data stream
+ * @returns 'TS' for time_series streams, 'FROM' for all others
+ */
+export function getEsqlSourceCommand(indexMode: IngestStreamIndexMode | undefined): 'TS' | 'FROM' {
+  return indexMode === 'time_series' ? 'TS' : 'FROM';
+}

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -179,6 +179,38 @@ export class StreamsApp {
     }
   }
 
+  async verifyDiscoverButtonSourceCommand(
+    streamName: string,
+    expectedCommand: 'FROM' | 'TS'
+  ): Promise<void> {
+    const locator = this.page.locator(
+      `[data-test-subj="streamsDiscoverActionButton-${streamName}"]`
+    );
+    await locator.waitFor();
+
+    const href = await locator.getAttribute('href');
+    if (!href) {
+      throw new Error(`Missing href for Discover action button of stream ${streamName}`);
+    }
+
+    // Check for the expected source command in the URL-encoded ESQL query
+    const expectedFragment = encodeURIComponent(`${expectedCommand} ${streamName}`);
+    const unexpectedCommand = expectedCommand === 'FROM' ? 'TS' : 'FROM';
+    const unexpectedFragment = encodeURIComponent(`${unexpectedCommand} ${streamName}`);
+
+    if (!href.includes(expectedFragment)) {
+      throw new Error(
+        `Expected "${expectedCommand} ${streamName}" in Discover link but it was not found. href=${href}`
+      );
+    }
+
+    if (href.includes(unexpectedFragment)) {
+      throw new Error(
+        `Unexpected "${unexpectedCommand} ${streamName}" found in Discover link. Expected "${expectedCommand}". href=${href}`
+      );
+    }
+  }
+
   async verifyStreamsAreInTable(streamNames: string[]) {
     for (const name of streamNames) {
       await expect(

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/esql_source_command.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/streams_list_view/esql_source_command.spec.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsClient } from '@kbn/scout';
+import { test } from '../../fixtures';
+import { generateLogsData } from '../../fixtures/generators';
+
+const STANDARD_STREAM = 'logs-standard-esql-test';
+const TIME_SERIES_STREAM = 'metrics-tsdb-esql-test';
+
+/**
+ * Creates an index template for a time-series (TSDB) data stream.
+ * Time-series data streams require dimension fields and proper settings.
+ */
+async function createTimeSeriesIndexTemplate(esClient: EsClient, streamName: string) {
+  await esClient.indices.putIndexTemplate({
+    name: `${streamName}-template`,
+    index_patterns: [streamName],
+    priority: 500, // High priority to override default templates
+    data_stream: {},
+    template: {
+      settings: {
+        index: {
+          mode: 'time_series',
+          routing_path: ['host.name'],
+        },
+      },
+      mappings: {
+        properties: {
+          '@timestamp': { type: 'date' },
+          host: {
+            properties: {
+              name: { type: 'keyword', time_series_dimension: true },
+            },
+          },
+          cpu: {
+            properties: {
+              usage: { type: 'double', time_series_metric: 'gauge' },
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+/**
+ * Indexes a single document to the time-series data stream.
+ */
+async function indexTimeSeriesDocument(esClient: EsClient, streamName: string) {
+  await esClient.index({
+    index: streamName,
+    document: {
+      '@timestamp': new Date().toISOString(),
+      host: { name: 'test-host' },
+      cpu: { usage: 50.5 },
+    },
+    refresh: true,
+  });
+}
+
+/**
+ * Cleans up the time-series data stream and its template.
+ */
+async function cleanupTimeSeriesStream(esClient: EsClient, streamName: string) {
+  try {
+    await esClient.indices.deleteDataStream({ name: streamName });
+  } catch {
+    // Ignore if doesn't exist
+  }
+  try {
+    await esClient.indices.deleteIndexTemplate({ name: `${streamName}-template` });
+  } catch {
+    // Ignore if doesn't exist
+  }
+}
+
+test.describe(
+  'ESQL source command - Verify FROM vs TS based on index_mode',
+  { tag: ['@ess', '@svlOblt'] },
+  () => {
+    test.beforeAll(async ({ logsSynthtraceEsClient, esClient }) => {
+      // Create standard stream with logs data
+      await generateLogsData(logsSynthtraceEsClient)({
+        index: STANDARD_STREAM,
+        startTime: 'now-15m',
+        endTime: 'now',
+        docsPerMinute: 5,
+      });
+
+      // Create time-series stream
+      await createTimeSeriesIndexTemplate(esClient, TIME_SERIES_STREAM);
+      await indexTimeSeriesDocument(esClient, TIME_SERIES_STREAM);
+    });
+
+    test.beforeEach(async ({ browserAuth, pageObjects }) => {
+      await browserAuth.loginAsAdmin();
+      await pageObjects.streams.gotoStreamMainPage();
+      await pageObjects.streams.expectStreamsTableVisible();
+    });
+
+    test.afterAll(async ({ apiServices, logsSynthtraceEsClient, esClient }) => {
+      // Cleanup standard stream
+      try {
+        await apiServices.streams.deleteStream(STANDARD_STREAM);
+      } catch {
+        // Ignore cleanup errors
+      }
+      await logsSynthtraceEsClient.clean();
+
+      // Cleanup time-series stream
+      await cleanupTimeSeriesStream(esClient, TIME_SERIES_STREAM);
+    });
+
+    test('standard/logsdb streams should use FROM in Discover link', async ({ pageObjects }) => {
+      // Verify the standard stream exists in the table
+      await pageObjects.streams.verifyStreamsAreInTable([STANDARD_STREAM]);
+
+      // Verify the Discover button uses FROM (not TS)
+      await pageObjects.streams.verifyDiscoverButtonSourceCommand(STANDARD_STREAM, 'FROM');
+    });
+
+    test('time-series (TSDB) streams should use TS in Discover link', async ({ pageObjects }) => {
+      // Verify the time-series stream exists in the table
+      await pageObjects.streams.verifyStreamsAreInTable([TIME_SERIES_STREAM]);
+
+      // Verify the Discover button uses TS (not FROM)
+      await pageObjects.streams.verifyDiscoverButtonSourceCommand(TIME_SERIES_STREAM, 'TS');
+    });
+  }
+);


### PR DESCRIPTION
## 🍒 Summary

Fixes "Explore in Discover" links in Streams to use `TS` instead of `FROM` for time-series data streams. When a data stream has `index_mode: 'time_series'`, ES|QL queries should use the `TS` source command to enable proper time-series functionality.

Closes #246220

## 🛠️ Changes

- Added `IngestStreamIndexMode` type and schema to `kbn-streams-schema` package
- Extended `IngestBaseStream.GetResponse` to include optional `index_mode` field
- Updated `read_stream.ts` to include `index_mode` from Elasticsearch data stream response
- Updated internal list streams route to expose `index_mode` as a top-level field in `ListStreamDetail`
- Created `getEsqlSourceCommand()` utility function that returns `'TS'` for time-series streams and `'FROM'` for all others
- Updated `streams_list/index.tsx` to pass `index_mode` through the stream tree and use proper source command
- Updated `useWiredStreams` hook to use internal API that includes `index_mode`
- Updated `stream_badges/index.tsx` to use `getEsqlSourceCommand()` for Discover links
- Updated `stream_chart_panel.tsx` to use `getEsqlSourceCommand()` for base query
- Added unit tests for `getEsqlSourceCommand()` covering all index modes

## 🎙️ Prompts

- Implement fix for issue #246220: Use TS source command for time-series streams
- Add `index_mode` field to stream API responses
- Create utility function to determine ES|QL source command based on index mode

🤖 This pull request was assisted by Cursor
