### PR TITLE
[8.19] [ResponseOps][Rules] Create rule not available when selecting Logs tab (#249163)

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/home.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/home.test.tsx
@@ -17,6 +17,7 @@ import TriggersActionsUIHome, { MatchParams } from './home';
 import { hasShowActionsCapability } from './lib/capabilities';
 import { getIsExperimentalFeatureEnabled } from '../common/get_experimental_features';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { useKibana } from '../common/lib/kibana';
 
 jest.mock('../common/lib/kibana');
 jest.mock('../common/get_experimental_features');
@@ -36,12 +37,15 @@ jest.mock('./context/health_context', () => ({
 jest.mock('@kbn/alerts-ui-shared/src/common/hooks/use_get_rule_types_permissions', () => ({
   useGetRuleTypesPermissions: jest.fn().mockReturnValue({
     authorizedToReadAnyRules: true,
+    authorizedToCreateAnyRules: true,
   }),
 }));
 
 const { useGetRuleTypesPermissions } = jest.requireMock(
   '@kbn/alerts-ui-shared/src/common/hooks/use_get_rule_types_permissions'
 );
+
+const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 
 const queryClient = new QueryClient();
 
@@ -141,5 +145,88 @@ describe('home', () => {
 
     // Just rules
     expect(home.find('span.euiTab__content').length).toBe(1);
+  });
+
+  describe('setHeaderActions', () => {
+    beforeEach(() => {
+      useKibanaMock().services.application.capabilities = {
+        ...useKibanaMock().services.application.capabilities,
+        rulesSettings: {
+          show: true,
+          readFlappingSettingsUI: true,
+          readQueryDelaySettingsUI: true,
+        },
+      };
+    });
+    it('should render the header actions correctly when the user is authorized to create rules', async () => {
+      useGetRuleTypesPermissions.mockReturnValue({
+        authorizedToReadAnyRules: true,
+        authorizedToCreateAnyRules: true,
+      });
+      const props: RouteComponentProps<MatchParams> = {
+        history: createMemoryHistory({
+          initialEntries: ['/rules'],
+        }),
+        location: createLocation('/rules'),
+        match: {
+          isExact: true,
+          path: `/rules`,
+          url: '',
+          params: {
+            section: 'rules',
+          },
+        },
+      };
+
+      render(
+        <IntlProvider locale="en">
+          <Router history={props.history}>
+            <QueryClientProvider client={queryClient}>
+              <TriggersActionsUIHome {...props} />
+            </QueryClientProvider>
+          </Router>
+        </IntlProvider>
+      );
+
+      expect(await screen.findByTestId('createRuleButton')).toBeInTheDocument();
+      expect(await screen.findByTestId('rulesSettingsLink')).toBeInTheDocument();
+      expect(await screen.findByTestId('documentationLink')).toBeInTheDocument();
+    });
+
+    it('should not render the create rule button when the user is not authorized to create rules', async () => {
+      useGetRuleTypesPermissions.mockReturnValue({
+        authorizedToReadAnyRules: true,
+        authorizedToCreateAnyRules: false,
+      });
+
+      const props: RouteComponentProps<MatchParams> = {
+        history: createMemoryHistory({
+          initialEntries: ['/rules'],
+        }),
+        location: createLocation('/rules'),
+        match: {
+          isExact: true,
+          path: `/rules`,
+          url: '',
+          params: {
+            section: 'rules',
+          },
+        },
+      };
+
+      render(
+        <IntlProvider locale="en">
+          <Router history={props.history}>
+            <QueryClientProvider client={queryClient}>
+              <TriggersActionsUIHome {...props} />
+            </QueryClientProvider>
+          </Router>
+        </IntlProvider>
+      );
+
+      expect(await screen.queryByTestId('createRuleButton')).not.toBeInTheDocument();
+      expect(await screen.findByTestId('rulesSettingsLink')).toBeInTheDocument();
+      expect(await screen.findByTestId('documentationLink')).toBeInTheDocument();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/home.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/home.tsx
@@ -14,9 +14,8 @@ import { EuiSpacer, EuiPageTemplate } from '@elastic/eui';
 
 import { RuleTypeModal } from '@kbn/response-ops-rule-form';
 import { useGetRuleTypesPermissions } from '@kbn/alerts-ui-shared/src/common/hooks/use_get_rule_types_permissions';
-import { PerformanceContextProvider } from '@kbn/ebt-tools';
-import { Section, routeToRules, routeToLogs } from './constants';
 import { getCreateRuleRoute, getCreateRuleFromTemplateRoute } from '@kbn/rule-data-utils';
+import { Section, routeToRules, routeToLogs } from './constants';
 import { RulesSettingsLink } from './components/rules_setting/rules_settings_link';
 import { RulesListDocLink } from './sections/rules_list/components/rules_list_doc_link';
 import { CreateRuleButton } from './sections/rules_list/components/create_rule_button';

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/home.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/home.tsx
@@ -12,8 +12,16 @@ import { Routes, Route } from '@kbn/shared-ux-router';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiSpacer, EuiPageTemplate } from '@elastic/eui';
 
+import { RuleTypeModal } from '@kbn/response-ops-rule-form';
 import { useGetRuleTypesPermissions } from '@kbn/alerts-ui-shared/src/common/hooks/use_get_rule_types_permissions';
+import { PerformanceContextProvider } from '@kbn/ebt-tools';
 import { Section, routeToRules, routeToLogs } from './constants';
+import { getCreateRuleRoute, getCreateRuleFromTemplateRoute } from '@kbn/rule-data-utils';
+import { RulesSettingsLink } from './components/rules_setting/rules_settings_link';
+import { RulesListDocLink } from './sections/rules_list/components/rules_list_doc_link';
+import { CreateRuleButton } from './sections/rules_list/components/create_rule_button';
+import type { Section } from './constants';
+import { routeToRules, routeToLogs } from './constants';
 import { getAlertingSectionBreadcrumb } from './lib/breadcrumb';
 import { getCurrentDocTitle } from './lib/doc_title';
 
@@ -37,14 +45,15 @@ export const TriggersActionsUIHome: React.FunctionComponent<RouteComponentProps<
   },
   history,
 }) => {
-  const [headerActions, setHeaderActions] = useState<React.ReactNode[] | undefined>();
   const {
     chrome,
     setBreadcrumbs,
     http,
     notifications: { toasts },
+    ruleTypeRegistry,
+    application: { navigateToApp },
   } = useKibana().services;
-  const { authorizedToReadAnyRules } = useGetRuleTypesPermissions({
+  const { authorizedToReadAnyRules, authorizedToCreateAnyRules } = useGetRuleTypesPermissions({
     http,
     toasts,
     filteredRuleTypes: [],
@@ -75,25 +84,33 @@ export const TriggersActionsUIHome: React.FunctionComponent<RouteComponentProps<
     history.push(`/${newSection}`);
   };
 
+  const [ruleTypeModalVisible, setRuleTypeModalVisibility] = useState<boolean>(false);
+
+  const openRuleTypeModal = useCallback(() => {
+    setRuleTypeModalVisibility(true);
+  }, []);
+
+  const headerActions = [
+    ...(authorizedToCreateAnyRules ? [<CreateRuleButton openFlyout={openRuleTypeModal} />] : []),
+    <RulesSettingsLink
+      alertDeleteCategoryIds={['management', 'observability', 'securitySolution']}
+    />,
+    <RulesListDocLink />,
+  ];
+
   const renderRulesList = useCallback(() => {
     return suspendedComponentWithProps(
       RulesList,
       'xl'
     )({
       showCreateRuleButtonInPrompt: true,
-      setHeaderActions,
     });
   }, []);
 
   const renderLogsList = useCallback(() => {
     return (
       <EuiPageTemplate.Section grow={false} paddingSize="none">
-        {suspendedComponentWithProps(
-          LogsList,
-          'xl'
-        )({
-          setHeaderActions,
-        })}
+        <LogsList />
       </EuiPageTemplate.Section>
     );
   }, []);
@@ -138,6 +155,28 @@ export const TriggersActionsUIHome: React.FunctionComponent<RouteComponentProps<
           </Routes>
         </HealthCheck>
       </HealthContextProvider>
+
+      {ruleTypeModalVisible && (
+        <RuleTypeModal
+          onClose={() => setRuleTypeModalVisibility(false)}
+          onSelectRuleType={(ruleTypeId) => {
+            navigateToApp('management', {
+              path: `insightsAndAlerting/triggersActions/${getCreateRuleRoute(ruleTypeId)}`,
+            });
+          }}
+          onSelectTemplate={(templateId) => {
+            navigateToApp('management', {
+              path: `insightsAndAlerting/triggersActions/${getCreateRuleFromTemplateRoute(
+                encodeURIComponent(templateId)
+              )}`,
+            });
+          }}
+          http={http}
+          toasts={toasts}
+          registeredRuleTypes={ruleTypeRegistry.list()}
+          filteredRuleTypes={[]}
+        />
+      )}
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/home.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/home.tsx
@@ -164,7 +164,7 @@ export const TriggersActionsUIHome: React.FunctionComponent<RouteComponentProps<
           http={http}
           toasts={toasts}
           registeredRuleTypes={ruleTypeRegistry.list()}
-          filteredRuleTypes={filteredRuleTypes}
+          filteredRuleTypes={[]}
         />
       )}
     </>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/home.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/home.tsx
@@ -14,13 +14,11 @@ import { EuiSpacer, EuiPageTemplate } from '@elastic/eui';
 
 import { RuleTypeModal } from '@kbn/response-ops-rule-form';
 import { useGetRuleTypesPermissions } from '@kbn/alerts-ui-shared/src/common/hooks/use_get_rule_types_permissions';
-import { getCreateRuleRoute, getCreateRuleFromTemplateRoute } from '@kbn/rule-data-utils';
+import { getCreateRuleRoute } from '@kbn/rule-data-utils';
 import { Section, routeToRules, routeToLogs } from './constants';
 import { RulesSettingsLink } from './components/rules_setting/rules_settings_link';
 import { RulesListDocLink } from './sections/rules_list/components/rules_list_doc_link';
 import { CreateRuleButton } from './sections/rules_list/components/create_rule_button';
-import type { Section } from './constants';
-import { routeToRules, routeToLogs } from './constants';
 import { getAlertingSectionBreadcrumb } from './lib/breadcrumb';
 import { getCurrentDocTitle } from './lib/doc_title';
 
@@ -163,17 +161,10 @@ export const TriggersActionsUIHome: React.FunctionComponent<RouteComponentProps<
               path: `insightsAndAlerting/triggersActions/${getCreateRuleRoute(ruleTypeId)}`,
             });
           }}
-          onSelectTemplate={(templateId) => {
-            navigateToApp('management', {
-              path: `insightsAndAlerting/triggersActions/${getCreateRuleFromTemplateRoute(
-                encodeURIComponent(templateId)
-              )}`,
-            });
-          }}
           http={http}
           toasts={toasts}
           registeredRuleTypes={ruleTypeRegistry.list()}
-          filteredRuleTypes={[]}
+          filteredRuleTypes={filteredRuleTypes}
         />
       )}
     </>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/global_rule_event_log_list.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/global_rule_event_log_list.tsx
