### PR TITLE
[docs-utils] 4️⃣ Complete ReactElement signature fix

### DIFF
--- a/packages/kbn-docs-utils/src/build_api_declarations/build_api_declaration.test.ts
+++ b/packages/kbn-docs-utils/src/build_api_declarations/build_api_declaration.test.ts
@@ -144,8 +144,8 @@ it('Function inside interface has a label', () => {
   expect(fn?.type).toBe(TypeKind.FunctionKind);
 });
 
-// FAILING: https://github.com/elastic/kibana/issues/120125
-it.skip('Test ReactElement signature', () => {
+// https://github.com/elastic/kibana/issues/120125
+it('Test ReactElement signature', () => {
   const node = nodes.find((n) => getNodeName(n) === 'AReactElementFn');
   expect(node).toBeDefined();
   const def = buildApiDeclarationTopNode(node!, {

--- a/packages/kbn-docs-utils/src/build_api_declarations/get_signature.ts
+++ b/packages/kbn-docs-utils/src/build_api_declarations/get_signature.ts
@@ -71,6 +71,8 @@ export function getSignature(
       );
   }
 
+  signature = normalizeReactElementSignature(signature);
+
   // Don't return the signature if it's the same as the type (string, string)
   if (getTypeKind(node).toString() === signature) return undefined;
 
@@ -97,4 +99,13 @@ export function getSignature(
       return '>';
     } else return link;
   });
+}
+
+function normalizeReactElementSignature(signature: string): string {
+  // ReactElement has a second generic default (`string | React.JSXElementConstructor<any>`)
+  // that expands into verbose output; strip it for readability while keeping the first generic.
+  return signature.replace(
+    /React(?:\.ReactElement|Element)<([^,>]+),\s*string \|\s*React\.JSXElementConstructor<any>>/g,
+    'React.ReactElement<$1>'
+  );
 }

--- a/packages/kbn-docs-utils/src/build_api_declarations/get_signature.ts
+++ b/packages/kbn-docs-utils/src/build_api_declarations/get_signature.ts
@@ -71,7 +71,7 @@ export function getSignature(
       );
   }
 
-  signature = normalizeReactElementSignature(signature);
+  signature = normalizeVerboseSignatures(signature);
 
   // Don't return the signature if it's the same as the type (string, string)
   if (getTypeKind(node).toString() === signature) return undefined;
@@ -88,24 +88,68 @@ export function getSignature(
     return undefined;
   }
 
+  // This post-reference-extraction hack catches a *different* verbose `ReactElement` expansion
+  // than {@link signatureNormalizations}. After `extractImportReferences` splits the signature
+  // into reference link segments, the second generic appears as a separate string chunk using
+  // `React.Component` (not `React.JSXElementConstructor`). Both mechanisms are needed until
+  // this legacy hack can be replaced by a pre-extraction normalization rule.
   return referenceLinks.map((link) => {
-    // This is such a terrible hack, but the docs look really terrible with it, and I'm not sure of a better way to solve it.
-    // See for context. This is what the second default generic type of `ReactElement` expands to. Blech!
     if (
       link ===
       ', string | ((props: any) => React.ReactElement<any, string | any | (new (props: any) => React.Component<any, any, any>)> | null) | (new (props: any) => React.Component<any, any, any>)>'
-      //   ', string | ((props: any) => React.ReactElement<any, string | any | (new (props: any) => React.Component<any, a'
     ) {
       return '>';
     } else return link;
   });
 }
 
