### PR TITLE
[Metrics] Fix LensWrapper mark color regression

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/lens_wrapper.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/lens_wrapper.tsx
@@ -73,6 +73,13 @@ export function LensWrapper({
       left: 50%;
       transform: translate(-50%, -50%);
     }
+
+    // Style mark elements (from EuiHighlight) in panel headers to match Discover's highlight colors
+    & .embPanel__header mark,
+    & [data-test-subj='embeddablePanelTitle'] mark {
+      color: ${euiTheme.colors.textAccent};
+      background-color: ${euiTheme.colors.backgroundLightAccent};
+    }
   `;
 
   const handleExploreInDiscoverTab = useCallback(


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/pull/249450 we added a `titleHighlight` prop to Lens. This allowed us to remove our custom header implementation in the Metrics panel and rely on core Lens for the panel titles.

Unfortunately, this removed custom styling that matched our highlight feature with the underlying Discover style. We want to keep this consistent.

This PR adds a CSS override for the `mark` elements within the metrics LensWrapper component, which will cause `EuiHighlight` to show the color consistent with Discover, `euiTheme.colors.textAccent`.

## Testing the PR

Index some metrics data, then perform a search for some content in the panel header.

### Current (in main)

<img width="1568" height="312" alt="image" src="https://github.com/user-attachments/assets/48433064-5b43-4406-b77d-a5075a37e9be" />


### This PR branch

<img width="1581" height="532" alt="image" src="https://github.com/user-attachments/assets/16847ed0-2c43-4576-9dc6-081e9e8758e4" />


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->