### PR TITLE
[Dashboards as Code] Add snake case object keys util

### DIFF
--- a/src/platform/packages/shared/presentation/presentation_publishing/constants.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/constants.ts
@@ -7,12 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Reference } from '@kbn/content-management-utils';
-
 export const SAVED_OBJECT_REF_NAME = 'savedObjectRef';
-
-export function findSavedObjectRef(savedObjectType: string, references?: Reference[]) {
-  return references
-    ? references.find((ref) => savedObjectType === ref.type && ref.name === SAVED_OBJECT_REF_NAME)
-    : undefined;
-}

--- a/src/platform/packages/shared/presentation/presentation_publishing/index.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/index.ts
@@ -186,3 +186,5 @@ export {
   type PublishingSubject,
 } from './publishing_subject';
 export { SAVED_OBJECT_REF_NAME, findSavedObjectRef } from './saved_object_ref';
+
+export { convertCamelCasedKeysToSnakeCase } from './utils/snake_case';

--- a/src/platform/packages/shared/presentation/presentation_publishing/index.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/index.ts
@@ -185,6 +185,5 @@ export {
   useStateFromPublishingSubject,
   type PublishingSubject,
 } from './publishing_subject';
-export { SAVED_OBJECT_REF_NAME, findSavedObjectRef } from './saved_object_ref';
-
+export { SAVED_OBJECT_REF_NAME } from './constants';
 export { convertCamelCasedKeysToSnakeCase } from './utils/snake_case';

--- a/src/platform/packages/shared/presentation/presentation_publishing/moon.yml
+++ b/src/platform/packages/shared/presentation/presentation_publishing/moon.yml
@@ -22,7 +22,6 @@ dependsOn:
   - '@kbn/data-views-plugin'
   - '@kbn/expressions-plugin'
   - '@kbn/core-execution-context-common'
-  - '@kbn/content-management-utils'
   - '@kbn/utility-types'
   - '@kbn/presentation-publishing-schemas'
   - '@kbn/esql-types'

--- a/src/platform/packages/shared/presentation/presentation_publishing/state_manager/state_manager.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/state_manager/state_manager.ts
@@ -7,9 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { camelCase } from 'lodash';
 import { BehaviorSubject, map, merge } from 'rxjs';
-import type { StateComparators, StateManager, WithAllKeys } from './types';
 import { runComparator } from './state_comparators';
+import type { StateComparators, StateManager, WithAllKeys } from './types';
 
 type SubjectOf<StateType extends object> = BehaviorSubject<WithAllKeys<StateType>[keyof StateType]>;
 
