### PR TITLE
[Scout] update fleet tests and fleet api service

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/fleet/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/fleet/index.ts
@@ -10,11 +10,12 @@
 import type { KbnClient, ScoutLogger } from '../../../../../../common';
 import { measurePerformanceAsync } from '../../../../../../common';
 import type {
-  AgentPolicyCreateBody,
+  AgentPolicyCreateOptions,
+  AgentPolicyUpdateOptions,
   BulkGetBody,
   FleetOutputBody,
   FleetServerHostCreateBody,
-  AgentPolicyUpdateBody,
+  PackagePolicyCreateBody,
 } from './types';
 
 export interface FleetApiService {
@@ -28,24 +29,14 @@ export interface FleetApiService {
   package_policies: {
     get: (queryParams?: Record<string, any>) => Promise<any>;
     getById: (id: string) => Promise<any>;
+    create: (body: PackagePolicyCreateBody, queryParams?: Record<string, string>) => Promise<any>;
     delete: (id: string) => Promise<any>;
     bulkDelete: (ids: [string]) => Promise<any>;
   };
   agent_policies: {
     get: (queryParams?: Record<string, any>) => Promise<any>;
-    create: (
-      policyName: string,
-      policyNamespace: string,
-      sysMonitoring?: boolean,
-      params?: AgentPolicyCreateBody
-    ) => Promise<any>;
-    update: (
-      policyName: string,
-      policyNamespace: string,
-      agentPolicyId: string,
-      params?: AgentPolicyUpdateBody,
-      queryParams?: Record<string, string>
-    ) => Promise<any>;
+    create: (options: AgentPolicyCreateOptions) => Promise<any>;
+    update: (options: AgentPolicyUpdateOptions) => Promise<any>;
     bulkGet: (
       bulkGetIds: string[],
       params?: BulkGetBody,
@@ -132,7 +123,7 @@ export const getFleetApiHelper = (log: ScoutLogger, kbnClient: KbnClient): Fleet
       },
     },
     package_policies: {
-      get: async () => {
+      get: async (queryParams?: Record<string, any>) => {
         return await measurePerformanceAsync(log, `fleetApi.package_policies.get`, async () => {
           return await kbnClient.request({
             method: 'GET',
@@ -140,6 +131,7 @@ export const getFleetApiHelper = (log: ScoutLogger, kbnClient: KbnClient): Fleet
             headers: {
               'Content-Type': 'application/json',
             },
+            query: queryParams,
           });
         });
       },
@@ -151,6 +143,23 @@ export const getFleetApiHelper = (log: ScoutLogger, kbnClient: KbnClient): Fleet
             return await kbnClient.request({
               method: 'GET',
               path: `/api/fleet/package_policies/${id}`,
+            });
+          }
+        );
+      },
+      create: async (body: PackagePolicyCreateBody, queryParams?: Record<string, string>) => {
+        return await measurePerformanceAsync(
+          log,
+          `fleetApi.package_policies.create [${body.name}]`,
+          async () => {
+            return await kbnClient.request({
+              method: 'POST',
+              path: `/api/fleet/package_policies`,
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              query: queryParams,
+              body,
             });
           }
         );
@@ -193,12 +202,12 @@ export const getFleetApiHelper = (log: ScoutLogger, kbnClient: KbnClient): Fleet
           });
         });
       },
