### PR TITLE
[@kbn/scout-{oblt,search,security}] Update Solutions API tests to use API `expect`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2722,6 +2722,13 @@ module.exports = {
       },
     },
     {
+      // Ensure correct expect import path in solutions scout API tests
+      files: ['x-pack/solutions/**/plugins/**/test/scout/api/**/*.ts'],
+      rules: {
+        '@kbn/eslint/scout_expect_import': 'error',
+      },
+    },
+    {
       // Deployment-agnostic test files must use proper context and services
       files: [
         'x-pack/platform/test/api_integration_deployment_agnostic/apis/**/*.{js,ts}',

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -29,6 +29,7 @@ module.exports = {
     scout_require_api_client_in_api_test: require('./rules/scout_require_api_client_in_api_test'),
     scout_require_global_setup_hook_in_parallel_tests: require('./rules/scout_require_global_setup_hook_in_parallel_tests'),
     scout_no_es_archiver_in_parallel_tests: require('./rules/scout_no_es_archiver_in_parallel_tests'),
+    scout_expect_import: require('./rules/scout_expect_import'),
     require_kbn_fs: require('./rules/require_kbn_fs'),
     require_include_in_check_a11y: require('./rules/require_include_in_check_a11y'),
     no_wrapped_error_in_logger: require('./rules/no_wrapped_error_in_logger'),

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_expect_import.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_expect_import.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+/** @typedef {import("@typescript-eslint/typescript-estree").TSESTree.ImportDeclaration} ImportDeclaration */
+
+const SOLUTION_PACKAGES = {
+  observability: '@kbn/scout-oblt',
+  search: '@kbn/scout-search',
+  security: '@kbn/scout-security',
+};
+
+/**
+ * Determines the test type (api/ui) based on file path.
+ * @param {string} filePath
+ * @returns {'api' | 'ui' | null}
+ */
+const getTestType = (filePath) => {
+  if (/\/test\/scout\/api\//.test(filePath)) {
+    return 'api';
+  }
+  if (/\/test\/scout\/ui\//.test(filePath)) {
+    return 'ui';
+  }
+  return null;
+};
+
+/**
+ * Gets the recommended package based on file path.
+ * @param {string} filePath
+ * @returns {string}
+ */
+const getRecommendedPackage = (filePath) => {
+  const solutionMatch = filePath.match(/x-pack\/solutions\/(\w+)\//);
+  if (solutionMatch) {
+    const solution = solutionMatch[1];
+    return SOLUTION_PACKAGES[solution] || '@kbn/scout';
+  }
+  return '@kbn/scout';
+};
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Ensure `expect` is imported from the correct scout subpath based on test type (api/ui).',
+      category: 'Best Practices',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      wrongImportPath:
+        'Import `expect` from `{{recommendedImport}}` in {{testType}} tests. Found: `{{actualImport}}`.',
+    },
+  },
+
+  create(context) {
+    const filePath = context.getFilename();
+    const testType = getTestType(filePath);
+
+    if (!testType) {
+      return {};
+    }
+
+    const recommendedPackage = getRecommendedPackage(filePath);
+    const recommendedImport = `${recommendedPackage}/${testType}`;
+
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value;
+
+        const hasExpectImport = node.specifiers.some(
+          (specifier) =>
+            specifier.type === 'ImportSpecifier' &&
+            specifier.imported &&
+            specifier.imported.name === 'expect'
+        );
+
+        if (!hasExpectImport) {
+          return;
+        }
+
+        if (source === recommendedImport) {
+          return;
+        }
+
+        context.report({
+          node: node.source,
+          messageId: 'wrongImportPath',
+          data: {
+            testType,
+            recommendedImport,
+            actualImport: source,
+          },
+          fix(fixer) {
+            return fixer.replaceText(node.source, `'${recommendedImport}'`);
+          },
+        });
+      },
+    };
+  },
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_expect_import.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_expect_import.test.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const { RuleTester } = require('eslint');
+const rule = require('./scout_expect_import');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2018,
+  },
+});
+
+// Solutions test files
+const OBLT_API_FILE =
+  'x-pack/solutions/observability/plugins/apm/test/scout/api/tests/example.spec.ts';
+const OBLT_UI_FILE =
+  'x-pack/solutions/observability/plugins/apm/test/scout/ui/tests/example.spec.ts';
+
+// Platform test files
+const PLATFORM_API_FILE = 'src/platform/plugins/example/test/scout/api/tests/example.spec.ts';
+
+ruleTester.run('@kbn/eslint/scout_expect_import', rule, {
+  valid: [
+    // Solutions: correct imports
+    {
+      filename: OBLT_API_FILE,
+      code: `import { expect } from '@kbn/scout-oblt/api';`,
+    },
+    {
+      filename: OBLT_UI_FILE,
+      code: `import { expect } from '@kbn/scout-oblt/ui';`,
+    },
+    // Platform: correct import
+    {
+      filename: PLATFORM_API_FILE,
+      code: `import { expect } from '@kbn/scout/api';`,
+    },
+    // Non-expect imports are ignored
+    {
+      filename: OBLT_API_FILE,
+      code: `import { test } from '@kbn/scout-oblt';`,
+    },
+    // Files outside scout directories are ignored
+    {
+      filename:
+        'x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/search_filters.test.ts',
+      code: `import { expect } from 'expect';`,
+    },
+  ],
+
+  invalid: [
+    // Solutions API: missing /api suffix → suggests @kbn/scout-oblt/api
+    {
+      filename: OBLT_API_FILE,
+      code: `import { expect } from '@kbn/scout-oblt';`,
+      output: `import { expect } from '@kbn/scout-oblt/api';`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    // Solutions API: wrong /ui suffix → suggests @kbn/scout-oblt/api
+    {
+      filename: OBLT_API_FILE,
+      code: `import { expect } from '@kbn/scout-oblt/ui';`,
+      output: `import { expect } from '@kbn/scout-oblt/api';`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    // Solutions UI: wrong /api suffix → suggests @kbn/scout-oblt/ui
+    {
+      filename: OBLT_UI_FILE,
+      code: `import { expect } from '@kbn/scout-oblt/api';`,
+      output: `import { expect } from '@kbn/scout-oblt/ui';`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    // Platform API: missing suffix → suggests @kbn/scout/api
+    {
+      filename: PLATFORM_API_FILE,
+      code: `import { expect } from '@kbn/scout';`,
+      output: `import { expect } from '@kbn/scout/api';`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+    // Playwright import → suggests correct scout package
+    {
+      filename: OBLT_API_FILE,
+      code: `import { expect } from '@playwright/test';`,
+      output: `import { expect } from '@kbn/scout-oblt/api';`,
+      errors: [{ messageId: 'wrongImportPath' }],
+    },
+  ],
+});

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/generic_matchers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/generic_matchers.ts
@@ -9,6 +9,7 @@
 
 import { expect as baseExpect } from '@playwright/test';
 import type { GenericMatchers } from './types';
+import { wrapMatcher } from './utils';
 
 /**
  * Create generic matchers delegating to Playwright/Jest expect
@@ -17,25 +18,28 @@ export function createGenericMatchers(actual: unknown): GenericMatchers {
   // eslint-disable-next-line playwright/valid-expect
   const base = baseExpect(actual);
   return {
-    toBe: (expected: unknown) => base.toBe(expected),
-    toBeDefined: () => base.toBeDefined(),
-    toBeUndefined: () => base.toBeUndefined(),
-    toContain: (expected: unknown) => base.toContain(expected),
-    toHaveLength: (expected: number) => base.toHaveLength(expected),
-    toStrictEqual: (expected: unknown) => base.toStrictEqual(expected),
-    toBeGreaterThan: (expected: number) => base.toBeGreaterThan(expected),
-    toBeLessThan: (expected: number) => base.toBeLessThan(expected),
-    toMatchObject: (expected: Record<string, unknown> | unknown[]) => base.toMatchObject(expected),
+    toBe: wrapMatcher((expected: unknown) => base.toBe(expected)),
+    toBeDefined: wrapMatcher(() => base.toBeDefined()),
+    toBeUndefined: wrapMatcher(() => base.toBeUndefined()),
+    toContain: wrapMatcher((expected: unknown) => base.toContain(expected)),
+    toHaveLength: wrapMatcher((expected: number) => base.toHaveLength(expected)),
+    toStrictEqual: wrapMatcher((expected: unknown) => base.toStrictEqual(expected)),
+    toBeGreaterThan: wrapMatcher((expected: number) => base.toBeGreaterThan(expected)),
+    toBeLessThan: wrapMatcher((expected: number) => base.toBeLessThan(expected)),
+    toMatchObject: wrapMatcher((expected: Record<string, unknown> | unknown[]) =>
+      base.toMatchObject(expected)
+    ),
     not: {
-      toBe: (expected: unknown) => base.not.toBe(expected),
-      toBeUndefined: () => base.not.toBeUndefined(),
-      toContain: (expected: unknown) => base.not.toContain(expected),
-      toHaveLength: (expected: number) => base.not.toHaveLength(expected),
-      toStrictEqual: (expected: unknown) => base.not.toStrictEqual(expected),
-      toBeGreaterThan: (expected: number) => base.not.toBeGreaterThan(expected),
-      toBeLessThan: (expected: number) => base.not.toBeLessThan(expected),
-      toMatchObject: (expected: Record<string, unknown> | unknown[]) =>
-        base.not.toMatchObject(expected),
+      toBe: wrapMatcher((expected: unknown) => base.not.toBe(expected)),
+      toBeUndefined: wrapMatcher(() => base.not.toBeUndefined()),
+      toContain: wrapMatcher((expected: unknown) => base.not.toContain(expected)),
+      toHaveLength: wrapMatcher((expected: number) => base.not.toHaveLength(expected)),
+      toStrictEqual: wrapMatcher((expected: unknown) => base.not.toStrictEqual(expected)),
+      toBeGreaterThan: wrapMatcher((expected: number) => base.not.toBeGreaterThan(expected)),
+      toBeLessThan: wrapMatcher((expected: number) => base.not.toBeLessThan(expected)),
+      toMatchObject: wrapMatcher((expected: Record<string, unknown> | unknown[]) =>
+        base.not.toMatchObject(expected)
+      ),
     },
   };
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/response_matchers.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/response_matchers.ts
@@ -10,6 +10,7 @@
 import { toHaveHeaders } from './to_have_headers';
 import { toHaveStatusCode } from './to_have_status_code';
 import { toHaveStatusText } from './to_have_status_text';
+import { wrapMatcher } from './utils';
 import type { ToHaveStatusCodeOptions } from './to_have_status_code';
 import type { ResponseMatchers } from './types';
 
@@ -19,8 +20,10 @@ import type { ResponseMatchers } from './types';
  */
 export function createResponseMatchers(obj: unknown): ResponseMatchers {
   return {
-    toHaveStatusCode: (code: number | ToHaveStatusCodeOptions) => toHaveStatusCode(obj, code),
-    toHaveStatusText: (text: string) => toHaveStatusText(obj, text),
-    toHaveHeaders: (headers: Record<string, string>) => toHaveHeaders(obj, headers),
+    toHaveStatusCode: wrapMatcher((code: number | ToHaveStatusCodeOptions) =>
+      toHaveStatusCode(obj, code)
+    ),
+    toHaveStatusText: wrapMatcher((text: string) => toHaveStatusText(obj, text)),
+    toHaveHeaders: wrapMatcher((headers: Record<string, string>) => toHaveHeaders(obj, headers)),
   };
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/utils.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/matchers/api/utils.test.ts
@@ -36,36 +36,4 @@ describe('createMatcherError', () => {
 
     expect(error.message).toContain('Expected: not');
   });
-
-  it('skips stack lines when skipStackLines is provided', () => {
-    const errorWithoutSkip = createMatcherError({
-      expected: 200,
-      matcherName: 'toHaveStatusCode',
-      received: 404,
-      skipStackLines: 0,
-    });
-    const errorWithSkip = createMatcherError({
-      expected: 200,
-      matcherName: 'toHaveStatusCode',
-      received: 404,
-      skipStackLines: 1,
-    });
-
-    const getStackLines = (err: Error) =>
-      err.stack!.split('\n').filter((l) => l.trimStart().startsWith('at '));
-
-    const stackLinesWithoutSkip = getStackLines(errorWithoutSkip);
-    const stackLinesWithSkip = getStackLines(errorWithSkip);
-
-    // After skipping 1 line, first stack line now points to current test file
-    expect(stackLinesWithSkip[0]).toContain(__filename);
-
-    // One less stack line
-    expect(stackLinesWithSkip.length).toBe(stackLinesWithoutSkip.length - 1);
-
-    // Message content is preserved
-    expect(errorWithSkip.stack).toContain('toHaveStatusCode');
-    expect(errorWithSkip.stack).toContain('Expected:');
-    expect(errorWithSkip.stack).toContain('Received:');
-  });
 });

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/api.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/api.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { expect } from '@kbn/scout/api';

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_no_setup.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_no_setup.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/api';
 import type { RoleApiCredentials } from '@kbn/scout-oblt';
 import { apiTest } from '../../common/fixtures';
 import { esResourcesEndpoint } from '../../common/fixtures/constants';
@@ -30,9 +30,9 @@ apiTest.describe('Profiling is not setup and no data is loaded', { tag: ['@ess']
       },
     });
     const adminStatus = adminRes.body;
-    expect(adminStatus.has_setup).toBeFalsy();
-    expect(adminStatus.has_data).toBeFalsy();
-    expect(adminStatus.pre_8_9_1_data).toBeFalsy();
+    expect(adminStatus.has_setup).toBe(false);
+    expect(adminStatus.has_data).toBe(false);
+    expect(adminStatus.pre_8_9_1_data).toBe(false);
   });
 
   apiTest('Viewer users', async ({ apiClient }) => {
@@ -44,9 +44,9 @@ apiTest.describe('Profiling is not setup and no data is loaded', { tag: ['@ess']
       },
     });
     const readStatus = readRes.body;
-    expect(readStatus.has_setup).toBeFalsy();
-    expect(readStatus.has_data).toBeFalsy();
-    expect(readStatus.pre_8_9_1_data).toBeFalsy();
-    expect(readStatus.has_required_role).toBeFalsy();
+    expect(readStatus.has_setup).toBe(false);
+    expect(readStatus.has_data).toBe(false);
+    expect(readStatus.pre_8_9_1_data).toBe(false);
+    expect(readStatus.has_required_role).toBe(false);
   });
 });

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_apm_not_installed.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/api';
 import type { RoleApiCredentials } from '@kbn/scout-oblt';
 import { apiTest } from '../../common/fixtures';
 import { esResourcesEndpoint } from '../../common/fixtures/constants';
