### PR TITLE
[SharedUX] Enforce feedback enablement check for data-discovery

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/esql_dataview_transition/esql_dataview_transition_modal.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/esql_dataview_transition/esql_dataview_transition_modal.tsx
@@ -41,7 +41,7 @@ export default function ESQLToDataViewTransitionModal({
     setDismissModalChecked(e.target.checked);
   }, []);
   const { notifications } = useDiscoverServices();
-  const isFeedbackEnabled = notifications?.feedback?.isEnabled() ?? true;
+  const isFeedbackEnabled = notifications.feedback.isEnabled();
   const modalTitleId = useGeneratedHtmlId({
     prefix: 'discover-esql-to-dataview-modal-title',
   });

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/esql_dataview_transition/esql_dataview_transition_modal.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/esql_dataview_transition/esql_dataview_transition_modal.tsx
@@ -26,6 +26,7 @@ import {
   EuiHorizontalRule,
   useGeneratedHtmlId,
 } from '@elastic/eui';
+import { useDiscoverServices } from '../../../../../hooks/use_discover_services';
 
 export interface ESQLToDataViewTransitionModalProps {
   onClose: (dismissFlag?: boolean, needsSave?: boolean) => void;
@@ -39,7 +40,8 @@ export default function ESQLToDataViewTransitionModal({
   const onTransitionModalDismiss = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setDismissModalChecked(e.target.checked);
   }, []);
-
+  const { notifications } = useDiscoverServices();
+  const isFeedbackEnabled = notifications?.feedback?.isEnabled() ?? true;
   const modalTitleId = useGeneratedHtmlId({
     prefix: 'discover-esql-to-dataview-modal-title',
   });
@@ -66,15 +68,17 @@ export default function ESQLToDataViewTransitionModal({
               'Switching data views removes the current ES|QL query. Save this session to avoid losing work.',
           })}
         </EuiText>
-        <EuiFlexGroup alignItems="center" justifyContent="flexEnd" gutterSize="xs">
-          <EuiFlexItem grow={false}>
-            <EuiLink external href={FEEDBACK_LINK} target="_blank">
-              {i18n.translate('discover.esqlToDataViewTransitionModal.feedbackLink', {
-                defaultMessage: 'Submit ES|QL feedback',
-              })}
-            </EuiLink>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        {isFeedbackEnabled && (
+          <EuiFlexGroup alignItems="center" justifyContent="flexEnd" gutterSize="xs">
+            <EuiFlexItem grow={false}>
+              <EuiLink external href={FEEDBACK_LINK} target="_blank">
+                {i18n.translate('discover.esqlToDataViewTransitionModal.feedbackLink', {
+                  defaultMessage: 'Submit ES|QL feedback',
+                })}
+              </EuiLink>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        )}
         <EuiHorizontalRule margin="s" />
       </EuiModalBody>
       <EuiModalFooter css={{ paddingBlockStart: 0 }}>


### PR DESCRIPTION
## Summary

As part of [[Epic] Setting to disable feedback snippets, guided tours and announcements in Kibana](https://github.com/elastic/kibana/issues/234771) SharedUX has added two new `core.notifications` services for `feedback` and `tours`. Their `isEnabled()` API verifies if users should be shown that kind of elements by reading their preferences from global UI settings (`hideFeedback` and `hideAnnouncements`).

From now on, every feedback or tour component should call `isEnabled()` before rendering to honor user preferences. 

> [!IMPORTANT]
SharedUX will be opening PRs for existing occurrences per team. Each team should manually test their PR to verify toggling those settings results in the expected behavior. If your team owns more `feedback` or `tours` occurrences or are planning on doing so, this check needs to be added to honor user preferences.
>  

### Testing

**Feedback elements**
- This is a read-only setting, you need to override it via `kibana.dev.yml` with `uiSettings.globalOverrides.hideFeedback: true`.
- Verify changing the setting value hides/render the element as expected.

**Tours/announcements elements**
- Toggle either the deprecated `hideAnnouncements` space setting or the global one on the Stack Management > Advanced Settings UI.
- Verify toggling the setting hides/render the element as expected.

Related PR: [[SharedUX] Add feedback and tours to core notifications](https://github.com/elastic/kibana/pull/248248)