### PR TITLE
[Cascade] Row interaction improvements

### DIFF
--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.styles.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/components/data_cascade_impl/data_cascade_impl.styles.tsx
@@ -26,6 +26,9 @@ const slideIn = keyframes({
 export const dataCascadeImplStyles = (euiTheme: UseEuiTheme['euiTheme']) => ({
   container: css({
     flex: '1 1 auto',
+    // Creates a new stacking context to prevent z-index values
+    // from the virtualized rows from bleeding out to other elements
+    isolation: 'isolate',
   }),
   containerInner: css([relativePosition, { height: '100%' }]),
   cascadeTreeGridBlock: css([
@@ -47,6 +50,18 @@ export const dataCascadeImplStyles = (euiTheme: UseEuiTheme['euiTheme']) => ({
     [euiCanAnimate]: {
       animation: `${slideIn} ${euiTheme.animation.slow} ${euiTheme.animation.resistance}`,
     },
+  }),
+  // Hidden variant - keeps the element in DOM so ref is always available,
+  // but visually hidden and non-interactive
+  cascadeTreeGridHeaderStickyRenderSlotHidden: css({
+    position: 'sticky',
+    top: 0,
+    left: 0,
+    right: 0,
+    visibility: 'hidden',
+    pointerEvents: 'none',
+    height: 0,
+    overflow: 'hidden',
   }),
   cascadeTreeGridWrapper: css({
     background: euiTheme.colors.backgroundBaseSubdued,

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/table/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/table/index.tsx
@@ -242,7 +242,5 @@ export function TableCellRender<G extends GroupNode, L extends LeafNode>({
 }: {
   cell: Cell<G, L>;
 }) {
-  return (
-    <React.Fragment>{flexRender(cell.column.columnDef.cell, cell.getContext())}</React.Fragment>
-  );
+  return useMemo(() => flexRender(cell.column.columnDef.cell, cell.getContext()), [cell]);
 }

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.test.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.test.tsx
@@ -55,7 +55,7 @@ describe('virtualizer', () => {
 
       expect(result.current).toHaveProperty('getVirtualItems');
       expect(result.current).toHaveProperty('getTotalSize');
-      expect(result.current).toHaveProperty('activeStickyIndex');
+      expect(result.current).toHaveProperty('range');
       expect(result.current).toHaveProperty('virtualizedRowsSizeCache');
       expect(result.current).toHaveProperty('virtualizedRowComputedTranslateValue');
       expect(result.current).toHaveProperty('scrollToVirtualizedIndex');
@@ -67,13 +67,10 @@ describe('virtualizer', () => {
 
   describe('useCascadeVirtualizerRangeExtractor', () => {
     it('should return the default virtualizer range when the prop `enableStickyGroupHeader` is false', () => {
-      const setActiveStickyIndex = jest.fn();
-
       const { result } = renderHook(() =>
         useCascadeVirtualizerRangeExtractor({
           rows: rowsToRender(100),
           enableStickyGroupHeader: false,
-          setActiveStickyIndex,
         })
       );
 
@@ -85,7 +82,6 @@ describe('virtualizer', () => {
       };
 
       expect(result.current(range)).toEqual(defaultRangeExtractor(range));
-      expect(setActiveStickyIndex).not.toHaveBeenCalled();
     });
 
     it('will mark a row with depth 0 as sticky when the prop `enableStickyGroupHeader` is true and the row is expanded', () => {
@@ -96,13 +92,10 @@ describe('virtualizer', () => {
       // mock the group row with depth 0 as expanded
       jest.spyOn(rows[expandedRowIndex], 'getIsExpanded').mockReturnValue(true);
 
-      const setActiveStickyIndex = jest.fn();
-
       const { result } = renderHook(() =>
         useCascadeVirtualizerRangeExtractor({
           rows,
           enableStickyGroupHeader: true,
-          setActiveStickyIndex,
         })
       );
 
@@ -115,7 +108,6 @@ describe('virtualizer', () => {
       };
 
       expect(result.current(range)).toEqual(defaultRangeExtractor(range));
-      expect(setActiveStickyIndex).toHaveBeenCalledWith(expandedRowIndex);
     });
 
     it('when the range passed starts with a child row, the index for its parent row is included in the returned range value', () => {
@@ -136,18 +128,14 @@ describe('virtualizer', () => {
         count: 15,
       };
 
-      const setActiveStickyIndex = jest.fn();
-
       const { result } = renderHook(() =>
         useCascadeVirtualizerRangeExtractor({
           rows,
           enableStickyGroupHeader: true,
-          setActiveStickyIndex,
         })
       );
 
       expect(result.current(range)).toEqual(expect.arrayContaining([parentRowIndex]));
-      expect(setActiveStickyIndex).toHaveBeenCalledWith(parentRowIndex);
     });
   });
 

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.test.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.test.tsx
@@ -167,6 +167,7 @@ describe('virtualizer', () => {
           virtualItem: expect.any(Object),
           virtualRowStyle: expect.objectContaining({
             transform: expect.stringMatching(/translateY\(\d+px\)/),
+            zIndex: expect.any(Number),
           }),
           isActiveSticky: expect.any(Boolean),
         })

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/lib/core/virtualizer/index.tsx
@@ -15,6 +15,50 @@ import type { GroupNode } from '../../../store_provider';
 type UseVirtualizerOptions = Parameters<typeof useVirtualizer>[0];
 type UseVirtualizerReturnType = ReturnType<typeof useVirtualizer>;
 
+/**
+ * Calculates the active sticky index from the current visible range.
+ * Idea here is to find the nearest expanded parent index
+ * and add the index of the current row to the range of visible items rendered to the user.
+ * This should be called directly in the consuming component to ensure the value
+ * is always current and never stale due to intermediate memoization.
+ */
+export function calculateActiveStickyIndex<G extends GroupNode>(
+  rows: Row<G>[],
+  startIndex: number,
+  enableStickyGroupHeader: boolean
+): number | null {
+  if (!enableStickyGroupHeader) {
+    return null;
+  }
+
+  const rangeStartRow = rows[startIndex];
+  if (!rangeStartRow) {
+    return null;
+  }
+
+  const rangeStartParentRows = rangeStartRow.getParentRows();
+
+  if (!rangeStartParentRows.length && !rangeStartRow.getIsExpanded()) {
+    return null;
+  }
+
+  if (!rangeStartParentRows.length && rangeStartRow.getIsExpanded()) {
+    return rangeStartRow.index;
+  }
+
+  const nearestExpandedParentIndex = rangeStartParentRows.reduce<number>((acc, row, idx) => {
+    return (acc += row.index + idx);
+  }, 0);
+
+  const isExpandedLeafRow = !rangeStartRow.subRows.length && rangeStartRow.getIsExpanded();
+
+  return isExpandedLeafRow
+    ? // we add 1 to the index to account for the fact that
+      // we get an zero based index for children in relation to the parent
+      nearestExpandedParentIndex + rangeStartRow.index + 1
+    : nearestExpandedParentIndex;
+}
+
 export interface CascadeVirtualizerProps<G extends GroupNode>
   extends Pick<UseVirtualizerOptions, 'getScrollElement' | 'overscan'> {
   rows: Row<G>[];
@@ -35,8 +79,8 @@ export interface CascadeVirtualizerReturnValue
     | 'measureElement'
     | 'scrollOffset'
     | 'scrollElement'
+    | 'range'
   > {
-  activeStickyIndex: number | null;
   virtualizedRowComputedTranslateValue: Map<number, number>;
   virtualizedRowsSizeCache: Map<number, number>;
   scrollToVirtualizedIndex: UseVirtualizerReturnType['scrollToIndex'];
@@ -46,7 +90,6 @@ export interface CascadeVirtualizerReturnValue
 export interface VirtualizerRangeExtractorArgs<G extends GroupNode> {
   rows: Row<G>[];
   enableStickyGroupHeader: boolean;
-  setActiveStickyIndex: (index: number | null) => void;
 }
 
 /**
@@ -58,50 +101,23 @@ export interface VirtualizerRangeExtractorArgs<G extends GroupNode> {
 export const useCascadeVirtualizerRangeExtractor = <G extends GroupNode>({
   rows,
   enableStickyGroupHeader,
-  setActiveStickyIndex,
 }: VirtualizerRangeExtractorArgs<G>) => {
-  const activeStickyIndexRef = useRef<number | null>(null);
-
   return useCallback<NonNullable<UseVirtualizerOptions['rangeExtractor']>>(
     (range) => {
-      const rangeStartRow = rows[range.startIndex];
-
       if (!enableStickyGroupHeader) {
         return defaultRangeExtractor(range);
       }
 
-      const rangeStartParentRows = rangeStartRow.getParentRows();
-
-      if (!Boolean(rangeStartParentRows.length) && !rangeStartRow.getIsExpanded()) {
-        activeStickyIndexRef.current = null;
-      } else if (!Boolean(rangeStartParentRows.length) && rangeStartRow.getIsExpanded()) {
-        activeStickyIndexRef.current = rangeStartRow.index;
-      } else {
-        const nearestExpandedParentIndex = rangeStartParentRows.reduce<number>((acc, row, idx) => {
-          return (acc! += row.index + idx);
-        }, 0);
-
-        const isExpandedLeafRow =
-          !Boolean(rangeStartRow.subRows.length) && rangeStartRow.getIsExpanded();
-
-        activeStickyIndexRef.current = isExpandedLeafRow
-          ? // we add 1 to the index to account for the fact that
-            // we get an zero based index for children in relation to the parent
-            nearestExpandedParentIndex + rangeStartRow.index + 1
-          : nearestExpandedParentIndex;
-      }
+      // Calculate the sticky index to include in the render range
+      const activeStickyIndex = calculateActiveStickyIndex(rows, range.startIndex, true);
 
       const next = new Set(
-        [activeStickyIndexRef.current, ...defaultRangeExtractor(range)].filter(
-          Number.isInteger
-        ) as number[]
+        [activeStickyIndex, ...defaultRangeExtractor(range)].filter(Number.isInteger) as number[]
       );
-
-      setActiveStickyIndex(activeStickyIndexRef.current);
 
       return Array.from(next).sort((a, b) => a - b);
     },
-    [rows, enableStickyGroupHeader, setActiveStickyIndex]
+    [rows, enableStickyGroupHeader]
   );
 };
 
@@ -113,16 +129,10 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
   getScrollElement,
 }: CascadeVirtualizerProps<G>): CascadeVirtualizerReturnValue => {
   const virtualizedRowsSizeCacheRef = useRef<Map<number, number>>(new Map());
-  const activeStickyIndexRef = useRef<number | null>(null);
-
-  const setActiveStickyIndex = useCallback((index: number | null) => {
-    activeStickyIndexRef.current = index;
-  }, []);
 
   const rangeExtractor = useCascadeVirtualizerRangeExtractor<G>({
     rows,
     enableStickyGroupHeader,
-    setActiveStickyIndex,
   });
 
   /**
@@ -152,8 +162,11 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
 
   return useMemo(
     () => ({
-      get activeStickyIndex() {
-        return activeStickyIndexRef.current;
+      get scrollOffset() {
+        return virtualizerImpl.scrollOffset;
+      },
+      get range() {
+        return virtualizerImpl.range;
       },
       getTotalSize: virtualizerImpl.getTotalSize.bind(virtualizerImpl),
       getVirtualItems: virtualizerImpl.getVirtualItems.bind(virtualizerImpl),
@@ -167,9 +180,6 @@ export const useCascadeVirtualizer = <G extends GroupNode>({
       },
       get scrollToLastVirtualizedRow() {
         return () => this.scrollToVirtualizedIndex(rows.length - 1);
-      },
-      get scrollOffset() {
-        return virtualizerImpl.scrollOffset;
       },
       get virtualizedRowComputedTranslateValue() {
         return virtualizedRowComputedTranslateValueRef.current;
@@ -197,9 +207,10 @@ export const getGridRowPositioningStyle = (
 export interface VirtualizedCascadeListProps<G extends GroupNode>
   extends Pick<
     CascadeVirtualizerReturnValue,
-    'virtualizedRowComputedTranslateValue' | 'getVirtualItems' | 'activeStickyIndex'
+    'virtualizedRowComputedTranslateValue' | 'getVirtualItems'
   > {
   rows: Row<G>[];
+  activeStickyIndex: number | null;
   listItemRenderer: (props: {
     isActiveSticky: boolean;
     virtualItem: VirtualItem;


### PR DESCRIPTION
## Summary

Culled from https://github.com/elastic/kibana/pull/250604

This PR makes changes to the cascade component to resolve couple of UI jankiness; 

- Row header becomes sticky as soon as the row is scrolled, as opposed to only when there's a pause in scrolling
	
	![ScreenRecording2026-01-29at13 48 13-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/9ef32b11-93ac-4607-bde1-10245b001d23)
	
- On expanding a row that's just loading it's data, the issue where the unexpanded row would be layered over the expanded row has been resolved
	#### Before
	![ScreenRecording2026-01-29at12 00 09-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ea44312e-30af-424b-848b-19eadc534a8d)
	#### After	
	![ScreenRecording2026-01-29at12 09 11-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/b4070797-ae34-4148-8120-c2de74def2ee)

<!--

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->

