### PR TITLE
[Synthtrace] Wait for all workers to finish before teardown

### DIFF
--- a/src/platform/packages/shared/kbn-synthtrace/src/cli/utils/start_historical_data_upload.ts
+++ b/src/platform/packages/shared/kbn-synthtrace/src/cli/utils/start_historical_data_upload.ts
@@ -138,7 +138,7 @@ export async function startHistoricalDataUpload({
           })
         );
 
-  await Promise.race(workerServices);
+  await Promise.all(workerServices);
 
   await teardown();
 }


### PR DESCRIPTION
## Summary

Replace `Promise.race` for `Promise.all` so all workers are finished before the teardown






