### PR TITLE
[OpenAPI] Do not generate imports for local references

### DIFF
--- a/src/platform/packages/shared/kbn-openapi-generator/src/parser/lib/get_imports_map.ts
+++ b/src/platform/packages/shared/kbn-openapi-generator/src/parser/lib/get_imports_map.ts
@@ -10,6 +10,7 @@
 import { uniq } from 'lodash';
 import type { OpenApiDocument } from '../openapi_types';
 import { findRefs } from './helpers/find_refs';
+import { isLocalRef } from './helpers/is_local_ref';
 
 export interface ImportsMap {
   [importPath: string]: string[];
@@ -26,6 +27,11 @@ export const getImportsMap = (parsedSchema: OpenApiDocument): ImportsMap => {
   const importMap: Record<string, string[]> = {}; // key: import path, value: list of symbols to import
   const refs = findRefs(parsedSchema);
   refs.forEach((ref) => {
+    // Skip local references (e.g., #/components/schemas/SomeName) as they don't need imports
+    if (isLocalRef(ref)) {
+      return;
+    }
+
     const refParts = ref.split('#/components/schemas/');
     const importedSymbol = refParts[1];
     let importPath = refParts[0];


### PR DESCRIPTION
## Summary

I noticed that when generating schemas from yaml files with local references, the generator will create import statements for the referenced types.

```yml
openapi: 3.0.1
paths:
  /api/cases:
    post:
      parameters:
        - $ref: '#/components/parameters/kbn_xsrf'
components:
  parameters:
    kbn_xsrf:
      schema:
        type: string
```

Will generate:

```typescript
import {, #/components/parameters/kbn_xsrf' } (...)
```

The fix I am proposing will skip generating import statements for local references.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->