@@ -31,9 +31,9 @@ apiTest.describe('APM integration not installed but setup completed', { tag: ['@
     });
 
     const adminStatus = adminRes.body;
-    expect(adminStatus.has_setup).toBeTruthy();
-    expect(adminStatus.has_data).toBeFalsy();
-    expect(adminStatus.pre_8_9_1_data).toBeFalsy();
+    expect(adminStatus.has_setup).toBe(true);
+    expect(adminStatus.has_data).toBe(false);
+    expect(adminStatus.pre_8_9_1_data).toBe(false);
   });
 
   apiTest('Viewer user', async ({ apiClient }) => {
@@ -46,9 +46,9 @@ apiTest.describe('APM integration not installed but setup completed', { tag: ['@
     });
 
     const readStatus = readRes.body;
-    expect(readStatus.has_setup).toBeTruthy();
-    expect(readStatus.has_data).toBeFalsy();
-    expect(readStatus.pre_8_9_1_data).toBeFalsy();
-    expect(readStatus.has_required_role).toBeFalsy();
+    expect(readStatus.has_setup).toBe(true);
+    expect(readStatus.has_data).toBe(false);
+    expect(readStatus.pre_8_9_1_data).toBe(false);
+    expect(readStatus.has_required_role).toBe(false);
   });
 });

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_data.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_data.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/api';
 import type { RoleApiCredentials } from '@kbn/scout-oblt';
 import { apiTest } from '../../common/fixtures';
 import { esArchiversPath, esResourcesEndpoint } from '../../common/fixtures/constants';
