### PR TITLE
[SharedUX] Enforce tours and feedback enablement check for obs-ai

### DIFF
--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.test.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.test.tsx
@@ -35,23 +35,20 @@ jest.mock('@kbn/ai-assistant/src/hooks', () => ({
   }),
 }));
 
-jest.mock('@kbn/kibana-react-plugin/public', () => ({
-  useKibana: () => ({
-    services: {
-      notifications: {
-        toasts: {
-          addSuccess: jest.fn(),
-          addError: jest.fn(),
-          addWarning: jest.fn(),
-          addInfo: jest.fn(),
+jest.mock('@kbn/kibana-react-plugin/public', () => {
+  const { notificationServiceMock } = jest.requireActual('@kbn/core/public/mocks');
+
+  return {
+    useKibana: () => ({
+      services: {
+        notifications: notificationServiceMock.createStartContract(),
+        overlays: {
+          openConfirm: jest.fn(() => Promise.resolve(true)),
         },
       },
-      overlays: {
-        openConfirm: jest.fn(() => Promise.resolve(true)),
-      },
-    },
-  }),
-}));
+    }),
+  };
+});
 
 const mockSetEisKnowledgeBaseCalloutDismissed = jest.fn();
 

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/buttons/feedback_buttons.tsx
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/buttons/feedback_buttons.tsx
@@ -23,6 +23,7 @@ const THANK_YOU_MESSAGE = i18n.translate(
 
 export function FeedbackButtons({ onClickFeedback }: FeedbackButtonsProps) {
   const { notifications } = useKibana().services;
+  const isFeedbackEnabled = notifications.feedback.isEnabled();
 
   const [hasBeenClicked, setHasBeenClicked] = useState(false);
 
@@ -37,6 +38,8 @@ export function FeedbackButtons({ onClickFeedback }: FeedbackButtonsProps) {
     setHasBeenClicked(true);
     notifications.toasts.addSuccess(THANK_YOU_MESSAGE);
   };
+
+  if (!isFeedbackEnabled) return null;
 
   return (
     <EuiFlexGroup responsive={false} direction="row" alignItems="center" gutterSize="s" wrap>

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/tour_callout/tour_callout.tsx
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/tour_callout/tour_callout.tsx
@@ -10,6 +10,7 @@ import React, { useEffect, useState } from 'react';
 import type { EuiTourStepProps } from '@elastic/eui';
 import { EuiButtonEmpty, EuiText, EuiTourStep } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { useKibana } from '../../hooks/use_kibana';
 
 interface TourCalloutBaseProps
   extends Pick<
@@ -59,6 +60,9 @@ export const TourCallout = ({
   footerAction,
   ...rest
 }: TourCalloutProps) => {
+  const { notifications } = useKibana().services;
+  const isTourEnabled = notifications.tours.isEnabled();
+
   const [isStepOpen, setIsStepOpen] = useState<boolean>(false);
 
   const handleFinish = () => {
@@ -85,6 +89,8 @@ export const TourCallout = ({
       }
     };
   }, [isOpen]);
+
+  if (!isTourEnabled) return <>{children}</>;
 
   return (
     <EuiTourStep

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/tour_callout/tour_callout.tsx
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/tour_callout/tour_callout.tsx
@@ -61,7 +61,7 @@ export const TourCallout = ({
   ...rest
 }: TourCalloutProps) => {
   const { notifications } = useKibana().services;
-  const isTourEnabled = notifications.tours.isEnabled();
+  const isTourEnabled = notifications?.tours?.isEnabled() ?? true;
 
   const [isStepOpen, setIsStepOpen] = useState<boolean>(false);
 


### PR DESCRIPTION
## Summary

As part of [[Epic] Setting to disable feedback snippets, guided tours and announcements in Kibana](https://github.com/elastic/kibana/issues/234771) SharedUX has added two new `core.notifications` services for `feedback` and `tours`. Their `isEnabled()` API verifies if users should be shown that kind of elements by reading their preferences from global UI settings (`hideFeedback` and `hideAnnouncements`).

From now on, every feedback or tour component should call `isEnabled()` before rendering to honor user preferences. 

> [!IMPORTANT]
SharedUX will be opening PRs for existing occurrences per team. Each team should manually test their PR to verify toggling those settings results in the expected behavior. If your team owns more `feedback` or `tours` occurrences or are planning on doing so, this check needs to be added to honor user preferences.
>  

### Testing

**Feedback elements**
- This is a read-only setting, you need to override it via `kibana.dev.yml` with `uiSettings.globalOverrides.hideFeedback: true`.
- Verify changing the setting value hides/render the element as expected.

**Tours/announcements elements**
- Toggle either the deprecated `hideAnnouncements` space setting or the global one on the Stack Management > Advanced Settings UI.
- Verify toggling the setting hides/render the element as expected.

Related PR: [[SharedUX] Add feedback and tours to core notifications](https://github.com/elastic/kibana/pull/248248)