### PR TITLE
Remove conditional --no-serverless flag from OAS snapshot capture

### DIFF
--- a/.buildkite/scripts/steps/checks/capture_oas_snapshot.sh
+++ b/.buildkite/scripts/steps/checks/capture_oas_snapshot.sh
@@ -22,10 +22,6 @@ cmd="node scripts/capture_oas_snapshot\
   --include-path /api/maintenance_window \
   --include-path /api/agent_builder"
 
-if [[ $BUILDKITE_PULL_REQUEST != "false" && "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" != "main" ]] || [[ $BUILDKITE_PULL_REQUEST == "false" && "$BUILDKITE_BRANCH" != "main" ]]; then
-  cmd="$cmd --no-serverless"
-fi
-
 run_check() {
   eval "$cmd"
 }


### PR DESCRIPTION
## Summary

This PR removes the branch-based conditional logic that adds the `--no-serverless` flag to the `capture_oas_snapshot` command in the OAS snapshot capture script.

## Changes

- Removed the conditional check that added `--no-serverless` flag based on branch conditions
- Simplifies the script to ensure consistent behavior across all branches

## Testing

The script will now run consistently without the `--no-serverless` flag regardless of the branch.

Made with [Cursor](https://cursor.com)