### PR TITLE
[9.3] Skipping Sec Solution basic license assertion tests for FIPS pipeline (#250045)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/basic_license_essentials_tier/api_feature_access.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/monitoring/basic_license_essentials_tier/api_feature_access.ts
@@ -14,7 +14,8 @@ export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const privilegedUserMonitoringRoutes = privilegeMonitoringRouteHelpersFactory(supertest);
 
-  describe('@ess Basic License API Access', () => {
+  describe('@ess Basic License API Access', function () {
+    this.tags('skipFIPS');
     it('should not be able to access init engine api due to license', async () => {
       const response = await privilegedUserMonitoringRoutes.init(403);
       expect(response.body.message).toEqual(licenseMessage);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Skipping Sec Solution basic license assertion tests for FIPS pipeline (#250045)](https://github.com/elastic/kibana/pull/250045)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kurt","email":"kc13greiner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-23T13:32:15Z","message":"Skipping Sec Solution basic license assertion tests for FIPS pipeline (#250045)\n\n## Summary\n\nSince FIPS Pipelines always run with a `trial` license, we need to skip\nthese tests","sha":"b48bd6d1dbd6fb65c4eed9d8812d0d1279ab1b49","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:skip","v9.4.0"],"title":"Skipping Sec Solution basic license assertion tests for FIPS pipeline","number":250045,"url":"https://github.com/elastic/kibana/pull/250045","mergeCommit":{"message":"Skipping Sec Solution basic license assertion tests for FIPS pipeline (#250045)\n\n## Summary\n\nSince FIPS Pipelines always run with a `trial` license, we need to skip\nthese tests","sha":"b48bd6d1dbd6fb65c4eed9d8812d0d1279ab1b49"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250045","number":250045,"mergeCommit":{"message":"Skipping Sec Solution basic license assertion tests for FIPS pipeline (#250045)\n\n## Summary\n\nSince FIPS Pipelines always run with a `trial` license, we need to skip\nthese tests","sha":"b48bd6d1dbd6fb65c4eed9d8812d0d1279ab1b49"}}]}] BACKPORT-->