### PR TITLE
[WIP][Inference Connectors] Dynamically create preconfigured connectors from inference endpoints response

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/action_type_registry.ts
+++ b/x-pack/platform/plugins/shared/actions/server/action_type_registry.ts
@@ -44,8 +44,8 @@ export class ActionTypeRegistry {
   private readonly taskRunnerFactory: TaskRunnerFactory;
   private readonly actionsConfigUtils: ActionsConfigurationUtilities;
   private readonly licenseState: ILicenseState;
-  private readonly inMemoryConnectors: InMemoryConnector[];
   private readonly licensing: LicensingPluginSetup;
+  private inMemoryConnectors: InMemoryConnector[];
 
   constructor(constructorParams: ActionTypeRegistryOpts) {
     this.taskManager = constructorParams.taskManager;
@@ -54,6 +54,10 @@ export class ActionTypeRegistry {
     this.licenseState = constructorParams.licenseState;
     this.inMemoryConnectors = constructorParams.inMemoryConnectors;
     this.licensing = constructorParams.licensing;
+  }
+
+  public updateInMemoryConnectors(connectors: InMemoryConnector[]) {
+    this.inMemoryConnectors.push(...connectors);
   }
 
   /**

--- a/x-pack/platform/plugins/shared/actions/server/create_inference_connector_config.ts
+++ b/x-pack/platform/plugins/shared/actions/server/create_inference_connector_config.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { InferenceInferenceEndpointInfo } from '@elastic/elasticsearch/lib/api/types';
+
+export const createInferenceConnectorConfig = (endpoint: InferenceInferenceEndpointInfo) => {
+  // @ts-ignore metadata does not exist on the type definition - this will be added to the endpoint return info
+  const { metadata } = endpoint;
+  return {
+    id: metadata.name.replace(/\s+|(?<=\d)\.(?=\d)/g, '-'),
+    name: metadata.name,
+    actionTypeId: '.inference',
+    exposeConfig: true,
+    config: {
+      provider: 'elastic',
+      taskType: endpoint.task_type ?? 'chat_completion',
+      inferenceId: endpoint.inference_id,
+      providerConfig: {
+        model_id: endpoint.service_settings.model_id,
+      },
+    },
+    secrets: {},
+    isPreconfigured: true,
+    isSystemAction: false,
+    isConnectorTypeDeprecated: false,
+    isDeprecated: false,
+  };
+};


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/248200

Right now preconfigured (built-in) connectors are configured in kibana.yml. We can only ship changes to that file in Cloud Hosted with new releases. Inference endpoints can already be dynamically updated. Preconfigured AI connectors currently cannot.

This PR is an exploration of a potential solution for being able to dynamically generate preconfigured AI/Inference connectors based on present but unused inference endpoints of the chat_completion type.

This PR keeps the preconfig connectors setup in the actions plugin setup method.
It leverages the `getStartServices` method to ensure the es client and inference api are available to be called. 
The endpoints are filtered by a metadata property indicating that they are to be used for inference connectors.
(Currently it looks like the path will be `endpoint.metadata.name` but this could change. Backend changes are in progress). 
The endpoints are then used to create the connector configs, which are then added to the local `inMemoryConnectors` and updated in the `ActionsTypeRegistry` instance created in the plugin. 


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



