### PR TITLE
[Index Management] Add length validation for enrich policies create route

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/enrich_policies/register_create_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/enrich_policies/register_create_route.ts
@@ -25,9 +25,9 @@ const validationSchema = schema.object({
       schema.literal('range'),
       schema.literal('geo_match'),
     ]),
-    matchField: schema.string(),
-    enrichFields: schema.arrayOf(schema.string()),
-    sourceIndices: schema.arrayOf(schema.string()),
+    matchField: schema.string({ maxLength: 1000 }),
+    enrichFields: schema.arrayOf(schema.string({ maxLength: 1000 })),
+    sourceIndices: schema.arrayOf(schema.string({ maxLength: 1000 })),
     query: schema.maybe(schema.any()),
   }),
 });
@@ -38,10 +38,13 @@ const querySchema = schema.object({
   ),
 });
 
-const getMatchingIndicesSchema = schema.object({ pattern: schema.string() }, { unknowns: 'allow' });
+const getMatchingIndicesSchema = schema.object(
+  { pattern: schema.string({ maxLength: 1000 }) },
+  { unknowns: 'allow' }
+);
 
 const getFieldsFromIndicesSchema = schema.object({
-  indices: schema.arrayOf(schema.string()),
+  indices: schema.arrayOf(schema.string({ maxLength: 1000 })),
 });
 
 export function registerCreateRoute({ router, lib: { handleEsError } }: RouteDependencies) {

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/enrich_policies/register_create_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/enrich_policies/register_create_route.ts
@@ -26,8 +26,8 @@ const validationSchema = schema.object({
       schema.literal('geo_match'),
     ]),
     matchField: schema.string({ maxLength: 1000 }),
-    enrichFields: schema.arrayOf(schema.string({ maxLength: 1000 })),
-    sourceIndices: schema.arrayOf(schema.string({ maxLength: 1000 })),
+    enrichFields: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
+    sourceIndices: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
     query: schema.maybe(schema.any()),
   }),
 });
@@ -44,7 +44,7 @@ const getMatchingIndicesSchema = schema.object(
 );
 
 const getFieldsFromIndicesSchema = schema.object({
-  indices: schema.arrayOf(schema.string({ maxLength: 1000 })),
+  indices: schema.arrayOf(schema.string({ maxLength: 1000 }), { maxSize: 1000 }),
 });
 
 export function registerCreateRoute({ router, lib: { handleEsError } }: RouteDependencies) {


### PR DESCRIPTION
## Summary

This PR adds a validation on the string length of the Enrich policies create routes.

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->