@@ -28,9 +28,9 @@ apiTest.describe('Profiling is setup and data is loaded', { tag: ['@ess'] }, () 
       },
     });
     const adminStatus = adminRes.body;
-    expect(adminStatus.has_setup).toBeTruthy();
-    expect(adminStatus.has_data).toBeTruthy();
-    expect(adminStatus.pre_8_9_1_data).toBeFalsy();
+    expect(adminStatus.has_setup).toBe(true);
+    expect(adminStatus.has_data).toBe(true);
+    expect(adminStatus.pre_8_9_1_data).toBe(false);
   });
 
   apiTest('Viewer user', async ({ apiClient }) => {
@@ -43,9 +43,9 @@ apiTest.describe('Profiling is setup and data is loaded', { tag: ['@ess'] }, () 
     });
 
     const readStatus = readRes.body;
-    expect(readStatus.has_setup).toBeTruthy();
-    expect(readStatus.has_data).toBeTruthy();
-    expect(readStatus.pre_8_9_1_data).toBeFalsy();
-    expect(readStatus.has_required_role).toBeFalsy();
+    expect(readStatus.has_setup).toBe(true);
+    expect(readStatus.has_data).toBe(true);
+    expect(readStatus.pre_8_9_1_data).toBe(false);
+    expect(readStatus.has_required_role).toBe(false);
   });
 });