-      create: async (
-        policyName: string,
-        policyNamespace: string,
-        sysMonitoring?: boolean,
-        params?: AgentPolicyCreateBody
-      ) => {
+      create: async ({
+        policyName,
+        policyNamespace,
+        sysMonitoring,
+        params,
+      }: AgentPolicyCreateOptions) => {
         return await measurePerformanceAsync(
           log,
           `fleetApi.agent_policies.create [${policyName}]`,
@@ -222,13 +231,13 @@ export const getFleetApiHelper = (log: ScoutLogger, kbnClient: KbnClient): Fleet
         );
       },
 
-      update: async (
-        policyName: string,
-        policyNamespace: string,
-        agentPolicyId: string,
-        params?: AgentPolicyUpdateBody,
-        queryParams?: Record<string, string>
-      ) => {
+      update: async ({
+        policyName,
+        policyNamespace,
+        agentPolicyId,
+        params,
+        queryParams,
+      }: AgentPolicyUpdateOptions) => {
         return await measurePerformanceAsync(
           log,
           `fleetApi.agent_policies.update [${agentPolicyId}]`,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/fleet/types.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/apis/fleet/types.ts
@@ -48,6 +48,25 @@ export interface AgentPolicyCreateBody {
   unenroll_timeout?: number;
 }
 
+export interface AgentPolicyCreateOptions {
+  policyName: string;
+  policyNamespace: string;
+  sysMonitoring?: boolean;
+  params?: AgentPolicyCreateBody;
+}
+
+export interface PackagePolicyCreateBody {
+  policy_ids: string[];
+  package: {
+    name: string;
+    version?: string;
+  };
+  name: string;
+  description?: string;
+  namespace: string;
+  inputs: Record<string, any>;
+}
+
 export interface FleetOutputBody {
   allow_edit?: string[];
   ca_sha256?: string;
@@ -165,4 +184,12 @@ export interface AgentPolicyUpdateBody {
   space_ids?: string[];
   supports_agentless?: boolean;
   unenroll_timeout?: number;
+}
+
+export interface AgentPolicyUpdateOptions {
+  policyName: string;
+  policyNamespace: string;
+  agentPolicyId: string;
+  params?: AgentPolicyUpdateBody;
+  queryParams?: Record<string, string>;
 }

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/fleet.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/fleet.spec.ts
@@ -262,7 +262,8 @@ apiTest.describe('Fleet Server Hosts Management', { tag: ['@svlSecurity', '@ess'
   apiTest('should get fleet server hosts', async ({ apiServices }) => {
     // Note: The get method doesn't return a value in current implementation
     // This test verifies it doesn't throw an error
-    await apiServices.fleet.server_hosts.get();
+    const resp = await apiServices.fleet.server_hosts.get();
+    expect(resp.status).toBe(200);
   });
 
   apiTest('should create a fleet server host with parameters', async ({ apiServices }) => {

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/fleet.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/fleet.spec.ts
@@ -78,15 +78,14 @@ apiTest.describe('Fleet Agent Policies Management', { tag: ['@svlSecurity', '@es
     const paramsPolicyNamespace = 'default';
     const paramsPolicyName = `${policyName}-params`;
 
-    const response = await apiServices.fleet.agent_policies.create(
-      paramsPolicyName,
-      paramsPolicyNamespace,
-      undefined,
-      {
+    const response = await apiServices.fleet.agent_policies.create({
+      policyName: paramsPolicyName,
+      policyNamespace: paramsPolicyNamespace,
+      params: {
         description: 'Test policy with parameters',
         monitoring_enabled: ['logs', 'metrics'],
-      }
-    );
+      },
+    });
 
     expect(response.status).toBe(200);
     expect(response.data.item.name).toBe(paramsPolicyName);
@@ -99,22 +98,22 @@ apiTest.describe('Fleet Agent Policies Management', { tag: ['@svlSecurity', '@es
     const policyNamespace = 'default';
 
     // First create a policy
-    const createResponse = await apiServices.fleet.agent_policies.create(
+    const createResponse = await apiServices.fleet.agent_policies.create({
       policyName,
-      policyNamespace
-    );
+      policyNamespace,
+    });
     policyId = createResponse.data.item.id;
 
     // Then update it
     const updatedName = `${policyName}-updated`;
-    const updateResponse = await apiServices.fleet.agent_policies.update(
-      updatedName,
+    const updateResponse = await apiServices.fleet.agent_policies.update({
+      policyName: updatedName,
       policyNamespace,
-      policyId,
-      {
+      agentPolicyId: policyId,
+      params: {
         description: 'Updated policy description',
-      }
-    );
+      },
+    });
 
     expect(updateResponse.status).toBe(200);
     expect(updateResponse.data.item.name).toBe(updatedName);
@@ -125,8 +124,14 @@ apiTest.describe('Fleet Agent Policies Management', { tag: ['@svlSecurity', '@es
     const policy1Name = `bulk-test-1-${Date.now()}`;
     const policy2Name = `bulk-test-2-${Date.now()}`;
 
-    const policy1Response = await apiServices.fleet.agent_policies.create(policy1Name, 'default');
-    const policy2Response = await apiServices.fleet.agent_policies.create(policy2Name, 'default');
+    const policy1Response = await apiServices.fleet.agent_policies.create({
+      policyName: policy1Name,
+      policyNamespace: 'default',
+    });
+    const policy2Response = await apiServices.fleet.agent_policies.create({
+      policyName: policy2Name,
+      policyNamespace: 'default',
+    });
 
     const policyIds = [policy1Response.data.item.id, policy2Response.data.item.id];
     // Bulk get the policies
@@ -142,7 +147,10 @@ apiTest.describe('Fleet Agent Policies Management', { tag: ['@svlSecurity', '@es
 
   apiTest('should delete an agent policy', async ({ apiServices }) => {
     // First create a policy
-    const createResponse = await apiServices.fleet.agent_policies.create(policyName, 'default');
+    const createResponse = await apiServices.fleet.agent_policies.create({
+      policyName,
+      policyNamespace: 'default',
+    });
     const agentPolicyId = createResponse.data.item.id;
 
     // Then delete it
@@ -153,7 +161,10 @@ apiTest.describe('Fleet Agent Policies Management', { tag: ['@svlSecurity', '@es
 
   apiTest('should delete an agent policy with force flag', async ({ apiServices }) => {
     // First create a policy
-    const createResponse = await apiServices.fleet.agent_policies.create(policyName, 'default');
+    const createResponse = await apiServices.fleet.agent_policies.create({
+      policyName,
+      policyNamespace: 'default',
+    });
     const agentPolicyId = createResponse.data.item.id;
 
     // Then delete it with force

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/copy_integration_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/copy_integration_page.ts
@@ -15,7 +15,10 @@ export class CopyIntegrationPage {
   }
 
   async waitForPageToLoad() {
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.page.testSubj.waitForSelector('createPackagePolicy_page', {
+      state: 'visible',
+      timeout: 20_000,
+    });
   }
 
   getPackagePolicyNameInput() {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/create_integration_landing_page.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/create_integration_landing_page.ts
@@ -23,7 +23,10 @@ export class CreateIntegrationLandingPage {
   }
 
   async waitForPageToLoad() {
-    await this.page.waitForLoadingIndicatorHidden();
+    await this.page
+      .getByTestId('kbnAppWrapper visibleChrome')
+      .getByTestId('kbnRedirectAppLink')
+      .waitFor({ state: 'visible', timeout: 20_000 });
   }
 
   getLicensePaywallCard() {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_home.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_home.ts
@@ -18,8 +18,10 @@ export class FleetHomePage {
   }
 
   async waitForPageToLoad() {
-    await this.page.waitForLoadingIndicatorHidden();
-    await this.page.testSubj.waitForSelector(FLEET_AGENTS_TAB_SELECTOR, { state: 'visible' });
+    await this.page.testSubj.waitForSelector(FLEET_AGENTS_TAB_SELECTOR, {
+      state: 'visible',
+      timeout: 20_000,
+    });
     await this.page.testSubj.waitForSelector(FLEET_SETUP_LOADING_SELECTOR, { state: 'hidden' });
   }
 

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/integration_home.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/integration_home.ts
@@ -16,8 +16,10 @@ export class IntegrationHomePage {
   }
 
   async waitForPageToLoad() {
-    await this.page.waitForLoadingIndicatorHidden();
-    await this.page.testSubj.waitForSelector('epmList.integrationCards', { state: 'visible' });
+    await this.page.testSubj.waitForSelector('epmList.integrationCards', {
+      state: 'visible',
+      timeout: 20_000,
+    });
   }
 
   getIntegrationCard(integration: string) {

--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/copy_integration.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/copy_integration.spec.ts
@@ -15,25 +15,18 @@ test.describe('Copy integration', { tag: ['@ess'] }, () => {
   let agentPolicyId: string;
   let packagePolicyId: string;
 
-  test.beforeAll(async ({ kbnClient }) => {
-    const agentPolicyResponse = await kbnClient.request<{ item: { id: string } }>({
-      method: 'POST',
-      path: '/api/fleet/agent_policies',
-      body: {
-        name: testAgentPolicyName,
-        namespace: 'default',
+  test.beforeAll(async ({ apiServices }) => {
+    const agentPolicyResponse = await apiServices.fleet.agent_policies.create({
+      policyName: testAgentPolicyName,
+      policyNamespace: 'default',
+      params: {
         monitoring_enabled: ['logs', 'metrics'],
       },
     });
     agentPolicyId = agentPolicyResponse.data.item.id;
 
-    const packagePolicyResponse = await kbnClient.request<{ item: { id: string } }>({
-      method: 'POST',
-      path: '/api/fleet/package_policies',
-      query: {
-        format: 'simplified',
-      },
-      body: {
+    const packagePolicyResponse = await apiServices.fleet.package_policies.create(
+      {
         policy_ids: [agentPolicyId],
         package: {
           name: 'nginx',
@@ -84,11 +77,14 @@ test.describe('Copy integration', { tag: ['@ess'] }, () => {
           },
         },
       },
-    });
+      {
+        format: 'simplified',
+      }
+    );
     packagePolicyId = packagePolicyResponse.data.item.id;
   });
 
-  test.afterAll(async ({ kbnClient }) => {
+  test.afterAll(async ({ apiServices, kbnClient }) => {
     if (packagePolicyId) {
       await kbnClient.request({
         method: 'POST',
@@ -99,14 +95,8 @@ test.describe('Copy integration', { tag: ['@ess'] }, () => {
       });
     }
 
-    const packagePoliciesResponse = await kbnClient.request<{
-      items: Array<{ id: string; name: string }>;
-    }>({
-      method: 'GET',
-      path: '/api/fleet/package_policies',
-      query: {
-        kuery: `ingest-package-policies.name:${packagePolicyName}*`,
-      },
+    const packagePoliciesResponse = await apiServices.fleet.package_policies.get({
+      kuery: `ingest-package-policies.name:${packagePolicyName}*`,
     });
     for (const policy of packagePoliciesResponse.data.items) {
       if (policy.name.startsWith(packagePolicyName)) {
@@ -121,13 +111,7 @@ test.describe('Copy integration', { tag: ['@ess'] }, () => {
     }
 
     if (agentPolicyId) {
-      await kbnClient.request({
-        method: 'POST',
-        path: '/api/fleet/agent_policies/delete',
-        body: {
-          agentPolicyId,
-        },
-      });
+      await apiServices.fleet.agent_policies.delete(agentPolicyId);
     }
   });
 

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/common/fixtures/index.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/common/fixtures/index.ts
@@ -31,15 +31,15 @@ export const apiTest = base.extend<{}, { profilingHelper: ProfilingHelper }>({
         );
 
         if (!apmPolicyData) {
-          await apiServices.fleet.agent_policies.create(
-            'Elastic APM',
-            'default',
-            false, // sysMonitoring
-            {
+          await apiServices.fleet.agent_policies.create({
+            policyName: 'Elastic APM',
+            policyNamespace: 'default',
+            sysMonitoring: false,
+            params: {
               id: APM_AGENT_POLICY_ID,
               description: 'Elastic APM agent policy created via Fleet API',
-            }
-          );
+            },
+          });
           log.info(`APM agent policy '${APM_AGENT_POLICY_ID}' is created`);
         } else {
           log.info(`APM agent policy '${APM_AGENT_POLICY_ID}' already exists`);

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/ui/parallel_tests/global.setup.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/ui/parallel_tests/global.setup.ts
@@ -28,15 +28,15 @@ globalSetupHook(
       );
 
       if (!apmPolicyData) {
-        await apiServices.fleet.agent_policies.create(
-          'Elastic APM',
-          'default',
-          false, // sysMonitoring
-          {
+        await apiServices.fleet.agent_policies.create({
+          policyName: 'Elastic APM',
+          policyNamespace: 'default',
+          sysMonitoring: false,
+          params: {
             id: APM_AGENT_POLICY_ID,
             description: 'Elastic APM agent policy created via Fleet API',
-          }
-        );
+          },
+        });
         log.info(`APM agent policy '${APM_AGENT_POLICY_ID}' is created`);
       } else {
         log.info(`APM agent policy '${APM_AGENT_POLICY_ID}' already exists`);


### PR DESCRIPTION
## Summary

This PR makes a few changes in Scout `FleetApiService`:

adds:
- `package_policies.create: (body: PackagePolicyCreateBody, queryParams?: Record<string, string>)`

updates:
- `agent_policies.create` with a new argument `(options: AgentPolicyCreateOptions)`
- `agent_policies.update` with a new argument `(options: AgentPolicyUpdateOptions)`
- fixes `package_policies.get` implementation to accept `queryParams ` argument.

It also update fleet, apm and profiling scout tests according the updates.

Global loading indicator check was removed from Fleet UI tests, it is deprecated and often leads to flakiness.

closes https://github.com/elastic/kibana/issues/250273

