### PR TITLE
[Streams] Fix condition deletion revert bug

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/types.ts
@@ -75,6 +75,8 @@ export interface StreamEnrichmentContextType {
   // Validation errors for processors (namespace, reserved fields, type mismatches)
   validationErrors: Map<string, StreamlangValidationError[]>;
   fieldTypesByProcessor: Map<string, Map<string, FieldType>>;
+  // Whether a save operation is in progress (used to prevent stream.received from interrupting save)
+  isSaving: boolean;
 }
 
 export type StreamEnrichmentEvent =

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -644,6 +644,11 @@ export class StreamsApp {
     await this.page.getByRole('button', { name: 'Delete processor' }).click();
   }
 
+  async removeCondition(pos: number) {
+    await this.clickEditCondition(pos);
+    await this.page.getByRole('button', { name: 'Delete condition' }).click();
+  }
+
   async waitForModifiedFieldsDetection() {
     const badge = this.page.getByTestId('streamsAppModifiedFieldsBadge');
     await expect(badge).toBeVisible({ timeout: 30_000 });

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/edit_steps.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/edit_steps.spec.ts
@@ -124,4 +124,28 @@ test.describe('Stream data processing - editing steps', { tag: ['@ess', '@svlObl
     // Edit button should be disabled or show tooltip
     await expect(await pageObjects.streams.getProcessorEditButton(0)).toBeDisabled();
   });
+
+  test('should delete a condition and persist after save', async ({ page, pageObjects }) => {
+    // Verify condition exists before deletion
+    await expect(page.getByTestId('streamsAppConditionBlock')).toBeVisible();
+    expect(await pageObjects.streams.getConditionsListItems()).toHaveLength(1);
+
+    // Delete the condition
+    await pageObjects.streams.removeCondition(0);
+    await pageObjects.streams.confirmDeleteInModal();
+
+    // Verify condition is removed from the UI
+    expect(await pageObjects.streams.getConditionsListItemsFast()).toHaveLength(0);
+
+    // Save the changes
+    await pageObjects.streams.saveStepsListChanges();
+
+    // Wait for save to complete and verify condition remains deleted
+    // Reload the page to verify the deletion persisted
+    await pageObjects.streams.gotoProcessingTab('logs-generic-default');
+
+    // Verify condition is still gone after reload
+    expect(await pageObjects.streams.getConditionsListItemsFast()).toHaveLength(0);
+    await expect(page.getByTestId('streamsAppConditionBlock')).toBeHidden();
+  });
 });


### PR DESCRIPTION
## 🍒 Summary

Fixes the issue where deleting a processing condition in Streams data management would be saved but automatically reverted. The deletion appeared to succeed but the condition would reappear after the save completed.

Closes #246529

## 🛠️ Changes

- Added `isSaving` context flag to track when a save operation is in progress
- Added `setSaving` and `clearSaving` actions for entry/exit of the `updating` state
- Added `isNotSaving` guard to prevent `stream.received` events from resetting state during save operations
- Added UI integration test to verify condition deletion persists after save
- Added `removeCondition` helper method to page objects for testing

## 🎙️ Prompts

- Investigate and fix the condition deletion revert bug - trace the full flow from UI deletion through save to definition refresh
- Add UI integration test for deleting a condition completely and verify it persists after save

🤖 This pull request was assisted by Cursor