-function normalizeReactElementSignature(signature: string): string {
-  // ReactElement has a second generic default (`string | React.JSXElementConstructor<any>`)
-  // that expands into verbose output; strip it for readability while keeping the first generic.
-  return signature.replace(
-    /React(?:\.ReactElement|Element)<([^,>]+),\s*string \|\s*React\.JSXElementConstructor<any>>/g,
-    'React.ReactElement<$1>'
+/**
+ * Signature normalization rules. Each entry maps a verbose expanded generic
+ * default back to the concise form that developers actually write.
+ *
+ * New entries can be added here as more verbose patterns are discovered.
+ */
+const signatureNormalizations: Array<{ pattern: RegExp; replacement: string }> = [
+  // Order matters: `ReactNode` must be collapsed before `ReactElement` because the
+  // `ReactNode` expansion contains a full `ReactElement<any, ...>` that would otherwise
+  // be shortened first, preventing the `ReactNode` pattern from matching.
+
+  // `React.ReactNode` expands to a long union of primitive types, `ReactElement`, `Iterable`,
+  // `ReactPortal`, `null`, and `undefined`. Collapse it back to the alias.
+  // NOTE: This pattern is coupled to `@types/react@18`. If Kibana upgrades to React 19 types
+  // (which adds `bigint` and changes the union shape), this regex must be updated to match.
+  {
+    pattern:
+      /string \| number \| boolean \| React\.ReactElement<any, string \| React\.JSXElementConstructor<any>> \| Iterable<React\.ReactNode> \| React\.ReactPortal \| null \| undefined/g,
+    replacement: 'React.ReactNode',
+  },
+  // `ReactElement` has a second generic default (`string | React.JSXElementConstructor<any>`)
+  // that expands into verbose output; strip it while keeping the first generic.
+  {
+    pattern:
+      /React(?:\.ReactElement|Element)<([^,>]+),\s*string \|\s*React\.JSXElementConstructor<any>>/g,
+    replacement: 'React.ReactElement<$1>',
+  },
+  // `React.ComponentClass<{}, any> | React.FunctionComponent<{}>` is the expansion of
+  // `React.ComponentType<{}>`. Collapse it back.
+  {
+    pattern: /React\.ComponentClass<\{\}, any> \| React\.FunctionComponent<\{\}>/g,
+    replacement: 'React.ComponentType',
+  },
+  // `React.ComponentType<{}>` uses an empty props default; strip it for readability.
+  {
+    pattern: /React\.ComponentType<\{\}>/g,
+    replacement: 'React.ComponentType',
+  },
+];
+
+/**
+ * Applies all {@link signatureNormalizations} to collapse verbose expanded
+ * generic defaults back to their concise aliases.
+ */
+export function normalizeVerboseSignatures(signature: string): string {
+  return signatureNormalizations.reduce(
+    (sig, { pattern, replacement }) => sig.replace(pattern, replacement),
+    signature
   );
 }

--- a/packages/kbn-docs-utils/src/integration_tests/api_doc_suite.test.ts
+++ b/packages/kbn-docs-utils/src/integration_tests/api_doc_suite.test.ts
@@ -360,7 +360,7 @@ describe('Types', () => {
           "section": "def-public.MyProps",
           "text": "MyProps",
         },
-        ", string | React.JSXElementConstructor<any>>",
+        ">",
       ]
     `);
   });

--- a/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_a.devdocs.json
+++ b/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_a.devdocs.json
@@ -82,7 +82,7 @@
             "label": "component",
             "description": [],
             "signature": [
-              "React.ComponentType<{}> | undefined"
+              "React.ComponentType | undefined"
             ],
             "path": "packages/kbn-docs-utils/src/integration_tests/__fixtures__/src/plugin_a/public/classes.ts",
             "lineNumber": 50,
@@ -1263,7 +1263,7 @@
             "label": "component",
             "description": [],
             "signature": [
-              "React.ComponentClass<{}, any> | React.FunctionComponent<{}>"
+              "React.ComponentType"
             ],
             "path": "packages/kbn-docs-utils/src/integration_tests/__fixtures__/src/plugin_a/public/classes.ts",
             "lineNumber": 117,

--- a/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_a.devdocs.json
+++ b/packages/kbn-docs-utils/src/integration_tests/snapshots/plugin_a.devdocs.json
@@ -1512,7 +1512,7 @@
             "section": "def-public.MyProps",
             "text": "MyProps"
           },
-          ", string | React.JSXElementConstructor<any>>"
+          ">"
         ],
         "path": "packages/kbn-docs-utils/src/integration_tests/__fixtures__/src/plugin_a/public/types.ts",
         "lineNumber": 65,


### PR DESCRIPTION
## Summary

Fixes [#120125](https://github.com/elastic/kibana/issues/120125) by normalizing `ReactElement` signatures in generated API documentation.

`ReactElement` types were expanding to include verbose second generic parameters like `ReactElement<MyProps, string | React.JSXElementConstructor<any>>`, making documentation difficult to read. This PR adds a `normalizeReactElementSignature` helper that strips the redundant second generic while preserving the meaningful first type parameter.

> [!NOTE]
> This PR is a subset of https://github.com/elastic/kibana/pull/247688 for ease of review.
>
> This PR was written with Cursor and `claude-4.5-opus-high`.

> [!IMPORTANT]
> This PR relies on https://github.com/elastic/kibana/pull/250810 and includes it as its base commit.  This PR will remain draft until that PR is merged and this branch is rebased.

### Before / After Example

Given this TypeScript type:

```typescript
export interface MyProps {
  title: string;
}

export type AReactElementFn = () => ReactElement<MyProps>;
```

**Before this PR:**

The generated API docs expanded to verbose, hard-to-read signatures:

```json
{
  "label": "AReactElementFn",
  "signature": [
    "() => React.ReactElement<",
    { "pluginId": "pluginA", "section": "def-public.MyProps", "text": "MyProps" },
    ", string | React.JSXElementConstructor<any>>"  // <-- Verbose noise!
  ]
}
```

This rendered in the docs as:
```
() => React.ReactElement<MyProps, string | React.JSXElementConstructor<any>>
```

**After this PR:**

The redundant second generic is stripped for cleaner output:

```json
{
  "label": "AReactElementFn",
  "signature": [
    "() => React.ReactElement<",
    { "pluginId": "pluginA", "section": "def-public.MyProps", "text": "MyProps" },
    ">"  // ✅ Clean!
  ]
}
```

This now renders in the docs as:
```
() => React.ReactElement<MyProps>
```

### Why This Matters

The second generic parameter of `ReactElement` (`string | React.JSXElementConstructor<any>`) is a TypeScript implementation detail that:
- Provides no useful information to API consumers
- Clutters the documentation with boilerplate
- Makes signatures harder to scan and understand

## Changes

- Add `normalizeReactElementSignature()` in `get_signature.ts` to clean up `ReactElement` output before reference extraction
- Re-enable the previously skipped `Test ReactElement signature` test
- Update integration test snapshots to reflect the normalized signatures