### PR TITLE
[One Workflow] Enhance workflow management with alert normalization and data handling

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/moon.yml
+++ b/src/platform/plugins/shared/workflows_execution_engine/moon.yml
@@ -31,6 +31,7 @@ dependsOn:
   - '@kbn/core-data-streams-server'
   - '@kbn/data-streams'
   - '@kbn/es-mappings'
+  - '@kbn/object-utils'
   - '@kbn/workflows-extensions'
   - '@kbn/licensing-plugin'
 tags:

--- a/src/platform/plugins/shared/workflows_execution_engine/server/alert_payload_integration.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/alert_payload_integration.test.ts
@@ -1,0 +1,402 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { unflattenObject } from '@kbn/object-utils';
+import { WorkflowTemplatingEngine } from './templating_engine';
+
+/**
+ * Integration tests for alert payload normalization through the templating engine.
+ *
+ * These tests verify that:
+ * 1. Alert payloads with flat ECS fields are properly normalized
+ * 2. Both new (recommended) dot notation and old (deprecated) bracket notation work
+ * 3. Flat keys are preserved for backward compatibility
+ * 4. Both syntaxes produce the same results
+ *
+ * Related to GitHub issue #250069: Alert Payload Structure Breaking Change in Workflows
+ */
+describe('Alert Payload Integration', () => {
+  let templatingEngine: WorkflowTemplatingEngine;
+
+  beforeEach(() => {
+    templatingEngine = new WorkflowTemplatingEngine();
+  });
+
+  /**
+   * Simulates the normalizeAlert function behavior for testing.
+   * In production, this is done by normalizeAlert() in workflows_management.
+   * This preserves flat keys for backward compatibility.
+   */
+  function createNormalizedAlert(rawAlert: Record<string, unknown>) {
+    const expanded = unflattenObject(rawAlert);
+
+    // Preserve original flat keys for backward compatibility (DEPRECATED)
+    const flatKeys: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(rawAlert)) {
+      if (key.includes('.') && key !== '_id' && key !== '_index') {
+        flatKeys[key] = value;
+      }
+    }
+
+    const kibanaAlert = (expanded.kibana as Record<string, unknown>)?.alert as
+      | Record<string, unknown>
+      | undefined;
+
+    return {
+      ...flatKeys, // Flat keys (deprecated, for backward compat)
+      ...expanded, // Nested structure (new recommended access)
+      id: rawAlert._id,
+      index: rawAlert._index,
+      status: kibanaAlert?.status,
+      severity: kibanaAlert?.severity,
+      reason: kibanaAlert?.reason,
+      rule: kibanaAlert?.rule,
+      _id: rawAlert._id,
+      _index: rawAlert._index,
+    };
+  }
+
+  /**
+   * Creates a realistic raw alert payload as it comes from Elasticsearch.
+   * This uses flat ECS-style field names.
+   */
+  function createRawAlertPayload() {
+    return {
+      _id: '7bdca0df-14a7-4500-9a4e-1732e594ef6b',
+      _index: '.internal.alerts-stack.alerts-default-000002',
+      '@timestamp': '2026-01-21T17:37:03.729Z',
+      'kibana.alert.status': 'active',
+      'kibana.alert.severity': 'high',
+      'kibana.alert.reason': 'Latency threshold exceeded',
+      'kibana.alert.rule.name': 'latency-threshold-alert-critical',
+      'kibana.alert.rule.uuid': '3c515c5a-0f9a-441a-8a0f-e28208ad685a',
+      'kibana.alert.rule.rule_type_id': '.es-query',
+      'kibana.alert.rule.consumer': 'stackAlerts',
+      'kibana.alert.rule.producer': 'stackAlerts',
+      'kibana.alert.rule.tags': ['critical', 'production'],
+      'kibana.alert.rule.parameters': {
+        esQuery: '{"query":{"bool":{"filter":[{"range":{"latency_ms":{"gte":800}}}]}}}',
+        threshold: 800,
+      },
+      'service.name': 'payment-service',
+      'host.name': 'prod-server-01',
+    };
+  }
+
+  /**
+   * Creates a complete event context as it would be passed to workflow execution.
+   */
+  function createAlertEventContext() {
+    const rawAlert = createRawAlertPayload();
+    const normalizedAlert = createNormalizedAlert(rawAlert);
+
+    return {
+      event: {
+        alerts: [normalizedAlert],
+        rule: {
+          id: '3c515c5a-0f9a-441a-8a0f-e28208ad685a',
+          name: 'latency-threshold-alert-critical',
+          tags: ['critical', 'production'],
+          consumer: 'stackAlerts',
+          producer: 'stackAlerts',
+          ruleTypeId: '.es-query',
+        },
+        ruleUrl:
+          'https://kibana.example.com/app/management/insightsAndAlerting/triggersActions/rule/3c515c5a',
+        spaceId: 'default',
+      },
+    };
+  }
+
+  describe('new recommended syntax (dot notation)', () => {
+    it('should access alert id via convenience accessor', () => {
+      const context = createAlertEventContext();
+      const template = '{{ event.alerts[0].id }}';
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('7bdca0df-14a7-4500-9a4e-1732e594ef6b');
+    });
+
+    it('should access alert status via convenience accessor', () => {
+      const context = createAlertEventContext();
+      const template = '{{ event.alerts[0].status }}';
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('active');
+    });
+
+    it('should access rule name via convenience accessor', () => {
+      const context = createAlertEventContext();
+      const template = '{{ event.alerts[0].rule.name }}';
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('latency-threshold-alert-critical');
+    });
+
+    it('should access rule parameters via convenience accessor', () => {
+      const context = createAlertEventContext();
+      const template = '{{ event.alerts[0].rule.parameters.threshold }}';
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('800');
+    });
+
+    it('should access full nested path (kibana.alert.rule.name)', () => {
+      const context = createAlertEventContext();
+      const template = '{{ event.alerts[0].kibana.alert.rule.name }}';
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('latency-threshold-alert-critical');
+    });
+
+    it('should access other ECS fields via nested path', () => {
+      const context = createAlertEventContext();
+      const template =
+        'Service: {{ event.alerts[0].service.name }}, Host: {{ event.alerts[0].host.name }}';
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('Service: payment-service, Host: prod-server-01');
+    });
+
+    it('should access event-level rule information', () => {
+      const context = createAlertEventContext();
+      const template = 'Rule: {{ event.rule.name }} ({{ event.rule.id }})';
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe(
+        'Rule: latency-threshold-alert-critical (3c515c5a-0f9a-441a-8a0f-e28208ad685a)'
+      );
+    });
+  });
+
+  describe('backward compatibility - bracket notation with flat keys', () => {
+    /**
+     * NOTE: For backward compatibility, normalizeAlert preserves original flat keys
+     * alongside the expanded nested structure. This allows old bracket notation
+     * syntax to continue working while users migrate to the new dot notation.
+     *
+     * The old syntax (bracket notation with dotted keys) is DEPRECATED and will
+     * be removed in a future release after customer testing.
+     */
+    it('should work with dotted keys in brackets (backward compatibility)', () => {
+      const context = createAlertEventContext();
+      const template = "{{ event.alerts[0]['kibana.alert.rule.name'] }}";
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('latency-threshold-alert-critical');
+    });
+
+    it('should work with status via bracket notation', () => {
+      const context = createAlertEventContext();
+      const template = "{{ event.alerts[0]['kibana.alert.status'] }}";
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('active');
+    });
+
+    it('should work with severity via bracket notation', () => {
+      const context = createAlertEventContext();
+      const template = "{{ event.alerts[0]['kibana.alert.severity'] }}";
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('high');
+    });
+
+    it('should work with rule uuid via bracket notation', () => {
+      const context = createAlertEventContext();
+      const template = "{{ event.alerts[0]['kibana.alert.rule.uuid'] }}";
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('3c515c5a-0f9a-441a-8a0f-e28208ad685a');
+    });
+
+    it('should work with service name via bracket notation', () => {
+      const context = createAlertEventContext();
+      const template = "{{ event.alerts[0]['service.name'] }}";
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('payment-service');
+    });
+
+    it('should work with simple bracket notation for existing keys', () => {
+      const context = createAlertEventContext();
+      // This works because 'id' is a real key on the normalized alert
+      const template = "{{ event.alerts[0]['id'] }}";
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('7bdca0df-14a7-4500-9a4e-1732e594ef6b');
+    });
+  });
+
+  describe('both syntaxes produce same results', () => {
+    it('should render same value for rule name using both syntaxes', () => {
+      const context = createAlertEventContext();
+
+      // Old syntax (deprecated, but still works for backward compatibility)
+      const oldSyntax = templatingEngine.render(
+        "{{ event.alerts[0]['kibana.alert.rule.name'] }}",
+        context
+      );
+
+      // New syntax (recommended) - Full path:
+      const newSyntaxFull = templatingEngine.render(
+        '{{ event.alerts[0].kibana.alert.rule.name }}',
+        context
+      );
+
+      // New syntax (recommended) - Convenience accessor:
+      const newSyntaxConvenience = templatingEngine.render(
+        '{{ event.alerts[0].rule.name }}',
+        context
+      );
+
+      expect(oldSyntax).toBe('latency-threshold-alert-critical');
+      expect(newSyntaxFull).toBe('latency-threshold-alert-critical');
+      expect(newSyntaxConvenience).toBe('latency-threshold-alert-critical');
+      expect(oldSyntax).toBe(newSyntaxFull);
+      expect(oldSyntax).toBe(newSyntaxConvenience);
+    });
+
+    it('should render same value for status using both syntaxes', () => {
+      const context = createAlertEventContext();
+
+      const oldSyntax = templatingEngine.render(
+        "{{ event.alerts[0]['kibana.alert.status'] }}",
+        context
+      );
+      const newSyntax = templatingEngine.render(
+        '{{ event.alerts[0].kibana.alert.status }}',
+        context
+      );
+      const convenienceSyntax = templatingEngine.render('{{ event.alerts[0].status }}', context);
+
+      expect(oldSyntax).toBe('active');
+      expect(newSyntax).toBe('active');
+      expect(convenienceSyntax).toBe('active');
+      expect(oldSyntax).toBe(newSyntax);
+      expect(oldSyntax).toBe(convenienceSyntax);
+    });
+  });
+
+  describe('complex workflow template scenarios', () => {
+    it('should render a complete alert notification message', () => {
+      const context = createAlertEventContext();
+      const template = `Alert '{{ event.alerts[0].rule.name }}' fired!
+Status: {{ event.alerts[0].status }}
+Severity: {{ event.alerts[0].severity }}
+Service: {{ event.alerts[0].service.name }}
+Host: {{ event.alerts[0].host.name }}
+Alert ID: {{ event.alerts[0].id }}`;
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe(`Alert 'latency-threshold-alert-critical' fired!
+Status: active
+Severity: high
+Service: payment-service
+Host: prod-server-01
+Alert ID: 7bdca0df-14a7-4500-9a4e-1732e594ef6b`);
+    });
+
+    it('should work with json filter for rule parameters', () => {
+      const context = createAlertEventContext();
+      const template = '{{ event.alerts[0].rule.parameters | json }}';
+
+      const result = templatingEngine.render(template, context);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.threshold).toBe(800);
+      expect(parsed.esQuery).toContain('latency_ms');
+    });
+
+    it('should work with json_parse filter for esQuery', () => {
+      const context = createAlertEventContext();
+      const template =
+        '{% assign query = event.alerts[0].rule.parameters.esQuery | json_parse %}{{ query.query.bool.filter[0].range.latency_ms.gte }}';
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('800');
+    });
+
+    it('should access rule tags array', () => {
+      const context = createAlertEventContext();
+      const template = '{{ event.alerts[0].rule.tags | join: ", " }}';
+
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('critical, production');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle missing optional fields gracefully', () => {
+      const rawAlert = {
+        _id: 'test-id',
+        _index: '.alerts-test',
+        'kibana.alert.status': 'active',
+        'kibana.alert.rule.name': 'test-rule',
+        'kibana.alert.rule.uuid': 'test-uuid',
+        // No severity, reason, or other optional fields
+      };
+      const normalizedAlert = createNormalizedAlert(rawAlert);
+      const context = {
+        event: {
+          alerts: [normalizedAlert],
+          rule: { id: 'test-uuid', name: 'test-rule' },
+        },
+      };
+
+      const template =
+        'Status: {{ event.alerts[0].status }}, Severity: {{ event.alerts[0].severity }}';
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('Status: active, Severity: ');
+    });
+
+    it('should handle multiple alerts in the array', () => {
+      const rawAlert1 = {
+        _id: 'alert-1',
+        _index: '.alerts-test',
+        'kibana.alert.status': 'active',
+        'kibana.alert.rule.name': 'rule-1',
+      };
+      const rawAlert2 = {
+        _id: 'alert-2',
+        _index: '.alerts-test',
+        'kibana.alert.status': 'recovered',
+        'kibana.alert.rule.name': 'rule-2',
+      };
+
+      const context = {
+        event: {
+          alerts: [createNormalizedAlert(rawAlert1), createNormalizedAlert(rawAlert2)],
+        },
+      };
+
+      const template = 'First: {{ event.alerts[0].id }}, Second: {{ event.alerts[1].id }}';
+      const result = templatingEngine.render(template, context);
+
+      expect(result).toBe('First: alert-1, Second: alert-2');
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_execution_engine/tsconfig.json
@@ -26,6 +26,7 @@
     "@kbn/core-data-streams-server",
     "@kbn/data-streams",
     "@kbn/es-mappings",
+    "@kbn/object-utils",
     "@kbn/workflows-extensions",
     "@kbn/licensing-plugin",
   ],

--- a/src/platform/plugins/shared/workflows_management/common/types/alert_types.ts
+++ b/src/platform/plugins/shared/workflows_management/common/types/alert_types.ts
@@ -7,8 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { AlertHit } from '@kbn/alerting-plugin/server/types';
-
 export interface AlertSelection {
   _id: string;
   _index: string;
@@ -30,8 +28,66 @@ export interface AlertEventRule {
   ruleTypeId: string;
 }
 
+/**
+ * Represents an alert rule extracted from the nested kibana.alert.rule structure.
+ * This is the convenience accessor available at alert.rule
+ */
+export interface NormalizedAlertRule {
+  uuid?: string;
+  name?: string;
+  tags?: string[];
+  consumer?: string;
+  producer?: string;
+  rule_type_id?: string;
+  parameters?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * A normalized alert document with expanded dotted fields and convenience accessors.
+ *
+ * Raw alerts from Elasticsearch use flat ECS-style field names (e.g., "kibana.alert.rule.name").
+ * This interface represents the normalized structure where:
+ * - Dotted fields are expanded to nested objects (e.g., kibana.alert.rule.name)
+ * - Convenience properties are added at the root level (e.g., id, status, rule)
+ */
+export interface NormalizedAlert {
+  // Convenience accessors for common fields
+  /** Alert ID (same as _id) */
+  id: string;
+  /** Alert index (same as _index) */
+  index: string;
+  /** Alert status from kibana.alert.status */
+  status?: string;
+  /** Alert severity from kibana.alert.severity */
+  severity?: string;
+  /** Alert reason from kibana.alert.reason */
+  reason?: string;
+  /** Rule information from kibana.alert.rule */
+  rule?: NormalizedAlertRule;
+
+  // Original metadata
+  _id: string;
+  _index: string;
+
+  // Expanded nested structure (from unflattenObject)
+  kibana?: {
+    alert?: {
+      status?: string;
+      severity?: string;
+      reason?: string;
+      rule?: NormalizedAlertRule;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+
+  // Allow other fields from the expanded alert
+  [key: string]: unknown;
+}
+
 export interface AlertEvent {
-  alerts: AlertHit[];
+  alerts: NormalizedAlert[];
   rule: AlertEventRule;
   ruleUrl?: string;
   spaceId: string;

--- a/src/platform/plugins/shared/workflows_management/common/utils/build_alert_event.ts
+++ b/src/platform/plugins/shared/workflows_management/common/utils/build_alert_event.ts
@@ -8,12 +8,17 @@
  */
 
 import type { CombinedSummarizedAlerts } from '@kbn/alerting-plugin/server/types';
+import { normalizeAlert } from './normalize_alert';
 import type { AlertEvent, AlertEventRule } from '../types/alert_types';
 
 /**
  * Builds the alert event structure used in workflow execution.
  * This function creates the standardized event format that contains
  * alerts, rule information, and context.
+ *
+ * Each alert is normalized to expand flat ECS-style field names
+ * (e.g., "kibana.alert.rule.name") into nested objects that can be
+ * accessed using dot notation in workflow templates.
  */
 export function buildAlertEvent(params: {
   alerts: CombinedSummarizedAlerts;
@@ -22,7 +27,7 @@ export function buildAlertEvent(params: {
   spaceId: string;
 }): AlertEvent {
   return {
-    alerts: params.alerts.new.data,
+    alerts: params.alerts.new.data.map(normalizeAlert),
     rule: {
       id: params.rule.id,
       name: params.rule.name,

--- a/src/platform/plugins/shared/workflows_management/common/utils/normalize_alert.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/utils/normalize_alert.test.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { normalizeAlert } from './normalize_alert';
+
+describe('normalizeAlert', () => {
+  const createMockAlert = (overrides: Record<string, unknown> = {}) => ({
+    _id: 'test-alert-id',
+    _index: '.internal.alerts-stack.alerts-default-000001',
+    ...overrides,
+  });
+
+  it('should expand dotted field names to nested objects', () => {
+    const alert = createMockAlert({
+      'kibana.alert.status': 'active',
+      'kibana.alert.rule.name': 'test-rule',
+      'kibana.alert.rule.uuid': 'rule-uuid-123',
+    });
+
+    const normalized = normalizeAlert(alert as any);
+
+    // Verify nested structure is created
+    expect(normalized.kibana?.alert?.status).toBe('active');
+    expect(normalized.kibana?.alert?.rule?.name).toBe('test-rule');
+    expect(normalized.kibana?.alert?.rule?.uuid).toBe('rule-uuid-123');
+  });
+
+  it('should add convenience accessors at the root level', () => {
+    const alert = createMockAlert({
+      'kibana.alert.status': 'active',
+      'kibana.alert.severity': 'high',
+      'kibana.alert.reason': 'Threshold exceeded',
+      'kibana.alert.rule.name': 'test-rule',
+      'kibana.alert.rule.uuid': 'rule-uuid-123',
+      'kibana.alert.rule.parameters': { threshold: 100 },
+    });
+
+    const normalized = normalizeAlert(alert as any);
+
+    // Verify convenience accessors
+    expect(normalized.id).toBe('test-alert-id');
+    expect(normalized.index).toBe('.internal.alerts-stack.alerts-default-000001');
+    expect(normalized.status).toBe('active');
+    expect(normalized.severity).toBe('high');
+    expect(normalized.reason).toBe('Threshold exceeded');
+    expect(normalized.rule?.name).toBe('test-rule');
+    expect(normalized.rule?.uuid).toBe('rule-uuid-123');
+    expect(normalized.rule?.parameters).toEqual({ threshold: 100 });
+  });
+
+  it('should handle deeply nested dotted fields', () => {
+    const alert = createMockAlert({
+      'kibana.alert.rule.parameters.esQuery': '{"query":{"bool":{}}}',
+      'service.name': 'payment-service',
+      'host.name': 'server-01',
+    });
+
+    const normalized = normalizeAlert(alert as any);
+
+    // Verify deeply nested fields
+    expect(normalized.kibana?.alert?.rule?.parameters?.esQuery).toBe('{"query":{"bool":{}}}');
+    expect((normalized as Record<string, unknown>).service).toEqual({ name: 'payment-service' });
+    expect((normalized as Record<string, unknown>).host).toEqual({ name: 'server-01' });
+  });
+
+  it('should handle null values in alert fields', () => {
+    const alert = createMockAlert({
+      'kibana.alert.severity': null,
+      'kibana.alert.reason': null,
+    });
+
+    const normalized = normalizeAlert(alert as any);
+
+    expect(normalized.kibana?.alert?.severity).toBeNull();
+    expect(normalized.kibana?.alert?.reason).toBeNull();
+  });
+
+  it('should handle arrays in alert fields', () => {
+    const alert = createMockAlert({
+      'kibana.alert.rule.tags': ['critical', 'production'],
+    });
+
+    const normalized = normalizeAlert(alert as any);
+
+    expect(normalized.kibana?.alert?.rule?.tags).toEqual(['critical', 'production']);
+    expect(normalized.rule?.tags).toEqual(['critical', 'production']);
+  });
+
+  it('should handle a realistic ES query alert payload', () => {
+    const alert = createMockAlert({
+      _id: '7bdca0df-14a7-4500-9a4e-1732e594ef6b',
+      _index: '.internal.alerts-stack.alerts-default-000002',
+      'kibana.alert.status': 'active',
+      'kibana.alert.rule.name': 'latency-threshold-alert-critical',
+      'kibana.alert.rule.uuid': '3c515c5a-0f9a-441a-8a0f-e28208ad685a',
+      'kibana.alert.rule.rule_type_id': '.es-query',
+      'kibana.alert.rule.consumer': 'stackAlerts',
+      'kibana.alert.rule.producer': 'stackAlerts',
+      'kibana.alert.rule.tags': ['critical'],
+      'kibana.alert.rule.parameters': {
+        esQuery: '{"query":{"bool":{"filter":[{"range":{"latency_ms":{"gte":800}}}]}}}',
+      },
+      '@timestamp': '2026-01-21T17:37:03.729Z',
+    });
+
+    const normalized = normalizeAlert(alert as any);
+
+    // Test the access patterns from the GitHub issue
+    expect(normalized.id).toBe('7bdca0df-14a7-4500-9a4e-1732e594ef6b');
+    expect(normalized.rule?.name).toBe('latency-threshold-alert-critical');
+    expect(normalized.rule?.parameters?.esQuery).toBe(
+      '{"query":{"bool":{"filter":[{"range":{"latency_ms":{"gte":800}}}]}}}'
+    );
+
+    // Also verify the full nested path works
+    expect(normalized.kibana?.alert?.rule?.name).toBe('latency-threshold-alert-critical');
+    expect(normalized.kibana?.alert?.status).toBe('active');
+  });
+
+  it('should handle alerts without kibana.alert fields gracefully', () => {
+    const alert = createMockAlert({
+      'some.other.field': 'value',
+    });
+
+    const normalized = normalizeAlert(alert as any);
+
+    // Should not throw, convenience accessors should be undefined
+    expect(normalized.id).toBe('test-alert-id');
+    expect(normalized.status).toBeUndefined();
+    expect(normalized.rule).toBeUndefined();
+    expect((normalized as Record<string, unknown>).some).toEqual({ other: { field: 'value' } });
+  });
+
+  describe('backward compatibility - flat keys preservation', () => {
+    it('should preserve original flat keys for backward compatibility', () => {
+      const alert = createMockAlert({
+        'kibana.alert.status': 'active',
+        'kibana.alert.rule.name': 'test-rule',
+        'kibana.alert.rule.uuid': 'rule-uuid-123',
+        'service.name': 'payment-service',
+      });
+
+      const normalized = normalizeAlert(alert as any);
+
+      // Verify flat keys are preserved (for old bracket notation syntax)
+      expect((normalized as Record<string, unknown>)['kibana.alert.status']).toBe('active');
+      expect((normalized as Record<string, unknown>)['kibana.alert.rule.name']).toBe('test-rule');
+      expect((normalized as Record<string, unknown>)['kibana.alert.rule.uuid']).toBe(
+        'rule-uuid-123'
+      );
+      expect((normalized as Record<string, unknown>)['service.name']).toBe('payment-service');
+    });
+
+    it('should preserve flat keys alongside nested structure', () => {
+      const alert = createMockAlert({
+        'kibana.alert.rule.name': 'test-rule',
+      });
+
+      const normalized = normalizeAlert(alert as any);
+
+      // Both access patterns should work:
+      // 1. Old syntax (flat key) - for backward compatibility
+      expect((normalized as Record<string, unknown>)['kibana.alert.rule.name']).toBe('test-rule');
+      // 2. New syntax (nested) - recommended
+      expect(normalized.kibana?.alert?.rule?.name).toBe('test-rule');
+      // 3. Convenience accessor
+      expect(normalized.rule?.name).toBe('test-rule');
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/common/utils/normalize_alert.ts
+++ b/src/platform/plugins/shared/workflows_management/common/utils/normalize_alert.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { AlertHit } from '@kbn/alerting-plugin/server/types';
+import { unflattenObject } from '@kbn/object-utils';
+import type { NormalizedAlert } from '../types/alert_types';
+
+/**
+ * Normalizes an alert document for workflow consumption.
+ *
+ * This function transforms raw alert documents from Elasticsearch (which use
+ * flat ECS-style field names like "kibana.alert.rule.name") into a nested
+ * object structure that can be accessed using dot notation in workflow templates.
+ *
+ * For backward compatibility, it preserves the original flat keys alongside
+ * the expanded nested structure, allowing both old bracket notation and new
+ * dot notation to work in Liquid templates.
+ *
+ * It also adds convenience properties at the root level for commonly accessed fields.
+ *
+ * @example
+ * // Input (raw alert):
+ * {
+ *   "_id": "abc123",
+ *   "_index": ".internal.alerts-...",
+ *   "kibana.alert.rule.name": "my-rule",
+ *   "kibana.alert.status": "active"
+ * }
+ *
+ * // Output (normalized):
+ * {
+ *   "_id": "abc123",
+ *   "_index": ".internal.alerts-...",
+ *   "kibana.alert.rule.name": "my-rule",  // Preserved flat key (deprecated, for backward compat)
+ *   "kibana.alert.status": "active",       // Preserved flat key (deprecated, for backward compat)
+ *   "id": "abc123",                        // convenience accessor
+ *   "status": "active",                     // convenience accessor
+ *   "rule": { name: "my-rule", ... },      // convenience accessor
+ *   "kibana": {
+ *     "alert": {
+ *       "rule": { "name": "my-rule" },     // Nested structure (new recommended access)
+ *       "status": "active"
+ *     }
+ *   }
+ * }
+ */
+export function normalizeAlert(alert: AlertHit): NormalizedAlert {
+  // Expand dotted fields to nested structure
+  const expanded = unflattenObject(alert as Record<string, unknown>) as Record<string, unknown>;
+
+  // Preserve original flat keys for backward compatibility (DEPRECATED)
+  // This allows {{ alert['kibana.alert.rule.name'] }} to still work in Liquid templates
+  const flatKeys: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(alert)) {
+    // Preserve keys that contain dots (ECS-style flat field names)
+    // Skip _id and _index as they're handled separately
+    if (key.includes('.') && key !== '_id' && key !== '_index') {
+      flatKeys[key] = value;
+    }
+  }
+
+  // Extract nested alert properties for convenience accessors
+  const kibanaAlert = (expanded.kibana as Record<string, unknown>)?.alert as
+    | Record<string, unknown>
+    | undefined;
+
+  // Combine flat keys (for backward compat), expanded structure (for new syntax),
+  // and convenience accessors
+  return {
+    ...flatKeys, // Flat keys (deprecated, for backward compat)
+    ...expanded, // Nested structure (new recommended access)
+    // Convenience properties for common access patterns
+    id: alert._id,
+    index: alert._index,
+    status: kibanaAlert?.status as string | undefined,
+    severity: kibanaAlert?.severity as string | undefined,
+    reason: kibanaAlert?.reason as string | undefined,
+    rule: kibanaAlert?.rule as NormalizedAlert['rule'],
+    // Preserve original metadata
+    _id: alert._id,
+    _index: alert._index,
+  } as NormalizedAlert;
+}

--- a/src/platform/plugins/shared/workflows_management/common/utils/normalize_data.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/utils/normalize_data.test.ts
@@ -1,0 +1,202 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { normalizeData } from './normalize_data';
+
+describe('normalizeData', () => {
+  it('should expand dotted field names to nested objects', () => {
+    const data = {
+      'kibana.alert.status': 'active',
+      'kibana.alert.rule.name': 'test-rule',
+      'kibana.alert.rule.uuid': 'rule-uuid-123',
+    };
+
+    const normalized = normalizeData(data);
+
+    // Verify nested structure is created
+    expect((normalized as Record<string, unknown>).kibana).toBeDefined();
+    expect(
+      ((normalized as Record<string, unknown>).kibana as Record<string, unknown>)?.alert
+    ).toBeDefined();
+    expect(
+      (
+        ((normalized as Record<string, unknown>).kibana as Record<string, unknown>)
+          ?.alert as Record<string, unknown>
+      )?.status
+    ).toBe('active');
+    expect(
+      (
+        (
+          ((normalized as Record<string, unknown>).kibana as Record<string, unknown>)
+            ?.alert as Record<string, unknown>
+        )?.rule as Record<string, unknown>
+      )?.name
+    ).toBe('test-rule');
+  });
+
+  it('should preserve original flat keys for backward compatibility', () => {
+    const data = {
+      'kibana.alert.status': 'active',
+      'kibana.alert.rule.name': 'test-rule',
+      'service.name': 'payment-service',
+    };
+
+    const normalized = normalizeData(data);
+
+    // Verify flat keys are preserved
+    expect((normalized as Record<string, unknown>)['kibana.alert.status']).toBe('active');
+    expect((normalized as Record<string, unknown>)['kibana.alert.rule.name']).toBe('test-rule');
+    expect((normalized as Record<string, unknown>)['service.name']).toBe('payment-service');
+  });
+
+  it('should preserve flat keys alongside nested structure', () => {
+    const data = {
+      'kibana.alert.rule.name': 'test-rule',
+    };
+
+    const normalized = normalizeData(data);
+
+    // Both access patterns should work:
+    // 1. Old syntax (flat key) - for backward compatibility
+    expect((normalized as Record<string, unknown>)['kibana.alert.rule.name']).toBe('test-rule');
+    // 2. New syntax (nested) - recommended
+    expect(
+      (
+        (
+          ((normalized as Record<string, unknown>).kibana as Record<string, unknown>)
+            ?.alert as Record<string, unknown>
+        )?.rule as Record<string, unknown>
+      )?.name
+    ).toBe('test-rule');
+  });
+
+  it('should not preserve _id and _index as flat keys (handled separately)', () => {
+    const data = {
+      _id: 'test-id',
+      _index: '.alerts-test',
+      'kibana.alert.status': 'active',
+    };
+
+    const normalized = normalizeData(data);
+
+    // _id and _index should be preserved but not as flat keys
+    expect((normalized as Record<string, unknown>)._id).toBe('test-id');
+    expect((normalized as Record<string, unknown>)._index).toBe('.alerts-test');
+
+    // But they shouldn't be duplicated as flat keys
+    // eslint-disable-next-line dot-notation
+    expect((normalized as Record<string, unknown>)['_id']).toBe('test-id');
+    // eslint-disable-next-line dot-notation
+    expect((normalized as Record<string, unknown>)['_index']).toBe('.alerts-test');
+  });
+
+  it('should handle arrays recursively', () => {
+    const data = {
+      items: [
+        {
+          'service.name': 'service-1',
+          'host.name': 'host-1',
+        },
+        {
+          'service.name': 'service-2',
+          'host.name': 'host-2',
+        },
+      ],
+    };
+
+    const normalized = normalizeData(data);
+
+    const items = (normalized as Record<string, unknown>).items as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(2);
+
+    // First item
+    expect(items[0]['service.name']).toBe('service-1');
+    expect((items[0].service as Record<string, unknown>)?.name).toBe('service-1');
+    expect(items[0]['host.name']).toBe('host-1');
+    expect((items[0].host as Record<string, unknown>)?.name).toBe('host-1');
+
+    // Second item
+    expect(items[1]['service.name']).toBe('service-2');
+    expect((items[1].service as Record<string, unknown>)?.name).toBe('service-2');
+  });
+
+  it('should handle nested objects recursively', () => {
+    const data = {
+      event: {
+        'kibana.alert.status': 'active',
+        'kibana.alert.rule.name': 'test-rule',
+        nested: {
+          'service.name': 'payment-service',
+        },
+      },
+    };
+
+    const normalized = normalizeData(data);
+
+    const event = (normalized as Record<string, unknown>).event as Record<string, unknown>;
+    expect(event['kibana.alert.status']).toBe('active');
+    expect((event.kibana as Record<string, unknown>)?.alert).toBeDefined();
+
+    const nested = event.nested as Record<string, unknown>;
+    expect(nested['service.name']).toBe('payment-service');
+    expect((nested.service as Record<string, unknown>)?.name).toBe('payment-service');
+  });
+
+  it('should handle objects without dotted keys', () => {
+    const data = {
+      name: 'test',
+      value: 123,
+      nested: {
+        foo: 'bar',
+      },
+    };
+
+    const normalized = normalizeData(data);
+
+    expect((normalized as Record<string, unknown>).name).toBe('test');
+    expect((normalized as Record<string, unknown>).value).toBe(123);
+    expect(((normalized as Record<string, unknown>).nested as Record<string, unknown>)?.foo).toBe(
+      'bar'
+    );
+  });
+
+  it('should handle empty objects', () => {
+    const data = {};
+
+    const normalized = normalizeData(data);
+
+    expect(Object.keys(normalized)).toHaveLength(0);
+  });
+
+  it('should handle mixed flat and nested keys', () => {
+    const data = {
+      'kibana.alert.status': 'active',
+      regularKey: 'value',
+      nested: {
+        'service.name': 'payment-service',
+        regularNestedKey: 'nested-value',
+      },
+    };
+
+    const normalized = normalizeData(data);
+
+    // Flat keys preserved
+    expect((normalized as Record<string, unknown>)['kibana.alert.status']).toBe('active');
+    expect((normalized as Record<string, unknown>).regularKey).toBe('value');
+
+    // Nested structure created
+    expect((normalized as Record<string, unknown>).kibana).toBeDefined();
+
+    // Nested object also normalized
+    const nested = (normalized as Record<string, unknown>).nested as Record<string, unknown>;
+    expect(nested['service.name']).toBe('payment-service');
+    expect((nested.service as Record<string, unknown>)?.name).toBe('payment-service');
+    expect(nested.regularNestedKey).toBe('nested-value');
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/common/utils/normalize_data.ts
+++ b/src/platform/plugins/shared/workflows_management/common/utils/normalize_data.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { unflattenObject } from '@kbn/object-utils';
+
+/**
+ * Normalizes any object with flat ECS-style field names into nested structure.
+ * Preserves original flat keys for backward compatibility.
+ *
+ * Similar to normalizeAlert but works on any object structure.
+ * This function:
+ * 1. Expands dotted fields (e.g., "kibana.alert.rule.name") into nested objects
+ * 2. Preserves original flat keys alongside the expanded structure
+ * 3. Works recursively on nested objects and arrays
+ *
+ * @example
+ * // Input:
+ * {
+ *   "kibana.alert.rule.name": "test-rule",
+ *   "service.name": "payment-service"
+ * }
+ *
+ * // Output:
+ * {
+ *   "kibana.alert.rule.name": "test-rule",  // Preserved flat key
+ *   "service.name": "payment-service",       // Preserved flat key
+ *   "kibana": {
+ *     "alert": {
+ *       "rule": { "name": "test-rule" }      // Nested structure
+ *     }
+ *   },
+ *   "service": {
+ *     "name": "payment-service"              // Nested structure
+ *   }
+ * }
+ */
+export function normalizeData<T extends Record<string, unknown>>(data: T): T {
+  /**
+   * Checks if a value is a plain object (not null, not array, is object)
+   */
+  function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+  }
+  // Helper to recursively merge flat keys from original with unflattened structure
+  function mergeFlatKeys(
+    original: Record<string, unknown>,
+    unflattenedObj: Record<string, unknown>
+  ): Record<string, unknown> {
+    // Extract flat keys at current level
+    const flatKeys: Record<string, unknown> = {};
+    for (const key of Object.keys(original)) {
+      if (key.includes('.') && key !== '_id' && key !== '_index') {
+        flatKeys[key] = original[key];
+      }
+    }
+
+    // Merge unflattened structure, recursively handling nested objects and arrays
+    const merged = { ...flatKeys, ...unflattenedObj };
+    for (const key of Object.keys(unflattenedObj)) {
+      const originalValue = original[key];
+      const unflattenedValue = unflattenedObj[key];
+
+      if (isPlainObject(originalValue) && isPlainObject(unflattenedValue)) {
+        // Recursively merge nested objects
+        merged[key] = mergeFlatKeys(originalValue, unflattenedValue);
+      } else if (Array.isArray(originalValue) && Array.isArray(unflattenedValue)) {
+        // Recursively merge arrays
+        merged[key] = originalValue.map((item, index) => {
+          const unflattenedItem = unflattenedValue[index];
+          if (isPlainObject(item) && isPlainObject(unflattenedItem)) {
+            return mergeFlatKeys(item, unflattenedItem);
+          }
+          return unflattenedItem;
+        });
+      }
+    }
+
+    return merged;
+  }
+
+  // Recursively unflatten the entire structure
+  // Note: unflattenObject doesn't mutate the source, it only reads from it
+  const unflattened = unflattenObject(data) as Record<string, unknown>;
+  return mergeFlatKeys(data, unflattened) as T;
+}

--- a/src/platform/plugins/shared/workflows_management/moon.yml
+++ b/src/platform/plugins/shared/workflows_management/moon.yml
@@ -82,6 +82,7 @@ dependsOn:
   - '@kbn/shared-ux-utility'
   - '@kbn/licensing-types'
   - '@kbn/core-lifecycle-server-mocks'
+  - '@kbn/object-utils'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/model/use_workflow_actions.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/model/use_workflow_actions.ts
@@ -172,8 +172,12 @@ export function useWorkflowActions() {
   >({
     mutationKey: ['POST', 'workflows', 'id', 'run'],
     mutationFn: ({ id, inputs }) => {
+      const { _normalizeData, ...actualInputs } = inputs;
       return http.post(`/api/workflows/${id}/run`, {
-        body: JSON.stringify({ inputs }),
+        body: JSON.stringify({
+          inputs: actualInputs,
+          normalizeData: _normalizeData,
+        }),
       });
     },
     onSuccess: (_, { id }) => {

--- a/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/test_workflow_thunk.ts
+++ b/src/platform/plugins/shared/workflows_management/public/entities/workflows/store/workflow_detail/thunks/test_workflow_thunk.ts
@@ -37,15 +37,19 @@ export const testWorkflowThunk = createAsyncThunk<
         return rejectWithValue('No YAML content to test');
       }
 
+      const { _normalizeData, ...actualInputs } = inputs;
       const requestBody: Record<string, unknown> = {
         workflowYaml: yamlString,
-        inputs,
+        inputs: actualInputs,
       };
 
       if (workflow?.id) {
         requestBody.workflowId = workflow.id;
       }
 
+      if (_normalizeData !== undefined) {
+        requestBody.normalizeData = _normalizeData;
+      }
       // Make the API call to test the workflow
       const response = await http.post<TestWorkflowResponse>(`/api/workflows/test`, {
         body: JSON.stringify(requestBody),

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_manual_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_manual_form.tsx
@@ -306,7 +306,7 @@ export const WorkflowExecuteManualForm = ({
             <EuiToolTip
               content={i18n.translate('workflows.workflowExecuteManualForm.normalizeDataTooltip', {
                 defaultMessage:
-                  'When enabled, workflow engine will expands flat ECS-style field names (e.g., "kibana.alert.rule.name") into nested objects while preserving original flat keys for backward compatibility.',
+                  'When enabled, workflow engine will expand flat ECS-style field names (e.g., "kibana.alert.rule.name") into nested objects while preserving original flat keys for backward compatibility.',
               })}
             >
               <EuiFlexGroup gutterSize="xs" alignItems="center">

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -75,13 +75,15 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
       selectedTrigger,
     });
     const [executionInputErrors, setExecutionInputErrors] = useState<string | null>(null);
+    const [normalizeDataEnabled, setNormalizeDataEnabled] = useState(false);
 
     const { euiTheme } = useEuiTheme();
 
     const handleSubmit = useCallback(() => {
-      onSubmit(JSON.parse(executionInput));
+      const inputs = JSON.parse(executionInput);
+      onSubmit({ ...inputs, _normalizeData: normalizeDataEnabled });
       onClose();
-    }, [onSubmit, onClose, executionInput]);
+    }, [onSubmit, onClose, executionInput, normalizeDataEnabled]);
 
     const handleChangeTrigger = useCallback(
       (trigger: TriggerType): void => {
@@ -168,6 +170,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
         the modal and its overlay don't block it.
       */}
         <Global
+          // eslint-disable-next-line @elastic/eui/no-static-z-index
           styles={css`
             .euiOverlayMask:has(.workflowExecuteModal) {
               z-index: 4000;
@@ -270,6 +273,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
                 errors={executionInputErrors}
                 setErrors={setExecutionInputErrors}
                 setValue={setExecutionInput}
+                onNormalizeDataChange={setNormalizeDataEnabled}
               />
             )}
             {selectedTrigger === 'index' && (

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -77,7 +77,8 @@
     "@kbn/alerts-as-data-utils",
     "@kbn/shared-ux-utility",
     "@kbn/licensing-types",
-    "@kbn/core-lifecycle-server-mocks"
+    "@kbn/core-lifecycle-server-mocks",
+    "@kbn/object-utils"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_extraction.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/entity_extraction.spec.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-security/api';
-import { apiTest } from '@kbn/scout-security';
+import { apiTest, expect } from '@kbn/scout-security/api';
 import { COMMON_HEADERS, ENTITY_STORE_ROUTES, ENTITY_STORE_TAGS } from '../fixtures/constants';
 import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
 

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/install.spec.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-security/api';
-import { apiTest } from '@kbn/scout-security';
+import { apiTest, expect } from '@kbn/scout-security/api';
 import { COMMON_HEADERS, ENTITY_STORE_ROUTES, ENTITY_STORE_TAGS } from '../fixtures/constants';
 import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
 


### PR DESCRIPTION
closes: https://github.com/elastic/kibana/issues/250069

Alerts now automatically normalized to nested structure. For backward compatibility original dot-notated fields are still stay in input data. Manual execution UI now allows users to enable data normalisation.


https://github.com/user-attachments/assets/69ab6b6d-8005-452b-b3e2-49708add1bde

Implementation details:

- Added `NormalizedAlert` and `NormalizedAlertRule` interfaces to improve alert data structure.
- Updated `buildAlertEvent` to normalize alerts, expanding ECS-style field names into nested objects.
- Introduced normalization flag in workflow execution and testing routes to control data normalization.
- Enhanced UI components to support normalization toggle for manual workflow execution.
- Included `@kbn/object-utils` in TypeScript configuration for better utility access.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



