### PR TITLE
[9.2] [Alerting] mark auth errors as user errors (#249461)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
@@ -6,6 +6,7 @@
  */
 
 import sinon from 'sinon';
+import { errors } from '@elastic/elasticsearch';
 import { usageCountersServiceMock } from '@kbn/usage-collection-plugin/server/usage_counters/usage_counters_service.mock';
 import type { SavedObject } from '@kbn/core/server';
 import type {
@@ -1807,6 +1808,39 @@ describe('Task Runner', () => {
     );
 
     expect(mockUsageCounter.incrementCounter).not.toHaveBeenCalled();
+  });
+
+  test('should set authentication errors as user-error', async () => {
+    jest.spyOn(getExecutorServicesModule, 'getExecutorServices').mockImplementation(() => {
+      throw new errors.ResponseError({
+        warnings: [],
+        meta: {} as never,
+        statusCode: 401,
+      });
+    });
+
+    const taskRunner = new TaskRunner({
+      ruleType,
+      internalSavedObjectsRepository,
+      taskInstance: mockedTaskInstance,
+      context: taskRunnerFactoryInitializerParams,
+      inMemoryMetrics,
+    });
+    expect(AlertingEventLogger).toHaveBeenCalled();
+    mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(mockedRawRuleSO);
+
+    await taskRunner.run();
+
+    expect(logger.error).toBeCalledTimes(1);
+
+    const loggerCall = logger.error.mock.calls[0][0];
+    const loggerMeta = logger.error.mock.calls[0][1];
+    const loggerCallPrefix = (loggerCall as string).split('-');
+    expect(loggerCallPrefix[0].trim()).toMatchInlineSnapshot(
+      `"Executing Rule default:test:1 has resulted in Error: Response Error"`
+    );
+    expect(loggerMeta?.tags).toEqual(['1', 'test', 'rule-run-failed', 'user-error']);
   });
 
   test('should set unexpected errors as framework-error', async () => {

--- a/x-pack/platform/plugins/shared/task_manager/moon.yml
+++ b/x-pack/platform/plugins/shared/task_manager/moon.yml
@@ -48,6 +48,7 @@ dependsOn:
   - '@kbn/spaces-utils'
   - '@kbn/licensing-types'
   - '@kbn/lazy-object'
+  - '@kbn/es-errors'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/errors.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/errors.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { errors } from '@elastic/elasticsearch';
+
 import {
   createTaskRunError,
   getErrorSource,
@@ -50,6 +52,24 @@ describe('Error Types', () => {
 
     it('getErrorSource return undefined when there is no source data', () => {
       expect(getErrorSource(new Error('OMG'))).toBeUndefined();
+    });
+
+    it('getErrorSource return USER for authentication response errors', () => {
+      const error = new errors.ResponseError({
+        warnings: [],
+        meta: {} as never,
+        statusCode: 401,
+      });
+      expect(getErrorSource(error)).toBe(TaskErrorSource.USER);
+    });
+
+    it('getErrorSource return undefined for non-authentication response errors', () => {
+      const error = new errors.ResponseError({
+        warnings: [],
+        meta: {} as never,
+        statusCode: 404,
+      });
+      expect(getErrorSource(error)).toBe(undefined);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/errors.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/errors.ts
@@ -4,6 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
+import { isUnauthorizedError } from '@kbn/es-errors';
+
 import { TaskErrorSource } from '../../common';
 
 export { TaskErrorSource };
@@ -67,6 +70,10 @@ function isTaskRunError(error: Error | DecoratedError): error is DecoratedError 
 export function getErrorSource(error: Error | DecoratedError): TaskErrorSource | undefined {
   if (isTaskRunError(error) && error[source]) {
     return error[source];
+  }
+
+  if (isUnauthorizedError(error)) {
+    return TaskErrorSource.USER;
   }
 }
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
@@ -6,6 +6,7 @@
  */
 
 import _ from 'lodash';
+import { errors } from '@elastic/elasticsearch';
 import { secondsFromNow } from '../lib/intervals';
 import { asOk, asErr } from '../lib/result_type';
 import {
@@ -960,6 +961,36 @@ describe('TaskManagerRunner', () => {
       const loggerCall = logger.error.mock.calls[0][0];
       const loggerMeta = logger.error.mock.calls[0][1];
       expect(loggerCall as string).toMatchInlineSnapshot(`"Task bar \\"foo\\" failed: Error: rar"`);
+      expect(loggerMeta?.tags).toEqual(['bar', 'foo', 'task-run-failed', 'user-error']);
+    });
+    test('logs ES auth errors as user errors', async () => {
+      const { runner, logger } = await readyToRunStageSetup({
+        instance: {
+          params: { a: 'b' },
+          state: { hey: 'there' },
+        },
+        definitions: {
+          bar: {
+            title: 'Bar!',
+            createTaskRunner: () => ({
+              async run() {
+                throw new errors.ResponseError({
+                  warnings: [],
+                  meta: {} as never,
+                  statusCode: 401,
+                });
+              },
+            }),
+          },
+        },
+      });
+      await runner.run();
+
+      const loggerCall = logger.error.mock.calls[0][0];
+      const loggerMeta = logger.error.mock.calls[0][1];
+      expect(loggerCall as string).toMatchInlineSnapshot(
+        `"Task bar \\"foo\\" failed: ResponseError: Response Error"`
+      );
       expect(loggerMeta?.tags).toEqual(['bar', 'foo', 'task-run-failed', 'user-error']);
     });
     test('provides execution context on run', async () => {

--- a/x-pack/platform/plugins/shared/task_manager/tsconfig.json
+++ b/x-pack/platform/plugins/shared/task_manager/tsconfig.json
@@ -40,6 +40,7 @@
     "@kbn/spaces-utils",
     "@kbn/licensing-types",
     "@kbn/lazy-object",
+    "@kbn/es-errors",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Alerting] mark auth errors as user errors (#249461)](https://github.com/elastic/kibana/pull/249461)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2026-01-29T05:43:07Z","message":"[Alerting] mark auth errors as user errors (#249461)\n\nChanges to errors caused by authentication - typically (always?) from API keys:\n\n- mark the error as a User error vs a Framework error","sha":"915a37f9b9459875a47b1e35ef52b38dd8f013e0","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","backport:all-open","v9.4.0"],"title":"[Alerting] mark auth errors as user errors","number":249461,"url":"https://github.com/elastic/kibana/pull/249461","mergeCommit":{"message":"[Alerting] mark auth errors as user errors (#249461)\n\nChanges to errors caused by authentication - typically (always?) from API keys:\n\n- mark the error as a User error vs a Framework error","sha":"915a37f9b9459875a47b1e35ef52b38dd8f013e0"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249461","number":249461,"mergeCommit":{"message":"[Alerting] mark auth errors as user errors (#249461)\n\nChanges to errors caused by authentication - typically (always?) from API keys:\n\n- mark the error as a User error vs a Framework error","sha":"915a37f9b9459875a47b1e35ef52b38dd8f013e0"}},{"url":"https://github.com/elastic/kibana/pull/250844","number":250844,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->