### PR TITLE
Update alerting-settings.md and add serverless value for one parameter

### DIFF
--- a/docs/reference/configuration-reference/alerting-settings.md
+++ b/docs/reference/configuration-reference/alerting-settings.md
@@ -893,7 +893,7 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
     
     :::{note}
     :applies_to: serverless:
-    In Serverless, the maximum number of rules to run per minute is set to `400`. This setting is not configurable by user. 
+    In Serverless, the maximum number of rules to run per minute is set to `400` and can't be configured.
     :::
 
 `xpack.alerting.rules.minimumScheduleInterval.value` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")

--- a/docs/reference/configuration-reference/alerting-settings.md
+++ b/docs/reference/configuration-reference/alerting-settings.md
@@ -889,7 +889,8 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
 :   Specifies the maximum number of rules to run per minute.
 
     Data type: `int`
-    Default: `10000`
+    * {applies_to}`serverless: ga` Defaults to `400`.
+    * {applies_to}`stack: ga 9.0+` Defaults to `10000`.
 
 `xpack.alerting.rules.minimumScheduleInterval.value` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the minimum schedule interval for rules. This minimum is applied to all rules created or updated after you set this value. The time is formatted as a number and a time unit (`s`, `m`, `h`, or `d`). For example, `20m`, `24h`, `7d`. This duration cannot exceed `1d`.

--- a/docs/reference/configuration-reference/alerting-settings.md
+++ b/docs/reference/configuration-reference/alerting-settings.md
@@ -893,7 +893,7 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
     
     :::{note}
     :applies_to: serverless:
-    In Serverless, the maximum number of rules to run per minute is set to `400`.
+    In Serverless, the maximum number of rules to run per minute is set to `400`. This setting is not configurable by user. 
     :::
 
 `xpack.alerting.rules.minimumScheduleInterval.value` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")

--- a/docs/reference/configuration-reference/alerting-settings.md
+++ b/docs/reference/configuration-reference/alerting-settings.md
@@ -889,8 +889,12 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
 :   Specifies the maximum number of rules to run per minute.
 
     Data type: `int`
-    * {applies_to}`serverless: ga` Defaults to `400`.
-    * {applies_to}`stack: ga 9.0+` Defaults to `10000`.
+    Default: `10000`
+    
+    :::{note}
+    :applies_to: serverless:
+    In Serverless, the maximum number of rules to run per minute is set to `400`.
+    :::
 
 `xpack.alerting.rules.minimumScheduleInterval.value` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the minimum schedule interval for rules. This minimum is applied to all rules created or updated after you set this value. The time is formatted as a number and a time unit (`s`, `m`, `h`, or `d`). For example, `20m`, `24h`, `7d`. This duration cannot exceed `1d`.


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

Context in https://github.com/elastic/docs-content-internal/issues/694

cc @maggieghamry @ppf2

## Preview / View

* Before merge: [docs/reference/configuration-reference/alerting-settings.md](https://docs-v3-preview.elastic.dev/elastic/kibana/pull/250842/reference/configuration-reference/alerting-settings)
* After merge: https://www.elastic.co/docs/reference/kibana/configuration-reference/alerting-settings#:~:text=xpack.alerting.rules.maxScheduledPerMinute


### Checklist

No hit as this is a doc PR. 

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



