### PR TITLE
[Workplace AI] Unified chat interface with embeddable

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { ConversationInput } from './conversation_input';

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.tsx
@@ -205,7 +205,9 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
             <AppLeaveContext.Provider value={noopOnAppLeave}>
               <ConversationContext.Provider value={conversationContextValue}>
                 <AgentBuilderTourProvider>
-                  <SendMessageProvider>{children}</SendMessageProvider>
+                  <SendMessageProvider onMessageSubmit={currentProps.onMessageSubmit}>
+                    {children}
+                  </SendMessageProvider>
                 </AgentBuilderTourProvider>
               </ConversationContext.Provider>
             </AppLeaveContext.Provider>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { EmbeddableConversationsProvider } from './conversation/embeddable_conversations_provider';
+export { SendMessageProvider } from './send_message/send_message_context';
+export { AgentBuilderServicesContext } from './agent_builder_services_context';
+export { ConversationContext } from './conversation/conversation_context';

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/send_message/send_message_context.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/send_message/send_message_context.tsx
@@ -5,11 +5,17 @@
  * 2.0.
  */
 
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useCallback } from 'react';
+import type { Conversation } from '@kbn/agent-builder-common';
 import type { ConversationRoundStep } from '@kbn/agent-builder-common';
+import { useQueryClient } from '@kbn/react-query';
 import { useSendMessageMutation } from './use_send_message_mutation';
 import { useResumeRoundMutation } from './use_resume_round_mutation';
 import { useConnectorSelection } from '../../hooks/chat/use_connector_selection';
