### PR TITLE
[kibana-visualizations] Remove node-fetch dependency in favor of native fetch

### DIFF
--- a/src/platform/plugins/private/vis_types/timelion/server/series_functions/worldbank.js
+++ b/src/platform/plugins/private/vis_types/timelion/server/series_functions/worldbank.js
@@ -9,7 +9,6 @@
 
 import { i18n } from '@kbn/i18n';
 import _ from 'lodash';
-import fetch from 'node-fetch';
 import moment from 'moment';
 import Datasource from '../lib/classes/datasource';
 


### PR DESCRIPTION
## Summary

This PR removes the `node-fetch` dependency for files owned by `@elastic/kibana-visualizations`.

### Why

Node.js 18+ includes a native `fetch` API (built on undici internally), making the `node-fetch` package unnecessary. This reduces the dependency footprint by removing one runtime dependency and its transitive dependencies.

### Changes
- Updated Timelion `worldbank` series function to use native fetch

> [!WARNING]
> These changes were vibe-coded using the AI agent `claude-4.5-opus-high`. Please review carefully.

## Test plan
- [x] Type check passes
- [x] ESLint passes
- [ ] Unit tests pass for modified files