--- a/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_integrations.spec.ts
+++ b/x-pack/solutions/observability/plugins/profiling/test/scout/api/tests/has_setup_with_integrations.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expect } from '@kbn/scout-oblt';
+import { expect } from '@kbn/scout-oblt/api';
 import type { RoleApiCredentials } from '@kbn/scout-oblt';
 import { apiTest } from '../../common/fixtures';
 import { esResourcesEndpoint } from '../../common/fixtures/constants';
@@ -30,9 +30,9 @@ apiTest.describe('Collector integration is not installed', { tag: ['@ess'] }, ()
 
     const adminRes = await apiClient.get(esResourcesEndpoint);
     const adminStatus = adminRes.body;
-    expect(adminStatus.has_setup).toBeFalsy();
-    expect(adminStatus.has_data).toBeFalsy();
-    expect(adminStatus.pre_8_9_1_data).toBeFalsy();
+    expect(adminStatus.has_setup).toBeUndefined();
+    expect(adminStatus.has_data).toBeUndefined();
+    expect(adminStatus.pre_8_9_1_data).toBeUndefined();
 
     const readRes = await apiClient.get(esResourcesEndpoint, {
       headers: {
@@ -42,10 +42,10 @@ apiTest.describe('Collector integration is not installed', { tag: ['@ess'] }, ()
       },
     });
     const readStatus = readRes.body;
-    expect(readStatus.has_setup).toBeFalsy();
-    expect(readStatus.has_data).toBeFalsy();
-    expect(readStatus.pre_8_9_1_data).toBeFalsy();
-    expect(readStatus.has_required_role).toBeFalsy();
+    expect(readStatus.has_setup).toBe(false);
+    expect(readStatus.has_data).toBe(false);
+    expect(readStatus.pre_8_9_1_data).toBe(false);
+    expect(readStatus.has_required_role).toBe(false);
   });
 
   apiTest(
@@ -67,9 +67,9 @@ apiTest.describe('Collector integration is not installed', { tag: ['@ess'] }, ()
         },
       });
       const adminStatus = adminRes.body;
