### PR TITLE
Fix synthtrace `fetch` usage

### DIFF
--- a/src/platform/packages/shared/kbn-synthtrace/src/cli/utils/get_service_urls.test.ts
+++ b/src/platform/packages/shared/kbn-synthtrace/src/cli/utils/get_service_urls.test.ts
@@ -34,24 +34,28 @@ describe('getServiceUrls', () => {
     it('should discover local service urls and auth if none provided', async () => {
       const expectedValidAuth = 'elastic:changeme';
 
-      mockFetchWithAllowedSegments([expectedValidAuth]);
+      mockFetchWithAllowedSegments([expectedValidAuth, 'http://localhost:5601']);
       await expectServiceUrls(undefined, undefined, undefined, {
         esUrl: 'http://elastic:changeme@localhost:9200',
-        kibanaUrl: 'http://elastic:changeme@localhost:5601',
+        kibanaUrl: 'http://localhost:5601',
         esHeaders: undefined,
-        kibanaHeaders: undefined,
+        kibanaHeaders: {
+          Authorization: `Basic ${Buffer.from('elastic:changeme').toString('base64')}`,
+        },
       });
     });
 
     it('should discover auth for local service urls', async () => {
       const expectedValidAuth = 'elastic:changeme';
 
-      mockFetchWithAllowedSegments([expectedValidAuth]);
+      mockFetchWithAllowedSegments([expectedValidAuth, 'http://localhost:5601']);
       await expectServiceUrls('http://localhost:9200', 'http://localhost:5601', undefined, {
         esUrl: 'http://elastic:changeme@localhost:9200',
-        kibanaUrl: 'http://elastic:changeme@localhost:5601',
+        kibanaUrl: 'http://localhost:5601',
         esHeaders: undefined,
-        kibanaHeaders: undefined,
+        kibanaHeaders: {
+          Authorization: `Basic ${Buffer.from('elastic:changeme').toString('base64')}`,
+        },
       });
     });
 
@@ -59,12 +63,14 @@ describe('getServiceUrls', () => {
       const kibana = 'http://elastic:changeme@localhost:5601';
       const expectedValidAuth = 'elastic:changeme';
 
-      mockFetchWithAllowedSegments([expectedValidAuth]);
+      mockFetchWithAllowedSegments([expectedValidAuth, 'http://localhost:5601']);
       await expectServiceUrls(undefined, kibana, undefined, {
         esUrl: 'http://elastic:changeme@localhost:9200',
-        kibanaUrl: 'http://elastic:changeme@localhost:5601',
+        kibanaUrl: 'http://localhost:5601',
         esHeaders: undefined,
-        kibanaHeaders: undefined,
+        kibanaHeaders: {
+          Authorization: `Basic ${Buffer.from('elastic:changeme').toString('base64')}`,
+        },
       });
     });
 
@@ -72,12 +78,14 @@ describe('getServiceUrls', () => {
       const target = 'http://elastic:changeme@localhost:9200';
       const expectedValidAuth = 'elastic:changeme';
 
-      mockFetchWithAllowedSegments([expectedValidAuth]);
+      mockFetchWithAllowedSegments([expectedValidAuth, 'http://localhost:5601']);
       await expectServiceUrls(target, undefined, undefined, {
         esUrl: 'http://elastic:changeme@localhost:9200',
-        kibanaUrl: 'http://elastic:changeme@localhost:5601',
+        kibanaUrl: 'http://localhost:5601',
         esHeaders: undefined,
-        kibanaHeaders: undefined,
+        kibanaHeaders: {
+          Authorization: `Basic ${Buffer.from('elastic:changeme').toString('base64')}`,
+        },
       });
     });
 
@@ -91,7 +99,7 @@ describe('getServiceUrls', () => {
         undefined,
         {
           esUrl: 'http://elastic:changeme@localhost:9200',
-          kibanaUrl: 'http://elastic:changeme@localhost:5601',
+          kibanaUrl: 'http://localhost:5601',
           esHeaders: undefined,
           kibanaHeaders: undefined,
         },
@@ -110,7 +118,7 @@ describe('getServiceUrls', () => {
         undefined,
         {
           esUrl: 'http://elastic:changeme@localhost:9200',
-          kibanaUrl: 'http://elastic:changeme@localhost:5601',
+          kibanaUrl: 'http://localhost:5601',
           esHeaders: undefined,
           kibanaHeaders: undefined,
         },
@@ -129,9 +137,11 @@ describe('getServiceUrls', () => {
         undefined,
         {
           esUrl: 'http://elastic:changeme@localhost:9200',
-          kibanaUrl: 'http://elastic:changeme@localhost:5601',
+          kibanaUrl: 'http://localhost:5601',
           esHeaders: undefined,
-          kibanaHeaders: undefined,
+          kibanaHeaders: {
+            Authorization: `Basic ${Buffer.from('elastic:changeme').toString('base64')}`,
+          },
         },
         `Could not discover Elasticsearch URL based on Kibana URL ${kibana.replace(authStr, '.*')}.` // On CI auth is stripped
       );
@@ -144,25 +154,32 @@ describe('getServiceUrls', () => {
 
       mockFetchWithAllowedSegments([
         `https://${expectedValidAuth}@localhost:9200`,
-        `http://${expectedValidAuth}@localhost:5601`,
+        'http://localhost:5601',
       ]); // Only allow https for ES and http for Kibana
       await expectServiceUrls(undefined, undefined, undefined, {
         esUrl: 'https://elastic_serverless:changeme@localhost:9200',
-        kibanaUrl: 'http://elastic_serverless:changeme@localhost:5601',
+        kibanaUrl: 'http://localhost:5601',
         esHeaders: undefined,
-        kibanaHeaders: undefined,
+        kibanaHeaders: {
+          Authorization: `Basic ${Buffer.from('elastic_serverless:changeme').toString('base64')}`,
+        },
       });
     });
 
     it('should discover auth for local https service urls', async () => {
       const expectedValidAuth = 'elastic_serverless:changeme';
 
-      mockFetchWithAllowedSegments([`https://${expectedValidAuth}`]); // Only allow https urls
+      mockFetchWithAllowedSegments([
+        'https://elastic_serverless:changeme@localhost:9200',
+        'https://localhost:5601',
+      ]); // Only allow https urls
       await expectServiceUrls('https://localhost:9200', 'https://localhost:5601', undefined, {
         esUrl: 'https://elastic_serverless:changeme@localhost:9200',
-        kibanaUrl: 'https://elastic_serverless:changeme@localhost:5601',
+        kibanaUrl: 'https://localhost:5601',
         esHeaders: undefined,
-        kibanaHeaders: undefined,
+        kibanaHeaders: {
+          Authorization: `Basic ${Buffer.from('elastic_serverless:changeme').toString('base64')}`,
+        },
       });
     });
 
@@ -182,16 +199,18 @@ describe('getServiceUrls', () => {
     it('throws error if target is https but https Kibana is not reachable', async () => {
       const target = 'https://elastic_serverless:changeme@localhost:9200';
 
-      mockFetchWithAllowedSegments([target, 'http://elastic_serverless:changeme@localhost:5601']); // Only allow http Kibana URL
+      mockFetchWithAllowedSegments([target, 'http://localhost:5601']); // Only allow http Kibana URL
       await expectServiceUrls(
         target,
         undefined,
         undefined,
         {
           esUrl: 'https://elastic_serverless:changeme@localhost:9200',
-          kibanaUrl: 'http://elastic_serverless:changeme@localhost:5601',
+          kibanaUrl: 'https://localhost:5601',
           esHeaders: undefined,
-          kibanaHeaders: undefined,
+          kibanaHeaders: {
+            Authorization: `Basic ${Buffer.from('elastic_serverless:changeme').toString('base64')}`,
+          },
         },
         `Could not connect to Kibana.`
       );
@@ -200,27 +219,33 @@ describe('getServiceUrls', () => {
     it('allows a different https Kibana and a different https ES URL', async () => {
       const target = 'https://elastic_serverless:changeme@host-1:9200';
       const kibana = 'https://elastic_serverless:changeme@host-2:5601';
+      const kibanaWithoutAuth = 'https://host-2:5601';
 
-      mockFetchWithAllowedSegments([target, kibana]); // Allow both URLs
+      mockFetchWithAllowedSegments([target, kibanaWithoutAuth]); // Allow both URLs
       await expectServiceUrls(target, kibana, undefined, {
         esUrl: 'https://elastic_serverless:changeme@host-1:9200',
-        kibanaUrl: 'https://elastic_serverless:changeme@host-2:5601',
+        kibanaUrl: 'https://host-2:5601',
         esHeaders: undefined,
-        kibanaHeaders: undefined,
+        kibanaHeaders: {
+          Authorization: `Basic ${Buffer.from('elastic_serverless:changeme').toString('base64')}`,
+        },
       });
     });
 
     it('logs the certificate warning if 127.0.0.1 is used', async () => {
       const target = 'https://elastic_serverless:changeme@127.0.0.1:9200';
       const kibana = 'https://elastic_serverless:changeme@localhost:5601';
+      const kibanaWithoutAuth = 'https://localhost:5601';
 
       const warnSpy = jest.spyOn(logger, 'warning');
-      mockFetchWithAllowedSegments([target, kibana]);
+      mockFetchWithAllowedSegments([target, kibanaWithoutAuth]);
       await expectServiceUrls(target, kibana, undefined, {
         esUrl: 'https://elastic_serverless:changeme@127.0.0.1:9200',
-        kibanaUrl: 'https://elastic_serverless:changeme@localhost:5601',
+        kibanaUrl: 'https://localhost:5601',
         esHeaders: undefined,
-        kibanaHeaders: undefined,
+        kibanaHeaders: {
+          Authorization: `Basic ${Buffer.from('elastic_serverless:changeme').toString('base64')}`,
+        },
       });
 
       expect(warnSpy).toHaveBeenCalledWith(
@@ -231,28 +256,34 @@ describe('getServiceUrls', () => {
 
   describe('Elastic Cloud', () => {
     it('should discover .kb url if .es target is provided', async () => {
-      const target = 'https://username:1223334444@cluster.kb.us-west2.gcp.elastic-cloud.com';
-      const expectedKibanaUrl = target.replace('.es', '.kb');
+      const target = 'https://username:1223334444@cluster.es.us-west2.gcp.elastic-cloud.com';
+      const targetWithoutAuth = 'https://cluster.es.us-west2.gcp.elastic-cloud.com';
+      const expectedKibanaUrl = targetWithoutAuth.replace('.es', '.kb');
 
       mockFetchWithAllowedSegments([target, expectedKibanaUrl]);
       await expectServiceUrls(target, undefined, undefined, {
         esUrl: target,
         kibanaUrl: expectedKibanaUrl,
         esHeaders: undefined,
-        kibanaHeaders: undefined,
+        kibanaHeaders: {
+          Authorization: `Basic ${Buffer.from('username:1223334444').toString('base64')}`,
+        },
       });
     });
 
     it('should discover .es url if .kb Kibana is provided', async () => {
       const kibana = 'https://username:1223334444@cluster.kb.us-west2.gcp.elastic-cloud.com';
+      const kibanaWithoutAuth = 'https://cluster.kb.us-west2.gcp.elastic-cloud.com';
       const expectedEsUrl = kibana.replace('.kb', '.es');
 
-      mockFetchWithAllowedSegments([kibana, expectedEsUrl]);
+      mockFetchWithAllowedSegments([kibanaWithoutAuth, expectedEsUrl]);
       await expectServiceUrls(undefined, kibana, undefined, {
         esUrl: expectedEsUrl,
-        kibanaUrl: kibana,
+        kibanaUrl: kibanaWithoutAuth,
         esHeaders: undefined,
-        kibanaHeaders: undefined,
+        kibanaHeaders: {
+          Authorization: `Basic ${Buffer.from('username:1223334444').toString('base64')}`,
+        },
       });
     });
   });

--- a/src/platform/packages/shared/kbn-synthtrace/src/cli/utils/get_service_urls.test.ts
+++ b/src/platform/packages/shared/kbn-synthtrace/src/cli/utils/get_service_urls.test.ts
@@ -167,8 +167,6 @@ describe('getServiceUrls', () => {
     });
 
     it('should discover auth for local https service urls', async () => {
-      const expectedValidAuth = 'elastic_serverless:changeme';
-
       mockFetchWithAllowedSegments([
         'https://elastic_serverless:changeme@localhost:9200',
         'https://localhost:5601',


### PR DESCRIPTION
## Summary

Native `fetch` doesn't support URLs in the format `http://user:pass@host`, so we need to parse it and place the credentials as the correct auth headers.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



