### PR TITLE
[9.3] [Cloud Connect] Enable EIS by default after connection (#250197)

### DIFF
--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/app.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/app.tsx
@@ -64,6 +64,10 @@ export const CloudConnectedAppMain: React.FC = () => {
     clusterConfig: config!,
     hasConfigurePermission: appContext.application.capabilities.cloudConnect?.configure === true,
     hasActionsSavePrivilege: appContext.application.capabilities.actions?.save === true,
+    justConnected: appContext.justConnected,
+    setJustConnected: appContext.setJustConnected,
+    autoEnablingEis: appContext.autoEnablingEis,
+    setAutoEnablingEis: appContext.setAutoEnablingEis,
   };
 
   return (

--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/app_context.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/app_context.tsx
@@ -28,6 +28,10 @@ export interface CloudConnectedAppContextValue {
   hasActionsSavePrivilege?: boolean;
   hasAnyDefaultLLMConnectors?: boolean;
   setHasAnyDefaultLLMConnectors?: (value: boolean) => void;
+  justConnected: boolean;
+  setJustConnected: (value: boolean) => void;
+  autoEnablingEis: boolean;
+  setAutoEnablingEis: (value: boolean) => void;
 }
 
 const CloudConnectedAppContext = createContext<CloudConnectedAppContextValue | null>(null);

--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/services_section/index.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/services_section/index.tsx
@@ -12,6 +12,7 @@ import { i18n } from '@kbn/i18n';
 import { ServiceCard } from './details_card';
 import { DisableServiceModal } from './disable_service_modal';
 import { useServiceActions } from './use_service_actions';
+import { useCloudConnectedAppContext } from '../../../app_context';
 import type { CloudService, ServiceType } from '../../../../types';
 
 interface ServicesSectionProps {
@@ -30,6 +31,7 @@ export const ServicesSection: React.FC<ServicesSectionProps> = ({
   subscription,
   currentLicenseType,
 }) => {
+  const { autoEnablingEis } = useCloudConnectedAppContext();
   const {
     loadingService,
     disableModalService,
@@ -72,7 +74,7 @@ export const ServicesSection: React.FC<ServicesSectionProps> = ({
             defaultMessage: 'Elastic Inference Service',
           })
         ),
-      isLoading: loadingService === 'eis',
+      isLoading: loadingService === 'eis' || autoEnablingEis,
       subscriptionRequired: services.eis?.subscription?.required,
       hasActiveSubscription,
       validLicenseTypes: services.eis?.support?.valid_license_types,

--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/use_cluster_connection.test.ts
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/use_cluster_connection.test.ts
@@ -5,19 +5,33 @@
  * 2.0.
  */
 
-import { updateServiceEnabled } from './use_cluster_connection';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useClusterConnection } from './use_cluster_connection';
+import { useCloudConnectedAppContext } from '../../app_context';
 import type { ClusterDetails } from '../../../types';
 
+jest.mock('../../app_context');
+
 describe('use_cluster_connection', () => {
-  describe('updateServiceEnabled', () => {
-    const mockClusterDetails: ClusterDetails = {
+  describe('useClusterConnection - auto-enable EIS', () => {
+    const mockUseCloudConnectedAppContext = useCloudConnectedAppContext as jest.MockedFunction<
+      typeof useCloudConnectedAppContext
+    >;
+
+    const mockSetJustConnected = jest.fn();
+    const mockSetAutoEnablingEis = jest.fn();
+    const mockUpdateServices = jest.fn();
+    const mockAddError = jest.fn();
+    const mockResendRequest = jest.fn();
+
+    const createMockClusterDetails = (overrides: Partial<ClusterDetails> = {}): ClusterDetails => ({
       id: 'cluster-123',
       name: 'Test Cluster',
       metadata: {
         created_at: '2024-01-01T00:00:00Z',
         created_by: 'user@example.com',
         organization_id: 'org-456',
-        subscription: 'premium',
+        subscription: 'active',
       },
       self_managed_cluster: {
         id: 'es-cluster-789',
@@ -25,55 +39,172 @@ describe('use_cluster_connection', () => {
         version: '8.15.0',
       },
       license: {
-        type: 'platinum',
+        type: 'trial',
         uid: 'license-uid-123',
       },
       services: {
-        auto_ops: {
+        eis: {
           enabled: false,
           support: {
             supported: true,
-            minimum_stack_version: '8.0.0',
-            valid_license_types: ['platinum', 'enterprise'],
-          },
-          config: {
-            region_id: 'us-east-1',
-          },
-          metadata: {
-            documentation_url: 'https://docs.elastic.co/auto-ops',
+            minimum_stack_version: '9.3.0',
+            valid_license_types: ['trial', 'enterprise'],
           },
           subscription: {
             required: true,
           },
         },
-        eis: {
-          enabled: true,
-          support: {
-            supported: true,
-          },
+      },
+      ...overrides,
+    });
+
+    const createMockContext = (overrides: Record<string, any> = {}) => ({
+      apiService: {
+        useLoadClusterDetails: jest.fn().mockReturnValue({
+          data: createMockClusterDetails(),
+          isLoading: false,
+          error: null,
+          resendRequest: mockResendRequest,
+        }),
+        updateServices: mockUpdateServices,
+      },
+      justConnected: false,
+      setJustConnected: mockSetJustConnected,
+      autoEnablingEis: false,
+      setAutoEnablingEis: mockSetAutoEnablingEis,
+      hasConfigurePermission: true,
+      notifications: {
+        toasts: {
+          addError: mockAddError,
         },
       },
-    };
-
-    it('should update enabled property for existing service', () => {
-      const result = updateServiceEnabled(mockClusterDetails, 'auto_ops', true);
-
-      expect(result).not.toBeNull();
-      expect(result!.services.auto_ops?.enabled).toBe(true);
+      ...overrides,
     });
 
-    it('should preserve all other service properties', () => {
-      const result = updateServiceEnabled(mockClusterDetails, 'auto_ops', true);
-
-      expect(result).not.toBeNull();
-
-      expect(result!.services.eis?.enabled).toBe(true);
+    beforeEach(() => {
+      jest.clearAllMocks();
     });
 
-    it('should handle null clusterDetails gracefully', () => {
-      const result = updateServiceEnabled(null, 'auto_ops', true);
+    it('should auto-enable EIS when justConnected is true and all conditions are met', async () => {
+      mockUpdateServices.mockResolvedValue({ data: { success: true }, error: null });
 
-      expect(result).toBeNull();
+      mockUseCloudConnectedAppContext.mockReturnValue(
+        createMockContext({ justConnected: true }) as any
+      );
+
+      renderHook(() => useClusterConnection());
+
+      await waitFor(() => {
+        expect(mockSetJustConnected).toHaveBeenCalledWith(false);
+        expect(mockSetAutoEnablingEis).toHaveBeenCalledWith(true);
+        expect(mockUpdateServices).toHaveBeenCalledWith({ eis: { enabled: true } });
+        expect(mockSetAutoEnablingEis).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it('should not auto-enable EIS when justConnected is false', () => {
+      mockUseCloudConnectedAppContext.mockReturnValue(
+        createMockContext({ justConnected: false }) as any
+      );
+
+      renderHook(() => useClusterConnection());
+
+      expect(mockUpdateServices).not.toHaveBeenCalled();
+    });
+
+    it('should not auto-enable EIS when EIS is already enabled', () => {
+      const clusterDetailsWithEisEnabled = createMockClusterDetails({
+        services: {
+          eis: {
+            enabled: true,
+            support: { supported: true },
+            subscription: { required: true },
+          },
+        },
+      });
+
+      mockUseCloudConnectedAppContext.mockReturnValue(
+        createMockContext({
+          justConnected: true,
+          apiService: {
+            useLoadClusterDetails: jest.fn().mockReturnValue({
+              data: clusterDetailsWithEisEnabled,
+              isLoading: false,
+              error: null,
+              resendRequest: mockResendRequest,
+            }),
+            updateServices: mockUpdateServices,
+          },
+        }) as any
+      );
+
+      renderHook(() => useClusterConnection());
+
+      expect(mockSetJustConnected).toHaveBeenCalledWith(false);
+      expect(mockUpdateServices).not.toHaveBeenCalled();
+    });
+
+    it('should not auto-enable EIS when user does not have configure permission', () => {
+      mockUseCloudConnectedAppContext.mockReturnValue(
+        createMockContext({
+          justConnected: true,
+          hasConfigurePermission: false,
+        }) as any
+      );
+
+      renderHook(() => useClusterConnection());
+
+      expect(mockSetJustConnected).toHaveBeenCalledWith(false);
+      expect(mockUpdateServices).not.toHaveBeenCalled();
+    });
+
+    it('should not auto-enable EIS when subscription is required but not active', () => {
+      const clusterDetailsWithInactiveSubscription = createMockClusterDetails({
+        metadata: {
+          created_at: '2024-01-01T00:00:00Z',
+          created_by: 'user@example.com',
+          organization_id: 'org-456',
+          subscription: 'expired',
+        },
+      });
+
+      mockUseCloudConnectedAppContext.mockReturnValue(
+        createMockContext({
+          justConnected: true,
+          apiService: {
+            useLoadClusterDetails: jest.fn().mockReturnValue({
+              data: clusterDetailsWithInactiveSubscription,
+              isLoading: false,
+              error: null,
+              resendRequest: mockResendRequest,
+            }),
+            updateServices: mockUpdateServices,
+          },
+        }) as any
+      );
+
+      renderHook(() => useClusterConnection());
+
+      expect(mockSetJustConnected).toHaveBeenCalledWith(false);
+      expect(mockUpdateServices).not.toHaveBeenCalled();
+    });
+
+    it('should show error toast when auto-enable fails', async () => {
+      const mockError = new Error('Failed to enable EIS');
+      mockUpdateServices.mockResolvedValue({ data: null, error: mockError });
+
+      mockUseCloudConnectedAppContext.mockReturnValue(
+        createMockContext({ justConnected: true }) as any
+      );
+
+      renderHook(() => useClusterConnection());
+
+      await waitFor(() => {
+        expect(mockAddError).toHaveBeenCalledWith(mockError, {
+          title: 'Failed to auto-enable Elastic Inference Service',
+        });
+        expect(mockSetAutoEnablingEis).toHaveBeenCalledWith(false);
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/components/onboarding/connection_wizard/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/components/onboarding/connection_wizard/index.test.tsx
@@ -43,6 +43,7 @@ describe('ConnectionWizard', () => {
     updateServices: jest.fn(),
     disconnectCluster: jest.fn(),
   };
+  const mockSetJustConnected = jest.fn();
   const mockContext: CloudConnectedAppContextValue = {
     chrome: {} as any,
     application: {} as any,
@@ -66,6 +67,10 @@ describe('ConnectionWizard', () => {
     },
     hasConfigurePermission: true,
     licensing: {} as any,
+    justConnected: false,
+    setJustConnected: mockSetJustConnected,
+    autoEnablingEis: false,
+    setAutoEnablingEis: jest.fn(),
   };
 
   beforeEach(() => {
@@ -232,5 +237,24 @@ describe('ConnectionWizard', () => {
 
     // No error should be displayed
     expect(screen.queryByTestId('connectionWizardError')).not.toBeInTheDocument();
+  });
+
+  it('should set justConnected to true on successful authentication', async () => {
+    mockApiService.authenticate = jest.fn().mockResolvedValue({
+      data: { success: true, cluster_id: 'cluster-123', organization_id: 'org-123' },
+      error: null,
+    });
+
+    renderWithIntl(<ConnectionWizard onConnect={mockOnConnect} />);
+
+    const input = screen.getByTestId('connectionWizardApiKeyInput');
+    const connectButton = screen.getByTestId('connectionWizardConnectButton');
+
+    await userEvent.type(input, 'valid-api-key');
+    await userEvent.click(connectButton);
+
+    await waitFor(() => {
+      expect(mockSetJustConnected).toHaveBeenCalledWith(true);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/components/onboarding/connection_wizard/index.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/components/onboarding/connection_wizard/index.tsx
@@ -38,7 +38,7 @@ interface ConnectionWizardProps {
 }
 
 export const ConnectionWizard: React.FC<ConnectionWizardProps> = ({ onConnect }) => {
-  const { docLinks, clusterConfig, cloudUrl, telemetryService, apiService } =
+  const { docLinks, clusterConfig, cloudUrl, telemetryService, apiService, setJustConnected } =
     useCloudConnectedAppContext();
   const [apiKey, setApiKey] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -71,6 +71,7 @@ export const ConnectionWizard: React.FC<ConnectionWizardProps> = ({ onConnect })
 
     if (data?.success) {
       telemetryService.trackClusterConnected();
+      setJustConnected(true);
       onConnect();
     }
 

--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/mount_plugin.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/mount_plugin.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import type { CoreStart, AppMountParameters } from '@kbn/core/public';
 import { CloudConnectedAppContextProvider } from './app_context';
@@ -26,6 +26,10 @@ const CloudConnectedAppComponent: React.FC<CloudConnectedAppComponentProps> = ({
   apiService,
   licensing,
 }) => {
+  const [justConnected, setJustConnected] = useState(false);
+  const [autoEnablingEis, setAutoEnablingEis] = useState(false);
+  const hasConfigurePermission = application.capabilities.cloudConnect?.configure === true;
+
   return (
     <CloudConnectedAppContextProvider
       value={{
@@ -39,6 +43,11 @@ const CloudConnectedAppComponent: React.FC<CloudConnectedAppComponentProps> = ({
         telemetryService,
         apiService,
         licensing,
+        justConnected,
+        setJustConnected,
+        autoEnablingEis,
+        setAutoEnablingEis,
+        hasConfigurePermission,
       }}
     >
       <CloudConnectedAppMain />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Cloud Connect] Enable EIS by default after connection (#250197)](https://github.com/elastic/kibana/pull/250197)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ignacio Rivas","email":"rivasign@gmail.com"},"sourceCommit":{"committedDate":"2026-01-26T19:44:06Z","message":"[Cloud Connect] Enable EIS by default after connection (#250197)","sha":"af3152ebf9357e8b8ddd2c564781f1b97a89bba8","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport:version","Feature:Cloud Connect","v9.4.0","v9.3.1"],"title":"[Cloud Connect] Enable EIS by default after connection","number":250197,"url":"https://github.com/elastic/kibana/pull/250197","mergeCommit":{"message":"[Cloud Connect] Enable EIS by default after connection (#250197)","sha":"af3152ebf9357e8b8ddd2c564781f1b97a89bba8"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250197","number":250197,"mergeCommit":{"message":"[Cloud Connect] Enable EIS by default after connection (#250197)","sha":"af3152ebf9357e8b8ddd2c564781f1b97a89bba8"}},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->