### PR TITLE
fix: Enable Add Connector button and Assistant Settings Menu when use…

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.tsx
@@ -217,6 +217,10 @@ export const AssistantSettingsContextMenu: React.FC<Params> = React.memo(
       return isDisabled || !assistantAvailability.hasAgentBuilderManagePrivilege;
     }, [assistantAvailability, isDisabled]);
 
+    const isMenuDisabled = useMemo(() => {
+      return isDisabled && !assistantAvailability.hasAssistantPrivilege;
+    }, [assistantAvailability, isDisabled]);
+
     const onContinueTour = useCallback(() => {
       handleOpenAIAgentModal('security_ab_tour');
     }, [handleOpenAIAgentModal]);
@@ -234,7 +238,7 @@ export const AssistantSettingsContextMenu: React.FC<Params> = React.memo(
               button={
                 <EuiButtonIcon
                   aria-label={i18n.AI_ASSISTANT_MENU}
-                  isDisabled={isDisabled}
+                  isDisabled={isMenuDisabled}
                   iconType="controls"
                   onClick={onButtonClick}
                   data-test-subj="chat-context-menu"

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
@@ -146,6 +146,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
     );
     const buttonLabel = selectedOrDefaultConnector?.name ?? i18n.INLINE_CONNECTOR_PLACEHOLDER;
     const localIsDisabled = isDisabled || !assistantAvailability.hasConnectorsReadPrivilege;
+    const canAddConnector = assistantAvailability.hasConnectorsAllPrivilege;
 
     // Group connectors into pre-configured and custom
     const { customConnectors, preConfiguredConnectors } = useMemo(
@@ -204,7 +205,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
         content: (
           <ConnectorSelectable
             onAddConnectorClick={
-              assistantAvailability.hasConnectorsAllPrivilege
+              canAddConnector
                 ? () => setIsConnectorModalVisible(true)
                 : undefined
             }
@@ -269,7 +270,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
           <EuiButtonEmpty
             data-test-subj="addNewConnectorButton"
             iconType="plusInCircle"
-            isDisabled={localIsDisabled}
+            isDisabled={!canAddConnector}
             size="xs"
             onClick={() => setIsConnectorModalVisible(true)}
           >


### PR DESCRIPTION
Fix: #250635

- fixes the "+ Add connector" button and Assistant Settings Menu being disabled when EIS is unavailable and no connectors exist, even when users have permission.

- Changes:

"+ Add connector" button checks hasConnectorsAllPrivilege instead of localIsDisabled
Assistant Settings Menu checks hasAssistantPrivilege to ensure accessibility

- Impact:

Users with permission can add connectors regardless of EIS status or existing connectors
Assistant Settings Menu remains accessible when users have privileges