### PR TITLE
[Bug][Cases] - Fix syncAlerts

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/cases_context/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/cases_context/index.tsx
@@ -133,6 +133,10 @@ export const CasesProvider: FC<
       permissions.reopenCase,
       permissions.createComment,
       permissions.assign,
+      // Interim bug fix until we refactor this code to avoid passing objects in deps
+      // Need to revisit the re-rendering strategy in general as disabling exhaustive-deps is an anti-pattern
+      features.alerts?.all,
+      features.alerts?.read,
     ]
   );
 


### PR DESCRIPTION
## Summary

This PR resolves this following issue: https://github.com/elastic/kibana/issues/250735 where the syncAlerts toggle disappeared on application refresh. 


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->