### PR TITLE
[APM][Scout]  Attempt to fix service_overview_transaction_details.spec test

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_overview/service_overview_transaction_details.spec.ts
+++ b/x-pack/solutions/observability/plugins/apm/test/scout/ui/parallel_tests/service_overview/service_overview_transaction_details.spec.ts
@@ -71,8 +71,10 @@ test.describe('Service Overview - Transaction Details', { tag: ['@ess', '@svlObl
       end: testData.END_DATE,
     });
 
+    const child1Span = page.getByTestId('waterfallItem').filter({ hasText: 'child1' });
+
     await test.step('Verify waterfall item is initially visible', async () => {
-      await expect(page.getByLabel('View details for child1')).toBeVisible({
+      await expect(child1Span).toBeVisible({
         timeout: EXTENDED_TIMEOUT,
       });
     });
@@ -81,16 +83,16 @@ test.describe('Service Overview - Transaction Details', { tag: ['@ess', '@svlObl
       await page.getByTestId('apmWaterfallButton').click();
     });
 
-    await test.step('Verify transaction details flyout is hidden', async () => {
-      await expect(page.getByLabel('View details for child1')).toBeHidden();
+    await test.step('Verify waterfall item is hidden after folding', async () => {
+      await expect(child1Span).toBeHidden();
     });
 
     await test.step('Click on the same waterfall accordion to unfold', async () => {
       await page.getByTestId('apmWaterfallButton').click();
     });
 
-    await test.step('Verify transaction details flyout is visible', async () => {
-      await expect(page.getByLabel('View details for child1')).toBeVisible();
+    await test.step('Verify waterfall item is visible after unfolding', async () => {
+      await expect(child1Span).toBeVisible();
     });
   });
 


### PR DESCRIPTION
fixes https://github.com/elastic/kibana/issues/248315

## Summary

Attempt to fix the flakiness through a safer way of getting the element: `page.getByTestId('waterfallItem').filter({ hasText: 'child1' })`





<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->