### PR TITLE
[Streams] Fix error toast Full error modal to show server error messages

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/failure_store/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/failure_store/index.tsx
@@ -80,11 +80,10 @@ export const StreamDetailFailureStore = ({
         }),
       });
     } catch (error) {
-      notifications.toasts.addError(error, {
+      notifications.toasts.addError(getFormattedError(error), {
         title: i18n.translate('xpack.streams.streamDetailFailureStore.updateFailureStoreFailed', {
           defaultMessage: "We couldn't update the failure store settings.",
         }),
-        toastMessage: getFormattedError(error).message,
       });
     } finally {
       closeModal();

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/general_data/index.tsx
@@ -89,11 +89,10 @@ export const StreamDetailGeneralData = ({
         }),
       });
     } catch (error) {
-      notifications.toasts.addError(error, {
+      notifications.toasts.addError(getFormattedError(error), {
         title: i18n.translate('xpack.streams.streamDetailLifecycle.failed', {
           defaultMessage: 'Failed to update lifecycle',
         }),
-        toastMessage: getFormattedError(error).message,
       });
     } finally {
       setUpdateInProgress(false);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/advanced_view/settings.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/advanced_view/settings.tsx
@@ -150,11 +150,10 @@ export function Settings({
 
       refreshDefinition();
     } catch (error) {
-      notifications.toasts.addError(error, {
+      notifications.toasts.addError(getFormattedError(error), {
         title: i18n.translate('xpack.streams.settings.failedToUpdateSettings', {
           defaultMessage: 'Failed to update settings',
         }),
-        toastMessage: getFormattedError(error).message,
       });
     } finally {
       setIsUpdating(false);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_delete_modal/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_delete_modal/index.tsx
@@ -30,6 +30,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useState } from 'react';
 import { useKibana } from '../../hooks/use_kibana';
 import { buildRequestPreviewCodeContent } from '../data_management/shared/utils';
+import { getFormattedError } from '../../util/errors';
 
 export function StreamDeleteModal({
   onClose,
@@ -63,7 +64,7 @@ export function StreamDeleteModal({
       onClose();
     } catch (error) {
       setDeleteInProgress(false);
-      notifications.toasts.addError(error, {
+      notifications.toasts.addError(getFormattedError(error), {
         title: i18n.translate('xpack.streams.failedToDelete', {
           defaultMessage: 'Failed to delete stream {id}',
           values: {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_description/use_stream_description_api.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_description/use_stream_description_api.ts
@@ -82,14 +82,13 @@ export const useStreamDescriptionApi = ({
         })
         .catch((error) => {
           if (!silent) {
-            notifications.toasts.addError(error, {
+            notifications.toasts.addError(getFormattedError(error), {
               title: i18n.translate(
                 'xpack.streams.streamDetailView.streamDescription.saveErrorTitle',
                 {
                   defaultMessage: 'Failed to save description',
                 }
               ),
-              toastMessage: getFormattedError(error).message,
             });
           }
         })

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/classic_stream_creation_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/classic_stream_creation_flyout.tsx
@@ -18,6 +18,7 @@ import { useKibana } from '../../hooks/use_kibana';
 import { useStreamsAppFetch } from '../../hooks/use_streams_app_fetch';
 import { useStreamsAppRouter } from '../../hooks/use_streams_app_router';
 import { useTimeRange } from '../../hooks/use_time_range';
+import { getFormattedError } from '../../util/errors';
 
 interface ClassicStreamCreationFlyoutProps {
   onClose: () => void;
@@ -115,7 +116,7 @@ export function ClassicStreamCreationFlyout({ onClose }: ClassicStreamCreationFl
 
         onClose();
       } catch (error) {
-        core.notifications.toasts.addError(error as Error, {
+        core.notifications.toasts.addError(getFormattedError(error), {
           title: i18n.translate(
             'xpack.streams.classicStreamCreationFlyout.streamCreationFailedToastTitle',
             {
@@ -162,7 +163,7 @@ export function ClassicStreamCreationFlyout({ onClose }: ClassicStreamCreationFl
 
         return { errorType: null };
       } catch (error) {
-        core.notifications.toasts.addError(error as Error, {
+        core.notifications.toasts.addError(getFormattedError(error), {
           title: i18n.translate(
             'xpack.streams.classicStreamCreationFlyout.streamValidationFailedToastTitle',
             {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
@@ -32,6 +32,7 @@ import { ClassicStreamCreationFlyout } from './classic_stream_creation_flyout';
 import { StreamsListEmptyPrompt } from './streams_list_empty_prompt';
 import { StreamsSettingsFlyout } from './streams_settings_flyout';
 import { StreamsTreeTable } from './tree_table';
+import { getFormattedError } from '../../util/errors';
 
 export function StreamListView() {
   const { euiTheme } = useEuiTheme();
@@ -74,7 +75,7 @@ export function StreamListView() {
         const status = await getClassicStatus();
         setCanManageClassicElasticsearch(Boolean(status.can_manage));
       } catch (error) {
-        core.notifications.toasts.addError(error, {
+        core.notifications.toasts.addError(getFormattedError(error), {
           title: i18n.translate('xpack.streams.streamsListView.fetchClassicStatusErrorToastTitle', {
             defaultMessage: 'Error fetching classic streams status',
           }),

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/streams_settings_flyout.tsx
@@ -39,6 +39,7 @@ import { OBSERVABILITY_STREAMS_ENABLE_SIGNIFICANT_EVENTS } from '@kbn/management
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 import { useKibana } from '../../hooks/use_kibana';
 import { useStreamsPrivileges } from '../../hooks/use_streams_privileges';
+import { getFormattedError } from '../../util/errors';
 
 export function StreamsSettingsFlyout({
   onClose,
@@ -80,7 +81,7 @@ export function StreamsSettingsFlyout({
         setWiredChecked(status.enabled === true);
         setCanManageWiredElasticsearch(Boolean(status.can_manage));
       } catch (error) {
-        core.notifications.toasts.addError(error, {
+        core.notifications.toasts.addError(getFormattedError(error), {
           title: i18n.translate('xpack.streams.streamsListView.fetchWiredStatusErrorToastTitle', {
             defaultMessage: 'Error fetching wired streams status',
           }),
@@ -104,12 +105,10 @@ export function StreamsSettingsFlyout({
         setWiredChecked(true);
         refreshStreams();
       } catch (error) {
-        core.notifications.toasts.addError(error, {
+        core.notifications.toasts.addError(getFormattedError(error), {
           title: i18n.translate('xpack.streams.streamsListView.enableWiredStreamsErrorToastTitle', {
             defaultMessage: 'Error updating wired streams setting',
           }),
-          toastMessage:
-            error?.body?.message || (error instanceof Error ? error.message : String(error)),
           toastLifeTimeMs: 5000,
         });
       } finally {
@@ -128,12 +127,10 @@ export function StreamsSettingsFlyout({
       setShowDisableModal(false);
       setDisableConfirmChecked(false);
     } catch (error) {
-      core.notifications.toasts.addError(error, {
+      core.notifications.toasts.addError(getFormattedError(error), {
         title: i18n.translate('xpack.streams.streamsListView.enableWiredStreamsErrorToastTitle', {
           defaultMessage: 'Error updating wired streams setting',
         }),
-        toastMessage:
-          error?.body?.message || (error instanceof Error ? error.message : String(error)),
         toastLifeTimeMs: 5000,
       });
     } finally {
@@ -158,15 +155,13 @@ export function StreamsSettingsFlyout({
               })
         );
       } catch (error) {
-        core.notifications.toasts.addError(error, {
+        core.notifications.toasts.addError(getFormattedError(error), {
           title: i18n.translate(
             'xpack.streams.streamsListView.significantEventsToggleErrorToastTitle',
             {
               defaultMessage: 'Error updating Significant events setting',
             }
           ),
-          toastMessage:
-            error?.body?.message || (error instanceof Error ? error.message : String(error)),
           toastLifeTimeMs: 5000,
         });
       }

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_fetch_error_toast.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_fetch_error_toast.ts
@@ -8,6 +8,7 @@
 import { i18n } from '@kbn/i18n';
 import { useCallback } from 'react';
 import { useKibana } from './use_kibana';
+import { getFormattedError } from '../util/errors';
 
 export function useFetchErrorToast() {
   const {
@@ -16,20 +17,6 @@ export function useFetchErrorToast() {
 
   return useCallback(
     (error: Error) => {
-      if (
-        'body' in error &&
-        typeof error.body === 'object' &&
-        !!error.body &&
-        'message' in error.body &&
-        typeof error.body.message === 'string'
-      ) {
-        error.message = error.body.message;
-      }
-
-      if (error instanceof AggregateError) {
-        error.message = error.errors.map((err) => err.message).join(', ');
-      }
-
       let requestUrl: string | undefined;
       if (
         'request' in error &&
@@ -41,7 +28,7 @@ export function useFetchErrorToast() {
         requestUrl = error.request.url;
       }
 
-      return notifications.toasts.addError(error, {
+      return notifications.toasts.addError(getFormattedError(error), {
         title: i18n.translate('xpack.streams.failedToFetchError', {
           defaultMessage: 'Failed to fetch data{requestUrlSuffix}',
           values: {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/error_handling.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/error_handling.spec.ts
@@ -77,5 +77,45 @@ test.describe(
       await pageObjects.toasts.waitFor();
       expect(await pageObjects.toasts.getHeaderText()).toBe('Stream saved');
     });
+
+    test('should show server error message in Full error modal', async ({ page, pageObjects }) => {
+      const serverErrorMessage = 'Stream name contains invalid characters: must be lowercase';
+
+      // Intercept the fork stream API endpoint and return an error with a specific message
+      await page.route('**/api/streams/**/_fork*', async (route) => {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            statusCode: 400,
+            error: 'Bad Request',
+            message: serverErrorMessage,
+          }),
+        });
+      });
+
+      await pageObjects.streams.clickCreateRoutingRule();
+      await pageObjects.streams.fillRoutingRuleName('test-error-modal');
+      await pageObjects.streams.saveRoutingRule();
+
+      // Wait for the error toast
+      await pageObjects.toasts.waitFor();
+
+      // Click "See the full error" button
+      const fullErrorButton = page.getByTestId('errorToastBtn');
+      await expect(fullErrorButton).toBeVisible();
+      await fullErrorButton.click();
+
+      // Verify the modal shows the server error message
+      const errorModalBody = page.getByTestId('errorModalBody');
+      await expect(errorModalBody).toBeVisible();
+      await expect(errorModalBody).toContainText(serverErrorMessage);
+
+      // Close the modal
+      await page.getByRole('button', { name: 'Close', exact: true }).click();
+
+      // Restore normal API behavior
+      await page.unroute('**/api/streams/**/_fork*');
+    });
   }
 );


### PR DESCRIPTION
## 🍒 Summary

Fixes #246042 - Error toast "Full error" modal now shows the actual server error message instead of a generic JavaScript stack trace.

## 🛠️ Changes

- Wrapped all `addError()` calls in streams_app components with `getFormattedError()` to extract the server error message from `error.body.message`
- Updated 9 files with 13 total `addError()` call sites:
  - `stream_delete_modal/index.tsx` - stream deletion errors
  - `stream_list_view/index.tsx` - stream list fetch errors
  - `classic_stream_creation_flyout.tsx` - classic stream creation errors (2 locations)
  - `advanced_view/settings.tsx` - stream settings errors
  - `use_fetch_error_toast.ts` - generic fetch error hook
  - `streams_settings_flyout.tsx` - streams settings errors (4 locations, simplified from manual extraction)
  - `general_data/index.tsx` - lifecycle general data errors
  - `failure_store/index.tsx` - failure store errors
  - `use_stream_description_api.ts` - stream description API errors
- Added UI integration test to verify the "Full error" modal shows server error messages

## 🎙️ Prompts

- Check out what to do in the GitHub issue and related code
- Fix error toast handling to show proper server error messages
- Add UI integration test to verify error toasts show server error messages in "Full error" modal
- Run linting and type checking

🤖 This pull request was assisted by Cursor
