### PR TITLE
[9.3] [@kbn/scout] Add Scout API `expect` with custom matchers (#247008)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/api.ts
+++ b/src/platform/packages/shared/kbn-scout/api.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { expect } from './src/playwright/matchers/api';

--- a/src/platform/packages/shared/kbn-scout/src/playwright/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/index.ts
@@ -13,6 +13,8 @@ import './peggy_setup';
 // Config and utilities
 export { createPlaywrightConfig } from './config';
 export { createLazyPageObject } from './page_objects/utils';
+
+// Matchers
 export { expect } from './expect';
 
 // Types for Playwright options

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/README.md
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/README.md
@@ -1,0 +1,110 @@
+# Scout API Matchers
+
+## Summary
+
+Scout exposes a custom API `expect` object with custom and default matchers for API testing. To enforce best practices, Playwright's default matchers are restricted.
+
+```typescript
+import { expect } from '@kbn/scout/api';
+```
+
+---
+
+## Custom Response Matchers
+
+Scout-specific matchers for API response assertions. These support both `apiClient` and `kbnClient` response interfaces.
+
+### toHaveStatusCode
+
+Asserts response has the expected HTTP status code. Checks `status` or `statusCode` property.
+
+```typescript
+expect(response).toHaveStatusCode(200);
+expect(response).toHaveStatusCode({ oneOf: [200, 201] });
+```
+
+### toHaveStatusText
+
+Asserts response has the expected status text. Checks `statusText` or `statusMessage` property.
+
+```typescript
+expect(response).toHaveStatusText('OK');
+```
+
+### toHaveHeaders
+
+Asserts response contains the expected headers (partial match). Checks `headers` property. Case-insensitive keys. Response header arrays are joined with `, ` before comparison.
+
+```typescript
+expect(response).toHaveHeaders({ 'content-type': 'application/json' });
+expect(response).toHaveHeaders({ 'set-cookie': 'session=abc, token=xyz' });
+```
+
+---
+
+## Custom Asymmetric Matchers
+
+Custom asymmetric matchers for use with `toMatchObject`:
+
+- **`expect.toBeGreaterThan(n)`** - Matches if value > n
+- **`expect.toBeLessThan(n)`** - Matches if value < n
+
+```typescript
+expect(response).toMatchObject({
+  body: {
+    count: expect.toBeGreaterThan(0),
+    limit: expect.toBeLessThan(100),
+  },
+});
+```
+
+---
+
+## Supported Playwright Matchers
+
+The following [Playwright matchers](https://playwright.dev/docs/api/class-genericassertions) are available:
+
+**Matchers:**
+
+- `toBe(expected)` - compares using `Object.is`, use for primitive literals
+- `toBeDefined()` - value is not `undefined`
+- `toBeUndefined()` - value is `undefined`
+- `toContain(expected)` - string contains substring, or Array/Set contains item
+- `toHaveLength(n)` - value has `.length` property equal to n
+- `toStrictEqual(expected)` - deep equality with type checking
+- `toBeGreaterThan(n)` - value > n
+- `toBeLessThan(n)` - value < n
+- `toMatchObject(expected)` - partial object matching
+
+**Asymmetric matchers:**
+
+- `expect.arrayContaining(array)` - array contains all expected elements
+- `expect.objectContaining(object)` - object contains expected properties
+
+---
+
+## Restricted Matchers
+
+To enforce best practices, some Playwright matchers are restricted. Use these alternatives:
+
+```typescript
+expect({ name: 'Alice', metadata: undefined }).toEqual({ name: 'Alice' }); // ❌ would pass even if extra keys exist
+expect({ name: 'Alice', metadata: undefined }).toStrictEqual({ name: 'Alice' }); // ✅ fails if extra/missing keys exist
+
+expect(response).toHaveProperty('apiKey'); // ❌ passes even if apiKey is undefined
+expect(response.apiKey).toBeDefined(); // ✅ it will fail if undefined
+
+expect(exists).toBeTruthy(); // ❌ too loose
+expect(exists).toBe(true); // ✅ be explicit
+
+expect(response.apiKey).not.toBeDefined(); // ❌ not available
+expect(response.apiKey).toBeUndefined(); // ✅ preferred by playwright
+```
+
+**UI-specific matchers** like `toBeVisible`, `toBeEnabled`, `toHaveAttribute`, etc. are not available for API tests.
+
+## Notes
+
+- Custom matchers throw Playwright-style errors
+- Stack traces can be trimmed via `skipStackLines` to point directly at the test file
+- `toHaveStatusCode` options interface is designed for extensibility (e.g., future `range` option)

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/asymmetric_matchers.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/asymmetric_matchers.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expect as apiExpect } from '.';
+
+describe('custom asymmetric matchers', () => {
+  describe('expect.toBeGreaterThan()', () => {
+    it('matches numbers greater than threshold', () => {
+      expect(() =>
+        apiExpect({ count: 5 }).toMatchObject({ count: apiExpect.toBeGreaterThan(4) })
+      ).not.toThrow();
+      expect(() =>
+        apiExpect({ count: 5 }).toMatchObject({ count: apiExpect.toBeGreaterThan(5) })
+      ).toThrow();
+    });
+  });
+
+  describe('expect.toBeLessThan()', () => {
+    it('matches numbers less than threshold', () => {
+      expect(() =>
+        apiExpect({ count: 5 }).toMatchObject({ count: apiExpect.toBeLessThan(6) })
+      ).not.toThrow();
+      expect(() =>
+        apiExpect({ count: 5 }).toMatchObject({ count: apiExpect.toBeLessThan(5) })
+      ).toThrow();
+    });
+  });
+
+  it('supports nesting and combining with Playwright matchers', () => {
+    const response = {
+      data: {
+        id: 'abc-123',
+        count: 5,
+        items: [{ name: 'a', extra: 'ignored' }, { name: 'b' }],
+      },
+    };
+    expect(() =>
+      apiExpect(response).toMatchObject({
+        data: {
+          count: apiExpect.toBeGreaterThan(0),
+          items: apiExpect.arrayContaining([apiExpect.objectContaining({ name: 'a' })]),
+        },
+      })
+    ).not.toThrow();
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/asymmetric_matchers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/asymmetric_matchers.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expect as baseExpect } from '@playwright/test';
+import type { AsymmetricMatcher, AsymmetricMatchers } from './types';
+
+// Symbol used by Jest/Playwright to identify asymmetric matchers
+const ASYMMETRIC_MATCHER_SYMBOL = Symbol.for('jest.asymmetricMatcher');
+
+/**
+ * Creates a custom asymmetric matcher that can be used inside toMatchObject().
+ */
+function createAsymmetricMatcher(
+  matchFn: (actual: unknown) => boolean,
+  description: string
+): AsymmetricMatcher {
+  return {
+    $$typeof: ASYMMETRIC_MATCHER_SYMBOL,
+    asymmetricMatch: matchFn,
+    toString: () => description,
+    toAsymmetricMatcher: () => description,
+  };
+}
+
+/**
+ * Asymmetric matchers that allow partial, flexible, or pattern-based assertions
+ * inside objects or arrays without requiring an exact value match
+ *
+ * @example
+ * expect({ count: 5 }).toMatchObject({ count: expect.toBeGreaterThan(0) });
+ */
+export const asymmetricMatchers: AsymmetricMatchers = {
+  /** Ensures that `value > expected` for number values */
+  toBeGreaterThan: (min: number) =>
+    createAsymmetricMatcher(
+      (actual) => typeof actual === 'number' && actual > min,
+      `toBeGreaterThan(${min})`
+    ),
+
+  /** Ensures that `value < expected` for number values */
+  toBeLessThan: (max: number) =>
+    createAsymmetricMatcher(
+      (actual) => typeof actual === 'number' && actual < max,
+      `toBeLessThan(${max})`
+    ),
+
+  /** Matches an array that contains all of the elements in the expected array, in any order */
+  arrayContaining: <T>(expected: T[]) => baseExpect.arrayContaining(expected),
+
+  /** Matches an object that contains and matches all of the properties in the expected object */
+  objectContaining: <T extends Record<string, unknown>>(expected: T) =>
+    baseExpect.objectContaining(expected),
+};

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/generic_matchers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/generic_matchers.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expect as baseExpect } from '@playwright/test';
+import type { GenericMatchers } from './types';
+
+/**
+ * Create generic matchers delegating to Playwright/Jest expect
+ */
+export function createGenericMatchers(actual: unknown): GenericMatchers {
+  // eslint-disable-next-line playwright/valid-expect
+  const base = baseExpect(actual);
+  return {
+    toBe: (expected: unknown) => base.toBe(expected),
+    toBeDefined: () => base.toBeDefined(),
+    toBeUndefined: () => base.toBeUndefined(),
+    toContain: (expected: unknown) => base.toContain(expected),
+    toHaveLength: (expected: number) => base.toHaveLength(expected),
+    toStrictEqual: (expected: unknown) => base.toStrictEqual(expected),
+    toBeGreaterThan: (expected: number) => base.toBeGreaterThan(expected),
+    toBeLessThan: (expected: number) => base.toBeLessThan(expected),
+    toMatchObject: (expected: Record<string, unknown> | unknown[]) => base.toMatchObject(expected),
+    not: {
+      toBe: (expected: unknown) => base.not.toBe(expected),
+      toBeUndefined: () => base.not.toBeUndefined(),
+      toContain: (expected: unknown) => base.not.toContain(expected),
+      toHaveLength: (expected: number) => base.not.toHaveLength(expected),
+      toStrictEqual: (expected: unknown) => base.not.toStrictEqual(expected),
+      toBeGreaterThan: (expected: number) => base.not.toBeGreaterThan(expected),
+      toBeLessThan: (expected: number) => base.not.toBeLessThan(expected),
+      toMatchObject: (expected: Record<string, unknown> | unknown[]) =>
+        base.not.toMatchObject(expected),
+    },
+  };
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/index.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Matchers } from './types';
+import { createGenericMatchers } from './generic_matchers';
+import { createResponseMatchers } from './response_matchers';
+import { asymmetricMatchers } from './asymmetric_matchers';
+
+/**
+ * Custom expect wrapper for API tests with generic and response matchers.
+ *
+ * @example
+ * expect(response).toHaveStatusCode(200);
+ * expect(response).toMatchObject({ body: { count: expect.toBeGreaterThan(0) } });
+ */
+function expectFn(actual: unknown): Matchers {
+  const genericMatchers = createGenericMatchers(actual);
+  const responseMatchers = createResponseMatchers(actual);
+
+  return {
+    ...genericMatchers,
+    ...responseMatchers,
+    not: { ...genericMatchers.not },
+  };
+}
+
+export const expect = Object.assign(expectFn, asymmetricMatchers);

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/response_matchers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/response_matchers.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { toHaveHeaders } from './to_have_headers';
+import { toHaveStatusCode } from './to_have_status_code';
+import { toHaveStatusText } from './to_have_status_text';
+import type { ToHaveStatusCodeOptions } from './to_have_status_code';
+import type { ResponseMatchers } from './types';
+
+/**
+ * Create response matchers for API response assertions.
+ * Matchers validate that the object has required properties before asserting.
+ */
+export function createResponseMatchers(obj: unknown): ResponseMatchers {
+  return {
+    toHaveStatusCode: (code: number | ToHaveStatusCodeOptions) => toHaveStatusCode(obj, code),
+    toHaveStatusText: (text: string) => toHaveStatusText(obj, text),
+    toHaveHeaders: (headers: Record<string, string>) => toHaveHeaders(obj, headers),
+  };
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_headers.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_headers.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expect as apiExpect } from '.';
+
+describe('toHaveHeaders', () => {
+  it('should pass when expected headers are present (partial match)', () => {
+    const response = {
+      headers: { 'content-type': 'application/json', 'x-custom': 'value', 'x-other': 'data' },
+    };
+    expect(() =>
+      apiExpect(response).toHaveHeaders({ 'content-type': 'application/json', 'x-custom': 'value' })
+    ).not.toThrow();
+  });
+
+  it('should fail when header is missing', () => {
+    expect(() =>
+      apiExpect({ headers: { 'content-type': 'application/json' } }).toHaveHeaders({
+        'x-missing': 'value',
+      })
+    ).toThrow();
+  });
+
+  it('should fail when header value does not match', () => {
+    expect(() =>
+      apiExpect({ headers: { 'content-type': 'text/plain' } }).toHaveHeaders({
+        'content-type': 'application/json',
+      })
+    ).toThrow();
+  });
+
+  it('should be case-insensitive for header keys', () => {
+    expect(() =>
+      apiExpect({ headers: { 'Content-Type': 'application/json' } }).toHaveHeaders({
+        'content-type': 'application/json',
+      })
+    ).not.toThrow();
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_headers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_headers.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expect as baseExpect } from '@playwright/test';
+import { createMatcherError } from './utils';
+
+/**
+ * Asserts that the response contains the expected headers.
+ * This is a partial match - the response can contain additional headers.
+ * Header keys are case-insensitive.
+ *
+ * @example
+ * expect(response).toHaveHeaders({ 'content-type': 'application/json' });
+ * expect(response).not.toHaveHeaders({ 'x-forbidden': 'value' });
+ */
+export function toHaveHeaders(
+  obj: unknown,
+  expectedHeaders: Record<string, string>,
+  isNegated = false
+): void {
+  if (typeof obj !== 'object' || obj === null || !('headers' in obj)) {
+    throw createMatcherError({
+      expected: JSON.stringify({ headers: expectedHeaders }),
+      matcherName: 'toHaveHeaders',
+      received: obj,
+      isNegated,
+    });
+  }
+
+  const actualHeaders: Record<string, string> = {};
+  const headers = obj.headers ?? {};
+  for (const [key, value] of Object.entries(headers)) {
+    actualHeaders[key.toLowerCase()] = Array.isArray(value) ? value.join(', ') : value;
+  }
+
+  const normalizedExpected: Record<string, string> = {};
+  for (const [key, value] of Object.entries(expectedHeaders)) {
+    normalizedExpected[key.toLowerCase()] = value;
+  }
+
+  try {
+    if (isNegated) {
+      baseExpect(actualHeaders).not.toMatchObject(normalizedExpected);
+    } else {
+      baseExpect(actualHeaders).toMatchObject(normalizedExpected);
+    }
+  } catch {
+    throw createMatcherError({
+      expected: JSON.stringify(normalizedExpected),
+      matcherName: 'toHaveHeaders',
+      received: JSON.stringify(actualHeaders),
+      isNegated,
+    });
+  }
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_code.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_code.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expect as apiExpect } from '.';
+
+describe('toHaveStatusCode', () => {
+  it('should pass when status code matches', () => {
+    // kbnClient interface (status)
+    expect(() => apiExpect({ status: 200 }).toHaveStatusCode(200)).not.toThrow();
+    // apiClient interface (statusCode)
+    expect(() => apiExpect({ statusCode: 200 }).toHaveStatusCode(200)).not.toThrow();
+  });
+
+  it('should fail when status code does not match', () => {
+    expect(() => apiExpect({ status: 404 }).toHaveStatusCode(200)).toThrow();
+  });
+
+  describe('oneOf option', () => {
+    it('should pass when status is one of the expected codes', () => {
+      expect(() =>
+        apiExpect({ status: 404 }).toHaveStatusCode({ oneOf: [400, 404] })
+      ).not.toThrow();
+    });
+
+    it('should fail when status is not one of the expected codes', () => {
+      expect(() => apiExpect({ status: 500 }).toHaveStatusCode({ oneOf: [400, 404] })).toThrow();
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_code.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_code.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expect as baseExpect } from '@playwright/test';
+import { createMatcherError } from './utils';
+
+export interface ToHaveStatusCodeOptions {
+  /** Match if the status code is one of these values */
+  oneOf: number[];
+  // Future: range?: [number, number];
+}
+
+/**
+ * Asserts that the response has the expected HTTP status code.
+ *
+ * @example
+ * expect(response).toHaveStatusCode(200);
+ * expect(response).toHaveStatusCode({ oneOf: [200, 201] });
+ * expect(response).not.toHaveStatusCode(404);
+ */
+export function toHaveStatusCode(
+  obj: unknown,
+  expected: number | ToHaveStatusCodeOptions,
+  isNegated = false
+): void {
+  if (typeof obj !== 'object' || obj === null || (!('status' in obj) && !('statusCode' in obj))) {
+    const expectedValue = typeof expected === 'number' ? expected : expected.oneOf;
+    throw createMatcherError({
+      expected: `${JSON.stringify({ status: expectedValue })} or ${JSON.stringify({
+        statusCode: expectedValue,
+      })}`,
+      matcherName: 'toHaveStatusCode',
+      received: obj,
+      isNegated,
+    });
+  }
+
+  const actual = 'status' in obj ? obj.status : obj.statusCode;
+  const codes = typeof expected === 'number' ? [expected] : expected.oneOf;
+
+  try {
+    if (isNegated) {
+      baseExpect(codes).not.toContain(actual);
+    } else {
+      baseExpect(codes).toContain(actual);
+    }
+  } catch {
+    throw createMatcherError({
+      expected,
+      matcherName: 'toHaveStatusCode',
+      received: actual,
+      isNegated,
+    });
+  }
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_text.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_text.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expect as apiExpect } from '.';
+
+describe('toHaveStatusText', () => {
+  it('should pass when status text matches', () => {
+    // kbnClient interface (statusText)
+    expect(() => apiExpect({ statusText: 'OK' }).toHaveStatusText('OK')).not.toThrow();
+    // apiClient interface (statusMessage)
+    expect(() => apiExpect({ statusMessage: 'OK' }).toHaveStatusText('OK')).not.toThrow();
+  });
+
+  it('should fail when status text does not match', () => {
+    expect(() => apiExpect({ statusText: 'Not Found' }).toHaveStatusText('OK')).toThrow();
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_text.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/to_have_status_text.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { expect as baseExpect } from '@playwright/test';
+import { createMatcherError } from './utils';
+
+/**
+ * Asserts that the response has the expected status text.
+ *
+ * @example
+ * expect(response).toHaveStatusText('OK');
+ * expect(response).not.toHaveStatusText('Not Found');
+ */
+export function toHaveStatusText(obj: unknown, expected: string, isNegated = false): void {
+  if (
+    typeof obj !== 'object' ||
+    obj === null ||
+    (!('statusText' in obj) && !('statusMessage' in obj))
+  ) {
+    throw createMatcherError({
+      expected: `${JSON.stringify({ statusText: expected })} or ${JSON.stringify({
+        statusMessage: expected,
+      })}`,
+      matcherName: 'toHaveStatusText',
+      received: obj,
+      isNegated,
+    });
+  }
+
+  const actual = 'statusText' in obj ? obj.statusText : obj.statusMessage;
+  try {
+    if (isNegated) {
+      baseExpect(actual).not.toBe(expected);
+    } else {
+      baseExpect(actual).toBe(expected);
+    }
+  } catch {
+    throw createMatcherError({
+      expected,
+      matcherName: 'toHaveStatusText',
+      received: actual,
+      isNegated,
+    });
+  }
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/types.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/types.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { expect as baseExpect } from '@playwright/test';
+import type { ToHaveStatusCodeOptions } from './to_have_status_code';
+
+/**
+ * Generic matchers that delegate to Playwright/Jest expect.
+ * These work on any value type.
+ */
+export interface GenericMatchers {
+  /** Compares value with `expected` by calling `Object.is`. Compares objects by reference instead of their contents, similarly to the strict equality operator `===` */
+  toBe(expected: unknown): void;
+  /** Ensures that value is not `undefined` */
+  toBeDefined(): void;
+  /** Ensures that value is `undefined` */
+  toBeUndefined(): void;
+  /** Ensures that string value contains an expected substring. Comparison is case-sensitive. Also ensures that an Array or Set contains an expected item */
+  toContain(expected: unknown): void;
+  /** Ensures that value has a `.length` property equal to `expected`. Useful for arrays and strings */
+  toHaveLength(expected: number): void;
+  /** Compares contents of the value with contents of `expected` and their types */
+  toStrictEqual(expected: unknown): void;
+  /** Ensures that `value > expected` for number or big integer values */
+  toBeGreaterThan(expected: number): void;
+  /** Ensures that `value < expected` for number or big integer values */
+  toBeLessThan(expected: number): void;
+  /** Compares contents of the value with contents of `expected`, performing "deep equality" check. Allows extra properties to be present in the value */
+  toMatchObject(expected: unknown): void;
+
+  not: Omit<GenericMatchers, 'not' | 'toBeDefined'>;
+}
+
+/**
+ * Response matchers for API response assertions.
+ * These validate HTTP response properties.
+ */
+export interface ResponseMatchers {
+  /** Asserts the response has the expected status code */
+  toHaveStatusCode(code: number | ToHaveStatusCodeOptions): void;
+  /** Asserts the response has the expected status text */
+  toHaveStatusText(text: string): void;
+  /** Asserts the response has the expected headers */
+  toHaveHeaders(headers: Record<string, string>): void;
+}
+
+/**
+ * Combined matchers returned by expect().
+ * Includes both generic matchers and response matchers.
+ */
+export type Matchers = GenericMatchers &
+  ResponseMatchers & {
+    not: Omit<GenericMatchers, 'not' | 'toBeDefined'>;
+  };
+
+/**
+ * Playwright's AsymmetricMatcher type is not exported, so it's derived from
+ * `baseExpect.anything`, but all asymmetric matchers (anything, arrayContaining,
+ * objectContaining, etc.) return the same type.
+ */
+export type AsymmetricMatcher = ReturnType<typeof baseExpect.anything>;
+
+/**
+ * Asymmetric matchers available on the expect object.
+ * These can be used inside toMatchObject() for flexible value matching.
+ */
+export interface AsymmetricMatchers {
+  /** Ensures that `value > expected` for number values */
+  toBeGreaterThan(min: number): AsymmetricMatcher;
+  /** Ensures that `value < expected` for number values */
+  toBeLessThan(max: number): AsymmetricMatcher;
+  /** Matches an array that contains all of the elements in the expected array, in any order */
+  arrayContaining<T>(expected: T[]): AsymmetricMatcher;
+  /** Matches an object that contains and matches all of the properties in the expected object */
+  objectContaining<T extends Record<string, unknown>>(expected: T): AsymmetricMatcher;
+}

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/utils.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/utils.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createMatcherError } from './utils';
+
+describe('createMatcherError', () => {
+  it('creates error with expected format', () => {
+    const error = createMatcherError({
+      expected: 200,
+      matcherName: 'toHaveStatusCode',
+      received: 404,
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain('expect(');
+    expect(error.message).toContain('toHaveStatusCode');
+    expect(error.message).toContain('Expected:');
+    expect(error.message).toContain('200');
+    expect(error.message).toContain('Received:');
+    expect(error.message).toContain('404');
+  });
+
+  it('includes "not" in expected when negated', () => {
+    const error = createMatcherError({
+      expected: 200,
+      matcherName: 'toHaveStatusCode',
+      received: 200,
+      isNegated: true,
+    });
+
+    expect(error.message).toContain('Expected: not');
+  });
+
+  it('skips stack lines when skipStackLines is provided', () => {
+    const errorWithoutSkip = createMatcherError({
+      expected: 200,
+      matcherName: 'toHaveStatusCode',
+      received: 404,
+      skipStackLines: 0,
+    });
+    const errorWithSkip = createMatcherError({
+      expected: 200,
+      matcherName: 'toHaveStatusCode',
+      received: 404,
+      skipStackLines: 1,
+    });
+
+    const getStackLines = (err: Error) =>
+      err.stack!.split('\n').filter((l) => l.trimStart().startsWith('at '));
+
+    const stackLinesWithoutSkip = getStackLines(errorWithoutSkip);
+    const stackLinesWithSkip = getStackLines(errorWithSkip);
+
+    // After skipping 1 line, first stack line now points to current test file
+    expect(stackLinesWithSkip[0]).toContain(__filename);
+
+    // One less stack line
+    expect(stackLinesWithSkip.length).toBe(stackLinesWithoutSkip.length - 1);
+
+    // Message content is preserved
+    expect(errorWithSkip.stack).toContain('toHaveStatusCode');
+    expect(errorWithSkip.stack).toContain('Expected:');
+    expect(errorWithSkip.stack).toContain('Received:');
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/utils.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/utils.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export interface MatcherErrorOptions {
+  expected: unknown;
+  matcherName: string;
+  received: unknown;
+  isNegated?: boolean;
+  skipStackLines?: number;
+}
+
+/**
+ * Format error messages for API matchers like Playwright.
+ */
+export function createMatcherError(options: MatcherErrorOptions): Error {
+  const { expected, matcherName, received, isNegated = false, skipStackLines = 0 } = options;
+  const gray = '\x1b[90m';
+  const red = '\x1b[31m';
+  const green = '\x1b[32m';
+  const reset = '\x1b[0m';
+
+  // Gray for syntax, red for received, green for expected, matcherName in default (white)
+  const matcherCall =
+    `${gray}expect(${red}received${gray}).${reset}` +
+    `${matcherName}` +
+    `${gray}(${green}expected${gray})${reset}`;
+
+  const error = new Error(
+    `${matcherCall}\n\n` +
+      `Expected: ${isNegated ? 'not ' : ''}${green}${expected}${reset}\n` +
+      `Received: ${red}${received}${reset}`
+  );
+
+  if (skipStackLines > 0 && error.stack) {
+    const lines = error.stack.split('\n');
+    // First line is the error message, rest are stack frames
+    const messageLines = lines.filter((line) => !line.trimStart().startsWith('at '));
+    const stackLines = lines.filter((line) => line.trimStart().startsWith('at '));
+    error.stack = [...messageLines, ...stackLines.slice(skipStackLines)].join('\n');
+  }
+
+  return error;
+}

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/alerting_rules.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/alerting_rules.spec.ts
@@ -8,8 +8,9 @@
  */
 
 import { randomUUID } from 'crypto';
-import { apiTest, expect } from '../../../../../src/playwright';
+import { apiTest } from '../../../../../src/playwright';
 import { createAlertRuleParams } from '../../../fixtures/constants';
+import { expect } from '../../../../../api';
 
 apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, () => {
   let ruleId: string;
@@ -28,7 +29,7 @@ apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, ()
       params: createAlertRuleParams,
       tags: ['test'],
     });
-    expect(createdResponse.status).toBe(200);
+    expect(createdResponse).toHaveStatusCode(200);
     expect(createdResponse.data.enabled).toBe(false);
     ruleId = createdResponse.data.id;
   });
@@ -38,13 +39,13 @@ apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, ()
     const fetchedResponse = await apiServices.alerting.rules.get(ruleId, undefined, {
       ignoreErrors: [404],
     });
-    expect(fetchedResponse.status).toBe(404);
+    expect(fetchedResponse).toHaveStatusCode(404);
     ruleId = '';
   });
 
   apiTest(`should fetch alert with 'alerting.rules.get'`, async ({ apiServices }) => {
     const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
-    expect(fetchedResponse.status).toBe(200);
+    expect(fetchedResponse).toHaveStatusCode(200);
     expect(fetchedResponse.data.enabled).toBe(false);
     expect(fetchedResponse.data.name).toBe(alertName);
     expect(fetchedResponse.data.rule_type_id).toBe(ruleTypeId);
@@ -54,7 +55,7 @@ apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, ()
     const updatedResponse = await apiServices.alerting.rules.update(ruleId, {
       name: updatedAlertName,
     });
-    expect(updatedResponse.status).toBe(200);
+    expect(updatedResponse).toHaveStatusCode(200);
     expect(updatedResponse.data.name).toBe(updatedAlertName);
   });
 
@@ -62,14 +63,14 @@ apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, ()
     await apiTest.step(`with 'alerting.rules.enable'`, async () => {
       await apiServices.alerting.rules.enable(ruleId);
       const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
-      expect(fetchedResponse.status).toBe(200);
+      expect(fetchedResponse).toHaveStatusCode(200);
       expect(fetchedResponse.data.enabled).toBe(true);
     });
 
     await apiTest.step(`with 'alerting.rules.disable'`, async () => {
       await apiServices.alerting.rules.disable(ruleId);
       const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
-      expect(fetchedResponse.status).toBe(200);
+      expect(fetchedResponse).toHaveStatusCode(200);
       expect(fetchedResponse.data.enabled).toBe(false);
     });
   });
@@ -81,7 +82,7 @@ apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, ()
       per_page: 10,
       page: 1,
     });
-    expect(foundResponse.status).toBe(200);
+    expect(foundResponse).toHaveStatusCode(200);
     const match = foundResponse.data.data.find((obj: any) => obj.name === alertName);
     expect(match).toBeDefined();
     expect(match?.id).toBe(ruleId);
@@ -92,7 +93,7 @@ apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, ()
       await apiServices.alerting.rules.muteAll(ruleId);
 
       const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
-      expect(fetchedResponse.status).toBe(200);
+      expect(fetchedResponse).toHaveStatusCode(200);
       expect(fetchedResponse.data.mute_all).toBe(true);
     });
 
@@ -100,7 +101,7 @@ apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, ()
       await apiServices.alerting.rules.unmuteAll(ruleId);
 
       const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
-      expect(fetchedResponse.status).toBe(200);
+      expect(fetchedResponse).toHaveStatusCode(200);
       expect(fetchedResponse.data.mute_all).toBe(false);
     });
   });
@@ -111,7 +112,7 @@ apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, ()
       await apiServices.alerting.rules.muteAlert(ruleId, mockAlertId);
 
       const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
-      expect(fetchedResponse.status).toBe(200);
+      expect(fetchedResponse).toHaveStatusCode(200);
       expect(fetchedResponse.data.muted_alert_ids).toContain(mockAlertId);
     });
 
@@ -120,7 +121,7 @@ apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, ()
       await apiServices.alerting.rules.unmuteAlert(ruleId, mockAlertId);
 
       const fetchedResponse = await apiServices.alerting.rules.get(ruleId);
-      expect(fetchedResponse.status).toBe(200);
+      expect(fetchedResponse).toHaveStatusCode(200);
       expect(fetchedResponse.data.muted_alert_ids).not.toContain(mockAlertId);
     });
   });
