### PR TITLE
[ES|QL] Add metrics and labels to Promql

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -30,6 +30,7 @@ import {
   getEsqlPolicies,
   getJoinIndices,
   getTimeseriesIndices,
+  getPromqlFields,
   getInferenceEndpoints,
   getEditorExtensions,
   fixESQLQueryWithVariables,
@@ -685,6 +686,9 @@ const ESQLEditorInternal = function ESQLEditor({
       getJoinIndices: getJoinIndicesCallback,
       getTimeseriesIndices: async () => {
         return (await getTimeseriesIndices(core.http)) || [];
+      },
+      getPromqlFields: async (indexPattern: string) => {
+        return await getPromqlFields(core.http, indexPattern);
       },
       getEditorExtensions: async (queryString: string) => {
         // Only fetch recommendations if there's an active solutionId and a non-empty query

--- a/src/platform/packages/shared/kbn-esql-language/src/__tests__/commands/context_fixtures.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/__tests__/commands/context_fixtures.ts
@@ -113,6 +113,18 @@ export const editorExtensions = {
   ],
 };
 
+export const promqlMetrics = [
+  { name: 'http_requests_total', type: 'counter_long', metricType: 'counter' as const },
+  { name: 'bytes_counter', type: 'counter_double', metricType: 'counter' as const },
+  { name: 'cpu_usage', type: 'gauge', metricType: 'gauge' as const },
+];
+
+export const promqlLabels = [
+  { name: 'job', type: 'keyword' },
+  { name: 'instance', type: 'keyword' },
+  { name: 'status_code', type: 'keyword' },
+];
+
 export const mockContext: ICommandContext = {
   columns: new Map<string, ESQLColumnData>([
     [
@@ -196,6 +208,10 @@ export const mockContext: ICommandContext = {
   })),
   joinSources: joinIndices,
   timeSeriesSources: timeseriesIndices,
+  promqlFields: {
+    metrics: promqlMetrics,
+    labels: promqlLabels,
+  },
   inferenceEndpoints,
   histogramBarTarget: 50,
   activeProduct: {
@@ -222,6 +238,10 @@ export const getMockCallbacks = (): MockedICommandCallbacks => {
     getSuggestedUserDefinedColumnName: jest.fn(),
     getColumnsForQuery: jest.fn(),
     hasMinimumLicenseRequired: jest.fn().mockReturnValue(true),
+    getPromqlFields: jest.fn().mockResolvedValue({
+      metrics: promqlMetrics,
+      labels: promqlLabels,
+    }),
     canCreateLookupIndex: jest.fn().mockReturnValue(true),
     isServerless: false,
   };

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/promql.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/definitions/utils/promql.ts
@@ -8,6 +8,7 @@
  */
 import type { ISuggestionItem } from '../../registry/types';
 import type { ESQLAstPromqlCommand, ESQLMapEntry } from '../../../types';
+import { EDITOR_MARKER } from '../constants';
 import { PromQLFunctionDefinitionTypes, type PromQLFunctionDefinition } from '../types';
 import { promqlFunctionDefinitions } from '../generated/promql_functions';
 import { buildFunctionDocumentation } from './documentation';
@@ -85,7 +86,7 @@ export function getIndexFromPromQLParams({
 
     const { value } = indexEntry ?? {};
 
-    if (isIdentifier(value) || isSource(value)) {
+    if ((isIdentifier(value) || isSource(value)) && !value.name.includes(EDITOR_MARKER)) {
       return value.name;
     }
   }
@@ -94,5 +95,6 @@ export function getIndexFromPromQLParams({
   // Needed by autocomplete and external consumers (e.g. getIndexPatternFromESQLQuery).
   const indexMatch = query?.text?.match(INDEX_PARAM_REGEX);
 
-  return indexMatch?.[1];
+  // same stuffs of getSourcesFromCommands for the other sources
+  return indexMatch?.[1]?.includes(EDITOR_MARKER) ? undefined : indexMatch?.[1];
 }

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/promql/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/promql/autocomplete.test.ts
@@ -7,7 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { mockContext, getMockCallbacks } from '../../../__tests__/commands/context_fixtures';
+import {
+  mockContext,
+  getMockCallbacks,
+  promqlMetrics,
+  promqlLabels,
+} from '../../../__tests__/commands/context_fixtures';
 import { suggest } from '../../../__tests__/commands/autocomplete';
 import { autocomplete } from './autocomplete';
 import {
@@ -267,10 +272,11 @@ describe('aggregation functions (by clause)', () => {
     });
   });
 
-  test('suggests functions inside incomplete aggregation function', async () => {
-    // Inside function args - suggest functions and metrics for completion
+  test('suggests functions and metrics inside incomplete aggregation function', async () => {
+    const metricNames = promqlMetrics.map(({ name }) => name);
+
     await expectPromqlSuggestions('PROMQL sum( ', {
-      labelsContain: promqlFunctionLabels,
+      labelsContain: [...promqlFunctionLabels, ...metricNames],
       labelsNotContain: [promqlByCompleteItem.label],
     });
   });
@@ -296,8 +302,11 @@ describe('aggregation functions (by clause)', () => {
     });
   });
 
-  test('inside by() returns empty suggestions (labels not yet supported)', async () => {
+  test('suggests labels inside by() grouping clause', async () => {
+    const labelNames = promqlLabels.map(({ name }) => name);
+
     await expectPromqlSuggestions('PROMQL sum(rate(http_requests[5m])) by (', {
+      labelsContain: labelNames,
       labelsNotContain: ['sum', 'rate', 'avg'],
     });
   });

--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/types.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/types.ts
@@ -14,6 +14,7 @@ import type {
   ESQLSourceResult,
   ESQLFieldWithMetadata,
   ESQLCallbacks,
+  PromQLFieldsAutocompleteResult,
 } from '@kbn/esql-types';
 import type { LicenseType } from '@kbn/licensing-types';
 import type { PricingProduct } from '@kbn/core-pricing-common/src/types';
@@ -155,6 +156,7 @@ export interface ICommandCallbacks {
   getColumnsForQuery?: (query: string) => Promise<ESQLColumnData[]>;
   hasMinimumLicenseRequired?: (minimumLicenseRequired: LicenseType) => boolean;
   getJoinIndices?: () => Promise<{ indices: IndexAutocompleteItem[] }>;
+  getPromqlFields?: (indexPattern: string) => Promise<PromQLFieldsAutocompleteResult>;
   canCreateLookupIndex?: (indexName: string) => Promise<boolean>;
   isServerless?: boolean;
   getKqlSuggestions?: ESQLCallbacks['getKqlSuggestions'];
@@ -165,6 +167,7 @@ export interface ICommandContext {
   sources?: ESQLSourceResult[];
   joinSources?: IndexAutocompleteItem[];
   timeSeriesSources?: IndexAutocompleteItem[];
+  promqlFields?: PromQLFieldsAutocompleteResult;
   inferenceEndpoints?: InferenceEndpointAutocompleteItem[];
   policies?: Map<string, ESQLPolicy>;
   editorExtensions?: EditorExtensions;

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
@@ -277,6 +277,7 @@ async function getSuggestionsWithinCommandExpression(
           }
         : undefined,
       hasMinimumLicenseRequired,
+      getPromqlFields: callbacks?.getPromqlFields,
       getKqlSuggestions: callbacks?.getKqlSuggestions,
       canCreateLookupIndex: callbacks?.canCreateLookupIndex,
       isServerless: callbacks?.isServerless,

--- a/src/platform/packages/shared/kbn-esql-types/index.ts
+++ b/src/platform/packages/shared/kbn-esql-types/index.ts
@@ -36,9 +36,16 @@ export {
 } from './src/inference_endpoint_autocomplete_types';
 
 export {
+  type PromQLFieldsAutocompleteResult,
+  type PromQLMetricField,
+  type PromQLLabelField,
+} from './src/promql_fields_autocomplete_types';
+
+export {
   REGISTRY_EXTENSIONS_ROUTE,
   SOURCES_AUTOCOMPLETE_ROUTE,
   TIMEFIELD_ROUTE,
+  PROMQL_FIELDS_ROUTE,
   SOURCES_TYPES,
   LOOKUP_INDEX_CREATE_ROUTE,
   LOOKUP_INDEX_UPDATE_ROUTE,

--- a/src/platform/packages/shared/kbn-esql-types/src/constants.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/constants.ts
@@ -10,6 +10,7 @@
 export const REGISTRY_EXTENSIONS_ROUTE = '/internal/esql_registry/extensions/';
 export const SOURCES_AUTOCOMPLETE_ROUTE = '/internal/esql/autocomplete/sources/';
 export const TIMEFIELD_ROUTE = '/internal/esql/get_timefield/';
+export const PROMQL_FIELDS_ROUTE = '/internal/esql/autocomplete/promql/fields';
 
 const LOOKUP_INDEX_ROUTE = '/internal/esql/lookup_index';
 export const LOOKUP_INDEX_CREATE_ROUTE = `${LOOKUP_INDEX_ROUTE}/create`;

--- a/src/platform/packages/shared/kbn-esql-types/src/editor_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/editor_types.ts
@@ -13,6 +13,7 @@ import type { RecommendedField, RecommendedQuery } from './extensions_autocomple
 import type { ESQLSourceResult, IndexAutocompleteItem } from './sources_autocomplete_types';
 import type { ESQLControlVariable } from './variables_types';
 import type { InferenceEndpointsAutocompleteResult } from './inference_endpoint_autocomplete_types';
+import type { PromQLFieldsAutocompleteResult } from './promql_fields_autocomplete_types';
 
 /** @internal **/
 type CallbackFn<Options = {}, Result = string> = (ctx?: Options) => Result[] | Promise<Result[]>;
@@ -113,6 +114,7 @@ export interface ESQLCallbacks {
     forceRefresh?: boolean;
   }) => Promise<{ indices: IndexAutocompleteItem[] }>;
   getTimeseriesIndices?: () => Promise<{ indices: IndexAutocompleteItem[] }>;
+  getPromqlFields?: (indexPattern: string) => Promise<PromQLFieldsAutocompleteResult>;
   getEditorExtensions?: (queryString: string) => Promise<{
     recommendedQueries: RecommendedQuery[];
     recommendedFields: RecommendedField[];

--- a/src/platform/packages/shared/kbn-esql-types/src/promql_fields_autocomplete_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/promql_fields_autocomplete_types.ts
@@ -7,11 +7,18 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { getESQLSources } from './sources';
-export { getEsqlColumns } from './columns';
-export { getEsqlPolicies } from './policies';
-export { getJoinIndices } from './lookup_indices';
-export { getTimeseriesIndices } from './timeseries_indices';
-export { getPromqlFields } from './promql_fields';
-export { getInferenceEndpoints } from './inference';
-export { getEditorExtensions } from './extensions';
+export interface PromQLMetricField {
+  name: string;
+  type: string;
+  metricType: string;
+}
+
+export interface PromQLLabelField {
+  name: string;
+  type: string;
+}
+
+export interface PromQLFieldsAutocompleteResult {
+  metrics: PromQLMetricField[];
+  labels: PromQLLabelField[];
+}

--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -59,6 +59,7 @@ export {
   getEsqlPolicies,
   getJoinIndices,
   getTimeseriesIndices,
+  getPromqlFields,
   getInferenceEndpoints,
   getEditorExtensions,
   hasDateBreakdown,

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/promql_fields.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/promql_fields.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { HttpStart } from '@kbn/core/public';
+import { PROMQL_FIELDS_ROUTE, type PromQLFieldsAutocompleteResult } from '@kbn/esql-types';
+import { cacheParametrizedAsyncFunction } from './utils/cache';
+
+export const getPromqlFields = cacheParametrizedAsyncFunction(
+  async (http: HttpStart, indexPattern: string) => {
+    const result = await http.get<PromQLFieldsAutocompleteResult>(PROMQL_FIELDS_ROUTE, {
+      query: { index: indexPattern },
+    });
+
+    return result;
+  },
+  (http: HttpStart, indexPattern: string) => `promql_fields_${indexPattern}`,
+  1000 * 60 * 5, // Keep the value in cache for 5 minutes
+  1000 * 15 // Refresh the cache in the background only if 15 seconds passed since the last call
+);

--- a/src/platform/plugins/shared/esql/server/routes/get_promql_fields.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_promql_fields.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { schema } from '@kbn/config-schema';
+import type { IRouter, PluginInitializerContext } from '@kbn/core/server';
+import { PROMQL_FIELDS_ROUTE } from '@kbn/esql-types';
+
+import { EsqlService } from '../services/esql_service';
+
+export const registerGetPromqlFieldsRoute = (
+  router: IRouter,
+  { logger }: PluginInitializerContext
+) => {
+  router.get(
+    {
+      path: PROMQL_FIELDS_ROUTE,
+      validate: {
+        query: schema.object({
+          index: schema.string(),
+        }),
+      },
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
+    },
+    async (requestHandlerContext, request, response) => {
+      try {
+        const { index } = request.query;
+        const core = await requestHandlerContext.core;
+        const service = new EsqlService({ client: core.elasticsearch.client.asCurrentUser });
+        const result = await service.getPromqlFields(index);
+
+        return response.ok({
+          body: result,
+        });
+      } catch (error) {
+        logger.get().debug(error);
+        throw error;
+      }
+    }
+  );
+};

--- a/src/platform/plugins/shared/esql/server/routes/index.ts
+++ b/src/platform/plugins/shared/esql/server/routes/index.ts
@@ -13,6 +13,7 @@ import type { ESQLExtensionsRegistry } from '../extensions_registry';
 
 import { registerGetJoinIndicesRoute } from './get_join_indices';
 import { registerGetTimeseriesIndicesRoute } from './get_timeseries_indices';
+import { registerGetPromqlFieldsRoute } from './get_promql_fields';
 import { registerESQLExtensionsRoute } from './get_esql_extensions_route';
 import { registerLookupIndexRoutes } from './lookup_index';
 import { registerGetSourcesRoute } from './get_all_sources';
@@ -27,6 +28,7 @@ export const registerRoutes = (
 
   registerGetJoinIndicesRoute(router, initContext);
   registerGetTimeseriesIndicesRoute(router, initContext);
+  registerGetPromqlFieldsRoute(router, initContext);
   registerESQLExtensionsRoute(router, extensionsRegistry, initContext);
   registerGetInferenceEndpointsRoute(router, initContext);
   registerLookupIndexRoutes(router, initContext);


### PR DESCRIPTION
## Summary

part of the Milestone 1 (almost done, we cover 2 points of  the last 3) https://github.com/elastic/kibana/issues/246728

https://github.com/user-attachments/assets/192f0e6d-d6cd-4649-b97f-95cf818914c2


**Context**

In PromQL`, data is organized around two concepts that differ from standard ES|QL columns:
-  **Metrics**: numeric time-series fields with a time_series_metric type (counter, gauge). These are the values that PromQL functions operate on (e.g., rate(http_requests_total[5m])).
- **Labels**: dimension fields marked as time_series_dimension in the index mapping (typically keyword type). These identify and filter time series (e.g., {job="api", ins```tance="localhost"}).

 This PR adds autocomplete support for both, fetching the classification from Elasticsearch's _field_caps API which exposes time_series_metric and time_series_dimension properties from the index mapping.

### What we do and what we don't do 

 Here, we support **metrics in functions and labels in aggregators like By** (in Milestone 1.1, we're complementing labels with more complicated cases).

## Testing with existing sample data

The `kibana_sample_data_logstsdb` sample dataset already includes timeseries mappings, so it can be used to test this feature without additional setup.

**Metrics** (`time_series_metric`):

| Field | Type | Metric Type |
|-------|------|-------------|
| `bytes_counter` | long | counter |
| `bytes_gauge` | long | gauge |

**Labels** (`time_series_dimension: true`):

| Field | Type |
|-------|------|
| `event.dataset` | keyword |



