### PR TITLE
[Discover] [Metrics] Fix: metrics grid titles do not update on order change

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_grid.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_grid.tsx
@@ -149,7 +149,7 @@ export const MetricsGrid = ({
               focusedCell.rowIndex === rowIndex && focusedCell.colIndex === colIndex;
 
             return (
-              <EuiFlexItem key={index}>
+              <EuiFlexItem key={id}>
                 <ChartItem
                   id={id}
                   index={index}


### PR DESCRIPTION
## Summary

Resolves #250687.

We are using the index of the items in the list for the grid. This is not specific enough for a `key` value, because when the list is reordered, or items are eliminated, the `index` can remain the same (the 0th item is different, but its index is unchanged), and React will choose not to unmount the existing component.

This change reuses the existing `id` value we already generate, which is a composite of the index and the metric's name. This makes the list's render process resilient to item changes where the index value remains the same.

## Verification

The linked issue lists several cases where this is broken, and I believe the fix addresses all of them. I have included some recordings. The issue has detailed repro instructions, so I recommend you review it for testing. But essentially, if you load any metrics data and perform filtering or narrowing your ES|QL query to cause the list to re-order without re-rendering the parent content, you should be able to verify the fix against `main`.

### Narrowing ES|QL via WHERE clause

![20260129131637](https://github.com/user-attachments/assets/bb00bab1-9b76-4887-92c1-3fbe730b1326)

### Searching for title

![20260129132000](https://github.com/user-attachments/assets/a5b3435b-1289-48ac-9f84-8997d07a2846)

### Checking breakdown -> details matches title

![20260129132042](https://github.com/user-attachments/assets/0a15c0ce-9117-4bc2-8ed0-3124ffaa4e9c)


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->