### PR TITLE
[CI] Add Storybooks from PR trigger comment

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -147,7 +147,9 @@
       "build_on_commit": false,
       "build_drafts": false,
       "enable_trigger_checkbox": true,
-      "kibana_versions_check": true
+      "kibana_versions_check": true,
+      "build_on_comment": true,
+      "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:deploy)\\W+(?:storybook))$"
     },
     {
       "repoOwner": "elastic",


### PR DESCRIPTION
## Summary

The new pipeline [storybooks from pr](https://buildkite.com/elastic/kibana-storybooks-from-pr) was triggering unintentionally due to the default comment regex (`buildkite test this`) since `build_on_comment` defaults to `true`. [Examples for this PR](https://buildkite.com/elastic/kibana-storybooks-from-pr/builds?branch=Ikuni17%3Afix%2Fsb-pipeline-comment-trigger) first build was triggered via checkbox, the second build via comment which cancelled the first.