### PR TITLE
[APM] Improve contrast of health badges in service inventory

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/common/service_health_status.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/service_health_status.ts
@@ -8,6 +8,7 @@
 import { i18n } from '@kbn/i18n';
 import type { EuiThemeComputed } from '@elastic/eui';
 import { ML_ANOMALY_SEVERITY } from '@kbn/ml-anomaly-utils/anomaly_severity';
+import type { NamedColor } from '@elastic/eui/src/components/icon/named_colors';
 
 export enum ServiceHealthStatus {
   healthy = 'healthy',
@@ -50,19 +51,16 @@ export function getServiceHealthStatusColor(
   }
 }
 
-export function getServiceHealthStatusBadgeColor(
-  euiTheme: EuiThemeComputed,
-  status: ServiceHealthStatus
-) {
+export function getServiceHealthStatusBadgeColor(status: ServiceHealthStatus): NamedColor {
   switch (status) {
     case ServiceHealthStatus.healthy:
-      return euiTheme.colors.severity.success;
+      return 'success';
     case ServiceHealthStatus.warning:
-      return euiTheme.colors.severity.warning;
+      return 'warning';
     case ServiceHealthStatus.critical:
-      return euiTheme.colors.severity.risk;
+      return 'danger';
     case ServiceHealthStatus.unknown:
-      return euiTheme.colors.mediumShade;
+      return 'default';
   }
 }
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/health_badge.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_inventory/service_list/health_badge.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiBadge, useEuiTheme } from '@elastic/eui';
+import { EuiBadge } from '@elastic/eui';
 import type { ServiceHealthStatus } from '../../../../../common/service_health_status';
 import {
   getServiceHealthStatusBadgeColor,
@@ -14,10 +14,8 @@ import {
 } from '../../../../../common/service_health_status';
 
 export function HealthBadge({ healthStatus }: { healthStatus: ServiceHealthStatus }) {
-  const { euiTheme } = useEuiTheme();
-
   return (
-    <EuiBadge color={getServiceHealthStatusBadgeColor(euiTheme, healthStatus)}>
+    <EuiBadge color={getServiceHealthStatusBadgeColor(healthStatus)}>
       {getServiceHealthStatusLabel(healthStatus)}
     </EuiBadge>
   );


### PR DESCRIPTION
## Summary

Health badges in the service inventory table have weak contrast between text and background. Instead of leveraging standard named colours for the health badges, we're passing `euiTheme` colours straight as HEX values. While this might seem equivalent at a glance, badges work differently visually with named colours than they do with HEX values.

In order to improve the contrast between text and background in the badge and to visually standardize health with other badges in the table (alerts & SLOs) this PR updates health badges to use named colours instead.

## UI Updates

### Before

<img width="1589" height="200" alt="Before" src="https://github.com/user-attachments/assets/7ae9fa8d-7c1d-4d0b-9d10-f2b36de506eb" />

### After

<img width="1584" height="202" alt="After" src="https://github.com/user-attachments/assets/513f0f3c-77a0-4c13-ab17-d2d646530e47" />
