### PR TITLE
[One Workflow][POC] Auto-infer workflow cost for Task Manager

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/infer_workflow_cost.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/infer_workflow_cost.ts
@@ -1,0 +1,267 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { WorkflowYaml } from '@kbn/workflows';
+import { type GraphNodeUnion, WorkflowGraph } from '@kbn/workflows/graph';
+import { StepCost } from '@kbn/workflows-extensions/common';
+import type { WorkflowsExtensionsServerPluginStart } from '@kbn/workflows-extensions/server';
+
+/**
+ * Workflow cost tier that maps to Task Manager's TaskCost.
+ * This is used to determine which task type variant to use for workflow execution.
+ */
+export type WorkflowCostTier = 'light' | 'normal' | 'heavy';
+
+/**
+ * Maps StepCost enum to WorkflowCostTier string.
+ */
+function stepCostToTier(cost: StepCost): WorkflowCostTier {
+  switch (cost) {
+    case StepCost.Light:
+      return 'light';
+    case StepCost.Heavy:
+      return 'heavy';
+    case StepCost.Normal:
+    default:
+      return 'normal';
+  }
+}
+
+/**
+ * Returns the higher of two cost tiers.
+ * Order: light < normal < heavy
+ */
+function getHigherCost(a: WorkflowCostTier, b: WorkflowCostTier): WorkflowCostTier {
+  const order: WorkflowCostTier[] = ['light', 'normal', 'heavy'];
+  return order.indexOf(a) >= order.indexOf(b) ? a : b;
+}
+
+/**
+ * Control flow node types that don't contribute to cost.
+ * These are structural nodes that don't perform actual work.
+ */
+const CONTROL_FLOW_TYPES = new Set([
+  'enter-foreach',
+  'exit-foreach',
+  'enter-if',
+  'exit-if',
+  'enter-then-branch',
+  'exit-then-branch',
+  'enter-else-branch',
+  'exit-else-branch',
+  'enter-retry',
+  'exit-retry',
+  'enter-continue',
+  'exit-continue',
+  'enter-try-block',
+  'exit-try-block',
+  'enter-normal-path',
+  'exit-normal-path',
+  'enter-fallback-path',
+  'exit-fallback-path',
+  'enter-timeout-zone',
+  'exit-timeout-zone',
+  'on-failure',
+  'step-level-on-failure',
+  'workflow-level-on-failure',
+]);
+
+/**
+ * Known AI service URL patterns for HTTP step cost inference.
+ */
+const AI_URL_PATTERNS = {
+  domains: [
+    /api\.openai\.com/i,
+    /api\.anthropic\.com/i,
+    /\.openai\.azure\.com/i,
+    /generativelanguage\.googleapis\.com/i,
+    /api\.cohere\.ai/i,
+    /api-inference\.huggingface\.co/i,
+    /bedrock-runtime\..*\.amazonaws\.com/i,
+    /api\.mistral\.ai/i,
+    /api\.together\.xyz/i,
+    /api\.groq\.com/i,
+    /api\.replicate\.com/i,
+  ],
+  paths: [/\/v1\/chat\/completions/i, /\/v1\/completions/i, /\/v1\/embeddings/i, /\/messages/i],
+};
+
+/**
+ * AI-related connector types.
+ */
+const AI_CONNECTOR_TYPES = new Set(['.gen-ai', '.bedrock', '.gemini', '.inference']);
+
+/**
+ * Infers the cost tier for a single graph node.
+ * Priority:
+ * 1. Check step registry for declared cost
+ * 2. Fall back to heuristics for built-in/unknown steps
+ */
+function inferNodeCost(
+  node: GraphNodeUnion,
+  stepRegistry?: WorkflowsExtensionsServerPluginStart
+): WorkflowCostTier {
+  const stepType = node.stepType;
+
+  // Control flow nodes don't contribute to cost
+  if (CONTROL_FLOW_TYPES.has(node.type)) {
+    return 'light';
+  }
+
+  // 1. Check if step has declared cost in registry
+  if (stepType && stepRegistry?.hasStepDefinition(stepType)) {
+    const stepDef = stepRegistry.getStepDefinition(stepType);
+    if (stepDef?.cost) {
+      return stepCostToTier(stepDef.cost);
+    }
+  }
+
+  // 2. Fall back to heuristics for built-in/unknown steps
+  return inferCostFromHeuristics(node);
+}
+
+/**
+ * Infers cost from heuristics for steps without declared cost.
+ * This handles built-in steps, HTTP steps, and connector steps.
+ */
+function inferCostFromHeuristics(node: GraphNodeUnion): WorkflowCostTier {
+  const stepType = node.stepType || node.type;
+
+  // AI step types (prefix matching)
+  if (stepType.startsWith('ai.') || stepType.startsWith('agent.')) {
+    return 'heavy';
+  }
+
+  // Light built-in steps
+  if (
+    stepType.startsWith('data.') ||
+    stepType.startsWith('elasticsearch.') ||
+    stepType.startsWith('kibana.') ||
+    stepType === 'wait' ||
+    stepType === 'console' ||
+    stepType === 'data-set'
+  ) {
+    return 'light';
+  }
+
+  // HTTP steps - analyze URL if available
+  if (node.type === 'http') {
+    return inferHttpStepCost(node);
+  }
+
+  // Atomic/connector steps - check connector type
+  if (node.type === 'atomic') {
+    return inferAtomicStepCost(node);
+  }
+
+  // Default for unknown step types
+  return 'normal';
+}
+
+/**
+ * Infers cost for HTTP steps by analyzing URL patterns.
+ */
+function inferHttpStepCost(node: GraphNodeUnion): WorkflowCostTier {
+  // Access configuration safely - node may have 'configuration' property
+  const config = (node as { configuration?: { with?: { url?: string; method?: string } } })
+    .configuration?.with;
+  if (!config) {
+    return 'normal';
+  }
+
+  const { url, method } = config;
+
+  // If URL is dynamic (contains template variables), we can't analyze it
+  if (typeof url === 'string' && !url.includes('{{')) {
+    // Check domain patterns for AI services
+    if (AI_URL_PATTERNS.domains.some((pattern) => pattern.test(url))) {
+      return 'heavy';
+    }
+
+    // Check path patterns for AI endpoints
+    if (AI_URL_PATTERNS.paths.some((pattern) => pattern.test(url))) {
+      return 'heavy';
+    }
+  }
+
+  // Simple GET requests are typically light
+  if (method === 'GET') {
+    return 'light';
+  }
+
+  // POST/PUT could be anything - default to normal
+  return 'normal';
+}
+
+/**
+ * Infers cost for atomic/connector steps by checking connector type.
+ */
+function inferAtomicStepCost(node: GraphNodeUnion): WorkflowCostTier {
+  // Access connectorTypeId safely
+  const connectorTypeId = (node as { configuration?: { connectorTypeId?: string } }).configuration
+    ?.connectorTypeId;
+
+  if (connectorTypeId && AI_CONNECTOR_TYPES.has(connectorTypeId)) {
+    return 'heavy';
+  }
+
+  return 'normal';
+}
+
+/**
+ * Infers the overall cost tier for a workflow based on its steps.
+ * The workflow cost is determined by the highest-cost step it contains.
+ *
+ * @param workflowDefinition - The workflow definition to analyze
+ * @param stepRegistry - Optional step registry to look up declared step costs
+ * @returns The inferred cost tier for the workflow
+ *
+ * @example
+ * ```typescript
+ * const cost = inferWorkflowCost(workflow.definition, workflowsExtensions);
+ * const taskType = `workflow:run:${cost}`; // e.g., 'workflow:run:heavy'
+ * ```
+ */
+export function inferWorkflowCost(
+  workflowDefinition: WorkflowYaml,
+  stepRegistry?: WorkflowsExtensionsServerPluginStart
+): WorkflowCostTier {
+  let maxCost: WorkflowCostTier = 'light';
+
+  try {
+    const workflowGraph = WorkflowGraph.fromWorkflowDefinition(workflowDefinition);
+    const nodes = workflowGraph.getAllNodes();
+
+    for (const node of nodes) {
+      const nodeCost = inferNodeCost(node, stepRegistry);
+      maxCost = getHigherCost(maxCost, nodeCost);
+
+      // Early exit optimization - if we hit heavy, that's the max
+      if (maxCost === 'heavy') {
+        return 'heavy';
+      }
+    }
+  } catch {
+    // If graph building fails, default to normal cost
+    return 'normal';
+  }
+
+  return maxCost;
+}
+
+/**
+ * Gets the task type name for a given base type and cost tier.
+ *
+ * @param baseType - The base task type (e.g., 'workflow:run')
+ * @param tier - The cost tier
+ * @returns The full task type name (e.g., 'workflow:run:heavy')
+ */
+export function getTaskTypeForCost(baseType: string, tier: WorkflowCostTier): string {
+  return `${baseType}:${tier}`;
+}

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.test.ts
@@ -36,7 +36,7 @@ describe('checkAndSkipIfExistingScheduledExecution', () => {
   ): ConcreteTaskInstance => {
     return {
       id: 'task-id',
-      taskType: 'workflow:scheduled',
+      taskType: 'workflow:scheduled:normal',
       params: { workflowId: workflow.id, spaceId, triggerType: 'scheduled' },
       state: {},
       attempts: 1,

--- a/src/platform/plugins/shared/workflows_extensions/common/index.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/index.ts
@@ -8,4 +8,5 @@
  */
 
 export type { CommonStepDefinition } from './step_registry/types';
+export { StepCost } from './step_registry/types';
 export { DataMapStepTypeId } from './steps/data';

--- a/src/platform/plugins/shared/workflows_extensions/common/step_registry/types.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/step_registry/types.ts
@@ -10,6 +10,33 @@
 import type { z } from '@kbn/zod/v4';
 
 /**
+ * Resource cost tier for workflow steps.
+ * Determines how much Task Manager capacity a workflow containing this step consumes.
+ *
+ * The workflow execution engine uses the highest cost step in a workflow to determine
+ * the overall workflow cost, which affects Task Manager slot allocation.
+ */
+export enum StepCost {
+  /**
+   * Low-cost steps: simple data transforms, quick IO operations.
+   * Examples: data.map, data.dedupe, elasticsearch.search
+   */
+  Light = 'light',
+
+  /**
+   * Default cost: typical API calls, moderate processing.
+   * Examples: HTTP calls to external APIs, webhook notifications
+   */
+  Normal = 'normal',
+
+  /**
+   * High-cost steps: LLM calls, large data processing, memory-intensive operations.
+   * Examples: ai.prompt, ai.summarize, agent.call
+   */
+  Heavy = 'heavy',
+}
+
+/**
  * Common step definition fields shared between server and public.
  * Input and output types are automatically inferred from the schemas.
  */
@@ -44,4 +71,17 @@ export interface CommonStepDefinition<
    * Example: `agent-id` for agent.call step.
    */
   configSchema?: ConfigSchema;
+
+  /**
+   * Resource cost tier for this step type.
+   * Used by the workflow execution engine to determine Task Manager slot allocation
+   * for workflows containing this step.
+   *
+   * - 'light': IO-bound operations, minimal memory (e.g., HTTP GET, ES queries)
+   * - 'normal': Standard operations (default if not specified)
+   * - 'heavy': Memory-intensive or long-running (e.g., LLM calls, large data processing)
+   *
+   * @default StepCost.Normal
+   */
+  cost?: StepCost;
 }

--- a/src/platform/plugins/shared/workflows_extensions/common/steps/ai/ai_classify_step.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/steps/ai/ai_classify_step.ts
@@ -9,6 +9,7 @@
 
 import { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '../../step_registry/types';
+import { StepCost } from '../../step_registry/types';
 
 /**
  * Step type ID for the AI classify step.
@@ -61,6 +62,7 @@ export const AiClassifyStepCommonDefinition: CommonStepDefinition<
   inputSchema: InputSchema,
   outputSchema: OutputSchema,
   configSchema: ConfigSchema,
+  cost: StepCost.Heavy,
 };
 
 /**

--- a/src/platform/plugins/shared/workflows_extensions/common/steps/ai/ai_prompt_step.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/steps/ai/ai_prompt_step.ts
@@ -9,6 +9,7 @@
 
 import { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '../../step_registry/types';
+import { StepCost } from '../../step_registry/types';
 
 /**
  * Step type ID for the AI prompt step.
@@ -51,4 +52,5 @@ export const AiPromptStepCommonDefinition: CommonStepDefinition<
   id: AiPromptStepTypeId,
   inputSchema: InputSchema,
   outputSchema: OutputSchema,
+  cost: StepCost.Heavy,
 };

--- a/src/platform/plugins/shared/workflows_extensions/common/steps/ai/ai_summarize_step.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/steps/ai/ai_summarize_step.ts
@@ -9,6 +9,7 @@
 
 import { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '../../step_registry/types';
+import { StepCost } from '../../step_registry/types';
 
 /**
  * Step type ID for the AI summarize step.
@@ -55,4 +56,5 @@ export const AiSummarizeStepCommonDefinition: CommonStepDefinition<
   inputSchema: InputSchema,
   outputSchema: OutputSchema,
   configSchema: ConfigSchema,
+  cost: StepCost.Heavy,
 };

--- a/src/platform/plugins/shared/workflows_extensions/common/steps/data/data_dedupe_step.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/steps/data/data_dedupe_step.ts
@@ -9,6 +9,7 @@
 
 import { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '../../step_registry/types';
+import { StepCost } from '../../step_registry/types';
 
 export const DataDedupeStepTypeId = 'data.dedupe' as const;
 
@@ -36,4 +37,5 @@ export const dataDedupeStepCommonDefinition: CommonStepDefinition<
   inputSchema: InputSchema,
   outputSchema: OutputSchema,
   configSchema: ConfigSchema,
+  cost: StepCost.Light,
 };

--- a/src/platform/plugins/shared/workflows_extensions/common/steps/data/data_map_step.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/steps/data/data_map_step.ts
@@ -9,6 +9,7 @@
 
 import { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '../../step_registry/types';
+import { StepCost } from '../../step_registry/types';
 
 export const DataMapStepTypeId = 'data.map';
 
@@ -38,4 +39,5 @@ export const dataMapStepCommonDefinition: CommonStepDefinition<
   inputSchema: InputSchema,
   outputSchema: OutputSchema,
   configSchema: ConfigSchema,
+  cost: StepCost.Light,
 };

--- a/src/platform/plugins/shared/workflows_extensions/common/steps/data/data_regex_extract_step.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/steps/data/data_regex_extract_step.ts
@@ -9,6 +9,7 @@
 
 import { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '../../step_registry/types';
+import { StepCost } from '../../step_registry/types';
 
 export const DataRegexExtractStepTypeId = 'data.regex_extract' as const;
 
@@ -42,4 +43,5 @@ export const dataRegexExtractStepCommonDefinition: CommonStepDefinition<
   inputSchema: InputSchema,
   outputSchema: OutputSchema,
   configSchema: ConfigSchema,
+  cost: StepCost.Light,
 };

--- a/src/platform/plugins/shared/workflows_extensions/common/steps/data/data_regex_replace_step.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/steps/data/data_regex_replace_step.ts
@@ -9,6 +9,7 @@
 
 import { z } from '@kbn/zod/v4';
 import type { CommonStepDefinition } from '../../step_registry/types';
+import { StepCost } from '../../step_registry/types';
 
 export const DataRegexReplaceStepTypeId = 'data.regex_replace' as const;
 
@@ -46,4 +47,5 @@ export const dataRegexReplaceStepCommonDefinition: CommonStepDefinition<
   inputSchema: InputSchema,
   outputSchema: OutputSchema,
   configSchema: ConfigSchema,
+  cost: StepCost.Light,
 };

--- a/src/platform/plugins/shared/workflows_management/server/lib/schedule_utils.integration.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/lib/schedule_utils.integration.test.ts
@@ -316,9 +316,10 @@ describe('RRule Scheduling Integration', () => {
       const schedule = convertWorkflowScheduleToTaskSchedule(trigger);
 
       // This is the format that would be passed to TaskManager.schedule()
+      // Note: taskType is now cost-tiered (e.g., workflow:scheduled:normal)
       const taskInstance = {
         id: 'workflow:test-workflow:scheduled',
-        taskType: 'workflow:scheduled',
+        taskType: 'workflow:scheduled:normal',
         schedule,
         params: {
           workflow: {

--- a/src/platform/plugins/shared/workflows_management/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_management/server/plugin.ts
@@ -194,7 +194,11 @@ export class WorkflowsPlugin
     stepSchemas.initialize(plugins.workflowsExtensions);
 
     // Initialize workflow task scheduler with the start contract
-    this.workflowTaskScheduler = new WorkflowTaskScheduler(this.logger, plugins.taskManager);
+    this.workflowTaskScheduler = new WorkflowTaskScheduler(
+      this.logger,
+      plugins.taskManager,
+      plugins.workflowsExtensions
+    );
 
     // Set task scheduler and security service in workflows service
     if (this.workflowsService) {

--- a/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_scheduler.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/tasks/workflow_task_scheduler.test.ts
@@ -12,6 +12,12 @@ import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type { EsWorkflow } from '@kbn/workflows';
 import { WorkflowTaskScheduler } from './workflow_task_scheduler';
 
+// Mock the infer_workflow_cost module
+jest.mock('@kbn/workflows-execution-engine/server/lib/infer_workflow_cost', () => ({
+  inferWorkflowCost: jest.fn().mockReturnValue('normal'),
+  getTaskTypeForCost: jest.fn((baseType: string, tier: string) => `${baseType}:${tier}`),
+}));
+
 // Mock logger
 const mockLogger: Logger = {
   debug: jest.fn(),
@@ -81,10 +87,11 @@ describe('WorkflowTaskScheduler RRule Validation', () => {
       expect(mockTaskManager.schedule).toHaveBeenCalledTimes(1);
 
       // Verify the task instance structure includes workflowid
+      // Note: taskType is now cost-tiered (e.g., workflow:scheduled:normal)
       expect(mockTaskManager.schedule).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 'workflow:test-workflow:scheduled',
-          taskType: 'workflow:scheduled',
+          taskType: 'workflow:scheduled:normal',
           params: expect.objectContaining({
             workflowId: 'test-workflow',
             spaceId: 'default',

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/workflows_management_service.ts
@@ -248,9 +248,28 @@ export class WorkflowsService {
 
     // Schedule the workflow if it has triggers
     if (this.taskScheduler && workflowToCreate.definition?.triggers) {
+      const workflowForScheduling: EsWorkflow = {
+        id,
+        name: workflowData.name,
+        enabled: workflowData.enabled,
+        tags: workflowData.tags,
+        definition: workflowData.definition ?? undefined,
+        yaml: workflowData.yaml,
+        createdBy: workflowData.createdBy,
+        lastUpdatedBy: workflowData.lastUpdatedBy,
+        valid: workflowData.valid,
+        deleted_at: workflowData.deleted_at,
+        createdAt: new Date(workflowData.created_at),
+        lastUpdatedAt: new Date(workflowData.updated_at),
+      };
       for (const trigger of workflowToCreate.definition.triggers) {
         if (trigger.type === 'scheduled') {
-          await this.taskScheduler.scheduleWorkflowTask(id, spaceId, trigger, request);
+          await this.taskScheduler.scheduleWorkflowTask(
+            workflowForScheduling,
+            spaceId,
+            trigger,
+            request
+          );
         }
       }
     }

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts
@@ -260,6 +260,10 @@ export function calculateStartingCapacity(
   logger: Logger,
   defaultCapacity: number
 ): number {
+  // TODO: Remove this override - hardcoded for testing
+  logger.info('Using hardcoded capacity of 40 for testing');
+  return 40;
+
   if (config.capacity !== undefined && config.max_workers !== undefined) {
     logger.warn(
       `Both "xpack.task_manager.capacity" and "xpack.task_manager.max_workers" configs are set, max_workers will be ignored in favor of capacity and the setting should be removed.`

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts
@@ -260,10 +260,6 @@ export function calculateStartingCapacity(
   logger: Logger,
   defaultCapacity: number
 ): number {
-  // TODO: Remove this override - hardcoded for testing
-  logger.info('Using hardcoded capacity of 40 for testing');
-  return 40;
-
   if (config.capacity !== undefined && config.max_workers !== undefined) {
     logger.warn(
       `Both "xpack.task_manager.capacity" and "xpack.task_manager.max_workers" configs are set, max_workers will be ignored in favor of capacity and the setting should be removed.`


### PR DESCRIPTION
### Dynamic Workflow Cost Inference for Scheduled Workflows

Previously, scheduled workflows were registered with a single `workflow:scheduled` task type without any cost information. This meant Task Manager couldn't properly manage capacity for workflows with varying resource requirements.

**Changes:**
- Registered cost-tiered task types for scheduled workflows: `workflow:scheduled:light`, `workflow:scheduled:normal`, `workflow:scheduled:heavy`
- Each tier maps to appropriate `TaskCost` values (Tiny, Normal, ExtraLarge)
- Updated `WorkflowTaskScheduler` to infer workflow cost using `inferWorkflowCost()` when scheduling
- Updated task queries in `unscheduleWorkflowTasks` to search across all cost tier variants
- Added `workflow_cost_tier` label to APM traces for observability
