### PR TITLE
[9.3] Fix Streams KQL Search Samples preview table

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/data_sources_flyout/data_source_card.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/data_sources_flyout/data_source_card.tsx
@@ -131,7 +131,7 @@ export const DataSourceCard = ({
         ) : (
           <PreviewTable
             documents={previewDocs.map(flattenObjectNestedLast) as FlattenRecord[]}
-            height={150}
+            height={350}
           />
         )}
       </EuiAccordion>


### PR DESCRIPTION
closes: #250327 

## Summary 📚 
Fixing preview table in KQL search query by increasing component's height.