### PR TITLE
[Streams][SigEvents] Propagate ES|QL execution errors

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/rules/esql/lib/execute_esql_request.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/rules/esql/lib/execute_esql_request.ts
@@ -48,7 +48,8 @@ export const executeEsqlRequest = async ({
 
     return results;
   } catch (error) {
-    logger.debug(`Error executing ES|QL request: ${error.message}`);
-    return [];
+    const message = `Error executing ES|QL request: ${error.message}`;
+    logger.debug(message);
+    throw new Error(message);
   }
 };


### PR DESCRIPTION
## Summary

Updates error handling in `executeEsqlRequest` to propagate errors instead of silently swallowing them.

**Before:** Errors were logged at debug level and an empty array was returned, hiding failures from callers.

**After:** Errors are logged at debug level and re-thrown with a sanitized message.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->