@@ -129,7 +130,7 @@ apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, ()
     await apiTest.step('alerting.rules.snooze', async () => {
       const durationMs = 3600000;
       const snoozeResponse = await apiServices.alerting.rules.snooze(ruleId, durationMs);
-      expect(snoozeResponse.status).toBe(204);
+      expect(snoozeResponse).toHaveStatusCode(204);
     });
 
     await apiTest.step('alerting.rules.unsnooze', async () => {
@@ -138,7 +139,7 @@ apiTest.describe(`Alerting Rules helpers`, { tag: ['@svlSecurity', '@ess'] }, ()
         beforeUnsnooze.data.snooze_schedule?.map((schedule: any) => schedule.id) || [];
 
       const unsnoozeResponse = await apiServices.alerting.rules.unsnooze(ruleId, scheduleIds);
-      expect(unsnoozeResponse.status).toBe(204);
+      expect(unsnoozeResponse).toHaveStatusCode(204);
     });
   });
 });

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/cases.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/cases.spec.ts
@@ -7,8 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { apiTest, expect } from '../../../../../src/playwright';
+import { apiTest } from '../../../../../src/playwright';
 import { createCasePayload } from '../../../fixtures/constants';
+import { expect } from '../../../../../api';
 
 apiTest.describe('Cases Helpers', { tag: ['@svlSecurity', '@ess'] }, () => {
   let caseId: string;
@@ -17,34 +18,34 @@ apiTest.describe('Cases Helpers', { tag: ['@svlSecurity', '@ess'] }, () => {
   apiTest.beforeEach(async ({ apiServices, config }) => {
     caseOwner =
       config.serverless && config.projectType === 'security' ? 'securitySolution' : 'cases';
-    const { data, status } = await apiServices.cases.create({
+    const response = await apiServices.cases.create({
       ...createCasePayload,
       owner: caseOwner,
       category: 'test',
     });
-    expect(status).toBe(200);
-    expect(data.owner).toBe(caseOwner);
-    expect(data.status).toBe('open');
-    caseId = data.id;
+    expect(response).toHaveStatusCode(200);
+    expect(response.data.owner).toBe(caseOwner);
+    expect(response.data.status).toBe('open');
+    caseId = response.data.id;
   });
 
   apiTest.afterEach(async ({ apiServices }) => {
     await apiServices.cases.cleanup.deleteAllCases();
     const fetchedResponse = await apiServices.cases.get(caseId);
-    expect(fetchedResponse.status).toBe(404);
+    expect(fetchedResponse).toHaveStatusCode(404);
     caseId = '';
   });
 
   apiTest(`should fetch case with 'cases.get'`, async ({ apiServices }) => {
     const fetchedResponse = await apiServices.cases.get(caseId);
-    expect(fetchedResponse.status).toBe(200);
+    expect(fetchedResponse).toHaveStatusCode(200);
   });
 
   apiTest(`should update case with a new severity with 'cases.update'`, async ({ apiServices }) => {
     // First get the case to obtain its current version
     const currentCase = await apiServices.cases.get(caseId);
 
-    const { data: cases, status } = await apiServices.cases.update([
+    const response = await apiServices.cases.update([
       {
         id: caseId,
         version: currentCase.data.version,
@@ -52,14 +53,14 @@ apiTest.describe('Cases Helpers', { tag: ['@svlSecurity', '@ess'] }, () => {
       },
     ]);
 
-    expect(status).toBe(200);
-    expect(cases).toHaveLength(1);
-    expect(cases[0].severity).toBe('medium');
+    expect(response).toHaveStatusCode(200);
+    expect(response.data).toHaveLength(1);
+    expect(response.data[0].severity).toBe('medium');
   });
 
   apiTest('should add a new connector to a case', async ({ apiServices }) => {
     const currentCase = await apiServices.cases.get(caseId);
-    const { status } = await apiServices.cases.update([
+    const response = await apiServices.cases.update([
       {
         id: caseId,
         version: currentCase.data.version,
@@ -72,7 +73,7 @@ apiTest.describe('Cases Helpers', { tag: ['@svlSecurity', '@ess'] }, () => {
       },
     ]);
 
-    expect(status).toBe(200);
+    expect(response).toHaveStatusCode(200);
   });
 
   apiTest('should delete multiple cases', async ({ apiServices }) => {
@@ -84,15 +85,15 @@ apiTest.describe('Cases Helpers', { tag: ['@svlSecurity', '@ess'] }, () => {
       ...createCasePayload,
       owner: caseOwner,
     });
-    expect(createdResponse1.status).toBe(200);
-    expect(createdResponse2.status).toBe(200);
+    expect(createdResponse1).toHaveStatusCode(200);
+    expect(createdResponse2).toHaveStatusCode(200);
 
     await apiServices.cases.cleanup.deleteAllCases();
 
     const fetchedResponse1 = await apiServices.cases.get(createdResponse1.data.id);
     const fetchedResponse2 = await apiServices.cases.get(createdResponse2.data.id);
-    expect(fetchedResponse1.status).toBe(404);
-    expect(fetchedResponse2.status).toBe(404);
+    expect(fetchedResponse1).toHaveStatusCode(404);
+    expect(fetchedResponse2).toHaveStatusCode(404);
   });
 
   apiTest('should delete cases by tags', async ({ apiServices }) => {
@@ -106,8 +107,8 @@ apiTest.describe('Cases Helpers', { tag: ['@svlSecurity', '@ess'] }, () => {
       owner: caseOwner,
       tags: ['tag2'],
     });
-    expect(createdResponse1.status).toBe(200);
-    expect(createdResponse2.status).toBe(200);
+    expect(createdResponse1).toHaveStatusCode(200);
+    expect(createdResponse2).toHaveStatusCode(200);
 
     // delete all cases with tag "tag1"
     await apiServices.cases.cleanup.deleteCasesByTags(['tag1']);
@@ -116,32 +117,31 @@ apiTest.describe('Cases Helpers', { tag: ['@svlSecurity', '@ess'] }, () => {
     const fetchedResponse2 = await apiServices.cases.get(createdResponse2.data.id);
 
     // this case should have been deleted because it was assigned "tag1"
-    expect(fetchedResponse1.status).toBe(404);
+    expect(fetchedResponse1).toHaveStatusCode(404);
 
     // this case shouldn't have been deleted because it was assigned "tag2"
-    expect(fetchedResponse2.status).toBe(200);
+    expect(fetchedResponse2).toHaveStatusCode(200);
   });
 
   apiTest('should post and find a comment', async ({ apiServices }) => {
-    const { data: updatedCase, status } = await apiServices.cases.comments.create(caseId, {
+    const response = await apiServices.cases.comments.create(caseId, {
       type: 'user',
       comment: 'This is a test comment',
       owner: caseOwner,
     });
 
-    expect(status).toBe(200);
-    expect(updatedCase.totalComment).toBe(1);
-    expect(updatedCase.comments).toHaveLength(1);
+    expect(response).toHaveStatusCode(200);
+    expect(response.data.totalComment).toBe(1);
+    expect(response.data.comments).toHaveLength(1);
 
     // find comment by ID
-    const commentId = updatedCase.comments?.[0]?.id;
+    const commentId = response.data.comments?.[0]?.id;
     if (!commentId) throw new Error('Comment not found');
 
-    const { data: fetchedComment, status: fetchCommentStatus } =
-      await apiServices.cases.comments.get(caseId, commentId);
+    const fetchedResponse = await apiServices.cases.comments.get(caseId, commentId);
 
-    expect(fetchCommentStatus).toBe(200);
-    expect(fetchedComment.comment).toBe('This is a test comment');
+    expect(fetchedResponse).toHaveStatusCode(200);
+    expect(fetchedResponse.data.comment).toBe('This is a test comment');
   });
 
   apiTest('should post an alert', async ({ apiServices }) => {
@@ -153,13 +153,13 @@ apiTest.describe('Cases Helpers', { tag: ['@svlSecurity', '@ess'] }, () => {
       rule: { id: 'test-rule-id', name: 'test-rule-name' },
     });
 
-    expect(createdAlert.status).toBe(200);
+    expect(createdAlert).toHaveStatusCode(200);
     expect(createdAlert.data.totalAlerts).toBe(1);
   });
 
   apiTest('should search for a case by category', async ({ apiServices }) => {
-    const { data: cases, status } = await apiServices.cases.find({ category: 'test' });
-    expect(status).toBe(200);
-    expect(cases).toHaveLength(1);
+    const response = await apiServices.cases.find({ category: 'test' });
+    expect(response).toHaveStatusCode(200);
+    expect(response.data).toHaveLength(1);
   });
 });

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/data_views.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/data_views.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { apiTest, expect } from '../../../../../src/playwright';
+import { apiTest } from '../../../../../src/playwright';
+import { expect } from '../../../../../api';
 
 apiTest.describe('Data Views API Service', { tag: ['@svlSecurity', '@ess'] }, () => {
   let dataViewId: string;
@@ -144,7 +145,7 @@ apiTest.describe('Data Views API Service', { tag: ['@svlSecurity', '@ess'] }, ()
         );
 
         expect(status).toBe(200);
-        expect(foundDataViews.length).toBeGreaterThanOrEqual(1);
+        expect(foundDataViews.length).toBeGreaterThan(0);
 
         const matchingDataView = foundDataViews.find((dv) => dv.id === id1);
         expect(matchingDataView).toBeDefined();
@@ -299,7 +300,7 @@ apiTest.describe('Data Views API Service', { tag: ['@svlSecurity', '@ess'] }, ()
       const { data: filteredDataViews } = await apiServices.dataViews.find((dv) =>
         dv.title.includes('multi-test')
       );
-      expect(filteredDataViews.length).toBeGreaterThanOrEqual(3);
+      expect(filteredDataViews.length).toBeGreaterThan(2);
 
       // Delete one by ID
       const { status: deleteStatus } = await apiServices.dataViews.delete(createdIds[0]);

--- a/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/fleet.spec.ts
+++ b/src/platform/packages/shared/kbn-scout/test/scout/api/tests/api_services/fleet.spec.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { apiTest, expect } from '../../../../../src/playwright';
+import { apiTest } from '../../../../../src/playwright';
+import { expect } from '../../../../../api';
 
 apiTest.describe('Fleet Integration Management', { tag: ['@svlSecurity', '@ess'] }, () => {
   let integrationName: string;
@@ -24,7 +25,7 @@ apiTest.describe('Fleet Integration Management', { tag: ['@svlSecurity', '@ess']
   apiTest('should install a custom integration', async ({ apiServices }) => {
     const response = await apiServices.fleet.integration.install(integrationName);
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
   });
 
   apiTest('should delete an integration and return status code', async ({ apiServices }) => {
@@ -34,7 +35,7 @@ apiTest.describe('Fleet Integration Management', { tag: ['@svlSecurity', '@ess']
     // Then delete it
     const response = await apiServices.fleet.integration.delete(integrationName);
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
   });
 
   apiTest('should handle delete of non-existent integration', async ({ apiServices }) => {
@@ -43,7 +44,7 @@ apiTest.describe('Fleet Integration Management', { tag: ['@svlSecurity', '@ess']
     const response = await apiServices.fleet.integration.delete(nonExistentIntegration);
 
     // Should return 400 for non-existent integration due to ignoreErrors
-    expect(response.status).toBe(400);
+    expect(response).toHaveStatusCode(400);
   });
 });
 
@@ -69,7 +70,7 @@ apiTest.describe('Fleet Agent Policies Management', { tag: ['@svlSecurity', '@es
       perPage: 10,
     });
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
     expect(response.data.page).toBe(1);
     expect(response.data.perPage).toBe(10);
   });
@@ -88,7 +89,7 @@ apiTest.describe('Fleet Agent Policies Management', { tag: ['@svlSecurity', '@es
       }
     );
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
     expect(response.data.item.name).toBe(paramsPolicyName);
     expect(response.data.item.namespace).toBe(paramsPolicyNamespace);
 
@@ -116,7 +117,7 @@ apiTest.describe('Fleet Agent Policies Management', { tag: ['@svlSecurity', '@es
       }
     );
 
-    expect(updateResponse.status).toBe(200);
+    expect(updateResponse).toHaveStatusCode(200);
     expect(updateResponse.data.item.name).toBe(updatedName);
   });
 
@@ -131,7 +132,7 @@ apiTest.describe('Fleet Agent Policies Management', { tag: ['@svlSecurity', '@es
     const policyIds = [policy1Response.data.item.id, policy2Response.data.item.id];
     // Bulk get the policies
     const bulkResponse = await apiServices.fleet.agent_policies.bulkGet(policyIds);
-    expect(bulkResponse.status).toBe(200);
+    expect(bulkResponse).toHaveStatusCode(200);
     expect(bulkResponse.data.items).toHaveLength(2);
     // Clean up both policies
     await Promise.all([
@@ -148,7 +149,7 @@ apiTest.describe('Fleet Agent Policies Management', { tag: ['@svlSecurity', '@es
     // Then delete it
     const response = await apiServices.fleet.agent_policies.delete(agentPolicyId);
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
   });
 
   apiTest('should delete an agent policy with force flag', async ({ apiServices }) => {
@@ -159,7 +160,7 @@ apiTest.describe('Fleet Agent Policies Management', { tag: ['@svlSecurity', '@es
     // Then delete it with force
     const response = await apiServices.fleet.agent_policies.delete(agentPolicyId, true);
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
   });
 });
 
@@ -177,7 +178,7 @@ apiTest.describe('Fleet Outputs Management', { tag: ['@svlSecurity', '@ess'] }, 
   apiTest('should get all outputs', async ({ apiServices }) => {
     const response = await apiServices.fleet.outputs.getOutputs();
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
     expect(response.data).toBeDefined();
     expect(response.data.items).toBeDefined();
   });
@@ -192,7 +193,7 @@ apiTest.describe('Fleet Outputs Management', { tag: ['@svlSecurity', '@ess'] }, 
 
     const response = await apiServices.fleet.outputs.getOutput(existingOutput.id);
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
     expect(response.data.item.id).toBe(existingOutput.id);
   });
 
@@ -210,7 +211,7 @@ apiTest.describe('Fleet Outputs Management', { tag: ['@svlSecurity', '@ess'] }, 
       }
     );
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
     expect(response.data.item.name).toBe(outputName);
     expect(response.data.item.is_default).toBe(false);
 
@@ -231,7 +232,7 @@ apiTest.describe('Fleet Outputs Management', { tag: ['@svlSecurity', '@ess'] }, 
     // Then delete it
     const response = await apiServices.fleet.outputs.delete(deleteOutputId);
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
     // Don't set outputId since we already deleted it
   });
 });
@@ -263,7 +264,7 @@ apiTest.describe('Fleet Server Hosts Management', { tag: ['@svlSecurity', '@ess'
       is_internal: true,
     });
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
     expect(response.data.item.name).toBe(hostName);
     expect(response.data.item.is_default).toBe(false);
     expect(response.data.item.is_internal).toBe(true);
@@ -283,7 +284,7 @@ apiTest.describe('Fleet Server Hosts Management', { tag: ['@svlSecurity', '@ess'
     // Then delete it
     const response = await apiServices.fleet.server_hosts.delete(deleteHostId);
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
     // Don't set hostId since we already deleted it
   });
 });
@@ -292,7 +293,7 @@ apiTest.describe('Fleet Agent Management', { tag: ['@svlSecurity', '@ess'] }, ()
   apiTest('should setup fleet agents', async ({ apiServices }) => {
     const response = await apiServices.fleet.agent.setup();
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
   });
 
   apiTest('should get agents with query parameters', async ({ apiServices }) => {
@@ -302,7 +303,7 @@ apiTest.describe('Fleet Agent Management', { tag: ['@svlSecurity', '@ess'] }, ()
       showInactive: false,
     });
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
   });
 
   apiTest('should handle delete of non-existent agent', async ({ apiServices }) => {
@@ -311,7 +312,7 @@ apiTest.describe('Fleet Agent Management', { tag: ['@svlSecurity', '@ess'] }, ()
     const response = await apiServices.fleet.agent.delete(nonExistentAgentId);
 
     // Should return 400 or 404 for non-existent agent due to ignoreErrors
-    expect([400, 404]).toContain(response.status);
+    expect(response).toHaveStatusCode({ oneOf: [400, 404] });
   });
 });
 
@@ -323,6 +324,6 @@ apiTest.describe('Fleet API Error Handling', { tag: ['@svlSecurity', '@ess'] }, 
       ignoreMissing: true,
     });
 
-    expect(response.status).toBe(200);
+    expect(response).toHaveStatusCode(200);
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[@kbn/scout] Add Scout API `expect` with custom matchers (#247008)](https://github.com/elastic/kibana/pull/247008)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stelios Mavro","email":"81311181+steliosmavro@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-27T09:04:48Z","message":"[@kbn/scout] Add Scout API `expect` with custom matchers (#247008)\n\n# Scout API Matchers\n\n## Summary\n\nScout exposes a custom API `expect` object with custom and default\nmatchers for API testing. To enforce best practices, Playwright's\ndefault matchers are restricted. Also updates all API tests in\n`@kbn/scout` to use the new matchers.\n\n```typescript\nimport { expect } from '@kbn/scout/api';\n```\n\n---\n\n## Custom Response Matchers\n\nScout-specific matchers for API response assertions. These support both\n`apiClient` and `kbnClient` response interfaces.\n\n### toHaveStatusCode\n\nAsserts response has the expected HTTP status code. Checks `status` or\n`statusCode` property.\n\n```typescript\nexpect(response).toHaveStatusCode(200);\nexpect(response).toHaveStatusCode({ oneOf: [200, 201] });\n```\n\n### toHaveStatusText\n\nAsserts response has the expected status text. Checks `statusText` or\n`statusMessage` property.\n\n```typescript\nexpect(response).toHaveStatusText('OK');\n```\n\n### toHaveHeaders\n\nAsserts response contains the expected headers (partial match). Checks\n`headers` property. Case-insensitive keys. Response header arrays are\njoined with `, ` before comparison.\n\n```typescript\nexpect(response).toHaveHeaders({ 'content-type': 'application/json' });\nexpect(response).toHaveHeaders({ 'set-cookie': 'session=abc, token=xyz' });\n```\n\n---\n\n## Custom Asymmetric Matchers\n\nCustom asymmetric matchers for use with `toMatchObject`:\n\n- **`expect.toBeGreaterThan(n)`** - Matches if value > n\n- **`expect.toBeLessThan(n)`** - Matches if value < n\n\n```typescript\nexpect(response).toMatchObject({\n  body: {\n    count: expect.toBeGreaterThan(0),\n    limit: expect.toBeLessThan(100),\n  },\n});\n```\n\n---\n\n## Supported Playwright Matchers\n\nThe following [Playwright\nmatchers](https://playwright.dev/docs/api/class-genericassertions) are\navailable:\n\n**Matchers:**\n\n- `toBe(expected)` - compares using `Object.is`, use for primitive\nliterals\n- `toBeDefined()` - value is not `undefined`\n- `toBeUndefined()` - value is `undefined`\n- `toContain(expected)` - string contains substring, or Array/Set\ncontains item\n- `toHaveLength(n)` - value has `.length` property equal to n\n- `toStrictEqual(expected)` - deep equality with type checking\n- `toBeGreaterThan(n)` - value > n\n- `toBeLessThan(n)` - value < n\n- `toMatchObject(expected)` - partial object matching\n\n**Asymmetric matchers:**\n\n- `expect.arrayContaining(array)` - array contains all expected elements\n- `expect.objectContaining(object)` - object contains expected\nproperties\n\n---\n\n## Restricted Matchers\n\nTo enforce best practices, some Playwright matchers are restricted. Use\nthese alternatives:\n\n```typescript\nexpect({ name: 'Alice', metadata: undefined }).toEqual({ name: 'Alice' }); // ❌ would pass even if extra keys exist\nexpect({ name: 'Alice', metadata: undefined }).toStrictEqual({ name: 'Alice' }); // ✅ fails if extra/missing keys exist\n\nexpect(response).toHaveProperty('apiKey'); // ❌ passes even if apiKey is undefined\nexpect(response.apiKey).toBeDefined(); // ✅ it will fail if undefined\n\nexpect(exists).toBeTruthy(); // ❌ too loose\nexpect(exists).toBe(true); // ✅ be explicit\n\nexpect(response.apiKey).not.toBeDefined(); // ❌ not available\nexpect(response.apiKey).toBeUndefined(); // ✅ preferred by playwright\n```\n\n**UI-specific matchers** like `toBeVisible`, `toBeEnabled`,\n`toHaveAttribute`, etc. are not available for API tests.\n\n## Notes\n\n- Custom matchers throw Playwright-style errors\n- Stack traces can be trimmed via `skipStackLines` to point directly at\nthe test file\n- `toHaveStatusCode` options interface is designed for extensibility\n(e.g., future `range` option)\n\n---------\n\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"284a6205b018008e8207af2969f95c26d8a455f6","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.4.0"],"title":"[@kbn/scout] Add Scout API `expect` with custom matchers","number":247008,"url":"https://github.com/elastic/kibana/pull/247008","mergeCommit":{"message":"[@kbn/scout] Add Scout API `expect` with custom matchers (#247008)\n\n# Scout API Matchers\n\n## Summary\n\nScout exposes a custom API `expect` object with custom and default\nmatchers for API testing. To enforce best practices, Playwright's\ndefault matchers are restricted. Also updates all API tests in\n`@kbn/scout` to use the new matchers.\n\n```typescript\nimport { expect } from '@kbn/scout/api';\n```\n\n---\n\n## Custom Response Matchers\n\nScout-specific matchers for API response assertions. These support both\n`apiClient` and `kbnClient` response interfaces.\n\n### toHaveStatusCode\n\nAsserts response has the expected HTTP status code. Checks `status` or\n`statusCode` property.\n\n```typescript\nexpect(response).toHaveStatusCode(200);\nexpect(response).toHaveStatusCode({ oneOf: [200, 201] });\n```\n\n### toHaveStatusText\n\nAsserts response has the expected status text. Checks `statusText` or\n`statusMessage` property.\n\n```typescript\nexpect(response).toHaveStatusText('OK');\n```\n\n### toHaveHeaders\n\nAsserts response contains the expected headers (partial match). Checks\n`headers` property. Case-insensitive keys. Response header arrays are\njoined with `, ` before comparison.\n\n```typescript\nexpect(response).toHaveHeaders({ 'content-type': 'application/json' });\nexpect(response).toHaveHeaders({ 'set-cookie': 'session=abc, token=xyz' });\n```\n\n---\n\n## Custom Asymmetric Matchers\n\nCustom asymmetric matchers for use with `toMatchObject`:\n\n- **`expect.toBeGreaterThan(n)`** - Matches if value > n\n- **`expect.toBeLessThan(n)`** - Matches if value < n\n\n```typescript\nexpect(response).toMatchObject({\n  body: {\n    count: expect.toBeGreaterThan(0),\n    limit: expect.toBeLessThan(100),\n  },\n});\n```\n\n---\n\n## Supported Playwright Matchers\n\nThe following [Playwright\nmatchers](https://playwright.dev/docs/api/class-genericassertions) are\navailable:\n\n**Matchers:**\n\n- `toBe(expected)` - compares using `Object.is`, use for primitive\nliterals\n- `toBeDefined()` - value is not `undefined`\n- `toBeUndefined()` - value is `undefined`\n- `toContain(expected)` - string contains substring, or Array/Set\ncontains item\n- `toHaveLength(n)` - value has `.length` property equal to n\n- `toStrictEqual(expected)` - deep equality with type checking\n- `toBeGreaterThan(n)` - value > n\n- `toBeLessThan(n)` - value < n\n- `toMatchObject(expected)` - partial object matching\n\n**Asymmetric matchers:**\n\n- `expect.arrayContaining(array)` - array contains all expected elements\n- `expect.objectContaining(object)` - object contains expected\nproperties\n\n---\n\n## Restricted Matchers\n\nTo enforce best practices, some Playwright matchers are restricted. Use\nthese alternatives:\n\n```typescript\nexpect({ name: 'Alice', metadata: undefined }).toEqual({ name: 'Alice' }); // ❌ would pass even if extra keys exist\nexpect({ name: 'Alice', metadata: undefined }).toStrictEqual({ name: 'Alice' }); // ✅ fails if extra/missing keys exist\n\nexpect(response).toHaveProperty('apiKey'); // ❌ passes even if apiKey is undefined\nexpect(response.apiKey).toBeDefined(); // ✅ it will fail if undefined\n\nexpect(exists).toBeTruthy(); // ❌ too loose\nexpect(exists).toBe(true); // ✅ be explicit\n\nexpect(response.apiKey).not.toBeDefined(); // ❌ not available\nexpect(response.apiKey).toBeUndefined(); // ✅ preferred by playwright\n```\n\n**UI-specific matchers** like `toBeVisible`, `toBeEnabled`,\n`toHaveAttribute`, etc. are not available for API tests.\n\n## Notes\n\n- Custom matchers throw Playwright-style errors\n- Stack traces can be trimmed via `skipStackLines` to point directly at\nthe test file\n- `toHaveStatusCode` options interface is designed for extensibility\n(e.g., future `range` option)\n\n---------\n\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"284a6205b018008e8207af2969f95c26d8a455f6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247008","number":247008,"mergeCommit":{"message":"[@kbn/scout] Add Scout API `expect` with custom matchers (#247008)\n\n# Scout API Matchers\n\n## Summary\n\nScout exposes a custom API `expect` object with custom and default\nmatchers for API testing. To enforce best practices, Playwright's\ndefault matchers are restricted. Also updates all API tests in\n`@kbn/scout` to use the new matchers.\n\n```typescript\nimport { expect } from '@kbn/scout/api';\n```\n\n---\n\n## Custom Response Matchers\n\nScout-specific matchers for API response assertions. These support both\n`apiClient` and `kbnClient` response interfaces.\n\n### toHaveStatusCode\n\nAsserts response has the expected HTTP status code. Checks `status` or\n`statusCode` property.\n\n```typescript\nexpect(response).toHaveStatusCode(200);\nexpect(response).toHaveStatusCode({ oneOf: [200, 201] });\n```\n\n### toHaveStatusText\n\nAsserts response has the expected status text. Checks `statusText` or\n`statusMessage` property.\n\n```typescript\nexpect(response).toHaveStatusText('OK');\n```\n\n### toHaveHeaders\n\nAsserts response contains the expected headers (partial match). Checks\n`headers` property. Case-insensitive keys. Response header arrays are\njoined with `, ` before comparison.\n\n```typescript\nexpect(response).toHaveHeaders({ 'content-type': 'application/json' });\nexpect(response).toHaveHeaders({ 'set-cookie': 'session=abc, token=xyz' });\n```\n\n---\n\n## Custom Asymmetric Matchers\n\nCustom asymmetric matchers for use with `toMatchObject`:\n\n- **`expect.toBeGreaterThan(n)`** - Matches if value > n\n- **`expect.toBeLessThan(n)`** - Matches if value < n\n\n```typescript\nexpect(response).toMatchObject({\n  body: {\n    count: expect.toBeGreaterThan(0),\n    limit: expect.toBeLessThan(100),\n  },\n});\n```\n\n---\n\n## Supported Playwright Matchers\n\nThe following [Playwright\nmatchers](https://playwright.dev/docs/api/class-genericassertions) are\navailable:\n\n**Matchers:**\n\n- `toBe(expected)` - compares using `Object.is`, use for primitive\nliterals\n- `toBeDefined()` - value is not `undefined`\n- `toBeUndefined()` - value is `undefined`\n- `toContain(expected)` - string contains substring, or Array/Set\ncontains item\n- `toHaveLength(n)` - value has `.length` property equal to n\n- `toStrictEqual(expected)` - deep equality with type checking\n- `toBeGreaterThan(n)` - value > n\n- `toBeLessThan(n)` - value < n\n- `toMatchObject(expected)` - partial object matching\n\n**Asymmetric matchers:**\n\n- `expect.arrayContaining(array)` - array contains all expected elements\n- `expect.objectContaining(object)` - object contains expected\nproperties\n\n---\n\n## Restricted Matchers\n\nTo enforce best practices, some Playwright matchers are restricted. Use\nthese alternatives:\n\n```typescript\nexpect({ name: 'Alice', metadata: undefined }).toEqual({ name: 'Alice' }); // ❌ would pass even if extra keys exist\nexpect({ name: 'Alice', metadata: undefined }).toStrictEqual({ name: 'Alice' }); // ✅ fails if extra/missing keys exist\n\nexpect(response).toHaveProperty('apiKey'); // ❌ passes even if apiKey is undefined\nexpect(response.apiKey).toBeDefined(); // ✅ it will fail if undefined\n\nexpect(exists).toBeTruthy(); // ❌ too loose\nexpect(exists).toBe(true); // ✅ be explicit\n\nexpect(response.apiKey).not.toBeDefined(); // ❌ not available\nexpect(response.apiKey).toBeUndefined(); // ✅ preferred by playwright\n```\n\n**UI-specific matchers** like `toBeVisible`, `toBeEnabled`,\n`toHaveAttribute`, etc. are not available for API tests.\n\n## Notes\n\n- Custom matchers throw Playwright-style errors\n- Stack traces can be trimmed via `skipStackLines` to point directly at\nthe test file\n- `toHaveStatusCode` options interface is designed for extensibility\n(e.g., future `range` option)\n\n---------\n\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"284a6205b018008e8207af2969f95c26d8a455f6"}},{"url":"https://github.com/elastic/kibana/pull/250533","number":250533,"branch":"8.19","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/250534","number":250534,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->