### PR TITLE
Disable lmdb/ci-stats in Codex sandbox

### DIFF
--- a/src/platform/packages/private/kbn-ci-stats-reporter/src/ci_stats_reporter.ts
+++ b/src/platform/packages/private/kbn-ci-stats-reporter/src/ci_stats_reporter.ts
@@ -133,6 +133,11 @@ export class CiStatsReporter {
    * for builds use #hasBuildConfig().
    */
   isEnabled() {
+    if (process.env.CODEX_SANDBOX) {
+      // Codex sandbox blocks outbound network access, so disable ci-stats there.
+      return false;
+    }
+
     return process.env.CI_STATS_DISABLED !== 'true';
   }
 


### PR DESCRIPTION
LMDB cache and ci-stats reporting don't work in the Codex sandbox, so guard both with CODEX_SANDBOX.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->