### PR TITLE
[Streams][SigEvents] Add task state timestamps

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/storage.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/storage.ts
@@ -18,6 +18,10 @@ export const taskStorageSettings = {
       stream: types.keyword(),
       space: types.keyword(),
       created_at: types.date(),
+      last_completed_at: types.date(),
+      last_acknowledged_at: types.date(),
+      last_canceled_at: types.date(),
+      last_failed_at: types.date(),
       // Workaround for https://github.com/elastic/kibana/issues/245974
       task: types.object({ enabled: false }),
     },

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_client.ts
@@ -107,6 +107,10 @@ export class TaskClient<TaskType extends string> {
       },
       status: TaskStatus.InProgress,
       created_at: new Date().toISOString(),
+      last_completed_at: storedTask.last_completed_at,
+      last_acknowledged_at: storedTask.last_acknowledged_at,
+      last_canceled_at: storedTask.last_canceled_at,
+      last_failed_at: storedTask.last_failed_at,
     };
 
     try {
@@ -166,6 +170,7 @@ export class TaskClient<TaskType extends string> {
     const taskDoc = {
       ...task,
       status: TaskStatus.Acknowledged,
+      last_acknowledged_at: new Date().toISOString(),
     } satisfies PersistedTask<TParams, TPayload>;
 
     await this.update(taskDoc);
@@ -199,6 +204,7 @@ export class TaskClient<TaskType extends string> {
     await this.update<TParams, TPayload>({
       ...task,
       status: TaskStatus.Completed,
+      last_completed_at: new Date().toISOString(),
       task: {
         params,
         payload,
@@ -219,6 +225,7 @@ export class TaskClient<TaskType extends string> {
     await this.update<TParams>({
       ...task,
       status: TaskStatus.Failed,
+      last_failed_at: new Date().toISOString(),
       task: {
         params,
         error,
@@ -235,6 +242,7 @@ export class TaskClient<TaskType extends string> {
     await this.update({
       ...task,
       status: TaskStatus.Canceled,
+      last_canceled_at: new Date().toISOString(),
     });
   }
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/types.ts
@@ -29,6 +29,10 @@ interface PersistedTaskBase<TParams extends {} = {}> {
   status: Exclude<TaskStatus, TaskStatus.Stale>;
   space: string;
   created_at: string;
+  last_completed_at?: string;
+  last_acknowledged_at?: string;
+  last_canceled_at?: string;
+  last_failed_at?: string;
   task: {
     params: TParams;
   };


### PR DESCRIPTION
## Summary

Adds timestamp tracking for task state transitions in the streams TaskClient.

**Changes:**
- Track `last_completed_at`, `last_acknowledged_at`, `last_canceled_at`, and `last_failed_at` timestamps when tasks transition to those states
- Added corresponding fields to the task storage schema
- Preserve historical timestamps when re-scheduling a task

This allows consumers to know when a task last reached each terminal state, useful for debugging and monitoring task lifecycle.