-      expect(adminStatus.has_setup).toBeFalsy();
-      expect(adminStatus.has_data).toBeFalsy();
-      expect(adminStatus.pre_8_9_1_data).toBeFalsy();
+      expect(adminStatus.has_setup).toBe(false);
+      expect(adminStatus.has_data).toBe(false);
+      expect(adminStatus.pre_8_9_1_data).toBe(false);
 
       const readRes = await apiClient.get(esResourcesEndpoint, {
         headers: {
@@ -77,10 +77,10 @@ apiTest.describe('Collector integration is not installed', { tag: ['@ess'] }, ()
         },
       });
       const readStatus = readRes.body;
-      expect(readStatus.has_setup).toBeFalsy();
-      expect(readStatus.has_data).toBeFalsy();
-      expect(readStatus.pre_8_9_1_data).toBeFalsy();
-      expect(readStatus.has_required_role).toBeFalsy();
+      expect(readStatus.has_setup).toBe(false);
+      expect(readStatus.has_data).toBe(false);
+      expect(readStatus.pre_8_9_1_data).toBe(false);
+      expect(readStatus.has_required_role).toBe(false);
     }
   );
 });

--- a/x-pack/solutions/search/packages/kbn-scout-search/api.ts
+++ b/x-pack/solutions/search/packages/kbn-scout-search/api.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { expect } from '@kbn/scout/api';

--- a/x-pack/solutions/security/packages/kbn-scout-security/api.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/api.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { expect } from '@kbn/scout/api';


### PR DESCRIPTION
## Summary

Updates Solutions API tests to use the dedicated API `expect` from `@kbn/scout/api` and adds an ESLint rule to enforce correct import paths.

### Changes

- Added `api.ts` exports for `@kbn/scout-oblt`, `@kbn/scout-search`, and `@kbn/scout-security` packages
- Updated solutions API tests to import `expect` from `@kbn/scout-oblt/api`
- Changed assertions from `toBeTruthy()`/`toBeFalsy()` to explicit `toBe(true)`/`toBe(false)`
- Refactored stack trace handling to use native `Error.captureStackTrace` instead of manually filtering stack lines
- Added ESLint rule `scout_expect_import` to validate `expect` imports based on test type (api/ui)

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->