### PR TITLE
Fix/apm error message fallback

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/errors/get_columns.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/errors/get_columns.tsx
@@ -32,7 +32,11 @@ const getErrorMessage = (error: ErrorData) => {
   if (error?.log?.message) {
     return error.log.message;
   }
-
+  
+ if (error?.message) {
+    return error.message;
+  }
+  
   return NOT_AVAILABLE_LABEL;
 };
 
@@ -53,7 +57,11 @@ export const getColumns = ({
       'unifiedDocViewer.observability.traces.docViewerSpanOverview.errors.table.error',
       { defaultMessage: 'Error message and culprit' }
     ),
-    sortable: (item) => item.error?.exception?.message || '',
+      sortable: (item) =>
+  item.error?.exception?.message ||
+  item.error?.log?.message ||
+  item.error?.message ||
+  '',
     render: (_, item) => {
       const href = generateDiscoverLink({
         [TRACE_ID]: traceId,

--- a/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_error_name.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/lib/helpers/get_error_name.ts
@@ -15,5 +15,5 @@ export function getErrorName<T extends ProxiedApmEvent<Partial<FlattenedApmEvent
   event: T,
   exception: Exception
 ): string {
-  return event[ERROR_LOG_MESSAGE] || exception.message || NOT_AVAILABLE_LABEL;
+  return event[ERROR_LOG_MESSAGE] || exception.message || event['error.message'] || NOT_AVAILABLE_LABEL;
 }


### PR DESCRIPTION
### Summary
APM UI currently renders "N/A" for errors ingested via ECS-formatted logs (e.g. Java APM `log_sending`) because it only checks `error.log.message` and `error.exception.message`.

This PR adds `error.message` as a fallback when rendering error names and error messages in the APM UI, aligning the behavior with ECS and `getMessageFieldWithFallbacks` used in Discover.

### Changes
- Add `error.message` fallback to `getErrorName`
- Ensure error rendering falls back to `error.message` when other fields are missing

### Screenshots
<!-- Optional: before / after -->

Fixes #249358