@@ -19,15 +20,6 @@ interface UnstructuredSettersAndSubjects<StateType extends object> {
 
 type KeyToSubjectMap<StateType extends object> = {
   [Key in keyof StateType]?: SubjectOf<StateType>;
-};
-
-const snakeToCamel = (key: string): string => {
-  if (!/[_-]/.test(key)) {
-    return key;
-  }
-  return key.replace(/([-_][a-z])/gi, (keyPart) => {
-    return keyPart.toUpperCase().replace('-', '').replace('_', '');
-  });
 };
 
 /**
@@ -68,7 +60,7 @@ export const initializeStateManager = <StateType extends object>(
       }
     };
 
-    const camelCaseKey = snakeToCamel(key as string);
+    const camelCaseKey = camelCase(key as string);
     const capitalizedKey = camelCaseKey.charAt(0).toUpperCase() + camelCaseKey.slice(1);
     acc[`set${capitalizedKey}`] = setter;
     acc[`${camelCaseKey as string}$`] = subject;

--- a/src/platform/packages/shared/presentation/presentation_publishing/state_manager/types.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/state_manager/types.ts
@@ -9,6 +9,7 @@
 
 import type { Observable } from 'rxjs';
 import type { PublishingSubject } from '../publishing_subject';
+import type { SnakeToCamelCase } from '../utils/types';
 
 export type WithAllKeys<T extends object> = { [Key in keyof Required<T>]: T[Key] };
 
@@ -18,13 +19,6 @@ export type ComparatorFunction<StateType, KeyType extends keyof StateType> = (
   lastState?: Partial<StateType>,
   currentState?: Partial<StateType>
 ) => boolean;
-
-/**
- * A type that converts a single key from snake case to camel case.
- */
-type SnakeToCamelCase<S extends string> = S extends `${infer P1}_${infer P2}${infer P3}`
-  ? `${P1}${Uppercase<P2>}${SnakeToCamelCase<P3>}`
-  : S;
 
 /**
  * A type that maps each key in a state type to a definition of how it should be compared. If a custom

--- a/src/platform/packages/shared/presentation/presentation_publishing/tsconfig.json
+++ b/src/platform/packages/shared/presentation/presentation_publishing/tsconfig.json
@@ -11,7 +11,6 @@
     "@kbn/data-views-plugin",
     "@kbn/expressions-plugin",
     "@kbn/core-execution-context-common",
-    "@kbn/content-management-utils",
     "@kbn/utility-types",
     "@kbn/presentation-publishing-schemas",
     "@kbn/esql-types"

--- a/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.test.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.test.ts
@@ -24,8 +24,8 @@ describe('snake case', () => {
   test('deeply nested object', () => {
     const deeplyNestedCamelCasedObject = {
       fruitColours: {
-        anApple: 'red',
-        aBanana: 'yellow',
+        someApples: 'red',
+        banana: 'yellow',
         cucumbersAreFruits: 'green',
         tomatoesAreAlsoFruits: {
           romaTomatoes: 'red',
@@ -35,8 +35,8 @@ describe('snake case', () => {
     };
     expect(convertCamelCasedKeysToSnakeCase(deeplyNestedCamelCasedObject)).toEqual({
       fruit_colours: {
-        an_apple: 'red',
-        a_banana: 'yellow',
+        some_apples: 'red',
+        banana: 'yellow',
         cucumbers_are_fruits: 'green',
         tomatoes_are_also_fruits: {
           roma_tomatoes: 'red',
@@ -62,6 +62,30 @@ describe('snake case', () => {
         count_to_two: [1, 2],
       },
       count_to_ten: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    });
+  });
+
+  test('object with null', () => {
+    const camelCasedObjectWithArray = {
+      iAmDefined: 'safe!',
+      iAmNull: null,
+      iAmUndefined: undefined,
+    };
+    expect(convertCamelCasedKeysToSnakeCase(camelCasedObjectWithArray)).toEqual({
+      i_am_defined: 'safe!',
+      i_am_null: null,
+      i_am_undefined: undefined,
+    });
+  });
+
+  test('object with snake cased keys', () => {
+    const camelCasedObjectWithArray = {
+      iAmCamelCased: true,
+      i_am_snake_cased: 'true',
+    };
+    expect(convertCamelCasedKeysToSnakeCase(camelCasedObjectWithArray)).toEqual({
+      i_am_camel_cased: true,
+      i_am_snake_cased: 'true',
     });
   });
 });

--- a/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.test.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { convertCamelCasedKeysToSnakeCase } from './snake_case';
+
+describe('snake case', () => {
+  test('flat object', () => {
+    const flatCamelCasedObject = {
+      test: 'this key should not be snake cased',
+      camelCasedKey: 'this key should be snake cased',
+    };
+    expect(convertCamelCasedKeysToSnakeCase(flatCamelCasedObject)).toEqual({
+      test: flatCamelCasedObject.test,
+      camel_cased_key: flatCamelCasedObject.camelCasedKey,
+    });
+  });
+
+  test('deeply nested object', () => {
+    const deeplyNestedCamelCasedObject = {
+      fruitColours: {
+        anApple: 'red',
+        aBanana: 'yellow',
+        cucumbersAreFruits: 'green',
+        tomatoesAreAlsoFruits: {
+          romaTomatoes: 'red',
+          cherryTomatoes: 'red',
+        },
+      },
+    };
+    expect(convertCamelCasedKeysToSnakeCase(deeplyNestedCamelCasedObject)).toEqual({
+      fruit_colours: {
+        an_apple: 'red',
+        a_banana: 'yellow',
+        cucumbers_are_fruits: 'green',
+        tomatoes_are_also_fruits: {
+          roma_tomatoes: 'red',
+          cherry_tomatoes: 'red',
+        },
+      },
+    });
+  });
+
+  test('object with array', () => {
+    const camelCasedObjectWithArray = {
+      one: 1,
+      two: {
+        twoPointThree: 2.3,
+        countToTwo: [1, 2],
+      },
+      countToTen: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    };
+    expect(convertCamelCasedKeysToSnakeCase(camelCasedObjectWithArray)).toEqual({
+      one: 1,
+      two: {
+        two_point_three: 2.3,
+        count_to_two: [1, 2],
+      },
+      count_to_ten: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    });
+  });
+});

--- a/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.ts
@@ -22,7 +22,7 @@ export const convertCamelCasedKeysToSnakeCase = (camelCased: {
     snakeCased: { [key: string]: any } = {}
   ): object => {
     for (const [key, value] of Object.entries(camelCasedSubObject)) {
-      if (typeof value === 'object' && !Array.isArray(value)) {
+      if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
         snakeCased[snakeCase(key)] = convertSubObject(value);
       } else {
         snakeCased[snakeCase(key)] = value;

--- a/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.ts
@@ -7,26 +7,23 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { set, snakeCase } from 'lodash';
+import { snakeCase } from 'lodash';
 
 export const convertCamelCasedKeysToSnakeCase = (camelCased: {
   [key: string]: any;
 }): { [key: string]: any } => {
-  const snakeCased: { [key: string]: any } = {};
-
-  const getSnakeCasedStringPath = (path: string, key: string) =>
-    `${path}${path.length ? '.' : ''}${snakeCase(key)}`;
-
-  const convertSubObject = (subObject: object, path: string = '') => {
-    for (const [key, value] of Object.entries(subObject)) {
+  const convertSubObject = (
+    camelCasedSubObject: object,
+    snakeCased: { [key: string]: any } = {}
+  ): object => {
+    for (const [key, value] of Object.entries(camelCasedSubObject)) {
       if (typeof value === 'object' && !Array.isArray(value)) {
-        convertSubObject(value, getSnakeCasedStringPath(path, key));
+        snakeCased[snakeCase(key)] = convertSubObject(value);
       } else {
-        set(snakeCased, getSnakeCasedStringPath(path, key), value);
+        snakeCased[snakeCase(key)] = value;
       }
     }
+    return snakeCased;
   };
-
-  convertSubObject(camelCased); // kick off recursion
-  return snakeCased;
+  return convertSubObject(camelCased);
 };

--- a/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.ts
@@ -9,6 +9,11 @@
 
 import { snakeCase } from 'lodash';
 
+/**
+ * This function takes an object and recursively converts all of the keys to `snaked_cased`
+ * @param camelCased The object with `camelCased` keys
+ * @returns The object with `snake_cased` keys
+ */
 export const convertCamelCasedKeysToSnakeCase = (camelCased: {
   [key: string]: any;
 }): { [key: string]: any } => {

--- a/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { set, snakeCase } from 'lodash';
+
+export const convertCamelCasedKeysToSnakeCase = (camelCased: {
+  [key: string]: any;
+}): { [key: string]: any } => {
+  const snakeCased: { [key: string]: any } = {};
+
+  const getSnakeCasedStringPath = (path: string, key: string) =>
+    `${path}${path.length ? '.' : ''}${snakeCase(key)}`;
+
+  const convertSubObject = (subObject: object, path: string = '') => {
+    for (const [key, value] of Object.entries(subObject)) {
+      if (typeof value === 'object' && !Array.isArray(value)) {
+        convertSubObject(value, getSnakeCasedStringPath(path, key));
+      } else {
+        set(snakeCased, getSnakeCasedStringPath(path, key), value);
+      }
+    }
+  };
+
+  convertSubObject(camelCased); // kick off recursion
+  return snakeCased;
+};

--- a/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/utils/snake_case.ts
@@ -8,15 +8,16 @@
  */
 
 import { snakeCase } from 'lodash';
+import type { SnakeCasedKeys } from './types';
 
 /**
  * This function takes an object and recursively converts all of the keys to `snaked_cased`
  * @param camelCased The object with `camelCased` keys
  * @returns The object with `snake_cased` keys
  */
-export const convertCamelCasedKeysToSnakeCase = (camelCased: {
-  [key: string]: any;
-}): { [key: string]: any } => {
+export const convertCamelCasedKeysToSnakeCase = <StateType extends object = object>(
+  camelCased: StateType
+): SnakeCasedKeys<StateType> => {
   const convertSubObject = (
     camelCasedSubObject: object,
     snakeCased: { [key: string]: any } = {}
@@ -30,5 +31,5 @@ export const convertCamelCasedKeysToSnakeCase = (camelCased: {
     }
     return snakeCased;
   };
-  return convertSubObject(camelCased);
+  return convertSubObject(camelCased) as SnakeCasedKeys<StateType>;
 };

--- a/src/platform/packages/shared/presentation/presentation_publishing/utils/types.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/utils/types.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * A type that converts a single key from snake case to camel case.
+ */
+export type SnakeToCamelCase<S extends string> = S extends `${infer P1}_${infer P2}${infer P3}`
+  ? `${P1}${Uppercase<P2>}${SnakeToCamelCase<P3>}`
+  : S;
+
+/**
+ * A type that converts a single key from camel case to snake case.
+ */
+export type CamelToSnakeCase<S extends string> = S extends `${infer C}${infer R}`
+  ? `${C extends Lowercase<C> ? '' : '_'}${Lowercase<C>}${CamelToSnakeCase<R>}`
+  : S;
+
+/**
+ * A type that converts all keys in an object from camel case to snake case.
+ */
+export type SnakeCasedKeys<StateType extends object = object> = {
+  [KeyType in keyof Required<StateType> as `${CamelToSnakeCase<
+    string & KeyType
+  >}`]: StateType[KeyType] extends object ? SnakeCasedKeys<StateType[KeyType]> : StateType[KeyType];
+};

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
@@ -65,29 +65,6 @@ export function DashboardRenderer({
   getCreationOptions,
   onApiAvailable,
 }: DashboardRendererProps) {
-  useEffect(() => {
-    console.log(convertCamelCasedKeysToSnakeCase({ testKey: 'something', anotherTestKey: 'idk' }));
-    console.log(
-      convertCamelCasedKeysToSnakeCase({
-        testKey: 'something',
-        anotherTestKey: 'idk',
-        nestedKey: {
-          testThisNestedKey: 'i bet this is flat',
-        },
-        deeplyNestedKey: {
-          oneKey: '1',
-          twoKey: '2',
-          threeKey: {
-            aKey: 'apple',
-            bKey: 'banana',
-            cKey: 'cucumber',
-          },
-        },
-        arrayKey: [1, 2, 3, 4],
-      })
-    );
-  }, []);
-
   const dashboardViewport = useRef(null);
   const dashboardContainerRef = useRef<HTMLElement | null>(null);
   const [dashboardApi, setDashboardApi] = useState<DashboardApi | undefined>();

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
@@ -14,7 +14,10 @@ import { EuiEmptyPrompt, EuiLoadingElastic, EuiLoadingSpinner } from '@elastic/e
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { SavedObjectNotFound } from '@kbn/kibana-utils-plugin/common';
-import { useStateFromPublishingSubject } from '@kbn/presentation-publishing';
+import {
+  convertCamelCasedKeysToSnakeCase,
+  useStateFromPublishingSubject,
+} from '@kbn/presentation-publishing';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import { ExitFullScreenButtonKibanaProvider } from '@kbn/shared-ux-button-exit-full-screen';
 
@@ -62,6 +65,29 @@ export function DashboardRenderer({
   getCreationOptions,
   onApiAvailable,
 }: DashboardRendererProps) {
+  useEffect(() => {
+    console.log(convertCamelCasedKeysToSnakeCase({ testKey: 'something', anotherTestKey: 'idk' }));
+    console.log(
+      convertCamelCasedKeysToSnakeCase({
+        testKey: 'something',
+        anotherTestKey: 'idk',
+        nestedKey: {
+          testThisNestedKey: 'i bet this is flat',
+        },
+        deeplyNestedKey: {
+          oneKey: '1',
+          twoKey: '2',
+          threeKey: {
+            aKey: 'apple',
+            bKey: 'banana',
+            cKey: 'cucumber',
+          },
+        },
+        arrayKey: [1, 2, 3, 4],
+      })
+    );
+  }, []);
+
   const dashboardViewport = useRef(null);
   const dashboardContainerRef = useRef<HTMLElement | null>(null);
   const [dashboardApi, setDashboardApi] = useState<DashboardApi | undefined>();

--- a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_renderer/dashboard_renderer.tsx
@@ -14,10 +14,7 @@ import { EuiEmptyPrompt, EuiLoadingElastic, EuiLoadingSpinner } from '@elastic/e
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { SavedObjectNotFound } from '@kbn/kibana-utils-plugin/common';
-import {
-  convertCamelCasedKeysToSnakeCase,
-  useStateFromPublishingSubject,
-} from '@kbn/presentation-publishing';
+import { useStateFromPublishingSubject } from '@kbn/presentation-publishing';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import { ExitFullScreenButtonKibanaProvider } from '@kbn/shared-ux-button-exit-full-screen';
 


### PR DESCRIPTION
## Summary

This PR adds a util to the `presentation-publishing` package that converts all `camelCased` keys in an object to `snake_case`. As we continue to snake case all of the dashboard state to make the API specifications, this util will make the state transforms much cleaner.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
