### PR TITLE
[Streams] Add tooltip to simulation playground refresh button

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/simulation_playground.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/simulation_playground.tsx
@@ -17,6 +17,7 @@ import {
   EuiSpacer,
   EuiTab,
   EuiTabs,
+  EuiToolTip,
 } from '@elastic/eui';
 import { ProcessorOutcomePreview } from './processor_outcome_preview';
 import {
@@ -78,15 +79,24 @@ export const SimulationPlayground = ({
                 append={
                   <EuiFlexGroup alignItems="center" gutterSize="xs">
                     <EuiFlexItem>
-                      <EuiButtonIcon
-                        iconType="refresh"
-                        onClick={refreshSimulation}
-                        isLoading={isDataSourceLoading}
-                        aria-label={i18n.translate(
-                          'xpack.streams.streamDetailView.managementTab.enrichment.simulationPlayground.refreshPreviewAriaLabel',
-                          { defaultMessage: 'Refresh data preview' }
+                      <EuiToolTip
+                        content={i18n.translate(
+                          'xpack.streams.streamDetailView.managementTab.enrichment.simulationPlayground.refreshPreviewTooltip',
+                          {
+                            defaultMessage: 'Refetch samples and rerun simulation',
+                          }
                         )}
-                      />
+                      >
+                        <EuiButtonIcon
+                          iconType="refresh"
+                          onClick={refreshSimulation}
+                          isLoading={isDataSourceLoading}
+                          aria-label={i18n.translate(
+                            'xpack.streams.streamDetailView.managementTab.enrichment.simulationPlayground.refreshPreviewAriaLabel',
+                            { defaultMessage: 'Refresh data preview' }
+                          )}
+                        />
+                      </EuiToolTip>
                     </EuiFlexItem>
                     {hasOutdatedDocuments && (
                       <EuiFlexItem data-test-subj="streamsAppProcessingOutdatedDocumentsTipAnchor">


### PR DESCRIPTION
## Summary

Adds a tooltip to the refresh button in the Streams simulation playground that explains it refetches samples and reruns the simulation.

Closes #229255

## Changes

- Added `EuiToolTip` import to `simulation_playground.tsx`
- Wrapped the refresh button (`EuiButtonIcon`) with `EuiToolTip`
- Tooltip content: "Refetch samples and rerun simulation" (i18n-ized)
- Preserved existing `aria-label` for accessibility

## Prompts

- Add tooltip to the refresh button in simulation_playground.tsx explaining it refetches samples and reruns simulation

🤖 This pull request was assisted by Cursor
