### PR TITLE
[8.19] [Security Solution] Fix flaky test on bulk edit rules actions using Flaky test doctor (#250154)

### DIFF
--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
@@ -73,7 +73,6 @@ const ruleNameToAssert = 'Custom rule name with actions';
 const expectedExistingSlackMessage = 'Existing slack action';
 const expectedSlackMessage = 'Slack action test message';
 
-// https://github.com/elastic/kibana/issues/179958
 describe(
   'Detection rules, bulk edit of rule actions',
   { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] },

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/api_calls/prebuilt_rules.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/api_calls/prebuilt_rules.ts
@@ -196,10 +196,11 @@ export const preventPrebuiltRulesPackageInstallation = () => {
   cy.intercept('POST', BOOTSTRAP_PREBUILT_RULES_URL, { packages: [] });
 };
 
-const installByUploadPrebuiltRulesPackage = (packagePath: string): void => {
-  cy.fixture(packagePath, 'binary')
+const installByUploadPrebuiltRulesPackage = (packagePath: string): Cypress.Chainable => {
+  return cy
+    .fixture(packagePath, 'binary')
     .then(Cypress.Blob.binaryStringToBlob)
-    .then((blob) => {
+    .then((blob) =>
       rootRequest({
         method: 'POST',
         url: '/api/fleet/epm/packages',
@@ -210,22 +211,24 @@ const installByUploadPrebuiltRulesPackage = (packagePath: string): void => {
         },
         body: blob,
         encoding: 'binary',
-      });
+        timeout: 120000, // 2 minutes for slow package installation in CI
+      })
+    )
+    .then(() => {
+      if (!Cypress.env(IS_SERVERLESS)) {
+        refreshSavedObjectIndices();
+      }
     });
-
-  if (!Cypress.env(IS_SERVERLESS)) {
-    refreshSavedObjectIndices();
-  }
 };
 
 /**
  * Installs a prepared mock prebuilt rules package `security_detection_engine`.
  * Installing it up front prevents installing the real package when making API requests.
  */
-export const installMockPrebuiltRulesPackage = (): void => {
+export const installMockPrebuiltRulesPackage = (): Cypress.Chainable => {
   cy.log('Install mock prebuilt rules package');
 
-  installByUploadPrebuiltRulesPackage(
+  return installByUploadPrebuiltRulesPackage(
     'security_detection_engine_packages/mock-security_detection_engine-99.0.0.zip'
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution] Fix flaky test on bulk edit rules actions using Flaky test doctor (#250154)](https://github.com/elastic/kibana/pull/250154)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Steven de Salas","email":"sdesalas@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-26T17:38:59Z","message":"[Security Solution] Fix flaky test on bulk edit rules actions using Flaky test doctor (#250154)\n\n**Closes: #249324**\n**Related: #179958**\n\n## Summary\n\nFixes flaky test: `Security Solution\nCypress.x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts\n- Detection rules, bulk edit of rule actions Restricted action\nprivileges \"before all\" hook for \"User with no privileges can't add rule\nactions\"`\n\nThe test was failing in the `before()` hook when installing the mock\nprebuilt rules package. The test suite was skipped in #249324 due to\nthis flakiness.\n\n**Changes:**\n\n- Fixed `installByUploadPrebuiltRulesPackage` to properly return the\nCypress chainable\n- Added 2-minute timeout for Fleet package installation in CI\nenvironments\n- Updated `installMockPrebuiltRulesPackage` to return the chainable\n- Unskipped the test suite\n\n**PLEASE NOTE:** This fix benefits all other tests that use\n`installMockPrebuiltRulesPackage` across the Security Solution Cypress\ntest suite (around 45 files).\n\n## Root Cause\n\nThe `installByUploadPrebuiltRulesPackage` function was not returning the\nchainable from `rootRequest()`, causing Cypress to not wait for the\nFleet package installation API call to complete. This led to:\n\n1. **Race condition**: The `before()` hook would proceed before the\npackage installation finished\n2. **Timeout failures**: In CI environments where Fleet package\ninstallation can take longer, the test would timeout waiting for\nresources that weren't ready\n3. **Intermittent failures**: The test would pass locally (where\ninstallation is faster) but fail in CI (where it's slower)\n\nThe function was structured as:\n\n```\nconst installByUploadPrebuiltRulesPackage = (packagePath: string): void => {\n  cy.fixture(packagePath, 'binary')\n    .then(Cypress.Blob.binaryStringToBlob)\n    .then((blob) => {\n      rootRequest({...}); // 👈 ❌ Here. Not returned - Cypress doesn't wait!\n    });\n  // ...\n};\n```\n\nSince the `rootRequest()` chainable wasn't returned, Cypress treated it\nas a fire-and-forget operation and didn't wait for completion.\n\n## Solution\n\nUpdated both `installByUploadPrebuiltRulesPackage` and\n`installMockPrebuiltRulesPackage` to:\n\n1. **Return the chainable**: Changed return type from `void` to\n`Cypress.Chainable` and return the chainable from `rootRequest()`\n2. **Add explicit timeout**: Added `timeout: 120000` (2 minutes) to\nhandle slow Fleet package installations in CI, which run much slower\nthan in our local machines, causing failures that are hard to\nanticipate.\n3. **Properly chain operations**: Ensured all async operations are\nproperly chained so Cypress waits for each step","sha":"d57ad8af2b010289a45fc0b44a6c0fb125d8c7b0","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["failed-test","release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Feature:Rule Management","Team:Detection Rule Management","testing","backport:version","reason:flaky-test","v9.4.0","v9.2.5","v8.19.11","v9.3.1"],"title":"[Security Solution] Fix flaky test on bulk edit rules actions using Flaky test doctor","number":250154,"url":"https://github.com/elastic/kibana/pull/250154","mergeCommit":{"message":"[Security Solution] Fix flaky test on bulk edit rules actions using Flaky test doctor (#250154)\n\n**Closes: #249324**\n**Related: #179958**\n\n## Summary\n\nFixes flaky test: `Security Solution\nCypress.x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts\n- Detection rules, bulk edit of rule actions Restricted action\nprivileges \"before all\" hook for \"User with no privileges can't add rule\nactions\"`\n\nThe test was failing in the `before()` hook when installing the mock\nprebuilt rules package. The test suite was skipped in #249324 due to\nthis flakiness.\n\n**Changes:**\n\n- Fixed `installByUploadPrebuiltRulesPackage` to properly return the\nCypress chainable\n- Added 2-minute timeout for Fleet package installation in CI\nenvironments\n- Updated `installMockPrebuiltRulesPackage` to return the chainable\n- Unskipped the test suite\n\n**PLEASE NOTE:** This fix benefits all other tests that use\n`installMockPrebuiltRulesPackage` across the Security Solution Cypress\ntest suite (around 45 files).\n\n## Root Cause\n\nThe `installByUploadPrebuiltRulesPackage` function was not returning the\nchainable from `rootRequest()`, causing Cypress to not wait for the\nFleet package installation API call to complete. This led to:\n\n1. **Race condition**: The `before()` hook would proceed before the\npackage installation finished\n2. **Timeout failures**: In CI environments where Fleet package\ninstallation can take longer, the test would timeout waiting for\nresources that weren't ready\n3. **Intermittent failures**: The test would pass locally (where\ninstallation is faster) but fail in CI (where it's slower)\n\nThe function was structured as:\n\n```\nconst installByUploadPrebuiltRulesPackage = (packagePath: string): void => {\n  cy.fixture(packagePath, 'binary')\n    .then(Cypress.Blob.binaryStringToBlob)\n    .then((blob) => {\n      rootRequest({...}); // 👈 ❌ Here. Not returned - Cypress doesn't wait!\n    });\n  // ...\n};\n```\n\nSince the `rootRequest()` chainable wasn't returned, Cypress treated it\nas a fire-and-forget operation and didn't wait for completion.\n\n## Solution\n\nUpdated both `installByUploadPrebuiltRulesPackage` and\n`installMockPrebuiltRulesPackage` to:\n\n1. **Return the chainable**: Changed return type from `void` to\n`Cypress.Chainable` and return the chainable from `rootRequest()`\n2. **Add explicit timeout**: Added `timeout: 120000` (2 minutes) to\nhandle slow Fleet package installations in CI, which run much slower\nthan in our local machines, causing failures that are hard to\nanticipate.\n3. **Properly chain operations**: Ensured all async operations are\nproperly chained so Cypress waits for each step","sha":"d57ad8af2b010289a45fc0b44a6c0fb125d8c7b0"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","8.19","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250154","number":250154,"mergeCommit":{"message":"[Security Solution] Fix flaky test on bulk edit rules actions using Flaky test doctor (#250154)\n\n**Closes: #249324**\n**Related: #179958**\n\n## Summary\n\nFixes flaky test: `Security Solution\nCypress.x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts\n- Detection rules, bulk edit of rule actions Restricted action\nprivileges \"before all\" hook for \"User with no privileges can't add rule\nactions\"`\n\nThe test was failing in the `before()` hook when installing the mock\nprebuilt rules package. The test suite was skipped in #249324 due to\nthis flakiness.\n\n**Changes:**\n\n- Fixed `installByUploadPrebuiltRulesPackage` to properly return the\nCypress chainable\n- Added 2-minute timeout for Fleet package installation in CI\nenvironments\n- Updated `installMockPrebuiltRulesPackage` to return the chainable\n- Unskipped the test suite\n\n**PLEASE NOTE:** This fix benefits all other tests that use\n`installMockPrebuiltRulesPackage` across the Security Solution Cypress\ntest suite (around 45 files).\n\n## Root Cause\n\nThe `installByUploadPrebuiltRulesPackage` function was not returning the\nchainable from `rootRequest()`, causing Cypress to not wait for the\nFleet package installation API call to complete. This led to:\n\n1. **Race condition**: The `before()` hook would proceed before the\npackage installation finished\n2. **Timeout failures**: In CI environments where Fleet package\ninstallation can take longer, the test would timeout waiting for\nresources that weren't ready\n3. **Intermittent failures**: The test would pass locally (where\ninstallation is faster) but fail in CI (where it's slower)\n\nThe function was structured as:\n\n```\nconst installByUploadPrebuiltRulesPackage = (packagePath: string): void => {\n  cy.fixture(packagePath, 'binary')\n    .then(Cypress.Blob.binaryStringToBlob)\n    .then((blob) => {\n      rootRequest({...}); // 👈 ❌ Here. Not returned - Cypress doesn't wait!\n    });\n  // ...\n};\n```\n\nSince the `rootRequest()` chainable wasn't returned, Cypress treated it\nas a fire-and-forget operation and didn't wait for completion.\n\n## Solution\n\nUpdated both `installByUploadPrebuiltRulesPackage` and\n`installMockPrebuiltRulesPackage` to:\n\n1. **Return the chainable**: Changed return type from `void` to\n`Cypress.Chainable` and return the chainable from `rootRequest()`\n2. **Add explicit timeout**: Added `timeout: 120000` (2 minutes) to\nhandle slow Fleet package installations in CI, which run much slower\nthan in our local machines, causing failures that are hard to\nanticipate.\n3. **Properly chain operations**: Ensured all async operations are\nproperly chained so Cypress waits for each step","sha":"d57ad8af2b010289a45fc0b44a6c0fb125d8c7b0"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->