### PR TITLE
feat(streams): add ID, expires at, and meta panel to feature details flyout

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_features/feature_details_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_features/feature_details_flyout.test.tsx
@@ -5,12 +5,6 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License 2.0.
- */
-
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_features/feature_details_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_features/feature_details_flyout.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import type { Feature } from '@kbn/streams-schema';
+import { FeatureDetailsFlyout } from './feature_details_flyout';
+
+function createMinimalFeature(overrides: Partial<Feature> = {}): Feature {
+  return {
+    id: 'feature-123',
+    type: 'service',
+    name: 'Test feature',
+    description: 'A test feature',
+    value: { key: 'value' },
+    confidence: 80,
+    evidence: [],
+    tags: [],
+    meta: {},
+    status: 'active',
+    last_seen: '2025-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(<I18nProvider>{ui}</I18nProvider>);
+};
+
+describe('FeatureDetailsFlyout', () => {
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the feature ID in the flyout', () => {
+    const feature = createMinimalFeature({ id: 'feature-123' });
+    renderWithProviders(
+      <FeatureDetailsFlyout feature={feature} onClose={mockOnClose} />
+    );
+
+    const idElement = screen.getByTestId('streamsAppFeatureDetailsFlyoutId');
+    expect(idElement).toBeInTheDocument();
+    expect(idElement).toHaveTextContent('feature-123');
+  });
+
+  it('shows the Meta section as JSON when meta has values', () => {
+    const feature = createMinimalFeature({
+      meta: { key1: 'value1', key2: 42 },
+    });
+    renderWithProviders(
+      <FeatureDetailsFlyout feature={feature} onClose={mockOnClose} />
+    );
+
+    const metaSection = screen.getByTestId('streamsAppFeatureDetailsFlyoutMeta');
+    expect(metaSection).toBeInTheDocument();
+    expect(metaSection.textContent).toContain('"key1"');
+    expect(metaSection.textContent).toContain('"value1"');
+    expect(metaSection.textContent).toContain('"key2"');
+    expect(metaSection.textContent).toContain('42');
+  });
+
+  it('shows the Meta section with "No meta information" when meta is empty', () => {
+    const feature = createMinimalFeature({ meta: {} });
+    renderWithProviders(
+      <FeatureDetailsFlyout feature={feature} onClose={mockOnClose} />
+    );
+
+    const metaSection = screen.getByTestId('streamsAppFeatureDetailsFlyoutMeta');
+    expect(metaSection).toBeInTheDocument();
+    expect(screen.getByText('No meta information')).toBeInTheDocument();
+  });
+
+  it('shows nested meta values as JSON in a code block', () => {
+    const feature = createMinimalFeature({
+      meta: { endpoints: [{ host: 'a' }] },
+    });
+    renderWithProviders(
+      <FeatureDetailsFlyout feature={feature} onClose={mockOnClose} />
+    );
+
+    const metaSection = screen.getByTestId('streamsAppFeatureDetailsFlyoutMeta');
+    expect(metaSection).toBeInTheDocument();
+    expect(metaSection.textContent).toContain('endpoints');
+    expect(metaSection.textContent).toContain('"host"');
+    expect(metaSection.textContent).toContain('"a"');
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_features/feature_details_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_features/feature_details_flyout.test.tsx
@@ -1,6 +1,13 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
  * 2.0; you may not use this file except in compliance with the Elastic License 2.0.
  */
 
@@ -40,9 +47,7 @@ describe('FeatureDetailsFlyout', () => {
 
   it('shows the feature ID in the flyout', () => {
     const feature = createMinimalFeature({ id: 'feature-123' });
-    renderWithProviders(
-      <FeatureDetailsFlyout feature={feature} onClose={mockOnClose} />
-    );
+    renderWithProviders(<FeatureDetailsFlyout feature={feature} onClose={mockOnClose} />);
 
     const idElement = screen.getByTestId('streamsAppFeatureDetailsFlyoutId');
     expect(idElement).toBeInTheDocument();
@@ -53,9 +58,7 @@ describe('FeatureDetailsFlyout', () => {
     const feature = createMinimalFeature({
       meta: { key1: 'value1', key2: 42 },
     });
-    renderWithProviders(
-      <FeatureDetailsFlyout feature={feature} onClose={mockOnClose} />
-    );
+    renderWithProviders(<FeatureDetailsFlyout feature={feature} onClose={mockOnClose} />);
 
     const metaSection = screen.getByTestId('streamsAppFeatureDetailsFlyoutMeta');
     expect(metaSection).toBeInTheDocument();
@@ -67,9 +70,7 @@ describe('FeatureDetailsFlyout', () => {
 
   it('shows the Meta section with "No meta information" when meta is empty', () => {
     const feature = createMinimalFeature({ meta: {} });
-    renderWithProviders(
-      <FeatureDetailsFlyout feature={feature} onClose={mockOnClose} />
-    );
+    renderWithProviders(<FeatureDetailsFlyout feature={feature} onClose={mockOnClose} />);
 
     const metaSection = screen.getByTestId('streamsAppFeatureDetailsFlyoutMeta');
     expect(metaSection).toBeInTheDocument();
@@ -80,9 +81,7 @@ describe('FeatureDetailsFlyout', () => {
     const feature = createMinimalFeature({
       meta: { endpoints: [{ host: 'a' }] },
     });
-    renderWithProviders(
-      <FeatureDetailsFlyout feature={feature} onClose={mockOnClose} />
-    );
+    renderWithProviders(<FeatureDetailsFlyout feature={feature} onClose={mockOnClose} />);
 
     const metaSection = screen.getByTestId('streamsAppFeatureDetailsFlyoutMeta');
     expect(metaSection).toBeInTheDocument();

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_features/feature_details_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_features/feature_details_flyout.tsx
@@ -7,6 +7,7 @@
 import {
   EuiBadge,
   EuiButtonIcon,
+  EuiCodeBlock,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiDescriptionList,
@@ -94,10 +95,6 @@ export function FeatureDetailsFlyout({
       ),
     },
     {
-      title: LAST_SEEN_LABEL,
-      description: <EuiText size="s">{feature.last_seen || noDataPlaceholder}</EuiText>,
-    },
-    {
       title: TAGS_LABEL,
       description:
         feature.tags.length > 0 ? (
@@ -111,6 +108,31 @@ export function FeatureDetailsFlyout({
         ) : (
           <EuiText size="s">{noDataPlaceholder}</EuiText>
         ),
+    },
+    {
+      title: ID_LABEL,
+      description: (
+        <EuiText size="s" data-test-subj="streamsAppFeatureDetailsFlyoutId">
+          <code
+            css={css`
+              font-family: ${euiTheme.font.familyCode};
+              font-size: ${euiTheme.font.scale.s};
+            `}
+          >
+            {feature.id}
+          </code>
+        </EuiText>
+      ),
+    },
+    {
+      title: LAST_SEEN_LABEL,
+      description: <EuiText size="s">{feature.last_seen || noDataPlaceholder}</EuiText>,
+    },
+    {
+      title: EXPIRES_AT_LABEL,
+      description: (
+        <EuiText size="s">{feature.expires_at ?? noDataPlaceholder}</EuiText>
+      ),
     },
   ];
 
@@ -222,6 +244,17 @@ export function FeatureDetailsFlyout({
               )}
             </InfoPanel>
           </EuiFlexItem>
+          <EuiFlexItem data-test-subj="streamsAppFeatureDetailsFlyoutMeta">
+            <InfoPanel title={META_LABEL}>
+              {Object.keys(feature.meta).length === 0 ? (
+                <EuiText size="s">{NO_META_AVAILABLE}</EuiText>
+              ) : (
+                <EuiCodeBlock language="json" paddingSize="s" fontSize="s" isCopyable>
+                  {JSON.stringify(feature.meta, null, 2)}
+                </EuiCodeBlock>
+              )}
+            </InfoPanel>
+          </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlyoutBody>
       {isDeleteModalVisible && onDelete && (
@@ -237,6 +270,10 @@ export function FeatureDetailsFlyout({
 }
 
 // i18n labels
+
+const ID_LABEL = i18n.translate('xpack.streams.featureDetailsFlyout.idLabel', {
+  defaultMessage: 'ID',
+});
 
 const NAME_LABEL = i18n.translate('xpack.streams.featureDetailsFlyout.nameLabel', {
   defaultMessage: 'Name',
@@ -268,6 +305,10 @@ const CONFIDENCE_LABEL = i18n.translate('xpack.streams.featureDetailsFlyout.conf
 
 const LAST_SEEN_LABEL = i18n.translate('xpack.streams.featureDetailsFlyout.lastSeenLabel', {
   defaultMessage: 'Last seen',
+});
+
+const EXPIRES_AT_LABEL = i18n.translate('xpack.streams.featureDetailsFlyout.expiresAtLabel', {
+  defaultMessage: 'Expires at',
 });
 
 const TAGS_LABEL = i18n.translate('xpack.streams.featureDetailsFlyout.tagsLabel', {
@@ -309,4 +350,13 @@ const EVIDENCE_LABEL = i18n.translate('xpack.streams.featureDetailsFlyout.eviden
 const NO_EVIDENCE_AVAILABLE = i18n.translate(
   'xpack.streams.featureDetailsFlyout.noEvidenceAvailable',
   { defaultMessage: 'No evidence available' }
+);
+
+const META_LABEL = i18n.translate('xpack.streams.featureDetailsFlyout.metaLabel', {
+  defaultMessage: 'Meta',
+});
+
+const NO_META_AVAILABLE = i18n.translate(
+  'xpack.streams.featureDetailsFlyout.noMetaAvailable',
+  { defaultMessage: 'No meta information' }
 );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_features/feature_details_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_features/feature_details_flyout.tsx
@@ -130,9 +130,7 @@ export function FeatureDetailsFlyout({
     },
     {
       title: EXPIRES_AT_LABEL,
-      description: (
-        <EuiText size="s">{feature.expires_at ?? noDataPlaceholder}</EuiText>
-      ),
+      description: <EuiText size="s">{feature.expires_at ?? noDataPlaceholder}</EuiText>,
     },
   ];
 
@@ -356,7 +354,6 @@ const META_LABEL = i18n.translate('xpack.streams.featureDetailsFlyout.metaLabel'
   defaultMessage: 'Meta',
 });
 
-const NO_META_AVAILABLE = i18n.translate(
-  'xpack.streams.featureDetailsFlyout.noMetaAvailable',
-  { defaultMessage: 'No meta information' }
-);
+const NO_META_AVAILABLE = i18n.translate('xpack.streams.featureDetailsFlyout.noMetaAvailable', {
+  defaultMessage: 'No meta information',
+});


### PR DESCRIPTION
- Show feature ID and expires at in the flyout description list
- Add Meta panel with JSON code block for feature.meta (or placeholder when empty)
- Add unit tests for FeatureDetailsFlyout (ID and meta section)
