### PR TITLE
[kibana-presentation] Remove node-fetch dependency in favor of native fetch

### DIFF
--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/wms_source/wms_client.js
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/wms_source/wms_client.js
@@ -7,7 +7,6 @@
 
 import _ from 'lodash';
 import { parseXmlString } from '../../../../common/parse_xml_string';
-import fetch from 'node-fetch';
 import { parse, format } from 'url';
 
 export class WmsClient {

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/glyphs.test.ts
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/glyphs.test.ts
@@ -26,6 +26,8 @@ jest.mock('../../kibana_services', () => ({
   },
 }));
 
+const mockedFetch = jest.spyOn(global, 'fetch');
+
 describe('EMS enabled', () => {
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -44,10 +46,9 @@ describe('EMS enabled', () => {
 
   describe('offline', () => {
     beforeAll(() => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      require('node-fetch').default = () => {
+      mockedFetch.mockImplementation(() => {
         throw new Error('Simulated offline environment with no EMS access');
-      };
+      });
     });
 
     test('should return EMS fonts template URL before canAccessEmsFontsPromise resolves', () => {
@@ -68,10 +69,9 @@ describe('EMS enabled', () => {
 
   describe('online', () => {
     beforeAll(() => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      require('node-fetch').default = () => {
-        return Promise.resolve({ status: 200 });
-      };
+      mockedFetch.mockImplementation(() => {
+        return Promise.resolve(new Response(null, { status: 200 }));
+      });
     });
 
     test('should return EMS fonts template URL before canAccessEmsFontsPromise resolves', () => {

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/glyphs.ts
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/glyphs.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import fetch from 'node-fetch';
 import { FONTS_API_PATH } from '../../../common/constants';
 import { getDocLinks, getHttp, getEMSSettings } from '../../kibana_services';
 


### PR DESCRIPTION
## Summary

This PR removes the `node-fetch` dependency for files owned by `@elastic/kibana-presentation`.

### Why

Node.js 18+ includes a native `fetch` API (built on undici internally), making the `node-fetch` package unnecessary. This reduces the dependency footprint by removing one runtime dependency and its transitive dependencies.

### Changes
- Updated Maps WMS client to use native fetch
- Updated Maps glyphs to use native fetch
- Updated all related test files to use `jest.spyOn(global, 'fetch')`

> [!WARNING]
> These changes were vibe-coded using the AI agent `claude-4.5-opus-high`. Please review carefully.

## Test plan
- [x] Type check passes
- [x] ESLint passes
- [x] Unit tests pass for modified files