### PR TITLE
[One Workflow] fix: Eliminate forced ES refresh on workflow status reads

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/types/v1.ts
+++ b/src/platform/packages/shared/kbn-workflows/types/v1.ts
@@ -112,6 +112,7 @@ export interface EsWorkflowExecution {
   entryTransactionId?: string; // APM root transaction ID for trace embeddable
   concurrencyGroupKey?: string; // Evaluated concurrency group key for grouping executions
   queueMetrics?: QueueMetrics; // Queue delay metrics for observability
+  stepExecutionsCount?: number; // How many step executions were produced when terminated
 }
 
 export interface ProviderInput {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_runtime_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_runtime_manager.ts
@@ -400,6 +400,8 @@ export class WorkflowExecutionRuntimeManager {
       const finishDate = new Date();
       workflowExecutionUpdate.finishedAt = finishDate.toISOString();
       workflowExecutionUpdate.duration = finishDate.getTime() - startedAt.getTime();
+      workflowExecutionUpdate.stepExecutionsCount =
+        this.workflowExecutionState.getAllStepExecutions().length;
       workflowExecutionUpdate.context = buildWorkflowContext(
         this.workflowExecution,
         this.coreStart,

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/get_workflow_execution.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/get_workflow_execution.ts
@@ -101,7 +101,7 @@ function shouldReportAsRunning(
 ): boolean {
   if (
     !isTerminalStatus(workflowExecution.status) ||
-    workflowExecution.stepExecutionsCount === undefined
+    workflowExecution.stepExecutionsCount === undefined // backward compatibility for those not having the field
   ) {
     return false;
   }

--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/get_workflow_execution.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/lib/get_workflow_execution.ts
@@ -99,11 +99,10 @@ function shouldReportAsRunning(
   workflowExecution: EsWorkflowExecution,
   stepExecutions: EsWorkflowStepExecution[]
 ): boolean {
-  if (!isTerminalStatus(workflowExecution.status)) {
-    return false;
-  }
-
-  if (workflowExecution.stepExecutionsCount === undefined) {
+  if (
+    !isTerminalStatus(workflowExecution.status) ||
+    workflowExecution.stepExecutionsCount === undefined
+  ) {
     return false;
   }
 


### PR DESCRIPTION
Replace forced Elasticsearch refresh with eventual consistency approach:

- **Before:** Forced `indices.refresh()` when workflow was terminal but steps incomplete
- **After:** Temporarily report workflow status as `RUNNING` to maintain client polling
- **Benefit:** Eliminates expensive ES operations, reduces cluster load
- **Trade-off:** Brief (<1s) UI inconsistency until natural ES refresh cycle completes

The race condition occurs because step executions are written with `refresh: false` for performance, creating a window where the workflow appears complete but steps aren't yet searchable.