@@ -13,7 +13,6 @@ import { useKibana } from '../../../../common/lib/kibana';
 const getEmptyFunctionComponent: React.FC<SpacesContextProps> = ({ children }) => <>{children}</>;
 
 export interface GlobalRuleEventLogListProps {
-  setHeaderActions?: RuleEventLogListCommonProps['setHeaderActions'];
   localStorageKey?: RuleEventLogListCommonProps['localStorageKey'];
   filteredRuleTypes?: RuleEventLogListCommonProps['filteredRuleTypes'];
   getRuleDetailsRoute?: RuleEventLogListCommonProps['getRuleDetailsRoute'];
@@ -32,7 +31,7 @@ const REFRESH_TOKEN = {
 };
 
 export const GlobalRuleEventLogList = (props: GlobalRuleEventLogListProps) => {
-  const { setHeaderActions, localStorageKey, filteredRuleTypes, getRuleDetailsRoute } = props;
+  const { localStorageKey, filteredRuleTypes, getRuleDetailsRoute } = props;
   const { spaces } = useKibana().services;
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -51,7 +50,6 @@ export const GlobalRuleEventLogList = (props: GlobalRuleEventLogListProps) => {
         hasAllSpaceSwitch={true}
         localStorageKey={localStorageKey || GLOBAL_EVENT_LOG_LIST_STORAGE_KEY}
         filteredRuleTypes={filteredRuleTypes}
-        setHeaderActions={setHeaderActions}
         getRuleDetailsRoute={getRuleDetailsRoute}
       />
     </SpacesContextWrapper>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list.test.tsx
@@ -15,6 +15,7 @@ import { mockRule, mockRuleType, mockRuleSummary, mockLogResponse } from './test
 import { RuleType } from '../../../../types';
 import { loadActionErrorLog } from '../../../lib/rule_api/load_action_error_log';
 import { getJsDomPerformanceFix } from '../../test_utils';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 jest.mock('../../../../common/lib/kibana');
@@ -36,10 +37,21 @@ const { getIsExperimentalFeatureEnabled } = jest.requireMock(
 );
 const { useLoadRuleEventLogs } = jest.requireMock('../../../hooks/use_load_rule_event_logs');
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      cacheTime: 0,
+    },
+  },
+});
+
 const RuleEventLogListWithProvider = (props: RuleEventLogListProps<'stackManagement'>) => {
   return (
     <IntlProvider locale="en">
-      <RuleEventLogList {...props} />
+      <QueryClientProvider client={queryClient}>
+        <RuleEventLogList {...props} />
+      </QueryClientProvider>
     </IntlProvider>
   );
 };

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list_table.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list_table.test.tsx
@@ -18,6 +18,7 @@ import {
 import { mockRule, mockLogResponse } from './test_helpers';
 import { getJsDomPerformanceFix } from '../../test_utils';
 import { loadActionErrorLog } from '../../../lib/rule_api/load_action_error_log';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 jest.mock('../../../../common/lib/kibana');
@@ -39,10 +40,21 @@ const { getIsExperimentalFeatureEnabled } = jest.requireMock(
 );
 const { useLoadRuleEventLogs } = jest.requireMock('../../../hooks/use_load_rule_event_logs');
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      cacheTime: 0,
+    },
+  },
+});
+
 const RuleEventLogListWithProvider = (props: RuleEventLogListTableProps<'stackManagement'>) => {
   return (
     <IntlProvider locale="en">
-      <RuleEventLogListTable {...props} />
+      <QueryClientProvider client={queryClient}>
+        <RuleEventLogListTable {...props} />
+      </QueryClientProvider>
     </IntlProvider>
   );
 };

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list_table.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list_table.tsx
@@ -720,7 +720,6 @@ export const RuleEventLogListTable = <T extends RuleEventLogListOptions>(
         <EuiFlexItem>
           {hasExceedLogs && (
             <EuiCallOut
-              announceOnMount
               title={
                 <FormattedMessage
                   id="xpack.triggersActionsUI.sections.exceedLog.refineSearch.prompt"

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list_table.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list_table.tsx
@@ -8,20 +8,18 @@
 import React, { useCallback, useEffect, useState, useMemo, useRef } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import type { EuiDataGridSorting, OnTimeChangeProps, EuiDataGridColumn } from '@elastic/eui';
 import {
   EuiFieldSearch,
   EuiFlexItem,
   EuiFlexGroup,
   EuiProgress,
   EuiSpacer,
-  EuiDataGridSorting,
   EuiSuperDatePicker,
-  OnTimeChangeProps,
   EuiSwitch,
-  EuiDataGridColumn,
   EuiCallOut,
 } from '@elastic/eui';
-import { IExecutionLog } from '@kbn/alerting-plugin/common';
+import type { IExecutionLog } from '@kbn/alerting-plugin/common';
 import { useKibana } from '../../../../common/lib/kibana';
 import {
   RULE_EXECUTION_DEFAULT_INITIAL_VISIBLE_COLUMNS,
@@ -42,16 +40,12 @@ import {
 import { CenterJustifiedSpinner } from '../../../components/center_justified_spinner';
 import { RuleActionErrorLogFlyout } from './rule_action_error_log_flyout';
 import { RefineSearchPrompt } from '../../common/components/refine_search_prompt';
-import { RulesListDocLink } from '../../rules_list/components/rules_list_doc_link';
-import { LoadExecutionLogAggregationsProps } from '../../../lib/rule_api';
+import type { LoadExecutionLogAggregationsProps } from '../../../lib/rule_api';
 import { RuleEventLogListKPIWithApi as RuleEventLogListKPI } from './rule_event_log_list_kpi';
 import { useMultipleSpaces } from '../../../hooks/use_multiple_spaces';
-import {
-  useLoadRuleEventLogs,
-  UseLoadRuleEventLogsProps,
-} from '../../../hooks/use_load_rule_event_logs';
-import { RulesSettingsLink } from '../../../components/rules_setting/rules_settings_link';
-import { RefreshToken } from './types';
+import type { UseLoadRuleEventLogsProps } from '../../../hooks/use_load_rule_event_logs';
+import { useLoadRuleEventLogs } from '../../../hooks/use_load_rule_event_logs';
+import type { RefreshToken } from './types';
 
 const API_FAILED_MESSAGE = i18n.translate(
   'xpack.triggersActionsUI.sections.ruleDetails.eventLogColumn.apiError',
@@ -98,7 +92,6 @@ export interface RuleEventLogListCommonProps {
   hasRuleNames?: boolean;
   hasAllSpaceSwitch?: boolean;
   filteredRuleTypes?: string[];
-  setHeaderActions?: (components?: React.ReactNode[]) => void;
   getRuleDetailsRoute?: (ruleId: string) => string;
 }
 
@@ -119,8 +112,7 @@ export const RuleEventLogListTable = <T extends RuleEventLogListOptions>(
     initialPageSize = 10,
     hasRuleNames = false,
     hasAllSpaceSwitch = false,
-    setHeaderActions,
-    filteredRuleTypes,
+    filteredRuleTypes = [],
     getRuleDetailsRoute,
   } = props;
 
@@ -192,17 +184,6 @@ export const RuleEventLogListTable = <T extends RuleEventLogListOptions>(
       },
     }));
   }, [sortingColumns]);
-
-  useEffect(() => {
-    setHeaderActions?.([
-      <RulesSettingsLink
-        alertDeleteCategoryIds={['management', 'observability', 'securitySolution']}
-      />,
-      <RulesListDocLink />,
-    ]);
-    return () => setHeaderActions?.();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const onError = useCallback<NonNullable<UseLoadRuleEventLogsProps['onError']>>(
     (e) => {
@@ -680,92 +661,95 @@ export const RuleEventLogListTable = <T extends RuleEventLogListOptions>(
   }, [refreshToken]);
 
   return (
-    <EuiFlexGroup gutterSize="none" direction="column" data-test-subj="ruleEventLogListTable">
-      <EuiFlexItem grow={false}>
-        <EuiFlexGroup gutterSize="m" alignItems="center">
-          <EuiFlexItem>
-            <EuiFieldSearch
-              fullWidth
-              isClearable
-              value={search}
-              onChange={onSearchChange}
-              onKeyUp={onKeyUp}
-              placeholder={SEARCH_PLACEHOLDER}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EventLogListStatusFilter selectedOptions={filter} onChange={onFilterChange} />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiSuperDatePicker
-              data-test-subj="ruleEventLogListDatePicker"
-              width="auto"
-              isLoading={isLoading}
-              start={dateStart}
-              end={dateEnd}
-              onTimeChange={onTimeChange}
-              onRefresh={onRefresh}
-              dateFormat={dateFormat}
-              commonlyUsedRanges={commonlyUsedRanges}
-              updateButtonProps={updateButtonProps}
-            />
-          </EuiFlexItem>
-          {hasAllSpaceSwitch && canAccessMultipleSpaces && (
-            <EuiFlexItem data-test-subj="showAllSpacesSwitch">
-              <EuiSwitch
-                label={ALL_SPACES_LABEL}
-                checked={showFromAllSpaces}
-                onChange={onShowAllSpacesChange}
+    <>
+      <EuiFlexGroup gutterSize="none" direction="column" data-test-subj="ruleEventLogListTable">
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup gutterSize="m" alignItems="center">
+            <EuiFlexItem>
+              <EuiFieldSearch
+                fullWidth
+                isClearable
+                value={search}
+                onChange={onSearchChange}
+                onKeyUp={onKeyUp}
+                placeholder={SEARCH_PLACEHOLDER}
               />
             </EuiFlexItem>
-          )}
-        </EuiFlexGroup>
-        <EuiSpacer />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <RuleEventLogListKPI
-          ruleId={ruleId}
-          dateStart={dateStart}
-          dateEnd={dateEnd}
-          outcomeFilter={filter}
-          message={searchText}
-          refreshToken={internalRefreshToken}
-          namespaces={namespaces}
-          filteredRuleTypes={filteredRuleTypes}
-        />
-        <EuiSpacer />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        {hasExceedLogs && (
-          <EuiCallOut
-            title={
-              <FormattedMessage
-                id="xpack.triggersActionsUI.sections.exceedLog.refineSearch.prompt"
-                defaultMessage="Results are limited to 10,000 documents, refine your search to see others."
+            <EuiFlexItem grow={false}>
+              <EventLogListStatusFilter selectedOptions={filter} onChange={onFilterChange} />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiSuperDatePicker
+                data-test-subj="ruleEventLogListDatePicker"
+                width="auto"
+                isLoading={isLoading}
+                start={dateStart}
+                end={dateEnd}
+                onTimeChange={onTimeChange}
+                onRefresh={onRefresh}
+                dateFormat={dateFormat}
+                commonlyUsedRanges={commonlyUsedRanges}
+                updateButtonProps={updateButtonProps}
               />
-            }
-            data-test-subj="exceedLimitLogsCallout"
-            size="m"
+            </EuiFlexItem>
+            {hasAllSpaceSwitch && canAccessMultipleSpaces && (
+              <EuiFlexItem data-test-subj="showAllSpacesSwitch">
+                <EuiSwitch
+                  label={ALL_SPACES_LABEL}
+                  checked={showFromAllSpaces}
+                  onChange={onShowAllSpacesChange}
+                />
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+          <EuiSpacer />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <RuleEventLogListKPI
+            ruleId={ruleId}
+            dateStart={dateStart}
+            dateEnd={dateEnd}
+            outcomeFilter={filter}
+            message={searchText}
+            refreshToken={internalRefreshToken}
+            namespaces={namespaces}
+            filteredRuleTypes={filteredRuleTypes}
+          />
+          <EuiSpacer />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          {hasExceedLogs && (
+            <EuiCallOut
+              announceOnMount
+              title={
+                <FormattedMessage
+                  id="xpack.triggersActionsUI.sections.exceedLog.refineSearch.prompt"
+                  defaultMessage="Results are limited to 10,000 documents, refine your search to see others."
+                />
+              }
+              data-test-subj="exceedLimitLogsCallout"
+              size="m"
+            />
+          )}
+          {!hasExceedLogs && renderList()}
+          {isOnLastPage && (
+            <RefineSearchPrompt
+              documentSize={actualTotalItemCount}
+              visibleDocumentSize={MAX_RESULTS}
+              backToTopAnchor="rule_event_log_list"
+            />
+          )}
+        </EuiFlexItem>
+        {isFlyoutOpen && selectedRunLog && (
+          <RuleActionErrorLogFlyout
+            runLog={selectedRunLog}
+            refreshToken={refreshToken}
+            onClose={onFlyoutClose}
+            activeSpaceId={activeSpace?.id}
           />
         )}
-        {!hasExceedLogs && renderList()}
-        {isOnLastPage && (
-          <RefineSearchPrompt
-            documentSize={actualTotalItemCount}
-            visibleDocumentSize={MAX_RESULTS}
-            backToTopAnchor="rule_event_log_list"
-          />
-        )}
-      </EuiFlexItem>
-      {isFlyoutOpen && selectedRunLog && (
-        <RuleActionErrorLogFlyout
-          runLog={selectedRunLog}
-          refreshToken={refreshToken}
-          onClose={onFlyoutClose}
-          activeSpaceId={activeSpace?.id}
-        />
-      )}
-    </EuiFlexGroup>
+      </EuiFlexGroup>
+    </>
   );
 };
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.test.tsx
@@ -30,9 +30,6 @@ import { getIsExperimentalFeatureEnabled } from '../../../../common/get_experime
 import { useKibana } from '../../../../common/lib/kibana';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { IToasts } from '@kbn/core/public';
-import { CreateRuleButton } from './create_rule_button';
-import { RulesListDocLink } from './rules_list_doc_link';
-import { RulesSettingsLink } from '../../../components/rules_setting/rules_settings_link';
 
 import {
   mockedRulesData,
@@ -436,38 +433,7 @@ describe('rules_list ', () => {
     });
   });
 
-  describe('setHeaderActions', () => {
-    it('should not render the Create Rule button', async () => {
-      renderWithProviders(<RulesList />);
-      await waitForElementToBeRemoved(() => screen.queryByTestId('centerJustifiedSpinner'));
-
-      expect(screen.queryAllByTestId('createRuleButton')).toHaveLength(0);
-    });
-
-    it('should set header actions correctly when the user is authorized to create rules', async () => {
-      const setHeaderActionsMock = jest.fn();
-      renderWithProviders(<RulesList setHeaderActions={setHeaderActionsMock} />);
-
-      await waitForElementToBeRemoved(() => screen.queryByTestId('centerJustifiedSpinner'));
-      expect(setHeaderActionsMock.mock.lastCall[0][0].type).toEqual(CreateRuleButton);
-      expect(setHeaderActionsMock.mock.lastCall[0][1].type).toEqual(RulesSettingsLink);
-      expect(setHeaderActionsMock.mock.lastCall[0][2].type).toEqual(RulesListDocLink);
-    });
-
-    it('should set header actions correctly when the user is not authorized to creat rules', async () => {
-      getRuleTypes.mockResolvedValueOnce([]);
-      const setHeaderActionsMock = jest.fn();
-      renderWithProviders(<RulesList setHeaderActions={setHeaderActionsMock} />);
-
-      await waitForElementToBeRemoved(() => screen.queryByTestId('centerJustifiedSpinner'));
-      // Do not render the create rule button since the user is not authorized
-      expect(setHeaderActionsMock.mock.lastCall[0][0].type).toEqual(RulesSettingsLink);
-      expect(setHeaderActionsMock.mock.lastCall[0][1].type).toEqual(RulesListDocLink);
-    });
-  });
-
-  // FLAKY: https://github.com/elastic/kibana/issues/149061
-  describe.skip('rules_list component with items', () => {
+  describe('rules_list component with items', () => {
     it('should render basic table and its row', async () => {
       renderWithProviders(<RulesList />);
       await waitFor(() => expect(screen.queryAllByTestId('rule-row')).toHaveLength(6));

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.test.tsx
@@ -433,7 +433,7 @@ describe('rules_list ', () => {
     });
   });
 
-  describe('rules_list component with items', () => {
+  describe.skip('rules_list component with items', () => {
     it('should render basic table and its row', async () => {
       renderWithProviders(<RulesList />);
       await waitFor(() => expect(screen.queryAllByTestId('rule-row')).toHaveLength(6));

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
@@ -69,12 +69,10 @@ import { RulesDeleteModalConfirmation } from '../../../components/rules_delete_m
 import { RulesListPrompts } from './rules_list_prompts';
 import { ALERT_STATUS_LICENSE_ERROR } from '../translations';
 import { useKibana } from '../../../../common/lib/kibana';
-import { CreateRuleButton } from './create_rule_button';
 import { ManageLicenseModal } from './manage_license_modal';
 import { getIsExperimentalFeatureEnabled } from '../../../../common/get_experimental_features';
 import { RulesListClearRuleFilterBanner } from './rules_list_clear_rule_filter_banner';
 import { RulesListTable, convertRulesToTableItems } from './rules_list_table';
-import { RulesListDocLink } from './rules_list_doc_link';
 import { UpdateApiKeyModalConfirmation } from '../../../components/update_api_key_modal_confirmation';
 import { BulkSnoozeModalWithApi as BulkSnoozeModal } from './bulk_snooze_modal';
 import { BulkSnoozeScheduleModalWithApi as BulkSnoozeScheduleModal } from './bulk_snooze_schedule_modal';
@@ -94,7 +92,6 @@ import {
   MULTIPLE_RULE_TITLE,
 } from '../translations';
 import { useBulkOperationToast } from '../../../hooks/use_bulk_operation_toast';
-import { RulesSettingsLink } from '../../../components/rules_setting/rules_settings_link';
 import { useRulesListUiState as useUiState } from '../../../hooks/use_rules_list_ui_state';
 import { useRulesListFilterStore } from './hooks/use_rules_list_filter_store';
 
@@ -122,7 +119,6 @@ export interface RulesListProps {
   onStatusFilterChange?: (status: RuleStatus[]) => void;
   onTypeFilterChange?: (type: string[]) => void;
   onRefresh?: (refresh: Date) => void;
-  setHeaderActions?: (components?: React.ReactNode[]) => void;
   initialSelectedConsumer?: RuleCreationValidConsumer | null;
   navigateToEditRuleForm?: (ruleId: string) => void;
 }
@@ -165,7 +161,6 @@ export const RulesList = ({
   onStatusFilterChange,
   onTypeFilterChange,
   onRefresh,
-  setHeaderActions,
   navigateToEditRuleForm,
 }: RulesListProps) => {
   const history = useHistory();
@@ -657,20 +652,6 @@ export const RulesList = ({
 
   const openRuleTypeModal = useCallback(() => {
     setRuleTypeModalVisibility(true);
-  }, []);
-
-  useEffect(() => {
-    setHeaderActions?.([
-      ...(authorizedToCreateAnyRules ? [<CreateRuleButton openFlyout={openRuleTypeModal} />] : []),
-      <RulesSettingsLink
-        alertDeleteCategoryIds={['management', 'observability', 'securitySolution']}
-      />,
-      <RulesListDocLink />,
-    ]);
-  }, [authorizedToCreateAnyRules]);
-
-  useEffect(() => {
-    return () => setHeaderActions?.();
   }, []);
 
   const [isDeleteModalFlyoutVisible, setIsDeleteModalVisibility] = useState<boolean>(false);

--- a/x-pack/solutions/observability/plugins/observability/public/pages/rules/rules.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/rules/rules.tsx
@@ -119,23 +119,19 @@ export function RulesPage({ activeTab = RULES_TAB_NAME }: RulesPageProps) {
   ];
 
   const rightSideItems = [
-    ...(activeTab === RULES_TAB_NAME
-      ? [
-          <EuiButton
-            data-test-subj="createRuleButton"
-            disabled={!authorizedToCreateAnyRules}
-            fill
-            iconType="plusInCircle"
-            key="create-alert"
-            onClick={() => setRuleTypeModalVisibility(true)}
-          >
-            <FormattedMessage
-              id="xpack.observability.rules.addRuleButtonLabel"
-              defaultMessage="Create rule"
-            />
-          </EuiButton>,
-        ]
-      : []),
+    <EuiButton
+      data-test-subj="createRuleButton"
+      disabled={!authorizedToCreateAnyRules}
+      fill
+      iconType="plusInCircle"
+      key="create-alert"
+      onClick={() => setRuleTypeModalVisibility(true)}
+    >
+      <FormattedMessage
+        id="xpack.observability.rules.addRuleButtonLabel"
+        defaultMessage="Create rule"
+      />
+    </EuiButton>,
     <RulesSettingsLink />,
     <EuiButtonEmpty
       data-test-subj="documentationLink"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ResponseOps][Rules] Create rule not available when selecting Logs tab (#249163)](https://github.com/elastic/kibana/pull/249163)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2026-01-27T08:15:56Z","message":"[ResponseOps][Rules] Create rule not available when selecting Logs tab (#249163)\n\nCloses https://github.com/elastic/kibana/issues/238582\n## Summary\n\n- centralized header actions logic (create rule button, rules settings,\ndocumentation link) from the **RulesList** and **RuleEventLogListTable**\ncomponents into the parent page components (`Home`, for the current\nactive page, and `RulesPage`, for the new unified rules page)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7b5384e828e1131db453c97df77b48fbbbf0f837","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:version","v9.3.0","v9.4.0","Team:obs-ux-management","v9.2.5","v8.19.11"],"title":"[ResponseOps][Rules] Create rule not available when selecting Logs tab","number":249163,"url":"https://github.com/elastic/kibana/pull/249163","mergeCommit":{"message":"[ResponseOps][Rules] Create rule not available when selecting Logs tab (#249163)\n\nCloses https://github.com/elastic/kibana/issues/238582\n## Summary\n\n- centralized header actions logic (create rule button, rules settings,\ndocumentation link) from the **RulesList** and **RuleEventLogListTable**\ncomponents into the parent page components (`Home`, for the current\nactive page, and `RulesPage`, for the new unified rules page)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7b5384e828e1131db453c97df77b48fbbbf0f837"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2","8.19"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249163","number":249163,"mergeCommit":{"message":"[ResponseOps][Rules] Create rule not available when selecting Logs tab (#249163)\n\nCloses https://github.com/elastic/kibana/issues/238582\n## Summary\n\n- centralized header actions logic (create rule button, rules settings,\ndocumentation link) from the **RulesList** and **RuleEventLogListTable**\ncomponents into the parent page components (`Home`, for the current\nactive page, and `RulesPage`, for the new unified rules page)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7b5384e828e1131db453c97df77b48fbbbf0f837"}},{"branch":"9.2","label":"v9.2.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->