### PR TITLE
[ResponseOps][Connectors] Fix connector validation when secrets are undefined.

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/lib/validate_with_schema.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/validate_with_schema.test.ts
@@ -325,7 +325,7 @@ test('should throw an error when custom validators fail', () => {
   ).toThrowErrorMatchingInlineSnapshot(`"error validating connector type secrets: test error"`);
 });
 
-describe('validateSecretes', () => {
+describe('validateSecrets', () => {
   test('should not run validation when secrets are undefined', () => {
     const schemaValidator = z3.object({ foo: z3.string() }).strict();
     const actionType: ActionType = {

--- a/x-pack/platform/plugins/shared/actions/server/lib/validate_with_schema.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/validate_with_schema.test.ts
@@ -327,16 +327,7 @@ test('should throw an error when custom validators fail', () => {
 
 describe('validateSecretes', () => {
   test('should not run validation when secrets are undefined', () => {
-    const schemaValidator = {
-      parse: (value: ActionTypeParams | ActionTypeConfig | ActionTypeSecrets) => value,
-    };
-    const customValidator = (
-      value: ActionTypeParams | ActionTypeConfig | ActionTypeSecrets,
-      services: ValidatorServices
-    ) => {
-      throw new Error('test error');
-    };
-
+    const schemaValidator = z3.object({ foo: z3.string() }).strict();
     const actionType: ActionType = {
       id: 'foo',
       name: 'bar',
@@ -352,7 +343,6 @@ describe('validateSecretes', () => {
         },
         secrets: {
           schema: schemaValidator,
-          customValidator,
         },
       },
     };
@@ -363,16 +353,7 @@ describe('validateSecretes', () => {
   });
 
   test('should not run validation when secrets are null', () => {
-    const schemaValidator = {
-      parse: (value: ActionTypeParams | ActionTypeConfig | ActionTypeSecrets) => value,
-    };
-    const customValidator = (
-      value: ActionTypeParams | ActionTypeConfig | ActionTypeSecrets,
-      services: ValidatorServices
-    ) => {
-      throw new Error('test error');
-    };
-
+    const schemaValidator = z3.object({ foo: z3.string() }).strict();
     const actionType: ActionType = {
       id: 'foo',
       name: 'bar',
@@ -388,7 +369,6 @@ describe('validateSecretes', () => {
         },
         secrets: {
           schema: schemaValidator,
-          customValidator,
         },
       },
     };

--- a/x-pack/platform/plugins/shared/actions/server/lib/validate_with_schema.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/validate_with_schema.test.ts
@@ -325,6 +325,44 @@ test('should throw an error when custom validators fail', () => {
   ).toThrowErrorMatchingInlineSnapshot(`"error validating connector type secrets: test error"`);
 });
 
+describe('validateSecretes', () => {
+  test('should not run validation when secrets are undefined', () => {
+    const schemaValidator = {
+      parse: (value: ActionTypeParams | ActionTypeConfig | ActionTypeSecrets) => value,
+    };
+    const customValidator = (
+      value: ActionTypeParams | ActionTypeConfig | ActionTypeSecrets,
+      services: ValidatorServices
+    ) => {
+      throw new Error('test error');
+    };
+
+    const actionType: ActionType = {
+      id: 'foo',
+      name: 'bar',
+      minimumLicenseRequired: 'basic',
+      supportedFeatureIds: ['alerting'],
+      executor,
+      validate: {
+        params: {
+          schema: schemaValidator,
+        },
+        config: {
+          schema: schemaValidator,
+        },
+        secrets: {
+          schema: schemaValidator,
+          customValidator,
+        },
+      },
+    };
+
+    expect(() =>
+      validateSecrets(actionType, undefined, { configurationUtilities })
+    ).not.toThrowError();
+  });
+});
+
 describe('validateConnectors', () => {
   const testValue = { any: ['old', 'thing'] };
   const selfValidator = { parse: (value: Record<string, unknown>) => value };

--- a/x-pack/platform/plugins/shared/actions/server/lib/validate_with_schema.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/validate_with_schema.test.ts
@@ -361,6 +361,40 @@ describe('validateSecretes', () => {
       validateSecrets(actionType, undefined, { configurationUtilities })
     ).not.toThrowError();
   });
+
+  test('should not run validation when secrets are null', () => {
+    const schemaValidator = {
+      parse: (value: ActionTypeParams | ActionTypeConfig | ActionTypeSecrets) => value,
+    };
+    const customValidator = (
+      value: ActionTypeParams | ActionTypeConfig | ActionTypeSecrets,
+      services: ValidatorServices
+    ) => {
+      throw new Error('test error');
+    };
+
+    const actionType: ActionType = {
+      id: 'foo',
+      name: 'bar',
+      minimumLicenseRequired: 'basic',
+      supportedFeatureIds: ['alerting'],
+      executor,
+      validate: {
+        params: {
+          schema: schemaValidator,
+        },
+        config: {
+          schema: schemaValidator,
+        },
+        secrets: {
+          schema: schemaValidator,
+          customValidator,
+        },
+      },
+    };
+
+    expect(() => validateSecrets(actionType, null, { configurationUtilities })).not.toThrowError();
+  });
 });
 
 describe('validateConnectors', () => {

--- a/x-pack/platform/plugins/shared/actions/server/lib/validate_with_schema.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/validate_with_schema.ts
@@ -132,7 +132,7 @@ function validateWithSchema<
           break;
         case 'secrets':
           name = 'connector type secrets';
-          if (actionType.validate.secrets) {
+          if (actionType.validate.secrets && value !== undefined) {
             const validatedValue = actionType.validate.secrets.schema.parse(value);
 
             if (actionType.validate.secrets.customValidator) {

--- a/x-pack/platform/plugins/shared/actions/server/lib/validate_with_schema.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/validate_with_schema.ts
@@ -132,7 +132,7 @@ function validateWithSchema<
           break;
         case 'secrets':
           name = 'connector type secrets';
-          if (actionType.validate.secrets && value !== undefined) {
+          if (actionType.validate.secrets && value !== undefined && value !== null) {
             const validatedValue = actionType.validate.secrets.schema.parse(value);
 
             if (actionType.validate.secrets.customValidator) {

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/cases_webhook/service.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/cases_webhook/service.test.ts
@@ -272,6 +272,48 @@ describe('Cases webhook service', () => {
         },
       });
     });
+
+    it('headers work as expected if secrets are undefined', () => {
+      createExternalService(
+        actionId,
+        {
+          config: { ...config, hasAuth: false },
+          // @ts-expect-error: should not happen but it does with very old SOs
+          secrets: undefined,
+        },
+        logger,
+        configurationUtilities,
+        connectorUsageCollector
+      );
+
+      expect(axios.create).toHaveBeenCalledWith({
+        headers: {
+          'content-type': 'application/json',
+          foo: 'bar',
+        },
+      });
+    });
+
+    it('headers work as expected if secrets are null', () => {
+      createExternalService(
+        actionId,
+        {
+          config: { ...config, hasAuth: false },
+          // @ts-expect-error: should not happen but it does with very old SOs
+          secrets: null,
+        },
+        logger,
+        configurationUtilities,
+        connectorUsageCollector
+      );
+
+      expect(axios.create).toHaveBeenCalledWith({
+        headers: {
+          'content-type': 'application/json',
+          foo: 'bar',
+        },
+      });
+    });
   });
 
   describe('getIncident', () => {

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/cases_webhook/service.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/cases_webhook/service.ts
@@ -92,7 +92,7 @@ export const createExternalService = (
     throw Error(`[Action]${CONNECTOR_NAME}: Wrong configuration.`);
   }
 
-  const mergedHeaders = mergeConfigHeadersWithSecretHeaders(headers, secrets.secretHeaders);
+  const mergedHeaders = mergeConfigHeadersWithSecretHeaders(headers, secrets?.secretHeaders);
 
   const headersWithBasicAuth = combineHeadersWithBasicAuthHeader({
     username: basicAuth.auth?.username,

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/get_axios_config.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/get_axios_config.test.ts
@@ -157,4 +157,34 @@ describe('getAxiosConfig', () => {
       'Unable to retrieve/refresh the access token: Failed to retrieve access token'
     );
   });
+
+  it('should not return an error if secrets are undefined', async () => {
+    const config = await getAxiosConfig({
+      ...params,
+      config: {
+        ...params.config,
+        authType: undefined,
+        hasAuth: false,
+      },
+      // @ts-expect-error: should not happen but it does with very old SOs
+      secrets: undefined,
+    });
+
+    expect(config[1]).toBeNull();
+  });
+
+  it('should not return an error if secrets are null', async () => {
+    const config = await getAxiosConfig({
+      ...params,
+      config: {
+        ...params.config,
+        authType: undefined,
+        hasAuth: false,
+      },
+      // @ts-expect-error: should not happen but it does with very old SOs
+      secrets: null,
+    });
+
+    expect(config[1]).toBeNull();
+  });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/get_axios_config.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/get_axios_config.ts
@@ -109,7 +109,7 @@ const getDefaultAxiosConfig = async ({ config, secrets }: GetDefaultAxiosConfig)
     ca,
   });
 
-  const mergedHeaders = mergeConfigHeadersWithSecretHeaders(headers, secrets.secretHeaders);
+  const mergedHeaders = mergeConfigHeadersWithSecretHeaders(headers, secrets?.secretHeaders);
   const headersWithAuth = combineHeadersWithBasicAuthHeader({
     username: basicAuth.auth?.username,
     password: basicAuth.auth?.password,

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/actions/migrations.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/actions/migrations.ts
@@ -126,7 +126,7 @@ export default function createGetTests({ getService }: FtrProviderContext) {
         connector_id: '0f8f2810-0a59-11ec-9a7c-fd0c2b83ff7d',
         status: 'error',
         errorSource: 'framework',
-        message: `error validating connector type secrets: Required`,
+        message: `error validating action type connector: secrets must be defined`,
         retry: false,
       });
     });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana-team/issues/2733

## Summary

After the migration from `kbn-cfg-schema` to `zod`, some **old** connectors started failing on `execute`.

The failing connector SO does not have the secrets field. Before running execute, we validate config, params, and secrets against the connector type schema. The behaviour towards `undefined` is different in zod and an error is being thrown.

In this PR we skip the secrets' validation if they are either `null` or `undefined`.

## How to test

Use the dev tools to create the following connector:

```
POST .kibana_alerting_cases/_create/action:af8f8940-a4cb-11ee-8dbc-2fa9d8f29424
{
  "action": {
    "name": "Webhook without secrets",
    "actionTypeId": ".webhook",
    "isMissingSecrets": false,
    "config": {
      "authType": null,
      "hasAuth": false,
      "headers": {
        "Accept": "application/json",
        "Content-Type": "application/json",
        "X-RFToken": "REDACTED"
      },
      "method": "post",
      "url": "https://webhook.site/d5d322a7-ddb3-4746-9176-b21dfaa489c3"
    }
  },
  "type": "action",
  "references": [],
  "managed": false,
  "namespaces": ["default"],
  "coreMigrationVersion": "8.8.0",
  "typeMigrationVersion": "10.1.0",
  "updated_at": "2024-08-27T16:27:10.691Z",
  "created_at": "2024-08-27T16:27:10.691Z"
}
```

Navigate to Stack Management > Connectors and press `Test` for this connector.

No error should be shown when running the test.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->