### PR TITLE
[App Menu] Change popoverTestId to use native EUI

### DIFF
--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_popover.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/components/app_menu_popover.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo, useState, type ReactElement } from 'react';
+import React, { useMemo, type ReactElement } from 'react';
 import { EuiContextMenu, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { getPopoverPanels, getTooltip } from '../utils';
 import type {
@@ -39,36 +39,35 @@ export const AppMenuPopover = ({
   popoverWidth,
   primaryActionItem,
   secondaryActionItem,
-  popoverTestId,
+  popoverTestId = 'app-menu-popover',
   onClose,
   onCloseOverflowButton,
 }: AppMenuContextMenuProps) => {
-  const [activePanelId, setActivePanelId] = useState<string>('0');
-
-  const { panels, panelIdToTestId } = useMemo(
+  const panels = useMemo(
     () =>
       getPopoverPanels({
         items,
         primaryActionItem,
         secondaryActionItem,
         rootPanelWidth: popoverWidth,
+        rootPopoverTestId: popoverTestId,
         onClose,
         onCloseOverflowButton,
       }),
-    [items, primaryActionItem, secondaryActionItem, popoverWidth, onClose, onCloseOverflowButton]
+    [
+      items,
+      primaryActionItem,
+      secondaryActionItem,
+      popoverWidth,
+      popoverTestId,
+      onClose,
+      onCloseOverflowButton,
+    ]
   );
 
   if (panels.length === 0) {
     return null;
   }
-
-  /**
-   * Determine the active test ID for the popover panel.
-   * EuiContextMenuPanelItemDescriptor does not support data-test-subj directly,
-   * so we map panel IDs to test IDs when creating the panels.
-   * TODO: Remove this implementation if EUI fix is provided: https://github.com/elastic/eui/issues/9321
-   */
-  const activeTestId = panelIdToTestId[activePanelId] || popoverTestId || 'app-menu-popover';
 
   const { content, title } = getTooltip({ tooltipContent, tooltipTitle });
   const showTooltip = Boolean(content || title);
@@ -89,15 +88,8 @@ export const AppMenuPopover = ({
       panelPaddingSize="none"
       hasArrow={false}
       anchorPosition="downLeft"
-      panelProps={{
-        'data-test-subj': activeTestId,
-      }}
     >
-      <EuiContextMenu
-        initialPanelId={0}
-        panels={panels}
-        onPanelChange={({ panelId }) => setActivePanelId(String(panelId))}
-      />
+      <EuiContextMenu initialPanelId={0} panels={panels} />
     </EuiPopover>
   );
 };

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.test.tsx
@@ -371,7 +371,7 @@ describe('utils', () => {
         { id: '2', label: 'Item 2', run: jest.fn(), order: 2 },
       ];
 
-      const { panels } = getPopoverPanels({ items });
+      const panels = getPopoverPanels({ items });
 
       expect(panels).toHaveLength(1);
       expect(panels[0].id).toBe(0);
@@ -388,7 +388,7 @@ describe('utils', () => {
         },
       ];
 
-      const { panels } = getPopoverPanels({ items });
+      const panels = getPopoverPanels({ items });
 
       expect(panels).toHaveLength(2);
       const mainPanel = panels.find((p) => p.id === 0);
@@ -404,7 +404,7 @@ describe('utils', () => {
         { id: '1', label: 'Item 1', run: jest.fn(), order: 1, separator: 'above' },
       ];
 
-      const { panels } = getPopoverPanels({ items });
+      const panels = getPopoverPanels({ items });
       const panelItems = panels[0].items as Array<{ isSeparator?: boolean; key?: string }>;
 
       expect(panelItems[0].isSeparator).toBe(true);
@@ -416,7 +416,7 @@ describe('utils', () => {
         { id: '1', label: 'Item 1', run: jest.fn(), order: 1, separator: 'below' },
       ];
 
-      const { panels } = getPopoverPanels({ items });
+      const panels = getPopoverPanels({ items });
       const panelItems = panels[0].items as Array<{ isSeparator?: boolean; key?: string }>;
 
       expect(panelItems[1].isSeparator).toBe(true);
@@ -426,7 +426,7 @@ describe('utils', () => {
     it('should append action items to main panel when provided', () => {
       const items: AppMenuPopoverItem[] = [{ id: '1', label: 'Item 1', run: jest.fn(), order: 1 }];
 
-      const { panels } = getPopoverPanels({
+      const panels = getPopoverPanels({
         items,
         primaryActionItem: { id: 'save', label: 'Save', run: jest.fn(), iconType: 'save' },
       });
@@ -442,7 +442,7 @@ describe('utils', () => {
     it('should use custom startPanelId', () => {
       const items: AppMenuPopoverItem[] = [{ id: '1', label: 'Item 1', run: jest.fn(), order: 1 }];
 
-      const { panels } = getPopoverPanels({ items, startPanelId: 10 });
+      const panels = getPopoverPanels({ items, startPanelId: 10 });
 
       expect(panels[0].id).toBe(10);
     });
@@ -464,12 +464,12 @@ describe('utils', () => {
         },
       ];
 
-      const { panels } = getPopoverPanels({ items });
+      const panels = getPopoverPanels({ items });
 
       expect(panels).toHaveLength(3);
     });
 
-    it('should create panelIdToTestId mapping for items with popoverTestId', () => {
+    it('should set data-test-subj on panels with popoverTestId', () => {
       const items: AppMenuPopoverItem[] = [
         {
           id: '1',
@@ -501,12 +501,16 @@ describe('utils', () => {
         },
       ];
 
-      const { panels, panelIdToTestId } = getPopoverPanels({ items });
+      const panels = getPopoverPanels({ items });
 
       expect(panels).toHaveLength(3);
-      expect(panelIdToTestId['1']).toBe('exportPopoverPanel');
-      expect(panelIdToTestId['2']).toBe('sharePopoverPanel');
-      expect(panelIdToTestId['0']).toBeUndefined(); // Main panel has no test ID
+      const exportPanel = panels.find((p) => p.title === 'Export');
+      const sharePanel = panels.find((p) => p.title === 'Share');
+      const mainPanel = panels.find((p) => p.id === 0);
+
+      expect(exportPanel?.['data-test-subj']).toBe('exportPopoverPanel');
+      expect(sharePanel?.['data-test-subj']).toBe('sharePopoverPanel');
+      expect(mainPanel?.['data-test-subj']).toBeUndefined(); // Main panel has no test ID by default
     });
   });
 

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/utils.tsx
@@ -220,6 +220,7 @@ export const getPopoverPanels = ({
   secondaryActionItem,
   startPanelId = 0,
   rootPanelWidth = DEFAULT_POPOVER_WIDTH,
+  rootPopoverTestId,
   onClose,
   onCloseOverflowButton,
 }: {
@@ -228,11 +229,11 @@ export const getPopoverPanels = ({
   secondaryActionItem?: AppMenuSecondaryActionItem;
   startPanelId?: number;
   rootPanelWidth?: number;
+  rootPopoverTestId?: string;
   onClose?: () => void;
   onCloseOverflowButton?: () => void;
-}): { panels: EuiContextMenuPanelDescriptor[]; panelIdToTestId: Record<string, string> } => {
+}): EuiContextMenuPanelDescriptor[] => {
   const panels: EuiContextMenuPanelDescriptor[] = [];
-  const panelIdToTestId: Record<string, string> = {};
   const hasActionItems = Boolean(primaryActionItem || secondaryActionItem);
   let currentPanelId = startPanelId;
 
@@ -250,10 +251,6 @@ export const getPopoverPanels = ({
     parentPopoverWidth?: number;
   }) => {
     const panelItems: EuiContextMenuPanelItemDescriptor[] = [];
-
-    if (parentPopoverTestId) {
-      panelIdToTestId[String(panelId)] = parentPopoverTestId;
-    }
 
     const sortedItems = [...itemsToProcess].sort((a, b) => a.order - b.order);
 
@@ -291,6 +288,7 @@ export const getPopoverPanels = ({
     panels.push({
       id: panelId,
       ...(parentTitle && { title: upperFirst(parentTitle) }),
+      ...(parentPopoverTestId && { 'data-test-subj': parentPopoverTestId }),
       ...(parentPopoverWidth && { width: parentPopoverWidth }),
       items: panelItems,
     });
@@ -299,6 +297,7 @@ export const getPopoverPanels = ({
   processItems({
     itemsToProcess: items,
     panelId: startPanelId,
+    parentPopoverTestId: rootPopoverTestId,
     parentPopoverWidth: rootPanelWidth,
   });
 
@@ -309,7 +308,7 @@ export const getPopoverPanels = ({
   if (hasActionItems) {
     const mainPanel = panels.find((panel) => panel.id === startPanelId);
 
-    if (!mainPanel) return { panels, panelIdToTestId };
+    if (!mainPanel) return panels;
 
     const actionItems: EuiContextMenuPanelItemDescriptor[] = getPopoverActionItems({
       primaryActionItem,
@@ -319,10 +318,10 @@ export const getPopoverPanels = ({
 
     mainPanel.items = [...(mainPanel.items as EuiContextMenuPanelItemDescriptor[]), ...actionItems];
 
-    return { panels, panelIdToTestId };
+    return panels;
   }
 
-  return { panels, panelIdToTestId };
+  return panels;
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR changes panels test id to use EUI `data-test-subj` that has been added to `EuiContextMenuPanelDescriptor` in EUI 112.1.0.

Closes: https://github.com/elastic/kibana-team/issues/2716
