### PR TITLE
[APM][Infra] Fix broken API in the Infrastructure tab on the Service page

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/build_kql_filter.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/build_kql_filter.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildKqlFilter } from './build_kql_filter';
+
+describe('buildKqlFilter', () => {
+  it('should build correct KQL for a single value', () => {
+    const field = 'host.name';
+    const values = ['host1'];
+    const expectedKql = 'host.name: ("host1")';
+
+    const kqlFilter = buildKqlFilter(field, values);
+
+    expect(kqlFilter).toBe(expectedKql);
+  });
+
+  it('should build correct KQL for multiple values', () => {
+    const field = 'host.name';
+    const values = ['host1', 'host2', 'host3'];
+    const expectedKql = 'host.name: ("host1" OR "host2" OR "host3")';
+
+    const kqlFilter = buildKqlFilter(field, values);
+
+    expect(kqlFilter).toBe(expectedKql);
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/build_kql_filter.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/build_kql_filter.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const buildKqlFilter = (field: string, value: string[]) =>
+  `${field}: (${value.map((v) => `"${v}"`).join(' OR ')})`;

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/use_tabs.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/use_tabs.tsx
@@ -7,7 +7,6 @@
 import type { EuiTabbedContentProps } from '@elastic/eui';
 import { useMemo } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import React from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -52,34 +51,18 @@ export function useTabs({
   );
 
   const hostsFilter = useMemo(
-    (): QueryDslQueryContainer => ({
-      bool: {
-        should: [
-          {
-            terms: {
-              [HOST_NAME]: hostNames,
-            },
-          },
-        ],
-        minimum_should_match: 1,
-      },
-    }),
+    () => `${HOST_NAME}: (${hostNames.map((hostName) => `"${hostName}"`).join(' OR ')})`,
     [hostNames]
   );
+
   const podsFilter = useMemo(
-    () => ({
-      bool: {
-        filter: [{ terms: { [KUBERNETES_POD_NAME]: podNames } }],
-      },
-    }),
+    () => `${KUBERNETES_POD_NAME}: (${podNames.map((podName) => `"${podName}"`).join(' OR ')})`,
     [podNames]
   );
+
   const containersFilter = useMemo(
-    () => ({
-      bool: {
-        filter: [{ terms: { [CONTAINER_ID]: containerIds } }],
-      },
-    }),
+    () =>
+      `${CONTAINER_ID}: (${containerIds.map((containerId) => `"${containerId}"`).join(' OR ')})`,
     [containerIds]
   );
 
@@ -89,7 +72,7 @@ export function useTabs({
       {ContainerMetricsTable &&
         ContainerMetricsTable({
           timerange,
-          filterClauseDsl: containersFilter,
+          kuery: containersFilter,
         })}
     </>
   );
@@ -100,7 +83,7 @@ export function useTabs({
       {PodMetricsTable &&
         PodMetricsTable({
           timerange,
-          filterClauseDsl: podsFilter,
+          kuery: podsFilter,
         })}
     </>
   );
@@ -111,7 +94,7 @@ export function useTabs({
       {HostMetricsTable &&
         HostMetricsTable({
           timerange,
-          filterClauseDsl: hostsFilter,
+          kuery: hostsFilter,
         })}
     </>
   );

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/use_tabs.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/use_tabs.tsx
@@ -12,6 +12,8 @@ import { EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { ApmPluginStartDeps } from '../../../../plugin';
 import { KUBERNETES_POD_NAME, HOST_NAME, CONTAINER_ID } from '../../../../../common/es_fields/apm';
+import { buildKqlFilter } from './build_kql_filter';
+
 type Tab = NonNullable<EuiTabbedContentProps['tabs']>[0] & {
   id: 'containers' | 'pods' | 'hosts';
   hidden?: boolean;
@@ -50,19 +52,10 @@ export function useTabs({
     [start, end]
   );
 
-  const hostsFilter = useMemo(
-    () => `${HOST_NAME}: (${hostNames.map((hostName) => `"${hostName}"`).join(' OR ')})`,
-    [hostNames]
-  );
-
-  const podsFilter = useMemo(
-    () => `${KUBERNETES_POD_NAME}: (${podNames.map((podName) => `"${podName}"`).join(' OR ')})`,
-    [podNames]
-  );
-
+  const hostsFilter = useMemo(() => buildKqlFilter(HOST_NAME, hostNames), [hostNames]);
+  const podsFilter = useMemo(() => buildKqlFilter(KUBERNETES_POD_NAME, podNames), [podNames]);
   const containersFilter = useMemo(
-    () =>
-      `${CONTAINER_ID}: (${containerIds.map((containerId) => `"${containerId}"`).join(' OR ')})`,
+    () => buildKqlFilter(CONTAINER_ID, containerIds),
     [containerIds]
   );
 

--- a/x-pack/solutions/observability/plugins/metrics_data_access/common/metrics_explorer_views/types.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/common/metrics_explorer_views/types.ts
@@ -69,7 +69,7 @@ export const metricExplorerOptionsRequiredRT = rt.type({
 export const metricExplorerOptionsOptionalRT = rt.partial({
   limit: rt.number,
   groupBy: rt.union([rt.string, rt.array(rt.string)]),
-  filterKuery: rt.string,
+  kuery: rt.string,
   source: rt.string,
   forceInterval: rt.boolean,
   dropLastBucket: rt.boolean,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/common/metrics_explorer_views/types.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/common/metrics_explorer_views/types.ts
@@ -69,7 +69,7 @@ export const metricExplorerOptionsRequiredRT = rt.type({
 export const metricExplorerOptionsOptionalRT = rt.partial({
   limit: rt.number,
   groupBy: rt.union([rt.string, rt.array(rt.string)]),
-  filterQuery: rt.string,
+  filterKuery: rt.string,
   source: rt.string,
   forceInterval: rt.boolean,
   dropLastBucket: rt.boolean,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/README.md
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/README.md
@@ -3,7 +3,7 @@
 This folder contains components that are used to display metrics about infrastructure components.
 Currently there are tables for containers, pods and hosts.
 
-For use within the Infra plugin, make use of the `useXMetricsTable` hooks and their matching 
+For use within the Infra plugin, make use of the `useXMetricsTable` hooks and their matching
 `XMetricsTable` components.
 
 For use outside of the Infra plugin, consume these components via the lazy components exposed on the
@@ -11,16 +11,16 @@ start contract of the plugin.
 
 ## The shared data hook
 
-All tables get their data from the Metrics Explorer API by making use of the 
+All tables get their data from the Metrics Explorer API by making use of the
 `useInfrastructureNodeMetrics` hook. The key input to the hook is the `MetricsMap` which defines
-which metrics should be requested (by field and type of aggregation). By passing a `MetricsMap` to 
-the helper `metricsToApiOptions` we get back the options we need to pass to 
-`useInfrastructureNodeMetrics`. `metricsToApiOptions` also returns a mapping object that is used to 
+which metrics should be requested (by field and type of aggregation). By passing a `MetricsMap` to
+the helper `metricsToApiOptions` we get back the options we need to pass to
+`useInfrastructureNodeMetrics`. `metricsToApiOptions` also returns a mapping object that is used to
 translate the field name to the format the API returns (e.g. `metric_0`).
 The `MetricsMap` type is mostly to ensure that the object key and the `field` value match to avoid
 mistakes when re-ordering the metrics being used.
 
-`useInfrastructureNodeMetrics` also expects a timerange and a filter (in ES DSL) and a function
+`useInfrastructureNodeMetrics` also expects a timerange, a filter (in KQL) and a function
 to transform the Metrics Explorer response to something more suitable for the table component to
 work with.
 
@@ -28,7 +28,7 @@ Internally, the hook manages loading the source, making the API request, sorting
 response. It also manages the loading state.
 
 Currently, it does a large request and then does sorting and pagination on the client. In the future
-we should replace this with a terms aggregation in the API instead, to do more work in 
+we should replace this with a terms aggregation in the API instead, to do more work in
 Elasticsearch.
 
 ## Hooks and tables per node type
@@ -41,18 +41,18 @@ function. The transformation function makes use of the `metricByField` to unpack
 in a type safe way.
 The body of the hook sets up the page and sort state, then invokes the shared data hook.
 
-The table itself is a fairly simple component that uses EUI components to render a table with 
+The table itself is a fairly simple component that uses EUI components to render a table with
 pagination. It makes use of components found in the shared folder for the things that are common
 across each node type such as the pagination and Node Details page link.
 
-When using the hook it is important to wrap the timerange and filter clause DSL parameters in 
+When using the hook it is important to wrap the timerange and filter kuery parameters in
 something like `useMemo` to avoid a re-rendering loop.
 
 ## The embeddable component factories
 
 To make it as easy as possible to consume these tables we expose them fully integrated on our start
 contract. The component that is exposed lazily loads our component, adds in all of our providers
-and calls the node type specific hook and passes the result to the node type specific table 
+and calls the node type specific hook and passes the result to the node type specific table
 component. Integration should be as simple as dropping in the component in a React hierarchy.
 
 The `createLazyXMetricsTable` factory function accepts our Kibana dependencies and return a new

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.test.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.test.tsx
@@ -31,18 +31,7 @@ describe('ContainerMetricsTable', () => {
     to: 'now',
   };
 
-  const filterClauseDsl = {
-    bool: {
-      should: [
-        {
-          match: {
-            'host.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9',
-          },
-        },
-      ],
-      minimum_should_match: 1,
-    },
-  };
+  const kuery = 'container.id: "gke-edge-oblt-pool-1-9a60016d-lgg9"';
 
   const mockData = {
     series: [
@@ -63,7 +52,7 @@ describe('ContainerMetricsTable', () => {
         metricsClient
       );
 
-      render(<LazyContainerMetricsTable timerange={timerange} filterClauseDsl={filterClauseDsl} />);
+      render(<LazyContainerMetricsTable timerange={timerange} kuery={kuery} />);
 
       expect(screen.queryByTestId(loadingIndicatorTestId)).not.toBeInTheDocument();
       expect(screen.queryByTestId('containerMetricsTable')).not.toBeInTheDocument();
@@ -93,7 +82,7 @@ describe('ContainerMetricsTable', () => {
       const { findByText } = render(
         <IntegratedContainerMetricsTable
           timerange={timerange}
-          filterClauseDsl={filterClauseDsl}
+          kuery={kuery}
           sourceId="default"
           metricsClient={metricsClient}
           {...coreProvidersPropsMock}

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/create_lazy_container_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/create_lazy_container_metrics_table.tsx
@@ -15,7 +15,7 @@ const LazyIntegratedContainerMetricsTable = lazy(
 );
 
 export function createLazyContainerMetricsTable(core: CoreStart, metricsClient: MetricsDataClient) {
-  return ({ timerange, filterClauseDsl, sourceId }: NodeMetricsTableProps) => {
+  return ({ timerange, kuery, sourceId }: NodeMetricsTableProps) => {
     return (
       <Suspense fallback={null}>
         <LazyIntegratedContainerMetricsTable
@@ -23,7 +23,7 @@ export function createLazyContainerMetricsTable(core: CoreStart, metricsClient: 
           metricsClient={metricsClient}
           sourceId={sourceId || 'default'}
           timerange={timerange}
-          filterClauseDsl={filterClauseDsl}
+          kuery={kuery}
         />
       </Suspense>
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/integrated_container_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/integrated_container_metrics_table.tsx
@@ -13,12 +13,12 @@ import { useContainerMetricsTable } from './use_container_metrics_table';
 
 function HookedContainerMetricsTable({
   timerange,
-  filterClauseDsl,
+  kuery,
   metricsClient,
 }: UseNodeMetricsTableOptions) {
   const containerMetricsTableProps = useContainerMetricsTable({
     timerange,
-    filterClauseDsl,
+    kuery,
     metricsClient,
   });
   return <ContainerMetricsTable {...containerMetricsTableProps} />;
@@ -26,7 +26,7 @@ function HookedContainerMetricsTable({
 
 function ContainerMetricsTableWithProviders({
   timerange,
-  filterClauseDsl,
+  kuery,
   sourceId,
   metricsClient,
   ...coreProvidersProps
@@ -35,7 +35,7 @@ function ContainerMetricsTableWithProviders({
     <CoreProviders {...coreProvidersProps}>
       <HookedContainerMetricsTable
         timerange={timerange}
-        filterClauseDsl={filterClauseDsl}
+        kuery={kuery}
         metricsClient={metricsClient}
       />
     </CoreProviders>

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
@@ -20,7 +20,7 @@ describe('useContainerMetricsTable hook', () => {
     typeof useInfrastructureNodeMetrics
   >;
 
-  it('should call useInfrastructureNodeMetrics hook with event.module filter in filterClauseDsl query', () => {
+  it('should call useInfrastructureNodeMetrics hook with event.module filter in kuery', () => {
     const kuery = 'container.id: "gke-edge-oblt-pool-1-9a60016d-lgg9"';
 
     // include this to prevent rendering error in test
@@ -37,7 +37,7 @@ describe('useContainerMetricsTable hook', () => {
       })
     );
 
-    const kueryWithEventModuleFilter = `(event.dataset: "kubernetes.container") AND (${kuery})`;
+    const kueryWithEventModuleFilter = `event.dataset: "kubernetes.container" AND (${kuery})`;
 
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
@@ -42,7 +42,7 @@ describe('useContainerMetricsTable hook', () => {
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterKuery: kueryWithEventModuleFilter,
+          kuery: kueryWithEventModuleFilter,
         }),
       })
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
@@ -21,17 +21,7 @@ describe('useContainerMetricsTable hook', () => {
   >;
 
   it('should call useInfrastructureNodeMetrics hook with event.module filter in filterClauseDsl query', () => {
-    const filterClauseDsl = {
-      bool: {
-        filter: [{ terms: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
-      },
-    };
-
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [{ term: { 'event.dataset': 'kubernetes.container' } }, { ...filterClauseDsl }],
-      },
-    };
+    const kuery = 'container.id: "gke-edge-oblt-pool-1-9a60016d-lgg9"';
 
     // include this to prevent rendering error in test
     useInfrastructureNodeMetricsMock.mockReturnValue({
@@ -42,15 +32,17 @@ describe('useContainerMetricsTable hook', () => {
     renderHook(() =>
       useContainerMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
       })
     );
 
+    const kueryWithEventModuleFilter = `(event.dataset: "kubernetes.container") AND (${kuery})`;
+
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          filterKuery: kueryWithEventModuleFilter,
         }),
       })
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.ts
@@ -25,11 +25,7 @@ type ContainerMetricsField =
   | 'kubernetes.container.memory.usage.bytes';
 
 const containerMetricsQueryConfig: MetricsQueryOptions<ContainerMetricsField> = {
-  sourceFilter: {
-    term: {
-      'event.dataset': 'kubernetes.container',
-    },
-  },
+  sourceFilter: `event.dataset: "kubernetes.container"`,
   groupByField: 'container.id',
   metricsMap: {
     'kubernetes.container.cpu.usage.limit.pct': {
@@ -54,7 +50,7 @@ export interface ContainerNodeMetricsRow {
 
 export function useContainerMetricsTable({
   timerange,
-  filterClauseDsl,
+  kuery,
   metricsClient,
 }: UseNodeMetricsTableOptions) {
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
@@ -64,8 +60,8 @@ export function useContainerMetricsTable({
   });
 
   const { options: containerMetricsOptions } = useMemo(
-    () => metricsToApiOptions(containerMetricsQueryConfig, filterClauseDsl),
-    [filterClauseDsl]
+    () => metricsToApiOptions(containerMetricsQueryConfig, kuery),
+    [kuery]
   );
 
   const { data, isLoading } = useInfrastructureNodeMetrics<ContainerNodeMetricsRow>({

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/create_lazy_host_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/create_lazy_host_metrics_table.tsx
@@ -13,7 +13,7 @@ import type { NodeMetricsTableProps } from '../shared';
 const LazyIntegratedHostMetricsTable = lazy(() => import('./integrated_host_metrics_table'));
 
 export function createLazyHostMetricsTable(core: CoreStart, metricsClient: MetricsDataClient) {
-  return ({ timerange, filterClauseDsl, sourceId }: NodeMetricsTableProps) => {
+  return ({ timerange, kuery, sourceId }: NodeMetricsTableProps) => {
     return (
       <Suspense fallback={null}>
         <LazyIntegratedHostMetricsTable
@@ -21,7 +21,7 @@ export function createLazyHostMetricsTable(core: CoreStart, metricsClient: Metri
           metricsClient={metricsClient}
           sourceId={sourceId || 'default'}
           timerange={timerange}
-          filterClauseDsl={filterClauseDsl}
+          kuery={kuery}
         />
       </Suspense>
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.test.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.test.tsx
@@ -31,18 +31,7 @@ describe('HostMetricsTable', () => {
     to: 'now',
   };
 
-  const filterClauseDsl = {
-    bool: {
-      should: [
-        {
-          match: {
-            'host.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9',
-          },
-        },
-      ],
-      minimum_should_match: 1,
-    },
-  };
+  const kuery = `host.name: "gke-edge-oblt-pool-1-9a60016d-lgg9"`;
 
   const mockData = {
     series: [
@@ -60,7 +49,7 @@ describe('HostMetricsTable', () => {
       const metricsClient = getMetricsClient();
       const LazyHostMetricsTable = createLazyHostMetricsTable(getStartServices()[0], metricsClient);
 
-      render(<LazyHostMetricsTable timerange={timerange} filterClauseDsl={filterClauseDsl} />);
+      render(<LazyHostMetricsTable timerange={timerange} kuery={kuery} />);
 
       expect(screen.queryByTestId(loadingIndicatorTestId)).not.toBeInTheDocument();
       expect(screen.queryByTestId('hostMetricsTable')).not.toBeInTheDocument();
@@ -90,7 +79,7 @@ describe('HostMetricsTable', () => {
       const { findByText } = render(
         <IntegratedHostMetricsTable
           timerange={timerange}
-          filterClauseDsl={filterClauseDsl}
+          kuery={kuery}
           sourceId="default"
           metricsClient={metricsClient}
           {...coreProvidersPropsMock}

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/integrated_host_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/integrated_host_metrics_table.tsx
@@ -11,29 +11,21 @@ import type { IntegratedNodeMetricsTableProps, UseNodeMetricsTableOptions } from
 import { HostMetricsTable } from './host_metrics_table';
 import { useHostMetricsTable } from './use_host_metrics_table';
 
-function HookedHostMetricsTable({
-  timerange,
-  filterClauseDsl,
-  metricsClient,
-}: UseNodeMetricsTableOptions) {
-  const hostMetricsTableProps = useHostMetricsTable({ timerange, filterClauseDsl, metricsClient });
+function HookedHostMetricsTable({ timerange, kuery, metricsClient }: UseNodeMetricsTableOptions) {
+  const hostMetricsTableProps = useHostMetricsTable({ timerange, kuery, metricsClient });
   return <HostMetricsTable {...hostMetricsTableProps} />;
 }
 
 function HostMetricsTableWithProviders({
   timerange,
-  filterClauseDsl,
+  kuery,
   sourceId,
   metricsClient,
   ...coreProvidersProps
 }: IntegratedNodeMetricsTableProps) {
   return (
     <CoreProviders {...coreProvidersProps}>
-      <HookedHostMetricsTable
-        timerange={timerange}
-        filterClauseDsl={filterClauseDsl}
-        metricsClient={metricsClient}
-      />
+      <HookedHostMetricsTable timerange={timerange} kuery={kuery} metricsClient={metricsClient} />
     </CoreProviders>
   );
 }

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
@@ -42,7 +42,7 @@ describe('useHostMetricsTable hook', () => {
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterKuery: kueryWithEventModuleFilter,
+          kuery: kueryWithEventModuleFilter,
         }),
       })
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
@@ -21,24 +21,7 @@ describe('useHostMetricsTable hook', () => {
   >;
 
   it('should call useInfrastructureNodeMetrics hook with event.module filter in filterClauseDsl query', () => {
-    const filterClauseDsl = {
-      bool: {
-        should: [
-          {
-            terms: {
-              'host.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9',
-            },
-          },
-        ],
-        minimum_should_match: 1,
-      },
-    };
-
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [{ term: { 'event.module': 'system' } }, { ...filterClauseDsl }],
-      },
-    };
+    const kuery = `host.name: "gke-edge-oblt-pool-1-9a60016d-lgg9"`;
 
     // include this to prevent rendering error in test
     useInfrastructureNodeMetricsMock.mockReturnValue({
@@ -49,15 +32,17 @@ describe('useHostMetricsTable hook', () => {
     renderHook(() =>
       useHostMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
       })
     );
 
+    const kueryWithEventModuleFilter = `(event.module: "system") AND (${kuery})`;
+
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          filterKuery: kueryWithEventModuleFilter,
         }),
       })
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
@@ -20,7 +20,7 @@ describe('useHostMetricsTable hook', () => {
     typeof useInfrastructureNodeMetrics
   >;
 
-  it('should call useInfrastructureNodeMetrics hook with event.module filter in filterClauseDsl query', () => {
+  it('should call useInfrastructureNodeMetrics hook with event.module filter in kuery', () => {
     const kuery = `host.name: "gke-edge-oblt-pool-1-9a60016d-lgg9"`;
 
     // include this to prevent rendering error in test
@@ -37,7 +37,7 @@ describe('useHostMetricsTable hook', () => {
       })
     );
 
-    const kueryWithEventModuleFilter = `(event.module: "system") AND (${kuery})`;
+    const kueryWithEventModuleFilter = `event.module: "system" AND (${kuery})`;
 
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.ts
@@ -27,11 +27,7 @@ type HostMetricsField =
   | 'system.memory.used.pct';
 
 const hostsMetricsQueryConfig: MetricsQueryOptions<HostMetricsField> = {
-  sourceFilter: {
-    term: {
-      'event.module': 'system',
-    },
-  },
+  sourceFilter: `event.module: "system"`,
   groupByField: 'host.name',
   metricsMap: {
     'system.cpu.cores': { aggregation: 'max', field: 'system.cpu.cores' },
@@ -60,7 +56,7 @@ export interface HostNodeMetricsRow {
 
 export function useHostMetricsTable({
   timerange,
-  filterClauseDsl,
+  kuery,
   metricsClient,
 }: UseNodeMetricsTableOptions) {
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
@@ -70,8 +66,8 @@ export function useHostMetricsTable({
   });
 
   const { options: hostMetricsOptions } = useMemo(
-    () => metricsToApiOptions(hostsMetricsQueryConfig, filterClauseDsl),
-    [filterClauseDsl]
+    () => metricsToApiOptions(hostsMetricsQueryConfig, kuery),
+    [kuery]
   );
 
   const { data, isLoading } = useInfrastructureNodeMetrics<HostNodeMetricsRow>({

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/create_lazy_pod_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/create_lazy_pod_metrics_table.tsx
@@ -13,7 +13,7 @@ import type { NodeMetricsTableProps } from '../shared';
 const LazyIntegratedPodMetricsTable = lazy(() => import('./integrated_pod_metrics_table'));
 
 export function createLazyPodMetricsTable(core: CoreStart, metricsClient: MetricsDataClient) {
-  return ({ timerange, filterClauseDsl, sourceId }: NodeMetricsTableProps) => {
+  return ({ timerange, kuery, sourceId }: NodeMetricsTableProps) => {
     return (
       <Suspense fallback={null}>
         <LazyIntegratedPodMetricsTable
@@ -21,7 +21,7 @@ export function createLazyPodMetricsTable(core: CoreStart, metricsClient: Metric
           metricsClient={metricsClient}
           sourceId={sourceId || 'default'}
           timerange={timerange}
-          filterClauseDsl={filterClauseDsl}
+          kuery={kuery}
         />
       </Suspense>
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/integrated_pod_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/integrated_pod_metrics_table.tsx
@@ -11,29 +11,21 @@ import type { IntegratedNodeMetricsTableProps, UseNodeMetricsTableOptions } from
 import { PodMetricsTable } from './pod_metrics_table';
 import { usePodMetricsTable } from './use_pod_metrics_table';
 
-function HookedPodMetricsTable({
-  timerange,
-  filterClauseDsl,
-  metricsClient,
-}: UseNodeMetricsTableOptions) {
-  const podMetricsTableProps = usePodMetricsTable({ timerange, filterClauseDsl, metricsClient });
+function HookedPodMetricsTable({ timerange, kuery, metricsClient }: UseNodeMetricsTableOptions) {
+  const podMetricsTableProps = usePodMetricsTable({ timerange, kuery, metricsClient });
   return <PodMetricsTable {...podMetricsTableProps} />;
 }
 
 function PodMetricsTableWithProviders({
   timerange,
-  filterClauseDsl,
+  kuery,
   sourceId,
   metricsClient,
   ...coreProvidersProps
 }: IntegratedNodeMetricsTableProps) {
   return (
     <CoreProviders {...coreProvidersProps}>
-      <HookedPodMetricsTable
-        timerange={timerange}
-        filterClauseDsl={filterClauseDsl}
-        metricsClient={metricsClient}
-      />
+      <HookedPodMetricsTable timerange={timerange} kuery={kuery} metricsClient={metricsClient} />
     </CoreProviders>
   );
 }

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.test.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.test.tsx
@@ -31,18 +31,7 @@ describe('PodMetricsTable', () => {
     to: 'now',
   };
 
-  const filterClauseDsl = {
-    bool: {
-      should: [
-        {
-          match: {
-            'pod.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9',
-          },
-        },
-      ],
-      minimum_should_match: 1,
-    },
-  };
+  const kuery = `pod.name: "gke-edge-oblt-pool-1-9a60016d-lgg9"`;
 
   const mockData = {
     series: [
@@ -60,7 +49,7 @@ describe('PodMetricsTable', () => {
       const metricsClient = getMetricsClient();
       const LazyPodMetricsTable = createLazyPodMetricsTable(getStartServices()[0], metricsClient);
 
-      render(<LazyPodMetricsTable timerange={timerange} filterClauseDsl={filterClauseDsl} />);
+      render(<LazyPodMetricsTable timerange={timerange} kuery={kuery} />);
 
       expect(screen.queryByTestId(loadingIndicatorTestId)).not.toBeInTheDocument();
       expect(screen.queryByTestId('podMetricsTable')).not.toBeInTheDocument();
@@ -90,7 +79,7 @@ describe('PodMetricsTable', () => {
       const { findByText } = render(
         <IntegratedPodMetricsTable
           timerange={timerange}
-          filterClauseDsl={filterClauseDsl}
+          kuery={kuery}
           sourceId="default"
           metricsClient={metricsClient}
           {...coreProvidersPropsMock}

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
@@ -42,7 +42,7 @@ describe('usePodMetricsTable hook', () => {
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterKuery: kueryWithEventModuleFilter,
+          kuery: kueryWithEventModuleFilter,
         }),
       })
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
@@ -37,7 +37,7 @@ describe('usePodMetricsTable hook', () => {
       })
     );
 
-    const kueryWithEventModuleFilter = `(event.dataset: "kubernetes.pod") AND (${kuery})`;
+    const kueryWithEventModuleFilter = `event.dataset: "kubernetes.pod" AND (${kuery})`;
 
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
@@ -20,18 +20,8 @@ describe('usePodMetricsTable hook', () => {
     typeof useInfrastructureNodeMetrics
   >;
 
-  it('should call useInfrastructureNodeMetrics hook with event.module filter in filterClauseDsl query', () => {
-    const filterClauseDsl = {
-      bool: {
-        filter: [{ terms: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
-      },
-    };
-
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [{ term: { 'event.dataset': 'kubernetes.pod' } }, { ...filterClauseDsl }],
-      },
-    };
+  it('should call useInfrastructureNodeMetrics hook with event.module filter in kuery', () => {
+    const kuery = 'container.id: "gke-edge-oblt-pool-1-9a60016d-lgg9"';
 
     // include this to prevent rendering error in test
     useInfrastructureNodeMetricsMock.mockReturnValue({
@@ -42,15 +32,17 @@ describe('usePodMetricsTable hook', () => {
     renderHook(() =>
       usePodMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
       })
     );
 
+    const kueryWithEventModuleFilter = `(event.dataset: "kubernetes.pod") AND (${kuery})`;
+
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          filterKuery: kueryWithEventModuleFilter,
         }),
       })
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.ts
@@ -23,11 +23,7 @@ import {
 type PodMetricsField = 'kubernetes.pod.cpu.usage.limit.pct' | 'kubernetes.pod.memory.usage.bytes';
 
 const podMetricsQueryConfig: MetricsQueryOptions<PodMetricsField> = {
-  sourceFilter: {
-    term: {
-      'event.dataset': 'kubernetes.pod',
-    },
-  },
+  sourceFilter: `event.dataset: "kubernetes.pod"`,
   groupByField: ['kubernetes.pod.uid', 'kubernetes.pod.name'],
   metricsMap: {
     'kubernetes.pod.cpu.usage.limit.pct': {
@@ -53,7 +49,7 @@ export interface PodNodeMetricsRow {
 
 export function usePodMetricsTable({
   timerange,
-  filterClauseDsl,
+  kuery,
   metricsClient,
 }: UseNodeMetricsTableOptions) {
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
@@ -63,8 +59,8 @@ export function usePodMetricsTable({
   });
 
   const { options: podMetricsOptions } = useMemo(
-    () => metricsToApiOptions(podMetricsQueryConfig, filterClauseDsl),
-    [filterClauseDsl]
+    () => metricsToApiOptions(podMetricsQueryConfig, kuery),
+    [kuery]
   );
 
   const { data, isLoading } = useInfrastructureNodeMetrics<PodNodeMetricsRow>({

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.test.ts
@@ -91,6 +91,6 @@ describe('metricsToApiOptions', () => {
   it("should join the source filter and the kuery when it's provided in the expected format", () => {
     const kuery = 'host.name: "my-host"';
     const { options } = metricsToApiOptions(testMetricsMapField1First, kuery);
-    expect(options.kuery).toBe(`(event.module: "test") AND (host.name: "my-host")`);
+    expect(options.kuery).toBe(`event.module: "test" AND (host.name: "my-host")`);
   });
 });

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.test.ts
@@ -13,11 +13,7 @@ describe('metricsToApiOptions', () => {
   type TestNodeTypeMetricsField = 'test.node.type.field1' | 'test.node.type.field2';
 
   const testMetricsMapField1First: MetricsQueryOptions<TestNodeTypeMetricsField> = {
-    sourceFilter: {
-      term: {
-        'event.module': 'test',
-      },
-    },
+    sourceFilter: `event.module: "test"`,
     groupByField: 'test.node.type.groupingField',
     metricsMap: {
       'test.node.type.field1': {
@@ -32,11 +28,7 @@ describe('metricsToApiOptions', () => {
   };
 
   const testMetricsMapField1Second: MetricsQueryOptions<TestNodeTypeMetricsField> = {
-    sourceFilter: {
-      term: {
-        'event.module': 'test',
-      },
-    },
+    sourceFilter: `event.module: "test"`,
     groupByField: 'test.node.type.groupingField',
     metricsMap: {
       'test.node.type.field2': {
@@ -57,7 +49,7 @@ describe('metricsToApiOptions', () => {
     expect(options).toEqual({
       aggregation: 'avg',
       groupBy: 'test.node.type.groupingField',
-      filterQuery: JSON.stringify({ bool: { filter: [{ term: { 'event.module': 'test' } }] } }),
+      filterKuery: `event.module: "test"`,
       metrics: [
         {
           field: 'test.node.type.field1',

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.test.ts
@@ -87,4 +87,10 @@ describe('metricsToApiOptions', () => {
     expect(firstListAsSet).toEqual(secondListAsSet);
     expect(firstList.length).toBe(secondList.length);
   }
+
+  it("should join the source filter and the kuery when it's provided in the expected format", () => {
+    const kuery = 'host.name: "my-host"';
+    const { options } = metricsToApiOptions(testMetricsMapField1First, kuery);
+    expect(options.filterKuery).toBe(`(event.module: "test") AND (host.name: "my-host")`);
+  });
 });

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.test.ts
@@ -49,7 +49,7 @@ describe('metricsToApiOptions', () => {
     expect(options).toEqual({
       aggregation: 'avg',
       groupBy: 'test.node.type.groupingField',
-      filterKuery: `event.module: "test"`,
+      kuery: `event.module: "test"`,
       metrics: [
         {
           field: 'test.node.type.field1',
@@ -91,6 +91,6 @@ describe('metricsToApiOptions', () => {
   it("should join the source filter and the kuery when it's provided in the expected format", () => {
     const kuery = 'host.name: "my-host"';
     const { options } = metricsToApiOptions(testMetricsMapField1First, kuery);
-    expect(options.filterKuery).toBe(`(event.module: "test") AND (host.name: "my-host")`);
+    expect(options.kuery).toBe(`(event.module: "test") AND (host.name: "my-host")`);
   });
 });

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
@@ -79,7 +79,7 @@ export function metricsToApiOptions<T extends string>(
     aggregation: 'avg',
     groupBy: metricsQueryOptions.groupByField,
     metrics,
-    filterKuery: buildFilterKuery(metricsQueryOptions.sourceFilter, kuery),
+    kuery: buildFilterKuery(metricsQueryOptions.sourceFilter, kuery),
   };
 
   return {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
@@ -88,7 +88,7 @@ export function metricsToApiOptions<T extends string>(
 }
 
 function buildFilterKuery(sourceFilter: string, kuery?: string): string {
-  return !!kuery ? `(${sourceFilter}) AND (${kuery})` : sourceFilter;
+  return !!kuery ? `${sourceFilter} AND (${kuery})` : sourceFilter;
 }
 
 export function createMetricByFieldLookup<T extends string>(metricMap: MetricsMap<T>) {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { ObjectValues } from '../../../../../common/utility_types';
 import type {
   MetricsExplorerOptions,
@@ -46,7 +45,7 @@ Then this code would no longer be needed.
 // sourceFilter is used to define filter to get only relevant docs that contain metrics info
 // e.g: { 'source.module': 'system' }
 export interface MetricsQueryOptions<T extends string> {
-  sourceFilter: QueryDslQueryContainer;
+  sourceFilter: string;
   groupByField: string | string[];
   metricsMap: MetricsMap<T>;
 }
@@ -70,7 +69,7 @@ export interface NodeMetricsExplorerOptionsMetric<Field extends string>
 
 export function metricsToApiOptions<T extends string>(
   metricsQueryOptions: MetricsQueryOptions<T>,
-  filterClauseDsl?: QueryDslQueryContainer
+  kuery?: string
 ) {
   const metrics = Object.values(metricsQueryOptions.metricsMap) as Array<
     NodeMetricsExplorerOptionsMetric<T>
@@ -80,9 +79,7 @@ export function metricsToApiOptions<T extends string>(
     aggregation: 'avg',
     groupBy: metricsQueryOptions.groupByField,
     metrics,
-    filterQuery: JSON.stringify(
-      buildFilterClause(metricsQueryOptions.sourceFilter, filterClauseDsl)
-    ),
+    filterQuery: buildFilterKuery(metricsQueryOptions.sourceFilter, kuery),
   };
 
   return {
@@ -90,15 +87,8 @@ export function metricsToApiOptions<T extends string>(
   };
 }
 
-function buildFilterClause(
-  sourceFilter: QueryDslQueryContainer,
-  filterClauseDsl?: QueryDslQueryContainer
-): QueryDslQueryContainer {
-  return {
-    bool: {
-      filter: !!filterClauseDsl ? [sourceFilter, filterClauseDsl] : [sourceFilter],
-    },
-  };
+function buildFilterKuery(sourceFilter: string, kuery?: string): string {
+  return !!kuery ? `(${sourceFilter}) AND (${kuery})` : sourceFilter;
 }
 
 export function createMetricByFieldLookup<T extends string>(metricMap: MetricsMap<T>) {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
@@ -79,7 +79,7 @@ export function metricsToApiOptions<T extends string>(
     aggregation: 'avg',
     groupBy: metricsQueryOptions.groupByField,
     metrics,
-    filterQuery: buildFilterKuery(metricsQueryOptions.sourceFilter, kuery),
+    filterKuery: buildFilterKuery(metricsQueryOptions.sourceFilter, kuery),
   };
 
   return {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/use_infrastructure_node_metrics.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/use_infrastructure_node_metrics.ts
@@ -114,7 +114,7 @@ export const useInfrastructureNodeMetrics = <T>(
           groupBy: metricsExplorerOptions.groupBy,
           limit: NODE_COUNT_LIMIT,
           indexPattern: metricIndices,
-          kuery: metricsExplorerOptions.filterQuery,
+          kuery: metricsExplorerOptions.filterKuery,
           timerange: timerangeWithInterval,
         };
 

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/use_infrastructure_node_metrics.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/use_infrastructure_node_metrics.ts
@@ -114,7 +114,7 @@ export const useInfrastructureNodeMetrics = <T>(
           groupBy: metricsExplorerOptions.groupBy,
           limit: NODE_COUNT_LIMIT,
           indexPattern: metricIndices,
-          kuery: metricsExplorerOptions.filterKuery,
+          kuery: metricsExplorerOptions.kuery,
           timerange: timerangeWithInterval,
         };
 

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/types.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/types.ts
@@ -5,13 +5,12 @@
  * 2.0.
  */
 
-import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { CoreProvidersProps } from '../../../apps/common_providers';
 import type { MetricsDataClient } from '../../../lib/metrics_client';
 
 export interface UseNodeMetricsTableOptions {
   timerange: { from: string; to: string };
-  filterClauseDsl?: QueryDslQueryContainer;
+  kuery?: string;
   metricsClient: MetricsDataClient;
 }
 


### PR DESCRIPTION
## Summary

Closes #249605

As part of #226336 this [PR](https://github.com/elastic/kibana/pull/229980) introduced a refactor on the metrics explorer API which updated it to use KQL instead of Query DSL.

But, as part of the refactoring we missed the infrastructure tab on the service page which was using that same API. As a result, this piece of UI is still sending filter queries in Query DSL format for which the API is now not prepared for. This is causing the tab to not work at all.

We've seen some instances where the network call gets rejected (400 error) and the UI crashes while in others the network call is not rejected but it doesn't return any results and the UI shows the empty results component. But, both cases originate from the same root cause that it's the query format miss match.

This PR addresses the issue described above by reworking the infrastructure tab code so that it generates KQL queries that can be properly parsed and applied by the metrics explorer endpoint 

## UI Comparison

## Before

<img width="2559" height="1327" alt="before" src="https://github.com/user-attachments/assets/005b6329-5d23-42ee-9adb-4f41796f76c5" />

## After

<img width="2559" height="1326" alt="after" src="https://github.com/user-attachments/assets/97781bc7-ed63-4d7a-8552-8980b415290c" />



<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->