### PR TITLE
[8.19] [CI] Increase all defend workflows step timeouts to 75m (#249523)

### DIFF
--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -260,7 +260,7 @@ steps:
           machineType: n2-standard-4
           diskSizeGb: 105
         depends_on: build
-        timeout_in_minutes: 60
+        timeout_in_minutes: 75
         parallelism: 12
         retry:
           automatic:

--- a/.buildkite/pipelines/pointer_compression.yml
+++ b/.buildkite/pipelines/pointer_compression.yml
@@ -408,7 +408,7 @@ steps:
       diskSizeGb: 105
     depends_on:
       - build
-    timeout_in_minutes: 60
+    timeout_in_minutes: 75
     parallelism: 20
     retry:
       automatic:
@@ -426,7 +426,7 @@ steps:
       diskSizeGb: 105
     depends_on:
       - build
-    timeout_in_minutes: 60
+    timeout_in_minutes: 75
     parallelism: 14
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -12,7 +12,7 @@ steps:
       - linting_with_types
       - check_types
       - check_oas_snapshot
-    timeout_in_minutes: 60
+    timeout_in_minutes: 75
     soft_fail: true
     parallelism: 1
     retry:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] Increase all defend workflows step timeouts to 75m (#249523)](https://github.com/elastic/kibana/pull/249523)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-01-20T15:28:34Z","message":"[CI] Increase all defend workflows step timeouts to 75m (#249523)\n\n## Summary\nNow that some suites are unskipped, we see an occasional timeout at 60m.\nIn many pipelines these jobs run with 75m, but secondary pipelines\nrunning these steps were still on the previous 60m value. This PR bumps\nall uses of the pipelines to 75m.","sha":"04399672fe4a7ee25d2342afd67cb982b73e250d","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport missing","Team:Defend Workflows","backport:all-open","v9.4.0"],"title":"[CI] Increase all defend workflows step timeouts to 75m","number":249523,"url":"https://github.com/elastic/kibana/pull/249523","mergeCommit":{"message":"[CI] Increase all defend workflows step timeouts to 75m (#249523)\n\n## Summary\nNow that some suites are unskipped, we see an occasional timeout at 60m.\nIn many pipelines these jobs run with 75m, but secondary pipelines\nrunning these steps were still on the previous 60m value. This PR bumps\nall uses of the pipelines to 75m.","sha":"04399672fe4a7ee25d2342afd67cb982b73e250d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249523","number":249523,"mergeCommit":{"message":"[CI] Increase all defend workflows step timeouts to 75m (#249523)\n\n## Summary\nNow that some suites are unskipped, we see an occasional timeout at 60m.\nIn many pipelines these jobs run with 75m, but secondary pipelines\nrunning these steps were still on the previous 60m value. This PR bumps\nall uses of the pipelines to 75m.","sha":"04399672fe4a7ee25d2342afd67cb982b73e250d"}}]}] BACKPORT-->