### PR TITLE
[Streams][SigEvents] Handle empty results in ES|QL rule execution

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/rules/esql/executor.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/rules/esql/executor.ts
@@ -53,6 +53,14 @@ export async function getRuleExecutor(
     logger,
   });
 
+  if (results.length === 0) {
+    return {
+      state: {
+        previousOriginalDocumentIds: [],
+      },
+    };
+  }
+
   const alertDocIdToDocumentIdMap = new Map<string, string>();
   const alerts = results.map((result) => {
     const alertDocId = objectHash([result._id, rule.id, spaceId]);

--- a/x-pack/platform/plugins/shared/streams/server/lib/rules/esql/lib/execute_esql_request.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/rules/esql/lib/execute_esql_request.ts
@@ -38,7 +38,7 @@ export const executeEsqlRequest = async ({
     ];
 
     if (sourceIndex === -1 || idIndex === -1) {
-      throw new Error('Invalid ES|QL response format: missing _source or _id column');
+      return [];
     }
 
     const results = values.map((row) => ({


### PR DESCRIPTION
## Summary

Fixes ES|QL rule execution to gracefully handle cases where no documents match the query, instead of throwing an error.

## Problem

When an ES|QL rule query returns no matching documents, the response doesn't contain `_source` or `_id` columns. Previously, this caused the execution to throw an error:

`
Error: Invalid ES|QL response format: missing source or _id column
`

This is not an actual error condition, it simply means the query didn't match any documents.


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->