### PR TITLE
Fix disabled connector button

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_header/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_header/index.test.tsx
@@ -120,6 +120,20 @@ describe('AssistantHeader', () => {
     ).not.toBeDisabled();
   });
 
+  it('disables assistant settings menu when isDisabled=true', () => {
+    render(<AssistantHeader {...testProps} isDisabled={true} />, {
+      wrapper: TestProviders,
+    });
+    expect(screen.getByTestId('chat-context-menu')).toBeDisabled();
+  });
+
+  it('enables assistant settings menu when isDisabled=false', () => {
+    render(<AssistantHeader {...testProps} isDisabled={false} />, {
+      wrapper: TestProviders,
+    });
+    expect(screen.getByTestId('chat-context-menu')).not.toBeDisabled();
+  });
+
   it('disables share badge when isConversationOwner=false', () => {
     render(<AssistantHeader {...testProps} isConversationOwner={false} />, {
       wrapper: TestProviders,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.test.tsx
@@ -27,6 +27,15 @@ import type { AIConnector } from '../connectorland/connector_selector';
 import type { FetchAnonymizationFields } from './api/anonymization_fields/use_fetch_anonymization_fields';
 import { useFetchAnonymizationFields } from './api/anonymization_fields/use_fetch_anonymization_fields';
 import { welcomeConvo } from '../mock/conversation';
+import {
+  CONTENT_REFERENCES_VISIBLE_LOCAL_STORAGE_KEY,
+  DEFAULT_KNOWLEDGE_BASE_SETTINGS,
+  KNOWLEDGE_BASE_LOCAL_STORAGE_KEY,
+  LAST_CONVERSATION_ID_LOCAL_STORAGE_KEY,
+  LAST_SELECTED_CONVERSATION_LOCAL_STORAGE_KEY,
+  SHOW_ANONYMIZED_VALUES_LOCAL_STORAGE_KEY,
+  STREAMING_LOCAL_STORAGE_KEY,
+} from '../assistant_context/constants';
 
 jest.mock('../connectorland/use_load_connectors');
 jest.mock('../connectorland/connector_setup');
@@ -141,6 +150,7 @@ describe('Assistant', () => {
         actionTypeId: '.gen-ai',
       },
     ];
+
     jest.mocked(useLoadConnectors).mockReturnValue({
       isFetched: true,
       isFetchedAfterMount: true,
@@ -150,12 +160,24 @@ describe('Assistant', () => {
     jest
       .mocked(useFetchCurrentUserConversations)
       .mockReturnValue(defaultFetchUserConversations as unknown as FetchCurrentUserConversations);
+
     jest.mocked(useFetchAnonymizationFields).mockReturnValue(mockAnonymizationFields);
-    jest
-      .mocked(useLocalStorage)
-      .mockReturnValue([mockData.welcome_id, persistToLocalStorage] as unknown as ReturnType<
-        typeof useLocalStorage
-      >);
+
+    const localStorageDefaults: Array<[string, unknown]> = [
+      [LAST_SELECTED_CONVERSATION_LOCAL_STORAGE_KEY, mockData.welcome_id],
+      [LAST_CONVERSATION_ID_LOCAL_STORAGE_KEY, mockData.welcome_id.id],
+      [SHOW_ANONYMIZED_VALUES_LOCAL_STORAGE_KEY, false],
+      [CONTENT_REFERENCES_VISIBLE_LOCAL_STORAGE_KEY, true],
+      [STREAMING_LOCAL_STORAGE_KEY, true],
+      [KNOWLEDGE_BASE_LOCAL_STORAGE_KEY, DEFAULT_KNOWLEDGE_BASE_SETTINGS],
+    ];
+
+    jest.mocked(useLocalStorage).mockImplementation((key, initialValue) => {
+      const match = localStorageDefaults.find(([storageKey]) => key.includes(storageKey));
+      const value = match ? match[1] : initialValue;
+      return [value, persistToLocalStorage] as unknown as ReturnType<typeof useLocalStorage>;
+    });
+
     jest
       .mocked(useSessionStorage)
       .mockReturnValue([undefined, persistToSessionStorage] as unknown as ReturnType<

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -202,7 +202,7 @@ const AssistantComponent: React.FC<Props> = ({
 
   const [_, setCodeBlockControlsVisible] = useState(false);
   useLayoutEffect(() => {
-    let unmountFunc = () => { };
+    let unmountFunc = () => {};
     if (currentConversation) {
       // need in order for code block controls to be added to the DOM
       setTimeout(() => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -192,10 +192,8 @@ const AssistantComponent: React.FC<Props> = ({
         : (connectors?.length ?? 0) === 0,
     [connectors?.length, conversations]
   );
-  const isDisabled = useMemo(
-    () => isWelcomeSetup || !isAssistantEnabled || isInitialLoad,
-    [isWelcomeSetup, isAssistantEnabled, isInitialLoad]
-  );
+
+  const isChatDisabled = isWelcomeSetup || !isAssistantEnabled || isInitialLoad;
 
   // Settings modal state (so it isn't shared between assistant instances like Timeline)
   const [isSettingsModalVisible, setIsSettingsModalVisible] = useState(false);
@@ -204,7 +202,7 @@ const AssistantComponent: React.FC<Props> = ({
 
   const [_, setCodeBlockControlsVisible] = useState(false);
   useLayoutEffect(() => {
-    let unmountFunc = () => {};
+    let unmountFunc = () => { };
     if (currentConversation) {
       // need in order for code block controls to be added to the DOM
       setTimeout(() => {
@@ -263,9 +261,7 @@ const AssistantComponent: React.FC<Props> = ({
     return false;
   }, [isFetchedConnectors, connectors, currentConversation, isLoadingCurrentUserConversations]);
 
-  const isSendingDisabled = useMemo(() => {
-    return isDisabled || showMissingConnectorCallout;
-  }, [showMissingConnectorCallout, isDisabled]);
+  const isSendingDisabled = isChatDisabled || showMissingConnectorCallout;
 
   // Fixes initial render not showing buttons as code block controls are added to the DOM really late
   useEffect(() => {
@@ -307,6 +303,8 @@ const AssistantComponent: React.FC<Props> = ({
     setSelectedPromptContexts,
     setCurrentConversation,
   });
+
+  const isHeaderDisabled = !isAssistantEnabled || isInitialLoad || isLoadingChatSend;
 
   useEffect(() => {
     if (
@@ -484,7 +482,7 @@ const AssistantComponent: React.FC<Props> = ({
                     defaultConnector={defaultConnector}
                     isAssistantEnabled={isAssistantEnabled}
                     isConversationOwner={isConversationOwner}
-                    isDisabled={isDisabled || isLoadingChatSend}
+                    isDisabled={isHeaderDisabled}
                     isLoading={isInitialLoad}
                     isSettingsModalVisible={isSettingsModalVisible}
                     onChatCleared={handleOnChatCleared}
@@ -524,7 +522,7 @@ const AssistantComponent: React.FC<Props> = ({
                     }
                   `}
                   banner={
-                    !isDisabled &&
+                    !isChatDisabled &&
                     isFetchedConnectors && (
                       <AssistantConversationBanner
                         isSettingsModalVisible={isSettingsModalVisible}
@@ -573,7 +571,7 @@ const AssistantComponent: React.FC<Props> = ({
                           overflow: auto;
                         `}
                       >
-                        {!isDisabled &&
+                        {!isChatDisabled &&
                           Object.keys(promptContexts).length !== selectedPromptContextsCount && (
                             <EuiFlexGroup>
                               <EuiFlexItem>
@@ -618,7 +616,7 @@ const AssistantComponent: React.FC<Props> = ({
                         </EuiFlexGroup>
                       </EuiPanel>
 
-                      {!isDisabled && (
+                      {!isChatDisabled && (
                         <EuiPanel
                           css={css`
                             background: ${euiTheme.colors.backgroundBaseSubdued};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -240,8 +240,7 @@ const AssistantComponent: React.FC<Props> = ({
 
   useEvent('keydown', onKeyDown);
 
-  // Show missing connector callout if no connectors are configured
-
+  // Show missing connector callout if the current conversation's connector doesn't exist in the connectors list
   const showMissingConnectorCallout = useMemo(() => {
     if (
       !isLoadingCurrentUserConversations &&

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.tsx
@@ -197,6 +197,7 @@ export const AssistantSettingsContextMenu: React.FC<Params> = React.memo(
           </EuiFlexGroup>
         </EuiContextMenuItem>,
         <TryAIAgentContextMenuItem
+          key="try-ai-agent"
           analytics={analytics}
           handleOpenAIAgentModal={handleOpenAIAgentModal}
           hasAgentBuilderManagePrivilege={assistantAvailability.hasAgentBuilderManagePrivilege}

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/add_connector_modal/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/add_connector_modal/index.tsx
@@ -21,6 +21,8 @@ interface Props {
   onSelectActionType: (actionType: ActionType) => void;
   selectedActionType: ActionType | null;
   actionTypeSelectorInline?: boolean;
+  isMissingConnectorPrivileges?: boolean;
+  missingPrivilegesTooltip?: string;
 }
 export const AddConnectorModal: React.FC<Props> = React.memo(
   ({
@@ -31,6 +33,8 @@ export const AddConnectorModal: React.FC<Props> = React.memo(
     onSelectActionType,
     selectedActionType,
     actionTypeSelectorInline = false,
+    isMissingConnectorPrivileges = false,
+    missingPrivilegesTooltip,
   }) => (
     <>
       <Suspense fallback={null}>
@@ -40,6 +44,8 @@ export const AddConnectorModal: React.FC<Props> = React.memo(
           onClose={onClose}
           onSelect={onSelectActionType}
           actionTypeSelectorInline={actionTypeSelectorInline}
+          isMissingConnectorPrivileges={isMissingConnectorPrivileges}
+          missingPrivilegesTooltip={missingPrivilegesTooltip}
         />
       </Suspense>
       {selectedActionType && (

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { ConnectorSelector } from '.';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { mockAssistantAvailability, TestProviders } from '../../mock/test_providers/test_providers';
 import { mockActionTypes, mockConnectors } from '../../mock/connectors';
 import * as i18n from '../translations';
@@ -137,6 +137,45 @@ describe('Connector selector', () => {
     const addButton = screen.getByTestId('addNewConnectorButton');
     expect(addButton).toBeInTheDocument();
     expect(addButton).toBeDisabled();
+  });
+
+  it('shows tooltip with missing privileges message when hovering disabled add connector button', () => {
+    jest.useFakeTimers();
+    jest.mocked(useLoadConnectors).mockReturnValue(
+      createMockUseLoadConnectorsResult({
+        data: [],
+        error: null,
+        isSuccess: true,
+        isLoading: false,
+        isFetching: false,
+        refetch: mockRefetchConnectors,
+      })
+    );
+
+    render(
+      <TestProviders
+        assistantAvailability={{
+          ...mockAssistantAvailability,
+          hasConnectorsAllPrivilege: false,
+          hasConnectorsReadPrivilege: true,
+        }}
+      >
+        <ConnectorSelector {...defaultProps} selectedConnectorId={undefined} />
+      </TestProviders>
+    );
+
+    const addButton = screen.getByTestId('addNewConnectorButton');
+    expect(addButton).toBeDisabled();
+
+    fireEvent.mouseOver(addButton);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(screen.getByRole('tooltip')).toHaveTextContent(
+      i18n.ADD_CONNECTOR_MISSING_PRIVILEGES_DESCRIPTION
+    );
+    jest.useRealTimers();
   });
 
   it('renders add new connector button if no selected connector is provided', () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.test.tsx
@@ -12,9 +12,7 @@ import { mockAssistantAvailability, TestProviders } from '../../mock/test_provid
 import { mockActionTypes, mockConnectors } from '../../mock/connectors';
 import * as i18n from '../translations';
 import { useLoadConnectors } from '../use_load_connectors';
-import type { QueryObserverSuccessResult } from '@kbn/react-query';
-import type { IHttpFetchError } from '@kbn/core-http-browser';
-import type { AIConnector } from '.';
+import { createMockUseLoadConnectorsResult } from '../../mock/test_helpers';
 
 const onConnectorSelectionChange = jest.fn();
 const setIsOpen = jest.fn();
@@ -28,41 +26,6 @@ const defaultProps = {
 const connectorTwo = mockConnectors[1];
 
 const mockRefetchConnectors = jest.fn();
-
-// Helper function to create a properly typed mock return value
-// Returns a QueryObserverSuccessResult which is compatible with UseQueryResult
-const createMockUseLoadConnectorsResult = (
-  overrides: Partial<QueryObserverSuccessResult<AIConnector[], IHttpFetchError>>
-): QueryObserverSuccessResult<AIConnector[], IHttpFetchError> => {
-  return {
-    data: [] as AIConnector[],
-    error: null,
-    isError: false,
-    isLoading: false,
-    isSuccess: true,
-    isFetching: false,
-    isInitialLoading: false,
-    isLoadingError: false,
-    isRefetchError: false,
-    isRefetching: false,
-    isStale: false,
-    isPreviousData: false,
-    status: 'success',
-    dataUpdatedAt: 0,
-    errorUpdatedAt: 0,
-    errorUpdateCount: 0,
-    failureCount: 0,
-    failureReason: null,
-    fetchStatus: 'idle',
-    isFetched: true,
-    isFetchedAfterMount: true,
-    isPaused: false,
-    isPlaceholderData: false,
-    refetch: jest.fn(),
-    remove: jest.fn(),
-    ...overrides,
-  };
-};
 
 jest.mock('../use_load_connectors', () => ({
   useLoadConnectors: jest.fn(),
@@ -142,7 +105,9 @@ describe('Connector selector', () => {
       </TestProviders>
     );
 
-    expect(screen.getByTestId('addNewConnectorButton')).toBeEnabled();
+    const addButton = screen.getByTestId('addNewConnectorButton');
+    expect(addButton).toBeInTheDocument();
+    expect(addButton).toBeEnabled();
   });
 
   it('disables add connector button when user cannot create connectors', () => {
@@ -169,7 +134,9 @@ describe('Connector selector', () => {
       </TestProviders>
     );
 
-    expect(screen.getByTestId('addNewConnectorButton')).toBeDisabled();
+    const addButton = screen.getByTestId('addNewConnectorButton');
+    expect(addButton).toBeInTheDocument();
+    expect(addButton).toBeDisabled();
   });
 
   it('renders add new connector button if no selected connector is provided', () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.test.tsx
@@ -47,6 +47,24 @@ jest.mock('../use_load_action_types', () => ({
 
 const newConnector = { actionTypeId: '.gen-ai', name: 'cool name' };
 
+const OriginalMutationObserver = global.MutationObserver;
+
+beforeAll(() => {
+  class MockMutationObserver {
+    observe() { }
+    disconnect() { }
+    takeRecords() {
+      return [];
+    }
+  }
+
+  global.MutationObserver = MockMutationObserver as unknown as typeof MutationObserver;
+});
+
+afterAll(() => {
+  global.MutationObserver = OriginalMutationObserver;
+});
+
 jest.mock('../add_connector_modal', () => ({
   // @ts-ignore
   AddConnectorModal: ({ onSaveConnector }) => (

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
@@ -13,6 +13,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiInputPopover,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import React, { Suspense, useCallback, useMemo, useState } from 'react';
@@ -55,6 +56,24 @@ export type AIConnector = ActionConnector & {
   // related to OpenAI connectors, ex: Azure OpenAI, OpenAI
   apiProvider?: OpenAiProviderType;
 };
+
+interface GroupedConnectors {
+  customConnectors: ConnectorSelectableComponentProps['customConnectors'];
+  preConfiguredConnectors: ConnectorSelectableComponentProps['preConfiguredConnectors'];
+}
+
+const groupConnectors = (connectors: ActionConnector[] | undefined): GroupedConnectors =>
+  (connectors ?? []).reduce<GroupedConnectors>(
+    (acc, connector) => {
+      const target = connector.isPreconfigured ? acc.preConfiguredConnectors : acc.customConnectors;
+      target.push({ label: connector.name, value: connector.id });
+      return acc;
+    },
+    {
+      customConnectors: [],
+      preConfiguredConnectors: [],
+    }
+  );
 
 export const ConnectorSelector: React.FC<Props> = React.memo(
   ({
@@ -146,36 +165,17 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
     );
     const buttonLabel = selectedOrDefaultConnector?.name ?? i18n.INLINE_CONNECTOR_PLACEHOLDER;
     const localIsDisabled = isDisabled || !assistantAvailability.hasConnectorsReadPrivilege;
-    const isAddConnectorDisabled = isDisabled || !assistantAvailability.hasConnectorsAllPrivilege;
+    const isAddConnectorMissingPrivileges = !assistantAvailability.hasConnectorsAllPrivilege;
+    const isAddConnectorDisabled = isDisabled || isAddConnectorMissingPrivileges;
 
     // Group connectors into pre-configured and custom
     const { customConnectors, preConfiguredConnectors } = useMemo(
-      () =>
-        (aiConnectors ?? []).reduce<{
-          customConnectors: ConnectorSelectableComponentProps['customConnectors'];
-          preConfiguredConnectors: ConnectorSelectableComponentProps['preConfiguredConnectors'];
-        }>(
-          (acc, connector) => {
-            if (connector.isPreconfigured) {
-              acc.preConfiguredConnectors.push({
-                label: connector.name,
-                value: connector.id,
-              });
-            } else {
-              acc.customConnectors.push({
-                label: connector.name,
-                value: connector.id,
-              });
-            }
-            return acc;
-          },
-          {
-            customConnectors: [],
-            preConfiguredConnectors: [],
-          }
-        ),
+      () => groupConnectors(aiConnectors),
       [aiConnectors]
     );
+
+    const totalConnectors = customConnectors.length + preConfiguredConnectors.length;
+    const hasNoConnectors = !connectorExists && totalConnectors === 0;
 
     const renderOption: ConnectorSelectableProps['renderOption'] = useCallback(
       (option: EuiSelectableOption) => {
@@ -264,18 +264,28 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
       euiTheme.colors.textPrimary,
     ]);
 
+    const addConnectorButton = (
+      <EuiButtonEmpty
+        data-test-subj="addNewConnectorButton"
+        iconType="plusInCircle"
+        isDisabled={isAddConnectorDisabled}
+        size="xs"
+        onClick={() => setIsConnectorModalVisible(true)}
+      >
+        {i18n.ADD_CONNECTOR}
+      </EuiButtonEmpty>
+    );
+
     return (
       <>
-        {!connectorExists && customConnectors.length + preConfiguredConnectors.length === 0 ? (
-          <EuiButtonEmpty
-            data-test-subj="addNewConnectorButton"
-            iconType="plusInCircle"
-            isDisabled={isAddConnectorDisabled}
-            size="xs"
-            onClick={() => setIsConnectorModalVisible(true)}
-          >
-            {i18n.ADD_CONNECTOR}
-          </EuiButtonEmpty>
+        {hasNoConnectors ? (
+          isAddConnectorMissingPrivileges ? (
+            <EuiToolTip content={i18n.ADD_CONNECTOR_MISSING_PRIVILEGES_DESCRIPTION}>
+              {addConnectorButton}
+            </EuiToolTip>
+          ) : (
+            addConnectorButton
+          )
         ) : (
           <EuiInputPopover
             input={input}

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
@@ -146,6 +146,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
     );
     const buttonLabel = selectedOrDefaultConnector?.name ?? i18n.INLINE_CONNECTOR_PLACEHOLDER;
     const localIsDisabled = isDisabled || !assistantAvailability.hasConnectorsReadPrivilege;
+    const isAddConnectorDisabled = isDisabled || !assistantAvailability.hasConnectorsAllPrivilege;
 
     // Group connectors into pre-configured and custom
     const { customConnectors, preConfiguredConnectors } = useMemo(
@@ -269,7 +270,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
           <EuiButtonEmpty
             data-test-subj="addNewConnectorButton"
             iconType="plusInCircle"
-            isDisabled={localIsDisabled}
+            isDisabled={isAddConnectorDisabled}
             size="xs"
             onClick={() => setIsConnectorModalVisible(true)}
           >

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/action_type_list.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/action_type_list.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ActionTypeList } from './action_type_list';
+import type { ActionType } from '@kbn/actions-plugin/common';
+import { actionTypeRegistryMock } from '@kbn/triggers-actions-ui-plugin/public/application/action_type_registry.mock';
+
+const actionTypes = [
+  {
+    id: '123',
+    name: 'Gen AI',
+    enabled: true,
+    enabledInConfig: true,
+    enabledInLicense: true,
+    minimumLicenseRequired: 'basic',
+    isSystemActionType: true,
+    supportedFeatureIds: ['generativeAI'],
+  } as ActionType,
+  {
+    id: '456',
+    name: 'Another one',
+    enabled: true,
+    enabledInConfig: true,
+    enabledInLicense: true,
+    minimumLicenseRequired: 'basic',
+    isSystemActionType: true,
+    supportedFeatureIds: ['generativeAI'],
+  } as ActionType,
+];
+
+const disabledActionType = {
+  id: '789',
+  name: 'Disabled Action',
+  enabled: false,
+  enabledInConfig: true,
+  enabledInLicense: false,
+  minimumLicenseRequired: 'platinum',
+  isSystemActionType: true,
+  supportedFeatureIds: ['generativeAI'],
+} as ActionType;
+
+const actionTypeRegistry = {
+  ...actionTypeRegistryMock.create(),
+  get: jest.fn().mockReturnValue({ iconClass: 'icon-class' }),
+};
+
+const onSelect = jest.fn();
+
+const defaultProps = {
+  actionTypes,
+  actionTypeRegistry,
+  onSelect,
+  isMissingConnectorPrivileges: false,
+};
+
+describe('ActionTypeList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render all action types', () => {
+    const { getAllByTestId } = render(<ActionTypeList {...defaultProps} />);
+
+    expect(getAllByTestId('action-option')).toHaveLength(actionTypes.length);
+  });
+
+  it('should render action type buttons with correct labels', () => {
+    const { getByTestId } = render(<ActionTypeList {...defaultProps} />);
+
+    expect(getByTestId(`action-option-${actionTypes[0].name}`)).toHaveTextContent('Gen AI');
+    expect(getByTestId(`action-option-${actionTypes[1].name}`)).toHaveTextContent('Another one');
+  });
+
+  it('should call onSelect with actionType when button is clicked', () => {
+    const { getByTestId } = render(<ActionTypeList {...defaultProps} />);
+
+    fireEvent.click(getByTestId(`action-option-${actionTypes[0].name}`));
+
+    expect(onSelect).toHaveBeenCalledWith(actionTypes[0]);
+  });
+
+  it('should disable buttons when isMissingConnectorPrivileges is true', () => {
+    const { getByTestId } = render(
+      <ActionTypeList {...defaultProps} isMissingConnectorPrivileges={true} />
+    );
+
+    expect(getByTestId(`action-option-${actionTypes[0].name}`)).toBeDisabled();
+    expect(getByTestId(`action-option-${actionTypes[1].name}`)).toBeDisabled();
+  });
+
+  it('should show tooltip on disabled buttons when missing privileges', async () => {
+    const missingPrivilegesTooltip = 'Test tooltip';
+    render(
+      <ActionTypeList
+        {...defaultProps}
+        isMissingConnectorPrivileges={true}
+        missingPrivilegesTooltip={missingPrivilegesTooltip}
+      />
+    );
+
+    const firstButton = screen.getByTestId(`action-option-${actionTypes[0].name}`);
+    fireEvent.mouseOver(firstButton);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(missingPrivilegesTooltip);
+  });
+
+  it('should not call onSelect when clicking a disabled button due to missing privileges', () => {
+    const { getByTestId } = render(
+      <ActionTypeList {...defaultProps} isMissingConnectorPrivileges={true} />
+    );
+
+    fireEvent.click(getByTestId(`action-option-${actionTypes[0].name}`));
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('should disable button when actionType.enabled is false', () => {
+    const { getByTestId } = render(
+      <ActionTypeList {...defaultProps} actionTypes={[disabledActionType]} />
+    );
+
+    expect(getByTestId(`action-option-${disabledActionType.name}`)).toBeDisabled();
+  });
+
+  it('should not call onSelect when clicking a button disabled due to actionType.enabled being false', () => {
+    const { getByTestId } = render(
+      <ActionTypeList {...defaultProps} actionTypes={[disabledActionType]} />
+    );
+
+    fireEvent.click(getByTestId(`action-option-${disabledActionType.name}`));
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('should render enabled buttons when isMissingConnectorPrivileges is false', () => {
+    const { getByTestId } = render(<ActionTypeList {...defaultProps} />);
+
+    expect(getByTestId(`action-option-${actionTypes[0].name}`)).toBeEnabled();
+    expect(getByTestId(`action-option-${actionTypes[1].name}`)).toBeEnabled();
+  });
+
+  it('should render empty list when actionTypes is empty', () => {
+    const { queryAllByTestId } = render(<ActionTypeList {...defaultProps} actionTypes={[]} />);
+
+    expect(queryAllByTestId('action-option')).toHaveLength(0);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/action_type_list.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/action_type_list.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiKeyPadMenuItem, EuiToolTip } from '@elastic/eui';
+import type { ActionType } from '@kbn/actions-plugin/common';
+import type { ActionTypeRegistryContract } from '@kbn/triggers-actions-ui-plugin/public';
+import { css } from '@emotion/css';
+import * as i18n from '../translations';
+
+const itemClassName = css`
+  inline-size: 150px;
+
+  .euiKeyPadMenuItem__label {
+    white-space: nowrap;
+    overflow: hidden;
+  }
+`;
+
+export interface ActionTypeListProps {
+  actionTypes: ActionType[];
+  actionTypeRegistry: ActionTypeRegistryContract;
+  onSelect: (actionType: ActionType) => void;
+  isMissingConnectorPrivileges?: boolean;
+  missingPrivilegesTooltip?: string;
+}
+
+export const ActionTypeList: React.FC<ActionTypeListProps> = ({
+  actionTypes,
+  actionTypeRegistry,
+  onSelect,
+  isMissingConnectorPrivileges = false,
+  missingPrivilegesTooltip = i18n.ADD_CONNECTOR_MISSING_PRIVILEGES_DESCRIPTION,
+}) => (
+  <EuiFlexGroup
+    justifyContent="center"
+    responsive={false}
+    wrap={true}
+    data-test-subj="action-type-list"
+  >
+    {actionTypes.map((actionType: ActionType) => {
+      const fullAction = actionTypeRegistry.get(actionType.id);
+      const buttonIsDisabled = isMissingConnectorPrivileges || !actionType.enabled;
+      const button = (
+        <EuiKeyPadMenuItem
+          className={itemClassName}
+          key={actionType.id}
+          isDisabled={buttonIsDisabled}
+          label={actionType.name}
+          data-test-subj={`action-option-${actionType.name}`}
+          onClick={() => onSelect(actionType)}
+        >
+          <EuiIcon size="xl" type={fullAction.iconClass} />
+        </EuiKeyPadMenuItem>
+      );
+      return (
+        <EuiFlexItem data-test-subj="action-option" key={actionType.id} grow={false}>
+          {isMissingConnectorPrivileges && missingPrivilegesTooltip ? (
+            <EuiToolTip content={missingPrivilegesTooltip}>{button}</EuiToolTip>
+          ) : (
+            button
+          )}
+        </EuiFlexItem>
+      );
+    })}
+  </EuiFlexGroup>
+);

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/action_type_selector_modal.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector_inline/action_type_selector_modal.tsx
@@ -5,12 +5,8 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
-  EuiKeyPadMenuItem,
   EuiModal,
   EuiModalBody,
   EuiModalHeader,
@@ -19,57 +15,44 @@ import {
 } from '@elastic/eui';
 import type { ActionType } from '@kbn/actions-plugin/common';
 import type { ActionTypeRegistryContract } from '@kbn/triggers-actions-ui-plugin/public';
-import { css } from '@emotion/css';
 import * as i18n from '../translations';
+import { ActionTypeList } from './action_type_list';
 
-interface Props {
+interface ActionTypeSelectorModalProps {
   actionTypes?: ActionType[];
   actionTypeRegistry: ActionTypeRegistryContract;
   onClose: () => void;
   onSelect: (actionType: ActionType) => void;
   actionTypeSelectorInline: boolean;
+  isMissingConnectorPrivileges?: boolean;
+  missingPrivilegesTooltip?: string;
 }
-const itemClassName = css`
-  inline-size: 150px;
 
-  .euiKeyPadMenuItem__label {
-    white-space: nowrap;
-    overflow: hidden;
-  }
-`;
-
-export const ActionTypeSelectorModal = React.memo(
-  ({ actionTypes, actionTypeRegistry, onClose, onSelect, actionTypeSelectorInline }: Props) => {
+export const ActionTypeSelectorModal: React.FC<ActionTypeSelectorModalProps> = React.memo(
+  ({
+    actionTypes,
+    actionTypeRegistry,
+    onClose,
+    onSelect,
+    actionTypeSelectorInline,
+    isMissingConnectorPrivileges = false,
+    missingPrivilegesTooltip,
+  }) => {
     const modalTitleId = useGeneratedHtmlId();
-
-    const content = useMemo(
-      () => (
-        <EuiFlexGroup justifyContent="center" responsive={false} wrap={true}>
-          {actionTypes?.map((actionType: ActionType) => {
-            const fullAction = actionTypeRegistry.get(actionType.id);
-            return (
-              <EuiFlexItem data-test-subj="action-option" key={actionType.id} grow={false}>
-                <EuiKeyPadMenuItem
-                  className={itemClassName}
-                  key={actionType.id}
-                  isDisabled={!actionType.enabled}
-                  label={actionType.name}
-                  data-test-subj={`action-option-${actionType.name}`}
-                  onClick={() => onSelect(actionType)}
-                >
-                  <EuiIcon size="xl" type={fullAction.iconClass} />
-                </EuiKeyPadMenuItem>
-              </EuiFlexItem>
-            );
-          })}
-        </EuiFlexGroup>
-      ),
-      [actionTypeRegistry, actionTypes, onSelect]
-    );
 
     if (!actionTypes?.length) return null;
 
-    if (actionTypeSelectorInline) return <>{content}</>;
+    const actionTypeList = (
+      <ActionTypeList
+        actionTypes={actionTypes}
+        actionTypeRegistry={actionTypeRegistry}
+        onSelect={onSelect}
+        isMissingConnectorPrivileges={isMissingConnectorPrivileges}
+        missingPrivilegesTooltip={missingPrivilegesTooltip}
+      />
+    );
+
+    if (actionTypeSelectorInline) return actionTypeList;
 
     return (
       <EuiModal
@@ -83,7 +66,7 @@ export const ActionTypeSelectorModal = React.memo(
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 
-        <EuiModalBody>{content}</EuiModalBody>
+        <EuiModalBody>{actionTypeList}</EuiModalBody>
       </EuiModal>
     );
   }

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_setup/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_setup/index.tsx
@@ -35,7 +35,10 @@ export const ConnectorSetup = ({
   );
   const { setApiConfig } = useConversation();
   // Access all conversations so we can add connector to all on initial setup
-  const { actionTypeRegistry, http, inferenceEnabled, settings } = useAssistantContext();
+  const { actionTypeRegistry, assistantAvailability, http, inferenceEnabled, settings } =
+    useAssistantContext();
+
+  const isMissingConnectorPrivileges = !assistantAvailability.hasConnectorsAllPrivilege;
 
   const { refetch: refetchConnectors } = useLoadConnectors({ http, inferenceEnabled, settings });
 
@@ -90,6 +93,7 @@ export const ConnectorSetup = ({
       onSelectActionType={setSelectedActionType}
       selectedActionType={selectedActionType}
       actionTypeSelectorInline={true}
+      isMissingConnectorPrivileges={isMissingConnectorPrivileges}
     />
   );
 };

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/mock/test_helpers.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/mock/test_helpers.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { QueryObserverSuccessResult } from '@kbn/react-query';
+import type { IHttpFetchError } from '@kbn/core-http-browser';
+import type { AIConnector } from '../connectorland/connector_selector';
+
+/**
+ * Helper function to create a properly typed mock return value for useLoadConnectors
+ * Returns a QueryObserverSuccessResult which is compatible with UseQueryResult
+ */
+export const createMockUseLoadConnectorsResult = (
+  overrides: Partial<QueryObserverSuccessResult<AIConnector[], IHttpFetchError>>
+): QueryObserverSuccessResult<AIConnector[], IHttpFetchError> => {
+  return {
+    data: [] as AIConnector[],
+    error: null,
+    isError: false,
+    isLoading: false,
+    isSuccess: true,
+    isFetching: false,
+    isInitialLoading: false,
+    isLoadingError: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isPreviousData: false,
+    status: 'success',
+    dataUpdatedAt: 0,
+    errorUpdatedAt: 0,
+    errorUpdateCount: 0,
+    failureCount: 0,
+    failureReason: null,
+    fetchStatus: 'idle',
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isPaused: false,
+    isPlaceholderData: false,
+    refetch: jest.fn(),
+    remove: jest.fn(),
+    ...overrides,
+  };
+};


### PR DESCRIPTION
## Summary

This PR fixes a bug where the "Add connector" button in the ConnectorSelector component was incorrectly checking `hasConnectorsReadPrivilege` instead of `hasConnectorsAllPrivilege`. Users with read-only access were able to see an enabled "Add connector" button, but would encounter errors when attempting to create connectors.

Additionally, this PR includes several test improvements:
- Resolves TypeScript type errors in test mocks by creating a properly typed helper function for `useLoadConnectors`
- Adds test coverage for the add connector button enable/disable behavior based on user privileges
- Improves test stability by adding MutationObserver mocks
- Refactors Assistant component disabled state logic for better clarity and granularity

Closes https://github.com/elastic/kibana/issues/250635

**Before fix:**

https://github.com/user-attachments/assets/c5a2a0cb-3006-4b58-845c-a5db1c57b432



**After fix:**

https://github.com/user-attachments/assets/70c3b76c-8bd5-4924-9a3e-839aed7d5d3a




### Changes

**Bug Fix:**
- Fixed `ConnectorSelector` to check `hasConnectorsAllPrivilege` instead of `hasConnectorsReadPrivilege` for the "Add connector" button disabled state

**Tests:**
- Added tests for add connector button enable/disable scenarios based on user privileges
- Added MutationObserver mock setup for better test stability
- Improved localStorage mock implementation in Assistant tests
- Added tests for AssistantHeader disabled state
- Added tests for connector scenarios (no connectors, connectors exist)

**Code Quality:**
- Refactored Assistant component to use more granular disabled state variables (`isChatDisabled`, `isHeaderDisabled`)
- Added missing `key` prop to TryAIAgentContextMenuItem


*PR developed with Cursor CLI + Composer 1, GPT Codex 5.2 Hight Fast*

<!--ONMERGE {"backportTargets":["8.19","9.1","9.2","9.3"]} ONMERGE-->