+import { useAgentId } from '../../hooks/use_conversation';
+import { useConversationId } from '../conversation/use_conversation_id';
+import { queryKeys } from '../../query_keys';
+import { newConversationId } from '../../utils/new_conversation';
 
 interface SendMessageState {
   sendMessage: ({ message }: { message: string }) => void;
@@ -33,11 +39,25 @@ interface SendMessageState {
 
 const SendMessageContext = createContext<SendMessageState | null>(null);
 
-export const SendMessageProvider = ({ children }: { children: React.ReactNode }) => {
+interface SendMessageProviderProps {
+  children: React.ReactNode;
+  onMessageSubmit?: (
+    message: string,
+    context: {
+      agentId?: string;
+      connectorId?: string;
+    }
+  ) => void;
+}
+
+export const SendMessageProvider = ({ children, onMessageSubmit }: SendMessageProviderProps) => {
   const connectorSelection = useConnectorSelection();
+  const agentId = useAgentId(); // Get current selected agent ID
+  const queryClient = useQueryClient();
+  const conversationId = useConversationId();
 
   const {
-    sendMessage,
+    sendMessage: originalSendMessage,
     isResponseLoading,
     pendingMessage,
     error,
@@ -59,6 +79,32 @@ export const SendMessageProvider = ({ children }: { children: React.ReactNode })
 
   // Combine agentReasoning from both mutations - use the one that's currently active
   const agentReasoning = isResuming ? resumeAgentReasoning : sendAgentReasoning;
+
+  // Override sendMessage if onMessageSubmit is provided (for input-only mode)
+  const sendMessage = useCallback(
+    ({ message }: { message: string }) => {
+      if (onMessageSubmit) {
+        const queryKey = queryKeys.conversations.byId(conversationId ?? newConversationId);
+        const conversation = queryClient.getQueryData<Conversation>(queryKey);
+        const currentAgentId = conversation?.agent_id || agentId;
+
+        onMessageSubmit(message, {
+          agentId: currentAgentId,
+          connectorId: connectorSelection.selectedConnector,
+        });
+      } else {
+        originalSendMessage({ message });
+      }
+    },
+    [
+      onMessageSubmit,
+      queryClient,
+      conversationId,
+      agentId,
+      connectorSelection.selectedConnector,
+      originalSendMessage,
+    ]
+  );
 
   return (
     <SendMessageContext.Provider

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_initial_message.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_initial_message.ts
@@ -9,20 +9,34 @@ import { useEffect } from 'react';
 import { useConversationContext } from '../context/conversation/conversation_context';
 import { useConversationId } from '../context/conversation/use_conversation_id';
 import { useSendMessage } from '../context/send_message/send_message_context';
+import { useAgentId } from './use_conversation';
+import { useValidateAgentId } from './agents/use_validate_agent_id';
 
 export const useSendPredefinedInitialMessage = () => {
   const { initialMessage, autoSendInitialMessage, resetInitialMessage } = useConversationContext();
   const conversationId = useConversationId();
   const { sendMessage } = useSendMessage();
+  const agentId = useAgentId();
+  const validateAgentId = useValidateAgentId();
 
   const isNewConversation = !conversationId;
+  const isAgentIdValid = validateAgentId(agentId);
 
   useEffect(() => {
-    if (initialMessage && isNewConversation && autoSendInitialMessage) {
+    // Only auto-send if we have a valid agent ID to prevent race conditions
+    if (initialMessage && isNewConversation && autoSendInitialMessage && isAgentIdValid) {
       sendMessage({ message: initialMessage });
       resetInitialMessage?.();
     }
-  }, [initialMessage, autoSendInitialMessage, isNewConversation, sendMessage, resetInitialMessage]);
+  }, [
+    initialMessage,
+    autoSendInitialMessage,
+    isNewConversation,
+    isAgentIdValid,
+    agentId,
+    sendMessage,
+    resetInitialMessage,
+  ]);
 
   return null;
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_navigation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_navigation.ts
@@ -12,6 +12,8 @@ import { useKibana } from './use_kibana';
 export interface LocationState {
   shouldStickToBottom?: boolean;
   initialMessage?: string;
+  agentId?: string;
+  connectorId?: string;
 }
 
 const MANAGEMENT_APP_ID = 'management';

--- a/x-pack/platform/plugins/shared/agent_builder/public/embeddable/create_embeddable_conversation_component.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/embeddable/create_embeddable_conversation_component.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { CoreStart } from '@kbn/core/public';
+import type { AgentBuilderInternalService } from '../services';
+import { EmbeddableConversationInternal } from './embeddable_conversation';
+import type { EmbeddableConversationProps } from './types';
+
+interface CreateEmbeddableConversationComponentOptions {
+  services: AgentBuilderInternalService;
+  coreStart: CoreStart;
+}
+
+/**
+ * Creates a React component bound with Agent Builder services.
+ * This component can be embedded in other plugins' UIs.
+ */
+export function createEmbeddableConversationComponent({
+  services,
+  coreStart,
+}: CreateEmbeddableConversationComponentOptions): React.ComponentType<EmbeddableConversationProps> {
+  return (props: EmbeddableConversationProps) => {
+    // For input-only mode, we don't need flyout props
+    if (props.renderMode === 'input-only') {
+      return (
+        <EmbeddableConversationInternal
+          {...props}
+          services={services}
+          coreStart={coreStart}
+          onClose={() => {}}
+          ariaLabelledBy=""
+        />
+      );
+    }
+
+    // For full mode, the component should be used inside a flyout
+    // which provides onClose and ariaLabelledBy
+    throw new Error(
+      'Full conversation mode is not supported via getEmbeddableConversationComponent. ' +
+        'Use openConversationFlyout() instead for full conversations with history.'
+    );
+  };
+}

--- a/x-pack/platform/plugins/shared/agent_builder/public/embeddable/embeddable_conversation.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/embeddable/embeddable_conversation.tsx
@@ -12,6 +12,7 @@ import type { EmbeddableConversationInternalProps } from './types';
 import { EmbeddableConversationsProvider } from '../application/context/conversation/embeddable_conversations_provider';
 import { Conversation } from '../application/components/conversations/conversation';
 import { ConversationHeader } from '../application/components/conversations/conversation_header/conversation_header';
+import { ConversationInput } from '../application/components/conversations/conversation_input';
 import {
   conversationBackgroundStyles,
   headerHeight,
@@ -23,7 +24,7 @@ export const EmbeddableConversationInternal: React.FC<EmbeddableConversationInte
   props
 ) => {
   const { euiTheme } = useEuiTheme();
-  const { onClose, ariaLabelledBy } = props;
+  const { onClose, ariaLabelledBy, renderMode = 'full', onMessageSubmit } = props;
 
   const wrapperStyles = css`
     display: flex;
@@ -61,6 +62,24 @@ export const EmbeddableConversationInternal: React.FC<EmbeddableConversationInte
     }
   `;
 
+  // Input-only mode: just render the conversation input without history
+  if (renderMode === 'input-only') {
+    const inputOnlyStyles = css`
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+    `;
+
+    return (
+      <div css={inputOnlyStyles}>
+        <EmbeddableConversationsProvider {...props}>
+          <ConversationInput />
+        </EmbeddableConversationsProvider>
+      </div>
+    );
+  }
+
+  // Full mode: render complete conversation with header and history
   return (
     <div css={wrapperStyles}>
       <EmbeddableConversationsProvider {...props}>

--- a/x-pack/platform/plugins/shared/agent_builder/public/embeddable/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/embeddable/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { EmbeddableConversationInternal } from './embeddable_conversation';
+export { createEmbeddableConversationComponent } from './create_embeddable_conversation_component';
+export type { EmbeddableConversationProps, EmbeddableConversationDependencies } from './types';

--- a/x-pack/platform/plugins/shared/agent_builder/public/embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/embeddable/types.ts
@@ -89,6 +89,34 @@ export interface EmbeddableConversationProps {
    * ```
    */
   browserApiTools?: Array<BrowserApiToolDefinition<any>>;
+
+  /**
+   * Render mode for the conversation component.
+   * - 'full': Complete conversation with history and input (default)
+   * - 'input-only': Just the input component for workplace ai getting started pages
+   *
+   * When 'input-only' is used with `onMessageSubmit`, the component renders
+   * only the conversation input without the message history.
+   *
+   * @default 'full'
+   */
+  renderMode?: 'full' | 'input-only';
+
+  /**
+   * Callback when message is submitted (only used in input-only mode).
+   * If provided with renderMode='input-only', prevents default conversation
+   * creation and calls this callback instead.
+   *
+   * This is useful for embedding the chat input in getting started pages
+   * where you want to redirect to the full Agent Builder app.
+   */
+  onMessageSubmit?: (
+    message: string,
+    context: {
+      agentId?: string;
+      connectorId?: string;
+    }
+  ) => void;
 }
 
 export interface EmbeddableConversationFlyoutProps {

--- a/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/plugin.tsx
@@ -45,6 +45,7 @@ import type {
 import { openConversationFlyout } from './flyout/open_conversation_flyout';
 import type { EmbeddableConversationProps } from './embeddable/types';
 import type { OpenConversationFlyoutOptions } from './flyout/types';
+import { createEmbeddableConversationComponent } from './embeddable/create_embeddable_conversation_component';
 
 export class AgentBuilderPlugin
   implements
@@ -201,6 +202,12 @@ export class AgentBuilderPlugin
         }
 
         openFlyoutInternal(options);
+      },
+      getEmbeddableConversationComponent: () => {
+        return createEmbeddableConversationComponent({
+          services: internalServices,
+          coreStart: core,
+        });
       },
     };
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/types.ts
@@ -114,4 +114,11 @@ export interface AgentBuilderPluginStart {
   toggleConversationFlyout: (options?: OpenConversationFlyoutOptions) => void;
   setConversationFlyoutActiveConfig: (config: EmbeddableConversationProps) => void;
   clearConversationFlyoutActiveConfig: () => void;
+  /**
+   * Returns a React component that can be embedded in your UI.
+   * This component can render in two modes:
+   * - 'full': Complete conversation with history (default)
+   * - 'input-only': Just the conversation input (for getting started pages)
+   */
+  getEmbeddableConversationComponent: () => React.ComponentType<EmbeddableConversationProps>;
 }

--- a/x-pack/solutions/workplaceai/plugins/workplace_ai_app/kibana.jsonc
+++ b/x-pack/solutions/workplaceai/plugins/workplace_ai_app/kibana.jsonc
@@ -13,8 +13,8 @@
     "server": true,
     "browser": true,
     "configPath": ["xpack", "workplaceAIApp"],
-    "requiredPlugins": ["inference", "actions", "features", "dataCatalog", "spaces", "triggersActionsUi", "workflowsExtensions"],
+    "requiredPlugins": ["agentBuilder", "inference", "actions", "features", "dataCatalog", "spaces", "triggersActionsUi", "workflowsExtensions"],
     "optionalPlugins": ["cloud", "share"],
-    "requiredBundles": ["kibanaReact", "stackConnectors"]
+    "requiredBundles": ["kibanaReact"]
   }
 }

--- a/x-pack/solutions/workplaceai/plugins/workplace_ai_app/public/types.ts
+++ b/x-pack/solutions/workplaceai/plugins/workplace_ai_app/public/types.ts
@@ -11,6 +11,7 @@ import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { TriggersAndActionsUIPublicPluginStart } from '@kbn/triggers-actions-ui-plugin/public';
 import type { WorkflowsExtensionsPublicPluginSetup } from '@kbn/workflows-extensions/public';
+import type { AgentBuilderPluginStart } from '@kbn/agent-builder-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface WorkplaceAIAppPluginSetup {}
@@ -23,6 +24,7 @@ export interface WorkplaceAIAppPluginSetupDependencies {
 }
 
 export interface WorkplaceAIAppPluginStartDependencies {
+  agentBuilder: AgentBuilderPluginStart;
   inference: InferencePublicStart;
   spaces: SpacesPluginStart;
   triggersActionsUi: TriggersAndActionsUIPublicPluginStart;

--- a/x-pack/solutions/workplaceai/plugins/workplace_ai_app/tsconfig.json
+++ b/x-pack/solutions/workplaceai/plugins/workplace_ai_app/tsconfig.json
@@ -15,6 +15,7 @@
   "kbn_references": [
     "@kbn/core",
     "@kbn/config-schema",
+    "@kbn/agent-builder-plugin",
     "@kbn/inference-plugin",
     "@kbn/kibana-react-plugin",
     "@kbn/i18n-react",


### PR DESCRIPTION
## Summary

### Problem
The Workplace AI `Getting Started` page currently has its own chat input UI that immediately redirects to Agent Builder when a conversation starts. This creates  two issues:

1. **UI Drift**: The Workplace AI chat input does not automatically inherit updates to Agent Builder's chat UI.
2. **Inconsistent UX**: Users experience different chat interfaces between the two pages.

### Solution
Rather than maintaining a duplicate implementation, we now **reuse Agent Builder's conversation input component** via its embeddable pattern.

### Implementation
1. **Extended Embeddable Pattern**: Added `input-only` render mode to Agent Builder's existing `EmbeddableConversation` component.
2. **Data Transfer**: Enhanced URL parameter and state handling to correctly transfer selected agent and connector from Workplace AI → Agent Builder.
3. **Race Condition Fixes**: 
   - Fixed query cache timing during conversation creation
   - Ensured agent validation completes before auto-sending initial message
4. **Persistence**: Agent and connector selections now properly sync to localStorage

### Recording

https://github.com/user-attachments/assets/7e705469-2dea-4a66-a655-86fe9533225b


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



